### PR TITLE
[CI] Add manual workflow to force cancel runs

### DIFF
--- a/.github/workflows/manual_force_cancel_runs.yaml
+++ b/.github/workflows/manual_force_cancel_runs.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+name: Force cancel workflow runs
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_ids:
+        description: "Workflow run IDs to force cancel, separated by spaces"
+        required: true
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  force-cancel:
+    name: Force cancel runs
+    runs-on: linux-amd64-cpu-2-hk
+    timeout-minutes: 5
+    steps:
+      - name: Force cancel workflow runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_RUN_IDS: ${{ inputs.run_ids }}
+        run: |
+          read -r -a run_ids <<< "$INPUT_RUN_IDS"
+
+          if [ "${#run_ids[@]}" -eq 0 ]; then
+            echo "::error::No workflow run IDs were provided."
+            exit 1
+          fi
+
+          failed_ids=()
+          for run_id in "${run_ids[@]}"; do
+            if [[ ! "$run_id" =~ ^[0-9]+$ ]]; then
+              echo "::error::Invalid workflow run ID: $run_id"
+              failed_ids+=("$run_id")
+              continue
+            fi
+
+            echo "Force cancelling workflow run $run_id..."
+            if curl --fail --silent --show-error \
+              --request POST \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "Accept: application/vnd.github+json" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/runs/$run_id/force-cancel"; then
+              echo "Force cancellation requested for workflow run $run_id."
+            else
+              echo "::error::Failed to force cancel workflow run $run_id."
+              failed_ids+=("$run_id")
+            fi
+          done
+
+          if [ "${#failed_ids[@]}" -ne 0 ]; then
+            echo "::error::Failed workflow run IDs: ${failed_ids[*]}"
+            exit 1
+          fi


### PR DESCRIPTION
### What this PR does / why we need it?
Add a manually triggered workflow for force cancelling stuck GitHub Actions workflow runs.

The workflow:

- Accepts one or more workflow run IDs separated by spaces.
- Validates that each supplied run ID is numeric.
- Calls GitHub's `force-cancel` API for every valid run ID.
- Continues processing the remaining IDs when one cancellation fails.
- Reports all failed run IDs before exiting.
- Uses the minimum required `actions: write` permission.

This is useful when a workflow run cannot be stopped through the GitHub Actions UI or the regular cancellation mechanism.
<img width="1256" height="555" alt="image" src="https://github.com/user-attachments/assets/8c288c48-0bfb-4761-aa2a-8716263244c6" />

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
