### PR TITLE
[Feature][Kimi-K3] Integrate optimized inference paths

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -837,6 +837,7 @@ estimated_times:
   tests/ut/ops/a2/test_gdn_layerwise_kv.py: 30
   tests/ut/ops/a2/test_token_dispatcher.py: 30
   tests/ut/ops/a3_2/test_activation.py: 50
+  tests/ut/ops/a3_2/test_kimi_kda_fused_norm_gate.py: 20
   tests/ut/ops/a3_2/test_select_experts.py: 20
   tests/ut/quantization/methods/a2/test_w4a16.py: 30
   tests/ut/quantization/methods/a2/test_w4a4_flatquant.py: 40

--- a/csrc/attention/recurrent_kda/README.md
+++ b/csrc/attention/recurrent_kda/README.md
@@ -32,7 +32,7 @@ out = torch.ops._C_ascend.recurrent_kda(
     - `safe_gate=False`：`gate = -exp(A_log) * softplus(g + dt_bias)`。
     - `safe_gate=True`：`gate = lower_bound * sigmoid(exp(A_log) * (g + dt_bias))`。
 - `use_beta_sigmoid_in_kernel=True` 时，kernel 使用 `sigmoid(beta)`；若 `allow_neg_eigval=True`，再乘 2。
-- `_C_ascend`/aclnn 入口支持非连续 state，并通过临时连续 tensor 回写原 view。
+- `_C_ascend`/aclnn 入口保留非连续 state 的 storage、stride 和 offset，kernel 按真实 stride 直接读写；仅允许 slot/head 外层维存在间隔，内部二维 state 矩阵必须行主序稠密。
 
 每个 token 的 recurrent 更新为：
 
@@ -52,5 +52,5 @@ o_t = S @ (q_t * scale)
   末项不得超过输入 token capacity，各相邻差值必须不超过 8。末项小于 capacity 时，仅有效 token
   对应的输出和 state 更新有定义，padding tail 输出不作保证。
 - 仅支持 `layout="BSND"` 和 `layout="TND"`。
-- 仅支持 `state_v_first=True`，state layout 为 `[state_capacity,HV,V,K]`；底层 aclnn 接口要求显式传入可变 state。
-- `HV` 必须能被 `H` 整除；`H/HV <= 256`。底层 kernel 支持 `K=128,V=128/256`，当前 Kimi K3 torch 入口收窄为 `K=V=128`。
+- Kimi K3 Torch 入口固定 `state_v_first=True`，state layout 为 `[state_capacity,HV,V,K]`；底层 aclnn/kernel 同时支持 V-first 和 `[state_capacity,HV,K,V]` 的 K-first 布局。
+- `HV` 必须能被 `H` 整除；`H/HV <= 256`。底层 kernel 与 Kimi K3 Torch 入口均支持 `K=128,V=128/256`。

--- a/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
+++ b/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.cpp
@@ -11,7 +11,6 @@
 #include "aclnn_recurrent_kda.h"
 #include "recurrent_kda.h"
 
-#include "aclnn_kernels/cast.h"
 #include "aclnn_kernels/common/op_error_check.h"
 #include "aclnn_kernels/contiguous.h"
 #include "opdev/common_types.h"
@@ -45,8 +44,8 @@ struct RecurrentKdaParams {
     const aclTensor *value = nullptr;
     const aclTensor *gate = nullptr;
     const aclTensor *beta = nullptr;
-    aclTensor *stateRef = nullptr;
-    const aclTensor *cuSeqlens = nullptr;
+    aclTensor *initialStateRef = nullptr;
+    const aclTensor *cuSeqlensOptional = nullptr;
     const aclTensor *ssmStateIndicesOptional = nullptr;
     const aclTensor *aLogOptional = nullptr;
     const aclTensor *dtBiasOptional = nullptr;
@@ -54,14 +53,16 @@ struct RecurrentKdaParams {
     const char *layout = "BSND";
     double scale = 1.0;
     bool outputFinalState = false;
+    bool inplaceFinalState = true;
     bool useQkL2normInKernel = false;
     bool useGateInKernel = false;
     bool useBetaSigmoidInKernel = false;
     bool allowNegEigval = false;
     bool safeGate = false;
     double lowerBound = -5.0;
-    bool stateVFirst = true;
-    const aclTensor *out = nullptr;
+    bool stateVFirst = false;
+    const aclTensor *attnOut = nullptr;
+    const aclTensor *finalState = nullptr;
 };
 
 static const std::initializer_list<op::DataType> QKV_TYPE_SUPPORT_LIST = {op::DataType::DT_BF16};
@@ -74,17 +75,17 @@ static const std::initializer_list<op::DataType> F32_TYPE_SUPPORT_LIST = {op::Da
 static const std::initializer_list<op::DataType> INT_TYPE_SUPPORT_LIST = {op::DataType::DT_INT32,
                                                                           op::DataType::DT_INT64};
 
-size_t Rank(const aclTensor *tensor)
+static size_t Rank(const aclTensor *tensor)
 {
     return tensor->GetViewShape().GetDimNum();
 }
 
-int64_t Dim(const aclTensor *tensor, size_t idx)
+static int64_t Dim(const aclTensor *tensor, size_t idx)
 {
     return tensor->GetViewShape().GetDim(idx);
 }
 
-bool SameShape(const aclTensor *lhs, const aclTensor *rhs)
+static bool SameShape(const aclTensor *lhs, const aclTensor *rhs)
 {
     if (Rank(lhs) != Rank(rhs)) {
         return false;
@@ -97,7 +98,7 @@ bool SameShape(const aclTensor *lhs, const aclTensor *rhs)
     return true;
 }
 
-bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
+static bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
 {
     if (layout == nullptr || std::strcmp(layout, "BSND") == 0) {
         parsed = RecurrentKdaLayout::BSND;
@@ -113,8 +114,12 @@ bool ParseLayout(const char *layout, RecurrentKdaLayout &parsed)
 
 bool CheckCuSeqlensShape(const aclTensor *cuSeqlens, const char *opName)
 {
+    if (cuSeqlens == nullptr) {
+        return true;
+    }
     if (Rank(cuSeqlens) != 1 || Dim(cuSeqlens, DIM0) < 2) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "%s: cu_seqlens must be a 1D tensor with at least two elements.", opName);
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID,
+                "%s: cuSeqlensOptional must be a 1D tensor with at least two elements.", opName);
         return false;
     }
     return true;
@@ -187,31 +192,33 @@ bool CheckShape(const RecurrentKdaParams &params, RecurrentKdaLayout layout)
                 kDim, vDim);
         return false;
     }
-    if (!CheckCuSeqlensShape(params.cuSeqlens, "npu_recurrent_kda")) {
+    if (!CheckCuSeqlensShape(params.cuSeqlensOptional, "npu_recurrent_kda")) {
         return false;
     }
-    int64_t seqNum = Dim(params.cuSeqlens, DIM0) - 1;
-    if (!params.stateVFirst) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: state_v_first=false is not supported.");
+    int64_t seqNum = params.cuSeqlensOptional == nullptr ?
+        ((layout == RecurrentKdaLayout::BSND) ? batch : 1) :
+        Dim(params.cuSeqlensOptional, DIM0) - 1;
+    if (Rank(params.initialStateRef) != 4) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: initialStateRef must be rank 4.");
         return false;
     }
-    if (Rank(params.stateRef) != 4) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID,
-                "npu_recurrent_kda: state must be rank 4 [state_capacity, HV, V, K].");
-        return false;
-    }
-    int64_t stateCapacity = Dim(params.stateRef, DIM0);
-    if (stateCapacity <= 0 ||
-        Dim(params.stateRef, DIM1) != hv || Dim(params.stateRef, DIM2) != vDim ||
-        Dim(params.stateRef, DIM3) != kDim ||
+    int64_t stateCapacity = Dim(params.initialStateRef, DIM0);
+    bool stateTailMatches = params.stateVFirst ?
+        (Dim(params.initialStateRef, DIM2) == vDim && Dim(params.initialStateRef, DIM3) == kDim) :
+        (Dim(params.initialStateRef, DIM2) == kDim && Dim(params.initialStateRef, DIM3) == vDim);
+    if (stateCapacity <= 0 || Dim(params.initialStateRef, DIM1) != hv || !stateTailMatches ||
         (params.ssmStateIndicesOptional == nullptr && stateCapacity != seqNum)) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID,
-                "npu_recurrent_kda: state must be [state_capacity, HV, V, K]; without ssm_state_indices, "
-                "state_capacity must equal seq_num.");
+                "npu_recurrent_kda: state must be [state_capacity,HV,V,K] when stateVFirst=true or "
+                "[state_capacity,HV,K,V] otherwise; without ssmStateIndicesOptional, state_capacity must equal seq_num.");
         return false;
     }
-    if (!SameShape(params.out, params.value)) {
-        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: out output shape must match value.");
+    if (!SameShape(params.attnOut, params.value)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: attnOut shape must match value.");
+        return false;
+    }
+    if (!SameShape(params.finalState, params.initialStateRef)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: finalState shape must match initialStateRef.");
         return false;
     }
     if (params.ssmStateIndicesOptional != nullptr) {
@@ -266,9 +273,9 @@ bool CheckNotNull(const RecurrentKdaParams &params)
     OP_CHECK_NULL(params.value, return false);
     OP_CHECK_NULL(params.gate, return false);
     OP_CHECK_NULL(params.beta, return false);
-    OP_CHECK_NULL(params.stateRef, return false);
-    OP_CHECK_NULL(params.cuSeqlens, return false);
-    OP_CHECK_NULL(params.out, return false);
+    OP_CHECK_NULL(params.initialStateRef, return false);
+    OP_CHECK_NULL(params.attnOut, return false);
+    OP_CHECK_NULL(params.finalState, return false);
     return true;
 }
 
@@ -279,9 +286,16 @@ bool CheckDtypeValid(const RecurrentKdaParams &params)
     OP_CHECK_DTYPE_NOT_SUPPORT(params.value, QKV_TYPE_SUPPORT_LIST, return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.gate, GATE_TYPE_SUPPORT_LIST, return false);
     OP_CHECK_DTYPE_NOT_SUPPORT(params.beta, GATE_TYPE_SUPPORT_LIST, return false);
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.stateRef, STATE_TYPE_SUPPORT_LIST, return false);
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.out, QKV_TYPE_SUPPORT_LIST, return false);
-    OP_CHECK_DTYPE_NOT_SUPPORT(params.cuSeqlens, INT_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.initialStateRef, STATE_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.attnOut, QKV_TYPE_SUPPORT_LIST, return false);
+    OP_CHECK_DTYPE_NOT_SUPPORT(params.finalState, STATE_TYPE_SUPPORT_LIST, return false);
+    if (params.finalState->GetDataType() != params.initialStateRef->GetDataType()) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "npu_recurrent_kda: finalState dtype must match initialStateRef.");
+        return false;
+    }
+    if (params.cuSeqlensOptional != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(params.cuSeqlensOptional, INT_TYPE_SUPPORT_LIST, return false);
+    }
     if (params.ssmStateIndicesOptional != nullptr) {
         OP_CHECK_DTYPE_NOT_SUPPORT(params.ssmStateIndicesOptional, INT_TYPE_SUPPORT_LIST, return false);
     }
@@ -321,46 +335,27 @@ void SetInputOriginalShape(RecurrentKdaParams &params)
     SetTensorOriginalShape(params.value);
     SetTensorOriginalShape(params.gate);
     SetTensorOriginalShape(params.beta);
-    SetTensorOriginalShape(params.stateRef);
-    SetTensorOriginalShape(params.cuSeqlens);
+    SetTensorOriginalShape(params.initialStateRef);
+    SetTensorOriginalShape(params.cuSeqlensOptional);
     SetTensorOriginalShape(params.ssmStateIndicesOptional);
     SetTensorOriginalShape(params.aLogOptional);
     SetTensorOriginalShape(params.dtBiasOptional);
     SetTensorOriginalShape(params.numAcceptedTokensOptional);
 }
 
