### PR TITLE
[CI][E2E] Make multi-node config paths explicit for nightly and weekly tests

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -3,7 +3,7 @@
 # a3 runners and -a3 images. Adding a new test case is just appending a
 # `- name: ...` entry under the matching section. PRs that add entries
 # here can be exercised via `/nightly <name>` without merging to main.
-# Every A3 multi-node case must set `config_base_path` to its internal_dp/config
+# Every A2/A3 multi-node case must set `config_base_path` to its internal_dp/config
 # or external_dp/config directory.
 
 a2:
@@ -30,12 +30,15 @@ a2:
     test_config:
       - name: multi-node-qwen3-235b-dp
         config_file_path: Qwen3-235B-A22B-A2.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-GLM-5.1-w8a8-A2
         config_file_path: GLM5_1-W8A8-A2-dual-nodes.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-Kimi-K2.5-W4A8-A2
         config_file_path: Kimi-K2_5-W4A8-A2-dual-nodes.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
   accuracy:
     nightly:

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -3,6 +3,8 @@
 # a3 runners and -a3 images. Adding a new test case is just appending a
 # `- name: ...` entry under the matching section. PRs that add entries
 # here can be exercised via `/nightly <name>` without merging to main.
+# Multi-node cases default to internal DP. External DP cases must set
+# `config_base_path` to their external_dp/config directory.
 
 a2:
   single_node:
@@ -81,9 +83,11 @@ a3:
         size: 4
       - name: DeepSeek-V4-Pro-w4a8-1M-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 4
       - name: DeepSeek-V4-Pro-w4a8-prefix-cache-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 4
   double_node:
     test_config:
@@ -122,12 +126,15 @@ a3:
         size: 2
       - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
         config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 2
       - name: DeepSeek-V4-flash-w8a8-PD-prefix
         config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 2
       - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
         config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 2
   single_node:
     test_config:

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -3,8 +3,8 @@
 # a3 runners and -a3 images. Adding a new test case is just appending a
 # `- name: ...` entry under the matching section. PRs that add entries
 # here can be exercised via `/nightly <name>` without merging to main.
-# Multi-node cases default to internal DP. External DP cases must set
-# `config_base_path` to their external_dp/config directory.
+# Every A3 multi-node case must set `config_base_path` to its internal_dp/config
+# or external_dp/config directory.
 
 a2:
   single_node:
@@ -80,6 +80,7 @@ a3:
     test_config:
       - name: multi-node-deepseek-v3.2-W8A8-EP
         config_file_path: DeepSeek-V3_2-W8A8-EP.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 4
       - name: DeepSeek-V4-Pro-w4a8-1M-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
@@ -93,36 +94,47 @@ a3:
     test_config:
       - name: multi-node-deepseek-r1-w8a8-longseq
         config_file_path: DeepSeek-R1-W8A8-longseq.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-qwen3-dp
         config_file_path: Qwen3-235B-A22B.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-GLM-5.1-w8a8-A3
         config_file_path: GLM5_1-W8A8-A3-dual-nodes.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-dpsk3.2-2node
         config_file_path: DeepSeek-V3_2-W8A8-A3-dual-nodes.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-qwen-disagg-pd
         config_file_path: Qwen3-235B-disagg-pd.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-qwen-vl-disagg-pd
         config_file_path: Qwen3-VL-235B-disagg-pd.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-qwenw8a8-2node-eplb
         config_file_path: Qwen3-235B-W8A8-EPLB.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-qwenw8a8-2node-longseq
         config_file_path: Qwen3-235B-W8A8-longseq.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-GLM-5.1-W8A8C8-A3_128k_90_50
         config_file_path: GLM-5.1-W8A8C8-A3_128k_90_50.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-deepseek-v3.1
         config_file_path: DeepSeek-V3.1-BF16.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: multi-node-GLM-5.2-w8a8-A3
         config_file_path: GLM5_2-W8A8-A3-dual-nodes.yaml
