### PR TITLE
[Bugfix][P/D] Release prefill KV on decode rejection

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -675,10 +675,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prefiller-ports", type=int, nargs="+", default=[8001])
     parser.add_argument("--decoder-hosts", type=str, nargs="+", default=["localhost"])
     parser.add_argument("--decoder-ports", type=int, nargs="+", default=[8002])
-    parser.add_argument("--max-retries", type=int, default=3, help="Maximum number of retries for HTTP requests")
-    parser.add_argument(
-        "--retry-delay", type=float, default=0.001, help="Base delay (seconds) for exponential backoff retries"
-    )
     parser.add_argument(
         "--max-waiting-retries", type=int, default=3, help="Maximum number of retries for waiting nodes to be started"
     )
@@ -839,62 +835,25 @@ async def send_request_to_service(
     endpoint: str,
     req_data: dict,
     request_id: str,
-    max_retries: int = 3,
-    base_delay: float = 0.2,
 ):
     req_data = build_prefill_request(req_data)
     headers = auth_headers(request_id)
-    last_exc = None
-    for attempt in range(1, max_retries + 1):
-        try:
-            response = await client.post(endpoint, json=req_data, headers=headers)
-            response.raise_for_status()
-            return response
-        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
-            logger.warning("Attempt %s failed for %s: %s", attempt, endpoint, exc)
-            last_exc = exc
-            if attempt < max_retries:
-                await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
-            else:
-                logger.error("All %s attempts failed for %s.", max_retries, endpoint)
-                raise last_exc
+    response = await client.post(endpoint, json=req_data, headers=headers)
+    response.raise_for_status()
+    return response
 
 
-async def stream_service_response_with_retry(
+async def stream_service_response(
     client: httpx.AsyncClient,
     endpoint: str,
     req_data: dict,
     request_id: str,
-    max_retries: int = 3,
-    base_delay: float = 0.2,
 ):
     headers = auth_headers(request_id)
-    for attempt in range(1, max_retries + 1):
-        try:
-            async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
-                response.raise_for_status()
-                first_chunk_sent = False
-                async for chunk in response.aiter_bytes():
-                    first_chunk_sent = True
-                    yield chunk
-                return
-        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
-            if attempt < max_retries:
-                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
-                await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
-            else:
-                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
-                raise exc
-        except Exception as exc:
-            if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error("Streaming to client interrupted after response started: %s", exc)
-                return
-            if attempt < max_retries:
-                logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
-                await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
-            else:
-                logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
-                raise exc
+    async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
+        response.raise_for_status()
+        async for chunk in response.aiter_bytes():
+            yield chunk
 
 
 async def _abort_prefill_selection(
@@ -929,7 +888,6 @@ async def assign_instances(
     is_initial_request: bool,
 ) -> InstanceInfo:
     runtime = get_runtime()
-    args = get_global_args()
     prefiller_score = calculate_prefill_score(request_length)
     decoder_score = calculate_decode_score(request_length)
     request_id = next_req_id()
@@ -943,8 +901,6 @@ async def assign_instances(
             api,
             req_data,
             request_id,
-            max_retries=args.max_retries,
-            base_delay=args.retry_delay,
         )
     except Exception:
         await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
@@ -991,7 +947,6 @@ async def reassign_instances(
 
 async def handle_completions_impl(api: str, request: Request):
     runtime = get_runtime()
-    args = get_global_args()
     request_released = False
     try:
         req_data = await request.json()
@@ -1032,13 +987,11 @@ async def handle_completions_impl(api: str, request: Request):
                 while retry:
                     retry = False
                     decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
-                    async for chunk in stream_service_response_with_retry(
+                    async for chunk in stream_service_response(
                         decoder_client,
                         api,
                         req_data,
                         request_id=instance_info.request_id,
-                        max_retries=args.max_retries,
-                        base_delay=args.retry_delay,
                     ):
                         if not released_kv and chunk:
                             await release_prefill_kv_once()

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1020,6 +1020,21 @@ class TestCoreFunctionality(unittest.TestCase):
         cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
         self.mock_queue.task_done.assert_called_once()
 
+    @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
+    @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
+    def test_handle_empty_transfer_sends_done(self, mock_send_done, mock_free_remote_port):
+        req = dict(self.test_req)
+        req["local_block_ids"] = ([],)
+        req["remote_block_ids"] = ([3, 4],)
+
+        self.thread._handle_request(req)
+
+        self.engine.batch_transfer_sync_read.assert_not_called()
+        mock_free_remote_port.assert_called_once_with("req1", "localhost", {6666: 1})
+        mock_send_done.assert_called_once_with("req1", "localhost", 6666, {6666: 1})
+        cast(Any, self.thread.task_tracker).update_done_task_count.assert_called_once_with("req1")
+        self.mock_queue.task_done.assert_called_once()
+
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
     def test_transfer_kv_cache(self, mock_get_meta):
         with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
@@ -1771,6 +1786,33 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         delay_free, params = self.scheduler.request_finished(request, [1, 2, 3])
         self.assertFalse(delay_free)
         self.assertIsNone(params)
+
+    def test_request_finished_rejected_remote_prefill_enqueues_empty_recv(self):
+        request = MockRequest(
+            "req1",
+            kv_transfer_params={
+                "do_remote_prefill": True,
+                "do_remote_decode": False,
+                "remote_block_ids": ([1, 2, 3],),
+                "remote_engine_id": "remote",
+                "remote_request_id": "remote_req1",
+                "remote_host": "localhost",
+                "remote_port": 5000,
+            },
+            status=RequestStatus.FINISHED_ABORTED,
+        )
+
+        delay_free, params = self.scheduler.request_finished(request, ([],))
+
+        self.assertFalse(delay_free)
+        self.assertIsNone(params)
+        self.assertFalse(request.kv_transfer_params["do_remote_prefill"])
+        self.assertEqual(self.scheduler._reqs_need_recv["req1"], (request, ([],), ([],), 0))
+
+        metadata = self.scheduler.build_connector_meta(MockSchedulerOutput())
+        self.assertEqual(metadata.requests["req1"].local_block_ids, ([],))
+        self.assertEqual(metadata.requests["req1"].num_external_tokens, 0)
+        self.assertEqual(metadata.requests["req1"].remote_request_id, "remote_req1")
 
     def test_get_transfer_block_ids_trims_attention_mtp_blocks(self):
         self.scheduler.group_transfer_info = [

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1916,11 +1916,27 @@ class MooncakeConnectorScheduler:
             "MooncakeConnector request_finished, request_status=%s, kv_transfer_params=%s", request.status, params
         )
 
-        if (
-            params is None
-            or not params.get("do_remote_decode")
-            or request.status != RequestStatus.FINISHED_LENGTH_CAPPED
-        ):
+        if params is None:
+            return False, None
+
+        # A remote-prefill request can be rejected before scheduler admission
+        # (for example, when prompt + max_tokens exceeds max_model_len). In
+        # that case update_state_after_alloc() never gets a chance to schedule
+        # the receive, so explicitly enqueue an empty receive. The worker skips
+        # the data transfer for empty block IDs but still sends the completion
+        # signal to the P node, allowing it to release the stranded KV blocks.
+        if params.get("do_remote_prefill"):
+            empty_block_ids: BlockIds = tuple([] for _ in self.kv_cache_groups)
+            self._reqs_need_recv[request.request_id] = (
+                request,
+                empty_block_ids,
+                empty_block_ids,
+                0,
+            )
+            params["do_remote_prefill"] = False
+            return False, None
+
+        if not params.get("do_remote_decode") or request.status != RequestStatus.FINISHED_LENGTH_CAPPED:
             return False, None
 
         num_prompt_blocks = math.ceil(len(request.prompt_token_ids) / self.block_size)


### PR DESCRIPTION
### What this PR does / why we need it?

In disaggregated prefill, the P node delays freeing KV blocks until the D node acknowledges the receive. If the D request is rejected before scheduler admission (for example, prompt tokens plus max_tokens exceeds max_model_len), update_state_after_alloc is never called and the P-side blocks remain allocated until the connector timeout. The load-balancing proxy also retried backend failures with the same KV-transfer metadata, even though the first rejected D request may already have released the P-side blocks.

This PR fixes both sides of the failure path:

- when request_finished observes an untouched do_remote_prefill request, enqueue an empty receive task;
- let the worker skip data transfer for the empty block list while still sending DONE to the P node;
- clear do_remote_prefill so the cleanup is scheduled only once;
- make each proxy P/D backend HTTP request a single attempt, without reusing stale KV-transfer metadata after an error;
- remove the obsolete max-retries and retry-delay proxy options;
- add scheduler and worker regression coverage for the empty-receive/DONE path.

This aligns the connector cleanup with vLLM Mooncake behavior introduced in https://github.com/vllm-project/vllm/pull/24718 and the pre-admission rejection notification path in https://github.com/vllm-project/vllm/pull/41269. It also matches the upstream toy and Mooncake proxies, which perform one P request and one D request per transaction.

The explicit stop_reason=recomputed path remains unchanged because it creates a fresh P-to-D transaction rather than retrying a failed backend request with stale transfer metadata. This PR intentionally does not address cancellation before the request reaches the D engine; that needs a separate proxy-to-D cancellation/cleanup design.

### Does this PR introduce _any_ user-facing change?

Yes. A D-side pre-admission rejection now triggers the Mooncake completion handshake so the P node releases the request KV cache immediately. The proxy no longer retries P or D backend HTTP failures with the same transaction metadata.

### How was this patch tested?

- cd vllm-ascend && uv run python .github/workflows/scripts/coverage.py
  - all 213 UT files covered
- cd vllm-ascend && uv run pytest -q tests/ut/kv_offload/test_mooncake_connector.py
  - 109 passed, 22 subtests passed
- cd vllm-ascend && SKIP=gitleaks-offline-scan uv run pre-commit run --files examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py tests/ut/kv_offload/test_mooncake_connector.py
  - all selected hooks passed; gitleaks was skipped because the local environment has neither gitleaks nor wget

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
