### PR TITLE
[Bugfix] Change AscendSFAIndexerCacheSpec to inherit MLAAttentionSpec…

### DIFF
--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -95,7 +95,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
 
 
 @dataclass(frozen=True, kw_only=True)
-class AscendSFAIndexerCacheSpec(FullAttentionSpec):
+class AscendSFAIndexerCacheSpec(MLAAttentionSpec):
     """KV cache spec for SFA indexer K/scale cache.
 
     The scheduler should treat this as a full-attention-compatible cache so it


### PR DESCRIPTION
### What this PR does / why we need it?

port #12849 to releases/v0.26.0rc.

The purpose of this PR is to prevent the misinterpretation of AscendSFAIndexerCacheSpec in to GQA based spec. Some codes might use `isinstance(xxx, MLAAttentionSpec)` to distinguish mla from gqa, and this could result in errors if we still require AscendSFAIndexerCacheSpec to inherit FullAttentionSpec.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
