### PR TITLE
[Refactor][SFA] Decouple DSA-CP and DCP backends

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -15,6 +15,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
+from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADSACPImpl
 from vllm_ascend.attention.sfa_kv_offload import (
     AscendSFAKVOffloadImpl,
     AscendSFAKVOffloadMetadataBuilder,
@@ -34,7 +35,6 @@ from vllm_ascend.quantization.methods import (
     AscendW8A8LinearMethod,
     AscendW8A8MXFP8DynamicLinearMethod,
 )
-from vllm_ascend.utils import enable_dsa_cp
 
 
 class TestAscendSFABackend(TestBase):
@@ -50,9 +50,12 @@ class TestAscendSFABackend(TestBase):
 
         self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
         self.utils_patcher.start()
+        self.dsa_patcher = patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_dsa_cp", return_value=False)
+        self.dsa_patcher.start()
 
     def tearDown(self):
         self.utils_patcher.stop()
+        self.dsa_patcher.stop()
         self.config_context.__exit__(None, None, None)
 
     def test_get_name(self):
@@ -73,7 +76,7 @@ class TestAscendSFABackend(TestBase):
         result = AscendSFABackend.get_impl_cls()
         self.assertEqual(result, AscendSFAImpl)
 
-    @patch("vllm_ascend.attention.sfa_v1.enable_sfa_dcp_replicated_indexer")
+    @patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer")
     @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
     def test_get_builder_cls_with_dcp(self, mock_get_ascend_config, mock_enable_dcp):
         mock_enable_dcp.return_value = True
@@ -81,7 +84,7 @@ class TestAscendSFABackend(TestBase):
         builder_cls = AscendSFABackend.get_builder_cls()
         self.assertIsNotNone(builder_cls)
 
-    @patch("vllm_ascend.attention.sfa_v1.enable_sfa_dcp_replicated_indexer")
+    @patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer")
     @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
     def test_get_impl_cls_with_dcp(self, mock_get_ascend_config, mock_enable_dcp):
         mock_enable_dcp.return_value = True
@@ -544,9 +547,6 @@ class TestAscendSFAMetadataBuilder(TestBase):
         )
         self.parent_init_patcher.start()
 
-        if hasattr(enable_dsa_cp, "cache_clear"):
-            enable_dsa_cp.cache_clear()
-
     def tearDown(self):
         self.patcher.stop()
         self.ascend_config_patcher.stop()
@@ -578,16 +578,12 @@ class TestAscendSFAMetadataBuilder(TestBase):
 
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
-    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp")
     @patch_distributed_groups(dcp_size=2, needs_mocks=False)
     def test_ascend_sfa_metadata_builder_build(
         self,
-        mock_enable_dsa_cp,
         mock_get_cos_and_sin_mla,
         mock_get_current_vllm_config,
     ):
-        mock_enable_dsa_cp.return_value = False
-
         cfg = MagicMock()
         cfg.model_config = MagicMock()
         cfg.model_config.hf_text_config = MagicMock()
@@ -638,67 +634,12 @@ class TestAscendSFAMetadataBuilder(TestBase):
         assert metadata.num_actual_tokens == common_attn_metadata.num_actual_tokens
         assert metadata.slot_mapping.shape == (100, 4, 1024)
 
-    @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
-    @patch("vllm_ascend.attention.sfa_v1.get_tp_group")
-    def test_dsa_cp_metadata_builder_masks_graph_padding(
-        self,
-        mock_get_tp_group,
-        mock_get_cos_and_sin_mla,
-    ):
-        # TP8, graph size 80 and MTP3 produce 20 four-token request slots. With
-        # nine real requests, rank 6 splits a padded slot at its local boundary.
-        tp_group = MagicMock()
-        tp_group.world_size = 8
-        tp_group.rank_in_group = 6
-        mock_get_tp_group.return_value = tp_group
-        mock_get_cos_and_sin_mla.return_value = (
-            torch.zeros(80, 1, 1, 64),
-            torch.zeros(80, 1, 1, 64),
-        )
-
-        builder = AscendSFAMetadataBuilder.__new__(AscendSFAMetadataBuilder)
-        builder.kernel_block_size = 128
-        builder.model_config = MagicMock()
-        builder.model_config.get_head_size.return_value = 64
-        builder.attn_mask_builder = MagicMock()
-        builder.enable_dsa_cp = True
-        builder.actual_seq_lengths_query = torch.zeros(21, dtype=torch.int32)
-        builder.actual_seq_lengths_key = torch.zeros(21, dtype=torch.int32)
-        builder.spec_actual_seq_lengths_query = None
-        builder.spec_actual_seq_lengths_key = None
-        builder.metadata_cls = AscendSFAMetadata
-
-        common_attn_metadata = MagicMock()
-        common_attn_metadata.num_reqs = 20
-        common_attn_metadata.num_actual_tokens = 36
-        common_attn_metadata.num_input_tokens = 80
-        common_attn_metadata.query_start_loc = torch.arange(0, 81, 4, dtype=torch.int32)
-        common_attn_metadata.seq_lens = torch.zeros(20, dtype=torch.int32)
-        common_attn_metadata.seq_lens[:9] = torch.arange(128, 137, dtype=torch.int32)
-        common_attn_metadata._seq_lens_cpu = common_attn_metadata.seq_lens.clone()
-        common_attn_metadata.seq_lens_cpu = common_attn_metadata.seq_lens.clone()
-        common_attn_metadata.block_table_tensor = torch.zeros(20, 1, dtype=torch.int32)
-        common_attn_metadata.slot_mapping = torch.arange(80, dtype=torch.int64)
-        common_attn_metadata.positions = torch.arange(80, dtype=torch.int64)
-        common_attn_metadata.attn_state = AscendAttentionState.DecodeOnly
-        common_attn_metadata.causal = True
-        common_attn_metadata.group_len = None
-        common_attn_metadata.group_key_idx = None
-        common_attn_metadata.group_key_cache_idx = None
-
-        metadata = builder._build(common_attn_metadata)
-
-        local_seq_lens = metadata.dsa_cp_context.actual_seq_lengths_key
-        assert local_seq_lens[17].item() == 0
-        assert torch.all(local_seq_lens >= 0)
-
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
-    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp", return_value=False)
     @patch("vllm.distributed.parallel_state.get_tp_group")
     @patch_distributed_groups(dcp_size=2, needs_mocks=False)
     def test_ascend_sfa_metadata_builder_build_for_graph_capture(
-        self, mock_get_tp_group, mock_enable_dsa_cp, mock_get_cos_and_sin_mla, mock_get_current_vllm_config
+        self, mock_get_tp_group, mock_get_cos_and_sin_mla, mock_get_current_vllm_config
     ):
         cfg = MagicMock()
         cfg.model_config = MagicMock()
@@ -752,12 +693,10 @@ class TestAscendSFAMetadataBuilder(TestBase):
 
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")
-    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp", return_value=False)
     @patch("torch.ops._C_ascend.store_kv_block_metadata", create=True)
     def test_ascend_sfa_metadata_builder_build_with_c8_reshape_optim(
         self,
         store_kv_block_metadata,
-        mock_enable_dsa_cp,
         mock_get_cos_and_sin_mla,
         mock_get_current_vllm_config,
     ):
