### PR TITLE
[CI] Improve workflow cancellation behavior

### DIFF
--- a/.github/workflows/_analyze_failure.yaml
+++ b/.github/workflows/_analyze_failure.yaml
@@ -114,7 +114,7 @@ jobs:
 
       # ---- Step 4: Upload report ----
       - name: Upload failure analysis report
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: failure-analysis-report

--- a/.github/workflows/_manual-hitest.yaml
+++ b/.github/workflows/_manual-hitest.yaml
@@ -67,7 +67,7 @@ jobs:
           python3 .github/workflows/scripts/run_hitest.py
 
       - name: Upload recommended pytest paths artifact
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: recommended-pytest-paths
@@ -77,7 +77,7 @@ jobs:
 
       - name: Export hitest_paths output
         id: export-paths
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           FILE=".github/workflows/scripts/recommended_pytest_paths.txt"
           if [ -f "$FILE" ]; then

--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -323,7 +323,7 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage data
-        if: ${{ always() && inputs.enable-coverage }}
+        if: ${{ !cancelled() && inputs.enable-coverage }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -336,7 +336,7 @@ jobs:
           compression-level: 0
 
       - name: Upload selected test logs
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -347,7 +347,7 @@ jobs:
           compression-level: 0
 
   upload-coverage-to-obs:
-      if: ${{ always() && inputs.enable-coverage }}
+      if: ${{ !cancelled() && inputs.enable-coverage }}
       needs: selected-tests
       runs-on: ubuntu-latest
       continue-on-error: true

--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -216,7 +216,7 @@ jobs:
   report:
     name: Report result
     needs: [e2e-test, trigger-selected-tests]
-    if: always() && needs.e2e-test.result == 'success' && needs.e2e-test.outputs.notify_comment_id != ''
+    if: ${{ !cancelled() && needs.e2e-test.result == 'success' && needs.e2e-test.outputs.notify_comment_id != '' }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Update comment with result

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -350,7 +350,6 @@ jobs:
       - ensure-csrc-cache
     if: >-
       ${{
-        always() &&
         needs.pre-commit.result == 'success' &&
         needs.select-tests.result == 'success' &&
         needs.select-tests.outputs.has_tests == 'true' &&
@@ -377,7 +376,6 @@ jobs:
       - ensure-csrc-cache
     if: >-
       ${{
-        always() &&
         needs.pre-commit.result == 'success' &&
         needs.select-tests.result == 'success' &&
         contains(github.event.pull_request.labels.*.name, 'ready') &&
@@ -472,7 +470,7 @@ jobs:
 
       - name: Export coverage paths output
         id: export-paths
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           FILE="recommended_pytest_paths.txt"
           if [ -f "$FILE" ]; then
@@ -506,7 +504,7 @@ jobs:
   # in GitHub branch protection rules instead of tracking individual matrix job names.
   ci-gate:
     needs: [pre-commit, select-tests, run-selected-tests, run-selected-tests-a5]
-    if: ${{ always() && (contains(github.event.pull_request.labels.*.name, 'ready') || contains(github.event.pull_request.labels.*.name, 'ready-a5')) }}
+    if: ${{ !cancelled() && (contains(github.event.pull_request.labels.*.name, 'ready') || contains(github.event.pull_request.labels.*.name, 'ready-a5')) }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Check all required jobs
@@ -576,7 +574,7 @@ jobs:
   analyze-failure-report:
     name: Analyze failure report
     needs: [run-selected-tests, recommend-tests-from-coverage]
-    if: always()
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/_analyze_failure.yaml
     with:
       log_artifact_pattern: selected-test-logs-*

--- a/.github/workflows/push_build_precommit_cache.yaml
+++ b/.github/workflows/push_build_precommit_cache.yaml
@@ -88,7 +88,7 @@ jobs:
           pre-commit run --all-files --hook-stage manual --show-diff-on-failure
 
       - name: Save pre-commit cache
-        if: always() && steps.check-cache.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && steps.check-cache.outputs.cache-hit != 'true' }}
         uses: runs-on/cache/save@v5
         with:
           path: /tmp/pre-commit-cache

--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -254,7 +254,6 @@ jobs:
           pip install uv pytest
 
       - name: Configure git identity
-        if: always()
         working-directory: ${{ github.workspace }}
         run: |
           set -eu
@@ -263,7 +262,7 @@ jobs:
           gh --version
 
       - name: Check npu and CANN info
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           npu-smi info || true
           if [ -d /usr/local/Ascend/ascend-toolkit/latest ]; then
@@ -513,7 +512,7 @@ jobs:
           fi
 
       - name: Upload workspace
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -524,7 +523,7 @@ jobs:
       - name: Summarize final status
         id: final-status
         working-directory: ${{ github.workspace }}
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           set -eu
           eval "${MAIN2MAIN_LOG_HELPERS}"

--- a/.github/workflows/schedule_update_estimated_times.yaml
+++ b/.github/workflows/schedule_update_estimated_times.yaml
@@ -153,7 +153,7 @@ jobs:
 
   update-estimated-times:
     needs: [run-tests-main, run-tests-release]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
### What this PR does / why we need it?
GitHub Actions reevaluates job and step conditions when a workflow is cancelled. Conditions using `always()` remain true during cancellation, which may keep dependent jobs queued or running, especially when custom runners or reusable workflows are involved. This can prevent `concurrency.cancel-in-progress` and normal UI cancellation from promptly terminating an old run.

This PR improves cancellation behavior for non-nightly workflows:

- Replaces necessary failure-handling conditions with `!cancelled()`, allowing jobs such as artifact uploads and failure reports to run after failures while skipping them after cancellation.
- Removes redundant `always()` conditions where jobs should only run after their dependencies succeed.
- Updates PR tests, E2E reporting, pre-commit cache handling, Main2Main, estimated-time updates, and weekly workflows.
- Leaves nightly workflows unchanged because some nightly jobs require unconditional cleanup or coordination.

cancel success: https://github.com/vllm-project/vllm-ascend/actions/runs/31394369115/job/93475456751
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
