### PR TITLE
[Performance] Support npu_grouped_matmul_swiglu_quant_v2 for W4A8MXFP

### DIFF
--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -4,6 +4,12 @@ import pytest
 import torch
 
 from vllm_ascend.device.device_op import A5DeviceAdaptor, BaseDeviceAdaptor
+from vllm_ascend.device.mxfp_compat import (
+    FLOAT4_E2M1FN_X2_DTYPE,
+    FLOAT8_E8M0FNU_DTYPE,
+    QUANT_DTYPES,
+)
+from vllm_ascend.quantization.quant_type import QuantType
 
 
 def test_reshape_and_cache_makes_scatter_inputs_contiguous():
@@ -69,6 +75,129 @@ def test_kv_cache_load_makes_seq_lens_contiguous():
     assert mock_gather.call_args.kwargs["seq_offset"] is seq_starts
     assert mock_gather.call_args.kwargs["key"] is key
     assert mock_gather.call_args.kwargs["value"] is value
+
+
+def test_a5_w4a8_mxfp_uses_fused_grouped_matmul_swiglu_quant_v2():
+    """W4A8MXFP must dispatch to the fused npu_grouped_matmul_swiglu_quant_v2
+    (MXFP4 weight) instead of the two-stage GMM + swiglu_group_quant combo."""
+    x = torch.randn(2, 8, dtype=torch.bfloat16)
+    weight = torch.randn(4, 8, dtype=torch.uint8)
+    weight_scale = torch.randn(4, 8, dtype=torch.uint8)
+    group_list = torch.tensor([2])
+    x_scale = torch.randn(2, 1, dtype=torch.bfloat16)
+    out = torch.randn(2, 4, dtype=torch.bfloat16)
+    # ndim != 2 so maybe_normalize_mxfp_scale_layout keeps it as-is.
+    out_scale = torch.randn(2, 1, 1, dtype=torch.bfloat16)
+
+    with (
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_grouped_matmul_swiglu_quant_v2",
+            return_value=(out, out_scale),
+        ) as mock_v2,
+        mock.patch("vllm_ascend.device.device_op.torch_npu.npu_grouped_matmul") as mock_gmm,
+        mock.patch(
+            "vllm_ascend.device.device_op.torch.ops._C_ascend.npu_swiglu_group_quant",
+            create=True,
+        ) as mock_swiglu_group_quant,
+    ):
+        result = A5DeviceAdaptor.npu_grouped_matmul_swiglu_quant(
+            x=x,
+            weight=weight,
+            group_list=group_list,
+            weight_scale=weight_scale,
+            x_scale=x_scale,
+            use_mxfp_quant=True,
+            mxfp_quant_dtype=QuantType.W4A8MXFP,
+            act_quant_type=torch.float8_e4m3fn,
+            weight_quant_type=FLOAT4_E2M1FN_X2_DTYPE,
+            swiglu_limit=0.0,
+        )
+
+    assert result[0] is out
+    assert result[1] is out_scale
+    assert result[2] is None
+    mock_gmm.assert_not_called()
+    mock_swiglu_group_quant.assert_not_called()
+    mock_v2.assert_called_once()
+    call_kwargs = mock_v2.call_args.kwargs
+    assert len(call_kwargs["weight"]) == 1 and call_kwargs["weight"][0] is weight
+    assert len(call_kwargs["weight_scale"]) == 1 and call_kwargs["weight_scale"][0] is weight_scale
+    assert call_kwargs["x_scale"] is x_scale
+    assert call_kwargs["group_list"] is group_list
+    assert call_kwargs["dequant_mode"] == 2
+    assert call_kwargs["quant_mode"] == 2
+    assert call_kwargs["quant_dtype"] == torch.float8_e4m3fn
+    expected_weight_dtype = FLOAT4_E2M1FN_X2_DTYPE if FLOAT4_E2M1FN_X2_DTYPE in QUANT_DTYPES else None
+    assert call_kwargs["weight_dtype"] == expected_weight_dtype
+    assert "swiglu_limit" not in call_kwargs
+
+
+def test_a5_w4a8_mxfp_falls_back_to_two_stage_for_swiglu_limit():
+    """v2 has no swiglu_limit input, so a non-zero limit falls back to the
+    two-stage GMM + swiglu_group_quant path."""
+    x = torch.randn(2, 8, dtype=torch.bfloat16)
+    weight = torch.randn(4, 8, dtype=torch.uint8)
+    weight_scale = torch.randn(4, 8, dtype=torch.uint8)
+    group_list = torch.tensor([2])
+    x_scale = torch.randn(2, 1, dtype=torch.bfloat16)
+    hidden_states = torch.randn(2, 8, dtype=torch.bfloat16)
+    out = torch.randn(2, 4, dtype=torch.bfloat16)
+    out_scale = torch.randn(2, 1, 1, dtype=torch.bfloat16)
+
+    with (
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_grouped_matmul",
+            return_value=[hidden_states],
+        ) as mock_gmm,
+        mock.patch(
+            "vllm_ascend.device.device_op.torch.ops._C_ascend.npu_swiglu_group_quant",
+            create=True,
+            return_value=(out, out_scale, None),
+        ) as mock_swiglu_group_quant,
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.npu_grouped_matmul_swiglu_quant_v2",
+            return_value=(out, out_scale),
+        ) as mock_v2,
+        mock.patch(
+            "vllm_ascend.device.device_op.torch_npu.float4_e2m1fn_x2",
+            FLOAT4_E2M1FN_X2_DTYPE,
+            create=True,
+        ),
+        mock.patch(
+            "vllm_ascend.device.device_op.torch.float8_e8m0fnu",
+            FLOAT8_E8M0FNU_DTYPE,
+            create=True,
+        ),
+    ):
+        result = A5DeviceAdaptor.npu_grouped_matmul_swiglu_quant(
+            x=x,
+            weight=weight,
+            group_list=group_list,
+            weight_scale=weight_scale,
+            x_scale=x_scale,
+            use_mxfp_quant=True,
+            mxfp_quant_dtype=QuantType.W4A8MXFP,
+            act_quant_type=torch.float8_e4m3fn,
+            weight_quant_type=FLOAT4_E2M1FN_X2_DTYPE,
+            swiglu_limit=7.0,
+        )
+
+    assert result[0] is out
+    assert result[1] is out_scale
+    assert result[2] is None
+    mock_v2.assert_not_called()
+    gmm_kwargs = mock_gmm.call_args.kwargs
+    assert gmm_kwargs["x"] == [x]
+    assert gmm_kwargs["weight"] == [weight]
+    assert gmm_kwargs["antiquant_scale"] == [weight_scale]
+    assert gmm_kwargs["per_token_scale"] == [x_scale]
+    assert gmm_kwargs["split_item"] == 2
+    assert gmm_kwargs["group_list"] is group_list
+    assert gmm_kwargs["output_dtype"] == torch.bfloat16
+    swiglu_kwargs = mock_swiglu_group_quant.call_args.kwargs
+    assert swiglu_kwargs["dst_type"] == torch.float8_e4m3fn
+    assert swiglu_kwargs["quant_mode"] == 2
+    assert swiglu_kwargs["clamp_value"] == 7.0
 
 
 def test_npu_flash_attention_uses_fusion_attention_for_fp32():

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -1203,30 +1203,48 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
 
         # W4A8 mxfp
         if mxfp_quant_dtype == QuantType.W4A8MXFP:
