### PR TITLE
[Performance] eliminate overhead TransData for prefetch offload

### DIFF
--- a/tests/e2e/pull_request/one_card/test_cpu_weight_offload.py
+++ b/tests/e2e/pull_request/one_card/test_cpu_weight_offload.py
@@ -34,12 +34,16 @@ def _compare_offload_logprobs(
     prompts: list[str],
     atol: float = 0.0689,
     decode_atol: float | None = None,
+    num_runs: int = 3,
 ) -> None:
     """Compare prefetch/offload run against a no-offload eager baseline.
 
     Unlike ``compare_logprobs``, this keeps ``additional_config`` (e.g.
     ``weight_nz_mode``) on both sides and strips offload-related kwargs from
     the baseline so accuracy of the offloader itself is exercised.
+
+    The offload runner generates ``num_runs`` times; each run must match
+    the same baseline outputs (stability across repeated inference).
     """
     if decode_atol is None:
         decode_atol = 2 * atol
@@ -55,28 +59,30 @@ def _compare_offload_logprobs(
             sampling_params=e2e_utils._LOGPROB_SAMPLING_PARAMS,
         )
 
-    # enabled offload
+    # enabled offload: repeat generate and compare each run to baseline
     with VllmRunner(**runner_kwargs) as runner:
-        offload_outputs = runner.model.generate(
-            prompts=prompts,
-            sampling_params=e2e_utils._LOGPROB_SAMPLING_PARAMS,
-        )
+        for run_idx in range(num_runs):
+            offload_outputs = runner.model.generate(
+                prompts=prompts,
+                sampling_params=e2e_utils._LOGPROB_SAMPLING_PARAMS,
+            )
 
-    for prompt_idx, (base_out, offload_out) in enumerate(zip(baseline_outputs, offload_outputs)):
-        base_seq = base_out.outputs[0]
-        offload_seq = offload_out.outputs[0]
+            for prompt_idx, (base_out, offload_out) in enumerate(zip(baseline_outputs, offload_outputs)):
+                base_seq = base_out.outputs[0]
+                offload_seq = offload_out.outputs[0]
 
-        assert base_seq.logprobs is not None and offload_seq.logprobs is not None, (
-            f"logprobs not returned for prompt {prompt_idx}"
-        )
-        assert len(base_seq.token_ids) == len(offload_seq.token_ids) == 3, (
-            f"Expected 3 tokens for prompt {prompt_idx}, "
-            f"got baseline={len(base_seq.token_ids)}, offload={len(offload_seq.token_ids)}"
-        )
+                assert base_seq.logprobs is not None and offload_seq.logprobs is not None, (
+                    f"logprobs not returned for prompt {prompt_idx} (run {run_idx})"
+                )
+                assert len(base_seq.token_ids) == len(offload_seq.token_ids) == 3, (
+                    f"Expected 3 tokens for prompt {prompt_idx} (run {run_idx}), "
+                    f"got baseline={len(base_seq.token_ids)}, "
+                    f"offload={len(offload_seq.token_ids)}"
+                )
 
-        e2e_utils._check_prefill_token(base_seq, offload_seq, prompt_idx, atol)
-        for token_idx in range(1, 3):
-            e2e_utils._check_decode_token(base_seq, offload_seq, token_idx, prompt_idx, decode_atol)
+                e2e_utils._check_prefill_token(base_seq, offload_seq, prompt_idx, atol)
+                for token_idx in range(1, 3):
+                    e2e_utils._check_decode_token(base_seq, offload_seq, token_idx, prompt_idx, decode_atol)
 
 
 # -------------------- Prefetch backend tests --------------------

