### PR TITLE
[Doc][BugFix] Fix Qwen3-Reranker deploy guide

### DIFF
--- a/docs/source/tutorials/models/Qwen3-Reranker.md
+++ b/docs/source/tutorials/models/Qwen3-Reranker.md
@@ -136,7 +136,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
 vllm serve Qwen/Qwen3-Reranker-0.6B \
   --served-model-name Qwen/Qwen3-Reranker-0.6B \
   --runner pooling \
-  --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
+  --hf_overrides '{"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
   --port 8000 \
   --max-model-len 1024
 ```
@@ -151,7 +151,7 @@ vllm serve Qwen/Qwen3-Reranker-0.6B \
 vllm serve Qwen/Qwen3-Reranker-0.6B \
   --served-model-name Qwen/Qwen3-Reranker-0.6B \
   --runner pooling \
-  --hf_overrides '{"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
+  --hf_overrides '{"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": true}' \
   --compilation-config '{"cudagraph_capture_sizes": [1024,512]}' \
   --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' \
   --dtype float16 \
@@ -279,7 +279,7 @@ Here are two accuracy evaluation methods.
                                     dtype="float16",
                                     enforce_eager=True,
                                     max_model_len=10240,
-                                    hf_overrides={"architectures": ["Qwen3VLForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": True})
+                                    hf_overrides={"architectures": ["Qwen3ForSequenceClassification"],"classifier_from_token": ["no", "yes"],"is_original_qwen3_reranker": True})
 
         cache = mteb.ResultCache("/home/data/mteb_data")
         tasks = mteb.get_tasks(


### PR DESCRIPTION
What this PR does / why we need it?
This PR corrects a typo in the Qwen3-Reranker deployment guide. The architectures override within the hf_overrides parameter was incorrectly specified as Qwen3VLForSequenceClassification. This has been corrected to Qwen3ForSequenceClassification to match the text-based nature of the reranker model.

This fix is applied consistently across all command-line examples and code snippets in the document, ensuring that users can follow the guide without encountering errors.

fix https://github.com/vllm-project/vllm-ascend/issues/13446

Does this PR introduce any user-facing change?
No, this is a documentation-only update and does not affect any user-facing functionality.

How was this patch tested?
The changes are limited to documentation and have been visually verified for correctness. The corrected commands are now aligned with the model's expected configuration.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