-const aclTensor *MaybeCast(const aclTensor *tensor, DataType dataType, aclOpExecutor *executor)
-{
-    if (tensor == nullptr || tensor->GetDataType() == dataType) {
-        return tensor;
-    }
-    return l0op::Cast(tensor, dataType, executor);
-}
-
 aclnnStatus PreProcess(RecurrentKdaParams &params, aclOpExecutor *executor)
 {
-    bool hasSsmStateIndices = params.ssmStateIndicesOptional != nullptr;
-    bool hasNumAcceptedTokens = params.numAcceptedTokensOptional != nullptr;
     SetInputOriginalShape(params);
     CHECK_RET(DataContiguous(params.query, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.key, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.value, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.gate, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.beta, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(DataContiguous(params.cuSeqlens, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
+    CHECK_RET(DataContiguous(params.cuSeqlensOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.ssmStateIndicesOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.aLogOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.dtBiasOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
     CHECK_RET(DataContiguous(params.numAcceptedTokensOptional, executor) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-    params.gate = MaybeCast(params.gate, DataType::DT_FLOAT, executor);
-    params.beta = MaybeCast(params.beta, DataType::DT_FLOAT, executor);
-    params.cuSeqlens = MaybeCast(params.cuSeqlens, DataType::DT_INT64, executor);
-    params.ssmStateIndicesOptional = MaybeCast(params.ssmStateIndicesOptional, DataType::DT_INT64, executor);
-    params.numAcceptedTokensOptional = MaybeCast(params.numAcceptedTokensOptional, DataType::DT_INT64, executor);
-    CHECK_RET(params.gate != nullptr && params.beta != nullptr && params.cuSeqlens != nullptr,
-              ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(!hasSsmStateIndices || params.ssmStateIndicesOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    CHECK_RET(!hasNumAcceptedTokens || params.numAcceptedTokensOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
     if (params.ssmStateIndicesOptional == nullptr && params.numAcceptedTokensOptional != nullptr) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID,
                 "npu_recurrent_kda: num_accepted_tokens requires ssm_state_indices.");
@@ -376,8 +371,8 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
@@ -385,6 +380,7 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const char *layout,
     double scale,
     bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -392,25 +388,28 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     uint64_t *workspaceSize,
     aclOpExecutor **executor)
 {
     L2_DFX_PHASE_1(aclnnRecurrentKda,
-                   DFX_IN(query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional,
-                          aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale, outputFinalState,
-                          useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate,
-                          lowerBound, stateVFirst),
-                   DFX_OUT(out, stateRef));
+                   DFX_IN(query, key, value, gate, beta, initialStateRef, cuSeqlensOptional,
+                          ssmStateIndicesOptional, aLogOptional, dtBiasOptional, numAcceptedTokensOptional,
+                          layout, scale, outputFinalState, inplaceFinalState, useQkL2normInKernel,
+                          useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBound,
+                          stateVFirst),
+                   DFX_OUT(attnOut, initialStateRef, finalState));
 
     auto uniqueExecutor = CREATE_EXECUTOR();
     CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
     auto executorPtr = uniqueExecutor.get();
 
-    RecurrentKdaParams params{query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional,
-                              aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale,
-                              outputFinalState, useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel,
-                              allowNegEigval, safeGate, lowerBound, stateVFirst, out};
+    RecurrentKdaParams params{query, key, value, gate, beta, initialStateRef, cuSeqlensOptional,
+                              ssmStateIndicesOptional, aLogOptional, dtBiasOptional,
+                              numAcceptedTokensOptional, layout, scale, outputFinalState, inplaceFinalState,
+                              useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel,
+                              allowNegEigval, safeGate, lowerBound, stateVFirst, attnOut, finalState};
 
     CHECK_RET(CheckNotNull(params), ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(CheckDtypeValid(params), ACLNN_ERR_PARAM_INVALID);
@@ -419,23 +418,43 @@ aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     CHECK_RET(CheckShape(params, parsedLayout), ACLNN_ERR_PARAM_INVALID);
     CHECK_RET(PreProcess(params, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_PARAM_INVALID);
 
-    aclTensor *stateForKernel = params.stateRef;
-    bool stateNeedViewCopy = !IsContiguous(params.stateRef);
-    if (stateNeedViewCopy) {
-        const aclTensor *contiguousState = params.stateRef;
-        CHECK_RET(DataContiguous(contiguousState, executorPtr) == ACLNN_SUCCESS, ACLNN_ERR_INNER_NULLPTR);
-        stateForKernel = const_cast<aclTensor *>(contiguousState);
+    aclTensor *initialStateForKernel = params.initialStateRef;
+    if (!IsContiguous(initialStateForKernel)) {
+        initialStateForKernel = executorPtr->CreateView(
+            initialStateForKernel,
+            initialStateForKernel->GetViewShape(),
+            initialStateForKernel->GetStorageShape(),
+            initialStateForKernel->GetViewStrides(),
+            initialStateForKernel->GetViewOffset());
+        CHECK_RET(initialStateForKernel != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+    const aclTensor *finalStateForKernel = params.finalState;
+    if (!params.inplaceFinalState || params.outputFinalState) {
+        if (!IsContiguous(finalStateForKernel)) {
+            finalStateForKernel = executorPtr->CreateView(
+                finalStateForKernel,
+                finalStateForKernel->GetViewShape(),
+                finalStateForKernel->GetStorageShape(),
+                finalStateForKernel->GetViewStrides(),
+                finalStateForKernel->GetViewOffset());
+            CHECK_RET(finalStateForKernel != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        }
     }
 
-    auto result = l0op::RecurrentKda(params.query, params.key, params.value, params.gate, params.beta,
-                                     stateForKernel, params.cuSeqlens, params.ssmStateIndicesOptional,
-                                     params.aLogOptional, params.dtBiasOptional, params.numAcceptedTokensOptional,
-                                     params.layout, params.scale, params.useQkL2normInKernel,
-                                     params.useGateInKernel, params.useBetaSigmoidInKernel, params.allowNegEigval,
-                                     params.safeGate, params.lowerBound, params.stateVFirst, params.out, executorPtr);
-    CHECK_RET(result[0] != nullptr && result[1] != nullptr, ACLNN_ERR_INNER_NULLPTR);
-    if (stateNeedViewCopy) {
-        CHECK_RET(l0op::ViewCopy(result[1], params.stateRef, executorPtr) != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    auto result = l0op::RecurrentKda(
+        params.query, params.key, params.value, params.gate, params.beta, initialStateForKernel,
+        params.cuSeqlensOptional, params.ssmStateIndicesOptional, params.aLogOptional,
+        params.dtBiasOptional, params.numAcceptedTokensOptional, params.layout, params.scale,
+        params.outputFinalState, params.inplaceFinalState, params.useQkL2normInKernel,
+        params.useGateInKernel, params.useBetaSigmoidInKernel, params.allowNegEigval,
+        params.safeGate, params.lowerBound, params.stateVFirst, params.attnOut,
+        finalStateForKernel, executorPtr);
+    CHECK_RET(result[0] != nullptr && result[1] != nullptr && result[2] != nullptr,
+              ACLNN_ERR_INNER_NULLPTR);
+    if (params.inplaceFinalState && params.outputFinalState &&
+        params.finalState != params.initialStateRef) {
+        CHECK_RET(l0op::ViewCopy(result[1], params.finalState, executorPtr) != nullptr,
+                  ACLNN_ERR_INNER_NULLPTR);
     }
 
     *workspaceSize = uniqueExecutor->GetWorkspaceSize();

--- a/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_host/op_api/aclnn_recurrent_kda.h
@@ -20,8 +20,8 @@ ACLNN_API aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
@@ -29,6 +29,7 @@ ACLNN_API aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     const char *layout,
     double scale,
     bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -36,7 +37,8 @@ ACLNN_API aclnnStatus aclnnRecurrentKdaGetWorkspaceSize(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     uint64_t *workspaceSize,
     aclOpExecutor **executor);
 

--- a/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.cpp
+++ b/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.cpp
@@ -23,20 +23,22 @@ namespace l0op {
 
 OP_TYPE_REGISTER(RecurrentKda);
 
-const std::array<const aclTensor *, 2> RecurrentKda(
+const std::array<const aclTensor *, 3> RecurrentKda(
     const aclTensor *query,
     const aclTensor *key,
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
     const aclTensor *numAcceptedTokensOptional,
     const char *layout,
     double scale,
+    bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -44,28 +46,31 @@ const std::array<const aclTensor *, 2> RecurrentKda(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     aclOpExecutor *executor)
 {
-    L0_DFX(RecurrentKda, query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional,
-           aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale, useQkL2normInKernel,
-           useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBound, stateVFirst, out,
-           stateRef);
+    L0_DFX(RecurrentKda, query, key, value, gate, beta, initialStateRef, cuSeqlensOptional,
+           ssmStateIndicesOptional, aLogOptional, dtBiasOptional, numAcceptedTokensOptional, layout, scale,
+           outputFinalState, inplaceFinalState, useQkL2normInKernel, useGateInKernel,
+           useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBound, stateVFirst, attnOut,
+           initialStateRef, finalState);
 
     float scaleAttr = static_cast<float>(scale);
     float lowerBoundAttr = static_cast<float>(lowerBound);
     auto ret = ADD_TO_LAUNCHER_LIST_AICORE(
         RecurrentKda,
-        OP_INPUT(query, key, value, gate, beta, stateRef, cuSeqlens, ssmStateIndicesOptional, aLogOptional,
-                 dtBiasOptional, numAcceptedTokensOptional),
-        OP_OUTPUT(out, stateRef),
-        OP_ATTR(layout, scaleAttr, useQkL2normInKernel, useGateInKernel, useBetaSigmoidInKernel, allowNegEigval,
-                safeGate, lowerBoundAttr, stateVFirst));
+        OP_INPUT(query, key, value, gate, beta, initialStateRef, cuSeqlensOptional, ssmStateIndicesOptional,
+                 aLogOptional, dtBiasOptional, numAcceptedTokensOptional),
+        OP_OUTPUT(attnOut, initialStateRef, finalState),
+        OP_ATTR(layout, scaleAttr, outputFinalState, inplaceFinalState, useQkL2normInKernel,
+                useGateInKernel, useBetaSigmoidInKernel, allowNegEigval, safeGate, lowerBoundAttr,
+                stateVFirst));
     if (ret != ACLNN_SUCCESS) {
         OP_LOGE(ACLNN_ERR_PARAM_INVALID, "RecurrentKda ADD_TO_LAUNCHER_LIST_AICORE failed.");
-        return {nullptr, nullptr};
+        return {nullptr, nullptr, nullptr};
     }
 
-    return {out, stateRef};
+    return {attnOut, initialStateRef, finalState};
 }
 } // namespace l0op

--- a/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_host/op_api/recurrent_kda.h
@@ -12,20 +12,22 @@
 #include <array>
 
 namespace l0op {
-const std::array<const aclTensor *, 2> RecurrentKda(
+const std::array<const aclTensor *, 3> RecurrentKda(
     const aclTensor *query,
     const aclTensor *key,
     const aclTensor *value,
     const aclTensor *gate,
     const aclTensor *beta,
-    aclTensor *stateRef,
-    const aclTensor *cuSeqlens,
+    aclTensor *initialStateRef,
+    const aclTensor *cuSeqlensOptional,
     const aclTensor *ssmStateIndicesOptional,
     const aclTensor *aLogOptional,
     const aclTensor *dtBiasOptional,
     const aclTensor *numAcceptedTokensOptional,
     const char *layout,
     double scale,
+    bool outputFinalState,
+    bool inplaceFinalState,
     bool useQkL2normInKernel,
     bool useGateInKernel,
     bool useBetaSigmoidInKernel,
@@ -33,7 +35,8 @@ const std::array<const aclTensor *, 2> RecurrentKda(
     bool safeGate,
     double lowerBound,
     bool stateVFirst,
-    const aclTensor *out,
+    const aclTensor *attnOut,
+    const aclTensor *finalState,
     aclOpExecutor *executor);
 }
 

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_def.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_def.cpp
@@ -16,56 +16,58 @@ public:
     explicit RecurrentKda(const char *name) : OpDef(name)
     {
         const std::initializer_list<ge::DataType> qkvTypes = {ge::DT_BF16, ge::DT_BF16};
-        const std::initializer_list<ge::DataType> f32Types = {ge::DT_FLOAT, ge::DT_FLOAT};
+        const std::initializer_list<ge::DataType> floatTypes = {ge::DT_FLOAT, ge::DT_FLOAT};
         const std::initializer_list<ge::DataType> stateTypes = {ge::DT_BF16, ge::DT_FLOAT};
-        const std::initializer_list<ge::DataType> i64Types = {ge::DT_INT64, ge::DT_INT64};
-        const std::initializer_list<ge::Format> formats = {ge::FORMAT_ND, ge::FORMAT_ND};
 
-        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Input("gate").ParamType(REQUIRED).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
-        this->Input("beta").ParamType(REQUIRED).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
-        this->Input("state")
+        this->Input("query").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Input("key").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Input("value").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Input("gate").ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
+        this->Input("beta").ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT, ge::DT_BF16, ge::DT_FLOAT16}).FormatList({ge::FORMAT_ND});
+        this->Input("initial_state")
             .ParamType(REQUIRED)
             .DataType(stateTypes)
-            .Format(formats)
-            .UnknownShapeFormat(formats)
+            .FormatList({ge::FORMAT_ND})
             .IgnoreContiguous();
         this->Input("cu_seqlens")
-            .ParamType(REQUIRED)
-            .DataType(i64Types)
-            .Format(formats)
-            .UnknownShapeFormat(formats);
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+            .FormatList({ge::FORMAT_ND});
         this->Input("ssm_state_indices")
             .ParamType(OPTIONAL)
-            .DataType(i64Types)
-            .Format(formats)
-            .UnknownShapeFormat(formats);
-        this->Input("A_log").ParamType(OPTIONAL).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
-        this->Input("dt_bias").ParamType(OPTIONAL).DataType(f32Types).Format(formats).UnknownShapeFormat(formats);
+            .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+            .FormatList({ge::FORMAT_ND});
+        this->Input("A_log").ParamType(OPTIONAL).DataType(floatTypes).FormatList({ge::FORMAT_ND});
+        this->Input("dt_bias").ParamType(OPTIONAL).DataType(floatTypes).FormatList({ge::FORMAT_ND});
         this->Input("num_accepted_tokens")
             .ParamType(OPTIONAL)
-            .DataType(i64Types)
-            .Format(formats)
-            .UnknownShapeFormat(formats);
-        this->Output("out").ParamType(REQUIRED).DataType(qkvTypes).Format(formats).UnknownShapeFormat(formats);
-        this->Output("state")
+            .DataTypeList({ge::DT_INT32, ge::DT_INT64})
+            .FormatList({ge::FORMAT_ND});
+        this->Output("attn_out").ParamType(REQUIRED).DataType(qkvTypes).FormatList({ge::FORMAT_ND});
+        this->Output("initial_state")
             .ParamType(REQUIRED)
             .DataType(stateTypes)
-            .Format(formats)
-            .UnknownShapeFormat(formats)
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Output("final_state")
+            .ParamType(REQUIRED)
+            .DataType(stateTypes)
+            .FormatList({ge::FORMAT_ND})
             .IgnoreContiguous();
 
         this->Attr("layout").AttrType(OPTIONAL).String("BSND");
         this->Attr("scale").AttrType(OPTIONAL).Float(1.0);
+        this->Attr("output_final_state").AttrType(OPTIONAL).Bool(false);
+        this->Attr("inplace_final_state").AttrType(OPTIONAL).Bool(true);
         this->Attr("use_qk_l2norm_in_kernel").AttrType(OPTIONAL).Bool(false);
         this->Attr("use_gate_in_kernel").AttrType(OPTIONAL).Bool(false);
         this->Attr("use_beta_sigmoid_in_kernel").AttrType(OPTIONAL).Bool(false);
         this->Attr("allow_neg_eigval").AttrType(OPTIONAL).Bool(false);
         this->Attr("safe_gate").AttrType(OPTIONAL).Bool(false);
         this->Attr("lower_bound").AttrType(OPTIONAL).Float(-5.0);
-        this->Attr("state_v_first").AttrType(OPTIONAL).Bool(true);
+        this->Attr("state_v_first").AttrType(OPTIONAL).Bool(false);
 
         OpAICoreConfig aicConfig;
         aicConfig.DynamicCompileStaticFlag(true)

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_infershape.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_infershape.cpp
@@ -23,6 +23,7 @@ const size_t STATE_INDEX = 5;
 
 const size_t DIM_0 = 0;
 const size_t DIM_1 = 1;
+const size_t DIM_2 = 2;
 
 static ge::graphStatus InferShapeRecurrentKda(InferShapeContext *context)
 {
@@ -35,13 +36,16 @@ static ge::graphStatus InferShapeRecurrentKda(InferShapeContext *context)
     auto shapeValue = context->GetInputShape(VALUE_INDEX);
     auto shapeInitialState = context->GetInputShape(STATE_INDEX);
     auto shapeOut = context->GetOutputShape(DIM_0);
-    auto shapeFinalState = context->GetOutputShape(DIM_1);
-    if (shapeValue == nullptr || shapeInitialState == nullptr || shapeOut == nullptr || shapeFinalState == nullptr) {
+    auto shapeInitialStateOut = context->GetOutputShape(DIM_1);
+    auto shapeFinalState = context->GetOutputShape(DIM_2);
+    if (shapeValue == nullptr || shapeInitialState == nullptr || shapeOut == nullptr ||
+        shapeInitialStateOut == nullptr || shapeFinalState == nullptr) {
         OP_LOGE(opName, "[InferShape] shape is null");
         return ge::GRAPH_FAILED;
     }
 
     *shapeOut = *shapeValue;
+    *shapeInitialStateOut = *shapeInitialState;
     *shapeFinalState = *shapeInitialState;
 
     return ge::GRAPH_SUCCESS;
@@ -51,6 +55,7 @@ static ge::graphStatus InferDataTypeRecurrentKda(gert::InferDataTypeContext *con
 {
     context->SetOutputDataType(0, ge::DT_BF16);
     context->SetOutputDataType(1, context->GetInputDataType(STATE_INDEX));
+    context->SetOutputDataType(2, context->GetInputDataType(STATE_INDEX));
     return ge::GRAPH_SUCCESS;
 }
 

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling.cpp
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling.cpp
@@ -34,15 +34,20 @@ const size_t A_LOG_INDEX = 8;
 const size_t DT_BIAS_INDEX = 9;
 const size_t ACC_TOKEN_INDEX = 10;
 
+const size_t INITIAL_STATE_OUTPUT_INDEX = 1;
+const size_t FINAL_STATE_OUTPUT_INDEX = 2;
+
 const size_t ATTR_LAYOUT_INDEX = 0;
 const size_t ATTR_SCALE_INDEX = 1;
-const size_t ATTR_USE_QK_L2NORM_INDEX = 2;
-const size_t ATTR_USE_GATE_INDEX = 3;
-const size_t ATTR_USE_BETA_SIGMOID_INDEX = 4;
-const size_t ATTR_ALLOW_NEG_EIGVAL_INDEX = 5;
-const size_t ATTR_SAFE_GATE_INDEX = 6;
-const size_t ATTR_LOWER_BOUND_INDEX = 7;
-const size_t ATTR_STATE_V_FIRST_INDEX = 8;
+const size_t ATTR_OUTPUT_FINAL_STATE_INDEX = 2;
+const size_t ATTR_INPLACE_FINAL_STATE_INDEX = 3;
+const size_t ATTR_USE_QK_L2NORM_INDEX = 4;
+const size_t ATTR_USE_GATE_INDEX = 5;
+const size_t ATTR_USE_BETA_SIGMOID_INDEX = 6;
+const size_t ATTR_ALLOW_NEG_EIGVAL_INDEX = 7;
+const size_t ATTR_SAFE_GATE_INDEX = 8;
+const size_t ATTR_LOWER_BOUND_INDEX = 9;
+const size_t ATTR_STATE_V_FIRST_INDEX = 10;
 
 void RecurrentKdaTiling::InitCompileInfo()
 {
@@ -70,6 +75,18 @@ void CopyOptionalOriginShape(gert::TilingContext *context, size_t index, gert::S
         dst = shape->GetOriginShape();
     }
 }
+
+template <typename StrideType>
+void CopyStateStrides(const StrideType *src, std::array<int64_t, RKDA_STATE_DIM_NUM> &dst, bool &hasStrides)
+{
+    if (src == nullptr || src->GetDimNum() != RKDA_STATE_DIM_NUM) {
+        return;
+    }
+    for (size_t i = 0; i < RKDA_STATE_DIM_NUM; ++i) {
+        dst[i] = src->GetStride(i);
+    }
+    hasStrides = true;
+}
 } // namespace
 
 RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
@@ -82,7 +99,15 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.gateShape = context_->GetInputShape(GATE_INDEX)->GetOriginShape();
     ctx.betaShape = context_->GetInputShape(BETA_INDEX)->GetOriginShape();
     ctx.stateShape = context_->GetInputShape(STATE_INDEX)->GetOriginShape();
-    ctx.cuSeqlensShape = context_->GetInputShape(CU_SEQLENS_INDEX)->GetOriginShape();
+    CopyStateStrides(context_->GetInputStride(STATE_INDEX), ctx.stateInStrides, ctx.hasStateInStrides);
+    const size_t stateOutputIndex = tilingData_.inplaceFinalState == 1 ?
+                                    INITIAL_STATE_OUTPUT_INDEX : FINAL_STATE_OUTPUT_INDEX;
+    CopyStateStrides(context_->GetOutputStride(stateOutputIndex), ctx.stateOutStrides, ctx.hasStateOutStrides);
+    if (!ctx.hasStateOutStrides && tilingData_.inplaceFinalState == 1 && ctx.hasStateInStrides) {
+        ctx.stateOutStrides = ctx.stateInStrides;
+        ctx.hasStateOutStrides = true;
+    }
+    CopyOptionalOriginShape(context_, CU_SEQLENS_INDEX, ctx.cuSeqlensShape);
     CopyOptionalOriginShape(context_, SSM_STATE_INDICES_INDEX, ctx.ssmStateShape);
     CopyOptionalOriginShape(context_, A_LOG_INDEX, ctx.aLogShape);
     CopyOptionalOriginShape(context_, DT_BIAS_INDEX, ctx.dtBiasShape);
@@ -90,9 +115,21 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.aivNum = compileInfo_.aivNum;
     ctx.ubSize = compileInfo_.ubSize;
     ctx.stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
+    ctx.gateDtype = context_->GetInputDesc(GATE_INDEX)->GetDataType();
+    ctx.betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
+    if (context_->GetOptionalInputDesc(CU_SEQLENS_INDEX) != nullptr) {
+        ctx.cuSeqlensDtype = context_->GetOptionalInputDesc(CU_SEQLENS_INDEX)->GetDataType();
+    }
+    if (context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX) != nullptr) {
+        ctx.ssmStateIndicesDtype = context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType();
+    }
+    if (context_->GetOptionalInputDesc(ACC_TOKEN_INDEX) != nullptr) {
+        ctx.acceptedTokensDtype = context_->GetOptionalInputDesc(ACC_TOKEN_INDEX)->GetDataType();
+    }
     ctx.scale = tilingData_.scale;
     ctx.lowerBound = tilingData_.lowerBound;
     ctx.layout = tilingData_.layout;
+    ctx.hasCuSeqlens = tilingData_.hasCuSeqlens;
     ctx.hasSsmStateIndices = tilingData_.hasSsmStateIndices;
     ctx.hasALog = tilingData_.hasALog;
     ctx.hasDtBias = tilingData_.hasDtBias;
@@ -103,6 +140,8 @@ RecurrentKdaTilingContext RecurrentKdaTiling::BuildProcessorContext() const
     ctx.allowNegEigval = tilingData_.allowNegEigval;
     ctx.safeGate = tilingData_.safeGate;
     ctx.stateVFirst = tilingData_.stateVFirst;
+    ctx.outputFinalState = tilingData_.outputFinalState;
+    ctx.inplaceFinalState = tilingData_.inplaceFinalState;
     return ctx;
 }
 
@@ -194,9 +233,7 @@ ge::graphStatus RecurrentKdaTiling::CheckContext()
     OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(BETA_INDEX));
     OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(STATE_INDEX));
     OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(STATE_INDEX));
-    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputShape(CU_SEQLENS_INDEX));
-    OP_CHECK_NULL_WITH_CONTEXT(context_, context_->GetInputDesc(CU_SEQLENS_INDEX));
-    return ge::GRAPH_SUCCESS;
+     return ge::GRAPH_SUCCESS;
 }
 
 ge::graphStatus RecurrentKdaTiling::AnalyzeDtype()
@@ -211,18 +248,23 @@ ge::graphStatus RecurrentKdaTiling::AnalyzeDtype()
     auto gateDtype = context_->GetInputDesc(GATE_INDEX)->GetDataType();
     auto betaDtype = context_->GetInputDesc(BETA_INDEX)->GetDataType();
     auto stateDtype = context_->GetInputDesc(STATE_INDEX)->GetDataType();
-    OP_CHECK_IF(gateDtype != ge::DT_FLOAT || betaDtype != ge::DT_FLOAT,
-                OP_LOGE(context_->GetNodeName(), "gate and beta dtype should be float32 after aclnn preprocessing"),
+    OP_CHECK_IF((gateDtype != ge::DT_FLOAT && gateDtype != ge::DT_BF16 && gateDtype != ge::DT_FLOAT16) ||
+                    (betaDtype != ge::DT_FLOAT && betaDtype != ge::DT_BF16 && betaDtype != ge::DT_FLOAT16),
+                OP_LOGE(context_->GetNodeName(), "gate and beta dtype should be float32, bfloat16 or float16"),
                 return ge::GRAPH_FAILED);
     OP_CHECK_IF(stateDtype != ge::DT_FLOAT && stateDtype != ge::DT_BF16,
                 OP_LOGE(context_->GetNodeName(), "initial_state dtype should be bfloat16 or float32"),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(context_->GetInputDesc(CU_SEQLENS_INDEX)->GetDataType() != ge::DT_INT64,
-                OP_LOGE(context_->GetNodeName(), "cu_seqlens dtype should be int64"),
-                return ge::GRAPH_FAILED);
+    if (context_->GetOptionalInputDesc(CU_SEQLENS_INDEX) != nullptr) {
+        auto dtype = context_->GetOptionalInputDesc(CU_SEQLENS_INDEX)->GetDataType();
+        OP_CHECK_IF(dtype != ge::DT_INT32 && dtype != ge::DT_INT64,
+                    OP_LOGE(context_->GetNodeName(), "cu_seqlens dtype should be int32 or int64"),
+                    return ge::GRAPH_FAILED);
+    }
     if (context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX) != nullptr) {
-        OP_CHECK_IF(context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType() != ge::DT_INT64,
-                    OP_LOGE(context_->GetNodeName(), "ssm_state_indices dtype should be int64"),
+        auto dtype = context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX)->GetDataType();
+        OP_CHECK_IF(dtype != ge::DT_INT32 && dtype != ge::DT_INT64,
+                    OP_LOGE(context_->GetNodeName(), "ssm_state_indices dtype should be int32 or int64"),
                     return ge::GRAPH_FAILED);
     }
     if (context_->GetOptionalInputDesc(A_LOG_INDEX) != nullptr) {
@@ -236,8 +278,9 @@ ge::graphStatus RecurrentKdaTiling::AnalyzeDtype()
                     return ge::GRAPH_FAILED);
     }
     if (context_->GetOptionalInputDesc(ACC_TOKEN_INDEX) != nullptr) {
-        OP_CHECK_IF(context_->GetOptionalInputDesc(ACC_TOKEN_INDEX)->GetDataType() != ge::DT_INT64,
-                    OP_LOGE(context_->GetNodeName(), "num_accepted_tokens dtype should be int64"),
+        auto dtype = context_->GetOptionalInputDesc(ACC_TOKEN_INDEX)->GetDataType();
+        OP_CHECK_IF(dtype != ge::DT_INT32 && dtype != ge::DT_INT64,
+                    OP_LOGE(context_->GetNodeName(), "num_accepted_tokens dtype should be int32 or int64"),
                     return ge::GRAPH_FAILED);
     }
     return ge::GRAPH_SUCCESS;
@@ -265,12 +308,12 @@ ge::graphStatus RecurrentKdaTiling::AnalyzeFormat()
         !CheckFormat(context_->GetInputDesc(VALUE_INDEX)->GetStorageFormat(), "value") ||
         !CheckFormat(context_->GetInputDesc(GATE_INDEX)->GetStorageFormat(), "gate") ||
         !CheckFormat(context_->GetInputDesc(BETA_INDEX)->GetStorageFormat(), "beta") ||
-        !CheckFormat(context_->GetInputDesc(STATE_INDEX)->GetStorageFormat(), "initial_state") ||
-        !CheckFormat(context_->GetInputDesc(CU_SEQLENS_INDEX)->GetStorageFormat(), "cu_seqlens")) {
+        !CheckFormat(context_->GetInputDesc(STATE_INDEX)->GetStorageFormat(), "initial_state")) {
         return ge::GRAPH_FAILED;
     }
 
-    const std::array<std::pair<size_t, const char *>, 4> optionalInputs = {{
+    const std::array<std::pair<size_t, const char *>, 5> optionalInputs = {{
+        {CU_SEQLENS_INDEX, "cu_seqlens"},
         {SSM_STATE_INDICES_INDEX, "ssm_state_indices"},
         {A_LOG_INDEX, "A_log"},
         {DT_BIAS_INDEX, "dt_bias"},
@@ -299,6 +342,8 @@ ge::graphStatus RecurrentKdaTiling::GetAttrsInfo()
         return ge::GRAPH_FAILED;
     }
     tilingData_.scale = *attrs->GetAttrPointer<float>(ATTR_SCALE_INDEX);
+    tilingData_.outputFinalState = *attrs->GetAttrPointer<bool>(ATTR_OUTPUT_FINAL_STATE_INDEX) ? 1 : 0;
+    tilingData_.inplaceFinalState = *attrs->GetAttrPointer<bool>(ATTR_INPLACE_FINAL_STATE_INDEX) ? 1 : 0;
     tilingData_.useQkL2norm = *attrs->GetAttrPointer<bool>(ATTR_USE_QK_L2NORM_INDEX) ? 1 : 0;
     tilingData_.useGateInKernel = *attrs->GetAttrPointer<bool>(ATTR_USE_GATE_INDEX) ? 1 : 0;
     tilingData_.useBetaSigmoid = *attrs->GetAttrPointer<bool>(ATTR_USE_BETA_SIGMOID_INDEX) ? 1 : 0;
@@ -311,6 +356,7 @@ ge::graphStatus RecurrentKdaTiling::GetAttrsInfo()
 
 ge::graphStatus RecurrentKdaTiling::GetOptionalInput()
 {
+    tilingData_.hasCuSeqlens = (context_->GetOptionalInputDesc(CU_SEQLENS_INDEX) == nullptr) ? 0 : 1;
     tilingData_.hasSsmStateIndices = (context_->GetOptionalInputDesc(SSM_STATE_INDICES_INDEX) == nullptr) ? 0 : 1;
     tilingData_.hasALog = (context_->GetOptionalInputDesc(A_LOG_INDEX) == nullptr) ? 0 : 1;
     tilingData_.hasDtBias = (context_->GetOptionalInputDesc(DT_BIAS_INDEX) == nullptr) ? 0 : 1;
@@ -338,6 +384,7 @@ void RecurrentKdaTiling::PrintTilingData()
     OP_LOGD(context_->GetNodeName(), "scale: [%f]", tilingData_.scale);
     OP_LOGD(context_->GetNodeName(), "lowerBound: [%f]", tilingData_.lowerBound);
     OP_LOGD(context_->GetNodeName(), "layout: [%u]", tilingData_.layout);
+    OP_LOGD(context_->GetNodeName(), "hasCuSeqlens: [%u]", tilingData_.hasCuSeqlens);
     OP_LOGD(context_->GetNodeName(), "hasSsmStateIndices: [%u]", tilingData_.hasSsmStateIndices);
     OP_LOGD(context_->GetNodeName(), "hasALog: [%u]", tilingData_.hasALog);
     OP_LOGD(context_->GetNodeName(), "hasDtBias: [%u]", tilingData_.hasDtBias);
@@ -348,6 +395,13 @@ void RecurrentKdaTiling::PrintTilingData()
     OP_LOGD(context_->GetNodeName(), "allowNegEigval: [%u]", tilingData_.allowNegEigval);
     OP_LOGD(context_->GetNodeName(), "safeGate: [%u]", tilingData_.safeGate);
     OP_LOGD(context_->GetNodeName(), "stateVFirst: [%u]", tilingData_.stateVFirst);
+    OP_LOGD(context_->GetNodeName(), "outputFinalState: [%u]", tilingData_.outputFinalState);
+    OP_LOGD(context_->GetNodeName(), "inplaceFinalState: [%u]", tilingData_.inplaceFinalState);
+    OP_LOGD(context_->GetNodeName(), "gateDtype: [%u]", tilingData_.gateDtype);
+    OP_LOGD(context_->GetNodeName(), "betaDtype: [%u]", tilingData_.betaDtype);
+    OP_LOGD(context_->GetNodeName(), "cuSeqlensDtype: [%u]", tilingData_.cuSeqlensDtype);
+    OP_LOGD(context_->GetNodeName(), "ssmStateIndicesDtype: [%u]", tilingData_.ssmStateIndicesDtype);
+    OP_LOGD(context_->GetNodeName(), "acceptedTokensDtype: [%u]", tilingData_.acceptedTokensDtype);
 }
 
 ge::graphStatus RecurrentKdaTiling::CalUbSize()

--- a/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
+++ b/csrc/attention/recurrent_kda/op_host/recurrent_kda_tiling_processor.h
@@ -62,6 +62,7 @@ struct RecurrentKdaTilingContext {
     float scale = 1.0f;
     float lowerBound = -5.0f;
     uint32_t layout = RKDA_LAYOUT_BSND;
+    uint32_t hasCuSeqlens = 0;
     uint32_t hasSsmStateIndices = 0;
     uint32_t hasALog = 0;
     uint32_t hasDtBias = 0;
@@ -71,8 +72,19 @@ struct RecurrentKdaTilingContext {
     uint32_t useBetaSigmoid = 0;
     uint32_t allowNegEigval = 0;
     uint32_t safeGate = 0;
-    uint32_t stateVFirst = 1;
+    uint32_t stateVFirst = 0;
+    uint32_t outputFinalState = 0;
+    uint32_t inplaceFinalState = 1;
     ge::DataType stateDtype = ge::DT_BF16;
+    ge::DataType gateDtype = ge::DT_FLOAT;
+    ge::DataType betaDtype = ge::DT_FLOAT;
+    ge::DataType cuSeqlensDtype = ge::DT_INT64;
+    ge::DataType ssmStateIndicesDtype = ge::DT_INT64;
+    ge::DataType acceptedTokensDtype = ge::DT_INT64;
+    std::array<int64_t, RKDA_STATE_DIM_NUM> stateInStrides = {};
+    std::array<int64_t, RKDA_STATE_DIM_NUM> stateOutStrides = {};
+    bool hasStateInStrides = false;
+    bool hasStateOutStrides = false;
     uint64_t aivNum = 0;
     uint64_t ubSize = 0;
 };
@@ -146,6 +158,63 @@ private:
 
     RecurrentKdaTilingContext ctx_;
 
+    std::array<int64_t, RKDA_STATE_DIM_NUM> ResolveStateStrides(bool output) const
+    {
+        const bool hasStrides = output ? ctx_.hasStateOutStrides : ctx_.hasStateInStrides;
+        if (hasStrides) {
+            return output ? ctx_.stateOutStrides : ctx_.stateInStrides;
+        }
+        const auto &shape = ctx_.stateShape;
+        std::array<int64_t, RKDA_STATE_DIM_NUM> strides = {};
+        strides[RKDA_DIM_3] = 1;
+        strides[RKDA_DIM_2] = shape.GetDim(RKDA_DIM_3);
+        strides[RKDA_DIM_1] = shape.GetDim(RKDA_DIM_2) * strides[RKDA_DIM_2];
+        strides[RKDA_DIM_0] = shape.GetDim(RKDA_DIM_1) * strides[RKDA_DIM_1];
+        return strides;
+    }
+
+    ge::graphStatus ValidateStateStrides(
+        const std::array<int64_t, RKDA_STATE_DIM_NUM> &strides, const char *name) const
+    {
+        for (size_t i = 0; i < RKDA_STATE_DIM_NUM; ++i) {
+            OP_CHECK_IF(strides[i] <= 0,
+                        OP_LOGE(ctx_.nodeName, "%s stride[%zu] must be positive, but it is %ld.",
+                                name, i, strides[i]),
+                        return ge::GRAPH_FAILED);
+        }
+        const auto &shape = ctx_.stateShape;
+        const int64_t denseRow = shape.GetDim(RKDA_DIM_3);
+        const int64_t densePlane = shape.GetDim(RKDA_DIM_2) * denseRow;
+        OP_CHECK_IF(strides[RKDA_DIM_3] != 1 || strides[RKDA_DIM_2] != denseRow,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s must keep its inner state matrix dense: stride[3]=1 and stride[2]=%ld, "
+                            "but got [%ld, %ld, %ld, %ld].",
+                            name, denseRow, strides[RKDA_DIM_0], strides[RKDA_DIM_1],
+                            strides[RKDA_DIM_2], strides[RKDA_DIM_3]),
+                    return ge::GRAPH_FAILED);
+        const int64_t minSlotStride =
+            (shape.GetDim(RKDA_DIM_1) - 1) * strides[RKDA_DIM_1] + densePlane;
+        OP_CHECK_IF(strides[RKDA_DIM_1] < densePlane ||
+                        strides[RKDA_DIM_0] < minSlotStride,
+                    OP_LOGE(ctx_.nodeName,
+                            "%s outer strides overlap state rows or heads: [%ld, %ld, %ld, %ld].",
+                            name, strides[RKDA_DIM_0], strides[RKDA_DIM_1],
+                            strides[RKDA_DIM_2], strides[RKDA_DIM_3]),
+                    return ge::GRAPH_FAILED);
+        return ge::GRAPH_SUCCESS;
+    }
+
+    ge::graphStatus CheckStateStrides() const
+    {
+        if (ValidateStateStrides(ResolveStateStrides(false), "initial_state") != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+        if (ValidateStateStrides(ResolveStateStrides(true), "state output") != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
+        return ge::GRAPH_SUCCESS;
+    }
+
     bool CheckDim(const gert::Shape &shape, const size_t dim, const std::string &dimDesc) const
     {
         if (shape.GetDimNum() != dim) {
@@ -168,23 +237,28 @@ private:
         return true;
     }
 
-    int64_t SeqNum(const gert::Shape &cuSeqlensShape) const
+    int64_t SeqNum(const gert::Shape &queryShape, const gert::Shape &cuSeqlensShape) const
     {
-        return cuSeqlensShape.GetDim(RKDA_DIM_0) - 1;
+        if (ctx_.hasCuSeqlens) {
+            return cuSeqlensShape.GetDim(RKDA_DIM_0) - 1;
+        }
+        return ctx_.layout == RKDA_LAYOUT_BSND ? queryShape.GetDim(RKDA_DIM_0) : 1;
     }
 
     ge::graphStatus CheckMetadataShapes(const gert::Shape &queryShape, const gert::Shape &cuSeqlensShape) const
     {
-        if (!CheckDim(cuSeqlensShape, RKDA_METADATA_RANK1, "cu_seqlens")) {
-            return ge::GRAPH_FAILED;
+        if (ctx_.hasCuSeqlens) {
+            if (!CheckDim(cuSeqlensShape, RKDA_METADATA_RANK1, "cu_seqlens")) {
+                return ge::GRAPH_FAILED;
+            }
+            OP_CHECK_IF(cuSeqlensShape.GetDim(RKDA_DIM_0) < 2,
+                        OP_LOGE(ctx_.nodeName, "cu_seqlens must contain at least 2 elements."),
+                        return ge::GRAPH_FAILED);
         }
-        OP_CHECK_IF(cuSeqlensShape.GetDim(RKDA_DIM_0) < 2,
-                    OP_LOGE(ctx_.nodeName, "cu_seqlens must contain at least 2 elements."),
-                    return ge::GRAPH_FAILED);
         int64_t totalTokens =
             (ctx_.layout == RKDA_LAYOUT_TND) ? queryShape.GetDim(RKDA_DIM_0) :
             queryShape.GetDim(RKDA_DIM_0) * queryShape.GetDim(RKDA_DIM_1);
-        int64_t seqNum = cuSeqlensShape.GetDim(RKDA_DIM_0) - 1;
+        int64_t seqNum = SeqNum(queryShape, cuSeqlensShape);
 
         if (ctx_.hasSsmStateIndices) {
             size_t rank = ctx_.ssmStateShape.GetDimNum();
@@ -315,19 +389,22 @@ private:
         if (!CheckDim(stateShape, RKDA_STATE_DIM_NUM, "initial_state")) {
             return ge::GRAPH_FAILED;
         }
-        OP_CHECK_IF(!ctx_.stateVFirst,
-                    OP_LOGE(ctx_.nodeName, "state_v_first=false is not supported by RecurrentKda."),
-                    return ge::GRAPH_FAILED);
-        int64_t seqNum = SeqNum(cuSeqlensShape);
+        int64_t seqNum = SeqNum(queryShape, cuSeqlensShape);
+        bool stateTailMatches = ctx_.stateVFirst ?
+            (stateShape.GetDim(RKDA_DIM_2) == vDim && stateShape.GetDim(RKDA_DIM_3) == kDim) :
+            (stateShape.GetDim(RKDA_DIM_2) == kDim && stateShape.GetDim(RKDA_DIM_3) == vDim);
         OP_CHECK_IF(stateShape.GetDim(RKDA_DIM_0) <= 0 ||
                         (!ctx_.hasSsmStateIndices && stateShape.GetDim(RKDA_DIM_0) != seqNum) ||
-                        stateShape.GetDim(RKDA_DIM_1) != hvNum ||
-                        stateShape.GetDim(RKDA_DIM_2) != vDim ||
-                        stateShape.GetDim(RKDA_DIM_3) != kDim,
+                        stateShape.GetDim(RKDA_DIM_1) != hvNum || !stateTailMatches,
                     OP_LOGE(ctx_.nodeName,
-                            "state must be [state_capacity, HV, V, K]; without ssm_state_indices, "
+                            "state must be [state_capacity, HV, V, K] when state_v_first=true or "
+                            "[state_capacity, HV, K, V] otherwise; without ssm_state_indices, "
                             "state_capacity must equal seq_num."),
                     return ge::GRAPH_FAILED);
+
+        if (CheckStateStrides() != ge::GRAPH_SUCCESS) {
+            return ge::GRAPH_FAILED;
+        }
 
         if (CheckMetadataShapes(queryShape, cuSeqlensShape) != ge::GRAPH_SUCCESS ||
             CheckOptionalGateShapes(hvNum, kDim) != ge::GRAPH_SUCCESS) {
@@ -347,7 +424,7 @@ private:
             tiling.dk = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_2));
             tiling.nv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_1));
             tiling.dv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_2));
-            tiling.b = static_cast<uint32_t>(cuSeqlensShape.GetDim(RKDA_DIM_0) - 1);
+            tiling.b = static_cast<uint32_t>(SeqNum(queryShape, cuSeqlensShape));
         } else {
             tiling.seqLen = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_1));
             tiling.t = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_0) * queryShape.GetDim(RKDA_DIM_1));
@@ -355,14 +432,25 @@ private:
             tiling.dk = static_cast<uint32_t>(queryShape.GetDim(RKDA_DIM_3));
             tiling.nv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_2));
             tiling.dv = static_cast<uint32_t>(valueShape.GetDim(RKDA_DIM_3));
-            tiling.b = static_cast<uint32_t>(cuSeqlensShape.GetDim(RKDA_DIM_0) - 1);
+            tiling.b = static_cast<uint32_t>(SeqNum(queryShape, cuSeqlensShape));
         }
         tiling.sBlockNum = static_cast<uint32_t>(stateShape.GetDim(RKDA_DIM_0));
         tiling.ssmStateStride = (ctx_.hasSsmStateIndices && ctx_.ssmStateShape.GetDimNum() == RKDA_METADATA_RANK2) ?
                                 static_cast<uint32_t>(ctx_.ssmStateShape.GetDim(RKDA_DIM_1)) : 0;
+        const auto stateInStrides = ResolveStateStrides(false);
+        const auto stateOutStrides = ResolveStateStrides(true);
+        tiling.stateInStride0 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_0]);
+        tiling.stateInStride1 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_1]);
+        tiling.stateInStride2 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_2]);
+        tiling.stateInStride3 = static_cast<uint64_t>(stateInStrides[RKDA_DIM_3]);
+        tiling.stateOutStride0 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_0]);
+        tiling.stateOutStride1 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_1]);
+        tiling.stateOutStride2 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_2]);
+        tiling.stateOutStride3 = static_cast<uint64_t>(stateOutStrides[RKDA_DIM_3]);
         tiling.scale = ctx_.scale;
         tiling.lowerBound = ctx_.lowerBound;
         tiling.layout = ctx_.layout;
