### PR TITLE
[Perf][GDN] Unify chunk state with KV-cache layout

### DIFF
--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch20/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch20/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -64,8 +64,6 @@ public:
         hUbTensor = resource.ubBuf.template GetBufferByByte<HElementInput>(PING_BUF_0_OFFSET);
 
         hOutputUbTensor = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_1_OFFSET);
-        finalOutputUbTensor = resource.ubBuf.template GetBufferByByte<FinalStateElement>(PING_BUF_1_OFFSET);
-
         glastUbTensor = resource.ubBuf.template GetBufferByByte<float>(PING_G_BUF_OFFSET);
 
     }
@@ -103,7 +101,6 @@ public:
         AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
         AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[offsetH];
         AscendC::GlobalTensor<float> hUpdateInputThisSubBlock = hUpdateInput[offsetH];
-        AscendC::GlobalTensor<FinalStateElement> finalStateThisSubBlock = finalState[offsetH];
 
         AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
@@ -145,14 +142,25 @@ public:
         AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
 
         if (isFinalState) {
-            if constexpr(!std::is_same<FinalStateElement, float>::value) {
-                AscendC::PipeBarrier<PIPE_ALL>();
-                AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock * nActual);
-                AscendC::PipeBarrier<PIPE_ALL>();
-                AscendC::DataCopy(finalStateThisSubBlock, finalOutputUbTensor, mActualThisSubBlock * nActual);
-            } else {
-                AscendC::PipeBarrier<PIPE_ALL>();
-                AscendC::DataCopy(finalStateThisSubBlock, hUpdateUbTensor, mActualThisSubBlock * nActual);
+            AscendC::PipeBarrier<PIPE_ALL>();
+            for (uint32_t vIdx = 0; vIdx < vHeadDim; ++vIdx) {
+                for (uint32_t localK = 0; localK < mActualThisSubBlock; ++localK) {
+                    calcUbTensor.SetValue(localK, hUpdateUbTensor.GetValue(localK * vHeadDim + vIdx));
+                }
+                if constexpr(!std::is_same<FinalStateElement, float>::value) {
+                    AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+                    AscendC::Cast(hUbTensor, calcUbTensor, AscendC::RoundMode::CAST_NONE, mActualThisSubBlock);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                    AscendC::DataCopy(finalState[vIdx * kHeadDim + mOffset], hUbTensor, mActualThisSubBlock);
+                } else {
+                    AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
+                    AscendC::DataCopy(finalState[vIdx * kHeadDim + mOffset], calcUbTensor, mActualThisSubBlock);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
             }
         } else {
             AscendC::PipeBarrier<PIPE_ALL>();
@@ -169,8 +177,6 @@ private:
     AscendC::LocalTensor<float> hUpdateUbTensor;
 
     AscendC::LocalTensor<HElementOutput> hOutputUbTensor;
-    AscendC::LocalTensor<FinalStateElement> finalOutputUbTensor;
-
     AscendC::LocalTensor<float> glastUbTensor;
 
 };

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch20/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch20/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -126,7 +126,6 @@ public:
     uint32_t kHeadDim;
     uint32_t vHeadDim;
     uint32_t chunkSize;
-    uint32_t initalStateStride0;
     bool useInitialState;
     bool storeFinalState;
     uint32_t isVariedLen;
@@ -174,7 +173,6 @@ public:
         kHeadDim = gdnFwdHTilingData->kHeadDim;
         vHeadDim = gdnFwdHTilingData->vHeadDim;
         chunkSize = gdnFwdHTilingData->chunkSize;
-        initalStateStride0 = gdnFwdHTilingData->initalStateStride0;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
         isVariedLen = gdnFwdHTilingData->isVariedLen;
@@ -244,20 +242,18 @@ public:
                         AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
                         auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
                         AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
-                        if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
-                            AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
-                            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                            AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_NONE, stateBlockSize);
-                            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                            AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
-                        } else {
-                            AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
-                            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                            AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
+                        AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateOffset], stateBlockSize);
+                        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(event_id);
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(event_id);
+                        for (uint32_t kIdx = 0; kIdx < kHeadDim; ++kIdx) {
+                            for (uint32_t vIdx = 0; vIdx < vHeadDim; ++vIdx) {
+                                hUbTensor.SetValue(kIdx * vHeadDim + vIdx,
+                                    static_cast<ElementH>(stateUbTensor.GetValue(vIdx * kHeadDim + kIdx)));
+                            }
                         }