@@ -830,16 +769,12 @@ class TestAscendSFAMetadataBuilder(TestBase):
 class TestAscendSFAImpl(TestBase):
     @patch("vllm.distributed.parallel_state._TP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
-    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp_with_o_proj_tp")
     @patch("vllm_ascend.attention.sfa_v1.enable_sp")
-    @patch("vllm_ascend.attention.sfa_v1.enable_dsa_cp")
     @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")
     def setUp(
         self,
         mock_get_ascend_config,
-        mock_enable_dsa_cp,
         mock_enable_sp,
-        mock_enable_dsa_cp_with_o_proj_tp,
         mock_get_current_vllm_config,
         mock_tp,
     ):
@@ -847,9 +782,7 @@ class TestAscendSFAImpl(TestBase):
         mock_tp.rank_in_group = 0
         mock_tp.device_group = MagicMock()
 
-        mock_enable_dsa_cp.return_value = False
         mock_enable_sp.return_value = False
-        mock_enable_dsa_cp_with_o_proj_tp.return_value = False
 
         # Default ascend config (non-MLAPO, non-C8)
         mock_ascend_config = MagicMock()
@@ -1007,7 +940,6 @@ class TestAscendSFAImpl(TestBase):
         """exec_kv with enable_sparse_sfa_c8 delegates to custom_kv_rmsnorm_rope."""
         self.impl.enable_sparse_sfa_c8 = True
         self.impl.c8_k_cache_dtype = torch.int8
-        self.impl.enable_dsa_cp = False
         self.impl.kv_a_layernorm = MagicMock()
         self.impl.kv_a_layernorm.weight = torch.ones(self.impl.kv_lora_rank)
         self.impl.kv_a_layernorm.variance_epsilon = 1e-5
@@ -1127,9 +1059,9 @@ class TestAscendSFAImpl(TestBase):
 
     def test_reasons_dsa_cp_blocked(self):
         self._setup_prolog_v3_state()
-        self.impl.enable_dsa_cp = True
-
-        reasons = self.impl._get_fused_type_unsupported_reasons(PreprocessType.PROLOG_V3)
+        impl = AscendSFADSACPImpl.__new__(AscendSFADSACPImpl)
+        impl.__dict__.update(self.impl.__dict__)
+        reasons = impl._get_fused_type_unsupported_reasons(PreprocessType.PROLOG_V3)
         self.assertTrue(any("DSA-CP" in r for r in reasons))
 
     def test_reasons_kv_producer_blocked(self):

--- a/tests/ut/attention/test_sfa_cp.py
+++ b/tests/ut/attention/test_sfa_cp.py
@@ -11,6 +11,14 @@ from vllm_ascend.attention.context_parallel.sfa_cp import (
     AscendSFADCPImpl,
     AscendSFADCPMetadata,
     AscendSFADCPMetadataBuilder,
+    AscendSFADSACPImpl,
+    AscendSFADSACPMetadata,
+    AscendSFADSACPMetadataBuilder,
+    AscendSFADSADCPImpl,
+    AscendSFADSADCPMetadata,
+    AscendSFADSADCPMetadataBuilder,
+    resolve_sfa_impl,
+    resolve_sfa_metadata_builder,
 )
 from vllm_ascend.attention.sfa_v1 import (
     AscendSFAImpl,
@@ -27,6 +35,113 @@ def test_sfa_dcp_extends_v1_backend() -> None:
     )
     assert "dcp_context" not in {field.name for field in fields(AscendSFAMetadata)}
     assert "dcp_context" in {field.name for field in fields(AscendSFADCPMetadata)}
+    assert "dsa_cp_context" not in {field.name for field in fields(AscendSFAMetadata)}
+    assert "dsa_cp_context" in {field.name for field in fields(AscendSFADSACPMetadata)}
+    assert issubclass(AscendSFADSADCPImpl, AscendSFADCPImpl)
+    assert issubclass(AscendSFADSADCPImpl, AscendSFADSACPImpl)
+    assert issubclass(AscendSFADSADCPMetadataBuilder, AscendSFADCPMetadataBuilder)
+    assert issubclass(AscendSFADSADCPMetadataBuilder, AscendSFADSACPMetadataBuilder)
+    assert issubclass(AscendSFADSADCPMetadata, AscendSFADCPMetadata)
+    impl_mro = AscendSFADSADCPImpl.__mro__
+    builder_mro = AscendSFADSADCPMetadataBuilder.__mro__
+    assert impl_mro.index(AscendSFADCPImpl) < impl_mro.index(AscendSFADSACPImpl)
+    assert builder_mro.index(AscendSFADCPMetadataBuilder) < builder_mro.index(AscendSFADSACPMetadataBuilder)
+
+
+def test_sfa_cp_four_mode_resolution() -> None:
+    expected = {
+        (False, False): (AscendSFAMetadataBuilder, AscendSFAImpl),
+        (True, False): (AscendSFADSACPMetadataBuilder, AscendSFADSACPImpl),
+        (False, True): (AscendSFADCPMetadataBuilder, AscendSFADCPImpl),
+        (True, True): (AscendSFADSADCPMetadataBuilder, AscendSFADSADCPImpl),
+    }
+    for flags, classes in expected.items():
+        with (
+            patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_dsa_cp", return_value=flags[0]),
+            patch(
+                "vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer",
+                return_value=flags[1],
+            ),
+        ):
+            assert resolve_sfa_metadata_builder() is classes[0]
+            assert resolve_sfa_impl() is classes[1]
+
+
+def test_sfa_cp_query_gather_axis_follows_composed_layout() -> None:
+    dcp_impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+    combined_impl = AscendSFADSADCPImpl.__new__(AscendSFADSADCPImpl)
+    assert dcp_impl._parallel_query_gather_dim() == 1
+    assert combined_impl._parallel_query_gather_dim() == 0
+
+
+def test_sfa_dsa_cp_builder_shards_tokens_and_sequence_lengths() -> None:
+    builder = AscendSFADSACPMetadataBuilder.__new__(AscendSFADSACPMetadataBuilder)
+    builder.actual_seq_lengths_query = torch.zeros(3, dtype=torch.int32)
+    builder.actual_seq_lengths_key = torch.zeros(3, dtype=torch.int32)
+    builder.spec_actual_seq_lengths_query = None
+    builder.spec_actual_seq_lengths_key = None
+    common = SimpleNamespace(
+        num_reqs=2,
+        num_input_tokens=5,
+        num_actual_tokens=5,
+        query_start_loc=torch.tensor([0, 3, 5], dtype=torch.int32),
+    )
+    tp_group = SimpleNamespace(world_size=2, rank_in_group=1)
+    with patch("vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group", return_value=tp_group):
+        cos, sin, slot_mapping, extra = builder._prepare_parallel_metadata(
+            common,
+            torch.arange(10, dtype=torch.float32).view(5, 1, 1, 2),
+            torch.arange(10, dtype=torch.float32).view(5, 1, 1, 2),
+            torch.arange(5, dtype=torch.int32),
+            torch.tensor([3, 5], dtype=torch.int32),
+            torch.tensor([3, 5], dtype=torch.int32),
+            draft_index=None,
+        )
+
+    assert cos.shape[0] == sin.shape[0] == 3
+    torch.testing.assert_close(slot_mapping, torch.tensor([0, 1, 2, 3, 4, -1], dtype=torch.int32))
+    context = extra["dsa_cp_context"]
+    torch.testing.assert_close(context.slot_mapping_cp, torch.tensor([3, 4, -1], dtype=torch.int32))
+    torch.testing.assert_close(context.actual_seq_lengths_query, torch.tensor([0, 2], dtype=torch.int32))
+    torch.testing.assert_close(context.actual_seq_lengths_key, torch.tensor([0, 5], dtype=torch.int32))
+
+
+def test_sfa_dsa_cp_metadata_builder_masks_graph_padding() -> None:
+    # TP8, graph size 80 and MTP3 produce 20 four-token request slots. With
+    # nine real requests, rank 6 splits a padded slot at its local boundary.
+    builder = AscendSFADSACPMetadataBuilder.__new__(AscendSFADSACPMetadataBuilder)
+    builder.actual_seq_lengths_query = torch.zeros(21, dtype=torch.int32)
+    builder.actual_seq_lengths_key = torch.zeros(21, dtype=torch.int32)
+    builder.spec_actual_seq_lengths_query = None
+    builder.spec_actual_seq_lengths_key = None
+    query_start_loc = torch.arange(0, 81, 4, dtype=torch.int32)
+    seq_lens = torch.zeros(20, dtype=torch.int32)
+    seq_lens[:9] = torch.arange(128, 137, dtype=torch.int32)
+    common = SimpleNamespace(
+        num_reqs=20,
+        num_input_tokens=80,
+        num_actual_tokens=36,
+        query_start_loc=query_start_loc,
+    )
+    tp_group = SimpleNamespace(world_size=8, rank_in_group=6)
+
+    with patch(
+        "vllm_ascend.attention.context_parallel.sfa_cp.get_tp_group",
+        return_value=tp_group,
+    ):
+        _, _, _, extra = builder._prepare_parallel_metadata(
+            common,
+            torch.zeros(80, 1, 1, 64),
+            torch.zeros(80, 1, 1, 64),
+            torch.arange(80, dtype=torch.int64),
+            query_start_loc[1:],
+            seq_lens,
+            draft_index=None,
+        )
+
+    local_seq_lens = extra["dsa_cp_context"].actual_seq_lengths_key
+    assert local_seq_lens[17].item() == 0
+    assert torch.all(local_seq_lens >= 0)
 
 
 def test_sfa_dcp_builder_sizes_replicated_view_from_padded_block_table() -> None:
@@ -100,7 +215,7 @@ def test_sfa_dcp_builds_replicated_block_table_view() -> None:
 
 
 def test_sfa_dcp_updates_dsa_cp_local_slot_mapping_with_padding() -> None:
-    builder = _make_builder()
+    builder = AscendSFADSADCPMetadataBuilder.__new__(AscendSFADSADCPMetadataBuilder)
     dsa_cp_context = SimpleNamespace(
         num_tokens_pad=6,
         local_start=2,
@@ -109,9 +224,9 @@ def test_sfa_dcp_updates_dsa_cp_local_slot_mapping_with_padding() -> None:
     )
     metadata = SimpleNamespace(dsa_cp_context=dsa_cp_context)
 
-    builder._update_dsa_cp_slot_mapping_for_dcp(
+    builder._update_parallel_slot_mapping(
         metadata,
-        dcp_slot_mapping=torch.tensor([10, 11, 12, 13], dtype=torch.int32),
+        slot_mapping=torch.tensor([10, 11, 12, 13], dtype=torch.int32),
         num_input_tokens=4,
     )
 

--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -22,7 +22,8 @@ from tests.ut.base import TestBase
 if "torch_npu._inductor" not in sys.modules:
     sys.modules["torch_npu._inductor"] = MagicMock()
 
-from vllm_ascend.attention.sfa_v1 import AscendSFAImpl, PreprocessType
+from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADSACPImpl
+from vllm_ascend.attention.sfa_v1 import PreprocessType, SFAForwardContext
 from vllm_ascend.quantization.tp_weight_switch import (
     TPWeightGatherSpec,
     TPWeightSwitchMixin,
@@ -54,10 +55,10 @@ class TestAscendSFAOProjTPParams(TestBase):
             self.quant_method = linear_method
 
     def setUp(self):
-        AscendSFAImpl.o_proj_full_pools.clear()
+        AscendSFADSACPImpl.o_proj_full_pools.clear()
 
     def _make_impl(self, linear_method=None):
-        impl = AscendSFAImpl.__new__(AscendSFAImpl)
+        impl = AscendSFADSACPImpl.__new__(AscendSFADSACPImpl)
         impl.tp_size = 2
         impl.o_proj = self._OProj(linear_method or _OProjLinearMethod())
         impl._o_proj_tp_weight_switch_enabled = False
@@ -77,7 +78,7 @@ class TestAscendSFAOProjTPParams(TestBase):
         self.assertEqual(state.gather_parts["weight_scale"].tp_tensor.data_ptr(), original_scale_ptr)
         self.assertEqual(state.gather_parts["weight"].full_tensor.shape, (8, 3))
         self.assertEqual(state.gather_parts["weight_scale"].full_tensor.shape, (4, 3))
-        self.assertEqual(len(AscendSFAImpl.o_proj_full_pools), 2)
+        self.assertEqual(len(AscendSFADSACPImpl.o_proj_full_pools), 2)
 
         impl._enable_o_proj_tp_full_weight_switch()
         self.assertIs(impl.o_proj_tp_weight_state, state)
@@ -98,15 +99,15 @@ class TestAscendSFAOProjTPParams(TestBase):
 
         impl._apply_o_proj_full_weight = MagicMock(side_effect=_apply_with_full_weight)
 
-        output, require_o_proj_forward = impl._handle_o_proj_weight_switch_and_forward(
+        impl.enable_dsa_cp_with_o_proj_tp = True
+        output = impl._finalize_o_proj(
             attn_output=torch.randn(2, 8),
             output=torch.empty(2, 3),
-            should_shard_weight=True,
+            gather_full_o_proj=True,
         )
 
         self.assertEqual(impl.o_proj.weight.data_ptr(), original_weight_ptr)
         self.assertEqual(impl.o_proj.weight_scale.data_ptr(), original_scale_ptr)
-        self.assertFalse(require_o_proj_forward)
         self.assertTrue(torch.equal(output, torch.ones(2, 3)))
 
     def test_enable_o_proj_switch_rejects_unsupported_method(self):
@@ -116,8 +117,7 @@ class TestAscendSFAOProjTPParams(TestBase):
             impl._enable_o_proj_tp_full_weight_switch()
 
     def test_no_indexer_full_o_proj_still_opens_gate_and_saves_layer(self):
-        impl = AscendSFAImpl.__new__(AscendSFAImpl)
-        impl.enable_dsa_cp = False
+        impl = AscendSFADSACPImpl.__new__(AscendSFADSACPImpl)
         impl.enable_dsa_cp_with_o_proj_tp = True
         impl.enable_sp = False
         impl.has_indexer = False
@@ -140,6 +140,8 @@ class TestAscendSFAOProjTPParams(TestBase):
         impl._q_proj_and_k_up_proj = MagicMock(return_value=(MagicMock(), MagicMock()))
         impl.rope_single = MagicMock(return_value=MagicMock())
         impl._record_query_gather_context = MagicMock()
+        impl._prepare_kv_for_parallel = MagicMock(return_value=(None, None, None, []))
+        impl._store_parallel_kv = MagicMock(return_value=(None, None, None))
         impl._get_indexcache_topk_indices = MagicMock(return_value=MagicMock())
         impl._execute_sparse_flash_attention_process = MagicMock(return_value=MagicMock())
         impl._v_up_proj = MagicMock(return_value=MagicMock())
@@ -148,12 +150,21 @@ class TestAscendSFAOProjTPParams(TestBase):
         output = MagicMock()
         kv_cache = (MagicMock(), MagicMock())
         impl._compose_sfa_kv_cache = MagicMock(return_value=kv_cache)
-        impl._handle_o_proj_weight_switch_and_forward = MagicMock(return_value=(output, False))
+        impl._finalize_o_proj = MagicMock(return_value=output)
 
         attn_metadata = MagicMock()
         attn_metadata.dcp_context = None
         attn_metadata.dsa_cp_context = None
         attn_metadata.num_input_tokens = 1
+        impl._get_parallel_forward_context = MagicMock(
+            return_value=SFAForwardContext(
+                actual_seq_lengths_query=MagicMock(),
+                actual_seq_lengths_key=MagicMock(),
+                kv_slot_mapping=MagicMock(),
+                topk_num_tokens=1,
+                gather_full_o_proj=True,
+            )
+        )
 
         with (
             patch("vllm_ascend.attention.sfa_v1.wait_for_kv_layer_from_connector"),

--- a/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
+++ b/tests/ut/spec_decode/test_speculators_vwn_eagle3.py
@@ -161,9 +161,10 @@ def _mock_npu_env():
         # backend's routing check.
         patch("vllm_ascend.attention.attention_v1.enable_dcp", return_value=False),
         patch(
-            "vllm_ascend.attention.sfa_v1.enable_sfa_dcp_replicated_indexer",
+            "vllm_ascend.attention.context_parallel.sfa_cp.enable_sfa_dcp_replicated_indexer",
             return_value=False,
         ),
+        patch("vllm_ascend.attention.context_parallel.sfa_cp.enable_dsa_cp", return_value=False),
         patch("vllm_ascend.attention.mla_v1.enable_dcp", return_value=False),
     ):
         yield

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -1,10 +1,13 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import NamedTuple, TypeVar
+from typing import Any, NamedTuple, TypeVar
 
 import torch
 import torch.distributed as dist
+import torch_npu
+from torch import nn
 from vllm.config import VllmConfig
+from vllm.distributed import get_tp_group
 from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec
 
@@ -18,13 +21,39 @@ from vllm_ascend.attention.sfa_v1 import (
     AscendSFAImpl,
     AscendSFAMetadata,
     AscendSFAMetadataBuilder,
-    DSACPContext,
+    SFAForwardContext,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, split_decodes_and_prefills
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.utils import all_gather_async
+from vllm_ascend.quantization.tp_weight_switch import TPWeightSwitchMixin
+from vllm_ascend.utils import (
+    _round_up,
+    enable_dsa_cp,
+    enable_dsa_cp_with_o_proj_tp,
+    enable_sfa_dcp_replicated_indexer,
+)
 
 M = TypeVar("M", bound=AscendSFAMetadata)
+
+
+@dataclass
+class DSACPContext:
+    num_tokens: int
+    num_tokens_pad: int
+    local_start: int
+    local_end: int
+    local_end_with_pad: int
+    slot_mapping_cp: torch.Tensor
+    actual_seq_lengths_query: torch.Tensor
+    actual_seq_lengths_key: torch.Tensor
+
+
+@dataclass
+class AscendSFADSACPMetadata(AscendSFAMetadata):
+    """SFA metadata fields used only by the DSA-CP execution path."""
+
+    dsa_cp_context: DSACPContext | None = None
 
 
 class DCPGatherContext(NamedTuple):
@@ -51,6 +80,402 @@ class AscendSFADCPMetadata(AscendSFAMetadata):
     """SFA metadata fields used only by the DCP execution path."""
 
     dcp_context: DCPContext | None = None
+
+
+@dataclass
+class AscendSFADSADCPMetadata(AscendSFADCPMetadata):
+    """SFA metadata for the combined DSA-CP and DCP execution path."""
+
+    dsa_cp_context: DSACPContext | None = None
+
+
+class AscendSFADSACPMetadataBuilder(AscendSFAMetadataBuilder):
+    """Adds TP-token-sharded DSA-CP metadata to the shared SFA builder."""
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+        metadata_cls: type[AscendSFAMetadata] | None = None,
+        supports_dcp_with_varlen: bool = False,
+    ):
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls or AscendSFADSACPMetadata,
+            supports_dcp_with_varlen,
+        )
+        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
+        self.actual_seq_lengths_query = torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device)
+        self.actual_seq_lengths_key = torch.empty_like(self.actual_seq_lengths_query)
+        self.spec_actual_seq_lengths_query: list[torch.Tensor] | None = None
+        self.spec_actual_seq_lengths_key: list[torch.Tensor] | None = None
+        if self.speculative_config:
+            spec_token_num = self.speculative_config.num_speculative_tokens
+            self.spec_actual_seq_lengths_query = [
+                torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
+                for _ in range(spec_token_num)
+            ]
+            self.spec_actual_seq_lengths_key = [
+                torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
+                for _ in range(spec_token_num)
+            ]
+
+    def _prepare_parallel_metadata(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        cum_query_lens: torch.Tensor,
+        seq_lens: torch.Tensor,
+        draft_index: int | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict[str, Any]]:
+        cos, sin, slot_mapping, extra = super()._prepare_parallel_metadata(
+            common_attn_metadata,
+            cos,
+            sin,
+            slot_mapping,
+            cum_query_lens,
+            seq_lens,
+            draft_index,
+        )
+        global_tp_size = get_tp_group().world_size
+        num_tokens = common_attn_metadata.num_input_tokens
+        num_tokens_pad = _round_up(num_tokens, global_tp_size)
+        num_tokens_per_device = num_tokens_pad // global_tp_size
+        local_start = get_tp_group().rank_in_group * num_tokens_per_device
+        local_end_with_pad = local_start + num_tokens_per_device
+        local_end = min(local_end_with_pad, common_attn_metadata.num_actual_tokens)
+
+        assert cos.shape == sin.shape, f"cos.shape must equal sin.shape, got {cos.shape} and {sin.shape}"
+        pad_size = num_tokens_pad - cos.shape[0]
+        if pad_size > 0:
+            cos = nn.functional.pad(cos, (0, 0, 0, 0, 0, 0, 0, pad_size))
+            sin = nn.functional.pad(sin, (0, 0, 0, 0, 0, 0, 0, pad_size))
+        pad_size_slot = num_tokens_pad - slot_mapping.shape[0]
+        if pad_size_slot > 0:
+            slot_mapping = nn.functional.pad(slot_mapping, (0, pad_size_slot), value=-1)
+        else:
+            slot_mapping = slot_mapping[:num_tokens_pad]
+
+        slot_mapping_cp = slot_mapping[local_start:local_end_with_pad]
+        cos = cos[local_start:local_end_with_pad]
+        sin = sin[local_start:local_end_with_pad]
+        assert cos.shape[0] == num_tokens_per_device
+        assert slot_mapping_cp.shape[0] == num_tokens_per_device
+        assert slot_mapping.shape[0] == num_tokens_pad
+
+        if draft_index is not None:
+            assert self.spec_actual_seq_lengths_query is not None
+            assert self.spec_actual_seq_lengths_key is not None
+            actual_seq_lengths_query = self.spec_actual_seq_lengths_query[draft_index - 1]
+            actual_seq_lengths_key = self.spec_actual_seq_lengths_key[draft_index - 1]
+        else:
+            actual_seq_lengths_query = self.actual_seq_lengths_query
+            actual_seq_lengths_key = self.actual_seq_lengths_key
+
+        num_segs = cum_query_lens.shape[0]
+        global_start = common_attn_metadata.query_start_loc[:num_segs]
+        global_end = cum_query_lens
+        req_local_start = global_start.clamp(min=local_start)
+        req_local_end = global_end.clamp(max=local_end_with_pad)
+        num_local_tokens = req_local_end - req_local_start
+        local_query_lens = torch.cumsum(num_local_tokens.clamp(min=0), dim=0)
+        offset = global_end - req_local_end
+        local_key_lens = torch.where(
+            num_local_tokens > 0,
+            torch.clamp_min(seq_lens - offset, 0),
+            0,
+        )
+        actual_seq_lengths_query[:num_segs] = local_query_lens
+        actual_seq_lengths_key[:num_segs] = local_key_lens
+
+        extra["dsa_cp_context"] = DSACPContext(
+            num_tokens=num_tokens,
+            num_tokens_pad=num_tokens_pad,
+            local_start=local_start,
+            local_end=local_end,
+            local_end_with_pad=local_end_with_pad,
+            slot_mapping_cp=slot_mapping_cp,
+            actual_seq_lengths_query=actual_seq_lengths_query[: common_attn_metadata.num_reqs],
+            actual_seq_lengths_key=actual_seq_lengths_key[: common_attn_metadata.num_reqs],
+        )
+        return cos, sin, slot_mapping, extra
+
+    def _update_parallel_slot_mapping(
+        self,
+        metadata: AscendSFAMetadata,
+        slot_mapping: torch.Tensor,
+        num_input_tokens: int,
+    ) -> None:
+        super()._update_parallel_slot_mapping(metadata, slot_mapping, num_input_tokens)
+        dsa_cp_context = getattr(metadata, "dsa_cp_context", None)
+        if dsa_cp_context is None:
+            return
+        local_mapping = slot_mapping[:num_input_tokens]
+        if dsa_cp_context.num_tokens_pad > local_mapping.shape[0]:
+            local_mapping = nn.functional.pad(
+                local_mapping,
+                (0, dsa_cp_context.num_tokens_pad - local_mapping.shape[0]),
+                value=-1,
+            )
+        else:
+            local_mapping = local_mapping[: dsa_cp_context.num_tokens_pad]
+        dsa_cp_context.slot_mapping_cp = local_mapping[
+            dsa_cp_context.local_start : dsa_cp_context.local_end_with_pad
+        ]
+
+
+class AscendSFADSACPImpl(AscendSFAImpl):
+    """SFA implementation for DSA-CP token sharding in the TP group."""
+
+    o_proj_full_pools: dict[Any, torch.Tensor] = {}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.local_num_heads = self.num_heads * self.tp_size
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
+
+    def process_weights_after_loading(self, act_dtype: torch.dtype):
+        result = super().process_weights_after_loading(act_dtype)
+        self._o_proj_tp_weight_switch_enabled = False
+        if self.enable_dsa_cp_with_o_proj_tp:
+            self._enable_o_proj_tp_full_weight_switch()
+        return result
+
+    def _get_fused_type_unsupported_reasons(self, pp_type):
+        reasons = super()._get_fused_type_unsupported_reasons(pp_type)
+        reasons.insert(0, "Fused preprocessing does not support DSA-CP.")
+        return reasons
+
+    def _parallel_query_gather_dim(self) -> int:
+        return 0
+
+    def _prepare_native_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        need_gather_q_kv: bool,
+    ) -> torch.Tensor:
+        return hidden_states
+
+    def _get_parallel_forward_context(
+        self,
+        attn_metadata: M,
+        num_input_tokens: int,
+        hidden_states: torch.Tensor,
+    ) -> SFAForwardContext:
+        context = getattr(attn_metadata, "dsa_cp_context", None)
+        assert context is not None, "DSA-CP requires attn_metadata.dsa_cp_context."
+        gather_full_o_proj = (
+            self.tp_size > 1
+            and self.enable_dsa_cp_with_o_proj_tp
+            and attn_metadata.attn_state
+            not in {
+                AscendAttentionState.DecodeOnly,
+                AscendAttentionState.SpecDecoding,
+            }
+        )
+        return SFAForwardContext(
+            actual_seq_lengths_query=context.actual_seq_lengths_query,
+            actual_seq_lengths_key=context.actual_seq_lengths_key,
+            kv_slot_mapping=context.slot_mapping_cp,
+            topk_num_tokens=context.local_end_with_pad - context.local_start,
+            gather_full_o_proj=gather_full_o_proj,
+        )
+
+    def exec_kv(
+        self,
+        kv_no_split: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        kv_cache: tuple,
+        slots: torch.Tensor,
+        attn_metadata: M,
+    ):
+        if self.enable_sparse_sfa_c8:
+            return super().exec_kv(kv_no_split, cos, sin, kv_cache, slots, attn_metadata)
+        B = kv_no_split.shape[0]
+        kv_no_split = kv_no_split.view(B, self.num_kv_heads, 1, self.kv_lora_rank + self.qk_rope_head_dim)
+        _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
+            kv_no_split,
+            self.kv_a_layernorm.weight,
+            cos,
+            sin,
+            slots.to(torch.int64),
+            kv_cache[1],
+            kv_cache[0],
+            epsilon=self.kv_a_layernorm.variance_epsilon,
+            cache_mode="PA",
+            is_output_kv=True,
+        )
+        return k_pe, k_nope, None
+
+    def _prepare_kv_for_parallel(
+        self,
+        k_pe,
+        k_nope,
+        knope_scale,
+        k_li,
+        k_li_scale,
+        full_gather_o_proj_enabled,
+    ):
+        assert k_pe is not None and k_nope is not None
+        async_op = full_gather_o_proj_enabled
+        handles: list[torch.distributed.Work] = []
+        if self.enable_sparse_sfa_c8:
+            assert knope_scale is not None
+            parts = [
+                k_nope.view(-1, k_nope.shape[-1]),
+                k_pe.view(-1, k_pe.shape[-1]),
+                knope_scale.view(-1, knope_scale.shape[-1]),
+            ]
+        else:
+            parts = [k_pe.view(-1, k_pe.shape[-1]), k_nope.view(-1, k_nope.shape[-1])]
+            if self.has_indexer and not self.enable_sparse_li_c8:
+                assert k_li is not None
+                parts.append(k_li.view(-1, k_li.shape[-1]))
+        fused_kv, handle = all_gather_async(torch.cat(parts, dim=1), get_tp_group(), async_op=async_op)
+        if handle is not None:
+            handles.append(handle)
+        if self.has_indexer and (self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8):
+            assert k_li is not None
+            k_li, handle = all_gather_async(k_li, get_tp_group(), async_op=async_op)
+            if handle is not None:
+                handles.append(handle)
+        if self.has_indexer and self.enable_sparse_li_c8:
+            assert k_li_scale is not None
+            k_li_scale, handle = all_gather_async(k_li_scale, get_tp_group(), async_op=async_op)
+            if handle is not None:
+                handles.append(handle)
+        return k_li, k_li_scale, fused_kv, handles
+
+    def _store_parallel_kv(
+        self,
+        k_pe,
+        k_nope,
+        knope_scale,
+        k_li,
+        fused_kv_no_split,
+        kv_ag_handles,
+        kv_cache,
+        slot_mapping_sfa,
+        attn_metadata,
+        full_gather_o_proj_enabled,
+    ):
+        for handle in kv_ag_handles:
+            handle.wait()
+        if full_gather_o_proj_enabled:
+            self._enable_o_proj_tp_full_weight_switch()
+            linear_method = self._get_o_proj_linear_method()
+            assert isinstance(linear_method, TPWeightSwitchMixin)
+            assert self.o_proj_tp_weight_state is not None
+            linear_method.all_gather_tp_weight(
+                self.o_proj_tp_weight_state,
+                get_tp_group(),
+            )
+
+        if kv_cache is not None:
+            assert fused_kv_no_split is not None
+            if self.enable_sparse_sfa_c8:
+                torch_npu.npu_scatter_nd_update_(
+                    kv_cache[0].view(-1, fused_kv_no_split.shape[-1]),
+                    slot_mapping_sfa[: attn_metadata.num_actual_tokens].view(-1, 1),
+                    fused_kv_no_split[: attn_metadata.num_actual_tokens],
+                )
+                k_pe = k_nope = None
+            elif not self.has_indexer:
+                k_pe, k_nope = fused_kv_no_split.split([self.qk_rope_head_dim, self.kv_lora_rank], dim=-1)
+            elif not self.enable_sparse_li_c8:
+                k_pe, k_nope, k_li = fused_kv_no_split.split(
+                    [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim], dim=-1
+                )
+            else:
+                k_pe, k_nope = fused_kv_no_split.split([self.qk_rope_head_dim, self.kv_lora_rank], dim=-1)
+            if not self.enable_sparse_sfa_c8:
+                assert k_pe is not None and k_nope is not None
+                k_nope = k_nope.view(k_nope.shape[0], 1, -1)
+                k_pe = k_pe.view(k_pe.shape[0], 1, -1)
+                DeviceOperator.reshape_and_cache(
+                    key=k_nope[: attn_metadata.num_actual_tokens],
+                    value=k_pe[: attn_metadata.num_actual_tokens],
+                    key_cache=kv_cache[0],
+                    value_cache=kv_cache[1],
+                    slot_mapping=slot_mapping_sfa[: attn_metadata.num_actual_tokens],
+                )
+        return k_pe, k_nope, k_li
+
+    def _enable_o_proj_tp_full_weight_switch(self) -> None:
+        if self._o_proj_tp_weight_switch_enabled:
+            return
+
+        linear_method = self._get_o_proj_linear_method()
+        if not isinstance(linear_method, TPWeightSwitchMixin) or not linear_method.supports_tp_weight_switch:
+            raise RuntimeError(
+                "SFA DSA-CP o_proj full-weight switching requires a TP weight-switch capable method, "
+                f"got {type(linear_method).__name__}."
+            )
+        self.o_proj_tp_weight_state = linear_method.enable_tp_weight_switch(
+            self.o_proj,
+            self.tp_size,
+            pool=AscendSFADSACPImpl.o_proj_full_pools,
+            pool_key_prefix=(type(linear_method).__qualname__, "sfa_o_proj"),
+        )
+        self._o_proj_tp_weight_switch_enabled = True
+
+    def _get_o_proj_linear_method(self):
+        quant_method = self.o_proj.quant_method
+        return getattr(quant_method, "quant_method", quant_method)
+
+    def _apply_o_proj_full_weight(self, attn_output: torch.Tensor) -> torch.Tensor:
+        return self._get_o_proj_linear_method().apply(self.o_proj, attn_output)
+
+    def _finalize_o_proj(
+        self,
+        attn_output,
+        output,
+        gather_full_o_proj,
+    ):
+        if not self.enable_dsa_cp_with_o_proj_tp:
+            return super()._finalize_o_proj(
+                attn_output,
+                output,
+                gather_full_o_proj,
+            )
+        if gather_full_o_proj:
+            linear_method = self._get_o_proj_linear_method()
+            assert isinstance(linear_method, TPWeightSwitchMixin)
+            assert self.o_proj_tp_weight_state is not None
+            linear_method.wait_tp_weight_all_gather(self.o_proj_tp_weight_state)
+            linear_method.switch_tp_weight(
+                self.o_proj,
+                self.o_proj_tp_weight_state,
+                use_full_weight=True,
+            )
+            output[...] = self._apply_o_proj_full_weight(attn_output)
+            linear_method.switch_tp_weight(
+                self.o_proj,
+                self.o_proj_tp_weight_state,
+                use_full_weight=False,
+            )
+            return output
+
+        send = (
+            attn_output.view(-1, self.tp_size, self.num_heads * self.v_head_dim)
+            .permute(1, 0, 2)
+            .reshape(-1, self.num_heads * self.v_head_dim)
+        )
+        sharded_output = torch.empty_like(send)
+        torch.distributed.all_to_all_single(sharded_output, send, group=get_tp_group().device_group)
+        return super()._finalize_o_proj(
+            sharded_output,
+            output,
+            gather_full_o_proj,
+        )
 
 
 # SFA DCP replicated-indexer layout:
@@ -247,27 +672,6 @@ class AscendSFADCPMetadataBuilder(
         )
         return slot_mapping_replicated_view
 
-    def _update_dsa_cp_slot_mapping_for_dcp(
-        self,
-        metadata: AscendSFAMetadata,
-        dcp_slot_mapping: torch.Tensor,
-        num_input_tokens: int,
-    ) -> None:
-        if metadata.dsa_cp_context is None:
-            return
-
-        dsa_cp_context = metadata.dsa_cp_context
-        slot_mapping = dcp_slot_mapping[:num_input_tokens]
-        if dsa_cp_context.num_tokens_pad > slot_mapping.shape[0]:
-            slot_mapping = torch.nn.functional.pad(
-                slot_mapping,
-                (0, dsa_cp_context.num_tokens_pad - slot_mapping.shape[0]),
-                value=-1,
-            )
-        else:
-            slot_mapping = slot_mapping[: dsa_cp_context.num_tokens_pad]
-        dsa_cp_context.slot_mapping_cp = slot_mapping[dsa_cp_context.local_start : dsa_cp_context.local_end_with_pad]
-
     def _build_compact_kv_gather_metadata(
         self,
         dcp_block_table: torch.Tensor,
@@ -340,40 +744,8 @@ class AscendSFADCPMetadataBuilder(
         metadata.num_decodes = num_decodes
         metadata.num_decode_tokens = num_decode_tokens
         metadata.num_prefills = num_prefills
-        self._update_dsa_cp_slot_mapping_for_dcp(metadata, dcp_slot_mapping, num_input_tokens)
+        self._update_parallel_slot_mapping(metadata, dcp_slot_mapping, num_input_tokens)
         return metadata
-
-    def build(
-        self,
-        common_prefix_len: int,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-        fast_build: bool = False,
-        **kwargs,
-    ) -> AscendSFAMetadata:
-        return self._build_with_metadata_view(
-            common_attn_metadata,
-            lambda: super(AscendSFADCPMetadataBuilder, self).build(
-                common_prefix_len,
-                common_attn_metadata,
-                fast_build,
-                **kwargs,
-            ),
-        )
-
-    def build_for_drafting(
-        self,
-        common_attn_metadata: AscendCommonAttentionMetadata,
-        draft_index: int,
-        **kwargs,
-    ) -> AscendSFAMetadata:
-        return self._build_with_metadata_view(
-            common_attn_metadata,
-            lambda: super(AscendSFADCPMetadataBuilder, self).build_for_drafting(
-                common_attn_metadata,
-                draft_index,
-                **kwargs,
-            ),
-        )
 
     def build_for_graph_capture(
         self,
@@ -650,7 +1022,7 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         ql_nope: torch.Tensor,
         q_pe: torch.Tensor,
     ) -> DCPGatherContext:
-        query_gather_dim = 0 if self.enable_dsa_cp else 1
+        query_gather_dim = self._parallel_query_gather_dim()
         assert self.dcp_group is not None, "DCP query gather requires dcp_group when dcp_size > 1."
         if ql_nope.shape[:-1] != q_pe.shape[:-1] or ql_nope.dtype != q_pe.dtype:
             raise RuntimeError(
@@ -693,7 +1065,7 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         assert attn_metadata.dcp_context is not None
         return attn_metadata.dcp_context.slot_mapping
 
-    def _maybe_store_kvcache_for_c8_n_dsacp(
+    def _store_parallel_kv(
         self,
         k_pe: torch.Tensor | None,
         k_nope: torch.Tensor | None,
@@ -710,7 +1082,7 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         torch.Tensor | None,
         torch.Tensor | None,
     ]:
-        result = super()._maybe_store_kvcache_for_c8_n_dsacp(
+        result = super()._store_parallel_kv(
             k_pe,
             k_nope,
             knope_scale,
@@ -779,7 +1151,8 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         dcp_context.gather_context = None
         if gather_context is None:
             gather_context = self._start_dcp_query_gather(ql_nope, q_pe)
-        if self.enable_dsa_cp:
+        dsa_cp_context = getattr(attn_metadata, "dsa_cp_context", None)
+        if dsa_cp_context is not None:
             # DSA-CP shards the token sequence. Restore the flat token order for
             # SFA, and use the original full query lengths for varlen metadata.
             actual_seq_lengths_query = attn_metadata.cum_query_lens
@@ -809,5 +1182,64 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
         softmax_lse = softmax_max + torch.log(softmax_sum)
         softmax_lse = softmax_lse.permute(1, 0, 2).reshape(softmax_lse.shape[1], -1, 1)
         output_dtype = sfa_output.dtype
-        output = self._merge_dcp_outputs(sfa_output, softmax_lse, attn_metadata.dsa_cp_context)
+        output = self._merge_dcp_outputs(
+            sfa_output,
+            softmax_lse,
+            getattr(attn_metadata, "dsa_cp_context", None),
+        )
         return output.to(output_dtype)
+
+
+class AscendSFADSADCPMetadataBuilder(
+    AscendSFADCPMetadataBuilder,
+    AscendSFADSACPMetadataBuilder,
+):
+    """Composes DCP's outer KV view with DSA-CP token sharding."""
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+        metadata_cls: type[AscendSFAMetadata] | None = None,
+        supports_dcp_with_varlen: bool = False,
+    ):
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls or AscendSFADSADCPMetadata,
+            supports_dcp_with_varlen,
+        )
+
+
+class AscendSFADSADCPImpl(AscendSFADCPImpl, AscendSFADSACPImpl):
+    """Composes DCP collectives around the DSA-CP SFA implementation."""
+
+
+def resolve_sfa_metadata_builder() -> type[AscendSFAMetadataBuilder]:
+    """Resolve one SFA metadata builder from the two independent CP switches."""
+    dsa_cp_enabled = enable_dsa_cp()
+    dcp_enabled = enable_sfa_dcp_replicated_indexer()
+    if dsa_cp_enabled and dcp_enabled:
+        return AscendSFADSADCPMetadataBuilder
+    if dsa_cp_enabled:
+        return AscendSFADSACPMetadataBuilder
+    if dcp_enabled:
+        return AscendSFADCPMetadataBuilder
+    return AscendSFAMetadataBuilder
+
+
+def resolve_sfa_impl() -> type[AscendSFAImpl]:
+    """Resolve one SFA implementation from the two independent CP switches."""
+    dsa_cp_enabled = enable_dsa_cp()
+    dcp_enabled = enable_sfa_dcp_replicated_indexer()
+    if dsa_cp_enabled and dcp_enabled:
+        return AscendSFADSADCPImpl
+    if dsa_cp_enabled:
+        return AscendSFADSACPImpl
+    if dcp_enabled:
+        return AscendSFADCPImpl
+    return AscendSFAImpl

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -297,17 +297,19 @@ class AscendSFADSACPImpl(AscendSFAImpl):
     ):
         if self.enable_sparse_sfa_c8:
             return super().exec_kv(kv_no_split, cos, sin, kv_cache, slots, attn_metadata)
+        kv_a_layernorm = self.kv_a_layernorm
+        assert kv_a_layernorm is not None, "kv_a_layernorm must be initialized for DSA-CP KV preprocessing"
         B = kv_no_split.shape[0]
         kv_no_split = kv_no_split.view(B, self.num_kv_heads, 1, self.kv_lora_rank + self.qk_rope_head_dim)
         _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
-            self.kv_a_layernorm.weight,
+            kv_a_layernorm.weight,
             cos,
             sin,
             slots.to(torch.int64),
             kv_cache[1],
             kv_cache[0],
-            epsilon=self.kv_a_layernorm.variance_epsilon,
+            epsilon=kv_a_layernorm.variance_epsilon,
             cache_mode="PA",
             is_output_kv=True,
         )

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -226,9 +226,7 @@ class AscendSFADSACPMetadataBuilder(AscendSFAMetadataBuilder):
             )
         else:
             local_mapping = local_mapping[: dsa_cp_context.num_tokens_pad]
-        dsa_cp_context.slot_mapping_cp = local_mapping[
-            dsa_cp_context.local_start : dsa_cp_context.local_end_with_pad
-        ]
+        dsa_cp_context.slot_mapping_cp = local_mapping[dsa_cp_context.local_start : dsa_cp_context.local_end_with_pad]
 
 
 class AscendSFADSACPImpl(AscendSFAImpl):

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -44,6 +44,7 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     get_sparse_kv_offload_manager,
 )