--- a/vllm_ascend/model_executor/offloader/prefetch.py
+++ b/vllm_ascend/model_executor/offloader/prefetch.py
@@ -1,6 +1,7 @@
 """Ascend prefetch-based CPU offloading with NZ-format static buffers."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import wraps
 from typing import Any
@@ -9,6 +10,7 @@ import torch
 import torch.nn as nn
 import torch_npu
 from vllm.logger import logger
+from vllm.model_executor.offloader.base import should_pin_memory
 from vllm.model_executor.offloader.prefetch import (
     ParamInfo as VllmParamInfo,
 )
@@ -20,64 +22,158 @@ from vllm.model_executor.offloader.prefetch import (
     _ModuleOffloader as VllmModuleOffloader,
 )
 
-from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, enable_custom_op
 
-# mark
-_ASCEND_PREFETCH_NZ_WEIGHT_ATTR = "_vllm_ascend_prefetch_offload_nz_weight"
+# FRACTAL_NZ variants with an explicit C0 size, used by newer SoCs.
+ACL_FORMAT_FRACTAL_NZ_C0_16 = 50
+ACL_FORMAT_FRACTAL_NZ_C0_32 = 51
+ACL_FORMAT_FRACTAL_NZ_C0_2 = 52
+ACL_FORMAT_FRACTAL_NZ_C0_4 = 53
+ACL_FORMAT_FRACTAL_NZ_C0_8 = 54
+
+# Storage formats whose physical layout is padded and reordered with respect to
+# the logical shape. torch_npu cannot transfer them between host and device
+# directly, so every copy_() against such a tensor also runs a TransData.
+_NZ_FORMATS = frozenset(
+    {
+        ACL_FORMAT_FRACTAL_NZ,  # 29
+        ACL_FORMAT_FRACTAL_NZ_C0_16,
+        ACL_FORMAT_FRACTAL_NZ_C0_32,
+        ACL_FORMAT_FRACTAL_NZ_C0_2,
+        ACL_FORMAT_FRACTAL_NZ_C0_4,
+        ACL_FORMAT_FRACTAL_NZ_C0_8,
+    }
+)
+
+# `direction` argument of torch.ops._C_ascend.swap_blocks_batch.
+_MEMCPY_HOST_TO_DEVICE = 0
+_MEMCPY_DEVICE_TO_HOST = 1
 
 
-def mark_prefetch_offload_nz_weight(param: nn.Parameter) -> None:
-    """Mark a parameter whose prefetch static buffer must use NZ format."""
-    setattr(param, _ASCEND_PREFETCH_NZ_WEIGHT_ATTR, True)
-
-
-def _is_using_nz_weight(param: nn.Parameter) -> bool:
-    """if its current NPU storage format is FRACTAL_NZ."""
-    if param.data.device.type != "npu":
-        return False
+def _get_nz_format(tensor: torch.Tensor) -> int | None:
+    """Return the NZ storage format of an NPU tensor, or None if it is not NZ."""
+    if tensor.device.type != "npu":
+        return None
 
     try:
-        npu_format = int(torch_npu.get_npu_format(param.data))
+        acl_format = int(torch_npu.get_npu_format(tensor))
     except (AttributeError, RuntimeError, TypeError, ValueError):
-        return False
+        return None
 
-    return npu_format == ACL_FORMAT_FRACTAL_NZ
+    return acl_format if acl_format in _NZ_FORMATS else None
 
 
-def _is_prefetch_offload_nz_weight(param: nn.Parameter) -> bool:
-    return bool(getattr(param, _ASCEND_PREFETCH_NZ_WEIGHT_ATTR, False))
+def _raw_memcpy_available() -> bool:
+    """Whether the pointer-level memcpy custom op can be used."""
+    return enable_custom_op() and hasattr(torch.ops._C_ascend, "swap_blocks_batch")
+
+
+def _as_pointer_tensor(values: list[int]) -> torch.Tensor:
+    return torch.tensor(values, dtype=torch.int64, device="cpu")
+
+
+def _raw_memcpy_async(
+    src_ptrs: torch.Tensor,
+    dst_ptrs: torch.Tensor,
+    sizes: torch.Tensor,
+    direction: int,
+) -> None:
+    """Enqueue pointer-level memcpys on the current NPU stream.
+
+    The copy is issued from raw addresses and byte counts, so it moves the
+    padded NZ storage verbatim instead of going through the format-aware
+    torch_npu copy path.
+    """
+    torch.ops._C_ascend.swap_blocks_batch(src_ptrs, dst_ptrs, sizes, direction)
+
+
+def _capture_nz_host_storage(tensor: torch.Tensor) -> torch.Tensor:
+    """Copy the padded NZ storage of a device tensor into host memory."""
+    storage_numel = int(torch_npu.get_storage_size(tensor))
+    host_storage = torch.empty(
+        storage_numel,
+        dtype=tensor.dtype,
+        device="cpu",
+        pin_memory=should_pin_memory(),
+    )
+    _raw_memcpy_async(
+        _as_pointer_tensor([tensor.data_ptr()]),
+        _as_pointer_tensor([host_storage.data_ptr()]),
+        _as_pointer_tensor([storage_numel * tensor.element_size()]),
+        _MEMCPY_DEVICE_TO_HOST,
+    )
+    torch.cuda.current_stream().synchronize()
+    return host_storage
+
+
+@contextmanager
+def _patched_vllm_prefetch(**attrs: Any) -> Generator[None, None, None]:
+    """Temporarily swap symbols that the vLLM offloader resolves at call time."""
+    import vllm.model_executor.offloader.prefetch as vllm_prefetch
+
+    originals = {name: getattr(vllm_prefetch, name) for name in attrs}
+    for name, value in attrs.items():
+        setattr(vllm_prefetch, name, value)
+    try:
+        yield
+    finally:
+        for name, value in originals.items():
+            setattr(vllm_prefetch, name, value)
 
 
 @dataclass
 class ParamInfo(VllmParamInfo):
     """Ascend parameter metadata with static-buffer format requirements."""
 
-    use_nz_buffer: bool = False
+    nz_format: int | None = None
 
 
-def _format_static_buffers_for_nz(
-    buffer_pool: StaticBufferPool,
-    param_infos: list[ParamInfo],
-) -> None:
-    """Cast static buffers to NZ format for keys whose parameters require it."""
-    key_to_use_nz: dict[tuple[str, tuple[int, ...], tuple[int, ...], torch.dtype], bool] = {}
+def _collect_nz_formats(param_infos: list[ParamInfo]) -> dict[tuple, int]:
+    """Map each buffer-pool key to the NZ format its parameters require."""
+    key_to_format: dict[tuple, int | None] = {}
 
     for info in param_infos:
-        if info.key in key_to_use_nz and key_to_use_nz[info.key] != info.use_nz_buffer:
+        if info.key in key_to_format and key_to_format[info.key] != info.nz_format:
             raise ValueError(
                 "Conflicting NZ buffer requirements for prefetch static buffer "
-                f"key {info.key}: both NZ and non-NZ parameters use this key."
+                f"key {info.key}: {key_to_format[info.key]} and {info.nz_format} "
+                "are both requested."
             )
-        key_to_use_nz[info.key] = info.use_nz_buffer
-        if info.use_nz_buffer:
-            logger.info("%s enables NZ buffer", info.name)
+        key_to_format[info.key] = info.nz_format
 
-    for key, use_nz_buffer in key_to_use_nz.items():
-        if not use_nz_buffer:
-            continue
-        buffer_pool._buffers[key] = [
-            torch_npu.npu_format_cast(buffer, ACL_FORMAT_FRACTAL_NZ) for buffer in buffer_pool._buffers[key]
-        ]
+    return {key: acl_format for key, acl_format in key_to_format.items() if acl_format is not None}
+
+
+class AscendStaticBufferPool(StaticBufferPool):
+    """Static buffer pool whose slots use the NZ format of their parameters.
+
+    The cast has to happen while the pool is being built: once
+    ``assign_buffer_slot`` has pointed the parameters at their buffers,
+    replacing the pooled tensors no longer has any effect.
+    """
+
+    def __init__(
+        self,
+        param_infos: list[ParamInfo],
+        slot_capacity: int,
+        device: torch.device,
+    ):
+        super().__init__(param_infos=param_infos, slot_capacity=slot_capacity, device=device)
+
+        nz_formats = _collect_nz_formats(param_infos)
+        for key, acl_format in nz_formats.items():
+            nd_buffers = self._buffers[key]
+            self._buffers[key] = [torch_npu.npu_format_cast(buffer, acl_format) for buffer in nd_buffers]
+            for nd_buffer, nz_buffer in zip(nd_buffers, self._buffers[key]):
+                padding_numel = int(torch_npu.get_storage_size(nz_buffer)) - nd_buffer.numel()
+                self.total_bytes += padding_numel * nd_buffer.element_size()
+
+        if nz_formats:
+            logger.info(
+                "[AscendPrefetchOffloader] %d of %d static buffer keys use NZ format",
+                len(nz_formats),
+                len(self._buffers),
+            )
 
 
 class AscendPrefetchOffloader(PrefetchOffloader):
@@ -104,33 +200,16 @@ class AscendPrefetchOffloader(PrefetchOffloader):
         self,
         modules_generator: Generator[nn.Module, None, None],
     ) -> list[nn.Module]:
-        import vllm.model_executor.offloader.prefetch as vllm_prefetch
-
-        original_module_offloader = vllm_prefetch._ModuleOffloader
-        vllm_prefetch._ModuleOffloader = _ModuleOffloader
-        try:
+        with _patched_vllm_prefetch(_ModuleOffloader=_ModuleOffloader):
             return super().wrap_modules(modules_generator)
-        finally:
-            vllm_prefetch._ModuleOffloader = original_module_offloader
 
     def post_init(self):
-        super().post_init()
-
-        device: torch.device | None = None
-        param_infos: list[ParamInfo] = []
-        for offloader in self.module_offloaders:
-            param_infos.extend(offloader.get_param_infos())
-            if device is None:
-                device = offloader.device
-        if device is None:
-            # No modules to offload
-            return
-
-        _format_static_buffers_for_nz(self.buffer_pool, param_infos)
+        with _patched_vllm_prefetch(StaticBufferPool=AscendStaticBufferPool):
+            super().post_init()
 
 
 class _ModuleOffloader(VllmModuleOffloader):
-    """vLLM module offloader with Ascend NZ-format detection."""
+    """vLLM module offloader that prefetches NZ weights as raw bytes."""
 
     def __init__(
         self,
@@ -147,23 +226,48 @@ class _ModuleOffloader(VllmModuleOffloader):
             whitelist_param_names=whitelist_param_names,
             layer_idx=layer_idx,
         )
-        self._wrap_process_weights_for_format_detection()
+        # NZ storage format per parameter name, needed to allocate matching
+        # static buffers.
+        self._nz_formats: dict[str, int] = {}
+        # Padded NZ storage per parameter <name, mirrored> in host memory.
+        self._nz_host_storages: dict[str, torch.Tensor] = {}
+        # Prefetch plan, built in post_init().
+        self._nz_src_ptrs = _as_pointer_tensor([])
+        self._nz_dst_ptrs = _as_pointer_tensor([])
+        self._nz_sizes = _as_pointer_tensor([])
+        self._nd_copies: list[tuple[str, torch.Tensor, torch.Tensor]] = []
+        self._wrap_process_weights_for_nz_capture()
 
-    def _capture_static_buffer_formats_from_npu_params(self) -> None:
-        """
-        This function should be invoked during the `process_weights_after_loading`.
-        And during `process_weights_after_loading`, the weights would be loaded to NPU
-        for quantization and transformation of NPU formats.
-        So the format of weights could be figured out during the `process_weights_after_loading`.
-        This function is for checking the format of the weights,
-        and set a mark to param if its weights is in NZ format.
-        """
-        for param_offloader in self._param_offloaders.values():
-            param = param_offloader._param
-            if _is_using_nz_weight(param):
-                mark_prefetch_offload_nz_weight(param)
+    def _capture_nz_weights(self) -> None:
+        """Record the NZ layout of this module's weights, and their raw bytes.
 