+                        AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(event_id);
+                        AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(event_id);
+                        AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
                         AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
                         pingpongFlag = 1 - pingpongFlag;
                     }
@@ -425,33 +421,29 @@ public:
                 uint32_t pingpongFlag = 1;
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-                AscendC::DataCopyParams repeatParams = {static_cast<uint16_t>(kHeadDim), static_cast<uint16_t>(vHeadDim * sizeof(ElementInitialState) / 32), 
-                    static_cast<uint16_t>((initalStateStride0 - vHeadDim)* sizeof(ElementInitialState) / 32), static_cast<uint16_t>(0)};
                 for (uint32_t shapeBatchIdx = 0; shapeBatchIdx < shapeBatch; shapeBatchIdx++) {
                     for (uint32_t vHeadIdx = 0; vHeadIdx < vNumHead; vHeadIdx++) {
                         for (uint32_t tokenBatchIdx = 0; tokenBatchIdx < vecBlockScheduler.tokenBatch; tokenBatchIdx++) {
                             uint32_t batchIdx = isVariedLen ? tokenBatchIdx : shapeBatchIdx;
                             uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
-                            uint32_t initialStateSrcOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * initalStateStride0;
+                            uint32_t initialStateSrcOffset = (batchIdx * vNumHead + vHeadIdx) * stateBlockSize;
                             uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
                             AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
                             AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
                             auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
                             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
-                            if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], repeatParams);
-                                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                                AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, stateBlockSize);
-                                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                                AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
-                            } else {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], repeatParams);
-                                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                                AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
+                            AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], stateBlockSize);
+                            AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(event_id);
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(event_id);
+                            for (uint32_t kIdx = 0; kIdx < kHeadDim; ++kIdx) {
+                                for (uint32_t vIdx = 0; vIdx < vHeadDim; ++vIdx) {
+                                    hUbTensor.SetValue(kIdx * vHeadDim + vIdx,
+                                        static_cast<ElementH>(stateUbTensor.GetValue(vIdx * kHeadDim + kIdx)));
+                                }
                             }
+                            AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(event_id);
+                            AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(event_id);
+                            AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
                             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
                             pingpongFlag = 1 - pingpongFlag;
                         }

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch22/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch22/epilogue/block/block_epilogue_gdn_fwdh_update.hpp
@@ -61,8 +61,6 @@ public:
         hUbTensor = resource.ubBuf.template GetBufferByByte<HElementInput>(PING_BUF_0_OFFSET);
 
         hOutputUbTensor = resource.ubBuf.template GetBufferByByte<HElementOutput>(PING_BUF_1_OFFSET);
-        finalOutputUbTensor = resource.ubBuf.template GetBufferByByte<FinalStateElement>(PING_BUF_1_OFFSET);
-
         glastUbTensor = resource.ubBuf.template GetBufferByByte<float>(PING_G_BUF_OFFSET);
 
     }
@@ -100,7 +98,6 @@ public:
         AscendC::GlobalTensor<GElementInput> gInputThisSubBlock = gInput;
         AscendC::GlobalTensor<HElementInput> hInputThisSubBlock = hInput[offsetH];
         AscendC::GlobalTensor<float> hUpdateInputThisSubBlock = hUpdateInput[offsetH];
-        AscendC::GlobalTensor<FinalStateElement> finalStateThisSubBlock = finalState[offsetH];
 
         AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
         AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