+from vllm_ascend.utils import enable_dsa_cp
 
 M = TypeVar("M", bound=AscendSFAMetadata)
 
@@ -162,7 +163,7 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
             kv_sharing_target_layer_name,
             **kwargs,
         )
-        if self.enable_dsa_cp:
+        if enable_dsa_cp():
             raise NotImplementedError("Sparse KV offload currently requires TP without context parallelism")
         if self.enable_sparse_sfa_c8:
             raise NotImplementedError(

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import scipy  # type: ignore
 import torch
 import torch_npu
-from torch import nn
 from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
 from vllm.logger import logger
@@ -42,7 +41,6 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
     OFFLOAD_KV_CACHE_TUPLE_LEN,
     OFFLOAD_V_CACHE_NPU_INDEX,
 )
-from vllm_ascend.distributed.utils import all_gather_async
 from vllm_ascend.memcache_comm_fence import (
     record_attention_compute_start,
 )
@@ -53,16 +51,11 @@ from vllm_ascend.quantization.methods import (
     AscendW8A8LinearMethod,
     AscendW8A8MXFP8DynamicLinearMethod,
 )
-from vllm_ascend.quantization.tp_weight_switch import TPWeightSwitchMixin
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
     ACL_FORMAT_FRACTAL_NZ,
     AscendDeviceType,