+        tiling.hasCuSeqlens = ctx_.hasCuSeqlens;
         tiling.hasSsmStateIndices = ctx_.hasSsmStateIndices;
         tiling.hasALog = ctx_.hasALog;
         tiling.hasDtBias = ctx_.hasDtBias;
@@ -373,6 +461,13 @@ private:
         tiling.allowNegEigval = ctx_.allowNegEigval;
         tiling.safeGate = ctx_.safeGate;
         tiling.stateVFirst = ctx_.stateVFirst;
+        tiling.outputFinalState = ctx_.outputFinalState;
+        tiling.inplaceFinalState = ctx_.inplaceFinalState;
+        tiling.gateDtype = ctx_.gateDtype == ge::DT_FLOAT ? 0 : (ctx_.gateDtype == ge::DT_BF16 ? 1 : 2);
+        tiling.betaDtype = ctx_.betaDtype == ge::DT_FLOAT ? 0 : (ctx_.betaDtype == ge::DT_BF16 ? 1 : 2);
+        tiling.cuSeqlensDtype = ctx_.cuSeqlensDtype == ge::DT_INT32 ? 0 : 1;
+        tiling.ssmStateIndicesDtype = ctx_.ssmStateIndicesDtype == ge::DT_INT32 ? 0 : 1;
+        tiling.acceptedTokensDtype = ctx_.acceptedTokensDtype == ge::DT_INT32 ? 0 : 1;
     }
 
     ge::graphStatus CheckShapeValueRangeAndRule(const RecurrentKdaTilingData &tiling) const
@@ -446,7 +541,7 @@ private:
     int64_t CalcWorkingUbBytes(int64_t aNv, int64_t aDv, int64_t aDk) const
     {
         int64_t usedUbBytes = CalcFixedUbBytes(aNv, aDv, aDk);
-        usedUbBytes += RKDA_MAX_MTP * (4 * aDv + 8 * aDk + 4 * aNv);
+        usedUbBytes += RKDA_MAX_MTP * (4 * aDv + 12 * aDk + 4 * aNv);
         return usedUbBytes;
     }
 

--- a/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/arch35/recurrent_kda.h
@@ -60,14 +60,24 @@ public:
     {
         B_ = tilingData->b;
         T_ = tilingData->t;
+        seqLen_ = tilingData->seqLen;
         NK_ = tilingData->nk;
         realK_ = tilingData->dk;
         NV_ = tilingData->nv;
         realV_ = tilingData->dv;
         stateCapacity_ = tilingData->sBlockNum;
         ssmStateStride_ = tilingData->ssmStateStride;
+        stateInStride0_ = tilingData->stateInStride0;
+        stateInStride1_ = tilingData->stateInStride1;
+        stateInStride2_ = tilingData->stateInStride2;
+        stateInStride3_ = tilingData->stateInStride3;
+        stateOutStride0_ = tilingData->stateOutStride0;
+        stateOutStride1_ = tilingData->stateOutStride1;
+        stateOutStride2_ = tilingData->stateOutStride2;
+        stateOutStride3_ = tilingData->stateOutStride3;
         scale_ = tilingData->scale;
         lowerBound_ = tilingData->lowerBound;
+        hasCuSeqlens_ = (tilingData->hasCuSeqlens == 1);
         hasSsmStateIndices_ = (tilingData->hasSsmStateIndices == 1);
         hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
         hasALog_ = (tilingData->hasALog == 1);
@@ -77,6 +87,13 @@ public:
         useBetaSigmoid_ = (tilingData->useBetaSigmoid == 1);
         allowNegEigval_ = (tilingData->allowNegEigval == 1);
         safeGate_ = (tilingData->safeGate == 1);
+        stateVFirst_ = (tilingData->stateVFirst == 1);
+        shouldStoreState_ = (tilingData->inplaceFinalState == 1 || tilingData->outputFinalState == 1);
+        gateDtype_ = tilingData->gateDtype;
+        betaDtype_ = tilingData->betaDtype;
+        cuSeqlensDtype_ = tilingData->cuSeqlensDtype;
+        ssmStateIndicesDtype_ = tilingData->ssmStateIndicesDtype;
+        acceptedTokensDtype_ = tilingData->acceptedTokensDtype;
         useAddFoldReduce_ = (RKDA_ENABLE_ADD_FOLD_REDUCE != 0);
         vStep_ = tilingData->vStep;
         stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
@@ -106,14 +123,21 @@ public:
         queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
         keyGm_.SetGlobalBuffer((__gm__ inType *)initParams.key);
         valueGm_.SetGlobalBuffer((__gm__ inType *)initParams.value);
-        gateGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
-        betaGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        gateFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
+        gateBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.gate);
+        gateFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.gate);
+        betaFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        betaBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.beta);
+        betaFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.beta);
         initStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.initState);
-        cuSeqlensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
-        ssmStateIndicesGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
+        cuSeqlensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.cuSeqlens);
+        cuSeqlensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
+        ssmStateIndicesInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.ssmStateIndices);
+        ssmStateIndicesInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
         aLogGm_.SetGlobalBuffer((__gm__ float *)initParams.aLog);
         dtBiasGm_.SetGlobalBuffer((__gm__ float *)initParams.dtBias);
-        numAcceptedTokensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
         finalStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.finalState);
         attnOutGm_.SetGlobalBuffer((__gm__ outType *)initParams.attnOut);
     }
@@ -153,6 +177,8 @@ public:
         broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
         buffOffset += cubeSize;
         betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaUbSize / sizeof(float)), buffOffset);
+        buffOffset += betaUbSize;
+        gateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
     }
 
     __aicore__ inline void SyncMte2ToV()
@@ -207,9 +233,13 @@ public:
             ReleaseEvents();
             return;
         }
-        for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
-            int64_t seq0 = cuSeqlensGm_.GetValue(batch_i);
-            int64_t seq1 = cuSeqlensGm_.GetValue(batch_i + 1);
+        uint64_t vectorCoreNum = GetBlockNum();
+        uint64_t taskNum = B_ * NV_;
+        for (uint64_t taskIdx = blockIdx; taskIdx < taskNum; taskIdx += vectorCoreNum) {
+            uint64_t batch_i = taskIdx / NV_;
+            uint64_t head_i = taskIdx % NV_;
+            int64_t seq0 = SequenceStart(batch_i);
+            int64_t seq1 = SequenceEnd(batch_i);
             int64_t seqLen64 = seq1 - seq0;
             if (seqLen64 == 0) {
                 continue;
@@ -220,23 +250,13 @@ public:
                 return;
             }
 
-            uint32_t copyFlag = 0;
-            uint64_t stateSlot = batch_i;
-            for (uint64_t head_i = 0; head_i < NV_; head_i++) {
-                if (!IsCurrentTask(batch_i, head_i)) {
-                    continue;
-                }
-                copyFlag++;
-                if (copyFlag == 1) {
-                    stateSlot = ResolveInitialStateSlot(batch_i, seq0, seqLen);
-                    if (stateSlot == INVALID_STATE_SLOT) {
-                        ReleaseEvents();
-                        return;
-                    }
-                    CopyInBeta(seq0, seq1);
-                }
-                ProcessHead(batch_i, seq0, seq1, head_i, stateSlot);
+            uint64_t stateSlot = ResolveInitialStateSlot(batch_i, seq0, seqLen);
+            if (stateSlot == INVALID_STATE_SLOT) {
+                ReleaseEvents();
+                return;
             }
+            CopyInBeta(seq0, seq1);
+            ProcessHead(batch_i, seq0, seq1, head_i, stateSlot);
         }
         ReleaseEvents();
     }
@@ -244,12 +264,15 @@ public:
 private:
     __aicore__ inline bool ValidateCuSeqlens() const
     {
-        int64_t seq0 = cuSeqlensGm_.GetValue(0);
+        if (!hasCuSeqlens_) {
+            return seqLen_ <= MAX_MTP;
+        }
+        int64_t seq0 = LoadCuSeqlens(0);
         if (seq0 != 0) {
             return false;
         }
         for (uint64_t i = 0; i < B_; i++) {
-            int64_t seq1 = cuSeqlensGm_.GetValue(i + 1);
+            int64_t seq1 = LoadCuSeqlens(i + 1);
             int64_t length = seq1 - seq0;
             if (seq1 < seq0 || seq1 > static_cast<int64_t>(T_) ||
                 length > static_cast<int64_t>(MAX_MTP) ||
@@ -259,6 +282,35 @@ private:
             seq0 = seq1;
         }
         return seq0 <= static_cast<int64_t>(T_);
+    }
+
+    __aicore__ inline int64_t LoadCuSeqlens(uint64_t index) const
+    {
+        return cuSeqlensDtype_ == 0 ? static_cast<int64_t>(cuSeqlensInt32Gm_.GetValue(index)) :
+                                     cuSeqlensInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t SequenceStart(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx) : static_cast<int64_t>(batchIdx * seqLen_);
+    }
+
+    __aicore__ inline int64_t SequenceEnd(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx + 1) :
+                               static_cast<int64_t>((batchIdx + 1) * seqLen_);
+    }
+
+    __aicore__ inline int64_t LoadSsmStateIndex(uint64_t index) const
+    {
+        return ssmStateIndicesDtype_ == 0 ? static_cast<int64_t>(ssmStateIndicesInt32Gm_.GetValue(index)) :
+                                           ssmStateIndicesInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t LoadAcceptedTokens(uint64_t index) const
+    {
+        return acceptedTokensDtype_ == 0 ? static_cast<int64_t>(numAcceptedTokensInt32Gm_.GetValue(index)) :
+                                          numAcceptedTokensInt64Gm_.GetValue(index);
     }
 
     __aicore__ inline uint64_t StateMetadataOffset(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -271,7 +323,7 @@ private:
 
     __aicore__ inline uint64_t LoadStateSlot(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
     {
-        int64_t stateSlot = ssmStateIndicesGm_.GetValue(StateMetadataOffset(batchIdx, seq0, tokenIdx));
+        int64_t stateSlot = LoadSsmStateIndex(StateMetadataOffset(batchIdx, seq0, tokenIdx));
         if (stateSlot < 0 || stateSlot >= static_cast<int64_t>(stateCapacity_)) {
             return INVALID_STATE_SLOT;
         }
@@ -284,7 +336,7 @@ private:
             return batchIdx < stateCapacity_;
         }
         if (hasAcceptedTokens_) {
-            int64_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batchIdx);
+            int64_t acceptedTokenNum = LoadAcceptedTokens(batchIdx);
             if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
                 return false;
             }
@@ -304,15 +356,16 @@ private:
         }
         int64_t tokenIdx = seq0;
         if (hasAcceptedTokens_) {
-            tokenIdx = seq0 + numAcceptedTokensGm_.GetValue(batchIdx) - 1;
+            tokenIdx = seq0 + LoadAcceptedTokens(batchIdx) - 1;
         }
         return LoadStateSlot(batchIdx, seq0, tokenIdx);
     }
 
-    __aicore__ inline void CopyFloatVectorIn(LocalTensor<float> &dst, GlobalTensor<float> &src, uint64_t offset,
-                                             uint64_t count)
+    template <typename dataType>
+    __aicore__ inline void CopyVectorIn(LocalTensor<dataType> &dst, GlobalTensor<dataType> &src, uint64_t offset,
+                                        uint64_t count)
     {
-        uint64_t rowBytes = count * sizeof(float);
+        uint64_t rowBytes = count * sizeof(dataType);
         if (rowBytes >= 32 && rowBytes % 32 == 0) {
             DataCopy(dst, src[offset], static_cast<uint32_t>(count));
         } else {
@@ -379,7 +432,7 @@ private:
         float expA = hasALog_ ? ExpScalar(ReadFloat(aLogGm_, head)) : 1.0f;
 
         if (hasDtBias_) {
-            CopyFloatVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
+            CopyVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
             SyncMte2ToV();
             for (int32_t row = 0; row < seqLen; ++row) {
                 Add(gateInUb[row * alignK_], gateInUb[row * alignK_], broadTmpInUb, alignK_);
@@ -414,39 +467,67 @@ private:
         }
     }
 
+    template <typename gateType>
+    __aicore__ inline void CopyInGate(uint64_t gateOffset, int32_t seqLen)
+    {
+        LocalTensor<gateType> gateLocal = gateInQueue_.AllocTensor<gateType>();
+        Duplicate<gateType>(gateLocal, static_cast<gateType>(0), alignK_ * static_cast<uint32_t>(seqLen));
+        SyncVToMte2();
+        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen),
+                                       static_cast<uint32_t>(realK_ * sizeof(gateType)),
+                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(gateType)), 0, 0};
+        DataCopyPadExtParams<gateType> gatePadParams{
+            true, 0, static_cast<uint8_t>(alignK_ - realK_), static_cast<gateType>(0)};
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            DataCopyPad(gateLocal, gateFloatGm_[gateOffset], gateInParams, gatePadParams);
+        } else if constexpr (std::is_same<gateType, bfloat16_t>()) {
+            DataCopyPad(gateLocal, gateBf16Gm_[gateOffset], gateInParams, gatePadParams);
+        } else {
+            DataCopyPad(gateLocal, gateFp16Gm_[gateOffset], gateInParams, gatePadParams);
+        }
+        gateInQueue_.EnQue<gateType>(gateLocal);
+        gateLocal = gateInQueue_.DeQue<gateType>();
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            Adds(gateInUb, gateLocal, 0.0f, alignK_ * static_cast<uint32_t>(seqLen));
+        } else {
+            Cast(gateInUb, gateLocal, AscendC::RoundMode::CAST_NONE,
+                 alignK_ * static_cast<uint32_t>(seqLen));
+        }
+        gateInQueue_.FreeTensor(gateLocal);
+        PipeBarrier<PIPE_V>();
+    }
+
     __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
                                          uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
-        LocalTensor<float> gateLocal = gateInQueue_.AllocTensor<float>();
-        Duplicate<float>(gateLocal, 0, alignK_ * static_cast<uint32_t>(seqLen));
-        SyncVToMte2();
 
         DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
                                      static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
                                     static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
-        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
-                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
-        DataCopyPadExtParams<float> gatePadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
 
         DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
-        DataCopyPad(gateLocal, gateGm_[gateOffset], gateInParams, gatePadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
         vInQueue_.EnQue<inType>(vLocal);
-        gateInQueue_.EnQue<float>(gateLocal);
+        if (gateDtype_ == 0) {
+            CopyInGate<float>(gateOffset, seqLen);
+        } else if (gateDtype_ == 1) {
+            CopyInGate<bfloat16_t>(gateOffset, seqLen);
+        } else {
+            CopyInGate<half>(gateOffset, seqLen);
+        }
 
         qLocal = qInQueue_.DeQue<inType>();
         kLocal = kInQueue_.DeQue<inType>();
         vLocal = vInQueue_.DeQue<inType>();
-        gateInUb = gateInQueue_.DeQue<float>();
         Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
@@ -468,13 +549,27 @@ private:
         vInQueue_.FreeTensor(vLocal);
     }
 
-    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
+    __aicore__ inline void PrefetchState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                          uint32_t curSingleV)
     {
         LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
-        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
-                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
-        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
-        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateInStride0_ * stateSlot + stateInStride1_ * head + stateInStride2_ * vOffset;
+            DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
+                                            static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+            DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+            DataCopyPad(stateLocal, initStateGm_[stateOffset], stateInParams, padParams);
+        } else {
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateInStride0_ * stateSlot + stateInStride1_ * head +
+                                           stateInStride2_ * k +
+                                           stateInStride3_ * (vOffset + v);
+                    stateLocal.SetValue(v * alignK_ + k, initStateGm_.GetValue(stateOffset));
+                }
+            }
+        }
         stateInQueue_.EnQue<stateType>(stateLocal);
     }
 
@@ -645,14 +740,16 @@ private:
         ProcessKQ(deltaInUb, kInUb[curQKOffset], stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV);
         AscendC::PipeBarrier<PIPE_V>();
         ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
-        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
         LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
-        if constexpr (std::is_same<stateType, float32_t>()) {
-            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
-        } else {
-            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+        if (shouldStoreState_) {
+            LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+            if constexpr (std::is_same<stateType, float32_t>()) {
+                DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+            } else {
+                Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+            }
+            stateOutQueue_.EnQue<stateType>(stateOutLocal);
         }
-        stateOutQueue_.EnQue<stateType>(stateOutLocal);
         Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
         attnOutQueue_.EnQue<outType>(attnOutLocal);
     }
@@ -665,30 +762,65 @@ private:
         attnOutQueue_.FreeTensor(attnLocal);
     }
 
-    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
+    __aicore__ inline void CopyOutState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                         uint32_t curSingleV)
     {
         LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
-        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
-                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
-        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateOutStride0_ * stateSlot + stateOutStride1_ * head + stateOutStride2_ * vOffset;
+            DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
+                                          static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+            DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        } else {
+            SyncVToS();
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateOutStride0_ * stateSlot + stateOutStride1_ * head +
+                                           stateOutStride2_ * k +
+                                           stateOutStride3_ * (vOffset + v);
+                    finalStateGm_.SetValue(stateOffset, stateOutLocal.GetValue(v * alignK_ + k));
+                }
+            }
+        }
         stateOutQueue_.FreeTensor(stateOutLocal);
+    }
+
+    template <typename betaType>
+    __aicore__ inline void CopyInBetaTyped(int64_t seq0, int64_t seq1)
+    {
+        int64_t seqLen = seq1 - seq0;
+        uint64_t betaCount = static_cast<uint64_t>(seqLen) * NV_;
+        uint64_t betaBatchSize = Ceil(betaCount, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
+        LocalTensor<betaType> betaLocal = betaInQueue_.AllocTensor<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            CopyVectorIn(betaLocal, betaFloatGm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else if constexpr (std::is_same<betaType, bfloat16_t>()) {
+            CopyVectorIn(betaLocal, betaBf16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else {
+            CopyVectorIn(betaLocal, betaFp16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        }
+        betaInQueue_.EnQue<betaType>(betaLocal);
+        betaLocal = betaInQueue_.DeQue<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            Adds(betaInUb, betaLocal, 0.0f, static_cast<uint32_t>(betaBatchSize));
+        } else {
+            Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, static_cast<uint32_t>(betaBatchSize));
+        }
+        betaInQueue_.FreeTensor(betaLocal);
+        PipeBarrier<PIPE_V>();
+        SyncVToS();
     }
 
     __aicore__ inline void CopyInBeta(int64_t seq0, int64_t seq1)
     {
-        int64_t seqLen = seq1 - seq0;
-        uint64_t betaBatchSize = Ceil(static_cast<uint64_t>(seqLen) * NV_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
-        LocalTensor<float> betaLocal = betaInQueue_.AllocTensor<float>();
-        CopyFloatVectorIn(betaLocal, betaGm_, static_cast<uint64_t>(seq0) * NV_,
-                          static_cast<uint64_t>(seqLen) * NV_);
-        betaInQueue_.EnQue<float>(betaLocal);
-        betaLocal = betaInQueue_.DeQue<float>();
-        DataCopy(betaInUb, betaLocal, betaBatchSize);
-        SyncMte2ToV();
-        betaInQueue_.FreeTensor(betaLocal);
-        Adds(betaInUb, betaInUb, 0.0f, betaBatchSize);
-        PipeBarrier<PIPE_V>();
-        SyncVToS();
+        if (betaDtype_ == 0) {
+            CopyInBetaTyped<float>(seq0, seq1);
+        } else if (betaDtype_ == 1) {
+            CopyInBetaTyped<bfloat16_t>(seq0, seq1);
+        } else {
+            CopyInBetaTyped<half>(seq0, seq1);
+        }
     }
 
     __aicore__ inline uint64_t StateSlotForToken(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -719,24 +851,21 @@ private:
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
         CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
-            gateInQueue_.FreeTensor(gateInUb);
             return;
         }
         uint64_t nextVOffset = 0;
         uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
-        uint64_t nextStateOffset = ((stateSlot * NV_ + head_i) * realV_) * realK_;
-        PrefetchState(nextStateOffset, nextSingleV);
+        PrefetchState(stateSlot, head_i, 0, nextSingleV);
         for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
             uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
             LoadPrefetchedState(curSingleV);
             nextVOffset = v_i + vStep_;
             if (nextVOffset < realV_) {
                 nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
-                nextStateOffset = ((stateSlot * NV_ + head_i) * realV_ + nextVOffset) * realK_;
-                PrefetchState(nextStateOffset, nextSingleV);
+                PrefetchState(stateSlot, head_i, nextVOffset, nextSingleV);
             }
             uint64_t pendingAttnOffset = 0;
-            uint64_t pendingStateOffset = 0;
+            uint64_t pendingStateSlot = 0;
             bool hasPendingAttn = false;
             bool hasPendingState = false;
             for (int64_t seq_i = seq0; seq_i < seq1; seq_i++) {
@@ -745,7 +874,7 @@ private:
                 uint64_t curVOffset = static_cast<uint64_t>(seq_i - seq0) * alignV_ + v_i;
                 uint64_t attnOffset = (static_cast<uint64_t>(seq_i) * NV_ + head_i) * realV_ + v_i;
                 uint64_t curStateSlot = StateSlotForToken(batchIdx, seq0, seq_i);
-                uint64_t curStateOutOffset = ((curStateSlot * NV_ + head_i) * realV_ + v_i) * realK_;
+                uint64_t curStateOutSlot = curStateSlot;
                 beta_ = LoadBeta(gbOffset);
                 Compute(curSingleV, curQKOffset, curVOffset);
                 if (attnOutBufferNum_ == BUFFER_NUM) {
@@ -757,43 +886,46 @@ private:
                     pendingAttnOffset = attnOffset;
                     hasPendingAttn = true;
                 }
-                if (stateOutBufferNum_ == BUFFER_NUM) {
-                    CopyOutState(curStateOutOffset, curSingleV);
-                } else {
-                    if (hasPendingState) {
-                        CopyOutState(pendingStateOffset, curSingleV);
+                if (shouldStoreState_) {
+                    if (stateOutBufferNum_ == BUFFER_NUM) {
+                        CopyOutState(curStateOutSlot, head_i, v_i, curSingleV);
+                    } else {
+                        if (hasPendingState) {
+                            CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
+                        }
+                        pendingStateSlot = curStateOutSlot;
+                        hasPendingState = true;
                     }
-                    pendingStateOffset = curStateOutOffset;
-                    hasPendingState = true;
                 }
             }
             if (hasPendingAttn) {
                 CopyOutAttn(pendingAttnOffset, curSingleV);
             }
             if (hasPendingState) {
-                CopyOutState(pendingStateOffset, curSingleV);
+                CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
             }
         }
-        gateInQueue_.FreeTensor(gateInUb);
-    }
-
-    __aicore__ inline bool IsCurrentTask(uint64_t batchIdx, uint64_t headIdx) const
-    {
-        return ((batchIdx * NV_ + headIdx) % GetBlockNum()) == blockIdx;
-    }
+     }
 
 private:
     GlobalTensor<inType> queryGm_;
     GlobalTensor<inType> keyGm_;
     GlobalTensor<inType> valueGm_;
-    GlobalTensor<float> gateGm_;
-    GlobalTensor<float> betaGm_;
+    GlobalTensor<float> gateFloatGm_;
+    GlobalTensor<bfloat16_t> gateBf16Gm_;
+    GlobalTensor<half> gateFp16Gm_;
+    GlobalTensor<float> betaFloatGm_;
+    GlobalTensor<bfloat16_t> betaBf16Gm_;
+    GlobalTensor<half> betaFp16Gm_;
     GlobalTensor<stateType> initStateGm_;
-    GlobalTensor<int64_t> cuSeqlensGm_;
-    GlobalTensor<int64_t> ssmStateIndicesGm_;
+    GlobalTensor<int32_t> cuSeqlensInt32Gm_;
+    GlobalTensor<int64_t> cuSeqlensInt64Gm_;
+    GlobalTensor<int32_t> ssmStateIndicesInt32Gm_;
+    GlobalTensor<int64_t> ssmStateIndicesInt64Gm_;
     GlobalTensor<float> aLogGm_;
     GlobalTensor<float> dtBiasGm_;
-    GlobalTensor<int64_t> numAcceptedTokensGm_;
+    GlobalTensor<int32_t> numAcceptedTokensInt32Gm_;
+    GlobalTensor<int64_t> numAcceptedTokensInt64Gm_;
     GlobalTensor<stateType> finalStateGm_;
     GlobalTensor<outType> attnOutGm_;
     TPipe *pipe_;
@@ -824,6 +956,7 @@ private:
     bool eventVToSInitialized_;
     uint32_t B_;
     uint32_t T_;
+    uint32_t seqLen_;
     uint32_t NK_;
     uint32_t alignK_;
     uint32_t realK_;
@@ -832,10 +965,24 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t stateInStride0_;
+    uint64_t stateInStride1_;
+    uint64_t stateInStride2_;
+    uint64_t stateInStride3_;
+    uint64_t stateOutStride0_;
+    uint64_t stateOutStride1_;
+    uint64_t stateOutStride2_;
+    uint64_t stateOutStride3_;
     uint32_t vStep_;
     uint32_t stateOutBufferNum_;
     uint32_t attnOutBufferNum_;
     uint32_t restUbSize_;
+    uint32_t gateDtype_;
+    uint32_t betaDtype_;
+    uint32_t cuSeqlensDtype_;
+    uint32_t ssmStateIndicesDtype_;
+    uint32_t acceptedTokensDtype_;
+    bool hasCuSeqlens_;
     bool hasSsmStateIndices_;
     bool hasAcceptedTokens_;
     bool hasALog_;
@@ -845,6 +992,8 @@ private:
     bool useBetaSigmoid_;
     bool allowNegEigval_;
     bool safeGate_;
+    bool stateVFirst_;
+    bool shouldStoreState_;
     bool useAddFoldReduce_;
     float beta_;
     float scale_;

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.cpp
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.cpp
@@ -24,15 +24,16 @@ using namespace RecurrentKda;
 extern "C" __global__ __aicore__ void
 recurrent_kda(GM_ADDR query, GM_ADDR key, GM_ADDR value, GM_ADDR gate, GM_ADDR beta, GM_ADDR initialState,
               GM_ADDR cuSeqlens, GM_ADDR ssmStateIndices, GM_ADDR aLog, GM_ADDR dtBias, GM_ADDR numAcceptedTokens,
-              GM_ADDR out, GM_ADDR finalState, GM_ADDR workspaceGM, GM_ADDR tilingGM)
+              GM_ADDR out, GM_ADDR initialStateOut, GM_ADDR finalState, GM_ADDR workspaceGM, GM_ADDR tilingGM)
 {
     REGISTER_TILING_DEFAULT(RecurrentKdaTilingData);
     GET_TILING_DATA(tilingData, tilingGM);
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
     TPipe pipe;
-    RKDA<bfloat16_t, bfloat16_t, DTYPE_STATE> op(&tilingData);
+    RKDA<bfloat16_t, bfloat16_t, DTYPE_INITIAL_STATE> op(&tilingData);
+    GM_ADDR stateOutput = tilingData.inplaceFinalState == 1 ? initialStateOut : finalState;
     RKDAInitParams initParams{query, key, value, gate, beta, initialState, cuSeqlens, ssmStateIndices,
-                              aLog, dtBias, numAcceptedTokens, out, finalState};
+                              aLog, dtBias, numAcceptedTokens, out, stateOutput};
     op.Init(initParams, &pipe);
     op.Process();
 }

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda.h
@@ -57,14 +57,24 @@ public:
     {
         B_ = tilingData->b;
         T_ = tilingData->t;
+        seqLen_ = tilingData->seqLen;
         NK_ = tilingData->nk;
         realK_ = tilingData->dk;
         NV_ = tilingData->nv;
         realV_ = tilingData->dv;
         stateCapacity_ = tilingData->sBlockNum;
         ssmStateStride_ = tilingData->ssmStateStride;
+        stateInStride0_ = tilingData->stateInStride0;
+        stateInStride1_ = tilingData->stateInStride1;
+        stateInStride2_ = tilingData->stateInStride2;
+        stateInStride3_ = tilingData->stateInStride3;
+        stateOutStride0_ = tilingData->stateOutStride0;
+        stateOutStride1_ = tilingData->stateOutStride1;
+        stateOutStride2_ = tilingData->stateOutStride2;
+        stateOutStride3_ = tilingData->stateOutStride3;
         scale_ = tilingData->scale;
         lowerBound_ = tilingData->lowerBound;
+        hasCuSeqlens_ = (tilingData->hasCuSeqlens == 1);
         hasSsmStateIndices_ = (tilingData->hasSsmStateIndices == 1);
         hasAcceptedTokens_ = (tilingData->hasAcceptedTokens == 1);
         hasALog_ = (tilingData->hasALog == 1);
@@ -74,6 +84,13 @@ public:
         useBetaSigmoid_ = (tilingData->useBetaSigmoid == 1);
         allowNegEigval_ = (tilingData->allowNegEigval == 1);
         safeGate_ = (tilingData->safeGate == 1);
+        stateVFirst_ = (tilingData->stateVFirst == 1);
+        shouldStoreState_ = (tilingData->inplaceFinalState == 1 || tilingData->outputFinalState == 1);
+        gateDtype_ = tilingData->gateDtype;
+        betaDtype_ = tilingData->betaDtype;
+        cuSeqlensDtype_ = tilingData->cuSeqlensDtype;
+        ssmStateIndicesDtype_ = tilingData->ssmStateIndicesDtype;
+        acceptedTokensDtype_ = tilingData->acceptedTokensDtype;
         useAddFoldReduce_ = (RKDA_ENABLE_ADD_FOLD_REDUCE != 0);
         vStep_ = tilingData->vStep;
         stateOutBufferNum_ = (tilingData->stateOutBufferNum == MAX_OUT_BUFFER_NUM) ? MAX_OUT_BUFFER_NUM : BUFFER_NUM;
@@ -103,14 +120,21 @@ public:
         queryGm_.SetGlobalBuffer((__gm__ inType *)initParams.query);
         keyGm_.SetGlobalBuffer((__gm__ inType *)initParams.key);
         valueGm_.SetGlobalBuffer((__gm__ inType *)initParams.value);
-        gateGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
-        betaGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        gateFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.gate);
+        gateBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.gate);
+        gateFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.gate);
+        betaFloatGm_.SetGlobalBuffer((__gm__ float *)initParams.beta);
+        betaBf16Gm_.SetGlobalBuffer((__gm__ bfloat16_t *)initParams.beta);
+        betaFp16Gm_.SetGlobalBuffer((__gm__ half *)initParams.beta);
         initStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.initState);
