### PR TITLE
[BugFix][v0.26.0] DeepSeek-V4 DSpark uses non-causal attention by default

### DIFF
--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -338,8 +338,11 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.max_seq_len = cad.max_seq_len + self.num_query_per_req
         cad.slot_mapping = self._per_group_query_slot_mapping_buffers[primary_gid][:num_query_total]
         cad.positions = self.positions  # this would be sliced in attention backend
-        # Currently, attention causality across draft layers are uniform.
-        cad.causal = self.model.get_draft_attn_causal()[0]
+        if hasattr(self.model, "get_draft_attn_causal"):
+            # Currently, attention causality across draft layers are uniform.
+            cad.causal = self.model.get_draft_attn_causal()[0]
+        else:
+            cad.causal = False
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 


### PR DESCRIPTION
Cherry-picked https://github.com/vllm-project/vllm-ascend/pull/13925
### What this PR does / why we need it?
`DSparkDeepseekV4ForCausalLM` does not extend `Qwen3DSparkForCausalLM`, so it does not have the attribute `get_draft_attn_causal`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Pass `test_dspark_deepseekv4.py`.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