@@ -143,16 +140,28 @@ public:
         AscendC::Add<float>(hUpdateUbTensor, calcUbTensor, hUpdateUbTensor, mActualThisSubBlock * nActual);
 
         if (isFinalState) {
-            if constexpr(!std::is_same<FinalStateElement, float>::value) {
-                AscendC::PipeBarrier<PIPE_V>();
-                AscendC::Cast(finalOutputUbTensor, hUpdateUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock * nActual);
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::DataCopy(finalStateThisSubBlock, finalOutputUbTensor, mActualThisSubBlock * nActual);
-            } else {
-                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
-                AscendC::DataCopy(finalStateThisSubBlock, hUpdateUbTensor, mActualThisSubBlock * nActual);
+            // hUpdate is [K, V], but the persistent cache is [V, K].
+            // Map the final write directly instead of materializing a
+            // transposed state in global memory.
+            AscendC::PipeBarrier<PIPE_ALL>();
+            for (uint32_t vIdx = 0; vIdx < vHeadDim; ++vIdx) {
+                for (uint32_t localK = 0; localK < mActualThisSubBlock; ++localK) {
+                    calcUbTensor.SetValue(localK, hUpdateUbTensor.GetValue(localK * vHeadDim + vIdx));
+                }
+                if constexpr(!std::is_same<FinalStateElement, float>::value) {
+                    AscendC::SetFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::S_V>(EVENT_ID0);
+                    AscendC::Cast(hUbTensor, calcUbTensor, AscendC::RoundMode::CAST_RINT, mActualThisSubBlock);
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                    AscendC::DataCopy(finalState[vIdx * kHeadDim + mOffset], hUbTensor, mActualThisSubBlock);
+                } else {
+                    AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(EVENT_ID0);
+                    AscendC::DataCopy(finalState[vIdx * kHeadDim + mOffset], calcUbTensor, mActualThisSubBlock);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE3_S>(EVENT_ID0);
             }
         } else {
             AscendC::PipeBarrier<PIPE_V>();
@@ -170,8 +179,6 @@ private:
     AscendC::LocalTensor<float> hUpdateUbTensor;
 
     AscendC::LocalTensor<HElementOutput> hOutputUbTensor;
-    AscendC::LocalTensor<FinalStateElement> finalOutputUbTensor;
-
     AscendC::LocalTensor<float> glastUbTensor;
 
 };

--- a/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch22/gemm/kernel/gdn_fwd_h_kernel.hpp
+++ b/csrc/moe/chunk_gated_delta_rule_fwd_h/op_kernel/arch22/gemm/kernel/gdn_fwd_h_kernel.hpp
@@ -154,7 +154,6 @@ public:
     uint32_t kHeadDim;
     uint32_t vHeadDim;
     uint32_t chunkSize;
-    uint32_t initalStateStride0;
     bool useInitialState;
     bool storeFinalState;
     uint32_t isVariedLen;
@@ -202,7 +201,6 @@ public:
         kHeadDim = gdnFwdHTilingData->kHeadDim;
         vHeadDim = gdnFwdHTilingData->vHeadDim;
         chunkSize = gdnFwdHTilingData->chunkSize;
-        initalStateStride0 = gdnFwdHTilingData->initalStateStride0;
         useInitialState = gdnFwdHTilingData->useInitialState;
         storeFinalState = gdnFwdHTilingData->storeFinalState;
         isVariedLen = gdnFwdHTilingData->isVariedLen;
@@ -322,33 +320,32 @@ public:
                 uint32_t pingpongFlag = 1;
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
                 AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
-                AscendC::DataCopyParams repeatParams = {static_cast<uint16_t>(kHeadDim), static_cast<uint16_t>(vHeadDim * sizeof(ElementInitialState) / 32), 
-                    static_cast<uint16_t>((initalStateStride0 - vHeadDim)* sizeof(ElementInitialState) / 32), static_cast<uint16_t>(0)};
                 for (uint32_t shapeBatchIdx = 0; shapeBatchIdx < shapeBatch; shapeBatchIdx++) {
                     for (uint32_t vHeadIdx = 0; vHeadIdx < vNumHead; vHeadIdx++) {
                         for (uint32_t tokenBatchIdx = 0; tokenBatchIdx < vecBlockScheduler.tokenBatch; tokenBatchIdx++) {
                             uint32_t batchIdx = isVariedLen ? tokenBatchIdx : shapeBatchIdx;
                             uint32_t chunkOffset = isVariedLen ? gmNumChunks.GetValue(tokenBatchIdx) : 0;
-                            uint32_t initialStateSrcOffset = (batchIdx * vNumHead + vHeadIdx) * kHeadDim * initalStateStride0;
+                            uint32_t initialStateSrcOffset = (batchIdx * vNumHead + vHeadIdx) * stateBlockSize;
                             uint32_t hOffset = (shapeBatchIdx * vNumHead * totalChunks + vHeadIdx * totalChunks + chunkOffset) * stateBlockSize;
                             AscendC::LocalTensor<ElementInitialState> stateUbTensor = pingpongFlag ? stateUbTensorPing : stateUbTensorPong;
                             AscendC::LocalTensor<ElementH> hUbTensor = pingpongFlag ? hUbTensorPing : hUbTensorPong;
                             auto event_id = pingpongFlag ? EVENT_ID1 : EVENT_ID0;
                             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
-                            if constexpr(!std::is_same<ElementInitialState, ElementH>::value) {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], repeatParams);
-                                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(event_id);
-                                AscendC::Cast(hUbTensor, stateUbTensor, AscendC::RoundMode::CAST_RINT, stateBlockSize);
-                                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(event_id);
-                                AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
-                            } else {
-                                AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], repeatParams);
-                                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                                AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(event_id);
-                                AscendC::DataCopy(gmH[hOffset], stateUbTensor, stateBlockSize);
+                            // The cache is contiguous [V, K], while the chunk
+                            // recurrence consumes [K, V].  Transpose in UB so
+                            // the state crosses HBM only once.
+                            AscendC::DataCopy(stateUbTensor, gmInitialState[initialStateSrcOffset], stateBlockSize);
+                            AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(event_id);
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(event_id);
+                            for (uint32_t kIdx = 0; kIdx < kHeadDim; ++kIdx) {
+                                for (uint32_t vIdx = 0; vIdx < vHeadDim; ++vIdx) {
+                                    hUbTensor.SetValue(kIdx * vHeadDim + vIdx,
+                                        static_cast<ElementH>(stateUbTensor.GetValue(vIdx * kHeadDim + kIdx)));
+                                }
                             }
+                            AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(event_id);
+                            AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(event_id);
+                            AscendC::DataCopy(gmH[hOffset], hUbTensor, stateBlockSize);
                             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(event_id);
                             pingpongFlag = 1 - pingpongFlag;
                         }

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2144,7 +2144,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_fwd_h(
     if (output_final_state_) {
         int N = cu_seqlens.has_value() ? cu_seqlens->size() - 1 : B;
         auto state_options = initial_state.has_value() ? initial_state->options() : h_out.options();
-        final_state_out = at::empty({N, HV, K, V}, state_options);
+        final_state_out = at::empty({N, HV, V, K}, state_options);
     } else {
         final_state_out = at::empty({1}, k.options());
     }

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1696,7 +1696,7 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> chunk_gated_delta_rule_fwd_h_meta
     if (output_final_state_) {
         int N = cu_seqlens.has_value() ? cu_seqlens->size() - 1 : B;
         auto state_options = initial_state.has_value() ? initial_state->options() : h_out.options();
-        final_state_out = at::empty({N, HV, K, V}, state_options);
+        final_state_out = at::empty({N, HV, V, K}, state_options);
     } else {
         final_state_out = at::empty({1}, k.options());
     }

--- a/tests/e2e/nightly/310p/single_node/ops/singlecard_ops/test_chunk_gated_delta_rule_fwd_h_aclnn.py
+++ b/tests/e2e/nightly/310p/single_node/ops/singlecard_ops/test_chunk_gated_delta_rule_fwd_h_aclnn.py
@@ -32,7 +32,7 @@ def cpu_reference(k, w, u, g, initial_state=None, chunk_size=64):
     B, Hg, T, K = k.shape
     HV, V = u.shape[1], u.shape[3]
     NT = T // chunk_size
-    h = initial_state.float().clone() if initial_state is not None else torch.zeros(B, HV, K, V)
+    h = initial_state.float().transpose(-1, -2).clone() if initial_state is not None else torch.zeros(B, HV, K, V)
     h_chunks = [h.clone()]
     v_new = torch.zeros_like(u)
 
@@ -70,6 +70,7 @@ class TestChunkGatedDeltaRuleFwdH310:
         "B,Hg,HV,T,K,V",
         [
             (1, 1, 1, 128, 128, 128),
+            (1, 1, 1, 128, 128, 64),
             (1, 2, 2, 128, 128, 128),
         ],
     )
@@ -80,7 +81,7 @@ class TestChunkGatedDeltaRuleFwdH310:
         w = torch.randn(B, Hg, T, K, dtype=DTYPE) * 0.1
         u = torch.randn(B, HV, T, V, dtype=DTYPE) * 0.1
         g = (-torch.rand(B, HV, T) * 0.1).float()
-        init = torch.randn(B, HV, K, V, dtype=DTYPE) * 0.01
+        init = torch.randn(B, HV, V, K, dtype=DTYPE) * 0.01
 
         h_ref, _ = cpu_reference(k, w, u, g, init, CHUNK_SIZE)
         h_out, _, _ = npu_chunk_gdr_fwd_h(
@@ -104,6 +105,7 @@ class TestChunkGatedDeltaRuleFwdH310:
         "B,Hg,HV,T,K,V",
         [
             (1, 1, 1, 128, 128, 128),
+            (1, 1, 1, 128, 128, 64),
             (1, 2, 2, 128, 128, 128),
         ],
     )
@@ -114,7 +116,7 @@ class TestChunkGatedDeltaRuleFwdH310:
         w = torch.randn(B, Hg, T, K, dtype=DTYPE) * 0.1
         u = torch.randn(B, HV, T, V, dtype=DTYPE) * 0.1
         g = (-torch.rand(B, HV, T) * 0.1).float()
-        init = torch.randn(B, HV, K, V, dtype=DTYPE) * 0.01
+        init = torch.randn(B, HV, V, K, dtype=DTYPE) * 0.01
 
         _, vn_ref = cpu_reference(k, w, u, g, init, CHUNK_SIZE)
         _, vn_out, _ = npu_chunk_gdr_fwd_h(
@@ -143,7 +145,7 @@ class TestChunkGatedDeltaRuleFwdH310:
         w = (torch.randn(B, Hg, T, K, dtype=DTYPE) * 0.1).npu()
         u = (torch.randn(B, HV, T, V, dtype=DTYPE) * 0.1).npu()
         g = (-torch.rand(B, HV, T).float() * 0.1).npu()
-        init = (torch.randn(B, HV, K, V, dtype=DTYPE) * 0.01).npu()
+        init = (torch.randn(B, HV, V, K, dtype=DTYPE) * 0.01).npu()
 
         h_out, vn_out, _ = npu_chunk_gdr_fwd_h(
             k,

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_gated_delta_rule.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_gated_delta_rule.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
 from tests.ut.base import PytestBase
@@ -46,6 +47,53 @@ class TestChunkGatedDeltaRule(PytestBase):
 
         assert core_attn_out_non_spec.shape == (1, 17, 8, 128)
         assert last_recurrent_state.shape == (3, 8, 128, 128)
+
+
+@pytest.mark.parametrize("initial_state_present", [False, True])
+@pytest.mark.parametrize("mixed_batch", [False, True])
+def test_qwen_chunk_gdn_real_state_shape(initial_state_present, mixed_batch):
+    """Compare output and [N, H, V, K] state for pure/mixed Qwen prefills."""
+    torch.manual_seed(7)
+    sequence_lengths = [1, 4] if mixed_batch else [5]
+    cu_seqlens = torch.tensor([0, *torch.tensor(sequence_lengths).cumsum(0).tolist()], dtype=torch.int32).npu()
+    num_sequences = len(sequence_lengths)
+    num_tokens, num_heads, key_dim, value_dim = 5, 2, 32, 64
+    shape = (1, num_tokens, num_heads)
+    q = torch.randn(*shape, key_dim, dtype=torch.bfloat16).npu()
+    k = torch.randn_like(q)
+    v = torch.randn(*shape, value_dim, dtype=torch.bfloat16).npu()
+    g = torch.randn(*shape, dtype=torch.float32).npu()
+    beta = torch.rand(*shape, dtype=torch.bfloat16).npu()
+    initial_state = (
+        torch.randn(num_sequences, num_heads, value_dim, key_dim, dtype=torch.float32).npu()
+        if initial_state_present
+        else None
+    )
+
+    actual_output, actual_state = chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+    )
+    expected_output, expected_state = chunk_gated_delta_rule_pytorch(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        initial_state=initial_state,
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+    )
+
+    assert actual_state.shape == (num_sequences, num_heads, value_dim, key_dim)
+    torch.testing.assert_close(actual_output, expected_output, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(actual_state, expected_state, rtol=2e-2, atol=2e-2)
 
 
 def test_chunk_gated_delta_rule_310_state_layout_matches_vllm():

--- a/tests/ut/ops/a2/test_gdn_chunk_meta.py
+++ b/tests/ut/ops/a2/test_gdn_chunk_meta.py
@@ -340,6 +340,48 @@ def test_chunk_gated_delta_rule_fwd_uses_prebuilt_metadata_without_runtime_tolis
     assert captured["chunk_indices"] == prebuilt_meta.chunk_indices_chunk64_host
 
 
+@pytest.mark.parametrize("initial_state_present", [False, True])
+def test_chunk_gated_delta_rule_uses_kv_cache_state_layout(
+    monkeypatch: pytest.MonkeyPatch,
+    initial_state_present: bool,
+):
+    """The AscendC boundary consumes and produces Qwen's [N, H, V, K] state."""
+    n, h, v_dim, k_dim = 2, 3, 5, 7
+    initial_state = torch.randn(n, h, v_dim, k_dim) if initial_state_present else None
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(chunk, "get_forward_context", lambda: type("Ctx", (), {"attn_metadata": None})())
+    monkeypatch.setattr(chunk, "get_pcp_group", lambda: type("Group", (), {"world_size": 1})())
+    monkeypatch.setattr(chunk, "chunk_local_cumsum", lambda *args, **kwargs: _DummyTensor("g"))
+    monkeypatch.setattr(chunk, "chunk_scaled_dot_kkt_fwd", lambda *args, **kwargs: _DummyTensor("A"))
+    monkeypatch.setattr(chunk, "solve_tril", lambda *args, **kwargs: _DummyTensor("A"))
+    monkeypatch.setattr(chunk, "recompute_w_u_fwd", lambda *args, **kwargs: (_DummyTensor("w"), _DummyTensor("u")))
+
+    final_state = torch.randn(n, h, v_dim, k_dim)
+
+    def fwd_h(*args, **kwargs):
+        captured["initial_state"] = kwargs["initial_state"]
+        return _DummyTensor("h"), _DummyTensor("v_new"), final_state
+
+    monkeypatch.setattr(torch.ops._C_ascend, "chunk_gated_delta_rule_fwd_h", fwd_h, raising=False)
+    monkeypatch.setattr(torch.ops._C_ascend, "chunk_fwd_o", lambda *args, **kwargs: _DummyTensor("o"), raising=False)
+
+    result = chunk.chunk_gated_delta_rule_fwd(
+        q=_DummyTensor("q"),
+        k=_DummyTensor("k"),
+        v=_DummyTensor("v"),
+        g=_DummyTensor("g"),
+        beta=_DummyTensor("beta"),
+        scale=1.0,
+        initial_state=initial_state,
+        output_final_state=True,
+    )
+
+    assert captured["initial_state"] is initial_state
+    assert result[3] is final_state
+    assert result[3].shape == (n, h, v_dim, k_dim)
+
+
 def test_chunk_gated_delta_rule_fwd_pcp_chaining_subtracts_initial_state(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
+++ b/vllm_ascend/_310p/ops/fla/chunk_gated_delta_rule.py
@@ -547,15 +547,13 @@ def chunk_gated_delta_rule_310(
         )
     else:
         state = initial_state
-    state_kernel = state.transpose(-1, -2).contiguous()
-
     h, v_new, final_state_kernel = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
         k_kernel,
         w_kernel,
         u_kernel,
         g=g_kernel,
         gk=None,
-        initial_state=state_kernel,
+        initial_state=state,
         output_final_state=output_final_state,
         chunk_size=CHUNK_SIZE,
         save_new_value=True,
@@ -582,5 +580,4 @@ def chunk_gated_delta_rule_310(
     out = _unpad_chunk_output(out, seq_ranges, original_tokens, input_was_tnd, cu_seqlens is not None)
     if not output_final_state:
         return out, None
-    final_state = final_state_kernel.transpose(-1, -2).contiguous()
-    return out, final_state
+    return out, final_state_kernel

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -397,7 +397,10 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 g_non_spec = g_non_spec[:, num_decode_tokens:]
                 beta_non_spec = beta_non_spec[:, num_decode_tokens:]
 
-            initial_state = ssm_state[prefill_state_indices].transpose(-1, -2).contiguous()
+            # The recurrent kernel and KV cache both use [N, H, V, K].  Keep
+            # that layout for chunk prefill as well; the AscendC kernel maps
+            # it to its internal [K, V] tiles while loading and storing.
+            initial_state = ssm_state[prefill_state_indices]
             clear_ssm_states(initial_state, prefill_has_initial_state)
             (core_attn_out_non_spec, last_recurrent_state) = chunk_gated_delta_rule(
                 q=query_non_spec,
@@ -412,7 +415,7 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
                 head_first=False,
                 use_qk_l2norm_in_kernel=True,
             )
-            ssm_state[prefill_state_indices] = last_recurrent_state.transpose(-1, -2).contiguous().to(ssm_state.dtype)
+            ssm_state[prefill_state_indices] = last_recurrent_state.to(ssm_state.dtype)
             if split_non_spec:
                 core_attn_out_non_spec = torch.cat(
                     [core_attn_out_decode, core_attn_out_non_spec],

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -130,10 +130,9 @@ def chunk_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens_kern,
         chunk_indices=chunk_indices_chunk64_host,
         use_exp2=False,
-        transpose_state_layout=False,
     )
     if keep_meta is not None:
-        # Scatter the compacted final_state back to the original [N, H, K, V]
+        # Scatter the compacted final_state back to the original [N, H, V, K]
         # layout the PCP state recursion expects; empty segments keep their
         # initial state.
         _fs_full = initial_state.clone()
@@ -167,9 +166,10 @@ def chunk_gated_delta_rule_fwd(
         updated_state = final_state.new_empty(get_pcp_group().world_size, *final_state.shape)
         updated_state[0, ...] = all_final_state[0]
         for i in range(1, get_pcp_group().world_size):
-            # correct_i = all_final_state[i] + Phi_i * (correct_{i-1} - s0)
-            updated_final_state = all_final_state[i] + torch.matmul(
-                all_final_h_update[i, ...], updated_state[i - 1, ...] - initial_state
+            # correct_i = all_final_state[i] + Φ_i · (correct_{i-1} - s0) = Φ_i · correct_{i-1} + p_i
+            state_delta = (updated_state[i - 1, ...] - initial_state).transpose(-1, -2)
+            updated_final_state = all_final_state[i] + torch.matmul(all_final_h_update[i, ...], state_delta).transpose(
+                -1, -2
             )
             updated_state[i, ...] = updated_final_state
 
@@ -210,7 +210,6 @@ def chunk_gated_delta_rule_fwd(
         cu_seqlens=cu_seqlens_host,
         chunk_indices=chunk_indices_chunk64_host,
         chunk_size=64,
-        transpose_state_layout=False,
     )
 
     o = o_ascendc.to(torch.bfloat16).transpose(1, 2).contiguous()
@@ -294,11 +293,12 @@ def chunk_gated_delta_rule(
             Scale factor for the RetNet attention scores.
             If not provided, it will default to `1 / sqrt(K)`. Default: `None`.
         initial_state (Optional[torch.Tensor]):
-            Initial state of shape `[N, H, K, V]` for `N` input sequences.
+            Initial state in the KV-cache layout `[N, H, V, K]` for `N` input sequences.
             For equal-length input sequences, `N` equals the batch size `B`.
             Default: `None`.
         output_final_state (Optional[bool]):
-            Whether to output the final state of shape `[N, H, K, V]`. Default: `False`.
+            Whether to output the final state in KV-cache layout `[N, H, V, K]`.
+            Default: `False`.
         cu_seqlens (torch.LongTensor):
             Cumulative sequence lengths of shape `[N+1]` used for variable-length training,
             consistent with the FlashAttention API.
@@ -310,7 +310,8 @@ def chunk_gated_delta_rule(
         o (torch.Tensor):
             Outputs of shape `[B, T, H, V]` if `head_first=False` else `[B, H, T, V]`.
         final_state (torch.Tensor):
-            Final state of shape `[N, H, K, V]` if `output_final_state=True` else `None`.
+            Final state in the KV-cache layout `[N, H, V, K]` if
+            `output_final_state=True` else `None`.
 
     Examples::
         >>> import torch


### PR DESCRIPTION
## What this PR does / why we need it?

Unifies Qwen GDN chunk-prefill recurrent state with the KV-cache `[N, H, V, K]` layout on the v0.23.0rc1 baseline.

- Removes the full state `transpose(...).contiguous()` operations before and after chunk prefill.
- Maps cache `[V, K]` state to the internal `[K, V]` representation during the AscendC initial load.
- Maps the internal final state directly back to `[V, K]` during the final store.
- Updates eager/meta output shapes, the 310P path, PCP chaining, and state-layout tests.

## Does this PR introduce _any_ user-facing change?

No public API change. The internal chunk GDN state contract now matches the existing KV-cache layout and avoids redundant HBM transfers.

## How was this patch tested?

- `ruff check` on the modified Python and test files.
- `python -m compileall` on the modified Python and test files.
- `git diff --check`.
- NPU kernel execution and `msprof` profiling require Ascend hardware and are left for hardware CI.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