-        cuSeqlensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
-        ssmStateIndicesGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
+        cuSeqlensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.cuSeqlens);
+        cuSeqlensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.cuSeqlens);
+        ssmStateIndicesInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.ssmStateIndices);
+        ssmStateIndicesInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.ssmStateIndices);
         aLogGm_.SetGlobalBuffer((__gm__ float *)initParams.aLog);
         dtBiasGm_.SetGlobalBuffer((__gm__ float *)initParams.dtBias);
-        numAcceptedTokensGm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt32Gm_.SetGlobalBuffer((__gm__ int32_t *)initParams.numAcceptedTokens);
+        numAcceptedTokensInt64Gm_.SetGlobalBuffer((__gm__ int64_t *)initParams.numAcceptedTokens);
         finalStateGm_.SetGlobalBuffer((__gm__ stateType *)initParams.finalState);
         attnOutGm_.SetGlobalBuffer((__gm__ outType *)initParams.attnOut);
     }
@@ -150,6 +174,8 @@ public:
         broadTmpInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(alignK_ * vStep_), buffOffset);
         buffOffset += cubeSize;
         betaInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(betaUbSize / sizeof(float)), buffOffset);
+        buffOffset += betaUbSize;
+        gateInUb = tmpBuff.GetWithOffset<float>(static_cast<uint32_t>(MAX_MTP * alignK_), buffOffset);
     }
 
     __aicore__ inline void SyncMte2ToV()
@@ -205,8 +231,8 @@ public:
             return;
         }
         for (uint64_t batch_i = 0; batch_i < B_; batch_i++) {
-            int64_t seq0 = cuSeqlensGm_.GetValue(batch_i);
-            int64_t seq1 = cuSeqlensGm_.GetValue(batch_i + 1);
+            int64_t seq0 = SequenceStart(batch_i);
+            int64_t seq1 = SequenceEnd(batch_i);
             int64_t seqLen64 = seq1 - seq0;
             if (seqLen64 == 0) {
                 continue;
@@ -241,12 +267,15 @@ public:
 private:
     __aicore__ inline bool ValidateCuSeqlens() const
     {
-        int64_t seq0 = cuSeqlensGm_.GetValue(0);
+        if (!hasCuSeqlens_) {
+            return seqLen_ <= MAX_MTP;
+        }
+        int64_t seq0 = LoadCuSeqlens(0);
         if (seq0 != 0) {
             return false;
         }
         for (uint64_t i = 0; i < B_; i++) {
-            int64_t seq1 = cuSeqlensGm_.GetValue(i + 1);
+            int64_t seq1 = LoadCuSeqlens(i + 1);
             int64_t length = seq1 - seq0;
             if (seq1 < seq0 || seq1 > static_cast<int64_t>(T_) ||
                 length > static_cast<int64_t>(MAX_MTP) ||
@@ -256,6 +285,35 @@ private:
             seq0 = seq1;
         }
         return seq0 <= static_cast<int64_t>(T_);
+    }
+
+    __aicore__ inline int64_t LoadCuSeqlens(uint64_t index) const
+    {
+        return cuSeqlensDtype_ == 0 ? static_cast<int64_t>(cuSeqlensInt32Gm_.GetValue(index)) :
+                                     cuSeqlensInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t SequenceStart(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx) : static_cast<int64_t>(batchIdx * seqLen_);
+    }
+
+    __aicore__ inline int64_t SequenceEnd(uint64_t batchIdx) const
+    {
+        return hasCuSeqlens_ ? LoadCuSeqlens(batchIdx + 1) :
+                               static_cast<int64_t>((batchIdx + 1) * seqLen_);
+    }
+
+    __aicore__ inline int64_t LoadSsmStateIndex(uint64_t index) const
+    {
+        return ssmStateIndicesDtype_ == 0 ? static_cast<int64_t>(ssmStateIndicesInt32Gm_.GetValue(index)) :
+                                           ssmStateIndicesInt64Gm_.GetValue(index);
+    }
+
+    __aicore__ inline int64_t LoadAcceptedTokens(uint64_t index) const
+    {
+        return acceptedTokensDtype_ == 0 ? static_cast<int64_t>(numAcceptedTokensInt32Gm_.GetValue(index)) :
+                                          numAcceptedTokensInt64Gm_.GetValue(index);
     }
 
     __aicore__ inline uint64_t StateMetadataOffset(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -268,7 +326,7 @@ private:
 
     __aicore__ inline uint64_t LoadStateSlot(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
     {
-        int64_t stateSlot = ssmStateIndicesGm_.GetValue(StateMetadataOffset(batchIdx, seq0, tokenIdx));
+        int64_t stateSlot = LoadSsmStateIndex(StateMetadataOffset(batchIdx, seq0, tokenIdx));
         if (stateSlot < 0 || stateSlot >= static_cast<int64_t>(stateCapacity_)) {
             return INVALID_STATE_SLOT;
         }
@@ -281,7 +339,7 @@ private:
             return batchIdx < stateCapacity_;
         }
         if (hasAcceptedTokens_) {
-            int64_t acceptedTokenNum = numAcceptedTokensGm_.GetValue(batchIdx);
+            int64_t acceptedTokenNum = LoadAcceptedTokens(batchIdx);
             if (acceptedTokenNum <= 0 || acceptedTokenNum > seqLen) {
                 return false;
             }
@@ -301,15 +359,16 @@ private:
         }
         int64_t tokenIdx = seq0;
         if (hasAcceptedTokens_) {
-            tokenIdx = seq0 + numAcceptedTokensGm_.GetValue(batchIdx) - 1;
+            tokenIdx = seq0 + LoadAcceptedTokens(batchIdx) - 1;
         }
         return LoadStateSlot(batchIdx, seq0, tokenIdx);
     }
 
-    __aicore__ inline void CopyFloatVectorIn(LocalTensor<float> &dst, GlobalTensor<float> &src, uint64_t offset,
-                                             uint64_t count)
+    template <typename dataType>
+    __aicore__ inline void CopyVectorIn(LocalTensor<dataType> &dst, GlobalTensor<dataType> &src, uint64_t offset,
+                                        uint64_t count)
     {
-        uint64_t rowBytes = count * sizeof(float);
+        uint64_t rowBytes = count * sizeof(dataType);
         if (rowBytes >= 32 && rowBytes % 32 == 0) {
             DataCopy(dst, src[offset], static_cast<uint32_t>(count));
         } else {
@@ -376,7 +435,7 @@ private:
         float expA = hasALog_ ? ExpScalar(ReadFloat(aLogGm_, head)) : 1.0f;
 
         if (hasDtBias_) {
-            CopyFloatVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
+            CopyVectorIn(broadTmpInUb, dtBiasGm_, head * realK_, realK_);
             SyncMte2ToV();
             for (int32_t row = 0; row < seqLen; ++row) {
                 Add(gateInUb[row * alignK_], gateInUb[row * alignK_], broadTmpInUb, alignK_);
@@ -411,39 +470,67 @@ private:
         }
     }
 
+    template <typename gateType>
+    __aicore__ inline void CopyInGate(uint64_t gateOffset, int32_t seqLen)
+    {
+        LocalTensor<gateType> gateLocal = gateInQueue_.AllocTensor<gateType>();
+        Duplicate<gateType>(gateLocal, static_cast<gateType>(0), alignK_ * static_cast<uint32_t>(seqLen));
+        SyncVToMte2();
+        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen),
+                                       static_cast<uint32_t>(realK_ * sizeof(gateType)),
+                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(gateType)), 0, 0};
+        DataCopyPadExtParams<gateType> gatePadParams{
+            true, 0, static_cast<uint8_t>(alignK_ - realK_), static_cast<gateType>(0)};
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            DataCopyPad(gateLocal, gateFloatGm_[gateOffset], gateInParams, gatePadParams);
+        } else if constexpr (std::is_same<gateType, bfloat16_t>()) {
+            DataCopyPad(gateLocal, gateBf16Gm_[gateOffset], gateInParams, gatePadParams);
+        } else {
+            DataCopyPad(gateLocal, gateFp16Gm_[gateOffset], gateInParams, gatePadParams);
+        }
+        gateInQueue_.EnQue<gateType>(gateLocal);
+        gateLocal = gateInQueue_.DeQue<gateType>();
+        if constexpr (std::is_same<gateType, float32_t>()) {
+            Adds(gateInUb, gateLocal, 0.0f, alignK_ * static_cast<uint32_t>(seqLen));
+        } else {
+            Cast(gateInUb, gateLocal, AscendC::RoundMode::CAST_NONE,
+                 alignK_ * static_cast<uint32_t>(seqLen));
+        }
+        gateInQueue_.FreeTensor(gateLocal);
+        PipeBarrier<PIPE_V>();
+    }
+
     __aicore__ inline void CopyInQKVGate(uint64_t vOffset, uint64_t qkOffset, uint64_t gateOffset, int32_t seqLen,
                                          uint64_t head)
     {
         LocalTensor<inType> qLocal = qInQueue_.AllocTensor<inType>();
         LocalTensor<inType> kLocal = kInQueue_.AllocTensor<inType>();
         LocalTensor<inType> vLocal = vInQueue_.AllocTensor<inType>();
-        LocalTensor<float> gateLocal = gateInQueue_.AllocTensor<float>();
-        Duplicate<float>(gateLocal, 0, alignK_ * static_cast<uint32_t>(seqLen));
-        SyncVToMte2();
 
         DataCopyExtParams qkInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(inType)),
                                      static_cast<uint32_t>((NK_ - 1) * realK_ * sizeof(inType)), 0, 0};
         DataCopyExtParams vInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realV_ * sizeof(inType)),
                                     static_cast<uint32_t>((NV_ - 1) * realV_ * sizeof(inType)), 0, 0};
-        DataCopyExtParams gateInParams{static_cast<uint16_t>(seqLen), static_cast<uint32_t>(realK_ * sizeof(float)),
-                                       static_cast<uint32_t>((NV_ - 1) * realK_ * sizeof(float)), 0, 0};
         DataCopyPadExtParams<inType> qkPadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
         DataCopyPadExtParams<inType> vPadParams{true, 0, static_cast<uint8_t>(alignV_ - realV_), 0};
-        DataCopyPadExtParams<float> gatePadParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
 
         DataCopyPad(qLocal, queryGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(kLocal, keyGm_[qkOffset], qkInParams, qkPadParams);
         DataCopyPad(vLocal, valueGm_[vOffset], vInParams, vPadParams);
-        DataCopyPad(gateLocal, gateGm_[gateOffset], gateInParams, gatePadParams);
         qInQueue_.EnQue<inType>(qLocal);
         kInQueue_.EnQue<inType>(kLocal);
         vInQueue_.EnQue<inType>(vLocal);
-        gateInQueue_.EnQue<float>(gateLocal);
+        if (gateDtype_ == 0) {
+            CopyInGate<float>(gateOffset, seqLen);
+        } else if (gateDtype_ == 1) {
+            CopyInGate<bfloat16_t>(gateOffset, seqLen);
+        } else {
+            CopyInGate<half>(gateOffset, seqLen);
+        }
 
         qLocal = qInQueue_.DeQue<inType>();
         kLocal = kInQueue_.DeQue<inType>();
         vLocal = vInQueue_.DeQue<inType>();
-        gateInUb = gateInQueue_.DeQue<float>();
         Cast(qInUb, qLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(kInUb, kLocal, AscendC::RoundMode::CAST_NONE, alignK_ * seqLen);
         Cast(vInUb, vLocal, AscendC::RoundMode::CAST_NONE, alignV_ * seqLen);
@@ -465,13 +552,27 @@ private:
         vInQueue_.FreeTensor(vLocal);
     }
 
-    __aicore__ inline void PrefetchState(uint64_t stateOffest, uint32_t curSingleV)
+    __aicore__ inline void PrefetchState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                          uint32_t curSingleV)
     {
         LocalTensor<stateType> stateLocal = stateInQueue_.AllocTensor<stateType>();
-        DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
-                                        static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
-        DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
-        DataCopyPad(stateLocal, initStateGm_[stateOffest], stateInParams, padParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateInStride0_ * stateSlot + stateInStride1_ * head + stateInStride2_ * vOffset;
+            DataCopyExtParams stateInParams{static_cast<uint16_t>(curSingleV),
+                                            static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0, 0};
+            DataCopyPadExtParams<stateType> padParams{true, 0, static_cast<uint8_t>(alignK_ - realK_), 0};
+            DataCopyPad(stateLocal, initStateGm_[stateOffset], stateInParams, padParams);
+        } else {
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateInStride0_ * stateSlot + stateInStride1_ * head +
+                                           stateInStride2_ * k +
+                                           stateInStride3_ * (vOffset + v);
+                    stateLocal.SetValue(v * alignK_ + k, initStateGm_.GetValue(stateOffset));
+                }
+            }
+        }
         stateInQueue_.EnQue<stateType>(stateLocal);
     }
 
@@ -598,14 +699,16 @@ private:
         MatVecMul(stateInUb, qInUb[curQKOffset], broadTmpInUb, curSingleV, false);
         AscendC::PipeBarrier<PIPE_V>();
         ReduceSumDispatch(attnInUb, broadTmpInUb, curSingleV);
-        LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
         LocalTensor<outType> attnOutLocal = attnOutQueue_.AllocTensor<outType>();
-        if constexpr (std::is_same<stateType, float32_t>()) {
-            DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
-        } else {
-            Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+        if (shouldStoreState_) {
+            LocalTensor<stateType> stateOutLocal = stateOutQueue_.AllocTensor<stateType>();
+            if constexpr (std::is_same<stateType, float32_t>()) {
+                DataCopy(stateOutLocal, stateInUb, alignK_ * curSingleV);
+            } else {
+                Cast(stateOutLocal, stateInUb, AscendC::RoundMode::CAST_RINT, alignK_ * curSingleV);
+            }
+            stateOutQueue_.EnQue<stateType>(stateOutLocal);
         }
-        stateOutQueue_.EnQue<stateType>(stateOutLocal);
         Cast(attnOutLocal, attnInUb, AscendC::RoundMode::CAST_RINT, curSingleV);
         attnOutQueue_.EnQue<outType>(attnOutLocal);
     }
@@ -618,30 +721,65 @@ private:
         attnOutQueue_.FreeTensor(attnLocal);
     }
 