-            hidden_states = torch_npu.npu_grouped_matmul(
-                x=[x],
-                weight=[weight],
-                scale=None,
-                antiquant_scale=[weight_scale],
-                scale_dtype=None,
-                per_token_scale=[x_scale],
-                per_token_scale_dtype=torch.float8_e8m0fnu,
-                split_item=2,
-                group_type=0,
-                group_list=group_list,
-                x_dtype=torch.float8_e4m3fn,
-                weight_dtype=torch_npu.float4_e2m1fn_x2,
-                output_dtype=torch.bfloat16,
-            )[0]
-            # DSV4 need swiglu_limit input
-            out, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
-                hidden_states,
-                topk_weight=None,
-                group_index=None,
-                dst_type=torch.float8_e4m3fn,
-                quant_mode=2,
-                clamp_value=swiglu_limit,
-            )
+            if swiglu_limit > 0:
+                # v2 has no swiglu_limit input, use two-stage path for clamped SwiGLU
+                hidden_states = torch_npu.npu_grouped_matmul(
+                    x=[x],
+                    weight=[weight],
+                    scale=None,
+                    antiquant_scale=[weight_scale],
+                    scale_dtype=None,
+                    per_token_scale=[x_scale],
+                    per_token_scale_dtype=torch.float8_e8m0fnu,
+                    split_item=2,
+                    group_type=0,
+                    group_list=group_list,
+                    x_dtype=torch.float8_e4m3fn,
+                    weight_dtype=torch_npu.float4_e2m1fn_x2,
+                    output_dtype=torch.bfloat16,
+                )[0]
+                # DSV4 need swiglu_limit input
+                out, out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
+                    hidden_states,
+                    topk_weight=None,
+                    group_index=None,
+                    dst_type=torch.float8_e4m3fn,
+                    quant_mode=2,
+                    clamp_value=swiglu_limit,
+                )
+            else:
+                out, out_scale = torch_npu.npu_grouped_matmul_swiglu_quant_v2(
+                    x=x,
+                    weight=[weight],
+                    group_list=group_list,
+                    weight_scale=[weight_scale],
+                    x_scale=x_scale,
+                    dequant_mode=2,
+                    quant_mode=2,
+                    dequant_dtype=torch.float32,
+                    quant_dtype=act_quant_type,
+                    x_dtype=act_quant_type if act_quant_type in QUANT_DTYPES else None,
+                    weight_dtype=weight_quant_type if weight_quant_type in QUANT_DTYPES else None,
+                    weight_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                    x_scale_dtype=FLOAT8_E8M0FNU_DTYPE,
+                )
         elif mxfp_quant_dtype == QuantType.W4A16MXFP:
             hidden_states = torch_npu.npu_grouped_matmul(
                 x=[x],

--- a/vllm_ascend/quantization/methods/w4a8_mxfp4.py
+++ b/vllm_ascend/quantization/methods/w4a8_mxfp4.py
@@ -29,6 +29,7 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.device.mxfp_compat import (
     FLOAT8_E8M0FNU_DTYPE,
     ensure_mxfp4_linear_available,
+    ensure_mxfp4_moe_available,
 )
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
@@ -103,6 +104,7 @@ class AscendW4A8MXFPDynamicFusedMoEMethod(AscendMoEScheme):
     quant_type: QuantType = QuantType.W4A8MXFP
 
     def __init__(self, *, use_weight_packed: bool = False):
+        ensure_mxfp4_moe_available("W4A8_MXFP4 MoE quantization")
         self.use_weight_packed = use_weight_packed
         self.ep_group = get_ep_group()
 


### PR DESCRIPTION
### What this PR does / why we need it?

  The A5 W4A8MXFP MoE path previously ran the MoE activation as two separate
  ops: a quantized `npu_grouped_matmul` (GMM) followed by
  `npu_swiglu_group_quant` for the SwiGLU + output quantization stage, materializing
  the intermediate hidden states in between.

  This PR replaces that two-stage combo with the fused
  `npu_grouped_matmul_swiglu_quant_v2` op, which takes the MXFP4 weight and its
  scale directly and produces the quantized output in one call. The GMM +
  swiglu_group_quant branches for `QuantType.W4A8MXFP` in `A5DeviceAdaptor` are
  removed accordingly. `AscendW4A8MXFPDynamicFusedMoEMethod` now also calls
  `ensure_mxfp4_moe_available` at construction so that unsupported environments
  fail early with a clear message.

  ### Does this PR introduce _any_ user-facing change?

  No. Behavior is unchanged; only the underlying op sequence is fused.

  ### How was this patch tested?

  - `pytest -sv tests/ut/device/test_device_op.py::test_a5_w4a8_mxfp_uses_fused_grouped_matmul_swiglu_quant_v2`


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
