### PR TITLE
[BugFix][KV Pool] Preserve MTP replay boundary and drain stale layerwise save events

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -96,6 +96,36 @@ class TestKVPoolScheduler(unittest.TestCase):
         return config
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    def test_layerwise_mtp_hit_preserves_replay_boundary(self, mock_client_cls):
+        # Under layerwise + eagle (MTP), the scheduler trims the declared hit
+        # back by one lcm_block_size (trailing block is dirty draft data) but
+        # keeps store_skip_tokens = raw hit so the layerwise load still fires.
+        config = self._make_config(block_size=16)
+        config.speculative_config.use_eagle.return_value = True
+        scheduler = KVPoolScheduler(config, use_layerwise=False)
+        scheduler.use_layerwise = True
+        scheduler.use_gva_layerwise = True
+        scheduler._get_layerwise_gva_hit_tokens = MagicMock(return_value=64)
+
+        request = MagicMock()
+        request.prompt_token_ids = list(range(80))
+        request.num_tokens = 80
+        request.request_id = "r1"
+        request.block_hashes = [b"h"] * 5
+
+        need, is_async = scheduler.get_num_new_matched_tokens(request, 48)
+
+        self.assertEqual(need, 0)
+        self.assertFalse(is_async)
+        load_spec = scheduler.load_specs["r1"]
+        self.assertEqual(load_spec.kvpool_cached_tokens, 48)
+        self.assertEqual(load_spec.kvpool_store_skip_tokens, 64)
+        self.assertTrue(load_spec.can_load)
+
+        scheduler.update_state_after_alloc(request, MagicMock(), 0)
+        self.assertTrue(load_spec.can_load)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_consumer_no_load(self, mock_client_cls):
         config = self._make_config(kv_role="kv_consumer")
         scheduler = KVPoolScheduler(config, use_layerwise=False)

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -90,6 +90,32 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         result = cls.find_all_discontinuous_hit_positions(arr, [16, 32, 48, 64, 80, 96], 6, 128, 16)
         self.assertEqual(result, [48])
 
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.reset_attention_compute_start_gate")
+    def test_start_load_kv_drains_stale_save_events(self, _mock_reset_gate):
+        # A step that fires fewer than num_layers hooks (MTP with
+        # num_speculative_tokens < num draft layers) never reaches the
+        # end-of-step clear in save_kv_layer, leaving set events behind.
+        # start_load_kv must drain them so the next step's save waits are safe.
+        import threading
+
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.use_layerwise = True
+        worker.layer_save_finished_events = [threading.Event() for _ in range(3)]
+        worker.layer_save_finished_events[1].set()  # stale leftover
+        worker.layer_save_finished_events[2].set()  # stale leftover
+        worker.layerwise_retrievers = []
+        # Empty metadata -> start_load_kv returns right after the drain.
+        metadata = MagicMock()
+        metadata.requests = []
+
+        worker.start_load_kv(metadata)
+
+        self.assertFalse(any(e.is_set() for e in worker.layer_save_finished_events))
+        self.assertEqual(worker.current_layer, 0)
+        self.assertEqual(worker.next_layer_to_submit, 0)
+
+
     def test_partial_prefill_block_index_boundaries(self):
         cls = self._make_worker_class()
 

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -1612,6 +1612,33 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         worker._process_load_for_layer_batch([req], 0)
         self.assertEqual(len(worker.layer_load_tasks[0]), 0)
 
+    def test_process_load_excludes_eagle_trailing_block(self):
+        # Eagle/MTP trims kvpool_cached_tokens by one block (dirty draft
+        # trailing block) while kvpool_store_skip_tokens keeps the raw hit.
+        # The load extent must follow the trimmed kvpool_cached_tokens so the
+        # trailing block is recomputed locally instead of loaded as stale
+        # draft KV.
+        worker = self._make_worker()
+        worker.layerwise_offload = False
+        worker.independent_layers = []
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            block_ids=[0, 1, 2, 3],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=48,  # trimmed: blocks 0,1,2
+                kvpool_store_skip_tokens=64,  # raw hit: also block 3 (trailing)
+                can_load=True,
+                token_len=64,
+            ),
+        )
+        worker._process_load_for_layer_batch([req], 0)
+        self.assertEqual(len(worker.layer_load_tasks[0]), 1)
+        br = worker.layer_load_tasks[0][0].block_ranges[0]
+        self.assertEqual((br.start_block, br.end_block), (0, 3))
+
     def test_reused_layer_loads_full_cached_prefix(self):
         worker = self._make_worker()
         worker.layerwise_offload = True

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -112,6 +112,9 @@ class KVPoolScheduler:
         self.num_speculative_blocks = (
             vllm_config.speculative_config.num_speculative_tokens if vllm_config.speculative_config else 0
         )
+        speculative_config = getattr(vllm_config, "speculative_config", None)
+        use_eagle_fn = getattr(speculative_config, "use_eagle", None)
+        self.use_eagle = use_eagle_fn() is True if callable(use_eagle_fn) else False
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
@@ -575,6 +578,12 @@ class KVPoolScheduler:
             return 0, False
 
         store_skip_tokens = num_external_hit_tokens
+        if self.use_layerwise and self.use_eagle:
+            # TODO(lf): Support loading the trailing block as dirty data.
+            num_external_hit_tokens = max(
+                num_computed_tokens,
+                num_external_hit_tokens - self.lcm_block_size,
+            )
         if num_external_hit_tokens == request.num_tokens:
             num_external_hit_tokens -= 1
 