+        config_base_path: tests/e2e/nightly/multi_node/internal_dp/config
         size: 2
       - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
         config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -3,7 +3,7 @@
 # exercised by schedule_weekly_test_a2.yaml and schedule_weekly_test_a3.yaml.
 # Adding a new weekly test case is just appending a `- name: ...` entry
 # under the matching section.
-# Every A3 multi-node case must set `config_base_path` to its internal_dp/config
+# Every A2/A3 multi-node case must set `config_base_path` to its internal_dp/config
 # or external_dp/config directory.
 
 a2:

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -3,8 +3,8 @@
 # exercised by schedule_weekly_test_a2.yaml and schedule_weekly_test_a3.yaml.
 # Adding a new weekly test case is just appending a `- name: ...` entry
 # under the matching section.
-# Multi-node cases default to internal DP. External DP cases must set
-# `config_base_path` to their external_dp/config directory.
+# Every A3 multi-node case must set `config_base_path` to its internal_dp/config
+# or external_dp/config directory.
 
 a2:
   accuracy:
@@ -24,10 +24,6 @@ a3:
         config_file_path: GLM-5.1-W8A8C8-128k-1k-90-50-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
-      - name: DeepSeek-V4-Pro-w4a8-1M-PD
-        config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 4
       - name: DeepSeek-V4-Pro-w4a8-prefix-cache-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
@@ -40,18 +36,7 @@ a3:
     test_config:
       - name: multi-node-GLM-5.1-W8A8C8-A3_64k_128k_90_50
         config_file_path: GLM-5.1-W8A8C8-A3_64k_128k_90_50.yaml
-        size: 2
-      - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
-        config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: DeepSeek-V4-flash-w8a8-PD-prefix
-        config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
-        config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        config_base_path: tests/e2e/weekly/multi_node/internal_dp/config
         size: 2
   single_node:
     test_config:

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -3,6 +3,8 @@
 # exercised by schedule_weekly_test_a2.yaml and schedule_weekly_test_a3.yaml.
 # Adding a new weekly test case is just appending a `- name: ...` entry
 # under the matching section.
+# Multi-node cases default to internal DP. External DP cases must set
+# `config_base_path` to their external_dp/config directory.
 
 a2:
   accuracy:
@@ -20,24 +22,31 @@ a3:
     test_config:
       - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
         config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
       - name: GLM-5.1-W8A8C8-128k-1k-90-50-PD
         config_file_path: GLM-5.1-W8A8C8-128k-1k-90-50-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
       - name: DeepSeek-V4-flash-w8a8-PD-prefix
         config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
       - name: DeepSeek-V4-Pro-w4a8-1M-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
       - name: DeepSeek-V4-Pro-w4a8-prefix-cache-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
       - name: GLM-5.1-W8A8C8-64k-1k-90-50-PD
         config_file_path: GLM-5.1-W8A8C8-64k-1k-90-50-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
       - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
         config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
   double_node:
     test_config:

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -20,18 +20,10 @@ a2:
 a3:
   multi_node:
     test_config:
-      - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
-        config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
       - name: GLM-5.1-W8A8C8-128k-1k-90-50-PD
         config_file_path: GLM-5.1-W8A8C8-128k-1k-90-50-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
-      - name: DeepSeek-V4-flash-w8a8-PD-prefix
-        config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
       - name: DeepSeek-V4-Pro-w4a8-1M-PD
         config_file_path: DeepSeek-V4-Pro-w4a8-1M-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
@@ -44,16 +36,23 @@ a3:
         config_file_path: GLM-5.1-W8A8C8-64k-1k-90-50-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 4
-      - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
-        config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
   double_node:
     test_config:
       - name: multi-node-GLM-5.1-W8A8C8-A3_64k_128k_90_50
         config_file_path: GLM-5.1-W8A8C8-A3_64k_128k_90_50.yaml
         size: 2