-    _round_up,
     dispose_layer,
-    enable_dsa_cp,
-    enable_dsa_cp_with_o_proj_tp,
-    enable_sfa_dcp_replicated_indexer,
     enable_sp,
     get_ascend_device_type,
     maybe_trans_nz,
@@ -119,11 +112,9 @@ class AscendSFABackend(AttentionBackend):
             from vllm_ascend.attention.sfa_kv_offload import AscendSFAKVOffloadMetadataBuilder
 
             return AscendSFAKVOffloadMetadataBuilder
-        if enable_sfa_dcp_replicated_indexer():
-            from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPMetadataBuilder
+        from vllm_ascend.attention.context_parallel.sfa_cp import resolve_sfa_metadata_builder
 
-            return AscendSFADCPMetadataBuilder
-        return AscendSFAMetadataBuilder
+        return resolve_sfa_metadata_builder()
 
     @staticmethod
     def get_kv_cache_shape(
@@ -141,27 +132,13 @@ class AscendSFABackend(AttentionBackend):
             from vllm_ascend.attention.sfa_kv_offload import AscendSFAKVOffloadImpl
 
             return AscendSFAKVOffloadImpl
-        if enable_sfa_dcp_replicated_indexer():
-            from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPImpl
+        from vllm_ascend.attention.context_parallel.sfa_cp import resolve_sfa_impl
 
-            return AscendSFADCPImpl
-        return AscendSFAImpl
+        return resolve_sfa_impl()
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int]:
         return [128]
-
-
-@dataclass
-class DSACPContext:
-    num_tokens: int
-    num_tokens_pad: int
-    local_start: int
-    local_end: int
-    local_end_with_pad: int
-    slot_mapping_cp: torch.Tensor
-    actual_seq_lengths_query: torch.Tensor
-    actual_seq_lengths_key: torch.Tensor
 
 
 @dataclass
@@ -195,7 +172,6 @@ class AscendSFAMetadata:
     attn_mask: torch.Tensor = None
     # chunked prefill by default if no attn_states passed
     attn_state: AscendAttentionState = AscendAttentionState.ChunkedPrefill