@@ -594,7 +603,7 @@ class KVPoolScheduler:
         # In layerwise mode, even when vLLM has local cached tokens, we still
         # need to load KV cache from the pool because layerwise transfer loads
         # per-layer data that may not be in HBM.
-        force_layerwise_load = self.use_layerwise and num_external_hit_tokens > 0
+        force_layerwise_load = self.use_layerwise and store_skip_tokens > 0
         if need_to_allocate <= 0 and not force_layerwise_load:
             return 0, False
 
@@ -641,8 +650,9 @@ class KVPoolScheduler:
 
         if num_external_tokens == 0:
             # No need to load anything
-            self.load_specs[request.request_id].can_load = (
-                self.use_layerwise and self.load_specs[request.request_id].kvpool_cached_tokens > 0
+            load_spec = self.load_specs[request.request_id]
+            self.load_specs[request.request_id].can_load = self.use_layerwise and (
+                load_spec.kvpool_cached_tokens > 0 or bool(load_spec.kvpool_store_skip_tokens)
             )
             logger.debug(
                 "KV pool load spec updated req=%s because num_external_tokens=0 "

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1090,11 +1090,11 @@ class KVPoolWorker:
         for request in requests:
             if request.load_spec is None or not request.load_spec.can_load:
                 continue
-            cached_tokens = (
-                request.load_spec.kvpool_store_skip_tokens
-                if request.load_spec.kvpool_store_skip_tokens is not None
-                else request.load_spec.kvpool_cached_tokens
-            )
+            # Use the (eagle-trimmed) kvpool_cached_tokens so the trailing
+            # dirty draft block is excluded from the load extent and recomputed
+            # locally; the save side still uses kvpool_store_skip_tokens to
+            # skip re-saving the full raw hit. Mirrors v0.23.0 semantics.
+            cached_tokens = request.load_spec.kvpool_cached_tokens
             group_block_hashes = get_block_hashes(
                 request.block_hashes,
                 block_size,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -870,6 +870,14 @@ class KVPoolWorker:
         if self.use_layerwise:
             self.next_layer_to_submit = 0
             reset_attention_compute_start_gate()
+            # Drain any save-finished events left set by a previous step that ran
+            # fewer than num_layers hooks (e.g. MTP with num_speculative_tokens <
+            # num draft layers), so its end-of-step clear in save_kv_layer never
+            # ran. Stale set events would make this step's save waits return early.
+            if self.layer_save_finished_events is not None:
+                for event in self.layer_save_finished_events:
+                    if event.is_set():
+                        event.clear()
         logger.debug("KV pool worker start_load_kv requests=%d", len(metadata.requests))
         if len(metadata.requests) == 0:
             return


### PR DESCRIPTION
## What this PR does / why we need it?

main already has the GVA layerwise addressing for MTP (group_layer_cache_entry_offsets, prefix-byte-sum rank_layer_offset, MTP-first physical layer index, save-side kvpool_store_skip_tokens). Three pieces from the v0.23.0 layerwise-MTP fixes were still missing on main; this ports them.

### 1. Scheduler: MTP replay boundary
- pool_scheduler: detect `use_eagle`; under layerwise+eagle trim the declared hit back by one `lcm_block_size` (the trailing block is dirty draft data) while keeping `store_skip_tokens` = raw hit.
- `force_layerwise_load = use_layerwise and store_skip_tokens > 0` (so the layerwise load still fires after the trim).
- `update_state_after_alloc`: `can_load` follows `kvpool_cached_tokens > 0 or store_skip_tokens`.

### 2. Worker: drain stale layerwise save events
- pool_worker.start_load_kv: clear `layer_save_finished_events` left set by a previous step that fired fewer than `num_layers` hooks (MTP with num_speculative_tokens < num draft layers), whose end-of-step clear in save_kv_layer never ran. Prevents stale set events making the next step's save waits return early.

### 3. Worker: exclude eagle trailing block from load extent
- pool_worker._process_load_for_layer_batch: drive the load block range from the (eagle-trimmed) `kvpool_cached_tokens` instead of `kvpool_store_skip_tokens` (raw hit). On main the load used the raw hit, so the scheduler trim did NOT actually skip the trailing dirty draft block -- it was still loaded as stale draft KV. This aligns the load extent with v0.23.0: the trailing block is excluded from the load and recomputed locally. The save side keeps using `kvpool_store_skip_tokens` to skip re-saving the full raw hit (matches v0.23.0). Non-eagle is unchanged (no trim, the two values are equal).

This is the main-side counterpart of the v0.23.0 fixes (ader47's commits for GVA addressing + MTP replay boundary); the rest already landed on main via the layerwise_cache_layout refactor.

## Does this PR introduce _any_ user-facing change?

No user-facing API changes. Internal fix for KV pool layerwise scheduler accounting, worker event hygiene, and load-extent trailing-block exclusion around MTP/eagle.

## How was this patch tested?

- Unit tests added:
  - `test_layerwise_mtp_hit_preserves_replay_boundary` (scheduler: trims hit to 48 with store_skip=64, can_load stays True).
  - `test_start_load_kv_drains_stale_save_events` (worker: stale set events cleared).
  - `test_process_load_excludes_eagle_trailing_block` (worker: load range (0,3) with cached=48/store_skip=64 over 4 blocks -- trailing block excluded).
- Manual verification (mock shims): all three behaviors verified; `py_compile` clean.
- CI verification (please run `pytest tests/ut/distributed/ascend_store/test_pool_scheduler.py tests/ut/distributed/ascend_store/test_pool_worker.py` + `bash format.sh ci`).

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/0351e9aa1fdf1a51329d1906881528dfe61fc88e