-    def _wrap_process_weights_for_format_detection(self) -> None:
+        Must run inside ``process_weights_after_loading``: that is where
+        quantization casts weights to NZ, and it is the only point at which the
+        NZ tensors still exist on device. Afterwards ``device_loading_context``
+        moves the parameters back to host memory, which silently converts them
+        to ND.
+        """
+        for name, param_offloader in self._param_offloaders.items():
+            if name in self._nz_formats:
+                continue
+
+            try:
+                param = param_offloader._param
+            except AttributeError:
+                # Transient parameters such as k_scale/v_scale are deleted by
+                # process_weights_after_loading; the base offloader prunes them
+                # later in sync_cpu_storage().
+                continue
+
+            acl_format = _get_nz_format(param.data)
+            if acl_format is None:
+                continue
+
+            self._nz_formats[name] = acl_format
+            if _raw_memcpy_available():
+                self._nz_host_storages[name] = _capture_nz_host_storage(param.data)
+
+    def _wrap_process_weights_for_nz_capture(self) -> None:
         """maybe_trans_nz was called only in quantization scenario"""
         wrapped_quant_methods: set[int] = set()
         for submodule in self.module.modules():
@@ -174,11 +278,11 @@ class _ModuleOffloader(VllmModuleOffloader):
                     quant_method.process_weights_after_loading = self._wrap_process_weights(process_weights)
                     wrapped_quant_methods.add(id(quant_method))
 
-    def _wrap_process_weights(self, process_weights: Any) -> Any:
+    def _wrap_process_weights(self, process_weights: Callable) -> Any:
         @wraps(process_weights)
         def wrapped_process_weights(*args: Any, **kwargs: Any) -> Any:
             result = process_weights(*args, **kwargs)
-            self._capture_static_buffer_formats_from_npu_params()
+            self._capture_nz_weights()
             return result
 
         return wrapped_process_weights
@@ -195,7 +299,82 @@ class _ModuleOffloader(VllmModuleOffloader):
                     stride=tuple(cpu_storage.stride()),
                     dtype=cpu_storage.dtype,
                     # NOTE(wangjin) different from base
-                    use_nz_buffer=_is_prefetch_offload_nz_weight(offloader._param),
+                    nz_format=self._nz_formats.get(name),
                 )
             )
         return infos
+
+    def post_init(self):
+        """Build the prefetch plan once the static buffers are assigned."""
+        super().post_init()
+
+        src_ptrs: list[int] = []
+        dst_ptrs: list[int] = []
+        sizes: list[int] = []
+
+        for name, offloader in self._param_offloaders.items():
+            gpu_buffer = offloader._gpu_buffer
+            assert gpu_buffer is not None, f"GPU buffer for {name} not assigned"
+
+            host_storage = self._nz_host_storages.get(name)
+            if host_storage is None:
+                cpu_storage = offloader._cpu_storage
+                assert cpu_storage is not None, f"CPU storage for {name} not initialized"
+                self._nd_copies.append((name, cpu_storage, gpu_buffer))
+                continue
+
+            buffer_numel = int(torch_npu.get_storage_size(gpu_buffer))
+            if buffer_numel != host_storage.numel():
+                raise RuntimeError(
+                    f"NZ storage size mismatch for {name}: static buffer holds "
+                    f"{buffer_numel} elements but the captured weight holds "
+                    f"{host_storage.numel()}. The static buffer layout does not "
+                    "match the weight produced by process_weights_after_loading."
+                )
+
+            src_ptrs.append(host_storage.data_ptr())
+            dst_ptrs.append(gpu_buffer.data_ptr())
+            sizes.append(host_storage.numel() * host_storage.element_size())
+            # The ND host copy is superseded by the raw NZ bytes.
+            offloader._cpu_storage = None
+
+        self._nz_src_ptrs = _as_pointer_tensor(src_ptrs)
+        self._nz_dst_ptrs = _as_pointer_tensor(dst_ptrs)
+        self._nz_sizes = _as_pointer_tensor(sizes)
+
+    def start_onload_to_static(self):
+        """Start async copy from host storage to the static NPU buffers.
+
+        Follows the same fork/record protocol as the base implementation; only
+        the copy itself differs. NZ weights are transferred by a single
+        pointer-level memcpy of their padded storage, which avoids the
+        ND -> NZ TransData that torch_npu inserts for every H2D copy_ into a
+        non-base-format tensor.
+        """
+        assert self._buffer_pool is not None, "Buffer pool not assigned"
+
+        self._prefetch_in_capture = torch.cuda.is_current_stream_capturing()
+
+        fork_event = torch.cuda.Event()
+        torch.cuda.current_stream().record_event(fork_event)
+        self.copy_stream.wait_event(fork_event)
+
+        with torch.cuda.stream(self.copy_stream):
+            if self._nz_sizes.numel():
+                _raw_memcpy_async(
+                    self._nz_src_ptrs,
+                    self._nz_dst_ptrs,
+                    self._nz_sizes,
+                    _MEMCPY_HOST_TO_DEVICE,
+                )
+            for name, cpu_storage, gpu_buffer in self._nd_copies:
+                assert not should_pin_memory() or cpu_storage.is_pinned(), (
+                    f"CPU storage for {name} is not pinned! "
+                    "non_blocking=True H2D copy from non-pinned memory "
+                    "causes stream synchronization that breaks "
+                    "event-based fork synchronization."
+                )
+                gpu_buffer.copy_(cpu_storage, non_blocking=True)
+
+        self._copy_done_event.record(self.copy_stream)
+        self._event_valid_for_eager = not torch.cuda.is_current_stream_capturing()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR eliminates the per-prefetch TransData (ND<->NZ) overhead for the Ascend prefetch offloader by preserving NZ weights as raw bytes on host and using pointer-level H2D memcpy at prefetch time.

#### Previous works

- [#10251](https://github.com/vllm-project/vllm-ascend/pull/10251) adds prefetch offloader support, but does not consider NZ format and causes precision bugs when NZ is enabled.
- [#11945](https://github.com/vllm-project/vllm-ascend/pull/11945) fixes NZ correctness by marking parameters whose weights are transformed during quantization, then casting the corresponding NPU static buffers in `post_init`.

As shown in [#11945](https://github.com/vllm-project/vllm-ascend/pull/11945), NZ degrades more than ND. The root cause is that every async H2D `copy_` into an NZ buffer triggers an extra ND→NZ TransData.

#### Why the overhead exists

Weights are converted ND->NZ in `process_weights_after_loading`. After that, when `device_loading_context` exits, parameters are moved back with `p.data.to(device="cpu")`, which goes through [copy_d2h](https://github.com/Ascend/pytorch/blob/master/torch_npu/csrc/aten/common/CopyKernel.cpp#L260).

So the host copy is ND, not the padded NZ storage.

Later, each prefetch does `gpu_buffer.copy_(cpu_storage, non_blocking=True)` into an NZ static buffer, which goes through [copy_h2d](https://github.com/Ascend/pytorch/blob/master/torch_npu/csrc/aten/common/CopyKernel.cpp#L248).

That inserts an ND->NZ TransData on every prefetch H2D, which dominates the NZ path cost.

#### Approach in this PR

Capture the NZ storage as raw bytes while the weights are still on device (inside `process_weights_after_loading`), keep that padded host buffer, and at `start_onload_to_static` perform a binary H2D async memcpy via `torch.ops._C_ascend.swap_blocks_batch`. This bypasses the format-aware PyTorch / torch-npu `copy_` path and avoids repeated TransData.

Non-NZ parameters continue to use the original `copy_(..., non_blocking=True)` path.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e
