### PR TITLE
[Test][BugFix] Migrate Qwen3-235B-W8A8 EPLB nightly case to MRV2 config

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
@@ -53,8 +53,6 @@ deployment:
                   }
             }
         }'
-        --additional-config
-        '{"eplb_config": {"load_collection_phase": "prefill"}}'
 
   -
     envs:
@@ -93,6 +91,4 @@ deployment:
                   }
             }
         }'
-        --additional-config
-        '{"eplb_config": {"load_collection_phase": "decode"}}'
 benchmarks:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
@@ -10,7 +10,6 @@ env_common: &env_common
   OMP_NUM_THREADS: 1
   HCCL_BUFFSIZE: 1024
   SERVER_PORT: 8080
-  DYNAMIC_EPLB: true
 disaggregated_prefill:
   enabled: true
   prefiller_host_index: [0]
@@ -29,6 +28,9 @@ deployment:
         --tensor-parallel-size 8
         --seed 1024
         --enable-expert-parallel
+        --enable-eplb
+        --eplb-config
+        '{"window_size": 50, "step_interval": 5, "use_async": false}'
         --max-num-seqs 16
         --max-model-len 8192
         --max-num-batched-tokens 8192
@@ -52,7 +54,7 @@ deployment:
             }
         }'
         --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":50,"algorithm_execution_interval":5}}'
+        '{"eplb_config": {"load_collection_phase": "prefill"}}'
 
   -
     envs:
@@ -70,6 +72,9 @@ deployment:
         --max-model-len 8192
         --max-num-batched-tokens 8192
         --enable-expert-parallel
+        --enable-eplb
+        --eplb-config
+        '{"window_size": 600, "step_interval": 50, "use_async": false}'
         --trust-remote-code
         --no-enable-prefix-caching
         --gpu-memory-utilization 0.9
@@ -89,5 +94,5 @@ deployment:
             }
         }'
         --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":600,"algorithm_execution_interval":50}}'
+        '{"eplb_config": {"load_collection_phase": "decode"}}'
 benchmarks:


### PR DESCRIPTION
### What this PR does / why we need it?

Migrates the nightly multi-node test case `Qwen3-235B-W8A8-EPLB.yaml` from the
legacy Model Runner V1 EPLB schema to the upstream Model Runner V2 EPLB
integration (#12804, RFC #13410).

Specifically:
- Removes `DYNAMIC_EPLB: true` from `env_common`.
- Adds `--enable-eplb` and `--eplb-config` (with `use_async=false`) to both
  prefill and decode deployments.
- Drops `--additional-config` entirely: MRv2's `load_collection_phase` defaults
  to `"all"`, and this case is PD-disaggregated (prefill node = `kv_producer`,
  decode node = `kv_consumer`), so a phase filter would always match and is not
  needed.
- Preserves the original interval/window intent: prefill
  `window_size=50, step_interval=5`; decode `window_size=600, step_interval=50`.

This is needed because since #12804,
`vllm_ascend/platform.py::_validate_eplb_config` rejects legacy EPLB fields and
the `DYNAMIC_EPLB` environment variable during `VllmConfig` construction on
MRv2, causing the nightly case to fail with `ValidationError`.

**Before (legacy MRV1 launch):**

```bash
# env_common: HCCL_OP_EXPANSION_MODE=AIV, VLLM_USE_MODELSCOPE=true,
#             TASK_QUEUE_ENABLE=1, OMP_PROC_BIND=false, OMP_NUM_THREADS=1,
#             HCCL_BUFFSIZE=1024, SERVER_PORT=8080, DYNAMIC_EPLB=true

# Node 0 - prefill / kv_producer
vllm serve "vllm-ascend/Qwen3-235B-A22B-W8A8" \
  --host 0.0.0.0 --port $SERVER_PORT \
  --data-parallel-size 2 --data-parallel-size-local 2 --tensor-parallel-size 8 \
  --seed 1024 --enable-expert-parallel --max-num-seqs 16 --max-model-len 8192 \
  --max-num-batched-tokens 8192 --quantization ascend --trust-remote-code \
  --no-enable-prefix-caching --gpu-memory-utilization 0.9 \
  --kv-transfer-config '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30000", "kv_connector_extra_config": { "prefill": { "dp_size": 2, "tp_size": 8 }, "decode": { "dp_size": 2, "tp_size": 8 } } }' \
  --additional-config '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":50,"algorithm_execution_interval":5}}'

# Node 1 - decode / kv_consumer
vllm serve "vllm-ascend/Qwen3-235B-A22B-W8A8" \
  --host 0.0.0.0 --port $SERVER_PORT \
  --data-parallel-size 2 --data-parallel-size-local 2 --tensor-parallel-size 8 \
  --seed 1024 --quantization ascend --max-num-seqs 16 --max-model-len 8192 \
  --max-num-batched-tokens 8192 --enable-expert-parallel --trust-remote-code \
  --no-enable-prefix-caching --gpu-memory-utilization 0.9 \
  --kv-transfer-config '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "kv_connector_extra_config": { "prefill": { "dp_size": 2, "tp_size": 8 }, "decode": { "dp_size": 2, "tp_size": 8 } } }' \
  --additional-config '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":600,"algorithm_execution_interval":50}}'
```

**After (MRV2 upstream EPLB launch):**

```bash
# env_common: same as before, minus DYNAMIC_EPLB

# Node 0 - prefill / kv_producer
vllm serve "vllm-ascend/Qwen3-235B-A22B-W8A8" \
  --host 0.0.0.0 --port $SERVER_PORT \
  --data-parallel-size 2 --data-parallel-size-local 2 --tensor-parallel-size 8 \
  --seed 1024 --enable-expert-parallel --enable-eplb \
  --eplb-config '{"window_size": 50, "step_interval": 5, "use_async": false}' \
  --max-num-seqs 16 --max-model-len 8192 \
  --max-num-batched-tokens 8192 --quantization ascend --trust-remote-code \
  --no-enable-prefix-caching --gpu-memory-utilization 0.9 \
  --kv-transfer-config '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30000", "kv_connector_extra_config": { "prefill": { "dp_size": 2, "tp_size": 8 }, "decode": { "dp_size": 2, "tp_size": 8 } } }'

# Node 1 - decode / kv_consumer
vllm serve "vllm-ascend/Qwen3-235B-A22B-W8A8" \
  --host 0.0.0.0 --port $SERVER_PORT \
  --data-parallel-size 2 --data-parallel-size-local 2 --tensor-parallel-size 8 \
  --seed 1024 --quantization ascend --max-num-seqs 16 --max-model-len 8192 \
  --max-num-batched-tokens 8192 --enable-expert-parallel --enable-eplb \
  --eplb-config '{"window_size": 600, "step_interval": 50, "use_async": false}' \
  --trust-remote-code \
  --no-enable-prefix-caching --gpu-memory-utilization 0.9 \
  --kv-transfer-config '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "kv_connector_extra_config": { "prefill": { "dp_size": 2, "tp_size": 8 }, "decode": { "dp_size": 2, "tp_size": 8 } } }'
```

### Does this PR introduce _any_ user-facing change?

No. This is a test configuration update only.

### How was this patch tested?

- Verified that the YAML parses correctly and the reconstructed `server_cmd`
  is intact.
- Verified against `_validate_eplb_config`: no legacy fields, no
  `DYNAMIC_EPLB`, `use_async=false`, no explicit `communicator`;
  `load_collection_phase` defaults to `"all"`.
- Real-hardware validation will be covered by the next nightly run on main.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