-    dsa_cp_context: DSACPContext | None = None
     reshape_cache_event: torch.npu.Event = None
     num_decodes: int = 0
     num_decode_tokens: int = 0
@@ -211,6 +187,17 @@ class AscendSFAMetadata:
 
 
 M = TypeVar("M", bound=AscendSFAMetadata)
+
+
+@dataclass
+class SFAForwardContext:
+    """Parallel-layout inputs consumed by the shared SFA forward template."""
+
+    actual_seq_lengths_query: torch.Tensor
+    actual_seq_lengths_key: torch.Tensor
+    kv_slot_mapping: torch.Tensor
+    topk_num_tokens: int
+    gather_full_o_proj: bool = False
 
 
 class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
@@ -244,11 +231,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
-        max_num_reqs = vllm_config.scheduler_config.max_num_seqs
-        self.actual_seq_lengths_query = torch.zeros(max_num_reqs + 1, dtype=torch.int32, device=device)
-        self.actual_seq_lengths_key = torch.empty_like(self.actual_seq_lengths_query)
-        self.spec_actual_seq_lengths_query: list[torch.Tensor] | None = None
-        self.spec_actual_seq_lengths_key: list[torch.Tensor] | None = None
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
             self.decode_threshold += spec_token_num
@@ -257,19 +239,32 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
                 npu_fused_infer_attention_score TND layout's limit of 16, \
                 got {self.decode_threshold}"
             )
-            self.spec_actual_seq_lengths_query = [
-                torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
-                for _ in range(spec_token_num)
-            ]
-            self.spec_actual_seq_lengths_key = [
-                torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
-                for _ in range(spec_token_num)
-            ]
 
         self.reorder_batch_threshold = self.decode_threshold
         self.attn_mask_builder = AttentionMaskBuilder(self.device)
         self.rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
-        self.enable_dsa_cp = enable_dsa_cp()
+
+    def _prepare_parallel_metadata(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        cum_query_lens: torch.Tensor,
+        seq_lens: torch.Tensor,
+        draft_index: int | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict[str, Any]]:
+        """Customize metadata tensors for a parallel SFA layout."""
+        return cos, sin, slot_mapping, {}
+
+    def _update_parallel_slot_mapping(
+        self,
+        metadata: AscendSFAMetadata,
+        slot_mapping: torch.Tensor,
+        num_input_tokens: int,
+    ) -> None:
+        """Update optional parallel metadata after an outer layout wrapper."""
+        return
 
     @staticmethod
     def determine_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
@@ -357,97 +352,15 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         cos, sin = get_cos_and_sin_mla(input_positions, use_cache=(draft_index is None))
 
