### PR TITLE
[BugFix][SpecDecode] Avoid DSpark crash when causality API is absent

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -61,6 +61,7 @@ class _DSparkProposerTestBase:
         num_reqs: int,
         block_size: int,
         hf_config: SimpleNamespace | None = None,
+        draft_attn_causal: bool | None = None,
     ):
         device = torch.device("cpu")
         vllm_config = cls._make_vllm_config(hf_config or SimpleNamespace())
@@ -81,11 +82,14 @@ class _DSparkProposerTestBase:
             proposer.hidden_size = _HIDDEN_SIZE
             proposer.hidden_states = torch.empty(0)
             proposer._dflash_hidden_states = torch.empty(0)
-            proposer.model = SimpleNamespace(get_draft_attn_causal=lambda: [False])
+            proposer.model = (
+                SimpleNamespace(get_draft_attn_causal=lambda: [draft_attn_causal])
+                if draft_attn_causal is not None
+                else SimpleNamespace()
+            )
 
         with patch.object(AscendDSparkProposer.__base__, "__init__", mock_parent_init):
             proposer = AscendDSparkProposer(vllm_config, device)
-
         num_query_total = num_reqs * proposer.num_query_per_req
         proposer.positions = torch.zeros(max_num_tokens, dtype=torch.int32, device=device)
         proposer.positions[:num_query_total] = torch.arange(num_query_total, dtype=torch.int32)
@@ -595,6 +599,20 @@ class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
         # optional attrs the proposer rewrites when present.
         assert cad.actual_seq_lengths_q == [block_size] * num_reqs
         assert cad.decode_token_per_req == block_size
+
+    def test_cad_uses_model_reported_causality(self):
+        num_reqs, block_size, max_num_tokens = 4, 5, 256
+        proposer = self._make_proposer(
+            max_num_tokens=max_num_tokens,
+            num_reqs=num_reqs,
+            block_size=block_size,
+            draft_attn_causal=True,
+        )
+        _, _, cad, _ = self._invoke_set_inputs_first_pass(
+            proposer, num_reqs=num_reqs, block_size=block_size
+        )[:4]
+
+        assert cad.causal is True
 
     def test_cad_query_start_loc_and_seq_lens(self):
         num_reqs, block_size, max_num_tokens = 4, 5, 256

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -437,8 +437,11 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.max_seq_len = cad.max_seq_len + self.num_query_per_req
         cad.slot_mapping = self._per_group_query_slot_mapping_buffers[primary_gid][:num_query_total]
         cad.positions = self.positions  # this would be sliced in attention backend
-        # Currently, attention causality across draft layers are uniform.
-        cad.causal = self.model.get_draft_attn_causal()[0]
+        if hasattr(self.model, "get_draft_attn_causal"):
+            # Currently, attention causality across draft layers are uniform.
+            cad.causal = self.model.get_draft_attn_causal()[0]
+        else:
+            cad.causal = False
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 


### PR DESCRIPTION
### What this PR does / why we need it?

PR #13531 added model-reported draft attention causality for GLM-5.2, but the
v1 Ascend DSpark proposer calls `get_draft_attn_causal()` unconditionally.
vLLM treats this model method as optional. Legacy non-causal DSpark models such
as DeepSeek V4 do not expose it, so DSpark initialization/warmup fails with:

```text
AttributeError: 'DSparkDeepseekV4ForCausalLM' object has no attribute 'get_draft_attn_causal'
```

This patch handles the optional capability directly in the attention metadata
path:

- use the model-reported value when `get_draft_attn_causal()` exists;
- otherwise preserve the previous non-causal DSpark behavior (`False`).

The unit tests cover both the missing-method fallback and an explicitly causal
model, so the GLM-5.2 behavior introduced by #13531 remains intact.

This is the main-branch counterpart of #13831. Refs #11126.

#### Duplicate check

Searched open PRs and issues for `get_draft_attn_causal`, `DSpark causality`,
and `DeepSeek V4 DSpark`.

- #13925 contains the same minimal runtime fallback but does not add regression
  coverage. Its author requested a main-branch PR from `jianzs` in #13926;
  this PR adds both missing-API and explicit-causal tests and is intended to
  supersede #13925 so only one implementation is merged.
- #11066 adds GLM-5.2 DSpark support and supplies model-specific causality; it
  does not cover models without the optional API.
- #12968 and #11126 track DeepSeek V4 DSpark model support, rather than this v1
  proposer interface regression.

### Does this PR introduce _any_ user-facing change?

Yes. DSpark models without `get_draft_attn_causal()` no longer crash and use
the legacy non-causal attention behavior. Models that explicitly report
causality are unchanged. There is no CLI or configuration change.

### How was this patch tested?

The fallback behavior is covered by unit tests for both a model without the
optional API and a model that explicitly reports causal attention. Changed-file
pre-commit, `py_compile`, and `git diff --check` passed during development.
Equivalent fallback behavior and the two regression paths were also validated
on the v0.26 integration branch on an Ascend dev0 node:

```bash
python3 -m pytest -q tests/ut/spec_decode/test_dspark_proposer.py
# 31 passed, 14 warnings
```

GitHub CI validates the current main head.

DeepSeek V4 Flash end-to-end evidence for that equivalent v0.26 fallback:

- TP=8, PP=1, DSpark: the server became ready; three short requests and one
  200-token request returned HTTP 200. Speculative-decoding metrics confirmed
  the DSpark path was active.
- TP=2, PP=4, DSpark, DSA-CP, KV producer (the original crash topology): the
  server became ready and three short requests returned HTTP 200 with the
  expected output. The original `AttributeError` and engine traceback did not
  recur.

The PP=4 direct KV-producer run also exposed an unrelated long-response content
anomaly. This PR's validation scope is the DSpark startup and optional-interface
compatibility regression; full long-output correctness remains separate.

No documentation update is needed because this restores compatibility without
changing configuration or public APIs.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR.
- [x] The test plan.
- [x] The test results and end-to-end evaluation.
- [x] Documentation impact considered.

</details>
