### PR TITLE
 Direct loading of C128 pages to target blocks bypassing staging

### DIFF
--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -552,7 +552,7 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         )
         return thread, store, get_staging, merge_staging
 
-    def test_hybrid_c128_async_load_uses_staging_and_merges_each_range(self):
+    def test_hybrid_c128_async_load_aggregates_pages_and_loads_directly(self):
         thread, store, get_staging, merge_staging = self._make_hybrid_c128_thread()
         load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=1024, can_load=True, token_len=1024)
         request = ReqMeta(
@@ -567,10 +567,14 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
 
         thread._handle_request(request)
 
-        self.assertEqual(store.get.call_count, 3)
-        self.assertEqual(get_staging.call_count, 2)
-        self.assertEqual([call.args[1].value_start for call in merge_staging.call_args_list], [0, 4])
-        self.assertEqual([call.args[1].value_end for call in merge_staging.call_args_list], [4, 8])
+        self.assertEqual(store.get.call_count, 2)
+        get_keys, get_addrs, get_sizes = store.get.call_args_list[1].args
+        self.assertEqual(len(get_keys), 1)
+        self.assertIn("@range:4_8", get_keys[0])
+        self.assertEqual(get_addrs, [[2000 + 9 * 1280]])
+        self.assertEqual(get_sizes, [[1280]])
+        get_staging.assert_not_called()
+        merge_staging.assert_not_called()
         self.assertIn("r1", thread.get_and_clear_finished_requests())
 
     def test_hybrid_c128_async_load_does_not_merge_failed_chunk(self):
@@ -589,7 +593,13 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
 
         thread._handle_request(request)
 
-        get_staging.assert_called_once_with(1)
+        self.assertEqual(store.get.call_count, 1)
+        get_keys, get_addrs, get_sizes = store.get.call_args.args
+        self.assertEqual(len(get_keys), 1)
+        self.assertIn("@range:0_4", get_keys[0])
+        self.assertEqual(get_addrs, [[2000 + 9 * 1280]])
+        self.assertEqual(get_sizes, [[1280]])
+        get_staging.assert_not_called()
         merge_staging.assert_not_called()
         self.assertIn("r1", thread.get_and_clear_finished_requests())
 

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -710,6 +710,11 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.token_database.mask_allows_chunk.return_value = True
         worker.token_database.is_c128_group.return_value = True
         worker.token_database.process_transfer_chunks_with_block_ids.return_value = [chunk]
+        worker.token_database.prepare_transfer_value.side_effect = lambda _chunk, _block_ids, **_kwargs: (
+            [target[1].data_ptr()],
+            [target[1].numel() * target[1].element_size()],
+            1,
+        )
         worker.m_store = MagicMock()
 
         def get(*_args):
@@ -730,18 +735,21 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         metadata.add_request(request)
         return worker, target, metadata
 
-    def test_start_load_kv_c128_merges_only_after_successful_get(self):
+    def test_start_load_kv_c128_loads_page_directly(self):
         worker, target, metadata = self._make_c128_load_worker([0])
 
         with self.assertLogs(level="INFO") as logs:
             worker.start_load_kv(metadata)
         self.assertTrue(any("kv Test load" in line for line in logs.output))
 
-        self.assertTrue(torch.equal(target[1, 0:4], torch.arange(8).view(4, 2)))
-        self.assertTrue(torch.all(target[1, 4:] == -1))
-        self.assertTrue(torch.all(target[0] == -1))
+        self.assertEqual(worker.m_store.get.call_count, 1)
+        keys, addrs, sizes = worker.m_store.get.call_args.args
+        self.assertEqual(len(keys), 1)
+        self.assertEqual(addrs, [[target[1].data_ptr()]])
+        self.assertEqual(sizes, [[target[1].numel() * target[1].element_size()]])
+        self.assertIn("hash", keys[0])
 
-    def test_start_load_kv_c128_aggregates_two_chunks_into_one_page(self):
+    def test_start_load_kv_c128_aggregates_chunks_into_one_page(self):
         worker, target, metadata = self._make_c128_load_worker([0])
         chunks = [
             TransferChunkWithBlockId(
@@ -758,28 +766,22 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
                 raw_end=1024,
                 value_start=4,
                 value_end=8,
-                target_block_index=1,
+                target_block_index=0,
                 key=PoolKey(KeyMetadata("hybrid-model", 0, 0, 0, 0), "hash1"),
                 block_id=1,
             ),
         ]
         worker.token_database.process_transfer_chunks_with_block_ids.return_value = chunks
-        staging = worker.c128_staging_tensors[1][0]
-        staging_values = iter((11, 22))
-
-        def get(*_args):
-            staging.fill_(next(staging_values))
-            return [0]
-
-        worker.m_store.get.side_effect = get
 
         worker.start_load_kv(metadata)
 
-        self.assertEqual(worker.m_store.get.call_count, 2)
-        self.assertTrue(torch.all(target[1, 0:4] == 11))
-        self.assertTrue(torch.all(target[1, 4:8] == 22))
-        self.assertTrue(torch.all(target[1, 8:] == -1))
-        self.assertTrue(torch.all(target[0] == -1))
+        self.assertEqual(worker.m_store.get.call_count, 1)
+        keys, addrs, sizes = worker.m_store.get.call_args.args
+        self.assertEqual(len(keys), 1)
+        self.assertIn("hash1", keys[0])
+        self.assertEqual(addrs, [[target[1].data_ptr()]])
+        self.assertEqual(sizes, [[target[1].numel() * target[1].element_size()]])
+        self.assertTrue(torch.all(target == -1))
 
     def test_start_load_kv_c128_does_not_merge_failed_get(self):
         for get_result in ([1], None):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -50,6 +50,28 @@ class TransferChunkWithBlockId(TransferChunk):
     block_ids: tuple[int, ...] = ()
 
 
+def aggregate_c128_page_chunks(
+    chunks: Iterable[TransferChunkWithBlockId],
+    slots_per_page: int | None = None,
+) -> list[TransferChunkWithBlockId]:
+    """Collapse C128 chunks to one representative key per physical page.
+
+    Every non-tail page must have its final authoritative range; an incomplete
+    page is retained only when it is the last page in the request.
+    """
+    pages: dict[tuple[int, int], TransferChunkWithBlockId] = {}
+    for chunk in chunks:
+        pages[(chunk.target_block_index, chunk.block_id)] = chunk
+    if slots_per_page is None or not pages:
+        return list(pages.values())
+    tail_page_index = max(chunk.target_block_index for chunk in pages.values())
+    return [
+        chunk
+        for chunk in pages.values()
+        if chunk.value_end >= slots_per_page or chunk.target_block_index == tail_page_index
+    ]
+
+
 # Parameters related to the key
 @dataclass
 class KeyMetadata:
@@ -719,9 +741,10 @@ class ChunkedTokenDatabase:
             )
 
         if self.is_c128_group(kv_cache_group_id):