-    __aicore__ inline void CopyOutState(uint64_t stateOffset, uint32_t curSingleV)
+    __aicore__ inline void CopyOutState(uint64_t stateSlot, uint64_t head, uint64_t vOffset,
+                                         uint32_t curSingleV)
     {
         LocalTensor<stateType> stateOutLocal = stateOutQueue_.DeQue<stateType>();
-        DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
-                                      static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
-        DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        if (stateVFirst_) {
+            uint64_t stateOffset =
+                stateOutStride0_ * stateSlot + stateOutStride1_ * head + stateOutStride2_ * vOffset;
+            DataCopyParams stateOutParams{static_cast<uint16_t>(curSingleV),
+                                          static_cast<uint16_t>(realK_ * sizeof(stateType)), 0, 0};
+            DataCopyPad(finalStateGm_[stateOffset], stateOutLocal, stateOutParams);
+        } else {
+            SyncVToS();
+            for (uint32_t v = 0; v < curSingleV; ++v) {
+                for (uint32_t k = 0; k < realK_; ++k) {
+                    uint64_t stateOffset = stateOutStride0_ * stateSlot + stateOutStride1_ * head +
+                                           stateOutStride2_ * k +
+                                           stateOutStride3_ * (vOffset + v);
+                    finalStateGm_.SetValue(stateOffset, stateOutLocal.GetValue(v * alignK_ + k));
+                }
+            }
+        }
         stateOutQueue_.FreeTensor(stateOutLocal);
+    }
+
+    template <typename betaType>
+    __aicore__ inline void CopyInBetaTyped(int64_t seq0, int64_t seq1)
+    {
+        int64_t seqLen = seq1 - seq0;
+        uint64_t betaCount = static_cast<uint64_t>(seqLen) * NV_;
+        uint64_t betaBatchSize = Ceil(betaCount, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
+        LocalTensor<betaType> betaLocal = betaInQueue_.AllocTensor<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            CopyVectorIn(betaLocal, betaFloatGm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else if constexpr (std::is_same<betaType, bfloat16_t>()) {
+            CopyVectorIn(betaLocal, betaBf16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        } else {
+            CopyVectorIn(betaLocal, betaFp16Gm_, static_cast<uint64_t>(seq0) * NV_, betaCount);
+        }
+        betaInQueue_.EnQue<betaType>(betaLocal);
+        betaLocal = betaInQueue_.DeQue<betaType>();
+        if constexpr (std::is_same<betaType, float32_t>()) {
+            Adds(betaInUb, betaLocal, 0.0f, static_cast<uint32_t>(betaBatchSize));
+        } else {
+            Cast(betaInUb, betaLocal, AscendC::RoundMode::CAST_NONE, static_cast<uint32_t>(betaBatchSize));
+        }
+        betaInQueue_.FreeTensor(betaLocal);
+        PipeBarrier<PIPE_V>();
+        SyncVToS();
     }
 
     __aicore__ inline void CopyInBeta(int64_t seq0, int64_t seq1)
     {
-        int64_t seqLen = seq1 - seq0;
-        uint64_t betaBatchSize = Ceil(static_cast<uint64_t>(seqLen) * NV_, FP32_NUM_PER_BLOCK) * FP32_NUM_PER_BLOCK;
-        LocalTensor<float> betaLocal = betaInQueue_.AllocTensor<float>();
-        CopyFloatVectorIn(betaLocal, betaGm_, static_cast<uint64_t>(seq0) * NV_,
-                          static_cast<uint64_t>(seqLen) * NV_);
-        betaInQueue_.EnQue<float>(betaLocal);
-        betaLocal = betaInQueue_.DeQue<float>();
-        DataCopy(betaInUb, betaLocal, betaBatchSize);
-        SyncMte2ToV();
-        betaInQueue_.FreeTensor(betaLocal);
-        Adds(betaInUb, betaInUb, 0.0f, betaBatchSize);
-        PipeBarrier<PIPE_V>();
-        SyncVToS();
+        if (betaDtype_ == 0) {
+            CopyInBetaTyped<float>(seq0, seq1);
+        } else if (betaDtype_ == 1) {
+            CopyInBetaTyped<bfloat16_t>(seq0, seq1);
+        } else {
+            CopyInBetaTyped<half>(seq0, seq1);
+        }
     }
 
     __aicore__ inline uint64_t StateSlotForToken(uint64_t batchIdx, int64_t seq0, int64_t tokenIdx) const
@@ -672,24 +810,21 @@ private:
         uint64_t gateOffset = (static_cast<uint64_t>(seq0) * NV_ + head_i) * realK_;
         CopyInQKVGate(vOffset, qkOffset, gateOffset, static_cast<int32_t>(seq1 - seq0), head_i);
         if (realV_ == 0) {
-            gateInQueue_.FreeTensor(gateInUb);
             return;
         }
         uint64_t nextVOffset = 0;
         uint32_t nextSingleV = realV_ > vStep_ ? vStep_ : realV_;
-        uint64_t nextStateOffset = ((stateSlot * NV_ + head_i) * realV_) * realK_;
-        PrefetchState(nextStateOffset, nextSingleV);
+        PrefetchState(stateSlot, head_i, 0, nextSingleV);
         for (uint64_t v_i = 0; v_i < realV_; v_i += vStep_) {
             uint32_t curSingleV = v_i + vStep_ > realV_ ? realV_ - v_i : vStep_;
             LoadPrefetchedState(curSingleV);
             nextVOffset = v_i + vStep_;
             if (nextVOffset < realV_) {
                 nextSingleV = nextVOffset + vStep_ > realV_ ? realV_ - nextVOffset : vStep_;
-                nextStateOffset = ((stateSlot * NV_ + head_i) * realV_ + nextVOffset) * realK_;
-                PrefetchState(nextStateOffset, nextSingleV);
+                PrefetchState(stateSlot, head_i, nextVOffset, nextSingleV);
             }
             uint64_t pendingAttnOffset = 0;
-            uint64_t pendingStateOffset = 0;
+            uint64_t pendingStateSlot = 0;
             bool hasPendingAttn = false;
             bool hasPendingState = false;
             for (int64_t seq_i = seq0; seq_i < seq1; seq_i++) {
@@ -698,7 +833,7 @@ private:
                 uint64_t curVOffset = static_cast<uint64_t>(seq_i - seq0) * alignV_ + v_i;
                 uint64_t attnOffset = (static_cast<uint64_t>(seq_i) * NV_ + head_i) * realV_ + v_i;
                 uint64_t curStateSlot = StateSlotForToken(batchIdx, seq0, seq_i);
-                uint64_t curStateOutOffset = ((curStateSlot * NV_ + head_i) * realV_ + v_i) * realK_;
+                uint64_t curStateOutSlot = curStateSlot;
                 beta_ = LoadBeta(gbOffset);
                 Compute(curSingleV, curQKOffset, curVOffset);
                 if (attnOutBufferNum_ == BUFFER_NUM) {
@@ -710,25 +845,26 @@ private:
                     pendingAttnOffset = attnOffset;
                     hasPendingAttn = true;
                 }
-                if (stateOutBufferNum_ == BUFFER_NUM) {
-                    CopyOutState(curStateOutOffset, curSingleV);
-                } else {
-                    if (hasPendingState) {
-                        CopyOutState(pendingStateOffset, curSingleV);
+                if (shouldStoreState_) {
+                    if (stateOutBufferNum_ == BUFFER_NUM) {
+                        CopyOutState(curStateOutSlot, head_i, v_i, curSingleV);
+                    } else {
+                        if (hasPendingState) {
+                            CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
+                        }
+                        pendingStateSlot = curStateOutSlot;
+                        hasPendingState = true;
                     }
-                    pendingStateOffset = curStateOutOffset;
-                    hasPendingState = true;
                 }
             }
             if (hasPendingAttn) {
                 CopyOutAttn(pendingAttnOffset, curSingleV);
             }
             if (hasPendingState) {
-                CopyOutState(pendingStateOffset, curSingleV);
+                CopyOutState(pendingStateSlot, head_i, v_i, curSingleV);
             }
         }
-        gateInQueue_.FreeTensor(gateInUb);
-    }
+     }
 
     __aicore__ inline bool IsCurrentTask(uint64_t batchIdx, uint64_t headIdx) const
     {
@@ -739,14 +875,21 @@ private:
     GlobalTensor<inType> queryGm_;
     GlobalTensor<inType> keyGm_;
     GlobalTensor<inType> valueGm_;
-    GlobalTensor<float> gateGm_;
-    GlobalTensor<float> betaGm_;
+    GlobalTensor<float> gateFloatGm_;
+    GlobalTensor<bfloat16_t> gateBf16Gm_;
+    GlobalTensor<half> gateFp16Gm_;
+    GlobalTensor<float> betaFloatGm_;
+    GlobalTensor<bfloat16_t> betaBf16Gm_;
+    GlobalTensor<half> betaFp16Gm_;
     GlobalTensor<stateType> initStateGm_;
-    GlobalTensor<int64_t> cuSeqlensGm_;
-    GlobalTensor<int64_t> ssmStateIndicesGm_;
+    GlobalTensor<int32_t> cuSeqlensInt32Gm_;
+    GlobalTensor<int64_t> cuSeqlensInt64Gm_;
+    GlobalTensor<int32_t> ssmStateIndicesInt32Gm_;
+    GlobalTensor<int64_t> ssmStateIndicesInt64Gm_;
     GlobalTensor<float> aLogGm_;
     GlobalTensor<float> dtBiasGm_;
-    GlobalTensor<int64_t> numAcceptedTokensGm_;
+    GlobalTensor<int32_t> numAcceptedTokensInt32Gm_;
+    GlobalTensor<int64_t> numAcceptedTokensInt64Gm_;
     GlobalTensor<stateType> finalStateGm_;
     GlobalTensor<outType> attnOutGm_;
     TPipe *pipe_;
@@ -777,6 +920,7 @@ private:
     bool eventVToSInitialized_;
     uint32_t B_;
     uint32_t T_;
+    uint32_t seqLen_;
     uint32_t NK_;
     uint32_t alignK_;
     uint32_t realK_;
@@ -785,10 +929,24 @@ private:
     uint32_t realV_;
     uint32_t stateCapacity_;
     uint32_t ssmStateStride_;
+    uint64_t stateInStride0_;
+    uint64_t stateInStride1_;
+    uint64_t stateInStride2_;
+    uint64_t stateInStride3_;
+    uint64_t stateOutStride0_;
+    uint64_t stateOutStride1_;
+    uint64_t stateOutStride2_;
+    uint64_t stateOutStride3_;
     uint32_t vStep_;
     uint32_t stateOutBufferNum_;
     uint32_t attnOutBufferNum_;
     uint32_t restUbSize_;
+    uint32_t gateDtype_;
+    uint32_t betaDtype_;
+    uint32_t cuSeqlensDtype_;
+    uint32_t ssmStateIndicesDtype_;
+    uint32_t acceptedTokensDtype_;
+    bool hasCuSeqlens_;
     bool hasSsmStateIndices_;
     bool hasAcceptedTokens_;
     bool hasALog_;
@@ -798,6 +956,8 @@ private:
     bool useBetaSigmoid_;
     bool allowNegEigval_;
     bool safeGate_;
+    bool stateVFirst_;
+    bool shouldStoreState_;
     bool useAddFoldReduce_;
     float beta_;
     float scale_;

--- a/csrc/attention/recurrent_kda/op_kernel/recurrent_kda_struct.h
+++ b/csrc/attention/recurrent_kda/op_kernel/recurrent_kda_struct.h
@@ -46,6 +46,22 @@ struct alignas(8) RecurrentKdaTilingData {
     uint32_t allowNegEigval;
     uint32_t safeGate;
     uint32_t stateVFirst;
+    uint32_t outputFinalState;
+    uint32_t inplaceFinalState;
+    uint32_t hasCuSeqlens;
+    uint32_t gateDtype;
+    uint32_t betaDtype;
+    uint32_t cuSeqlensDtype;
+    uint32_t ssmStateIndicesDtype;
+    uint32_t acceptedTokensDtype;
+    uint64_t stateInStride0;
+    uint64_t stateInStride1;
+    uint64_t stateInStride2;
+    uint64_t stateInStride3;
+    uint64_t stateOutStride0;
+    uint64_t stateOutStride1;
+    uint64_t stateOutStride2;
+    uint64_t stateOutStride3;
 };
 #pragma pack(pop)
 

--- a/csrc/attention/recurrent_kda/recurrent_kda_torch_adpt.h
+++ b/csrc/attention/recurrent_kda/recurrent_kda_torch_adpt.h
@@ -67,8 +67,8 @@ at::Tensor recurrent_kda(
                 "recurrent_kda: token and head dimensions must be positive.");
     TORCH_CHECK(hv % h == 0,
                 "recurrent_kda: HV must be divisible by H.");
-    TORCH_CHECK(k_dim == 128 && v_dim == 128,
-                "recurrent_kda: the Kimi K3 integration requires K=V=128.");
+    TORCH_CHECK(k_dim == 128 && (v_dim == 128 || v_dim == 256),
+                "recurrent_kda: the Kimi K3 integration requires K=128 and V=128 or 256.");
     TORCH_CHECK((is_tnd && value.size(0) == total_tokens && gate.size(0) == total_tokens &&
                  beta.size(0) == total_tokens && gate.size(1) == hv && gate.size(2) == k_dim &&
                  beta.size(1) == hv) ||
@@ -119,7 +119,10 @@ at::Tensor recurrent_kda(
     const at::Tensor& accepted = c10::value_or_else(
         num_accepted_tokens, [] { return at::Tensor(); });
     const char* layout = is_tnd ? "TND" : "BSND";
-    bool output_final_state = true;
+    // vLLM consumes the cache mutation through initial_state and returns only
+    // the attention output. Avoid materializing a second full state tensor.
+    bool output_final_state = false;
+    bool inplace_final_state = true;
     bool state_v_first = true;
     EXEC_NPU_CMD(
         aclnnRecurrentKda,
@@ -137,6 +140,7 @@ at::Tensor recurrent_kda(
         layout,
         scale,
         output_final_state,
+        inplace_final_state,
         use_qk_l2norm_in_kernel,
         use_gate_in_kernel,
         use_beta_sigmoid_in_kernel,
@@ -144,7 +148,8 @@ at::Tensor recurrent_kda(
         safe_gate,
         lower_bound,
         state_v_first,
-        output);
+        output,
+        final_state);
     return output;
 }
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_kimi_kda_recurrent_ascendc_npu.py
@@ -221,6 +221,96 @@ def test_kimi_k3_tp16_recurrent_kda_bsnd_single_token_decode_wrapper():
 
 
 @torch.inference_mode()
+def test_kimi_k3_tp16_recurrent_kda_non_contiguous_state_pool():
+    """Preserve a strided cache view while updating only selected Kimi slots."""
+    torch.manual_seed(20260806)
+    device = torch.device("npu")
+    batch, heads, dim = 4, 6, 128
+    state_capacity = 17
+    cu_seqlens_host = list(range(batch + 1))
+    state_indices_cpu = torch.tensor([9, 2, 15, 4], dtype=torch.int64)
+
+    q_cpu = torch.randn(1, batch, heads, dim, dtype=torch.bfloat16)
+    k_cpu = torch.randn_like(q_cpu)
+    v_cpu = torch.randn_like(q_cpu)
+    raw_gate_cpu = torch.randn(1, batch, heads, dim, dtype=torch.bfloat16) * 0.25
+    beta_cpu = torch.rand(1, batch, heads, dtype=torch.float32).sigmoid()
+    state_cpu = torch.randn(state_capacity, heads, dim, dim, dtype=torch.float32) * 0.01
+    a_log_cpu = torch.randn(heads, dtype=torch.float32) * 0.05
+    dt_bias_cpu = torch.randn(heads, dim, dtype=torch.float32) * 0.05
+
+    ref_out, ref_state = recurrent_kda_reference(
+        q_cpu,
+        k_cpu,
+        v_cpu,
+        raw_gate_cpu,
+        beta_cpu,
+        state_cpu,
+        cu_seqlens=cu_seqlens_host,
+        ssm_state_indices=state_indices_cpu,
+        A_log=a_log_cpu,
+        dt_bias=dt_bias_cpu,
+        layout="BSND",
+        scale=dim**-0.5,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        safe_gate=True,
+    )
+
+    state_pool = torch.full(
+        (state_capacity + 1, 2, heads, dim, dim),
+        7.0,
+        dtype=torch.float32,
+        device=device,
+    )
+    # Model-runner cache slots may be a strided view with a non-zero storage
+    # offset. Keep the adjacent layer as a guard against an incorrect write.
+    state_view = state_pool[1:, 0]
+    state_view.copy_(state_cpu.to(device))
+    guard_layer = state_pool[1:, 1].clone()
+    state_before = state_view.clone()
+    state_stride = state_view.stride()
+    state_storage = state_view.untyped_storage().data_ptr()
+    assert not state_view.is_contiguous()
+    assert state_view.storage_offset() > 0
+
+    out = torch.ops._C_ascend.recurrent_kda(
+        q_cpu.to(device),
+        k_cpu.to(device),
+        v_cpu.to(device),
+        raw_gate_cpu.to(device),
+        beta_cpu.to(device),
+        state_view,
+        torch.tensor(cu_seqlens_host, dtype=torch.int32, device=device),
+        state_indices_cpu.to(device),
+        a_log_cpu.to(device),
+        dt_bias_cpu.to(device),
+        scale=dim**-0.5,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        use_beta_sigmoid_in_kernel=False,
+        allow_neg_eigval=False,
+        safe_gate=True,
+        lower_bound=-5.0,
+    )
+    torch.npu.synchronize()
+
+    assert state_view.stride() == state_stride
+    assert state_view.untyped_storage().data_ptr() == state_storage
+    torch.testing.assert_close(out.cpu(), ref_out, rtol=0.02, atol=0.02)
+    torch.testing.assert_close(state_view.cpu(), ref_state, rtol=0.02, atol=0.02)
+    torch.testing.assert_close(state_pool[1:, 1], guard_layer, rtol=0, atol=0)
+    used_slots = set(state_indices_cpu.tolist())
+    untouched_slots = [slot for slot in range(state_capacity) if slot not in used_slots]
+    torch.testing.assert_close(
+        state_view[untouched_slots],
+        state_before[untouched_slots],
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.inference_mode()
 def test_kimi_k3_tp16_recurrent_kda_multistep_decode_matches_triton_and_reference():
     """Reuse real decode cache slots across steps, as the model wrapper does."""
     from torch import nn

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fusions.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kimi_k3_fusions.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Numerical regression coverage for the Kimi K3 attention-residual fusion."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+from vllm.triton_utils import HAS_TRITON
+
+if HAS_TRITON:
+    from vllm_ascend.ops.triton.kimi_k3.attention_residual import apply_attn_res
+
+
+pytestmark = [
+    pytest.mark.skipif(not HAS_TRITON, reason="Triton is not available"),
+    pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required"),
+    pytest.mark.skip_global_cleanup,
+]
+
+
+@torch.inference_mode()
+def test_kimi_k3_attention_residual_triton_matches_reference():
+    torch.manual_seed(1)
+    num_tokens = 7
+    hidden_size = 7168
+    num_blocks = 4
+    eps = 1e-6
+    prefix_sum = torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16, device="npu")
+    block_residual = torch.randn(
+        (num_tokens, num_blocks, hidden_size),
+        dtype=torch.bfloat16,
+        device="npu",
+    )
+    projection = SimpleNamespace(weight=torch.randn((1, hidden_size), dtype=torch.bfloat16, device="npu"))
+    norm = SimpleNamespace(weight=torch.randn((hidden_size,), dtype=torch.bfloat16, device="npu"), variance_epsilon=eps)
+
+    actual = apply_attn_res(prefix_sum, block_residual, projection, norm)
+
+    values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1).float()
+    normalized = values * torch.rsqrt(values.square().mean(dim=-1, keepdim=True) + eps)
+    score_weight = norm.weight.float() * projection.weight.squeeze(0).float()
+    scores = (normalized * score_weight).sum(dim=-1)
+    probabilities = scores.softmax(-1).unsqueeze(1)
+    expected = torch.matmul(probabilities, values).squeeze(1).to(prefix_sum.dtype)
+
+    torch.testing.assert_close(actual.cpu(), expected.cpu(), rtol=1e-2, atol=1e-2)

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1061,14 +1061,12 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(self.impl.kv_a_proj_with_mqa)
         self.assertIsNotNone(self.impl.kv_a_layernorm)
         self.assertEqual(self.impl.num_queries_per_kv, 32)
-        # 256 is power of 2, so padding should be 0
-        self.assertEqual(self.impl.num_heads_padded, 256)
-        self.assertEqual(self.impl.head_padding, 0)
+        self.assertFalse(self.impl.prefill_uses_combined_qk)
 
     @patch("vllm_ascend.attention.mla_v1.enable_fa_quant", return_value=True)
     @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    def test_kimi_k3_no_rope_disables_fused_rotary_preprocess(
+    def test_kimi_k3_no_rope_preserves_fa_quant_state(
         self,
         mock_get_current_vllm_config,
         mock_enabling_mlapo,
@@ -1108,8 +1106,62 @@ class TestAscendMLAImpl(TestBase):
             **kwargs,
         )
 
-        self.assertFalse(impl.fa_quant_layer)
-        self.assertFalse(impl.enable_mlapo)
+        self.assertTrue(impl.fa_quant_layer)
+        self.assertTrue(impl.enable_mlapo)
+
+    @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
+    @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad", side_effect=lambda value, enabled: value)
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
+    def test_kimi_k3_forwards_no_rope_to_fused_decode_preprocess(
+        self,
+        mock_device_operator,
+        mock_gather_unpad,
+        mock_save_kv,
+    ):
+        num_tokens = 2
+        self.impl.enable_mlapo = True
+        self.impl.fa_quant_layer = False
+        self.impl.use_mla_rope = False
+        self.impl.num_heads = 2
+        self.impl.v_head_dim = 4
+        hidden_states = torch.randn(num_tokens, 16)
+        attention_output = torch.randn(num_tokens, self.impl.num_heads * self.impl.v_head_dim)
+        projected = torch.randn_like(hidden_states)
+        decode_result = DecodeMLAPreprocessResult(
+            ql_nope=MagicMock(),
+            q_pe=MagicMock(),
+            k_nope=MagicMock(),
+            k_pe=MagicMock(),
+        )
+        mock_device_operator.mla_preprocess_only_decode.return_value = (decode_result, None)
+        self.impl._forward_decode = MagicMock(return_value=attention_output)
+        self.impl.o_proj = MagicMock(return_value=(projected,))
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=num_tokens,
+            num_decodes=num_tokens,
+            num_prefills=0,
+            num_decode_tokens=num_tokens,
+        )
+        kv_cache = (torch.empty(1, 4), torch.empty(1, 4))
+        output = torch.empty_like(projected)
+
+        with patch("vllm_ascend.attention.mla_v1._EXTRA_CTX", SimpleNamespace(num_tokens=num_tokens)):
+            self.impl.forward(
+                "model.layers.3.self_attn.attn",
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                output=output,
+            )
+
+        mock_device_operator.mla_preprocess_only_decode.assert_called_once_with(
+            self.impl,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            use_mla_rope=False,
+        )
+        torch.testing.assert_close(output, projected)
 
     @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")
@@ -1228,8 +1280,8 @@ class TestAscendMLAImpl(TestBase):
         torch.testing.assert_close(self.impl.g_proj.call_args.args[0], hidden_states)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):
-        """Test head padding computation for num_heads that are not power of 2 (e.g. GLM-4.7-Flash with 20 heads)."""
+    def test_init_prefill_combined_qk_for_non_power_of_two_heads(self, mock_get_current_vllm_config):
+        """Test the prefill Q/K fallback for non-power-of-two heads."""
         mock_get_current_vllm_config.return_value = MagicMock()
         kwargs = {
             "kv_lora_rank": 32,
@@ -1262,8 +1314,7 @@ class TestAscendMLAImpl(TestBase):
             **kwargs,
         )
         self.assertEqual(impl.num_heads, 20)
-        self.assertEqual(impl.num_heads_padded, 32)  # next power of 2
-        self.assertEqual(impl.head_padding, 12)  # 32 - 20
+        self.assertTrue(impl.prefill_uses_combined_qk)
 
     def test_q_proj_and_k_up_proj(self):
         batch_size = 4
@@ -1705,7 +1756,7 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
-        """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
+        """Test prefill retains its Q/K concat fallback for non-power-of-two heads."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -1761,7 +1812,7 @@ class TestAscendMLAImpl(TestBase):
 
         result = impl._forward_prefill(q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata)
 
-        # FIA should be called without query_rope/key_rope when head_padding > 0
+        # Prefill FIA uses concatenated Q/K instead of rope kwargs for this layout.
         mock_fia.assert_called_once()
         call_kwargs = mock_fia.call_args.kwargs
         self.assertNotIn("query_rope", call_kwargs)
@@ -1898,6 +1949,36 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.W_UV.shape[0], self.impl.num_heads)
         self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
         self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading_with_dynamic_mlapo_a3(self, mock_format_cast, mock_get_ascend_device_type):
+        layer = MagicMock(spec=LinearBase)
+        layer.quant_method = MagicMock(spec=UnquantizedLinearMethod)
+        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_1 = self.impl.kv_lora_rank
+        layer.weight = torch.randn(shape_0, shape_1)
+        self.impl.kv_b_proj = layer
+        mock_format_cast.return_value = layer.weight
+
+        from vllm_ascend.attention.mla_v1 import (
+            AscendDeviceType,
+            AscendW8A8DynamicLinearMethod,
+        )
+
+        dynamic_method = AscendW8A8DynamicLinearMethod()
+        self.impl.enable_mlapo = True
+        self.impl.fused_qkv_a_proj = MagicMock()
+        self.impl.fused_qkv_a_proj.quant_method.quant_method = dynamic_method
+        self.impl.q_proj.quant_method.quant_method = dynamic_method
+        mock_get_ascend_device_type.return_value = AscendDeviceType.A3
+        self.impl._process_weights_for_fused_mlapo = MagicMock()
+
+        self.impl.process_weights_after_loading(torch.bfloat16)
+
+        self.assertTrue(self.impl.enable_mlapo)
+        self.assertEqual(self.impl.mlapo_quant_mode, "per_token_quant_symm")
+        self.impl._process_weights_for_fused_mlapo.assert_called_once_with(torch.bfloat16)
 
     @patch("vllm_ascend.attention.mla_v1.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
@@ -2405,7 +2486,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test decode with non-power-of-2 heads pads to next power of 2 and slices output."""
+        """Test speculative decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2456,9 +2537,8 @@ class TestAscendMLAImpl(TestBase):
         impl.enable_kv_nz = True
         impl.fa_quant_layer = False
 
-        # Return padded output so slice logic works
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, impl.kv_lora_rank),
+            torch.randn(num_heads, B, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2468,10 +2548,13 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[1], num_heads)
         self.assertEqual(result.shape[2], HD)
 
-        # Verify num_query_heads passed to FIA is padded
+        # Verify v2 receives the model's native head count and unpadded Q.
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -2479,7 +2562,7 @@ class TestAscendMLAImpl(TestBase):
     def test_forward_decode_non_power_of_two_heads_normal(
         self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
     ):
-        """Test normal decode (BNSD_NBSD) with non-power-of-2 heads pads q and slices output."""
+        """Test normal decode passes native non-power-of-two head shapes."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
         kwargs = {
@@ -2533,7 +2616,7 @@ class TestAscendMLAImpl(TestBase):
         impl.speculative_config = None
 
         mock_npu_fused_infer_attention_score_v2.return_value = [
-            torch.randn(impl.num_heads_padded, B, 1, impl.kv_lora_rank),
+            torch.randn(num_heads, B, 1, impl.kv_lora_rank),
             None,
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
@@ -2544,8 +2627,11 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[2], HD)
 
         mock_npu_fused_infer_attention_score_v2.assert_called_once()
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
         call_kwargs = mock_npu_fused_infer_attention_score_v2.call_args.kwargs
-        self.assertEqual(call_kwargs.get("num_query_heads"), impl.num_heads_padded)
+        self.assertEqual(call_args.args[0].shape, (B, num_heads, 1, impl.qk_nope_head_dim))
+        self.assertEqual(call_kwargs["query_rope"].shape, (B, num_heads, 1, impl.qk_rope_head_dim))
+        self.assertEqual(call_kwargs.get("num_query_heads"), num_heads)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -1,9 +1,70 @@
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 import torch
 
 from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+
+
+@pytest.mark.parametrize("use_mla_rope", [True, False])
+def test_base_mla_preprocess_only_decode_passes_optional_rope(use_mla_rope):
+    num_tokens = 2
+    num_heads = 4
+    kv_lora_rank = 8
+    rope_dim = 6
+    hidden_states = torch.randn(num_tokens, 16)
+    cos = torch.randn(num_tokens, 1, 1, rope_dim)
+    sin = torch.randn_like(cos)
+    kv_cache = (
+        torch.randn(4, 1, 1, kv_lora_rank),
+        torch.randn(4, 1, 1, rope_dim),
+    )
+    attn_metadata = SimpleNamespace(
+        num_decode_tokens=num_tokens,
+        decode=SimpleNamespace(cos=cos, sin=sin),
+        slot_mapping=torch.arange(num_tokens, dtype=torch.int32),
+    )
+    atten_obj = SimpleNamespace(
+        fa_quant_layer=False,
+        W_UK_T=torch.randn(num_heads, rope_dim, kv_lora_rank),
+        wd_qkv=mock.MagicMock(),
+        deq_scale_qkv=mock.MagicMock(),
+        gamma1=mock.MagicMock(),
+        beta1=mock.MagicMock(),
+        wu_q=mock.MagicMock(),
+        qb_deq_scl=mock.MagicMock(),
+        gamma2=mock.MagicMock(),
+        quant_scale0=mock.MagicMock(),
+        quant_offset0=mock.MagicMock(),
+        quant_bias_qkv=mock.MagicMock(),
+        quant_scale1=mock.MagicMock(),
+        quant_offset1=mock.MagicMock(),
+        qb_qt_bias=mock.MagicMock(),
+        ctkv_scale=mock.MagicMock(),
+        q_nope_scale=mock.MagicMock(),
+        enable_kv_nz=False,
+        num_heads=num_heads,
+        kv_lora_rank=kv_lora_rank,
+        reorg_decode_q=mock.MagicMock(side_effect=lambda q_nope, q_pe: (q_nope, q_pe)),
+    )
+
+    with mock.patch.object(torch.ops._C_ascend, "mla_preprocess", create=True) as mock_preprocess:
+        BaseDeviceAdaptor.mla_preprocess_only_decode(
+            atten_obj,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            use_mla_rope=use_mla_rope,
+        )
+
+    call_args = mock_preprocess.call_args.args
+    if use_mla_rope:
+        torch.testing.assert_close(call_args[8], cos.view(num_tokens, rope_dim))
+        torch.testing.assert_close(call_args[9], sin.view(num_tokens, rope_dim))
+    else:
+        assert call_args[8] is None
+        assert call_args[9] is None
 
 
 def test_reshape_and_cache_makes_scatter_inputs_contiguous():

--- a/tests/ut/ops/a3_2/test_kimi_kda_fused_norm_gate.py
+++ b/tests/ut/ops/a3_2/test_kimi_kda_fused_norm_gate.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.ops.triton.kda.fused_norm_gate import apply_kda_rms_norm_sigmoid_gate
+
+
+@pytest.mark.skip_global_cleanup
+@torch.inference_mode()
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_kimi_kda_fused_rms_norm_sigmoid_gate(dtype: torch.dtype):
+    torch.manual_seed(20260801)
+    tokens, heads, head_dim = 37, 4, 128
+    eps = 1e-6
+    core_attn_out = torch.randn(
+        1,
+        tokens,
+        heads,
+        head_dim,
+        dtype=dtype,
+        device="npu",
+    )
+    output_gate = torch.randn(
+        tokens,
+        heads,
+        head_dim,
+        dtype=dtype,
+        device="npu",
+    )
+    weight = torch.randn(head_dim, dtype=dtype, device="npu")
+    core_attn_out_before = core_attn_out.clone()
+
+    actual = apply_kda_rms_norm_sigmoid_gate(
+        core_attn_out,
+        output_gate,
+        weight,
+        eps,
+    )
+
+    x_float = core_attn_out_before.float()
+    variance = x_float.square().mean(dim=-1, keepdim=True)
+    expected = x_float * torch.rsqrt(variance + eps)
+    expected = expected * weight.float()
+    expected = expected * output_gate.float().sigmoid().unsqueeze(0)
+    expected = expected.to(dtype)
+
+    torch.testing.assert_close(actual, expected, rtol=2e-3, atol=2e-3)
+    torch.testing.assert_close(core_attn_out, core_attn_out_before)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -438,7 +438,7 @@ def test_unquantized_shared_situ_uses_split_bf16_path(monkeypatch):
     runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
 
 
-def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
+def test_per_channel_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
     hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
@@ -455,12 +455,13 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     down_proj = MagicMock()
     down_proj.weight = torch.ones(2, 4, dtype=torch.int8)
     down_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
+    down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
     runner._shared_experts = SimpleNamespace(
         gate_up_proj=gate_up_proj,
         down_proj=down_proj,
         act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
     )
-    runner.quant_type = QuantType.W4A8
+    runner.quant_type = QuantType.W8A8
     runner.multistream_overlap_shared_expert = False
     stream = MagicMock()
     events = fused_moe_module.FusedMoEEvents(
@@ -498,12 +499,148 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     down_proj.assert_not_called()
     fast_dynamic_quant.assert_called_once_with(hidden_states)
     assert fast_quant_matmul.call_count == 2
+    gate_up_call = fast_quant_matmul.call_args_list[0]
+    assert gate_up_call.args == (quantized_input, gate_up_proj.weight, gate_up_proj.weight_scale)
+    assert gate_up_call.kwargs["pertoken_scale"] is None
+    assert gate_up_call.kwargs["output_dtype"] == torch.int32
     situ_call = custom_ops.dequant_situ_quant.call_args.kwargs
     assert situ_call["x"] is gate_up
     assert situ_call["weight_scale"] is gate_up_proj.weight_scale_fp32
     assert situ_call["activation_scale"] is input_scale
     assert situ_call["beta"] == 4.0
     assert situ_call["linear_beta"] == 25.0
+    down_call = fast_quant_matmul.call_args_list[1]
+    assert down_call.args == (quantized_situ, down_proj.weight, down_proj.weight_scale)
+    assert down_call.kwargs["pertoken_scale"] is situ_scale
+    assert down_call.kwargs["output_dtype"] == hidden_states.dtype
+
+
+def test_per_channel_w4a8_shared_situ_uses_single_expert_gmm_fusion(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    quantized_input = torch.ones(2, 4, dtype=torch.int8)
+    input_scale = torch.ones(2, dtype=torch.float32)
+    quantized_situ = torch.ones(2, 4, dtype=torch.int8)
+    situ_scale = torch.ones(2, dtype=torch.float32)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up_proj = MagicMock(return_value=(gate_up, None))
+    gate_up_proj.weight_scale = torch.ones(8, dtype=torch.int64)
+    gate_up_proj.weight_scale_fp32 = torch.ones(8, dtype=torch.float32)
+    down_proj = MagicMock(return_value=(down_out, None))
+    down_proj.weight_scale = torch.ones(4, dtype=torch.int64)
+    down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=gate_up_proj,
+        down_proj=down_proj,
+        act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
+    )
+    runner._shared_experts_part1 = MagicMock()
+    runner._shared_experts_part2 = MagicMock()
+    runner.quant_type = QuantType.W4A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        after_routed_experts=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    quant_matmul = MagicMock()
+    dynamic_quant = MagicMock(return_value=(quantized_input, input_scale))
+    custom_ops = SimpleNamespace(
+        dequant_situ_quant=MagicMock(return_value=(quantized_situ, situ_scale)),
+    )
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_quant_matmul", quant_matmul)
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_dynamic_quant", dynamic_quant, raising=False)
+    monkeypatch.setattr(fused_moe_module.torch.ops, "_C_ascend", custom_ops)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    assert output is down_out
+    dynamic_quant.assert_called_once_with(hidden_states)
+    gate_up_proj.assert_called_once()
+    gate_quantized, gate_scale = gate_up_proj.call_args.args[0]
+    assert gate_quantized is quantized_input
+    assert gate_scale is input_scale
+    situ_call = custom_ops.dequant_situ_quant.call_args.kwargs
+    assert situ_call["x"] is gate_up
+    assert situ_call["weight_scale"] is None
+    assert situ_call["activation_scale"] is None
+    assert situ_call["beta"] == 4.0
+    assert situ_call["linear_beta"] == 25.0
+    down_proj.assert_called_once()
+    down_quantized, down_scale = down_proj.call_args.args[0]
+    assert down_quantized is quantized_situ
+    assert down_scale is situ_scale
+    runner._shared_experts_part1.assert_not_called()
+    runner._shared_experts_part2.assert_not_called()
+    quant_matmul.assert_not_called()
+
+
+def test_per_group_w4a8_shared_experts_use_quantized_linear_path(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(weight_scale=torch.ones(1)),
+        down_proj=SimpleNamespace(weight_scale=torch.ones(1)),
+        act_fn=nn.Identity(),
+    )
+    runner._shared_experts_part1 = MagicMock(return_value=gate_up)
+    runner._shared_experts_part2 = MagicMock(return_value=down_out)
+    runner.quant_type = QuantType.W4A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    quant_matmul = MagicMock()
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_quant_matmul", quant_matmul)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    assert output is down_out
+    runner._shared_experts_part1.assert_called_once_with(hidden_states)
+    runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
+    quant_matmul.assert_not_called()
 
 
 @pytest.mark.parametrize("quant_type", [QuantType.W4A8MXFP, QuantType.W8A8MXFP])

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -225,6 +225,55 @@ def _build_attn_metadata(
     return builder, common_attn_metadata, attn_metadata
 
 
+def test_stateful_single_token_prefill_is_treated_as_decode():
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=BatchSpec(
+            seq_lens=[17, 1, 6],
+            query_lens=[1, 1, 2],
+            name="stateful_single_token_prefill",
+        ),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_attn_metadata.is_prefilling = torch.tensor([True, True, True])
+
+    transformed = ascend_gdn_attn_builder._treat_single_token_prefills_with_state_as_decodes(common_attn_metadata)
+
+    assert torch.equal(transformed.is_prefilling, torch.tensor([False, True, True]))
+    assert torch.equal(common_attn_metadata.is_prefilling, torch.tensor([True, True, True]))
+
+
+def test_stateful_spec_sized_prefill_is_folded_into_spec_metadata():
+    builder = _make_builder(
+        device=torch.device("cpu"),
+        num_heads=32,
+        num_speculative_tokens=3,
+    )
+    common_attn_metadata = create_common_attn_metadata(
+        batch_spec=BatchSpec(
+            seq_lens=[12, 4, 13],
+            query_lens=[4, 4, 4],
+            name="stateful_spec_sized_prefill",
+        ),
+        block_size=16,
+        device=torch.device("cpu"),
+    )
+    common_attn_metadata.is_prefilling = torch.tensor([True, True, False])
+    spec_sequence_masks = torch.tensor([False, False, True])
+    num_accepted_tokens = torch.tensor([1, 1, 2], dtype=torch.int32)
+
+    folded_masks, folded_accepted = builder._fold_spec_sized_prefill_chunks_into_spec(
+        common_attn_metadata,
+        spec_sequence_masks,
+        num_accepted_tokens,
+    )
+
+    assert torch.equal(folded_masks, torch.tensor([True, False, True]))
+    assert torch.equal(folded_accepted, torch.tensor([4, 1, 2], dtype=torch.int32))
+    assert torch.equal(spec_sequence_masks, torch.tensor([False, False, True]))
+    assert torch.equal(num_accepted_tokens, torch.tensor([1, 1, 2], dtype=torch.int32))
+
+
 def _assert_chunk_meta_matches_runtime(builder, chunk_meta, cu_seqlens: torch.Tensor) -> None:
     hf_text_config = getattr(builder.vllm_config.model_config, "hf_text_config", None)
     if hf_text_config is not None and hasattr(hf_text_config, "linear_num_value_heads"):

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -32,6 +32,8 @@ from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiGatedDeltaNetAttention,
     _load_a_log,
+    _resolve_kda_qkv_input,
+    _start_kda_qkv_concat,
     _zero_padded_spec_output,
 )
 
@@ -135,6 +137,88 @@ def test_load_a_log_rejects_unsupported_layout():
         _load_a_log(torch.empty(1, 1, 2, 1), torch.empty(2, 2), num_heads=4)
 
 
+def test_start_kda_qkv_concat_cpu_packs_without_streams():
+    q = torch.randn(4, 2)
+    k = torch.randn(4, 3)
+    v = torch.randn(4, 5)
+
+    mixed_qkv, main_stream, concat_stream = _start_kda_qkv_concat(q, k, v)
+
+    torch.testing.assert_close(mixed_qkv, torch.cat((q, k, v), dim=-1))
+    assert main_stream is None
+    assert concat_stream is None
+
+
+def test_resolve_kda_qkv_input_supports_packed_and_legacy_inputs():
+    q = torch.randn(4, 2)
+    k = torch.randn(4, 3)
+    v = torch.randn(4, 5)
+    packed = torch.cat((q, k, v), dim=-1)
+    sentinel = packed[:, :0]
+
+    resolved_packed = _resolve_kda_qkv_input(packed, sentinel, sentinel, 3)
+    resolved_legacy = _resolve_kda_qkv_input(q, k, v, 3)
+
+    torch.testing.assert_close(resolved_packed, packed[:3])
+    torch.testing.assert_close(resolved_legacy, packed[:3])
+
+
+def test_forward_passes_packed_qkv_sentinels_to_custom_op(monkeypatch):
+    attention = AscendKimiGatedDeltaNetAttention.__new__(AscendKimiGatedDeltaNetAttention)
+    nn.Module.__init__(attention)
+    attention.is_vl_first_layer = False
+    attention.use_full_rank_gate = True
+    attention.local_num_heads = 1
+    attention.head_dim = 2
+    attention.prefix = "model.layers.0.self_attn"
+
+    q = torch.randn(4, 2)
+    k = torch.randn(4, 2)
+    v = torch.randn(4, 2)
+
+    def fake_projection(result):
+        def project(_hidden_states):
+            return (result,)
+
+        return project
+
+    attention.q_proj = fake_projection(q)
+    attention.k_proj = fake_projection(k)
+    attention.v_proj = fake_projection(v)
+    attention.b_proj = fake_projection(torch.randn(4, 1))
+    attention.f_a_proj = fake_projection(torch.randn(4, 2))
+    attention.f_b_proj = fake_projection(torch.randn(4, 2))
+    attention.g_proj = fake_projection(torch.randn(4, 2))
+    attention.o_proj = fake_projection(q)
+
+    def fake_output_norm_gate(core_attn_out, output_gate):
+        del output_gate
+        return core_attn_out
+
+    attention._apply_output_norm_gate = fake_output_norm_gate
+
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "maybe_all_gather_and_maybe_unpad",
+        lambda hidden_states, enabled: hidden_states,
+    )
+
+    def fake_kda_attention(packed_qkv, k_sentinel, v_sentinel, raw_gate, beta, core_attn_out, prefix):
+        del raw_gate, beta
+        assert prefix == attention.prefix
+        assert packed_qkv.shape == (4, 6)
+        assert k_sentinel.shape == (4, 0)
+        assert v_sentinel.shape == (4, 0)
+        core_attn_out.copy_(packed_qkv[:, :2].reshape(1, 4, 1, 2))
+
+    monkeypatch.setattr(torch.ops.vllm, "kda_attention", fake_kda_attention)
+
+    output = torch.empty_like(q)
+    attention.forward(torch.randn(4, 8), torch.empty(0), output)
+
+    torch.testing.assert_close(output, q)
+
+
 def test_zero_padded_spec_output_clears_uninitialized_tail():
     output = torch.arange(16 * 2 * 3, dtype=torch.float32).reshape(1, 16, 2, 3)
     output[:, 8:] = torch.nan
@@ -169,6 +253,32 @@ def test_zero_padded_spec_output_supports_multiple_real_and_dummy_rows():
     assert masked.shape == output.shape
     assert masked.dtype == output.dtype
     assert masked.device == output.device
+
+
+def test_output_norm_gate_uses_kda_fused_triton_kernel():
+    attention = AscendKimiGatedDeltaNetAttention.__new__(AscendKimiGatedDeltaNetAttention)
+    nn.Module.__init__(attention)
+    attention.o_norm = SimpleNamespace(
+        weight=nn.Parameter(torch.randn(3)),
+        eps=1e-6,
+    )
+    core_attn_out = torch.randn(1, 4, 2, 3)
+    output_gate = torch.randn(4, 2, 3)
+    expected = torch.randn_like(core_attn_out)
+
+    with patch(
+        "vllm_ascend.ops.kimi_kda.apply_kda_rms_norm_sigmoid_gate",
+        return_value=expected,
+    ) as fused_norm_gate:
+        actual = attention._apply_output_norm_gate(core_attn_out, output_gate)
+
+    assert actual is expected
+    fused_norm_gate.assert_called_once_with(
+        core_attn_out,
+        output_gate,
+        attention.o_norm.weight,
+        attention.o_norm.eps,
+    )
 
 
 def test_conv_post_load_processing_packs_kernel_layout_in_place():

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import regex as re
@@ -53,6 +54,195 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         params = self.method.get_pergroup_param(8, 32, torch.bfloat16, layer_type="row")
         self.assertEqual(params["scale_bias"].dtype, torch.float32)
         self.assertEqual(params["scale_bias"].shape, (32, 16))
+
+    def test_per_channel_weight_uses_only_first_level_scale(self):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16)
+
+        self.assertEqual(params["weight_scale"].shape, (32, 1))
+        self.assertEqual(params["weight_offset"].shape, (32, 1))
+        self.assertNotIn("weight_scale_second", params)
+        self.assertNotIn("weight_offset_second", params)
+        self.assertEqual(params["scale_bias"].shape, (32, 1))
+
+    @patch("torch_npu.npu_quant_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_weight_uses_per_token_activation_scale(self, mock_dynamic_quant, mock_matmul):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(8, 4, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.bfloat16), requires_grad=False)
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        mock_dynamic_quant.return_value = (quantized_x, pertoken_scale)
+        mock_matmul.return_value = torch.empty(2, 8, dtype=torch.bfloat16)
+
+        self.method.apply(layer, x)
+
+        mock_dynamic_quant.assert_called_once_with(x)
+        self.assertEqual(mock_matmul.call_args.args, (quantized_x, layer.weight, layer.weight_scale))
+        self.assertIs(mock_matmul.call_args.kwargs["pertoken_scale"], pertoken_scale)
+        self.assertEqual(mock_matmul.call_args.kwargs["output_dtype"], x.dtype)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_kimi_shared_expert_uses_w4a8_grouped_matmul(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.arange(8, dtype=torch.float32), requires_grad=False)
+        x = torch.randn(2, 1, 4, dtype=torch.bfloat16)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        expected_2d = torch.empty(2, 8, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (quantized_x, pertoken_scale)
+        mock_grouped_matmul.return_value = [expected_2d]
+
+        # A host-backed ``torch.tensor(..., device="npu")`` is illegal during
+        # ACL Graph capture. Keep this unit test sensitive to that regression;
+        # the implementation should create group_list with a device fill op.
+        with patch(
+            "torch.tensor",
+            side_effect=AssertionError("host tensor construction is not graph-safe"),
+        ):
+            output = self.method.apply(layer, x)
+
+        self.assertEqual(output.shape, (2, 1, 8))
+        mock_dynamic_quant.assert_called_once()
+        torch.testing.assert_close(mock_dynamic_quant.call_args.args[0], x.reshape(2, 4))
+        mock_grouped_matmul.assert_called_once()
+        call = mock_grouped_matmul.call_args.kwargs
+        self.assertIs(call["x"][0], quantized_x)
+        self.assertIs(call["weight"][0], layer.weight)
+        torch.testing.assert_close(call["scale"][0], layer.weight_scale.reshape(1, 1, -1))
+        torch.testing.assert_close(call["bias"][0], layer.scale_bias.reshape(1, -1))
+        self.assertIs(call["per_token_scale"][0], pertoken_scale)
+        torch.testing.assert_close(call["group_list"], torch.tensor([2]))
+        self.assertEqual(call["split_item"], 2)
+        self.assertEqual(call["group_type"], 0)
+        self.assertEqual(call["group_list_type"], 1)
+        self.assertEqual(call["output_dtype"], x.dtype)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_kimi_shared_expert_reuses_quantized_input(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.arange(8, dtype=torch.float32), requires_grad=False)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        expected = torch.empty(2, 8, dtype=torch.bfloat16)
+        mock_grouped_matmul.return_value = [expected]
+
+        output = self.method.apply(layer, (quantized_x, pertoken_scale))
+
+        self.assertEqual(output.shape, expected.shape)
+        torch.testing.assert_close(output, expected)
+        mock_dynamic_quant.assert_not_called()
+        call = mock_grouped_matmul.call_args.kwargs
+        self.assertIs(call["x"][0], quantized_x)
+        self.assertIs(call["per_token_scale"][0], pertoken_scale)
+        self.assertEqual(call["output_dtype"], torch.bfloat16)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_kimi_shared_expert_sums_owned_tp_scale_bias(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        layer = torch.nn.Module()
+        layer.tp_size = 4
+        layer.tp_rank = 3
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(
+            torch.arange(8 * 16, dtype=torch.float32).reshape(8, 16),
+            requires_grad=False,
+        )
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (
+            torch.ones(2, 4, dtype=torch.int8),
+            torch.ones(2, dtype=torch.float32),
+        )
+        mock_grouped_matmul.return_value = [torch.empty(2, 8)]
+
+        self.method.apply(layer, x, tp_rank=3)
+
+        grouped_bias = mock_grouped_matmul.call_args.kwargs["bias"][0]
+        torch.testing.assert_close(grouped_bias, layer.scale_bias[:, 12:16].sum(dim=1).reshape(1, -1))
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_kimi_shared_expert_tp1_sums_all_scale_bias(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        layer = torch.nn.Module()
+        layer.tp_size = 1
+        layer.tp_rank = 0
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(
+            torch.arange(8 * 16, dtype=torch.float32).reshape(8, 16),
+            requires_grad=False,
+        )
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (
+            torch.ones(2, 4, dtype=torch.int8),
+            torch.ones(2, dtype=torch.float32),
+        )
+        mock_grouped_matmul.return_value = [torch.empty(2, 8)]
+
+        self.method.apply(layer, x)
+
+        grouped_bias = mock_grouped_matmul.call_args.kwargs["bias"][0]
+        torch.testing.assert_close(grouped_bias, layer.scale_bias.sum(dim=1).reshape(1, -1))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.get_tensor_model_parallel_world_size", return_value=1)
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
+    def test_kimi_k3_text_config_marks_only_shared_expert(self, mock_get_current_vllm_config, _mock_get_tp_world_size):
+        """Text-only K3 loading exposes kimi_linear as its immediate config."""
+        mock_get_current_vllm_config.return_value = SimpleNamespace(
+            quant_config=SimpleNamespace(quant_description={"group_size": 256}),
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(model_type="kimi_linear"),
+                hf_text_config=SimpleNamespace(
+                    model_type="kimi_linear",
+                    mla_use_output_gate=True,
+                    routed_expert_hidden_size=3584,
+                ),
+            ),
+        )
+        method = AscendW4A8DynamicLinearMethod()
+        shared_layer = SimpleNamespace(prefix="model.layers.0.block_sparse_moe.shared_experts.gate_up_proj")
+        routed_layer = SimpleNamespace(prefix="model.layers.0.block_sparse_moe.experts")
+
+        self.assertTrue(method._uses_per_channel_shared_expert(shared_layer))
+        self.assertFalse(method._uses_per_channel_shared_expert(routed_layer))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
+    def test_process_per_channel_weight_without_second_level_scale(self, _mock_maybe_trans_nz):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.empty((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.weight.data.shape, (8, 4))
+        self.assertEqual(layer.weight_scale.data.shape, (32,))
+        self.assertEqual(layer.weight_scale.dtype, torch.bfloat16)
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        torch.testing.assert_close(layer.weight_scale_fp32, layer.weight_scale.data.float())
+        self.assertFalse(hasattr(layer, "weight_scale_second"))
 
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_convert_weight_to_int4pack")
@@ -126,6 +316,65 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
             patch.object(self.method, "process_scale_second", return_value=(torch.ones((2, 20)), None)),
             self.assertRaisesRegex(AssertionError, re.escape(expected_message)),
         ):
+            self.method.process_weights_after_loading(layer)
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    @patch("torch_npu.npu_convert_weight_to_int4pack")
+    def test_process_kimi_shared_expert_prepares_grouped_nz_weight(self, mock_int4pack, mock_maybe_trans_nz):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        self.method.new_quant_version = True
+        mock_maybe_trans_nz.side_effect = identity
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(
+            torch.tensor([[1.0], [2.0]] + [[1.0]] * 30, dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        mock_int4pack.assert_not_called()
+        mock_maybe_trans_nz.assert_called_once()
+        nz_input = mock_maybe_trans_nz.call_args.args[0]
+        self.assertEqual(nz_input.shape, torch.Size([1, 8, 16]))
+        self.assertEqual(nz_input.dtype, torch.int8)
+        self.assertEqual(layer.weight.shape, torch.Size([1, 8, 4]))
+        self.assertEqual(layer.weight.dtype, torch.int32)
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        self.assertEqual(layer.weight_scale_fp32.shape, torch.Size([32]))
+        self.assertEqual(layer.weight_scale.dtype, torch.int64)
+        expected_scale_bits = layer.weight_scale_fp32.numpy().view("uint32").astype("int64")
+        torch.testing.assert_close(layer.weight_scale, torch.from_numpy(expected_scale_bits))
+        self.assertEqual(layer.scale_bias.shape, torch.Size([32]))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
+    def test_process_kimi_shared_expert_tp1_sums_down_scale_bias(self, _mock_maybe_trans_nz):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        self.method.new_quant_version = True
+        layer = torch.nn.Module()
+        layer.tp_size = 1
+        layer.tp_rank = 0
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        original_bias = torch.arange(32 * 16, dtype=torch.float32).reshape(32, 16)
+        layer.scale_bias = torch.nn.Parameter(original_bias.clone(), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        torch.testing.assert_close(layer.scale_bias, original_bias.sum(dim=1))
+
+    def test_process_kimi_shared_expert_rejects_old_quant_version(self):
+        self.method.enable_per_channel_for_kimi_shared_expert()
+        self.method.new_quant_version = False
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((32, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        with self.assertRaisesRegex(ValueError, "requires quantization version 1.0.0"):
             self.method.process_weights_after_loading(layer)
 
 

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -13,6 +13,7 @@ from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
     AscendModelSlimConfig,
@@ -191,6 +192,57 @@ class TestAscendModelSlimConfig(TestBase):
             "experts.0.up_proj",
             "experts.0.down_proj",
         ]
+
+    def test_kimi_k3_shared_expert_w4a8_uses_per_channel_scheme(self):
+        prefix = "model.layers.0.mlp.shared_experts.gate_up_proj"
+        config = AscendModelSlimConfig({f"{prefix}.weight": "W4A8_DYNAMIC"})
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "kimi_k3"
+        vllm_config.model_config.hf_text_config = MagicMock()
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_per_channel_for_kimi_shared_expert.assert_called_once_with()
+
+    def test_kimi_k3_text_config_shared_expert_w4a8_uses_per_channel_scheme(self):
+        """Keep the K3 override when vLLM exposes only the nested text config."""
+        prefix = "model.layers.0.block_sparse_moe.shared_experts.gate_up_proj"
+        config = AscendModelSlimConfig({f"{prefix}.weight": "W4A8_DYNAMIC"})
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "kimi_linear"
+        vllm_config.model_config.hf_text_config.model_type = "kimi_linear"
+        vllm_config.model_config.hf_text_config.mla_use_output_gate = True
+        vllm_config.model_config.hf_text_config.routed_expert_hidden_size = 3584
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_per_channel_for_kimi_shared_expert.assert_called_once_with()
 
     def test_missing_linear_weight_without_gate_capability_does_not_fall_back(self):
         config = AscendModelSlimConfig({})

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -47,6 +47,7 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla, get_identity_cos_and_sin_mla
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.methods.w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
 from vllm_ascend.quantization.methods.w8a8_static import AscendW8A8LinearMethod
 from vllm_ascend.quantization.utils import enable_fa_quant
@@ -931,22 +932,14 @@ class AscendMLAImpl(MLAAttentionImpl):
 
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)
-        if not self.use_mla_rope and (self.fa_quant_layer or self.enable_mlapo):
-            # Both optimized preprocess paths fuse rotary reordering into the
-            # q/kv prolog. A no-RoPE positional slice must remain in checkpoint
-            # order, so use the explicit no-RoPE baseline instead.
-            logger.warning_once("FA quant/MLAPO is disabled for MLA layers with RoPE disabled.")
-            self.fa_quant_layer = False
-            self.enable_mlapo = False
         if self.fa_quant_layer:
             self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
         else:
             self.dtype = self.vllm_config.model_config.dtype
-        # For models whose num_heads is not a power of 2 (e.g., GLM-4.7-Flash
-        # with 20 heads), ascend attention ops require padding heads to the
-        # next power of 2.
-        self.num_heads_padded = 1 << (self.num_heads - 1).bit_length()
-        self.head_padding = self.num_heads_padded - self.num_heads
+        # The prefill fused-attention operator requires combined Q/K inputs
+        # for models whose head count is not a power of two. Decode uses v2,
+        # which accepts the original head count and does not require padding.
+        self.prefill_uses_combined_qk = self.num_heads & (self.num_heads - 1) != 0
 
     @staticmethod
     def update_graph_params(
@@ -1155,23 +1148,34 @@ class AscendMLAImpl(MLAAttentionImpl):
         # TODO(zzzzwwjj): Currently, torch.ops._C_ascend.batch_matmul_transpose cannot support weight nz
         # self.W_UV = maybe_trans_nz(self.W_UV)
 
+        fused_qkv_quant_method = None
+        if self.fused_qkv_a_proj is not None:
+            fused_qkv_quant_method = getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None)
+        q_proj_quant_method = getattr(self.q_proj.quant_method, "quant_method", None)
+        self.mlapo_quant_mode = "per_tensor_quant_asymm"
+        dynamic_w8a8_mlapo = (
+            get_ascend_device_type() != AscendDeviceType.A5
+            and isinstance(fused_qkv_quant_method, AscendW8A8DynamicLinearMethod)
+            and isinstance(q_proj_quant_method, AscendW8A8DynamicLinearMethod)
+            and act_dtype == torch.bfloat16
+        )
         if self.enable_mlapo:
-            # Currently mlapo only supports W8A8 and W8A8MXFP8 quantization in MLA scenario
-            # TODO(whx): modify this limitation when mlapo supports floating point
+            # A3 supports W8A8 dynamic through mla_preprocess's
+            # per_token_quant_symm mode. The mode requires BF16 activations and
+            # both packed QKV-A and Q-B projections to use the dynamic scheme.
             if self.fused_qkv_a_proj is None or (
-                not isinstance(
-                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None), AscendW8A8LinearMethod
-                )
-                and not isinstance(
-                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None),
-                    AscendW8A8MXFP8DynamicLinearMethod,
-                )
+                not isinstance(fused_qkv_quant_method, AscendW8A8LinearMethod)
+                and not isinstance(fused_qkv_quant_method, AscendW8A8MXFP8DynamicLinearMethod)
+                and not dynamic_w8a8_mlapo
             ):
                 self.enable_mlapo = False
                 logger.warning_once(
-                    "mlapo only supports W8A8 quantization in MLA. "
-                    "Some layers not W8A8 quantized, mlapo disabled for these layers."
+                    "mlapo only supports static W8A8, A3 BF16 W8A8 dynamic, "
+                    "or W8A8 MXFP8 quantization in MLA. MLAPO is disabled "
+                    "for unsupported layers."
                 )
+        if self.enable_mlapo and dynamic_w8a8_mlapo:
+            self.mlapo_quant_mode = "per_token_quant_symm"
         if self.enable_mlapo:
             if get_ascend_device_type() == AscendDeviceType.A5:
                 self._process_weights_for_fused_mlapo_a5(act_dtype)
@@ -1211,6 +1215,15 @@ class AscendMLAImpl(MLAAttentionImpl):
         assert self.fused_qkv_a_proj is not None
         assert self.q_a_layernorm is not None
         assert self.kv_a_layernorm is not None
+        dynamic_w8a8 = getattr(self, "mlapo_quant_mode", "per_tensor_quant_asymm") == "per_token_quant_symm"
+        if dynamic_w8a8:
+            for linear in (self.fused_qkv_a_proj, self.q_proj):
+                if torch.count_nonzero(linear.weight_offset).item() != 0:
+                    raise ValueError(
+                        "A3 MLAPO W8A8 dynamic requires symmetric weights "
+                        f"(zero weight_offset), but {getattr(linear, 'prefix', '<unknown>')} has a non-zero offset."
+                    )
+
         kv_a_proj_wt = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
         q_a_proj_wt = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
         kv_a_proj_wt = kv_a_proj_wt.t().contiguous()
@@ -1221,19 +1234,25 @@ class AscendMLAImpl(MLAAttentionImpl):
         wd_qkv = transdata(wd_qkv, block_size=(16, 32)).unsqueeze(0).contiguous()
         self.wd_qkv = torch_npu.npu_format_cast(wd_qkv, 29)
 
-        kv_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
-        q_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[: self.q_lora_rank].contiguous()  # type: ignore[union-attr]
+        fused_qkv_scale = (
+            self.fused_qkv_a_proj.weight_scale.data.flatten() if dynamic_w8a8 else self.fused_qkv_a_proj.deq_scale
+        )
+        kv_a_proj_deq_scl = fused_qkv_scale[self.q_lora_rank :].contiguous()
+        q_a_proj_deq_scl = fused_qkv_scale[: self.q_lora_rank].contiguous()
         kv_a_proj_deq_scl = kv_a_proj_deq_scl.reshape(self.kv_lora_rank + self.qk_rope_head_dim, -1).contiguous()
         kv_a_proj_deq_scl = trans_rope_weight(kv_a_proj_deq_scl, self.qk_rope_head_dim)
         kv_a_proj_deq_scl = kv_a_proj_deq_scl.view(self.kv_lora_rank + self.qk_rope_head_dim).contiguous()
         self.deq_scale_qkv = torch.cat((kv_a_proj_deq_scl, q_a_proj_deq_scl), dim=-1).contiguous()
 
-        kv_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
-        q_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[: self.q_lora_rank].contiguous()  # type: ignore[union-attr]
-        kv_a_proj_qt_bias = kv_a_proj_qt_bias.reshape(self.kv_lora_rank + self.qk_rope_head_dim, -1).contiguous()
-        kv_a_proj_qt_bias = trans_rope_weight(kv_a_proj_qt_bias, self.qk_rope_head_dim)
-        kv_a_proj_qt_bias = kv_a_proj_qt_bias.view(self.kv_lora_rank + self.qk_rope_head_dim).contiguous()
-        self.quant_bias_qkv = torch.cat((kv_a_proj_qt_bias, q_a_proj_qt_bias), dim=-1).contiguous()
+        if dynamic_w8a8:
+            self.quant_bias_qkv = torch.zeros_like(self.deq_scale_qkv, dtype=torch.int32)
+        else:
+            kv_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[self.q_lora_rank :].contiguous()
+            q_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[: self.q_lora_rank].contiguous()
+            kv_a_proj_qt_bias = kv_a_proj_qt_bias.reshape(self.kv_lora_rank + self.qk_rope_head_dim, -1).contiguous()
+            kv_a_proj_qt_bias = trans_rope_weight(kv_a_proj_qt_bias, self.qk_rope_head_dim)
+            kv_a_proj_qt_bias = kv_a_proj_qt_bias.view(self.kv_lora_rank + self.qk_rope_head_dim).contiguous()
+            self.quant_bias_qkv = torch.cat((kv_a_proj_qt_bias, q_a_proj_qt_bias), dim=-1).contiguous()
 
         wu_q = self.q_proj.weight.data
         wu_q = wu_q.t().reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
@@ -1242,24 +1261,36 @@ class AscendMLAImpl(MLAAttentionImpl):
         wu_q = transdata(wu_q, block_size=(16, 32)).unsqueeze(0).contiguous()
         self.wu_q = torch_npu.npu_format_cast(wu_q, 29)
 
-        qb_deq_scl = self.q_proj.deq_scale.data
+        qb_deq_scl = self.q_proj.weight_scale.data.flatten() if dynamic_w8a8 else self.q_proj.deq_scale.data
         qb_deq_scl = qb_deq_scl.reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
         qb_deq_scl = trans_rope_weight(qb_deq_scl, self.qk_rope_head_dim)
         self.qb_deq_scl = qb_deq_scl.reshape(self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim))
 
-        qb_qt_bias = self.q_proj.quant_bias.data
-        qb_qt_bias = qb_qt_bias.reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
-        qb_qt_bias = trans_rope_weight(qb_qt_bias, self.qk_rope_head_dim)
-        self.qb_qt_bias = qb_qt_bias.reshape(self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim))
+        if dynamic_w8a8:
+            self.qb_qt_bias = torch.zeros_like(self.qb_deq_scl, dtype=torch.int32)
+        else:
+            qb_qt_bias = self.q_proj.quant_bias.data
+            qb_qt_bias = qb_qt_bias.reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
+            qb_qt_bias = trans_rope_weight(qb_qt_bias, self.qk_rope_head_dim)
+            self.qb_qt_bias = qb_qt_bias.reshape(self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim))
 
         device = self.q_proj.weight.device
-        self.gamma1 = self.q_a_layernorm.weight.data  # type: ignore[union-attr]
-        self.beta1 = torch.zeros_like(self.gamma1) if (_bias := self.q_a_layernorm.bias) is None else _bias.data  # type: ignore[union-attr]
-        self.gamma2 = self.kv_a_layernorm.weight.data  # type: ignore[union-attr]
-        self.quant_scale0 = self.fused_qkv_a_proj.input_scale.data  # type: ignore[union-attr]
-        self.quant_offset0 = self.fused_qkv_a_proj.input_offset.data  # type: ignore[union-attr]
-        self.quant_scale1 = self.q_proj.input_scale.data
-        self.quant_offset1 = self.q_proj.input_offset.data
+        self.gamma1 = self.q_a_layernorm.weight.data
+        self.beta1 = torch.zeros_like(self.gamma1) if (_bias := self.q_a_layernorm.bias) is None else _bias.data
+        self.gamma2 = self.kv_a_layernorm.weight.data
+        if dynamic_w8a8:
+            # per_token_quant_symm derives activation scales in the kernel.
+            # Keep valid placeholders because all quantized kernels initialize
+            # these input addresses.
+            self.quant_scale0 = torch.ones(1, dtype=act_dtype, device=device)
+            self.quant_offset0 = torch.zeros(1, dtype=torch.int8, device=device)
+            self.quant_scale1 = torch.ones(1, dtype=act_dtype, device=device)
+            self.quant_offset1 = torch.zeros(1, dtype=torch.int8, device=device)
+        else:
+            self.quant_scale0 = self.fused_qkv_a_proj.input_scale.data
+            self.quant_offset0 = self.fused_qkv_a_proj.input_offset.data
+            self.quant_scale1 = self.q_proj.input_scale.data
+            self.quant_offset1 = self.q_proj.input_offset.data
         self.ctkv_scale = torch.tensor([1], dtype=act_dtype, device=device)
         self.q_nope_scale = torch.tensor([1], dtype=act_dtype, device=device)
 
@@ -1271,12 +1302,18 @@ class AscendMLAImpl(MLAAttentionImpl):
             and self.vllm_config.kv_transfer_config.is_kv_consumer
             and self.vllm_config.scheduler_config.max_num_batched_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
         ):
-            self.fused_qkv_a_proj.weight = None  # type: ignore[union-attr]
-            self.fused_qkv_a_proj.deq_scale = None  # type: ignore[union-attr]
-            self.fused_qkv_a_proj.quant_bias = None  # type: ignore[union-attr]
+            self.fused_qkv_a_proj.weight = None
             self.q_proj.weight = None
-            self.q_proj.deq_scale = None
-            self.q_proj.quant_bias = None
+            if dynamic_w8a8:
+                self.fused_qkv_a_proj.weight_scale = None
+                self.fused_qkv_a_proj.weight_offset = None
+                self.q_proj.weight_scale = None
+                self.q_proj.weight_offset = None
+            else:
+                self.fused_qkv_a_proj.deq_scale = None
+                self.fused_qkv_a_proj.quant_bias = None
+                self.q_proj.deq_scale = None
+                self.q_proj.quant_bias = None
             torch.npu.empty_cache()
 
     def _process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
@@ -1362,7 +1399,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         out_list = [prefix_output.reshape(num_tokens * H, D)]
         lse_list = [prefix_lse.reshape(num_tokens * H)]
 
-        if self.head_padding > 0:
+        if self.prefill_uses_combined_qk:
             query = torch.cat((q_nope, q_pe), dim=-1)
 
         common_kwargs = {
@@ -1412,7 +1449,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
             common_kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
 
-            if self.head_padding > 0:
+            if self.prefill_uses_combined_qk:
                 key = torch.cat((k_nope, k_pe), dim=-1)
             else:
                 common_kwargs["query_rope"] = q_pe
@@ -1482,7 +1519,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         }
         record_attention_compute_start()
 
-        if self.head_padding > 0:
+        if self.prefill_uses_combined_qk:
             query = torch.cat((q_nope, q_pe), dim=-1)
             key = torch.cat((k_nope, k_pe), dim=-1)
         else:
@@ -1641,9 +1678,6 @@ class AscendMLAImpl(MLAAttentionImpl):
     ) -> torch.Tensor:
         decode_meta = attn_metadata.decode
         assert decode_meta is not None
-        # TODO: The CANN package is expected to support num_heads that are not
-        # powers of 2 in 2026 Q2. Once supported, all padding operations under
-        # `if self.head_padding > 0` in this function can be removed.
         num_tokens = q_nope.size(0)
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]
@@ -1687,11 +1721,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             # Input shape: [num_tokens, num_heads, dim]
             q_nope = q_nope.view(num_tokens, self.num_heads, -1).contiguous()
             q_pe = q_pe.view(num_tokens, self.num_heads, -1)
-            if self.head_padding > 0:
-                q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, self.kv_lora_rank)
             sparse_mode = 3
             attn_mask = attn_metadata.decode.attn_mask  # type:ignore
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
@@ -1705,20 +1736,14 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BNSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
-                attn_output_shape = (num_tokens, self.num_heads_padded, 1, self.kv_lora_rank)
+                attn_output_shape = (num_tokens, self.num_heads, 1, self.kv_lora_rank)
             else:
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1).contiguous()
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
-                attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1727,19 +1752,13 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, 1, self.num_heads, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             else:
                 # Input shape: [num_tokens, num_heads, seq_len, dim]
                 input_layout = "BNSD_NBSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
-                if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, seq_len, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+            attn_output_shape = (self.num_heads, num_tokens, 1, self.kv_lora_rank)
             sparse_mode = 0
             attn_mask = None
 
@@ -1778,18 +1797,18 @@ class AscendMLAImpl(MLAAttentionImpl):
 
             split_batch_size = num_tokens * fia_num_splits
             if input_layout.endswith("_NBSD"):
-                attn_output_shape = (self.num_heads_padded, split_batch_size, 1, self.kv_lora_rank)
+                attn_output_shape = (self.num_heads, split_batch_size, 1, self.kv_lora_rank)
             elif input_layout.startswith("BNSD"):
-                attn_output_shape = (split_batch_size, self.num_heads_padded, 1, self.kv_lora_rank)
+                attn_output_shape = (split_batch_size, self.num_heads, 1, self.kv_lora_rank)
             elif input_layout.startswith("BSND"):
-                attn_output_shape = (split_batch_size, 1, self.num_heads_padded, self.kv_lora_rank)
+                attn_output_shape = (split_batch_size, 1, self.num_heads, self.kv_lora_rank)
             else:
                 raise ValueError(f"Unsupported MLA FIA split input layout: {input_layout}")
 
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
-            "num_query_heads": self.num_heads_padded,
+            "num_query_heads": self.num_heads,
             "num_key_value_heads": self.num_kv_heads,
             "input_layout": input_layout,
             "atten_mask": attn_mask,
@@ -1831,7 +1850,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             attn_output = torch.empty(attn_output_shape, dtype=q_pe.dtype, device=q_pe.device)
             if fia_num_splits > 1:
                 softmax_lse = torch.empty(
-                    (split_batch_size, self.num_heads_padded, 1, 1),
+                    (split_batch_size, self.num_heads, 1, 1),
                     dtype=torch.float32,
                     device=q_nope.device,
                 )
@@ -1842,7 +1861,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 weak_ref_tensors(k_nope),
                 weak_ref_tensors(q_pe),
                 weak_ref_tensors(k_pe),
-                self.num_heads_padded,
+                self.num_heads,
                 self.num_kv_heads,
                 input_layout,
                 weak_ref_tensors(attn_mask) if attn_mask is not None else None,
@@ -1893,7 +1912,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 input_layout=input_layout,
                 batch_size=num_tokens,
                 num_splits=fia_num_splits,
-                num_heads=self.num_heads_padded,
+                num_heads=self.num_heads,
                 head_dim=self.kv_lora_rank,
                 seq_lens_device=decode_meta.seq_lens_device,
                 chunk_tokens=fia_blocks_per_split * block_size,
@@ -1907,14 +1926,12 @@ class AscendMLAImpl(MLAAttentionImpl):
                     attn_output,
                     input_layout=input_layout,
                     batch_size=num_tokens,
-                    num_heads=self.num_heads_padded,
+                    num_heads=self.num_heads,
                     head_dim=self.kv_lora_rank,
                 )
                 .permute(1, 0, 2)
                 .contiguous()
             )
-        if self.head_padding > 0:
-            attn_output = attn_output[: self.num_heads]
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):
@@ -2082,7 +2099,11 @@ class AscendMLAImpl(MLAAttentionImpl):
                 hidden_states.contiguous(), need_gather_q_kv
             )
             decode_preprocess_res, prefill_preprocess_res = DeviceOperator.mla_preprocess_only_decode(
-                self, hidden_states, kv_cache, attn_metadata
+                self,
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                use_mla_rope=self.use_mla_rope,
             )
         else:
             decode_preprocess_res, prefill_preprocess_res = self._mla_preprocess(

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -498,13 +498,4 @@ def transdata(nd_mat, block_size: tuple = (16, 16)):
 
 
 def enabling_mlapo(vllm_config: VllmConfig) -> bool:
-    config_val = get_ascend_config().enable_mlapo
-    if get_ascend_device_type() == AscendDeviceType.A5:
-        return bool(config_val)
-
-    is_decode_instance = (
-        vllm_config.kv_transfer_config is not None
-        and vllm_config.kv_transfer_config.is_kv_consumer
-        and not vllm_config.kv_transfer_config.is_kv_producer
-    )
-    return bool(config_val and is_decode_instance)
+    return bool(get_ascend_config().enable_mlapo)

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -307,7 +307,13 @@ class BaseDeviceAdaptor:
         )
 
     @staticmethod
-    def mla_preprocess_only_decode(atten_obj, hidden_states, kv_cache, attn_metadata):
+    def mla_preprocess_only_decode(
+        atten_obj,
+        hidden_states,
+        kv_cache,
+        attn_metadata,
+        use_mla_rope: bool = True,
+    ):
         bsz = attn_metadata.num_decode_tokens
         hidden_states = hidden_states[:bsz]
 
@@ -318,6 +324,9 @@ class BaseDeviceAdaptor:
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         dequant_scale_q_nope = None
         if atten_obj.fa_quant_layer:
+            # TODO: npu_mla_prolog_v2 does not yet support disabling RoPE.
+            # Keep its existing tensor inputs for FA-quant layers. No-RoPE
+            # support is currently limited to _C_ascend.mla_preprocess below.
             quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
             decode_q_nope, decode_q_pe, decode_k_nope, decode_k_pe, dequant_scale_q_nope = torch_npu.npu_mla_prolog_v2(
                 quantized_x,
@@ -340,6 +349,9 @@ class BaseDeviceAdaptor:
                 cache_mode="PA_NZ",
             )
         else:
+            if not use_mla_rope:
+                cos = None
+                sin = None
             decode_q_nope = torch.empty(
                 (hidden_states.shape[0], atten_obj.W_UK_T.shape[0], decode_k_nope.shape[-1]),
                 dtype=hidden_states.dtype,
@@ -375,7 +387,7 @@ class BaseDeviceAdaptor:
                 ctkv_scale=atten_obj.ctkv_scale,
                 q_nope_scale=atten_obj.q_nope_scale,
                 cache_mode="nzcache" if atten_obj.enable_kv_nz else "krope_ctkv",
-                quant_mode="per_tensor_quant_asymm",
+                quant_mode=atten_obj.mlapo_quant_mode,
                 q_out0=decode_q_nope,
                 kv_cache_out0=decode_k_nope,
                 q_out1=decode_q_pe,
@@ -1397,7 +1409,13 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )
 
     @staticmethod
-    def mla_preprocess_only_decode(atten_obj, hidden_states, kv_cache, attn_metadata):
+    def mla_preprocess_only_decode(
+        atten_obj,
+        hidden_states,
+        kv_cache,
+        attn_metadata,
+        use_mla_rope: bool = True,
+    ):
         bsz = attn_metadata.num_decode_tokens
         hidden_states = hidden_states[:bsz].unsqueeze(1)
         hidden_states, dynamic_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -17,7 +17,7 @@
 """Native multimodal Kimi K3 model for vLLM-Ascend."""
 
 import math
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
 from typing import Annotated, Any, Literal, cast
 
@@ -101,6 +101,7 @@ from vllm.multimodal.processing import (
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.processor import cached_get_image_processor
+from vllm.triton_utils import HAS_TRITON
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -110,6 +111,18 @@ from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
 from vllm_ascend.transformers_utils.configs.kimi_k3 import KimiK3Config, KimiK3TextConfig, KimiK3VisionConfig
 from vllm_ascend.transformers_utils.processors.kimi_k3 import KimiK3Processor
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
+
+apply_attn_res: (
+    Callable[
+        [torch.Tensor, torch.Tensor, nn.Module, nn.Module],
+        torch.Tensor,
+    ]
+    | None
+) = None
+if HAS_TRITON:
+    from vllm_ascend.ops.triton.kimi_k3.attention_residual import apply_attn_res as triton_apply_attn_res
+
+    apply_attn_res = triton_apply_attn_res
 
 
 def _routed_latent_quant_config(
@@ -884,16 +897,19 @@ def _apply_attention_residual(
     norm: RMSNorm,
 ) -> torch.Tensor:
     """Apply K3's learned normalized mixture over residual block starts."""
-    values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
-    values_fp32 = values.float()
-    normalized, _ = torch_npu.npu_rms_norm(
-        values_fp32,
-        norm.weight.float(),
-        norm.variance_epsilon,
-    )
-    scores = torch.matmul(normalized, projection.weight.t().float()).squeeze(-1)
-    probabilities = scores.softmax(-1).unsqueeze(1)
-    mixed = torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
+    if apply_attn_res is not None and prefix_sum.device.type == "npu" and prefix_sum.numel() > 0:
+        mixed = apply_attn_res(prefix_sum, block_residual, projection, norm)
+    else:
+        values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
+        values_fp32 = values.float()
+        normalized, _ = torch_npu.npu_rms_norm(
+            values_fp32,
+            norm.weight.float(),
+            norm.variance_epsilon,
+        )
+        scores = torch.matmul(normalized, projection.weight.t().float()).squeeze(-1)
+        probabilities = scores.softmax(-1).unsqueeze(1)
+        mixed = torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
     if _EXTRA_CTX.flash_comm_v1_enabled:
         # FlashComm changes the first decoder layer from the global token
         # layout to a TP-local layout.  The learned-residual arithmetic above

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -781,29 +781,49 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self._shared_experts.down_proj, "weight_scale"
             )
             shared_uses_situ = isinstance(self._shared_experts.act_fn, AscendSituAndMul)
-            if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+            # Kimi K3 shared experts use per-channel W4A8. Their Linear
+            # methods expose floating-point scales after converting the INT4
+            # checkpoint weights to the single-expert GMM layout. This path
+            # reuses those GMM methods with already-quantized activations,
+            # avoiding the incompatible QuantMatmul WeightNZ ABI.
+            has_per_channel_w4a8_situ_shared = (
+                self.quant_type == QuantType.W4A8
+                and shared_uses_situ
+                and all(
+                    hasattr(proj, "weight_scale_fp32")
+                    for proj in (self._shared_experts.gate_up_proj, self._shared_experts.down_proj)
+                )
+            )
+            if has_quantized_shared and (self.quant_type == QuantType.W8A8 or has_per_channel_w4a8_situ_shared):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.after_routed_experts)
-                hidden_states = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.gate_up_proj.weight,
-                    self._shared_experts.gate_up_proj.weight_scale,
-                    pertoken_scale=None,
-                    bias=None,
-                    output_dtype=torch.int32,
-                )
+                if has_per_channel_w4a8_situ_shared:
+                    hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
+                else:
+                    hidden_states = torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        self._shared_experts.gate_up_proj.weight,
+                        self._shared_experts.gate_up_proj.weight_scale,
+                        pertoken_scale=None,
+                        bias=None,
+                        output_dtype=torch.int32,
+                    )
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 if shared_uses_situ:
                     quantized_x, swiglu_out_scale = torch.ops._C_ascend.dequant_situ_quant(
                         x=hidden_states,
-                        weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
-                        activation_scale=pertoken_scale,
+                        weight_scale=(
+                            None
+                            if has_per_channel_w4a8_situ_shared
+                            else self._shared_experts.gate_up_proj.weight_scale_fp32
+                        ),
+                        activation_scale=None if has_per_channel_w4a8_situ_shared else pertoken_scale,
                         bias=None,
                         quant_scale=None,
                         quant_offset=None,
@@ -832,14 +852,17 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 # Execute the down projection concurrently with the combine
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.down_proj.weight,
-                    self._shared_experts.down_proj.weight_scale,
-                    pertoken_scale=swiglu_out_scale,
-                    bias=None,
-                    output_dtype=original_dtype,
-                )
+                if has_per_channel_w4a8_situ_shared:
+                    shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
+                else:
+                    shared_out = torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        self._shared_experts.down_proj.weight,
+                        self._shared_experts.down_proj.weight_scale,
+                        pertoken_scale=swiglu_out_scale,
+                        bias=None,
+                        output_dtype=original_dtype,
+                    )
             elif has_quantized_shared and self.quant_type in (QuantType.W8A8MXFP, QuantType.W4A8MXFP):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