-        dsa_cp_context = None
-        if self.enable_dsa_cp:
-            global_tp_size = get_tp_group().world_size
-            num_tokens = num_input_tokens
-            num_tokens_pad = _round_up(num_tokens, global_tp_size)
-            num_tokens_per_device = num_tokens_pad // global_tp_size
-            local_start = get_tp_group().rank_in_group * num_tokens_per_device
-            local_end_with_pad = local_start + num_tokens_per_device
-            local_end = min(local_end_with_pad, num_actual_tokens)
-
-            pad_size = num_tokens_pad - cos.shape[0]
-            assert cos.shape == sin.shape, f"cos.shape must be equal to sin.shape, got {cos.shape} and {sin.shape}"
-
-            if pad_size > 0:
-                cos = nn.functional.pad(cos, (0, 0, 0, 0, 0, 0, 0, pad_size))
-                sin = nn.functional.pad(sin, (0, 0, 0, 0, 0, 0, 0, pad_size))
-
-            pad_size_slot = num_tokens_pad - slot_mapping.shape[0]
-            if pad_size_slot > 0:
-                slot_mapping = nn.functional.pad(slot_mapping, (0, pad_size_slot), value=-1)
-            else:
-                slot_mapping = slot_mapping[:num_tokens_pad]
-            slot_mapping_cp = slot_mapping[local_start:local_end_with_pad]
-
-            cos = cos[local_start:local_end_with_pad]
-            sin = sin[local_start:local_end_with_pad]
-
-            assert cos.shape[0] == num_tokens_per_device, (
-                f"cos.shape[0] must be equal to num_tokens_per_device, \
-                    got {cos.shape[0]} and {num_tokens_per_device}"
-            )
-            assert slot_mapping_cp.shape[0] == num_tokens_per_device, (
-                f"slot_mapping_cp.shape[0] must be equal to num_tokens_per_device, \
-                    got {slot_mapping_cp.shape[0]} and {num_tokens_per_device}"
-            )
-            assert slot_mapping.shape[0] == num_tokens_pad, (
-                f"slot_mapping.shape[0] must be equal to num_tokens_pad, \
-                    got {slot_mapping.shape[0]} and {num_tokens_pad}"
-            )
-
-            if draft_index is not None:
-                assert self.spec_actual_seq_lengths_query is not None
-                assert self.spec_actual_seq_lengths_key is not None
-                # Per-draft-step buffers: independent, graph-stable storage so
-                # later draft steps don't clobber earlier ones' metadata.
-                actual_seq_lengths_query = self.spec_actual_seq_lengths_query[draft_index - 1]
-                actual_seq_lengths_key = self.spec_actual_seq_lengths_key[draft_index - 1]
-            else:
-                actual_seq_lengths_query = self.actual_seq_lengths_query
-                actual_seq_lengths_key = self.actual_seq_lengths_key
-
-            num_segs = cum_query_lens.shape[0]
-
-            # Vectorized per-request local query/key lengths for this rank's
-            # [local_start, local_end_with_pad) slice. Replaces a Python loop
-            # that did 2 .item() NPU->CPU syncs per request (2 * num_reqs
-            # syncs/step); now fully on-device with zero syncs.
-            # global_start[i] = 0 for i==0, else cum_query_lens[i-1]
-            global_start = common_attn_metadata.query_start_loc[:num_segs]
-            global_end = cum_query_lens
-
-            # Clip each request's [global_start, global_end) to the local range.
-            # num_local_tokens may be < 0 when the request falls entirely
-            # outside [local_start, local_end_with_pad); clamp before cumsum.
-            req_local_start = global_start.clamp(min=local_start)
-            req_local_end = global_end.clamp(max=local_end_with_pad)
-            num_local_tokens = req_local_end - req_local_start
-
-            local_query_lens = torch.cumsum(num_local_tokens.clamp(min=0), dim=0)
-            offset = global_end - req_local_end  # request tokens on later ranks
-            local_key_lens = torch.where(
-                num_local_tokens > 0,
-                torch.clamp_min(seq_lens - offset, 0),
-                0,
-            )
-
-            actual_seq_lengths_query[:num_segs] = local_query_lens
-            actual_seq_lengths_key[:num_segs] = local_key_lens
-            actual_seq_lengths_query = actual_seq_lengths_query[:num_reqs]
-            actual_seq_lengths_key = actual_seq_lengths_key[:num_reqs]
-
-            dsa_cp_context = DSACPContext(
-                num_tokens=num_tokens,
-                num_tokens_pad=num_tokens_pad,
-                local_start=local_start,
-                local_end=local_end,
-                local_end_with_pad=local_end_with_pad,
-                slot_mapping_cp=slot_mapping_cp,
-                actual_seq_lengths_query=actual_seq_lengths_query,
-                actual_seq_lengths_key=actual_seq_lengths_key,
-            )
+        cos, sin, slot_mapping, parallel_metadata = self._prepare_parallel_metadata(
+            common_attn_metadata,
+            cos,
+            sin,
+            slot_mapping,
+            cum_query_lens,
+            seq_lens,
+            draft_index,
+        )
 
         if get_ascend_config().c8_enable_reshape_optim:
             torch.ops._C_ascend.store_kv_block_metadata(
@@ -471,11 +384,11 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             block_table=block_table,
             sin=sin[:num_input_tokens],
             cos=cos[:num_input_tokens],
-            dsa_cp_context=dsa_cp_context,
             block_size=block_size,
             group_len=common_attn_metadata.group_len,
             group_key_idx=common_attn_metadata.group_key_idx,
             group_key_cache_idx=common_attn_metadata.group_key_cache_idx,
+            **parallel_metadata,
         )
 
     def build_for_graph_capture(
@@ -500,9 +413,6 @@ class AscendSFAImpl(MLAAttentionImpl):
     NOTE: Please read the comment at the top of the file before trying to
     understand this class
     """
-
-    # Reusable full-weight gather buffers for DSA-CP prefill/mixed requests.
-    o_proj_full_pools: dict[Any, torch.Tensor] = {}
 
     # q_hadamard and k_hadamard tensor shared when dsa c8 enabled
     q_hadamard: torch.Tensor | None = None
@@ -629,19 +539,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         self.enable_mlapo = bool(get_ascend_config().enable_mlapo)
 
-        # Effective in SFA when FlashComm is enabled.
-        self.enable_dsa_cp = enable_dsa_cp()
         self.enable_sp = enable_sp()
-
-        # SFA DSA-CP deployments keep o_proj in the existing TP layout. Decode
-        # can use the TP-sharded o_proj after an activation all-to-all, while
-        # prefill/mixed batches (including a PD-disaggregated P node)
-        # temporarily gather the TP shards into a full-weight buffer because
-        # their SFA output is not TP-sharded.
-        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
-
-        if self.enable_dsa_cp:
-            self.local_num_heads = self.num_heads * self.tp_size
 
     @property
     def kv_cache_indexer_k_idx(self) -> int:
@@ -716,10 +614,6 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # Dispose kv_b_proj since it is replaced by W_UV and W_UK_T to save memory
         dispose_layer(self.kv_b_proj)
-        self._o_proj_tp_weight_switch_enabled = False
-        if self.enable_dsa_cp and self.enable_dsa_cp_with_o_proj_tp:
-            self._enable_o_proj_tp_full_weight_switch()
-
         self.preprocess_type = self._resolve_preprocess_type(act_dtype)
 
         if self.preprocess_type == PreprocessType.NATIVE:
@@ -779,8 +673,6 @@ class AscendSFAImpl(MLAAttentionImpl):
 
     def _get_fused_type_unsupported_reasons(self, pp_type: PreprocessType) -> list[str]:
         reasons = []
-        if self.enable_dsa_cp:
-            reasons.append("Fused preprocessing does not support DSA-CP.")
         if self.kv_a_layernorm is None or self.q_a_layernorm is None:
             reasons.append("Fused preprocessing requires q_a_layernorm and kv_a_layernorm.")
         if self.fused_qkv_a_proj is None:
@@ -957,91 +849,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         x = torch_npu.npu_interleave_rope(x, cos, sin)
         return x.view(B, N, D)
 
-    def _enable_o_proj_tp_full_weight_switch(self) -> None:
-        """
-        Enable TP-mode aliases and full-mode buffers for DSA-CP o_proj.
-
-        In SFA DSA-CP execution:
-        - Decode-only batches all-to-all the SFA output in the TP group, then
-          run the original TP-sharded o_proj.
-        - Prefill/mixed batches produce SFA output that is not directly
-          compatible with TP-sharded o_proj, so each rank all-gathers the TP
-          o_proj shards and its declared TP parameters before running o_proj.
-
-        The DSA-CP backend enables this after weight loading. The original TP
-        parameter storage remains the persistent source of truth; the
-        full-weight tensors are temporary gather destinations reused across
-        DSA-CP forwards.
-        """
-        if self._o_proj_tp_weight_switch_enabled:
-            return
-
-        linear_method = self._get_o_proj_linear_method()
-        if not isinstance(linear_method, TPWeightSwitchMixin) or not linear_method.supports_tp_weight_switch:
-            raise RuntimeError(
-                "SFA DSA-CP o_proj full-weight switching requires a TP weight-switch capable method, "
-                f"got {type(linear_method).__name__}."
-            )
-        self.o_proj_tp_weight_state = linear_method.enable_tp_weight_switch(
-            self.o_proj,
-            self.tp_size,
-            pool=AscendSFAImpl.o_proj_full_pools,
-            pool_key_prefix=(type(linear_method).__qualname__, "sfa_o_proj"),
-        )
-        self._o_proj_tp_weight_switch_enabled = True
-
-    def _get_o_proj_linear_method(self):
-        quant_method = self.o_proj.quant_method
-        return getattr(quant_method, "quant_method", quant_method)
-
-    def _apply_o_proj_full_weight(self, attn_output: torch.Tensor) -> torch.Tensor:
-        return self._get_o_proj_linear_method().apply(self.o_proj, attn_output)
-
-    def _handle_o_proj_weight_switch_and_forward(
-        self,
-        attn_output: torch.Tensor,
-        output: torch.Tensor,
-        should_shard_weight: bool,
-    ) -> tuple[torch.Tensor, bool]:
-        """
-        Handle o_proj weight switching between TP-mode and Full-mode, and execute forward computation.
-        """
-        # Gather o_proj weight from all TP ranks for Full-mode computation
-        if should_shard_weight:
-            linear_method = self._get_o_proj_linear_method()
-            assert isinstance(linear_method, TPWeightSwitchMixin)
-            assert self.o_proj_tp_weight_state is not None
-            linear_method.wait_tp_weight_all_gather(self.o_proj_tp_weight_state)
-            linear_method.switch_tp_weight(
-                self.o_proj,
-                self.o_proj_tp_weight_state,
-                use_full_weight=True,
-            )
-            output[...] = self._apply_o_proj_full_weight(attn_output)
-            linear_method.switch_tp_weight(
-                self.o_proj,
-                self.o_proj_tp_weight_state,
-                use_full_weight=False,
-            )
-
-            return output, False
-        else:
-            # For decode scenario: perform all-to-all communication on o_proj input activations
-            # Reshape for all-to-all: [batch * seq, tp_size, head_dim] -> [tp_size, batch * seq, head_dim]
-            send = (
-                attn_output.view(-1, self.tp_size, self.num_heads * self.v_head_dim)
-                .permute(1, 0, 2)
-                .reshape(-1, self.num_heads * self.v_head_dim)
-            )
-
-            attn_output = torch.empty_like(send)
-            torch.distributed.all_to_all_single(attn_output, send, group=get_tp_group().device_group)
-
-            return attn_output, True
-
-    def _get_full_kv(self, k, attn_metadata):
-        return k
-
     def exec_kv(
         self,
         kv_no_split: torch.Tensor,
@@ -1074,33 +881,18 @@ class AscendSFAImpl(MLAAttentionImpl):
                 tile_size=self.sfa_qsfa_tile_size,
             )
 
-        if self.enable_dsa_cp:
-            _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
-                kv_no_split,
-                self.kv_a_layernorm.weight,  # type: ignore[union-attr]
-                cos,
-                sin,
-                slots.to(torch.int64),
-                kv_cache[1],
-                kv_cache[0],
-                epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
-                cache_mode=cache_mode,
-                is_output_kv=True,
-            )
-            return k_pe, k_nope, None
-        else:
-            torch_npu.npu_kv_rmsnorm_rope_cache(
-                kv_no_split,
-                self.kv_a_layernorm.weight,  # type: ignore[union-attr]
-                cos,
-                sin,
-                slots.to(torch.int64),
-                kv_cache[1],
-                kv_cache[0],
-                epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
-                cache_mode=cache_mode,
-            )
-            return None, None
+        torch_npu.npu_kv_rmsnorm_rope_cache(
+            kv_no_split,
+            self.kv_a_layernorm.weight,  # type: ignore[union-attr]
+            cos,
+            sin,
+            slots.to(torch.int64),
+            kv_cache[1],
+            kv_cache[0],
+            epsilon=self.kv_a_layernorm.variance_epsilon,  # type: ignore[union-attr]
+            cache_mode=cache_mode,
+        )
+        return None, None
 
     # Return `ql_nope`, `q_pe`
     def _q_proj_and_k_up_proj(self, x):
@@ -1512,7 +1304,11 @@ class AscendSFAImpl(MLAAttentionImpl):
     ) -> None:
         return
 
-    def _maybe_gather_kv_for_dsacp(
+    def _parallel_query_gather_dim(self) -> int:
+        """Dimension restored by an outer DCP query gather."""
+        return 1
+
+    def _prepare_kv_for_parallel(
         self,
         k_pe: torch.Tensor | None,
         k_nope: torch.Tensor | None,
@@ -1526,63 +1322,10 @@ class AscendSFAImpl(MLAAttentionImpl):
         torch.Tensor | None,
         list[torch.distributed.Work],
     ]:
-        """Gather native-preprocess KV tensors when DSA context parallel is enabled."""
-        if not self.enable_dsa_cp:
-            return k_li, k_li_scale, None, []
+        """Prepare native KV tensors for an optional parallel layout."""
+        return k_li, k_li_scale, None, []
 
-        assert k_pe is not None
-        assert k_nope is not None
-        async_op = full_gather_o_proj_enabled
-        kv_ag_handles: list[torch.distributed.Work] = []
-        # Support all-gather KV async for communication/calculation overlap.
-        if self.enable_sparse_sfa_c8:
-            assert knope_scale is not None
-            fused_kv_parts = [
-                k_nope.view(-1, k_nope.shape[-1]),
-                k_pe.view(-1, k_pe.shape[-1]),
-                knope_scale.view(-1, knope_scale.shape[-1]),
-            ]
-        else:
-            fused_kv_parts = [
-                k_pe.view(-1, k_pe.shape[-1]),
-                k_nope.view(-1, k_nope.shape[-1]),
-            ]
-            if self.has_indexer and not self.enable_sparse_li_c8:
-                assert k_li is not None
-                fused_kv_parts.append(k_li.view(-1, k_li.shape[-1]))
-
-        fused_kv_input = torch.cat(fused_kv_parts, dim=1)
-        fused_kv_no_split, kv_ag_handle = all_gather_async(
-            fused_kv_input,
-            get_tp_group(),
-            async_op=async_op,
-        )
-        if kv_ag_handle is not None:
-            kv_ag_handles.append(kv_ag_handle)
-
-        if self.has_indexer and (self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8):
-            assert k_li is not None
-            k_li, kv_ag_handle = all_gather_async(
-                k_li,
-                get_tp_group(),
-                async_op=async_op,
-            )
-            if kv_ag_handle is not None:
-                kv_ag_handles.append(kv_ag_handle)
-
-        if self.has_indexer and self.enable_sparse_li_c8:
-            assert k_li_scale is not None
-            k_li_scale, kv_ag_handle = all_gather_async(
-                k_li_scale,
-                get_tp_group(),
-                async_op=async_op,
-            )
-            if kv_ag_handle is not None:
-                kv_ag_handles.append(kv_ag_handle)
-
-        return k_li, k_li_scale, fused_kv_no_split, kv_ag_handles
-
-    def _maybe_store_kvcache_for_c8_n_dsacp(
+    def _store_parallel_kv(
         self,
         k_pe: torch.Tensor | None,
         k_nope: torch.Tensor | None,
@@ -1599,9 +1342,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         torch.Tensor | None,
         torch.Tensor | None,
     ]:
-        """Store KV produced by native preprocessing for C8 and DSA-CP paths."""
-
-        if self.enable_sparse_sfa_c8 and not self.enable_dsa_cp:
+        """Store KV produced by native preprocessing."""
+        if self.enable_sparse_sfa_c8:
             assert k_pe is not None
             assert k_nope is not None
             assert knope_scale is not None
@@ -1622,59 +1364,40 @@ class AscendSFAImpl(MLAAttentionImpl):
                 packed_kv.view(-1, packed_head_dim),
             )
 
-        if self.enable_dsa_cp:
-            for kv_ag_handle in kv_ag_handles:
-                kv_ag_handle.wait()
-
-            if full_gather_o_proj_enabled:
-                self._enable_o_proj_tp_full_weight_switch()
-                linear_method = self._get_o_proj_linear_method()
-                assert isinstance(linear_method, TPWeightSwitchMixin)
-                assert self.o_proj_tp_weight_state is not None
-                linear_method.all_gather_tp_weight(
-                    self.o_proj_tp_weight_state,
-                    get_tp_group(),
-                )
-
-            if kv_cache is not None:
-                assert fused_kv_no_split is not None
-                if self.enable_sparse_sfa_c8:
-                    torch_npu.npu_scatter_nd_update_(
-                        kv_cache[0].view(-1, fused_kv_no_split.shape[-1]),
-                        slot_mapping_sfa[: attn_metadata.num_actual_tokens].view(-1, 1),
-                        fused_kv_no_split[: attn_metadata.num_actual_tokens],
-                    )
-                    k_pe = None
-                    k_nope = None
-                elif not self.has_indexer:
-                    k_pe, k_nope = fused_kv_no_split.split(
-                        [self.qk_rope_head_dim, self.kv_lora_rank],
-                        dim=-1,
-                    )
-                elif not self.enable_sparse_li_c8:
-                    k_pe, k_nope, k_li = fused_kv_no_split.split(
-                        [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
-                        dim=-1,
-                    )
-                else:
-                    k_pe, k_nope = fused_kv_no_split.split(
-                        [self.qk_rope_head_dim, self.kv_lora_rank],
-                        dim=-1,
-                    )
-                if not self.enable_sparse_sfa_c8:
-                    assert k_pe is not None
-                    assert k_nope is not None
-                    k_nope = k_nope.view(k_nope.shape[0], 1, -1)
-                    k_pe = k_pe.view(k_pe.shape[0], 1, -1)
-                    DeviceOperator.reshape_and_cache(
-                        key=k_nope[: attn_metadata.num_actual_tokens],
-                        value=k_pe[: attn_metadata.num_actual_tokens],
-                        key_cache=kv_cache[0],
-                        value_cache=kv_cache[1],
-                        slot_mapping=slot_mapping_sfa[: attn_metadata.num_actual_tokens],
-                    )
-
         return k_pe, k_nope, k_li
+
+    def _get_parallel_forward_context(
+        self,
+        attn_metadata: M,
+        num_input_tokens: int,
+        hidden_states: torch.Tensor,
+    ) -> SFAForwardContext:
+        return SFAForwardContext(
+            actual_seq_lengths_query=attn_metadata.cum_query_lens,
+            actual_seq_lengths_key=attn_metadata.seq_lens,
+            kv_slot_mapping=self._get_sfa_kv_slot_mapping(attn_metadata),
+            topk_num_tokens=num_input_tokens or hidden_states.shape[0],
+        )
+
+    def _prepare_native_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        need_gather_q_kv: bool,
+    ) -> torch.Tensor:
+        if self.enable_sp:
+            return torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                hidden_states.contiguous(), need_gather_q_kv
+            )
+        return hidden_states
+
+    def _finalize_o_proj(
+        self,
+        attn_output: torch.Tensor,
+        output: torch.Tensor,
+        gather_full_o_proj: bool,
+    ) -> torch.Tensor:
+        output[...] = self.o_proj(attn_output)[0]
+        return output
 
     def _get_sfa_kv_slot_mapping(
         self,
@@ -1761,34 +1484,18 @@ class AscendSFAImpl(MLAAttentionImpl):
         cos = attn_metadata.cos
         sin = attn_metadata.sin
         slot_mapping = attn_metadata.slot_mapping
-        slot_mapping_cp = None
-        if self.enable_dsa_cp:
-            assert attn_metadata.dsa_cp_context is not None
-            slot_mapping_cp = attn_metadata.dsa_cp_context.slot_mapping_cp
-            actual_seq_lengths_query = attn_metadata.dsa_cp_context.actual_seq_lengths_query
-            actual_seq_lengths_key = attn_metadata.dsa_cp_context.actual_seq_lengths_key
-        else:
-            actual_seq_lengths_query = attn_metadata.cum_query_lens
-            actual_seq_lengths_key = attn_metadata.seq_lens
         slot_mapping_sfa = self._get_sfa_kv_slot_mapping(attn_metadata)
 
         # Inputs and outputs may be padded for CUDA graphs
         num_input_tokens = attn_metadata.num_input_tokens
         output_padded = output
-
-        # Asynchronously all-gather o_proj for DSA-CP prefill. This applies to
-        # both a mixed-role instance and a PD-disaggregated P node.
-        # Prefill/mixed DSA-CP computes o_proj with a temporary full weight.
-        # Decode keeps the original TP path and only exchanges activations.
-        full_gather_o_proj_enabled = (
-            self.tp_size > 1
-            and self.enable_dsa_cp_with_o_proj_tp
-            and attn_metadata.attn_state
-            not in {
-                AscendAttentionState.DecodeOnly,
-                AscendAttentionState.SpecDecoding,
-            }
+        parallel_context = self._get_parallel_forward_context(
+            attn_metadata,
+            num_input_tokens,
+            hidden_states,
         )
+        actual_seq_lengths_query = parallel_context.actual_seq_lengths_query
+        actual_seq_lengths_key = parallel_context.actual_seq_lengths_key
 
         fused_type: PreprocessType = self.preprocess_type
         if (
@@ -1834,10 +1541,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         # native
         else:
             assert self.fused_qkv_a_proj is not None, "q lora is required for DSA."
-            if self.enable_sp and not self.enable_dsa_cp:
-                hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
-                    hidden_states.contiguous(), need_gather_q_kv
-                )
+            hidden_states = self._prepare_native_hidden_states(hidden_states, need_gather_q_kv)
             qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
             q_c, kv_no_split = qkv_lora.split(
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
@@ -1857,21 +1561,23 @@ class AscendSFAImpl(MLAAttentionImpl):
 
             wait_for_kv_layer_from_connector(layer_name)
 
-            if self.enable_dsa_cp:
-                assert slot_mapping_cp is not None
-                kv_slots = slot_mapping_cp
-            else:
-                kv_slots = slot_mapping_sfa
-            kv_outputs = self.exec_kv(kv_no_split, cos, sin, kv_cache, kv_slots, attn_metadata)
+            kv_outputs = self.exec_kv(
+                kv_no_split,
+                cos,
+                sin,
+                kv_cache,
+                parallel_context.kv_slot_mapping,
+                attn_metadata,
+            )
             k_pe, k_nope = kv_outputs[:2]
             knope_scale = kv_outputs[2] if len(kv_outputs) == 3 else None
-            k_li, k_li_scale, fused_kv_no_split, kv_ag_handles = self._maybe_gather_kv_for_dsacp(
+            k_li, k_li_scale, fused_kv_no_split, kv_ag_handles = self._prepare_kv_for_parallel(
                 k_pe,
                 k_nope,
                 knope_scale,
                 k_li,
                 k_li_scale,
-                full_gather_o_proj_enabled,
+                parallel_context.gather_full_o_proj,
             )
 
             ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
@@ -1886,7 +1592,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 k_pe,
                 k_nope,
                 k_li,
-            ) = self._maybe_store_kvcache_for_c8_n_dsacp(
+            ) = self._store_parallel_kv(
                 k_pe,
                 k_nope,
                 knope_scale,
@@ -1896,12 +1602,8 @@ class AscendSFAImpl(MLAAttentionImpl):
                 kv_cache,
                 slot_mapping_sfa,
                 attn_metadata,
-                full_gather_o_proj_enabled,
+                parallel_context.gather_full_o_proj,
             )
-
-            if self.has_indexer:
-                assert k_li is not None
-                k_li = self._get_full_kv(k_li, attn_metadata)
 
         if kv_cache is not None and self.is_kv_producer:
             attn_metadata.reshape_cache_event = torch.npu.Event()
@@ -1947,18 +1649,13 @@ class AscendSFAImpl(MLAAttentionImpl):
                         )
             notify_kv_cache_written(self.layer_name or "")
 
-        if self.enable_dsa_cp and attn_metadata.dsa_cp_context is not None:
-            topk_num_tokens = attn_metadata.dsa_cp_context.local_end_with_pad - attn_metadata.dsa_cp_context.local_start
-        else:
-            topk_num_tokens = num_input_tokens or hidden_states.shape[0]
-
         # Open the prefetch gate for every SFA layer. Some GLM-5.2 layers
         # reuse cached top-k indices and have no indexer, so recording this
         # inside indexer_select_post_process would leave their gate closed.
         record_attention_compute_start()
 
         if self.skip_topk:
-            topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
+            topk_indices = self._get_indexcache_topk_indices(parallel_context.topk_num_tokens)
         else:
             if not self.has_indexer:
                 raise RuntimeError(f"skip_topk is False but indexer is None. layer_name={self.layer_name}.")
@@ -1988,23 +1685,11 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         attn_output = self._v_up_proj(attn_output)
 
-        if self.enable_dsa_cp_with_o_proj_tp:
-            # SFA DSA-CP keeps o_proj weight sharded in the TP domain:
-            # 1. prefill/mixed: gather TP shards into a temporary full weight.
-            # 2. decode-only: all-to-all hidden states, then run TP o_proj.
-            result, require_o_proj_forward = self._handle_o_proj_weight_switch_and_forward(
-                attn_output=attn_output,
-                output=output,
-                should_shard_weight=full_gather_o_proj_enabled,
-            )
-            if not require_o_proj_forward:
-                # The full-weight prefill path completes o_proj internally,
-                # but a pure P node must still publish this layer's KV cache.
-                maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
-                return result
-            attn_output = result
-
-        output[...] = self.o_proj(attn_output)[0]
+        output = self._finalize_o_proj(
+            attn_output,
+            output,
+            parallel_context.gather_full_o_proj,
+        )
 
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1385,9 +1385,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         need_gather_q_kv: bool,
     ) -> torch.Tensor:
         if self.enable_sp:
-            return torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
-                hidden_states.contiguous(), need_gather_q_kv
-            )
+            return torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states.contiguous(), need_gather_q_kv)
         return hidden_states
 
     def _finalize_o_proj(


### PR DESCRIPTION
### What this PR does

This PR decouples DSA-CP and DCP handling from the native SFA v1 backend while retaining a shared SFA execution flow. The detailed plan is descripted in RFC https://github.com/vllm-project/vllm-ascend/issues/14002.
- Removes DSA-CP state, metadata fields, buffers, and conditional branches from `AscendSFAMetadata`, `AscendSFAMetadataBuilder`, and `AscendSFAImpl`.
- Introduces neutral metadata and forward hooks in the base SFA backend for parallel metadata preparation, hidden-state handling, KV preparation/storage, query layout, sparse attention execution, and `o_proj` finalization.
- Moves DSA-CP-specific metadata and execution into `context_parallel/sfa_cp.py`, including token/rotary/slot sharding, local query/key sequence lengths, TP KV gathering, full-head layout handling, and DSA-CP `o_proj` processing.
- Keeps DCP-specific behavior in dedicated DCP builder and implementation classes, including the replicated LightningIndexer view, DCP-local SFA KV layout, block-table construction, query/KV gathering, sparse top-k remapping, and partial-output merging.
- Adds explicit combined DSA-CP + DCP metadata, builder, and implementation classes. The combined classes use DCP-first cooperative inheritance so DCP communication wraps DSA-CP token/layout handling without duplicating the shared SFA forward method.
- Centralizes builder and implementation selection in `resolve_sfa_metadata_builder()` and `resolve_sfa_impl()` for the four configurations: native SFA, DSA-CP only, DCP only, and DSA-CP + DCP.
- Updates Sparse KV offload compatibility handling so it no longer depends on DSA-CP state stored by the base SFA implementation.
- Updates unit tests for the four-mode resolver, class hierarchy and MRO, DSA-CP token metadata, DCP replicated views and local sequence lengths, combined slot mapping, query-gather layout, sparse-index remapping, and DSA-CP `o_proj` behavior.

### Does this PR introduce any user-facing change?

No configuration or command-line semantics are changed. Existing `enable_dsa_cp` and `decode_context_parallel_size` settings continue to select the corresponding SFA execution mode.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