-
+      - name: Minimax_m2.7_in128k_1k_prefix90_tpot50
+        config_file_path: Minimax_m2.7_in128k_1k_prefix90_tpot50.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
+      - name: DeepSeek-V4-flash-w8a8-PD-prefix
+        config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
+      - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
+        config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
   single_node:
     test_config:
       # pytest-driven tests

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -228,6 +228,7 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
+      config_base_path: ${{ matrix.test_config.config_base_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       should_run: >-

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -193,6 +193,8 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
+      config_base_path: >-
+        ${{ matrix.test_config.config_base_path || 'tests/e2e/nightly/multi_node/internal_dp/config' }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       request_id: ${{ inputs.request_id || '' }}
@@ -231,6 +233,8 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
+      config_base_path: >-
+        ${{ matrix.test_config.config_base_path || 'tests/e2e/nightly/multi_node/internal_dp/config' }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       request_id: ${{ inputs.request_id || '' }}

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -193,8 +193,7 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
-      config_base_path: >-
-        ${{ matrix.test_config.config_base_path || 'tests/e2e/nightly/multi_node/internal_dp/config' }}
+      config_base_path: ${{ matrix.test_config.config_base_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       request_id: ${{ inputs.request_id || '' }}
@@ -233,8 +232,7 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
-      config_base_path: >-
-        ${{ matrix.test_config.config_base_path || 'tests/e2e/nightly/multi_node/internal_dp/config' }}
+      config_base_path: ${{ matrix.test_config.config_base_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       request_id: ${{ inputs.request_id || '' }}

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -195,7 +195,8 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
-      config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+      config_base_path: >-
+        ${{ matrix.test_config.config_base_path || 'tests/e2e/weekly/multi_node/internal_dp/config' }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       testcase_timeout: 600
@@ -234,7 +235,8 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
-      config_base_path: tests/e2e/weekly/multi_node/internal_dp/config
+      config_base_path: >-
+        ${{ matrix.test_config.config_base_path || 'tests/e2e/weekly/multi_node/internal_dp/config' }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       testcase_timeout: 600

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -195,8 +195,7 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
-      config_base_path: >-
-        ${{ matrix.test_config.config_base_path || 'tests/e2e/weekly/multi_node/internal_dp/config' }}
+      config_base_path: ${{ matrix.test_config.config_base_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       testcase_timeout: 600
@@ -235,8 +234,7 @@ jobs:
       replicas: 1
       size: ${{ matrix.test_config.size }}
       config_file_path: ${{ matrix.test_config.config_file_path }}
-      config_base_path: >-
-        ${{ matrix.test_config.config_base_path || 'tests/e2e/weekly/multi_node/internal_dp/config' }}
+      config_base_path: ${{ matrix.test_config.config_base_path }}
       name: ${{ matrix.test_config.name }}
       vllm_ascend_ref: ${{ inputs.vllm_ascend_ref || needs.parse-trigger.outputs.ref }}
       testcase_timeout: 600


### PR DESCRIPTION
### What this PR does / why we need it?

This PR makes the config path explicit for A2/A3 multi-node nightly and weekly tests.

Previously:

- Nightly multi-node jobs did not pass `config_base_path`, so external DP cases could incorrectly fall back to the internal DP test runner.
- Weekly A3 selected internal or external DP through hardcoded job-level paths, making its behavior inconsistent with nightly tests.

This PR:

- Passes `matrix.test_config.config_base_path` through the Nightly A2, Nightly A3, and Weekly A3 multi-node workflows.
- Adds an explicit `config_base_path` to every current A2/A3 multi-node test case.
- Supports internal and external DP cases consistently in both the `multi_node` and `double_node` matrices.
- Removes the implicit config-path fallback so newly added multi-node cases must declare their config directory.
- Removes weekly matrix entries whose referenced YAML files are not present in the weekly config directory.

This prevents external DP cases from being routed through the internal DP test entry and makes the test configuration easier to understand and maintain.

### Does this PR introduce _any_ user-facing change?

No. This is a CI/E2E test configuration change only.

### How was this patch tested?

By running the test.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