@@ -878,6 +901,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
+                # Per-group W4A8 shared experts use this path. Kimi K3's
+                # per-channel W4A8 shared experts take the fused branch above.
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)

--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -51,6 +51,33 @@ def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
     return torch.argsort(tensor, stable=True)
 
 
+def _treat_single_token_prefills_with_state_as_decodes(
+    common_attn_metadata: CommonAttentionMetadata,
+) -> CommonAttentionMetadata:
+    """Match the stateful Mamba/GDN contract for uniform one-token rows.
+
+    Full-graph selection is shape based. A final one-token prompt chunk at a
+    PD handoff can therefore replay the same update graph as an ordinary
+    decode. Once a request already has recurrent state, the two cases must
+    construct identical GDN metadata, otherwise the replayed graph consumes
+    stale state indices. First-token prefills stay on the prefill path
+    because they have no prior state to update.
+    """
+    is_prefilling = common_attn_metadata.is_prefilling
+    seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+    if is_prefilling is None or seq_lens_cpu is None:
+        return common_attn_metadata
+
+    query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)
+    prefill_to_decode = is_prefilling & (query_lens_cpu == 1) & (seq_lens_cpu > 1)
+    if not torch.any(prefill_to_decode).item():
+        return common_attn_metadata
+
+    is_prefilling = is_prefilling.clone()
+    is_prefilling[prefill_to_decode] = False
+    return common_attn_metadata.replace(is_prefilling=is_prefilling)
+
+
 @dataclass
 class GDNChunkedPrefillMetadata:
     cu_seqlens_host: tuple[int, ...]