-            # Mooncake stores a complete physical C128 page.  The key's
-            # authoritative slot range is applied after load by the staging
-            # merge path; ordinary groups use their complete transfer block.
+            # Mooncake stores a complete physical C128 page.  The load path
+            # uses the representative key for lookup and writes this complete
+            # page directly to the target block; ordinary groups use their
+            # complete transfer block.
             value_start = 0
             value_end = self.get_block_size(kv_cache_group_id)
             return self.prepare_value(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -15,6 +15,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend im
 # isort: off
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
+    aggregate_c128_page_chunks,
     LayerMultiBlockReqMeta,
     ReqMeta,
     TransferChunkWithBlockId,
@@ -659,8 +660,6 @@ class KVCacheStoreRecvingThread(KVTransferThread):
     def _handle_hybrid_c128_request(self, req_meta: ReqMeta) -> None:
         transfer_config = self.token_database.hybrid_cache_c128_config
         assert transfer_config.chunk_tokens is not None
-        if self._get_c128_staging_value is None or self._merge_c128_staging_chunk is None:
-            raise RuntimeError("Hybrid C128 asynchronous load requires registered staging callbacks.")
 
         token_len = req_meta.load_spec.token_len  # type: ignore[union-attr]
         req_id = req_meta.req_id
@@ -718,19 +717,37 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             results = self.m_store.get(key_list, addr_list, size_list)
             self._record_load_failures(req_meta, block_id_list, results)
 
+        c128_groups: dict[int, list[TransferChunkWithBlockId]] = defaultdict(list)
         for group_id, chunk in c128_chunks:
-            staging_addrs, staging_sizes = self._get_c128_staging_value(group_id)
-            results = self.m_store.get(
-                [chunk.key.to_string()],
-                [staging_addrs],
-                [staging_sizes],
-            )
-            if results is not None and len(results) == 1 and results[0] == 0:
-                # The callback copies only the authoritative range and waits for
-                # that NPU copy before the single staging page is reused.
-                self._merge_c128_staging_chunk(group_id, chunk)
-            else:
-                self._record_load_failures(req_meta, [chunk.block_id], results)
+            c128_groups[group_id].append(chunk)
+        for group_id, chunks in c128_groups.items():
+            page_chunks = aggregate_c128_page_chunks(chunks, transfer_config.c128_slots_per_page)
+            page_keys: list[str] = []
+            page_addrs: list[list[int]] = []
+            page_sizes: list[list[int]] = []
+            page_block_ids: list[int] = []
+            for chunk in page_chunks:
+                block_ids = list(chunk.block_ids) or [chunk.block_id]
+                addr, size, block_id = self._prepare_transfer_value(
+                    chunk,
+                    block_ids,
+                    kv_cache_group_id=group_id,
+                )
+                if not addr:
+                    continue
+                page_keys.append(chunk.key.to_string())
+                page_addrs.append(addr)
+                page_sizes.append(size)
+                page_block_ids.append(block_id)
+            if not page_keys:
+                continue
+            rotation = self.tp_rank % len(page_keys)
+            page_keys = page_keys[rotation:] + page_keys[:rotation]
+            page_addrs = page_addrs[rotation:] + page_addrs[:rotation]
+            page_sizes = page_sizes[rotation:] + page_sizes[:rotation]
+            page_block_ids = page_block_ids[rotation:] + page_block_ids[:rotation]
+            results = self.m_store.get(page_keys, page_addrs, page_sizes)
+            self._record_load_failures(req_meta, page_block_ids, results)
 
         self.set_finished_request(req_id)
         self.request_queue.task_done()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -27,6 +27,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
     ChunkedTokenDatabase,
+    aggregate_c128_page_chunks,
     KeyMetadata,
     LayerMultiBlockReqMeta,
     ReqMeta,
@@ -569,7 +570,7 @@ class KVPoolWorker:
         size_list: list[list[int]] = []
         block_id_list: list[int] = []
         c128_load_plan: dict[int, list[TransferChunkWithBlockId]] = {}
-        c128_total_chunks = 0
+        c128_page_count = 0
         load_masks = self.token_database.load_mask(request.block_hashes, token_len)
         for (
             group_id,
@@ -592,7 +593,6 @@ class KVPoolWorker:
                     continue
                 if is_c128_group:
                     c128_load_plan.setdefault(group_id, []).append(chunk)
-                    c128_total_chunks += 1
                     continue
                 addr, size, block_id = self.token_database.prepare_transfer_value(
                     chunk,
@@ -603,13 +603,17 @@ class KVPoolWorker:
                 addr_list.append(addr)
                 size_list.append(size)
                 block_id_list.append(block_id)
+        c128_page_count = sum(
+            len(aggregate_c128_page_chunks(chunks, self.hybrid_cache_c128_config.c128_slots_per_page))
+            for chunks in c128_load_plan.values()
+        )
         return (
             key_list,
             addr_list,
             size_list,
             block_id_list,
             c128_load_plan,
-            c128_total_chunks,
+            c128_page_count,
         )
 
     def _load_direct_sync_chunks(
@@ -643,24 +647,35 @@ class KVPoolWorker:
         request: ReqMeta,
         c128_load_plan: dict[int, list[TransferChunkWithBlockId]],
     ) -> None:
-        for group_id, page_chunks in c128_load_plan.items():
-            staging_addrs, staging_sizes = self._get_c128_staging_value(group_id)
+        """Load one complete physical C128 page per aggregated page key."""
+        for group_id, chunks in c128_load_plan.items():
+            page_chunks = aggregate_c128_page_chunks(chunks, self.hybrid_cache_c128_config.c128_slots_per_page)
+            key_list: list[str] = []
+            addr_list: list[list[int]] = []
+            size_list: list[list[int]] = []
+            block_id_list: list[int] = []
             for chunk in page_chunks:
-                # A C128 group currently has one reusable staging page per worker.
-                # Each get overwrites that page, so get and merge must stay
-                # sequential unless multiple staging pages are introduced.
-                ret = self.m_store.get(
-                    [chunk.key.to_string()],
-                    [staging_addrs],
-                    [staging_sizes],
+                block_ids = list(chunk.block_ids) or [chunk.block_id]
+                addr, size, block_id = self.token_database.prepare_transfer_value(
+                    chunk,
+                    block_ids,
+                    kv_cache_group_id=group_id,
                 )
-                if ret is not None and len(ret) == 1 and ret[0] == 0:
-                    # Mooncake's synchronous get returns the completed byte
-                    # count/status. The merge then synchronizes its NPU copy
-                    # before this staging page is reused.
-                    self._merge_c128_staging_chunk(group_id, chunk)
-                else:
-                    self._record_sync_load_failures(request, [chunk.block_id], ret)
+                if not addr:
+                    continue
+                key_list.append(chunk.key.to_string())
+                addr_list.append(addr)
+                size_list.append(size)
+                block_id_list.append(block_id)
+            if not key_list:
+                continue
+            rotation = self.tp_rank % len(key_list)
+            key_list = key_list[rotation:] + key_list[:rotation]
+            addr_list = addr_list[rotation:] + addr_list[:rotation]
+            size_list = size_list[rotation:] + size_list[:rotation]
+            block_id_list = block_id_list[rotation:] + block_id_list[:rotation]
+            ret = self.m_store.get(key_list, addr_list, size_list)
+            self._record_sync_load_failures(request, block_id_list, ret)
 
     def _align_kv_ptrs(self, registered_regions: dict[int, tuple[int, int]]):
         """
@@ -873,7 +888,7 @@ class KVPoolWorker:
                     size_list,
                     block_id_list,
                     c128_load_plan,
-                    c128_total_chunks,
+                    c128_page_count,
                 ) = self._collect_sync_load_chunks(request, token_len, load_group_ids)
                 if not key_list and not c128_load_plan:
                     continue
@@ -894,7 +909,7 @@ class KVPoolWorker:
                     request.req_id,
                     token_len,
                     load_group_ids,
-                    len(key_list) + c128_total_chunks,
+                    len(key_list) + c128_page_count,
                 )
 
     def wait_for_layer_load(self) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?
This PR optimizes the KV transfer load path for C128 groups by directly loading complete physical C128 pages into target blocks, bypassing the previous staging tensors and sequential merge path. It introduces `aggregate_c128_page_chunks` to collapse chunks into representative page keys, enabling direct loading via `m_store.get`
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Updated existing unit tests in `test_kv_transfer.py` and `test_pool_worker.py` to reflect the direct loading behavior and verify page aggregation.
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