@@ -408,6 +435,57 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         )
         return attn_metadata
 
+    def _fold_spec_sized_prefill_chunks_into_spec(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        spec_sequence_masks_cpu: torch.Tensor,
+        num_accepted_tokens: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Restore the pre-#11735 state contract for spec-sized prompt chunks.
+
+        Decode-graph dispatch is shape based: a prompt chunk of exactly
+        num_spec + 1 tokens (typically the final chunk of a prompt) is
+        shape-identical to a speculative decode row, so its step can replay a
+        decode graph. Before #11735 the replay refreshed conv1d parameters
+        from the live per-step metadata, so such a row still updated its own
+        state; afterwards the graph reads padded buffers that are only filled
+        for pure decode batches, leaving the row's conv/recurrent state stale
+        and its output garbled from the first decoded token. Fold the row
+        into the spec metadata with all tokens accepted, which advances its
+        state over the whole chunk exactly like the prefill path would. Rows
+        without prior state (first chunks) stay on the prefill path.
+        """
+        is_prefilling = common_attn_metadata.is_prefilling
+        seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+        if is_prefilling is None or seq_lens_cpu is None or num_accepted_tokens is None:
+            return spec_sequence_masks_cpu, num_accepted_tokens
+
+        # The common metadata CPU tensors are padded; only the leading entries
+        # correspond to requests in this batch.
+        num_reqs = min(
+            spec_sequence_masks_cpu.numel(),
+            is_prefilling.numel(),
+            seq_lens_cpu.numel(),
+        )
+        is_prefilling = is_prefilling[:num_reqs]
+        seq_lens_cpu = seq_lens_cpu[:num_reqs]
+        query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)[:num_reqs]
+        fold = (
+            is_prefilling
+            & ~spec_sequence_masks_cpu
+            & (query_lens_cpu == self.num_spec + 1)
+            & (seq_lens_cpu > query_lens_cpu)
+        )
+        fold_indices = fold.nonzero(as_tuple=True)[0]
+        if fold_indices.numel() == 0:
+            return spec_sequence_masks_cpu, num_accepted_tokens
+
+        spec_sequence_masks_cpu = spec_sequence_masks_cpu.clone()
+        spec_sequence_masks_cpu[fold_indices] = True
+        num_accepted_tokens = num_accepted_tokens.clone()
+        num_accepted_tokens[fold_indices.to(num_accepted_tokens.device)] = self.num_spec + 1
+        return spec_sequence_masks_cpu, num_accepted_tokens
+
     def build(  # type: ignore[override]
         self,
         common_prefix_len: int,
@@ -416,7 +494,7 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
-        m = common_attn_metadata
+        m = _treat_single_token_prefills_with_state_as_decodes(common_attn_metadata)
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu
@@ -443,6 +521,9 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
                 num_decode_draft_tokens_cpu,
                 0,
                 out=spec_sequence_masks_cpu,
+            )
+            spec_sequence_masks_cpu, num_accepted_tokens = self._fold_spec_sized_prefill_chunks_into_spec(
+                m, spec_sequence_masks_cpu, num_accepted_tokens
             )
             num_spec_decodes = spec_sequence_masks_cpu.sum().item()
             if num_spec_decodes == 0:

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -47,11 +47,54 @@ from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+from vllm_ascend.ops.triton.kda.fused_norm_gate import apply_kda_rms_norm_sigmoid_gate
 from vllm_ascend.ops.triton.kda.kda import fused_kda_gate
 from vllm_ascend.utils import is_vl_model, parse_layer_idx
 
 _KDA_CHUNK_SIZE = 64
+_KDA_QKV_CONCAT_STREAM: torch.npu.Stream | None = None
 _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
+
+
+def _kda_qkv_concat_stream() -> torch.npu.Stream:
+    """Return the process-local stream used to overlap KDA QKV packing."""
+    global _KDA_QKV_CONCAT_STREAM
+    if _KDA_QKV_CONCAT_STREAM is None:
+        _KDA_QKV_CONCAT_STREAM = torch.npu.Stream()
+    return _KDA_QKV_CONCAT_STREAM
+
+
+def _start_kda_qkv_concat(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> tuple[torch.Tensor, torch.npu.Stream | None, torch.npu.Stream | None]:
+    """Pack QKV while independent gate projections run on the main stream."""
+    if q.device.type != "npu":
+        return torch.cat((q, k, v), dim=-1), None, None
+
+    main_stream = torch.npu.current_stream()
+    concat_stream = _kda_qkv_concat_stream()
+    q.record_stream(concat_stream)
+    k.record_stream(concat_stream)
+    v.record_stream(concat_stream)
+    concat_stream.wait_stream(main_stream)
+    with torch.npu.stream(concat_stream):
+        mixed_qkv = torch.cat((q, k, v), dim=-1)
+    return mixed_qkv, main_stream, concat_stream
+
+
+def _resolve_kda_qkv_input(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    num_actual_tokens: int,
+) -> torch.Tensor:
+    """Accept either legacy Q/K/V inputs or an already packed QKV tensor."""
+    q = q[:num_actual_tokens]
+    if k.numel() == 0 and v.numel() == 0:
+        return q
+    return torch.cat((q, k[:num_actual_tokens], v[:num_actual_tokens]), dim=-1)
 
 
 def _zero_padded_spec_output(
@@ -233,6 +276,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         q = self.q_proj(hidden_states)[0]
         k = self.k_proj(hidden_states)[0]
         v = self.v_proj(hidden_states)[0]
+        mixed_qkv, main_stream, qkv_concat_stream = _start_kda_qkv_concat(q, k, v)
 
         beta = self.b_proj(hidden_states)[0].float().sigmoid().unsqueeze(0)
         raw_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
@@ -249,18 +293,37 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
+        if qkv_concat_stream is not None:
+            assert main_stream is not None
+            main_stream.wait_stream(qkv_concat_stream)
+
+        # Keep the opaque custom-op boundary while avoiding a second concat in
+        # _forward. Empty K/V views mark the first argument as packed [Q|K|V].
+        packed_qkv_sentinel = mixed_qkv[:, :0]
         torch.ops.vllm.kda_attention(
-            q,
-            k,
-            v,
+            mixed_qkv,
+            packed_qkv_sentinel,
+            packed_qkv_sentinel,
             raw_gate,
             beta,
             core_attn_out,
             self.prefix,
         )
-        core_attn_out = self.o_norm(core_attn_out, output_gate)
+        core_attn_out = self._apply_output_norm_gate(core_attn_out, output_gate)
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
+
+    def _apply_output_norm_gate(
+        self,
+        core_attn_out: torch.Tensor,
+        output_gate: torch.Tensor,
+    ) -> torch.Tensor:
+        return apply_kda_rms_norm_sigmoid_gate(
+            core_attn_out,
+            output_gate,
+            self.o_norm.weight,
+            self.o_norm.eps,
+        )
 
     @staticmethod
     def _run_causal_conv1d(
@@ -492,14 +555,16 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         assert isinstance(attn_metadata, GDNAttentionMetadata)
 
         num_actual_tokens = attn_metadata.num_actual_tokens
-        q_proj_states = q_proj_states[:num_actual_tokens]
-        k_proj_states = k_proj_states[:num_actual_tokens]
-        v_proj_states = v_proj_states[:num_actual_tokens]
+        mixed_qkv = _resolve_kda_qkv_input(
+            q_proj_states,
+            k_proj_states,
+            v_proj_states,
+            num_actual_tokens,
+        )
         g1 = g1[:, :num_actual_tokens]
         beta = beta[:, :num_actual_tokens]
 
         conv_state, recurrent_state = self.kv_cache
-        mixed_qkv = torch.cat((q_proj_states, k_proj_states, v_proj_states), dim=-1)
         conv_weights_t = self._conv_weights_t()
 
         spec_masks = attn_metadata.spec_sequence_masks

--- a/vllm_ascend/ops/triton/kda/fused_norm_gate.py
+++ b/vllm_ascend/ops/triton/kda/fused_norm_gate.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+
+"""Fused RMSNorm and sigmoid output gate for Kimi KDA on Ascend.
+
+The Triton kernels below follow the supplied ``fused_norm_gate.py``
+implementation.  The thin KDA wrapper at the end only adapts it to vLLM's
+opaque custom-op boundary and K3's [1, T, H, D] output layout.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import cdiv, next_power_of_2
+from vllm.utils.torch_utils import direct_register_custom_op
+
+# Maximum rows per Triton block for layernorm gated kernel.
+MAX_ROWS_PER_BLOCK = 4
+
+
+@triton.jit
+def layer_norm_gated_fwd_kernel(
+    x,
+    g,
+    y,
+    w,
+    b,
+    residual,
+    residual_out,
+    mean,
+    rstd,
+    eps,
+    T,
+    D: tl.constexpr,
+    BT: tl.constexpr,
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+
+    o_d = tl.arange(0, BD)
+    m_d = o_d < D
+
+    p_x = tl.make_block_ptr(x, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    b_x = tl.load(p_x, boundary_check=(0, 1)).to(tl.float32)
+    if HAS_RESIDUAL:
+        p_res = tl.make_block_ptr(residual, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+        b_x += tl.load(p_res, boundary_check=(0, 1)).to(tl.float32)
+    if STORE_RESIDUAL_OUT:
+        p_res_out = tl.make_block_ptr(residual_out, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+        tl.store(p_res_out, b_x.to(p_res_out.dtype.element_ty), boundary_check=(0, 1))
+    if not IS_RMS_NORM:
+        b_mean = tl.sum(b_x, axis=1) / D
+        p_mean = tl.make_block_ptr(mean, (T,), (1,), (i_t * BT,), (BT,), (0,))
+        tl.store(p_mean, b_mean.to(p_mean.dtype.element_ty), boundary_check=(0,))
+        b_xbar = tl.where(m_d[None, :], b_x - b_mean[:, None], 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
+    else:
+        b_xbar = tl.where(m_d[None, :], b_x, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=1) / D
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+
+    p_rstd = tl.make_block_ptr(rstd, (T,), (1,), (i_t * BT,), (BT,), (0,))
+    tl.store(p_rstd, b_rstd.to(p_rstd.dtype.element_ty), boundary_check=(0,))
+
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=m_d).to(tl.float32)
+    b_x_hat = (b_x - b_mean[:, None]) * b_rstd[:, None] if not IS_RMS_NORM else b_x * b_rstd[:, None]
+    b_y = b_x_hat * b_w[None, :] if HAS_WEIGHT else b_x_hat
+    if HAS_BIAS:
+        b_y = b_y + b_b[None, :]
+
+    p_g = tl.make_block_ptr(g, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    b_g = tl.load(p_g, boundary_check=(0, 1)).to(tl.float32)
+    if ACTIVATION == "swish" or ACTIVATION == "silu":
+        b_y = b_y * b_g * tl.sigmoid(b_g)
+    elif ACTIVATION == "sigmoid":
+        b_y = b_y * tl.sigmoid(b_g)
+
+    p_y = tl.make_block_ptr(y, (T, D), (D, 1), (i_t * BT, 0), (BT, BD), (1, 0))
+    tl.store(p_y, b_y.to(p_y.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.jit
+def layer_norm_gated_fwd_kernel1(
+    x,
+    g,
+    y,
+    w,
+    b,
+    residual,
+    residual_out,
+    mean,
+    rstd,
+    eps,
+    D: tl.constexpr,
+    BD: tl.constexpr,
+    ACTIVATION: tl.constexpr,
+    IS_RMS_NORM: tl.constexpr,
+    STORE_RESIDUAL_OUT: tl.constexpr,
+    HAS_RESIDUAL: tl.constexpr,
+    HAS_WEIGHT: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    i_t = tl.program_id(0)
+    x += i_t * D
+    y += i_t * D
+    g += i_t * D
+    if HAS_RESIDUAL:
+        residual += i_t * D
+    if STORE_RESIDUAL_OUT:
+        residual_out += i_t * D
+
+    o_d = tl.arange(0, BD)
+    m_d = o_d < D
+    b_x = tl.load(x + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if HAS_RESIDUAL:
+        b_x += tl.load(residual + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if STORE_RESIDUAL_OUT:
+        tl.store(residual_out + o_d, b_x, mask=m_d)
+    if not IS_RMS_NORM:
+        b_mean = tl.sum(b_x, axis=0) / D
+        tl.store(mean + i_t, b_mean)
+        b_xbar = tl.where(m_d, b_x - b_mean, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    else:
+        b_xbar = tl.where(m_d, b_x, 0.0)
+        b_var = tl.sum(b_xbar * b_xbar, axis=0) / D
+    b_rstd = 1 / tl.sqrt(b_var + eps)
+    tl.store(rstd + i_t, b_rstd)
+
+    if HAS_WEIGHT:
+        b_w = tl.load(w + o_d, mask=m_d).to(tl.float32)
+    if HAS_BIAS:
+        b_b = tl.load(b + o_d, mask=m_d).to(tl.float32)
+    b_x_hat = (b_x - b_mean) * b_rstd if not IS_RMS_NORM else b_x * b_rstd
+    b_y = b_x_hat * b_w if HAS_WEIGHT else b_x_hat
+    if HAS_BIAS:
+        b_y = b_y + b_b
+
+    b_g = tl.load(g + o_d, mask=m_d, other=0.0).to(tl.float32)
+    if ACTIVATION == "swish" or ACTIVATION == "silu":
+        b_y = b_y * b_g * tl.sigmoid(b_g)
+    elif ACTIVATION == "sigmoid":
+        b_y = b_y * tl.sigmoid(b_g)
+
+    tl.store(y + o_d, b_y, mask=m_d)
+
+
+def layer_norm_gated_fwd(
+    x: torch.Tensor,
+    g: torch.Tensor,
+    weight: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    activation: str = "swish",
+    eps: float = 1e-5,
+    residual: torch.Tensor | None = None,
+    out_dtype: torch.dtype | None = None,
+    residual_dtype: torch.dtype | None = None,
+    is_rms_norm: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
+    if residual is not None:
+        residual_dtype = residual.dtype
+    T, D = x.shape
+    if residual is not None:
+        assert residual.shape == (T, D)
+    if weight is not None:
+        assert weight.shape == (D,)
+    if bias is not None:
+        assert bias.shape == (D,)
+
+    y = x if out_dtype is None else torch.empty_like(x, dtype=out_dtype)
+    if residual is not None or (residual_dtype is not None and residual_dtype != x.dtype):
+        residual_out = torch.empty(T, D, device=x.device, dtype=residual_dtype)
+    else:
+        residual_out = None
+    mean = torch.empty((T,), dtype=torch.float, device=x.device) if not is_rms_norm else None
+    rstd = torch.empty((T,), dtype=torch.float, device=x.device)
+    MAX_FUSED_SIZE = 65536 // x.element_size()
+    BD = min(MAX_FUSED_SIZE, next_power_of_2(D))
+    if D > BD:
+        raise RuntimeError("This layer norm doesn't support feature dim >= 64KB.")
+
+    if D <= 512:
+        BT = 32
+        layer_norm_gated_fwd_kernel[(cdiv(T, BT),)](
+            x=x,
+            g=g,
+            y=y,
+            w=weight,
+            b=bias,
+            residual=residual,
+            residual_out=residual_out,
+            mean=mean,
+            rstd=rstd,
+            eps=eps,
+            T=T,
+            D=D,
+            BD=BD,
+            BT=BT,
+            ACTIVATION=activation,
+            IS_RMS_NORM=is_rms_norm,
+            STORE_RESIDUAL_OUT=residual_out is not None,
+            HAS_RESIDUAL=residual is not None,
+            HAS_WEIGHT=weight is not None,
+            HAS_BIAS=bias is not None,
+            num_warps=4,
+        )
+    else:
+        layer_norm_gated_fwd_kernel1[(T,)](
+            x=x,
+            g=g,
+            y=y,
+            w=weight,
+            b=bias,
+            residual=residual,
+            residual_out=residual_out,
+            mean=mean,
+            rstd=rstd,
+            eps=eps,
+            D=D,
+            BD=BD,
+            ACTIVATION=activation,
+            IS_RMS_NORM=is_rms_norm,
+            STORE_RESIDUAL_OUT=residual_out is not None,
+            HAS_RESIDUAL=residual is not None,
+            HAS_WEIGHT=weight is not None,
+            HAS_BIAS=bias is not None,
+            num_warps=4,
+        )
+    return y, mean, rstd, residual_out if residual_out is not None else x
+
+
+def _kda_rms_norm_sigmoid_gate_impl(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Adapt the supplied fused kernel to K3's per-head output layout."""
+    if x.shape[-1] != gate.shape[-1]:
+        raise ValueError(f"KDA output and gate head dimensions differ: {x.shape[-1]} != {gate.shape[-1]}")
+    if x.numel() != gate.numel():
+        raise ValueError(f"KDA output and gate element counts differ: {x.numel()} != {gate.numel()}")
+
+    output_shape = x.shape
+    feature_dim = output_shape[-1]
+    output, _, _, _ = layer_norm_gated_fwd(
+        x=x.reshape(-1, feature_dim),
+        g=gate.reshape(-1, feature_dim),
+        weight=weight.contiguous(),
+        bias=None,
+        activation="sigmoid",
+        eps=eps,
+        out_dtype=x.dtype,
+        is_rms_norm=True,
+    )
+    return output.reshape(output_shape)
+
+
+def _kda_rms_norm_sigmoid_gate_fake(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    del gate, weight, eps
+    return torch.empty_like(x)
+
+
+direct_register_custom_op(
+    op_name="kda_rms_norm_sigmoid_gate",
+    op_func=_kda_rms_norm_sigmoid_gate_impl,
+    fake_impl=_kda_rms_norm_sigmoid_gate_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+
+def apply_kda_rms_norm_sigmoid_gate(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Call K3's opaque fused RMSNorm and sigmoid-gate operator."""
+    return torch.ops.vllm.kda_rms_norm_sigmoid_gate(x, gate, weight, eps)

--- a/vllm_ascend/ops/triton/kimi_k3/__init__.py
+++ b/vllm_ascend/ops/triton/kimi_k3/__init__.py
@@ -1,0 +1,1 @@
+"""Triton fusion kernels specific to Kimi K3."""

--- a/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
+++ b/vllm_ascend/ops/triton/kimi_k3/attention_residual.py
@@ -1,0 +1,106 @@
+"""Fused Kimi K3 attention-residual mixture.
+
+This is the supplied Kimi K3 implementation, adapted only to use the
+vLLM-Ascend Triton device-property helper.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_properties_triton
+
+
+@triton.jit(do_not_specialize=["N", "B"])
+def _apply_attn_res_kernel(
+    block_residual_ptr,
+    prefix_sum_ptr,
+    norm_w_ptr,
+    proj_w_ptr,
+    out_ptr,
+    N,
+    H: tl.constexpr,
+    B,
+    EPS: tl.constexpr,
+    NUM_CORES: tl.constexpr,
+    NB: tl.constexpr,
+):
+    block_size = (N - 1) // NUM_CORES + 1
+    pid = tl.program_id(0)
+    tok0 = pid * block_size
+    if tok0 >= N:
+        return
+    tok1 = tl.minimum(tok0 + block_size, N)
+
+    cols = tl.arange(0, H)
+    s_idx = tl.arange(0, NB)
+
+    norm_w = tl.load(norm_w_ptr + cols).to(tl.float32)
+    proj_w = tl.load(proj_w_ptr + cols).to(tl.float32)
+    w = norm_w * proj_w
+
+    br_stride = B * H
+
+    for tok in range(tok0, tok1):
+        scores = tl.full([NB], -float("inf"), dtype=tl.float32)
+        for s in range(B + 1):
+            if s < B:
+                v = tl.load(block_residual_ptr + tok * br_stride + s * H + cols).to(tl.float32)
+            else:
+                v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+            ms = tl.sum(v * v) / H
+            rstd = tl.rsqrt(ms + EPS)
+            k = v * rstd
+            scores = tl.where(s_idx == s, tl.sum(k * w), scores)
+
+        scores_max = tl.max(scores)
+        exp_scores = tl.exp(scores - scores_max)
+        weights = exp_scores / tl.sum(exp_scores)
+
+        out = tl.zeros([H], dtype=tl.float32)
+        for s in range(B + 1):
+            if s < B:
+                v = tl.load(block_residual_ptr + tok * br_stride + s * H + cols).to(tl.float32)
+            else:
+                v = tl.load(prefix_sum_ptr + tok * H + cols).to(tl.float32)
+            w_s = tl.sum(tl.where(s_idx == s, weights, 0.0))
+            out += w_s * v
+
+        tl.store(out_ptr + tok * H + cols, out.to(out_ptr.dtype.element_ty))
+
+
+def apply_attn_res(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    proj: torch.nn.Module,
+    norm: torch.nn.Module,
+) -> torch.Tensor:
+    """Return K3's learned softmax mixture of residual streams."""
+    num_tokens, hidden_size = prefix_sum.shape
+    num_blocks = block_residual.shape[1]
+    proj_w = proj.weight.squeeze(0)
+    norm_w = norm.weight
+    eps = norm.variance_epsilon
+
+    out = torch.empty(
+        (num_tokens, hidden_size),
+        dtype=prefix_sum.dtype,
+        device=prefix_sum.device,
+    )
+    num_streams = triton.next_power_of_2(num_blocks + 1)
+    init_device_properties_triton()
+    num_vectorcore = get_vectorcore_num()
+    _apply_attn_res_kernel[(num_vectorcore,)](
+        block_residual,
+        prefix_sum,
+        norm_w,
+        proj_w,
+        out,
+        N=num_tokens,
+        H=hidden_size,
+        B=num_blocks,
+        EPS=eps,
+        NUM_CORES=num_vectorcore,
+        NB=num_streams,
+        multibuffer=True,
+    )
+    return out

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -16,7 +16,7 @@
 #
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import torch
@@ -35,6 +35,28 @@ from .base import AscendLinearScheme, AscendMoEScheme, QuantType, get_moe_num_lo
 from .registry import register_scheme
 
 
+def _is_kimi_k3_model(vllm_config: Any) -> bool:
+    """Identify K3 from either its outer multimodal or inner text config.
+
+    The full K3 checkpoint has ``hf_config.model_type == "kimi_k3"``. Some
+    text-only loading paths expose the nested K3 text config instead, whose
+    inherited model type is ``"kimi_linear"``. The latter is distinguished
+    from a regular Kimi Linear model by the K3 MLA/output-gate and routed-MoE
+    fields.
+    """
+    model_config = getattr(vllm_config, "model_config", None)
+    hf_config = getattr(model_config, "hf_config", None)
+    if getattr(hf_config, "model_type", None) == "kimi_k3":
+        return True
+
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    return (
+        getattr(hf_text_config, "model_type", None) == "kimi_linear"
+        and bool(getattr(hf_text_config, "mla_use_output_gate", False))
+        and getattr(hf_text_config, "routed_expert_hidden_size", None) is not None
+    )
+
+
 @register_scheme("W4A8_DYNAMIC", "linear")
 class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     """Linear method for Ascend W4A8_DYNAMIC.
@@ -48,7 +70,8 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     The names below use ``linear`` as the checkpoint prefix of a linear layer,
     ``input_size`` as the logical input dimension, ``output_size`` as the
     logical output dimension, and ``group_size`` as the number of input
-    channels per weight quantization group.
+    channels per weight quantization group. A ``group_size`` of ``0`` selects
+    per-channel weight quantization.
 
     For ``quant_version != "1.0.0"``, the original linear weights are:
 
@@ -56,10 +79,11 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
       Each int8 element stores one 4-bit weight value.
     - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
     - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
-    - ``linear.weight_scale_second``: ``params_dtype``,
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
       ``[output_size, input_size // group_size]``.
-    - ``linear.weight_offset_second``: ``torch.int64``,
-      ``[output_size, input_size // group_size]``.
+    - For per-channel quantization, ``weight_scale`` and ``weight_offset``
+      are the only scale tensors; no second-level tensors are present.
 
     For ``quant_version == "1.0.0"``, the original linear weights are:
 
@@ -68,10 +92,10 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
       dimension.
     - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
     - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
-    - ``linear.weight_scale_second``: ``params_dtype``,
-      ``[output_size, input_size // group_size]``.
-    - ``linear.weight_offset_second``: ``torch.int64``,
-      ``[output_size, input_size // group_size]``.
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
+      ``[output_size, input_size // group_size]``. Per-channel quantization
+      does not store second-level scale or offset tensors.
     - ``linear.scale_bias``: ``torch.float32``, ``[output_size, 1]`` for
       column-parallel linear layers and ``[output_size, 16]`` for
       row-parallel linear layers.
@@ -83,20 +107,74 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     already packed as int4 pairs in int8 storage and are reinterpreted as int32
     by grouping four int8 values.
 
-    After processing, ``torch_npu.npu_weight_quant_batchmatmul`` is called with
-    ``weight`` as ``torch.int32`` in the operator-required packed layout
-    with shape ``[input_size, output_size // 8]`` and
-    ``antiquant_scale`` as ``weight_scale * weight_scale_second`` converted to
-    ``x.dtype`` with shape ``[input_size // group_size, output_size]``.
+    Per-group linear weights use ``torch_npu.npu_weight_quant_batchmatmul``.
+    Generic per-channel linear weights use ``torch_npu.npu_quant_matmul``.
+    K3 shared experts use the per-channel W4A8 grouped-matmul path: activations
+    are dynamically quantized to int8, packed int4 weights are converted to NZ,
+    and the projection is evaluated as a single expert by
+    ``torch_npu.npu_grouped_matmul``. This avoids silently degrading K3 shared
+    experts to W4A16.
+
+    The generic linear operators consume ``weight`` as ``torch.int32`` with
+    shape ``[input_size, output_size // 8]``. The K3 shared-expert grouped
+    operator consumes a leading singleton expert dimension, with shape
+    ``[1, input_size, output_size // 8]``.
     """
 
     def __init__(self):
         vllm_config = get_current_vllm_config()
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 256)
+        self.is_per_channel_weight = self.group_size == 0
         quant_version = vllm_config.quant_config.quant_description.get("version", "0")
         self.new_quant_version = quant_version == "1.0.0"
+        self._uses_kimi_k3_shared_expert_per_channel = _is_kimi_k3_model(vllm_config)
+        self._force_kimi_shared_expert_per_channel = False
 
         self.tp_size = get_tensor_model_parallel_world_size()
+
+    def _uses_per_channel_shared_expert(self, layer: torch.nn.Module) -> bool:
+        # This is deliberately not a model-wide K3 flag: only K3 shared
+        # experts have per-channel W4A8 scales. Routed experts stay per-group.
+        return self._force_kimi_shared_expert_per_channel or (
+            self._uses_kimi_k3_shared_expert_per_channel and ".shared_experts." in getattr(layer, "prefix", "")
+        )
+
+    def enable_per_channel_for_kimi_shared_expert(self) -> None:
+        """Select the per-channel W4A8 path for a Kimi shared expert."""
+        self.group_size = 0
+        self.is_per_channel_weight = True
+        # This scheme instance is attached to one shared-expert projection.
+        # Retain that selection through weight loading, where layer.prefix is
+        # not a reliable discriminator for every vLLM Linear wrapper.
+        self._force_kimi_shared_expert_per_channel = True
+
+    def _local_scale_bias(self, layer: torch.nn.Module, tp_rank: int | None = None) -> torch.Tensor:
+        """Combine the offline scale-bias shards owned by this projection.
+
+        ModelSlim stores row-parallel ``scale_bias`` with 16 columns, one for
+        each offline input shard.  A runtime TP rank may own more than one of
+        those shards (all 16 when shared-expert DP disables TP), so selecting a
+        single column is only correct for TP16.
+        """
+        scale_bias = layer.scale_bias
+        if scale_bias.dim() != 2:
+            return scale_bias
+        if scale_bias.shape[1] == 1:
+            return scale_bias.flatten()
+
+        tp_size = getattr(layer, "tp_size", self.tp_size)
+        rank = getattr(layer, "tp_rank", tp_rank if tp_rank is not None else 0)
+        num_offline_shards = scale_bias.shape[1]
+        if tp_size <= 0 or num_offline_shards % tp_size != 0:
+            raise ValueError(
+                f"scale_bias width {num_offline_shards} must be divisible by the projection TP size {tp_size}"
+            )
+        if rank < 0 or rank >= tp_size:
+            raise ValueError(f"tp_rank {rank} exceeds projection TP size {tp_size}")
+
+        shards_per_rank = num_offline_shards // tp_size
+        start = rank * shards_per_rank
+        return scale_bias[:, start : start + shards_per_rank].sum(dim=1)
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
         """Create weight parameters.
@@ -127,10 +205,13 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         params_dict = {}
         params_dict["weight_scale"] = torch.empty(output_size, 1, dtype=params_dtype)
         params_dict["weight_offset"] = torch.empty(output_size, 1, dtype=params_dtype)
-        params_dict["weight_scale_second"] = torch.empty(output_size, input_size // self.group_size, dtype=params_dtype)
-        params_dict["weight_offset_second"] = torch.empty(
-            output_size, input_size // self.group_size, dtype=params_dtype
-        )
+        if not self.is_per_channel_weight:
+            params_dict["weight_scale_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
+            params_dict["weight_offset_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
 
         # NOTE: In w4a8 quantization implementation,
         #       for down_proj and o_proj(layer_type == "row") scale_bias shape is [output_size, 16],
@@ -178,29 +259,122 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     def apply(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
         bias: torch.Tensor | None = None,
         tp_rank: int | None = None,
     ) -> torch.Tensor:
-        # NOTE: activation `x` is not quantized
+        tensor_x = cast(torch.Tensor, x)
+        if self.is_per_channel_weight:
+            if self._uses_per_channel_shared_expert(layer):
+                # QuantMatmul cannot consume the A3 per-channel INT4 WeightNZ
+                # representation. Model this projection as one grouped expert
+                # instead, which keeps both the int8 activation and int4 weight.
+                if isinstance(x, tuple):
+                    quantized_x, pertoken_scale = x
+                    input_shape = quantized_x.shape
+                    output_dtype = torch.bfloat16
+                else:
+                    input_shape = x.shape
+                    x_2d = x.reshape(-1, input_shape[-1])
+                    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x_2d)
+                    output_dtype = x.dtype
+                # Construct the single-group token count directly on the
+                # device. ``torch.tensor([count], device=x.device)`` performs
+                # a synchronous host-to-device copy, which is forbidden while
+                # ACL Graph is capturing in GLOBAL mode.
+                group_list = torch.full(
+                    (1,),
+                    quantized_x.shape[0],
+                    dtype=torch.int64,
+                    device=quantized_x.device,
+                )
+
+                scale_bias = self._local_scale_bias(layer, tp_rank)
+
+                output = torch_npu.npu_grouped_matmul(
+                    x=[quantized_x],
+                    weight=[layer.weight],
+                    scale=[layer.weight_scale.reshape(1, 1, -1)],
+                    bias=[scale_bias.reshape(1, -1)],
+                    per_token_scale=[pertoken_scale],
+                    split_item=2,
+                    group_list=group_list,
+                    group_type=0,
+                    group_list_type=1,
+                    output_dtype=output_dtype,
+                )[0]
+                if bias is not None:
+                    output = output + bias
+                return output.reshape(*input_shape[:-1], output.shape[-1])
+            quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(tensor_x)
+            need_unsqueeze = pertoken_scale.dim() == 2
+            if need_unsqueeze:
+                quantized_x = quantized_x.squeeze(dim=1)
+                pertoken_scale = pertoken_scale.squeeze(dim=1)
+
+            output = torch_npu.npu_quant_matmul(
+                quantized_x,
+                layer.weight,
+                layer.weight_scale,
+                pertoken_scale=pertoken_scale,
+                bias=bias,
+                output_dtype=tensor_x.dtype,
+            )
+            return output.unsqueeze(dim=1) if need_unsqueeze else output
+
+        # Per-group INT4 weights use the weight-only quantized operator.
         return torch_npu.npu_weight_quant_batchmatmul(
-            x,
+            tensor_x,
             layer.weight,
-            antiquant_scale=layer.weight_scale_second.to(x.dtype),
+            antiquant_scale=layer.weight_scale_second.to(tensor_x.dtype),
             antiquant_group_size=self.group_size,
         )
 
     def process_weights_after_loading(self, layer: torch.nn.Module):
+        uses_per_channel_shared_expert = self._uses_per_channel_shared_expert(layer)
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        layer.weight.data = maybe_trans_nz(layer.weight.data)
-        layer.weight_scale.data = layer.weight_scale.data.flatten().to(torch.float32)
+        layer.weight_scale.data = layer.weight_scale.data.flatten()
         layer.weight_offset.data = layer.weight_offset.data.flatten()
-        layer.weight_scale_second.data, scale_bias = self.process_scale_second(
-            layer.weight.data,
-            layer.weight_scale.data,
-            layer.weight_scale_second.data.transpose(0, 1).contiguous(),
-            is_new_quant=self.new_quant_version,
-        )
+
+        if uses_per_channel_shared_expert:
+            if not self.new_quant_version:
+                raise ValueError("K3 shared-expert W4A8 requires quantization version 1.0.0")
+
+            # Preserve the floating-point scale for the fused SiTU path, then
+            # bit-cast it to the int64 representation required by grouped
+            # matmul. Each int64 element stores one FP32 scale bit pattern.
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+            scale_np = layer.weight_scale_fp32.contiguous().cpu().numpy()
+            scale_np.dtype = np.uint32
+            layer.weight_scale.data = torch.from_numpy(scale_np.astype(np.int64)).to(layer.weight_scale.device)
+
+            if not hasattr(layer, "scale_bias"):
+                raise ValueError("K3 shared-expert W4A8 requires scale_bias")
+            layer.scale_bias.data = self._local_scale_bias(layer).contiguous()
+
+            # Treat the shared projection as one grouped expert. Keep packed
+            # int4 bytes while converting to NZ, then expose groups of four
+            # bytes as the int32 storage expected by the GMM interface.
+            assert layer.weight.data.shape[-1] % 4 == 0, (
+                f"the last dim of weight needs to be divided by 4 but got shape {layer.weight.data.shape}"
+            )
+            layer.weight.data = maybe_trans_nz(layer.weight.data.unsqueeze(0)).view(torch.int32).contiguous()
+            return
+
+        layer.weight.data = maybe_trans_nz(layer.weight.data)
+        if self.is_per_channel_weight:
+            # QuantMatmul consumes the checkpoint dtype, while the fused SiTU
+            # dequantization step requires an FP32 copy of the same scale.
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+        scale_bias = None
+        if not self.is_per_channel_weight:
+            layer.weight_scale.data = layer.weight_scale.data.to(torch.float32)
+            layer.weight_scale_second.data, scale_bias = self.process_scale_second(
+                layer.weight.data,
+                layer.weight_scale.data,
+                layer.weight_scale_second.data.transpose(0, 1).contiguous(),
+                is_new_quant=self.new_quant_version,
+            )
 
         if self.new_quant_version:
             # Process the loaded data based on layer type
@@ -209,22 +383,19 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
                     layer.scale_bias.data = layer.scale_bias.data.flatten()
                 else:
                     layer.scale_bias.data = layer.scale_bias.data.contiguous()
-        else:
-            if scale_bias is not None:
-                param = torch.nn.Parameter(scale_bias, requires_grad=False)
-                layer.register_parameter("weight_scale_bias", param)
+        elif scale_bias is not None:
+            param = torch.nn.Parameter(scale_bias, requires_grad=False)
+            layer.register_parameter("weight_scale_bias", param)
 
-        # Convert to NPU-specific int4pack format
+        # Convert to NPU-specific int4pack format.
         if self.new_quant_version:
-            # weights on disk are already in packed int4 format
-            # pack 4 int8(int4*2) to int32
+            # Weights on disk are already in packed int4 format; group four
+            # int8 bytes into one int32 storage element.
             assert layer.weight.data.shape[-1] % 4 == 0, (
                 f"the last dim of weight needs to be divided by 4 but got shape {layer.weight.data.shape}"
             )
             layer.weight.data = layer.weight.data.view(torch.int32).contiguous()
         else:
-            # weights are not compressed
-            # need to be packed via npu_convert_weight_to_int4pack
             layer.weight.data = torch_npu.npu_convert_weight_to_int4pack(layer.weight.data.to(torch.int32))
 
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -49,6 +49,7 @@ from vllm_ascend.utils import (
 )
 
 from .methods import get_scheme_class
+from .methods.w4a8 import _is_kimi_k3_model
 
 
 def _is_fused_moe_layer(layer: torch.nn.Module) -> bool:
@@ -713,6 +714,13 @@ class AscendModelSlimConfig(QuantizationConfig):
                 logger.debug("Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
                 return AscendUnquantizedLinearMethod()
             scheme = create_scheme_for_layer(self.quant_description, prefix, "linear", self.packed_modules_mapping)
+            if _is_kimi_k3_model(vllm_config) and ".shared_experts." in prefix:
+                # Kimi K3 stores W4A8 shared-expert linears with per-channel
+                # scales, while its routed experts remain per-group.
+                from .methods.w4a8 import AscendW4A8DynamicLinearMethod
+
+                if isinstance(scheme, AscendW4A8DynamicLinearMethod):
+                    scheme.enable_per_channel_for_kimi_shared_expert()
             logger.debug("Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
             return AscendLinearMethod(scheme)
         elif isinstance(layer, AttentionLayerBase) and (


### PR DESCRIPTION
## What this PR does / why we need it?

This PR combines the following Kimi K3 inference optimizations:

- Retains only the fused norm-gate and attention-residual integrations from #13509. The unrelated SiTU, causal-conv verification, target-verification, MoE, and activation changes are excluded.
- Integrates native MLA head-count handling from #13511.
- Integrates the dynamic W8A8 MLA preprocess path from #13760.
- Integrates the optimized RecurrentKDA implementation and ABI/metadata fixes from #13836.
- Fixes stateful single-token prefill and `num_spec + 1` prefill handling to prevent corrupted output.

## Does this PR introduce any user-facing change?

Yes. It improves Kimi K3 inference performance and fixes output corruption in specific chunked-prefill and speculative-decoding boundaries.

## How was this patch tested?

- Python syntax compilation passed for all changed Python files.
- `git diff --check` passed.
- Added/retained NPU numerical tests for fused norm-gate, attention residual, RecurrentKDA, MLA preprocess, and stateful-prefill metadata.
- Runtime tests were not executed locally because this workspace does not contain `torch`, `vllm`, `pytest`, or `pre-commit`; NPU validation is required in CI.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
