### PR TITLE
[Refactor][device][3/N] Migrate device-specific branches to hardware profiles

### DIFF
--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -19,6 +19,8 @@ import torch
 
 from vllm_ascend import utils
 from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 def test_register_customop_overrides_mm_encoder_attention_for_310p():
@@ -27,7 +29,10 @@ def test_register_customop_overrides_mm_encoder_attention_for_310p():
         utils._ASCEND_CUSTOMOP_IS_REIGISTERED = False
         with (
             mock.patch("vllm.model_executor.custom_op.CustomOp.register_oot"),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType._310P),
+            ),
         ):
             utils.register_ascend_customop()
 

--- a/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
@@ -22,6 +22,8 @@ from vllm_ascend._310p.quantization.methods.w8a8_dynamic import (
     AscendW8A8DynamicFusedMoEMethod310,
     AscendW8A8DynamicLinearMethod310,
 )
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 class TestAscendW8A8FusedMoEMethod310(TestBase):
@@ -121,7 +123,7 @@ class TestAscendW8A8DynamicLinearMethod310(TestBase):
 
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch("vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P))
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_is_310p):
         mock_npu_format_cast.side_effect = lambda x, fmt: x

--- a/tests/ut/_310p/quantization/test_w8a8_static_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_static_310.py
@@ -19,6 +19,8 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend._310p.quantization.methods.w8a8_static import AscendW8A8LinearMethod310
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 class TestAscendW8A8LinearMethod310(TestBase):
@@ -122,7 +124,7 @@ class TestAscendW8A8LinearMethod310(TestBase):
 
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch("vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P))
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_is_310p):
         mock_npu_format_cast.side_effect = lambda x, fmt: x

--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -20,6 +20,7 @@ from vllm_ascend.attention.utils import (
     using_paged_attention,
 )
 from vllm_ascend.device.device_op import A5DeviceAdaptor
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
 from vllm_ascend.utils import AscendDeviceType
 
@@ -48,7 +49,10 @@ class TestAttentionGraphHelpers(TestBase):
     def test_large_head_uses_paged_attention_on_a2(self):
         vllm_config = MagicMock()
         vllm_config.speculative_config = None
-        with patch("vllm_ascend.attention.utils.get_ascend_device_type", return_value=AscendDeviceType.A2):
+        with patch(
+            "vllm_ascend.attention.utils.get_current_hardware_profile",
+            return_value=get_hardware_profile(AscendDeviceType.A2),
+        ):
             self.assertTrue(using_paged_attention(1, vllm_config, head_size=FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE))
 
 

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -21,6 +21,8 @@ from vllm_ascend.attention.mla_v1 import (
     PrefillMLAPreprocessResult,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 class TestAscendMLABackend(TestBase):
@@ -1588,7 +1590,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
         self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
 
-    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
+    @patch("vllm_ascend.attention.mla_v1.get_current_hardware_profile")
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading_with_mlapo_a5(self, mock_format_cast, mock_get_ascend_device_type):
         # test with enable_mlapo=True and device_type=A5
@@ -1612,9 +1614,8 @@ class TestAscendMLAImpl(TestBase):
         self.impl.fused_qkv_a_proj = mock_fused_qkv_a_proj
 
         # set device_type=A5
-        from vllm_ascend.attention.mla_v1 import AscendDeviceType
 
-        mock_get_ascend_device_type.return_value = AscendDeviceType.A5
+        mock_get_ascend_device_type.return_value = get_hardware_profile(AscendDeviceType.A5)
 
         self.impl._process_weights_for_fused_mlapo_a5 = MagicMock()
 
@@ -1630,7 +1631,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.W_UV.shape[1], self.impl.kv_lora_rank)
         self.assertEqual(self.impl.W_UV.shape[2], self.impl.v_head_dim)
 
-    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
+    @patch("vllm_ascend.attention.mla_v1.get_current_hardware_profile")
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading_with_mlapo_non_a5(self, mock_format_cast, mock_get_ascend_device_type):
         # test with enable_mlapo=True and device_type!=A5
@@ -1654,9 +1655,7 @@ class TestAscendMLAImpl(TestBase):
         mock_fused_qkv_a_proj.quant_method = mock_quant_method
         self.impl.fused_qkv_a_proj = mock_fused_qkv_a_proj
 
-        from vllm_ascend.attention.mla_v1 import AscendDeviceType
-
-        mock_get_ascend_device_type.return_value = AscendDeviceType.A2
+        mock_get_ascend_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
 
         self.impl._process_weights_for_fused_mlapo = MagicMock()
 

--- a/tests/ut/device/test_device_config.py
+++ b/tests/ut/device/test_device_config.py
@@ -64,6 +64,7 @@ def test_device_config_supports_legacy_soc_build_info(monkeypatch):
 def test_import_time_config_does_not_probe_runtime(monkeypatch):
     import torch_npu
 
+    monkeypatch.setattr(_build_info, "__device_type__", "A2")
     get_soc_version = MagicMock(side_effect=AssertionError("runtime probe is not import-safe"))
     monkeypatch.setattr(torch_npu.npu, "get_soc_version", get_soc_version)
 
@@ -74,6 +75,7 @@ def test_import_time_config_does_not_probe_runtime(monkeypatch):
 def test_runtime_device_match_succeeds(monkeypatch):
     import torch_npu
 
+    monkeypatch.setattr(_build_info, "__device_type__", "A2")
     monkeypatch.setattr(torch_npu.npu, "get_soc_version", lambda: 220)
 
     check_ascend_device_type()
@@ -82,6 +84,7 @@ def test_runtime_device_match_succeeds(monkeypatch):
 def test_runtime_device_mismatch_raises_runtime_error(monkeypatch):
     import torch_npu
 
+    monkeypatch.setattr(_build_info, "__device_type__", "A2")
     monkeypatch.setattr(torch_npu.npu, "get_soc_version", lambda: 250)
 
     with pytest.raises(RuntimeError, match="does not match"):

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from typing import cast
+
+import pytest
+
+from vllm_ascend.device.device_config import DeviceConfig
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    WeightLayoutPolicy,
+    get_current_hardware_profile,
+    get_hardware_profile,
+)
+
+
+@pytest.mark.parametrize(
+    ("device_type", "weight_layout_policy", "capabilities"),
+    [
+        (
+            AscendDeviceType.A2,
+            WeightLayoutPolicy.CONFIGURABLE,
+            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+        ),
+        (
+            AscendDeviceType.A3,
+            WeightLayoutPolicy.CONFIGURABLE,
+            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+        ),
+        (AscendDeviceType._310P, WeightLayoutPolicy.FORCE_NZ, frozenset()),
+        (
+            AscendDeviceType.A5,
+            WeightLayoutPolicy.CONFIGURABLE,
+            frozenset(
+                {
+                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+                }
+            ),
+        ),
+    ],
+)
+def test_hardware_profile_matrix(
+    device_type: AscendDeviceType,
+    weight_layout_policy: WeightLayoutPolicy,
+    capabilities: frozenset[HardwareCapability],
+) -> None:
+    profile = get_hardware_profile(device_type)
+
+    assert profile._device_type is device_type
+    assert profile.weight_layout_policy is weight_layout_policy
+    assert profile.capabilities == capabilities
+    for capability in HardwareCapability:
+        assert profile.supports(capability) is (capability in capabilities)
+
+
+def test_current_hardware_profile_uses_device_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    import vllm_ascend.device.hardware_profile as profile_module
+
+    monkeypatch.setattr(
+        profile_module,
+        "get_device_config",
+        lambda: DeviceConfig(_device_type=AscendDeviceType.A5),
+    )
+
+    assert get_current_hardware_profile() is get_hardware_profile(AscendDeviceType.A5)
+
+
+def test_unknown_device_type_is_rejected() -> None:
+    unknown_device_type = cast(AscendDeviceType, object())
+
+    with pytest.raises(RuntimeError, match="No hardware profile is registered"):
+        get_hardware_profile(unknown_device_type)
+
+
+def test_every_device_type_has_a_profile() -> None:
+    for device_type in AscendDeviceType:
+        assert get_hardware_profile(device_type)._device_type is device_type

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -9,51 +9,180 @@ import pytest
 from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    CPUBindingMode,
+    DeviceAdaptorFamily,
+    DeviceAddressingMode,
     HardwareCapability,
+    MoECommPolicy,
+    QuantizationBackendFamily,
     WeightLayoutPolicy,
     get_current_hardware_profile,
     get_hardware_profile,
 )
 
+_STANDARD_CAPABILITIES = frozenset(
+    {
+        HardwareCapability.ATB_EXTENSIONS,
+        HardwareCapability.ATB_WARMUP,
+        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+        HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+        HardwareCapability.GRAPH_MULS_ADD_FUSION,
+        HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+        HardwareCapability.IRQ_CPU_RESERVATION,
+        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX,
+        HardwareCapability.PAGED_ATTENTION,
+        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
+        HardwareCapability.STANDARD_MAMBA_PATCH,
+        HardwareCapability.STANDARD_WORKER_PATCHES,
+        HardwareCapability.TRITON_BATCH_MEMCPY,
+    }
+)
+
+_EXPECTED_CAPABILITIES = {
+    AscendDeviceType.A2: _STANDARD_CAPABILITIES
+    | {
+        HardwareCapability.NPU_TOP_K_TOP_P,
+        HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION,
+    },
+    AscendDeviceType.A3: _STANDARD_CAPABILITIES
+    | {
+        HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+        HardwareCapability.NPU_TOP_K_TOP_P,
+    },
+    AscendDeviceType._310P: frozenset(
+        {
+            HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
+            HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
+            HardwareCapability.FUSED_MOE_COMPATIBILITY,
+            HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+            HardwareCapability.GDN_COMPATIBILITY,
+            HardwareCapability.IRQ_CPU_RESERVATION,
+            HardwareCapability.RC_DEVICE_DISCOVERY,
+            HardwareCapability.RUNTIME_CUSTOM_OPS,
+        }
+    ),
+    AscendDeviceType.A5: frozenset(
+        {
+            HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+            HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
+            HardwareCapability.CLUSTER_CPU_TOPOLOGY,
+            HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+            HardwareCapability.DSA_O_PROJ_TP,
+            HardwareCapability.DSV4_COMPRESSED_CACHE,
+            HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+            HardwareCapability.FP8_ATTENTION,
+            HardwareCapability.GRAPH_MULS_ADD_FUSION,
+            HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+            HardwareCapability.LOCAL_KV_COMM_RESOURCE,
+            HardwareCapability.LORA_CUSTOM_OPS,
+            HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+            HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
+            HardwareCapability.NPUGRAPH_EX,
+            HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
+            HardwareCapability.STANDARD_MAMBA_PATCH,
+            HardwareCapability.STANDARD_WORKER_PATCHES,
+            HardwareCapability.TRITON_BATCH_MEMCPY,
+            HardwareCapability.UNRESTRICTED_MLAPO,
+        }
+    ),
+}
+
 
 @pytest.mark.parametrize(
-    ("device_type", "weight_layout_policy", "capabilities"),
+    (
+        "device_type",
+        "attention_backend_family",
+        "cpu_binding_mode",
+        "default_worker_cls",
+        "device_adaptor_family",
+        "device_addressing_mode",
+        "weight_layout_policy",
+        "moe_comm_policy",
+        "quantization_backend_family",
+    ),
     [
         (
             AscendDeviceType.A2,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.STANDARD,
+            DeviceAddressingMode.DIRECT,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+            MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
+            QuantizationBackendFamily.STANDARD,
         ),
         (
             AscendDeviceType.A3,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.GLOBAL_SLICE,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.STANDARD,
+            DeviceAddressingMode.DUAL_CHIP_CARD,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+            MoECommPolicy.FUSED_OR_CAPACITY,
+            QuantizationBackendFamily.STANDARD,
         ),
-        (AscendDeviceType._310P, WeightLayoutPolicy.FORCE_NZ, frozenset()),
+        (
+            AscendDeviceType._310P,
+            AttentionBackendFamily.COMPATIBILITY,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend._310p.worker_310p.NPUWorker310",
+            DeviceAdaptorFamily.COMPATIBILITY,
+            DeviceAddressingMode.DIRECT,
+            WeightLayoutPolicy.FORCE_NZ,
+            MoECommPolicy.ALLGATHER,
+            QuantizationBackendFamily.COMPATIBILITY,
+        ),
         (
             AscendDeviceType.A5,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.FP8_OPTIMIZED,
+            DeviceAddressingMode.DIRECT,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset(
-                {
-                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
-                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
-                }
-            ),
+            MoECommPolicy.CAPACITY_AND_WORLD_SIZE,
+            QuantizationBackendFamily.STANDARD,
         ),
     ],
 )
-def test_hardware_profile_matrix(
+def test_hardware_profile_implementation_matrix(
     device_type: AscendDeviceType,
+    attention_backend_family: AttentionBackendFamily,
+    cpu_binding_mode: CPUBindingMode,
+    default_worker_cls: str,
+    device_adaptor_family: DeviceAdaptorFamily,
+    device_addressing_mode: DeviceAddressingMode,
     weight_layout_policy: WeightLayoutPolicy,
-    capabilities: frozenset[HardwareCapability],
+    moe_comm_policy: MoECommPolicy,
+    quantization_backend_family: QuantizationBackendFamily,
 ) -> None:
     profile = get_hardware_profile(device_type)
 
     assert profile._device_type is device_type
+    assert profile.attention_backend_family is attention_backend_family
+    assert profile.cpu_binding_mode is cpu_binding_mode
+    assert profile.default_worker_cls == default_worker_cls
+    assert profile.device_adaptor_family is device_adaptor_family
+    assert profile.device_addressing_mode is device_addressing_mode
     assert profile.weight_layout_policy is weight_layout_policy
-    assert profile.capabilities == capabilities
+    assert profile.moe_comm_policy is moe_comm_policy
+    assert profile.quantization_backend_family is quantization_backend_family
+
+
+@pytest.mark.parametrize("device_type", list(AscendDeviceType))
+def test_hardware_profile_capability_matrix(device_type: AscendDeviceType) -> None:
+    profile = get_hardware_profile(device_type)
+    expected_capabilities = _EXPECTED_CAPABILITIES[device_type]
+
+    assert profile.capabilities == expected_capabilities
     for capability in HardwareCapability:
-        assert profile.supports(capability) is (capability in capabilities)
+        assert profile.supports(capability) is (capability in expected_capabilities)
 
 
 def test_current_hardware_profile_uses_device_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import vllm_ascend.cpu_binding as cpu_binding_module
 from vllm_ascend.cpu_binding import CpuAlloc, DeviceInfo, bind_cpus, is_arm_cpu
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import AscendDeviceType
 
 
@@ -293,7 +294,10 @@ class TestCpuAlloc(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+        device_type_patcher = patch(
+            "vllm_ascend.cpu_binding.get_current_hardware_profile",
+            return_value=get_hardware_profile(AscendDeviceType.A2),
+        )
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 
@@ -326,18 +330,18 @@ class TestCpuAlloc(unittest.TestCase):
             },
         )
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     def test_binding_mode_table(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A2
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
         self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
-        mock_get_device_type.return_value = AscendDeviceType.A3
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A3)
         self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
-        mock_get_device_type.return_value = AscendDeviceType.A5
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A5)
         self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     def test_build_cpu_pools_fallback_to_global_slice(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A2
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
         self.cpu_alloc.device_info.npu_affinity = {}
         with (
             patch.object(self.cpu_alloc, "build_cpu_node_map") as mock_build_cpu_node_map,
@@ -347,9 +351,9 @@ class TestCpuAlloc(unittest.TestCase):
         mock_build_cpu_node_map.assert_called_once()
         mock_build_global_slice_cpu_pool.assert_called_once()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     def test_build_cpu_pools_global_slice_mode(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A3
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A3)
         with (
             patch.object(self.cpu_alloc, "build_cpu_node_map") as mock_build_cpu_node_map,
             patch.object(self.cpu_alloc, "build_global_slice_cpu_pool") as mock_build_global_slice_cpu_pool,
@@ -443,7 +447,9 @@ class TestCpuAlloc(unittest.TestCase):
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[0], [0, 1, 2, 3, 4, 5])
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[1], [6, 7, 8, 9, 10, 11])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_global_slice_cpu_pool_raises_when_cpu_insufficient(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(8))
@@ -452,7 +458,9 @@ class TestCpuAlloc(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.build_global_slice_cpu_pool()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_build_global_slice_cpu_pool_allows_ascend_950_without_irq_reservation(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(6))
@@ -482,7 +490,9 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.build_global_slice_cpu_pool()
         self.assertEqual(self.cpu_alloc.npu_cpu_pool, {})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_allocate(self, _mock_execute_command, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0]
@@ -495,7 +505,9 @@ class TestCpuAlloc(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.allocate()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_allocate_ascend_950_assigns_cluster_to_main_only(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0]
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
@@ -526,7 +538,7 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.bind_threads()
         mock_execute_command.assert_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     @patch("vllm_ascend.cpu_binding.os.listdir")
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which")
@@ -538,7 +550,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_access.return_value = True
         mock_which.return_value = None
         mock_listdir.side_effect = FileNotFoundError
-        mock_get_device_type.return_value = AscendDeviceType.A3
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A3)
         mock_execute_command.return_value = ("PCIe Bus Info 0000:03:00.0", 0)
         self.cpu_alloc.rank_id = 0
         self.cpu_alloc.device_info.running_npu_list = [3]
@@ -555,7 +567,10 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+        device_type_patcher = patch(
+            "vllm_ascend.cpu_binding.get_current_hardware_profile",
+            return_value=get_hardware_profile(AscendDeviceType.A2),
+        )
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 
@@ -707,11 +722,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(cpu_alloc.cpu_node, {0: 0, 1: 1})
         self.assertEqual(cpu_alloc.numa_to_cpu_map, {0: [0], 1: [1]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value="unknown")
-    def test_binding_mode_defaults_to_topo_affinity_for_unknown_device(self, _mock_get_device_type):
-        self.assertEqual(CpuAlloc._binding_mode(), "topo_affinity")
-
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_raises_on_affinity_conflict(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
@@ -721,7 +734,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         with patch.object(cpu_alloc, "build_cpu_node_map"), self.assertRaises(RuntimeError):
             cpu_alloc.build_cpu_pools()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_builds_and_splits_duplicate_groups(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1, 2]
@@ -737,7 +752,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [0, 1], 1: [2], 2: [3]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_skips_non_running_npu_without_cpuset_overlap(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1]
@@ -753,7 +770,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_excludes_non_running_npu_from_final_pool(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1]
@@ -774,7 +793,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193, 194, 195, 196]})
         self.assertEqual(cpu_alloc.assign_main, {0: [194]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_splits_hidden_same_affinity_npus_across_processes(self, _mock_get_device_type):
         def build_single_card_process(visible_npu):
             cpu_alloc = make_cpu_alloc()
@@ -810,7 +831,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertFalse(set(npu0_process.assign_acl[0]) & set(npu2_process.assign_acl[2]))
         self.assertFalse(set(npu0_process.assign_rel[0]) & set(npu2_process.assign_rel[2]))
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_build_ascend_950_cpu_pools_assigns_hidden_global_clusters(self, _mock_get_device_type):
         def build_dp_process(visible_npus):
             cpu_alloc = make_cpu_alloc()
@@ -854,7 +877,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         dp1_cpus = set().union(*(set(cpus) for cpus in dp1_process.npu_cpu_pool.values()))
         self.assertFalse(dp0_cpus & dp1_cpus)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_build_ascend_950_cpu_pools_skips_invalid_inputs(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0]
@@ -883,7 +908,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         with patch.object(cpu_alloc, "get_ascend_950_cluster_size", return_value=16):
             self.assertFalse(cpu_alloc.build_ascend_950_cpu_pools())
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
@@ -897,7 +924,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(mock_logger_info.call_count, 2)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_uses_ascend_950_worker_log(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
@@ -917,7 +946,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
             ],
         )
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
@@ -1007,7 +1038,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         mock_bind.assert_called_once_with("1000", [1, 2, 3], True)
         mock_bind_memory.assert_called_once_with("1000", 0)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.access", return_value=False)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_returns_when_irq_path_not_writable(
@@ -1018,7 +1051,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     @patch("vllm_ascend.cpu_binding.os.access")
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_skips_on_ascend_950(self, mock_execute_command, mock_access, _mock_get_device_type):
@@ -1031,7 +1066,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         mock_access.assert_not_called()
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_returns_when_current_npu_has_no_cpu_pool(
@@ -1045,7 +1082,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
@@ -1061,7 +1100,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
@@ -1077,7 +1118,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_called_once_with(["npu-smi", "info", "-t", "board", "-i", "0"])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["456", "457"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
@@ -1092,7 +1135,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         cpu_alloc.bind_npu_irq()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
@@ -1118,7 +1163,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         handle = mock_file()
         self.assertEqual(handle.write.call_args_list, [call("00000100"), call("00000200")])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
@@ -1140,7 +1187,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertNotIn(call(["systemctl", "stop", "irqbalance"]), mock_execute_command.call_args_list)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
@@ -1161,7 +1210,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertNotIn(call(["systemctl", "is-active", "--quiet", "irqbalance"]), mock_execute_command.call_args_list)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch(
         "builtins.open",

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -30,6 +30,8 @@ from vllm_ascend.ascend_config import (
     get_ascend_config,
     init_ascend_config,
 )
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import clear_enable_sp, enable_sp
 
 
@@ -292,7 +294,10 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.ascend_config.logger.warning")
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType._310P),
+    )
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     def test_init_ascend_config_disable_npugraph_ex_on_310p(
         self, mock_fix_incompatible_config, mock_is_310p, mock_warning
@@ -308,9 +313,9 @@ class TestAscendConfig(TestBase):
         self.assertFalse(ascend_compilation_config.enable_npugraph_ex)
         self.assertFalse(ascend_compilation_config.enable_static_kernel)
         warning_messages = [call.args[0] for call in mock_warning.call_args_list]
-        self.assertIn("npugraph_ex is not supported on Ascend 310P. Disabling it.", warning_messages)
+        self.assertIn("npugraph_ex is not supported by the current hardware profile. Disabling it.", warning_messages)
         self.assertIn(
-            "static kernel requires npugraph_ex, which is not supported on Ascend 310P. Disabling it.",
+            "static kernel requires npugraph_ex, which is not supported by the current hardware profile. Disabling it.",
             warning_messages,
         )
 

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -6,6 +6,8 @@ import torch
 
 from vllm_ascend import ascend_forward_context as afc
 from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 @pytest.fixture(autouse=True)
@@ -75,7 +77,7 @@ def _patch_select_moe_comm_method_deps(
 ):
     monkeypatch.setattr(afc, "is_moe_model", lambda _: is_moe)
     monkeypatch.setattr(afc, "get_mc2_tokens_capacity", lambda: capacity)
-    monkeypatch.setattr(afc, "get_ascend_device_type", lambda: device_type)
+    monkeypatch.setattr(afc, "get_current_hardware_profile", lambda: get_hardware_profile(device_type))
     monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=ep_world_size))
     monkeypatch.setattr(
         afc,
@@ -169,7 +171,7 @@ def test_set_mc2_tokens_capacity_prefill_mc2_uses_max_num_batched_tokens(monkeyp
 def test_select_moe_comm_method_returns_none_for_non_moe(monkeypatch):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         is_moe=False,
     )
 
@@ -190,7 +192,7 @@ def test_select_moe_comm_method_uses_allgather_without_effective_expert_parallel
 ):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         ep_world_size=ep_world_size,
     )
     vllm_config = _make_vllm_config(enable_expert_parallel=enable_expert_parallel)
@@ -208,7 +210,7 @@ def test_select_moe_comm_method_uses_allgather_without_effective_expert_parallel
 def test_select_moe_comm_method_a2_uses_mc2_within_capacity(monkeypatch, num_tokens, expected):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A2,
+        device_type=AscendDeviceType.A2,
         capacity=128,
         ep_world_size=16,
     )
@@ -234,7 +236,7 @@ def test_select_moe_comm_method_a3_enable_fused_mc2_mode_1(
 ):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         capacity=128,
         ep_world_size=ep_world_size,
         enable_fused_mc2=1,
@@ -259,7 +261,7 @@ def test_select_moe_comm_method_a3_without_fused_mc2(
 ):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         capacity=128,
         enable_prefill_mc2=1,
     )
@@ -282,7 +284,7 @@ def test_select_moe_comm_method_a3_quant_w4a16(
 ):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         capacity=128,
         ep_world_size=ep_world_size,
         enable_fused_mc2=1,
@@ -308,7 +310,7 @@ def test_select_moe_comm_method_a3_quant_w4a8(
 ):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         capacity=128,
         ep_world_size=ep_world_size,
         enable_fused_mc2=1,
@@ -334,7 +336,7 @@ def test_select_moe_comm_method_a3_quant_w8a8(
 ):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         capacity=128,
         ep_world_size=ep_world_size,
         enable_fused_mc2=1,
@@ -377,7 +379,7 @@ def test_select_moe_comm_method_a3_mc2_invalid_hidden_size(
 ):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A3,
+        device_type=AscendDeviceType.A3,
         capacity=128,
         ep_world_size=ep_world_size,
         enable_fused_mc2=1,
@@ -400,7 +402,7 @@ def test_select_moe_comm_method_a3_mc2_invalid_hidden_size(
 def test_select_moe_comm_method_a5(monkeypatch, num_tokens, world_size, top_k_experts, expected):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType.A5,
+        device_type=AscendDeviceType.A5,
         capacity=128,
     )
     vllm_config = _make_vllm_config(world_size=world_size, top_k_experts=top_k_experts)
@@ -411,7 +413,7 @@ def test_select_moe_comm_method_a5(monkeypatch, num_tokens, world_size, top_k_ex
 def test_select_moe_comm_method_310p_uses_allgather(monkeypatch):
     _patch_select_moe_comm_method_deps(
         monkeypatch,
-        device_type=afc.AscendDeviceType._310P,
+        device_type=AscendDeviceType._310P,
     )
 
     assert afc.select_moe_comm_method(128, _make_vllm_config()) == MoECommType.ALLGATHER

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -9,6 +9,7 @@ from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.platform import NPUPlatform, _validate_eplb_config
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
@@ -264,7 +265,7 @@ class TestNPUPlatform(TestBase):
         self.assertIsNone(vllm_config.compilation_config.max_cudagraph_capture_size)
 
     @patch("vllm_ascend.platform.refresh_block_size")
-    @patch("vllm_ascend.platform.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.platform.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A3))
     @patch("vllm_ascend.platform.enable_sp", return_value=False)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
@@ -306,7 +307,7 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(observed_inputs, [77])
 
     @patch("vllm_ascend.platform.refresh_block_size")
-    @patch("vllm_ascend.platform.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.platform.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A3))
     @patch("vllm_ascend.platform.enable_sp", return_value=True)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
@@ -417,7 +418,10 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("os.environ", {})
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_basic_config_update(
@@ -446,7 +450,10 @@ class TestNPUPlatform(TestBase):
         mock_init_ascend.assert_called_once_with(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_no_model_config_warning(
@@ -475,7 +482,10 @@ class TestNPUPlatform(TestBase):
         self.assertTrue("Model config is missing" in cm.output[0])
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_enforce_eager_mode(
@@ -517,7 +527,10 @@ class TestNPUPlatform(TestBase):
         )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_unsupported_compilation_level(
@@ -558,7 +571,10 @@ class TestNPUPlatform(TestBase):
 
     @pytest.mark.skip("Revert me when vllm support setting cudagraph_mode on oot platform")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_unsupported_cudagraph_mode(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -585,7 +601,10 @@ class TestNPUPlatform(TestBase):
             )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_cache_config_block_size(
@@ -610,7 +629,10 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(vllm_config.cache_config.block_size, 128)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_no_kv_transfer(
@@ -642,7 +664,10 @@ class TestNPUPlatform(TestBase):
         mock_init_recompute.assert_not_called()
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_kv_both(
@@ -675,7 +700,10 @@ class TestNPUPlatform(TestBase):
         mock_init_recompute.assert_not_called()
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_warns_and_disables_kv_producer(
@@ -717,7 +745,10 @@ class TestNPUPlatform(TestBase):
         )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_accepts_kv_consumer(
@@ -755,7 +786,10 @@ class TestNPUPlatform(TestBase):
         self.assertIs(vllm_config.scheduler_config, recompute_scheduler_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_rejects_unsupported_combinations(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -806,7 +840,10 @@ class TestNPUPlatform(TestBase):
                     self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_accepts_standard_prefill_paths(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -835,7 +872,10 @@ class TestNPUPlatform(TestBase):
                 self.assertIsNone(vllm_config.scheduler_config.scheduler_cls)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_selects_async_scheduler(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -868,7 +908,10 @@ class TestNPUPlatform(TestBase):
                 )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_short_request_first_survives_p_recompute_disable(
@@ -909,7 +952,10 @@ class TestNPUPlatform(TestBase):
             platform._validate_kv_load_failure_policy(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_balance_scheduler_rejects_pd_disaggregated_kv_producer(
@@ -941,7 +987,10 @@ class TestNPUPlatform(TestBase):
             self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_balance_scheduler_rejects_pd_disaggregated_kv_consumer(
@@ -1029,7 +1078,10 @@ class TestNPUPlatform(TestBase):
         platform._validate_parallel_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_v1_worker_class_selection(
@@ -1066,7 +1118,10 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType._310P)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType._310P),
+    )
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_310p_no_custom_ops(
         self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -22,6 +22,8 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import REGISTERED_ASCEND_OPS
 
 
@@ -311,7 +313,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 0
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -323,7 +327,10 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 0
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType._310P),
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -335,7 +342,10 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType._310P),
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float32)
             result = utils.maybe_trans_nz(weight)
@@ -347,7 +357,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -359,7 +371,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 2
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -371,7 +385,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 2
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.bfloat16)
             result = utils.maybe_trans_nz(weight)
@@ -383,7 +399,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.zeros(32, 64, dtype=torch.int8)
             result = utils.maybe_trans_nz(weight)
@@ -416,14 +434,18 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer():
 
 def test_is_rc_device_returns_false_on_non_310p():
     utils._IS_RC_DEVICE = None
-    with mock.patch("vllm_ascend.utils.is_310p", return_value=False):
+    with mock.patch(
+        "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    ):
         assert utils.is_rc_device() is False
 
 
 def test_is_rc_device_detects_ep_from_lspci():
     utils._IS_RC_DEVICE = None
     with (
-        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch(
+            "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P)
+        ),
         mock.patch("subprocess.run") as mock_run,
     ):
         mock_run.return_value.stdout = "00:00.0 accelerators: Huawei Technologies Co., Ltd."
@@ -433,7 +455,9 @@ def test_is_rc_device_detects_ep_from_lspci():
 def test_is_rc_device_detects_rc_from_lspci():
     utils._IS_RC_DEVICE = None
     with (
-        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch(
+            "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P)
+        ),
         mock.patch("subprocess.run") as mock_run,
     ):
         mock_run.return_value.stdout = "00:00.0 PCI bridge: Huawei Technologies Co., Ltd."
@@ -443,7 +467,9 @@ def test_is_rc_device_detects_rc_from_lspci():
 def test_is_rc_device_defaults_to_ep_when_lspci_unavailable():
     utils._IS_RC_DEVICE = None
     with (
-        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch(
+            "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P)
+        ),
         mock.patch("subprocess.run", side_effect=FileNotFoundError),
     ):
         assert utils.is_rc_device() is False

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -16,6 +16,7 @@ from vllm.v1.kv_cache_interface import (
 
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
@@ -439,7 +440,10 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
                     self.assertEqual(indexer_cache[1].shape, (2, 16, 1, 1))
                     self.assertEqual(indexer_cache[1].dtype, torch.float16)
 
-    @patch("vllm_ascend.worker.model_runner_v1.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
     @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
     @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
     def test_a5_sparse_c8_specs_keep_main_and_indexer_layouts_separate(

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -7,6 +7,8 @@ from vllm.config import CacheConfig, ModelConfig, ParallelConfig, ProfilerConfig
 from vllm.v1.kv_cache_interface import FullAttentionSpec
 
 from tests.ut.base import TestBase
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 init_cached_hf_modules_path = "vllm.utils.import_utils.init_cached_hf_modules"
 
@@ -405,7 +407,7 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.worker.worker.MemorySnapshot")
     @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")
     @patch("vllm_ascend.worker.worker.init_device_properties_triton")
-    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
+    @patch("vllm_ascend.worker.worker.get_current_hardware_profile")
     @patch("torch.npu.set_device")
     @patch("torch.npu.empty_cache")
     @patch("torch.npu.mem_get_info")
@@ -421,11 +423,11 @@ class TestNPUWorker(TestBase):
         mock_current_platform,
     ):
         """Test _init_device method"""
-        from vllm_ascend.worker.worker import AscendDeviceType, NPUWorker
+        from vllm_ascend.worker.worker import NPUWorker
 
         # Setup mock
         mock_mem_get_info.return_value = (1000, 2000)
-        mock_get_device_type.return_value = AscendDeviceType.A2
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
 
         # Mock MemorySnapshot
         mock_snapshot = MagicMock()
@@ -1197,8 +1199,7 @@ class TestNPUWorker(TestBase):
             self.assertIn("Sleep mode can only be", str(cm.exception))
 
     @patch("vllm_ascend.worker.worker.set_random_seed")
-    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
-    @patch("vllm_ascend.worker.worker.AscendDeviceType")
+    @patch("vllm_ascend.worker.worker.get_current_hardware_profile")
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
     @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
@@ -1207,7 +1208,6 @@ class TestNPUWorker(TestBase):
         mock_warm_up_atb,
         mock_logger,
         mock_get_ascend_config,
-        mock_ascend_device_type,
         mock_get_ascend_device_type,
         mock_set_random_seed,
     ):
@@ -1217,7 +1217,7 @@ class TestNPUWorker(TestBase):
         mock_ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         mock_ascend_config.enable_cpu_binding = False
         mock_get_ascend_config.return_value = mock_ascend_config
-        mock_get_ascend_device_type.return_value = mock_ascend_device_type.A9B
+        mock_get_ascend_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
         from vllm_ascend.worker.worker import NPUWorker
 
         # Create worker mock
@@ -1258,8 +1258,7 @@ class TestNPUWorker(TestBase):
             mock_warm_up_atb.assert_called_once()
 
     @patch("vllm_ascend.worker.worker.set_random_seed")
-    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
-    @patch("vllm_ascend.worker.worker.AscendDeviceType")
+    @patch("vllm_ascend.worker.worker.get_current_hardware_profile")
     @patch("vllm_ascend.worker.worker.CUDAGraphMode")
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.logger")
@@ -1270,7 +1269,6 @@ class TestNPUWorker(TestBase):
         mock_logger,
         mock_get_ascend_config,
         mock_cudagraph_mode,
-        mock_ascend_device_type,
         mock_get_ascend_device_type,
         mock_set_random_seed,
     ):
@@ -1280,7 +1278,7 @@ class TestNPUWorker(TestBase):
         mock_ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         mock_ascend_config.enable_cpu_binding = False
         mock_get_ascend_config.return_value = mock_ascend_config
-        mock_get_ascend_device_type.return_value = mock_ascend_device_type.A9B
+        mock_get_ascend_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
         mock_cudagraph_mode.NONE = mock_cudagraph_mode.NONE
         from vllm_ascend.worker.worker import NPUWorker
 

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -18,6 +18,7 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAMetadataBuilder,
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.models import deepseek_v4
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.v2 import attn_utils
@@ -73,13 +74,13 @@ def test_mrv2_initializes_dsv4_cache_only_layer(
 
     monkeypatch.setattr(
         deepseek_v4,
-        "get_ascend_device_type",
-        lambda: device_type,
+        "get_current_hardware_profile",
+        lambda: get_hardware_profile(device_type),
     )
     monkeypatch.setattr(
         attn_utils,
-        "get_ascend_device_type",
-        lambda: device_type,
+        "get_current_hardware_profile",
+        lambda: get_hardware_profile(device_type),
     )
     monkeypatch.setattr(
         attn_utils,

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -614,14 +614,15 @@ class AscendCompilationConfig:
                 Default: True
             **kwargs: Additional optional parameters for forward compatibility and configuration extension.
         """
-        from vllm_ascend.utils import is_310p
+        from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
-        if is_310p():
+        if not get_current_hardware_profile().supports(HardwareCapability.NPUGRAPH_EX):
             if enable_npugraph_ex:
-                logger.warning("npugraph_ex is not supported on Ascend 310P. Disabling it.")
+                logger.warning("npugraph_ex is not supported by the current hardware profile. Disabling it.")
             if enable_static_kernel:
                 logger.warning(
-                    "static kernel requires npugraph_ex, which is not supported on Ascend 310P. Disabling it."
+                    "static kernel requires npugraph_ex, which is not supported by the current hardware profile. "
+                    "Disabling it."
                 )
             enable_npugraph_ex = False
             enable_static_kernel = False

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -13,10 +13,9 @@ from vllm.forward_context import BatchDescriptor, get_forward_context, set_forwa
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.hardware_profile import MoECommPolicy, get_current_hardware_profile
 from vllm_ascend.utils import (
-    AscendDeviceType,
     enable_sp,
-    get_ascend_device_type,
     has_layer_idx,
     is_drafter_moe_model,
     is_moe_model,
@@ -283,7 +282,7 @@ def get_mc2_mask():
     return _reserved_mc2_mask
 
 
-def _select_a2_moe_comm_method(
+def _select_capacity_and_expert_density_moe_comm_method(
     num_tokens: int,
     vllm_config: VllmConfig,
     mc2_tokens_capacity: int,
@@ -302,10 +301,10 @@ def _select_a2_moe_comm_method(
     return MoECommType.ALLGATHER
 
 
-def _select_a3_moe_comm_method(
+def _select_fused_or_capacity_moe_comm_method(
     num_tokens: int,
-    mc2_tokens_capacity: int,
     vllm_config: VllmConfig,
+    mc2_tokens_capacity: int,
 ) -> MoECommType:
     if get_ascend_config().enable_fused_mc2 == 1:
         # TODO: drop the EP-size guard when mega_moe supports larger EP sizes
@@ -320,7 +319,7 @@ def _select_a3_moe_comm_method(
     return MoECommType.ALLTOALL
 
 
-def _select_a5_moe_comm_method(
+def _select_capacity_and_world_size_moe_comm_method(
     num_tokens: int,
     vllm_config: VllmConfig,
     mc2_tokens_capacity: int,
@@ -339,20 +338,8 @@ def _select_a5_moe_comm_method(
 
 
 def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommType | None:
-    """Select the MoE communication method according to parallel settings,
-    device generation, and token count.
-
-    1. Non-MoE models return `None`.
-    2. Without expert parallel, fall back to all-gather.
-    3. On A2 with expert parallel, pick MC2 when tokens fit the MC2 capacity
-       and the DP size is large enough; otherwise use all-gather.
-    4. On A3 with expert parallel, prefer fused MC2 when enabled and the EP
-       group size is small enough; otherwise use MC2 within capacity or
-       all-to-all.
-    5. On 310P, always use all-gather.
-    6. On A5 with expert parallel, use MC2 when tokens fit the MC2 capacity
-       and the EP size is large enough; otherwise use all-gather when
-       EP size is smaller than num of topK experts or all-to-all.
+    """Select the MoE communication method from the active hardware policy,
+    parallel settings, and token count.
 
     Args:
         num_tokens (int): The number of tokens in the current batch.
@@ -369,7 +356,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
         return None
 
     mc2_tokens_capacity = get_mc2_tokens_capacity()
-    soc_version = get_ascend_device_type()
+    moe_comm_policy = get_current_hardware_profile().moe_comm_policy
     lora_config = getattr(vllm_config, "lora_config", None)
     if not vllm_config.parallel_config.enable_expert_parallel or get_ep_group().world_size == 1:
         moe_comm_type = MoECommType.ALLGATHER
@@ -379,24 +366,22 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
         # is a single fused C++ op. This covers both normal model
         # forward and _dummy_run during profile_run.
         moe_comm_type = MoECommType.ALLTOALL
-    elif soc_version == AscendDeviceType.A2:
-        moe_comm_type = _select_a2_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)
-    elif soc_version == AscendDeviceType.A3:
-        moe_comm_type = _select_a3_moe_comm_method(
-            num_tokens,
-            mc2_tokens_capacity,
-            vllm_config,
-        )
-    elif soc_version == AscendDeviceType.A5:
-        moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)
-    elif soc_version == AscendDeviceType._310P:
+    elif moe_comm_policy is MoECommPolicy.ALLGATHER:
         moe_comm_type = MoECommType.ALLGATHER
-
     else:
-        raise ValueError(f"Unsupported soc_version: {soc_version}")
+        selector_by_policy = {
+            MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY: _select_capacity_and_expert_density_moe_comm_method,
+            MoECommPolicy.FUSED_OR_CAPACITY: _select_fused_or_capacity_moe_comm_method,
+            MoECommPolicy.CAPACITY_AND_WORLD_SIZE: _select_capacity_and_world_size_moe_comm_method,
+        }
+        moe_comm_type = selector_by_policy[moe_comm_policy](
+            num_tokens,
+            vllm_config,
+            mc2_tokens_capacity,
+        )
     logger.debug(
-        "MoE comm method selected: soc=%s, method=%s, num_tokens=%d, mc2_capacity=%s",
-        soc_version,
+        "MoE comm method selected: policy=%s, method=%s, num_tokens=%d, mc2_capacity=%s",
+        moe_comm_policy,
         moe_comm_type,
         num_tokens,
         mc2_tokens_capacity,

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -60,8 +60,9 @@ from vllm_ascend.compilation.acl_graph import (
     update_graph_params_workspaces,
 )
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
-from vllm_ascend.utils import is_950, weak_ref_tensors
+from vllm_ascend.utils import weak_ref_tensors
 
 # default max value of sliding window size
 SWA_INT_MAX = 2147483647
@@ -1363,7 +1364,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 # ChunkedPrefill mixing prefill+decode: split into a per-phase
                 # FIA call each (A5 only).
                 if (
-                    is_950()
+                    get_current_hardware_profile().supports(HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT)
                     and attn_metadata.attn_state == AscendAttentionState.ChunkedPrefill
                     and attn_metadata.num_decodes > 0
                     and attn_metadata.num_prefills > 0

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -26,6 +26,7 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import RopeDataProxy, get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
@@ -33,9 +34,7 @@ from vllm_ascend.ops.triton.dsa_cp import build_local_metadata_triton
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.tp_weight_switch import TPWeightSwitchMixin, TPWeightSwitchState
 from vllm_ascend.utils import (
-    AscendDeviceType,
     enable_dsa_cp_with_o_proj_tp,
-    get_ascend_device_type,
     olora_tp_enable,
 )
 
@@ -230,7 +229,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         else:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
@@ -1096,7 +1095,9 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
 
-        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp()
+        self.enable_dsa_cp_with_o_proj_tp = enable_dsa_cp_with_o_proj_tp() and get_current_hardware_profile().supports(
+            HardwareCapability.DSA_O_PROJ_TP
+        )
         self._o_proj_tp_weight_switch_enabled = False
 
         self.eps = kwargs["eps"]
@@ -1341,7 +1342,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             self._switch_o_proj_to_full_weight()
         o_proj_groups = self.n_group if full_gather_wo_a_enabled else self.n_local_groups
         try:
-            if get_ascend_device_type() in {AscendDeviceType.A5}:
+            if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
                 o = o_proj_input.view(num_tokens, o_proj_groups, -1)
                 wo_a_method = getattr(self.wo_a.quant_method, "quant_method", self.wo_a.quant_method)
                 if isinstance(wo_a_method, AscendUnquantizedLinearMethod):
@@ -1732,7 +1733,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             (not isinstance(self.inderxer_wq_b.quant_method, AscendUnquantizedLinearMethod))
             and isinstance(self.inderxer_wq_b.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
             and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
+            and not get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
         ):
             q = torch_npu.npu_quant_matmul(
                 qr,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -29,6 +29,7 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.parallel_state import get_otp_group
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
@@ -36,8 +37,6 @@ from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
 from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
     get_potential_max_tokens,
     npu_stream_switch,
     olora_tp_enable,
@@ -391,7 +390,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
         self.spec_slot_mapping = None
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens,)  # type: ignore
         else:
             self.slot_mapping_shape = (vllm_config.scheduler_config.max_num_batched_tokens, 2)  # type: ignore
@@ -1572,7 +1571,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         # A5 (Ascend950) uses an FP8-quantized o_proj path (dynamic MX quant
         # + quantized batch matmul). Preserve it as-is: it predates and is
         # orthogonal to the OTP / olora_tp paths below, so it must win first.
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             o = o_proj_input
             o, swiglu_out_scale = torch_npu.npu_dynamic_mx_quant(o, dst_type=torch.float8_e4m3fn)
             o = torch_npu.npu_transpose_quant_batchmatmul(
@@ -2493,7 +2492,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         if (
             _is_w8a8_dynamic(self.inderxer_wq_b)
             and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
+            and not get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
         ):
             q = torch_npu.npu_quant_matmul(
                 qr,

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -45,6 +45,7 @@ from vllm_ascend.compilation.acl_graph import (
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 from vllm_ascend.quantization.methods.w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
@@ -52,8 +53,6 @@ from vllm_ascend.quantization.methods.w8a8_static import AscendW8A8LinearMethod
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
-    AscendDeviceType,
-    get_ascend_device_type,
     maybe_trans_nz,
     weak_ref_tensors,
 )
@@ -743,7 +742,11 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)
         if self.fa_quant_layer:
-            self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+            self.dtype = (
+                torch.float8_e4m3fn
+                if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
+                else torch.int8
+            )
         else:
             self.dtype = self.vllm_config.model_config.dtype
         # For models whose num_heads is not a power of 2 (e.g., GLM-4.7-Flash
@@ -960,7 +963,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                     "Some layers not W8A8 quantized, mlapo disabled for these layers."
                 )
         if self.enable_mlapo:
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
                 self._process_weights_for_fused_mlapo_a5(act_dtype)
             else:
                 self._process_weights_for_fused_mlapo(act_dtype)
@@ -971,7 +974,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.W_UK_T = maybe_trans_nz(self.W_UK_T)
 
     def _process_weights_for_fused_fa_quant(self):
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
             self.fak_descale_float = layer.fak_descale_float
             self.quant_kscale = layer.quant_kscale
@@ -1188,7 +1191,7 @@ class AscendMLAImpl(MLAAttentionImpl):
                 toks=toks,
             )
             kv_c_normed = kv_c_normed.squeeze()
-            if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+            if self.fa_quant_layer and get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
                 kv_c_normed = torch.mul(kv_c_normed.to(self.fak_descale_float.dtype), self.fak_descale_float).to(
                     torch.bfloat16
                 )
@@ -1309,7 +1312,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
         c_kv_scale = None
-        if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION) and self.fa_quant_layer:
             c_kv_scale = self.fak_descale_reciprocal
         k_pe, k_nope, _, _ = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
@@ -1341,7 +1344,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
         cache_mode = "PA"
         c_kv_scale = None
-        if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION) and self.fa_quant_layer:
             c_kv_scale = self.fak_descale_reciprocal
         _, _, k_pe, k_nope = torch_npu.npu_kv_rmsnorm_rope_cache(
             kv_no_split,
@@ -1389,7 +1392,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         # shape of knope/k_pe for npu graph mode should be:
         # [num_blocks, num_kv_heads, block_size, self.kv_lora_rank/self.qk_rope_head_dim]
         actual_seq_lengths = None
-        if self.fa_quant_layer and get_ascend_device_type() != AscendDeviceType.A5:
+        if self.fa_quant_layer and not get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             nz_fmt_last_dim = 16
             k_nope = k_nope.view(
                 -1, self.num_kv_heads, self.kv_lora_rank // (nz_fmt_last_dim * 2), block_size, nz_fmt_last_dim * 2
@@ -1442,7 +1445,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             attn_mask = None
             sparse_mode = 0
             actual_seq_lengths = None
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
                 input_layout = "BNSD"
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
@@ -1613,7 +1616,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         )
         decode_q_pe = self.rope_single(decode_q_pe, cos, sin)
         dequant_scale_q_nope = None
-        if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+        if self.fa_quant_layer and get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             decode_ql_nope, dequant_scale_q_nope = torch_npu.npu_dynamic_quant(
                 decode_ql_nope, dst_type=torch.float8_e4m3fn
             )

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -37,6 +37,7 @@ from vllm_ascend.attention.utils import (
     wait_for_kv_layer_from_connector,
 )
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     OFFLOAD_K_CACHE_NPU_INDEX,
     OFFLOAD_KV_CACHE_TUPLE_LEN,
@@ -57,14 +58,12 @@ from vllm_ascend.quantization.tp_weight_switch import TPWeightSwitchMixin
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
     ACL_FORMAT_FRACTAL_NZ,
-    AscendDeviceType,
     _round_up,
     dispose_layer,
     enable_dsa_cp,
     enable_dsa_cp_with_o_proj_tp,
     enable_sfa_dcp_replicated_indexer,
     enable_sp,
-    get_ascend_device_type,
     maybe_trans_nz,
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
@@ -612,7 +611,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.enable_sparse_sfa_c8 = ascend_config.enable_sparse_sfa_c8
         self.enable_sparse_li_c8 = self.has_indexer and ascend_config.is_sparse_li_c8_layer(self.indexer.k_cache.prefix)
         if self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8:
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32
             else:

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -11,11 +11,10 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.utils.torch_utils import get_dtype_size
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.device.utils import FIA_TND_LARGE_HEAD_FALLBACK_HEAD_SIZE
 from vllm_ascend.utils import (
-    AscendDeviceType,
     get_ascend_config,
-    get_ascend_device_type,
     is_pd_decode_recompute_scheduler_enabled,
 )
 
@@ -170,7 +169,7 @@ def ascend_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
 def using_paged_attention(runtime_shape: int, vllm_config: VllmConfig, head_size: int | None = None) -> bool:
     if vllm_config.speculative_config is not None:
         return False
-    if get_ascend_device_type() == AscendDeviceType.A5:
+    if not get_current_hardware_profile().supports(HardwareCapability.PAGED_ATTENTION):
         return False
     # TODO: Remove this fallback when A2/A3 FIA TND supports Gemma4's
     # 512-dim global attention heads. Decode can use PA directly; prefill is
@@ -513,7 +512,7 @@ def transdata(nd_mat, block_size: tuple = (16, 16)):
 
 def enabling_mlapo(vllm_config: VllmConfig) -> bool:
     config_val = get_ascend_config().enable_mlapo
-    if get_ascend_device_type() == AscendDeviceType.A5:
+    if get_current_hardware_profile().supports(HardwareCapability.UNRESTRICTED_MLAPO):
         return bool(config_val)
 
     is_decode_instance = (

--- a/vllm_ascend/compilation/graph_fusion_pass_manager.py
+++ b/vllm_ascend/compilation/graph_fusion_pass_manager.py
@@ -21,6 +21,8 @@ from vllm.compilation.passes.inductor_pass import get_pass_context
 from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
 from vllm.config import VllmConfig
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+
 
 class GraphFusionPassManager:
     """
@@ -47,11 +49,13 @@ class GraphFusionPassManager:
         self.passes.append(pass_)
 
     def configure(self, config: VllmConfig):
-        from vllm_ascend.utils import is_310p
+        profile = get_current_hardware_profile()
 
         # By default, we enable the graph fusion and quantization fusion pass.
         self.ascend_compilation_config: dict = config.additional_config.get("ascend_compilation_config", {})
-        if self.ascend_compilation_config.get("fuse_norm_quant", True) and not is_310p():
+        if self.ascend_compilation_config.get("fuse_norm_quant", True) and profile.supports(
+            HardwareCapability.GRAPH_NORM_QUANT_FUSION
+        ):
             from .passes.norm_quant_fusion_pass import AddRMSNormQuantFusionPass
 
             self.passes.append(AddRMSNormQuantFusionPass(config))
@@ -61,7 +65,9 @@ class GraphFusionPassManager:
 
             self.passes.append(QKNormRopeFusionPass(config))
 
-        if self.ascend_compilation_config.get("fuse_muls_add", True) and not is_310p():
+        if self.ascend_compilation_config.get("fuse_muls_add", True) and profile.supports(
+            HardwareCapability.GRAPH_MULS_ADD_FUSION
+        ):
             from .passes.muls_add_pass import MulsAddFusionPass
 
             self.passes.append(MulsAddFusionPass(config))

--- a/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
+++ b/vllm_ascend/compilation/passes/norm_quant_fusion_pass.py
@@ -23,7 +23,8 @@ from vllm.config.compilation import Range
 from vllm.logger import logger
 
 from vllm_ascend.compilation.passes.base_pattern import BasePattern
-from vllm_ascend.utils import AscendDeviceType, enable_custom_op, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.utils import enable_custom_op
 
 
 class AddRMSNormQuantPattern(BasePattern):
@@ -699,7 +700,7 @@ class AddRMSNormQuantFusionPass(VllmInductorPass):
         for eps in common_epsilons:
             AddRMSNormDynamicQuantPattern(vllm_config, eps=eps).register(self.pattern_match_passes)
             AddRMSNormDynamicQuantSPPattern(vllm_config, eps=eps).register(self.pattern_match_passes)
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if get_current_hardware_profile().supports(HardwareCapability.DYNAMIC_MX_QUANT_FUSION):
                 AddRMSNormDynamicMXQuantPattern(vllm_config, eps=eps).register(self.pattern_match_passes)
                 AddRMSNormDynamicMXQuantSPPattern(vllm_config, eps=eps).register(self.pattern_match_passes)
                 RMSNormDynamicMXQuantPattern(vllm_config, eps=eps).register(self.pattern_match_passes)

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -10,25 +10,22 @@ import psutil
 import regex as re
 from vllm.logger import logger
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import (
+    CPUBindingMode,
+    DeviceAddressingMode,
+    HardwareCapability,
+    get_current_hardware_profile,
+)
 
 MASK_BIT = 32  # Number of bits in a CPU affinity mask group
 MIN_CPUS_PER_NPU = 5  # 2(IRQ) + 1(main, at least 1 CPU) + 1(acl) + 1(release) = 5 CPUs per NPU
 MIN_CPUS_PER_NPU_WITHOUT_IRQ = 3  # 1(main, at least 1 CPU) + 1(acl) + 1(release)
-ASCEND_950_PHYSICAL_CPUS_PER_CLUSTER = 8
+PHYSICAL_CPUS_PER_CLUSTER = 8
 ALLOWED_CPUS_PATH = "/proc/self/status"
 ASCEND_RT_VISIBLE_DEVICES = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
 
-TOPO_AFFINITY_MODE = "topo_affinity"
-GLOBAL_SLICE_MODE = "global_slice"
-
-DEVICE_BINDING_MODE: dict["AscendDeviceType", str] = {
-    AscendDeviceType.A2: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A3: GLOBAL_SLICE_MODE,
-    AscendDeviceType._310P: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A5: TOPO_AFFINITY_MODE,
-}
-NO_IRQ_BINDING_DEVICE_TYPES = {AscendDeviceType.A5}
+TOPO_AFFINITY_MODE = CPUBindingMode.TOPO_AFFINITY.value
+GLOBAL_SLICE_MODE = CPUBindingMode.GLOBAL_SLICE.value
 
 
 def is_arm_cpu() -> bool:
@@ -325,7 +322,7 @@ class CpuAlloc:
                 threads_per_core,
             )
             return None
-        return ASCEND_950_PHYSICAL_CPUS_PER_CLUSTER * threads_per_core
+        return PHYSICAL_CPUS_PER_CLUSTER * threads_per_core
 
     def get_single_numa_node(self, cpu_list: list[int]) -> int | None:
         if not cpu_list:
@@ -518,16 +515,15 @@ class CpuAlloc:
 
     @staticmethod
     def _binding_mode() -> str:
-        device_type = get_ascend_device_type()
-        return DEVICE_BINDING_MODE.get(device_type, TOPO_AFFINITY_MODE)
+        return get_current_hardware_profile().cpu_binding_mode.value
 
     @staticmethod
-    def _is_ascend_950() -> bool:
-        return get_ascend_device_type() == AscendDeviceType.A5
+    def _uses_cluster_cpu_topology() -> bool:
+        return get_current_hardware_profile().supports(HardwareCapability.CLUSTER_CPU_TOPOLOGY)
 
     @staticmethod
     def _reserve_irq_cpus() -> bool:
-        return get_ascend_device_type() not in NO_IRQ_BINDING_DEVICE_TYPES
+        return get_current_hardware_profile().supports(HardwareCapability.IRQ_CPU_RESERVATION)
 
     @staticmethod
     def _min_cpus_per_npu() -> int:
@@ -542,7 +538,7 @@ class CpuAlloc:
         logger.info(
             "[cpu_bind_mode] mode=%s rank=%s visible_npus=%s", mode, self.rank_id, self.device_info.running_npu_list
         )
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self.bind_uvb_poll_window_threads()
             return self.build_ascend_950_cpu_pools()
 
@@ -593,7 +589,7 @@ class CpuAlloc:
         self.npu_cpu_pool = {npu: final[npu] for npu in self.device_info.running_npu_list}
 
     def allocate(self) -> None:
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self._allocate_ascend_950_roles()
             return
         self._allocate_default_roles()
@@ -625,7 +621,7 @@ class CpuAlloc:
     def print_plan(self) -> None:
         logger.info("The CPU allocation plan is as follows:")
         current_npu = self.device_info.running_npu_list[self.rank_id]
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self._print_ascend_950_plan(current_npu)
             return
         self._print_default_plan(current_npu)
@@ -675,7 +671,7 @@ class CpuAlloc:
         )
 
     def bind_threads(self) -> None:
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self.bind_ascend_950_threads()
             return
         self._bind_default_threads()
@@ -743,14 +739,13 @@ class CpuAlloc:
         sq_cpu, cq_cpu = cpus[0], cpus[1]  # Reserved for IRQ binding
         pci_addr = ""
 
-        device_type = get_ascend_device_type()
-        if device_type == AscendDeviceType.A3:
-            # A3: logical npu_id = card_id*2 + chip_id
+        if get_current_hardware_profile().device_addressing_mode is DeviceAddressingMode.DUAL_CHIP_CARD:
+            # Dual-chip cards address each logical NPU by card and chip id.
             card_id = npu // 2
             chip_id = npu % 2
             info, _ = execute_command(["npu-smi", "info", "-t", "board", "-i", str(card_id), "-c", str(chip_id)])
         else:
-            # A2 / others: logical npu_id is card id
+            # Direct addressing uses the logical NPU id as the card id.
             info, _ = execute_command(["npu-smi", "info", "-t", "board", "-i", str(npu)])
 
         for line in info.splitlines():

--- a/vllm_ascend/device/__init__.py
+++ b/vllm_ascend/device/__init__.py
@@ -1,3 +1,18 @@
 from vllm_ascend.device.device_config import DeviceConfig, get_device_config
+from vllm_ascend.device.hardware_profile import (
+    HardwareCapability,
+    HardwareProfile,
+    WeightLayoutPolicy,
+    get_current_hardware_profile,
+    get_hardware_profile,
+)
 
-__all__ = ["DeviceConfig", "get_device_config"]
+__all__ = [
+    "DeviceConfig",
+    "HardwareCapability",
+    "HardwareProfile",
+    "WeightLayoutPolicy",
+    "get_current_hardware_profile",
+    "get_device_config",
+    "get_hardware_profile",
+]

--- a/vllm_ascend/device/__init__.py
+++ b/vllm_ascend/device/__init__.py
@@ -1,17 +1,29 @@
 from vllm_ascend.device.device_config import DeviceConfig, get_device_config
 from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    CPUBindingMode,
+    DeviceAdaptorFamily,
+    DeviceAddressingMode,
     HardwareCapability,
     HardwareProfile,
+    MoECommPolicy,
+    QuantizationBackendFamily,
     WeightLayoutPolicy,
     get_current_hardware_profile,
     get_hardware_profile,
 )
 
 __all__ = [
+    "AttentionBackendFamily",
+    "CPUBindingMode",
+    "DeviceAdaptorFamily",
+    "DeviceAddressingMode",
     "DeviceConfig",
     "HardwareCapability",
     "HardwareProfile",
     "WeightLayoutPolicy",
+    "MoECommPolicy",
+    "QuantizationBackendFamily",
     "get_current_hardware_profile",
     "get_device_config",
     "get_hardware_profile",

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -24,12 +24,12 @@ import torch_npu
 from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.device import utils as device_utils
+from vllm_ascend.device.hardware_profile import DeviceAdaptorFamily, get_current_hardware_profile
 from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.quantization.utils import QUANT_DTYPES, SCALE_DTYPES
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
 DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
@@ -1872,12 +1872,12 @@ class Ascend310PDeviceAdaptor(BaseDeviceAdaptor):
 
 
 def get_device_adaptor() -> type["BaseDeviceAdaptor"]:
-    ascend_device_type = get_ascend_device_type()
-    if ascend_device_type == AscendDeviceType.A5:
-        return A5DeviceAdaptor
-    if ascend_device_type == AscendDeviceType._310P:
-        return Ascend310PDeviceAdaptor
-    return BaseDeviceAdaptor
+    adaptor_by_family = {
+        DeviceAdaptorFamily.STANDARD: BaseDeviceAdaptor,
+        DeviceAdaptorFamily.FP8_OPTIMIZED: A5DeviceAdaptor,
+        DeviceAdaptorFamily.COMPATIBILITY: Ascend310PDeviceAdaptor,
+    }
+    return adaptor_by_family[get_current_hardware_profile().device_adaptor_family]
 
 
 DeviceOperator: type["BaseDeviceAdaptor"] = get_device_adaptor()

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+"""Capability-oriented profiles for supported Ascend hardware families."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum, auto
+from types import MappingProxyType
+
+from vllm_ascend.device.device_config import get_device_config
+from vllm_ascend.device.hardware import AscendDeviceType
+
+
+class HardwareCapability(Enum):
+    """Independent SoC capabilities consumed by shared business logic."""
+
+    AUTO_ENABLE_CUSTOM_OPS = auto()
+    DYNAMIC_MX_QUANT_FUSION = auto()
+
+
+class WeightLayoutPolicy(Enum):
+    """Weight layout selection policies for supported hardware families."""
+
+    CONFIGURABLE = auto()
+    FORCE_NZ = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class HardwareProfile:
+    """Immutable capabilities and implementation choices for one SoC family."""
+
+    _device_type: AscendDeviceType
+    weight_layout_policy: WeightLayoutPolicy
+    capabilities: frozenset[HardwareCapability]
+
+    def supports(self, capability: HardwareCapability) -> bool:
+        """Return whether this hardware family provides ``capability``."""
+
+        return capability in self.capabilities
+
+
+_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES = frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS})
+_HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
+    {
+        AscendDeviceType.A2: HardwareProfile(
+            _device_type=AscendDeviceType.A2,
+            weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+        ),
+        AscendDeviceType.A3: HardwareProfile(
+            _device_type=AscendDeviceType.A3,
+            weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+        ),
+        AscendDeviceType._310P: HardwareProfile(
+            _device_type=AscendDeviceType._310P,
+            weight_layout_policy=WeightLayoutPolicy.FORCE_NZ,
+            capabilities=frozenset(),
+        ),
+        AscendDeviceType.A5: HardwareProfile(
+            _device_type=AscendDeviceType.A5,
+            weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            capabilities=frozenset(
+                {
+                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+                }
+            ),
+        ),
+    }
+)
+
+
+def get_hardware_profile(device_type: AscendDeviceType) -> HardwareProfile:
+    """Return the immutable profile registered for ``device_type``."""
+
+    try:
+        return _HARDWARE_PROFILES[device_type]
+    except KeyError as exc:
+        raise RuntimeError(f"No hardware profile is registered for device type: {device_type}.") from exc
+
+
+def get_current_hardware_profile() -> HardwareProfile:
+    """Return the profile selected by the current device configuration."""
+
+    return get_hardware_profile(get_device_config()._device_type)

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -16,8 +16,85 @@ from vllm_ascend.device.hardware import AscendDeviceType
 class HardwareCapability(Enum):
     """Independent SoC capabilities consumed by shared business logic."""
 
+    ATB_EXTENSIONS = auto()
+    ATB_WARMUP = auto()
+    BGMV_SGMV_META_REGISTRATION = auto()
+    CHUNKED_PREFILL_PHASE_SPLIT = auto()
+    CLUSTER_CPU_TOPOLOGY = auto()
+    COMPATIBILITY_OP_IMPLEMENTATIONS = auto()
     AUTO_ENABLE_CUSTOM_OPS = auto()
+    DISTRIBUTED_COMMUNICATION_ADAPTATION = auto()
+    DSA_O_PROJ_TP = auto()
+    DSV4_COMPRESSED_CACHE = auto()
     DYNAMIC_MX_QUANT_FUSION = auto()
+    FP8_ATTENTION = auto()
+    FUSED_MOE_COMPATIBILITY = auto()
+    FUSED_SWIGLU_TUNING_ARGS = auto()
+    GDN_COMPATIBILITY = auto()
+    GRAPH_MULS_ADD_FUSION = auto()
+    GRAPH_NORM_QUANT_FUSION = auto()
+    IRQ_CPU_RESERVATION = auto()
+    LOCAL_KV_COMM_RESOURCE = auto()
+    LORA_CUSTOM_OPS = auto()
+    MOE_DISPATCH_EXTRA_ARGS = auto()
+    MOE_DISPATCH_SHARED_EXPERT_ARGS = auto()
+    NPUGRAPH_EX = auto()
+    NPU_TOP_K_TOP_P = auto()
+    PAGED_ATTENTION = auto()
+    RC_DEVICE_DISCOVERY = auto()
+    REDUCED_CUDAGRAPH_CAPTURE_SIZES = auto()
+    SKIP_REMOTE_H2D_BUFFER_REGISTRATION = auto()
+    RUNTIME_CUSTOM_OPS = auto()
+    SFA_DCP_REPLICATED_INDEXER = auto()
+    STANDARD_MAMBA_PATCH = auto()
+    STANDARD_WORKER_PATCHES = auto()
+    TRITON_BATCH_MEMCPY = auto()
+    UNRESTRICTED_MLAPO = auto()
+
+
+class AttentionBackendFamily(Enum):
+    """Attention backend implementation families."""
+
+    STANDARD = auto()
+    COMPATIBILITY = auto()
+
+
+class CPUBindingMode(Enum):
+    """CPU binding policies selected for worker processes."""
+
+    TOPO_AFFINITY = "topo_affinity"
+    GLOBAL_SLICE = "global_slice"
+
+
+class DeviceAdaptorFamily(Enum):
+    """Device operation adaptor implementation families."""
+
+    STANDARD = auto()
+    FP8_OPTIMIZED = auto()
+    COMPATIBILITY = auto()
+
+
+class DeviceAddressingMode(Enum):
+    """PCIe device addressing policies used by CPU binding."""
+
+    DIRECT = auto()
+    DUAL_CHIP_CARD = auto()
+
+
+class MoECommPolicy(Enum):
+    """MoE communication selection policies."""
+
+    CAPACITY_AND_EXPERT_DENSITY = auto()
+    FUSED_OR_CAPACITY = auto()
+    CAPACITY_AND_WORLD_SIZE = auto()
+    ALLGATHER = auto()
+
+
+class QuantizationBackendFamily(Enum):
+    """Quantization configuration implementation families."""
+
+    STANDARD = auto()
+    COMPATIBILITY = auto()
 
 
 class WeightLayoutPolicy(Enum):
@@ -32,7 +109,14 @@ class HardwareProfile:
     """Immutable capabilities and implementation choices for one SoC family."""
 
     _device_type: AscendDeviceType
+    attention_backend_family: AttentionBackendFamily
+    cpu_binding_mode: CPUBindingMode
+    default_worker_cls: str
+    device_adaptor_family: DeviceAdaptorFamily
+    device_addressing_mode: DeviceAddressingMode
     weight_layout_policy: WeightLayoutPolicy
+    moe_comm_policy: MoECommPolicy
+    quantization_backend_family: QuantizationBackendFamily
     capabilities: frozenset[HardwareCapability]
 
     def supports(self, capability: HardwareCapability) -> bool:
@@ -41,31 +125,116 @@ class HardwareProfile:
         return capability in self.capabilities
 
 
-_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES = frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS})
+_STANDARD_CAPABILITIES = frozenset(
+    {
+        HardwareCapability.ATB_EXTENSIONS,
+        HardwareCapability.ATB_WARMUP,
+        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+        HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+        HardwareCapability.GRAPH_MULS_ADD_FUSION,
+        HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+        HardwareCapability.IRQ_CPU_RESERVATION,
+        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX,
+        HardwareCapability.PAGED_ATTENTION,
+        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
+        HardwareCapability.STANDARD_MAMBA_PATCH,
+        HardwareCapability.STANDARD_WORKER_PATCHES,
+        HardwareCapability.TRITON_BATCH_MEMCPY,
+    }
+)
+_DEFAULT_WORKER_CLS = "vllm_ascend.worker.worker.NPUWorker"
 _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
     {
         AscendDeviceType.A2: HardwareProfile(
             _device_type=AscendDeviceType.A2,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+            moe_comm_policy=MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
+            capabilities=_STANDARD_CAPABILITIES
+            | {
+                HardwareCapability.NPU_TOP_K_TOP_P,
+                HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION,
+            },
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.GLOBAL_SLICE,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_addressing_mode=DeviceAddressingMode.DUAL_CHIP_CARD,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+            moe_comm_policy=MoECommPolicy.FUSED_OR_CAPACITY,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
+            capabilities=_STANDARD_CAPABILITIES
+            | {
+                HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+                HardwareCapability.NPU_TOP_K_TOP_P,
+            },
         ),
         AscendDeviceType._310P: HardwareProfile(
             _device_type=AscendDeviceType._310P,
+            attention_backend_family=AttentionBackendFamily.COMPATIBILITY,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls="vllm_ascend._310p.worker_310p.NPUWorker310",
+            device_adaptor_family=DeviceAdaptorFamily.COMPATIBILITY,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.FORCE_NZ,
-            capabilities=frozenset(),
+            moe_comm_policy=MoECommPolicy.ALLGATHER,
+            quantization_backend_family=QuantizationBackendFamily.COMPATIBILITY,
+            capabilities=frozenset(
+                {
+                    HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
+                    HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
+                    HardwareCapability.FUSED_MOE_COMPATIBILITY,
+                    HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+                    HardwareCapability.GDN_COMPATIBILITY,
+                    HardwareCapability.IRQ_CPU_RESERVATION,
+                    HardwareCapability.RC_DEVICE_DISCOVERY,
+                    HardwareCapability.RUNTIME_CUSTOM_OPS,
+                }
+            ),
         ),
         AscendDeviceType.A5: HardwareProfile(
             _device_type=AscendDeviceType.A5,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.FP8_OPTIMIZED,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            moe_comm_policy=MoECommPolicy.CAPACITY_AND_WORLD_SIZE,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
             capabilities=frozenset(
                 {
+                    HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+                    HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
+                    HardwareCapability.CLUSTER_CPU_TOPOLOGY,
                     HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+                    HardwareCapability.DSA_O_PROJ_TP,
+                    HardwareCapability.DSV4_COMPRESSED_CACHE,
                     HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+                    HardwareCapability.FP8_ATTENTION,
+                    HardwareCapability.GRAPH_MULS_ADD_FUSION,
+                    HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+                    HardwareCapability.LOCAL_KV_COMM_RESOURCE,
+                    HardwareCapability.LORA_CUSTOM_OPS,
+                    HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+                    HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
+                    HardwareCapability.NPUGRAPH_EX,
+                    HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
+                    HardwareCapability.STANDARD_MAMBA_PATCH,
+                    HardwareCapability.STANDARD_WORKER_PATCHES,
+                    HardwareCapability.TRITON_BATCH_MEMCPY,
+                    HardwareCapability.UNRESTRICTED_MLAPO,
                 }
             ),
         ),

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -8,6 +8,7 @@ from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import split_host_port
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.backend import Backend
 
 
@@ -83,6 +84,7 @@ class YuanrongBackend(Backend):
             and self.config.remote_h2d_transport_backend == "HIXL"
             and not self.config.enable_fabric_mem
             and self.config.enable_dev_mem_pregister
+            and not get_current_hardware_profile().supports(HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION)
         )
         self._registered_buffers: tuple[list[int], list[int]] | None = None
         self._buffers_registered = False

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -5,8 +5,8 @@ from collections.abc import Callable
 import torch
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.lora.utils import refresh_all_lora_classes
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 # The platforms that are compatible with the PyTorch-native implementation can
@@ -22,7 +22,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches, device)
         refresh_all_lora_classes()
         self.lora_config = kwargs.get("lora_config")
-        if get_ascend_device_type() == AscendDeviceType._310P or (
+        if not get_current_hardware_profile().supports(HardwareCapability.LORA_CUSTOM_OPS) or (
             self.lora_config is not None and self.lora_config.max_lora_rank >= 128
         ):
             from vllm.lora.ops.torch_ops import (

--- a/vllm_ascend/meta_registration.py
+++ b/vllm_ascend/meta_registration.py
@@ -1,7 +1,7 @@
 import torch
 from torch.library import Library
 
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 # This file provides a template and registration utilities for writing "meta" implementations
 # of custom operators in Python for the vllm_ascend project.
@@ -72,6 +72,6 @@ def sgmv_expand_meta(
     return y_out
 
 
-if not is_310p():
+if get_current_hardware_profile().supports(HardwareCapability.BGMV_SGMV_META_REGISTRATION):
     register_meta_if_necessary("_C_ascend", "bgmv_expand", bgmv_expand_meta)
     register_meta_if_necessary("_C_ascend", "sgmv_expand", sgmv_expand_meta)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -80,14 +80,13 @@ from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
 from vllm_ascend.utils import (
-    AscendDeviceType,
     enable_dsa_cp,
     extract_dsv4_layer_index,
-    get_ascend_device_type,
     get_dsv4_compress_ratio,
 )
 
@@ -152,7 +151,7 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             self.dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
@@ -168,7 +167,9 @@ class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
             compress_ratio=self.compress_ratio,
             cache_dtype_str=self.cache_config.cache_dtype,
             scale_dim=1 if self.head_dim == 128 else 0,
-            scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
+            scale_dtype=torch.float
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else torch.float16,
         )
 
     def forward(self): ...
@@ -192,10 +193,14 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
         self.block_size = _dsv4_block_sizes()[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             self.dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
-        cached_head_size = self.head_dim + 128 if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_dim
+        cached_head_size = (
+            self.head_dim + 128
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else self.head_dim
+        )
         return AscendSlidingWindowMLASpec(
             block_size=self.block_size,
             num_kv_heads=1,
@@ -578,8 +583,11 @@ class Indexer(nn.Module):
             prefix=f"{prefix}.weights_proj",
             return_bias=False,
         )
-        ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.int8
+        k_dtype = (
+            torch.float8_e4m3fn
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else torch.int8
+        )
 
         if self.compress_ratio == 4:
             # TODO(cmq): change the dtype of cache
@@ -637,7 +645,9 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=None
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else quant_config,
             prefix=f"{prefix}.wkv",
             return_bias=False,
         )
@@ -645,13 +655,17 @@ class Compressor(nn.Module):
             self.dim,
             self.coff * self.head_dim,
             bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            quant_config=None
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else quant_config,
             prefix=f"{prefix}.wgate",
             return_bias=False,
         )
 
-        # A5 compressor kernel needs float for norm_weight input
-        norm_dtype = torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else None
+        # current compressor kernel needs float for norm_weight input
+        norm_dtype = (
+            torch.float32 if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE) else None
+        )
         self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
 
         state_dtype = torch.float32
@@ -864,8 +878,11 @@ class DeepseekV4Attention(nn.Module):
                 if 0 <= indexer_seq_idx < len(pattern):
                     skip_topk = pattern[indexer_seq_idx] == "S"
 
-        ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.bfloat16
+        k_dtype = (
+            torch.float8_e4m3fn
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else torch.bfloat16
+        )
         swa_cache_layer = AscendDeepseekV4SWACache(
             head_dim=self.head_dim,
             window_size=self.window_size,

--- a/vllm_ascend/models/layer/attention/layer.py
+++ b/vllm_ascend/models/layer/attention/layer.py
@@ -22,10 +22,7 @@ from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-)
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 
 def get_dsv4_block_sizes():
@@ -35,13 +32,13 @@ def get_dsv4_block_sizes():
         64: [[64, 64, 4, 16], [8320, 65536]],
         32: [[32, 32, 2, 8], [4160, 32768]],
     }
-    _DSV4_BLOCK_SIZES_A5 = {
+    _DSV4_COMPRESSED_BLOCK_SIZES = {
         128: [[128, 128, 8, 16], [16896, 81920]],
         64: [[64, 64, 4, 8], [8448, 40960]],
         32: [[32, 32, 2, 4], [4224, 20480]],
     }
-    if get_ascend_device_type() in {AscendDeviceType.A5}:
-        return _DSV4_BLOCK_SIZES_A5
+    if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
+        return _DSV4_COMPRESSED_BLOCK_SIZES
     else:
         return _DSV4_BLOCK_SIZES
 
@@ -175,12 +172,14 @@ class DSAAttention(nn.Module, AttentionLayerBase):
         if self.compress_ratio <= 1:  # SWA part. Allocated separately as DeepseekV4SWACache.
             return None
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(self.kv_cache_dtype, vllm_config.model_config)
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             kv_cache_dtype = torch.float8_e4m3fn
             vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
 
         cached_head_size = (
-            (self.head_size + 128) if get_ascend_device_type() in {AscendDeviceType.A5} else self.head_size
+            (self.head_size + 128)
+            if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE)
+            else self.head_size
         )
         block_size = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0]
         return AscendMLAAttentionSpec(

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -31,11 +31,8 @@ from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backend import AttentionMetadata
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.models.layer.attention.layer import DSAAttention
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-)
 
 
 @dataclass
@@ -244,12 +241,12 @@ def _build_kv_cache(self, forward_context):
             compress_kv_cache = compress_kv_cache[virtual_engine]
     if self.compress_ratio == 4:
         indexer_state_cache = self.indexer.compressor.state_cache.kv_cache
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             indexer_k_cache, indexer_scale_cache, indexer_full_cache = unfold_kvcache(self.indexer.k_cache.kv_cache)
         else:
             indexer_k_cache, indexer_scale_cache = unfold_kvcache(self.indexer.k_cache.kv_cache)
 
-    if get_ascend_device_type() in {AscendDeviceType.A5}:
+    if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
         kv_cache = tuple(
             [
                 unfold_kvcache(cache)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -29,10 +29,7 @@ from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     dispose_tensor,
     enable_custom_op,
-    get_ascend_device_type,
 )
-
-ASCEND_DEVICE_TYPE = get_ascend_device_type()
 
 
 def _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation=None):

--- a/vllm_ascend/ops/fused_moe/router/router_factory.py
+++ b/vllm_ascend/ops/fused_moe/router/router_factory.py
@@ -5,11 +5,11 @@ from vllm.distributed.eplb.eplb_state import EplbLayerState
 from vllm.model_executor.layers.fused_moe import FusedMoERouter
 from vllm.model_executor.layers.fused_moe.router.custom_routing_router import CustomRoutingRouter
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.ops.fused_moe.router.fused_topk_router import (
     AscendFusedTopKRouter as AscendFusedMoERouter,
 )
 from vllm_ascend.ops.fused_moe.router.grouped_topk_router import AscendGroupedTopKRouter
-from vllm_ascend.utils import is_310p
 
 
 def check_npu_moe_gating_top_k(
@@ -59,7 +59,7 @@ def create_ascend_fused_moe_router(
             custom_routing_function=custom_routing_function,
             renormalize=renormalize,
         )
-    if is_310p():
+    if get_current_hardware_profile().supports(HardwareCapability.FUSED_MOE_COMPATIBILITY):
         from vllm_ascend._310p.fused_moe.grouped_topk_router import AscendGroupedTopKRouter310
 
         return AscendGroupedTopKRouter310(

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -26,11 +26,10 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoEMethodB
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.lora.fused_moe import has_lora
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
     npu_stream_switch,
     shared_expert_dp_enabled,
     shared_experts_calculation_stream,
@@ -180,7 +179,7 @@ class AscendSharedExperts:
                     clamp_limit=self.swiglu_limit,
                     **(
                         {}
-                        if get_ascend_device_type() == AscendDeviceType.A5
+                        if not get_current_hardware_profile().supports(HardwareCapability.FUSED_SWIGLU_TUNING_ARGS)
                         else {"glu_alpha": self.swiglu_alpha, "glu_bias": self.swiglu_beta}
                     ),
                 )

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -31,6 +31,7 @@ from vllm.distributed.parallel_state import get_ep_group
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.lora.fused_moe import (
     all2all_lora_indices,
@@ -50,8 +51,6 @@ from vllm_ascend.ops.fused_moe.dataclass.token_dispatcher import (
 from vllm_ascend.ops.fused_moe.moe_utils import async_all_to_all, gather_from_sequence_parallel_region
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
     is_hierarchical_communication_enabled,
     should_skip_allreduce_across_dp_group,
 )
@@ -121,8 +120,10 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         self.ep_rank_id = get_mc2_group().rank_in_group
         self.ep_world_size = get_mc2_group().world_size
         self.enable_dispatch_v2 = hasattr(torch_npu, "npu_moe_distribute_dispatch_v2")
-        self.need_extra_args = get_ascend_device_type() in [AscendDeviceType.A3, AscendDeviceType.A5]
-        self.a5_need_extra_args = get_ascend_device_type() == AscendDeviceType.A5
+        self.need_extra_args = get_current_hardware_profile().supports(HardwareCapability.MOE_DISPATCH_EXTRA_ARGS)
+        self.need_shared_expert_args = get_current_hardware_profile().supports(
+            HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS
+        )
         # NOTE: When in A2, setting the environment variables HCCL_INTRA_PCIE_ENABLE=1 and
         # HCCL_INTRA_ROCE_ENABLE=0 can reduce cross-machine communication traffic and significantly
         # improve communication performance.
@@ -181,7 +182,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         if comm_quant_mode is not None:
             quant_mode = comm_quant_mode
         elif token_dispatch_input.quant.dispatch_with_quant:
-            quant_mode = 4 if self.a5_need_extra_args and token_dispatch_input.quant.is_mxfp else 2
+            quant_mode = 4 if self.need_shared_expert_args and token_dispatch_input.quant.is_mxfp else 2
         else:
             quant_mode = 0
         self.moe_expert_num = len(expert_map) + global_redundant_expert_num
@@ -215,7 +216,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             )
         # Only dispatch-enabled MXFP paths pass y_dtype through MC2.
         if (
-            self.a5_need_extra_args
+            self.need_shared_expert_args
             and (token_dispatch_input.quant.is_mxfp or token_dispatch_input.quant.is_fp8)
             and token_dispatch_input.quant.dispatch_with_quant
         ):
@@ -226,7 +227,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             ):
                 y_dtype = token_dispatch_input.quant.mxfp.act_quant_type
             stage1_kwargs.update({"tp_world_size": 1, "tp_rank_id": 0, "y_dtype": y_dtype})
-        if self.need_expert_scale or self.a5_need_extra_args:
+        if self.need_expert_scale or self.need_shared_expert_args:
             stage1_kwargs.update(
                 {
                     "expert_scales": topk_weights.to(torch.float32),

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -40,13 +40,11 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, WeightLayoutPolicy, get_current_hardware_profile
 from vllm_ascend.ops.linear_op import get_parallel_op, get_replicated_op
 from vllm_ascend.quantization.tp_weight_switch import TPWeightGatherSpec, TPWeightSwitchMixin
 from vllm_ascend.utils import (
-    AscendDeviceType,
     enable_sp,
-    get_ascend_device_type,
-    is_310p,
     maybe_trans_nz,
 )
 
@@ -77,8 +75,12 @@ direct_register_custom_op(
 )
 
 
-def _should_keep_nd_for_310p_weight(weight: torch.Tensor) -> bool:
-    return is_310p() and weight.ndim >= 2 and (weight.shape[-1] == 1 or weight.shape[-2] == 1)
+def _should_keep_nd_for_compatibility_weight(weight: torch.Tensor) -> bool:
+    return (
+        get_current_hardware_profile().weight_layout_policy is WeightLayoutPolicy.FORCE_NZ
+        and weight.ndim >= 2
+        and (weight.shape[-1] == 1 or weight.shape[-2] == 1)
+    )
 
 
 class AscendUnquantizedLinearMethod(TPWeightSwitchMixin, UnquantizedLinearMethod):
@@ -90,7 +92,7 @@ class AscendUnquantizedLinearMethod(TPWeightSwitchMixin, UnquantizedLinearMethod
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
-        keep_nd_weight = _should_keep_nd_for_310p_weight(layer.weight.data)
+        keep_nd_weight = _should_keep_nd_for_compatibility_weight(layer.weight.data)
         # must use fp32 to avoid accuracy degradation in dsv4.
         if getattr(layer, "precast_fp32_weight", False):
             weight_fp32 = layer.weight.data.to(torch.float32)
@@ -470,7 +472,9 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         return super().forward(input_)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        if "wo_a" in self.prefix and get_ascend_device_type() != AscendDeviceType.A5:
+        if "wo_a" in self.prefix and not get_current_hardware_profile().supports(
+            HardwareCapability.DYNAMIC_MX_QUANT_FUSION
+        ):
             if self.weight.ndim == 2:
                 super().weight_loader(param, loaded_weight)
                 self.weight.data = (

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -191,7 +191,7 @@
 #       On 310P, override verify_and_update_config to align mamba_block_size and
 #       attention block size to the 128-token kernel alignment, ensuring the
 #       attention page size is >= mamba page size. This is the 310P counterpart
-#       of patch_mamba_config.py (loaded only when `is_310p()` is True).
+#       of patch_mamba_config.py (selected by the active hardware profile)..
 #    Related PR (if no, explain why):
 #       No, 310P-specific kernel alignment requirement.
 #    Future Plan:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -21,9 +21,9 @@ import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
-if not is_310p():
+if get_current_hardware_profile().supports(HardwareCapability.STANDARD_MAMBA_PATCH):
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa

--- a/vllm_ascend/patch/platform/patch_distributed.py
+++ b/vllm_ascend/patch/platform/patch_distributed.py
@@ -19,7 +19,7 @@
 
 import torch
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 
 class NullHandle:
@@ -85,5 +85,5 @@ def communication_adaptation_310p():
     )
 
 
-if get_ascend_device_type() == AscendDeviceType._310P:
+if get_current_hardware_profile().supports(HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION):
     communication_adaptation_310p()

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -17,7 +17,7 @@
 
 from vllm.triton_utils import HAS_TRITON
 
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 if HAS_TRITON:
     import vllm_ascend.patch.worker.patch_triton
@@ -32,7 +32,7 @@ import vllm_ascend.patch.worker.patch_mamba_utils  # noqa
 import vllm_ascend.patch.worker.patch_bind_kv_cache  # noqa
 import vllm_ascend.patch.worker.patch_step3p5  # noqa
 
-if not is_310p():
+if get_current_hardware_profile().supports(HardwareCapability.STANDARD_WORKER_PATCHES):
     import vllm_ascend.patch.worker.patch_qwen3_5  # noqa
     import vllm_ascend.patch.worker.patch_qwen3_dflash  # noqa
     import vllm_ascend.patch.worker.patch_qwen3vl  # noqa

--- a/vllm_ascend/patch/worker/patch_kimi_k25.py
+++ b/vllm_ascend/patch/worker/patch_kimi_k25.py
@@ -24,7 +24,7 @@ from vllm.model_executor.models.kimi_k25_vit import (
     get_rope_shape_decorate,
 )
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 
 @get_rope_shape_decorate
@@ -82,7 +82,7 @@ Learnable2DInterpPosEmbDivided_fixed.forward = AscendLearnable2DInterpPosEmbDivi
 # the `dtype=model_config.dtype` (e.g. bf16) would overwrite the fp8 parameters
 # created by the Ascend quantization scheme, causing a dtype mismatch later
 # in weight_loader when the checkpoint's fp8 weights are loaded.
-if get_ascend_device_type() == AscendDeviceType.A5:
+if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
     _original_moonvit_to = MoonViT3dPretrainedModel.to
 
     def _patched_moonvit_to(self, *args, **kwargs):

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -14,13 +14,13 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
 from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
-from vllm_ascend.utils import is_310p
 
 
 def _can_launch_triton_batch_memcpy() -> bool:
-    return not is_310p()
+    return get_current_hardware_profile().supports(HardwareCapability.TRITON_BATCH_MEMCPY)
 
 
 def _batch_memcpy_triton(src_ptrs, dst_ptrs, sizes):

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -33,8 +33,8 @@ except ImportError:
 from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
-from vllm_ascend.utils import is_310p
 
 
 def _ascend_all_gather_hidden_and_residual(
@@ -217,7 +217,7 @@ _GDN_PATCH_TARGET._split_ba_for_tp = AscendGatedDeltaNetAttention._split_ba_for_
 _GDN_PATCH_TARGET.get_state_shape = AscendGatedDeltaNetAttention.get_state_shape
 _GDN_PATCH_TARGET.get_attn_backend = AscendGatedDeltaNetAttention.get_attn_backend
 
-if is_310p():
+if get_current_hardware_profile().supports(HardwareCapability.GDN_COMPATIBILITY):
     from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
 
     _GDN_PATCH_TARGET._forward_core = AscendGatedDeltaNetAttention310._forward_core

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -34,6 +34,12 @@ os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 from vllm_ascend.ascend_config import init_ascend_config
+from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    HardwareCapability,
+    QuantizationBackendFamily,
+    get_current_hardware_profile,
+)
 
 # isort: off
 from vllm_ascend.utils import (
@@ -41,16 +47,13 @@ from vllm_ascend.utils import (
     COMPILATION_PASS_KEY,
     COMPRESSED_TENSORS_METHOD,
     FP8_METHOD,
-    AscendDeviceType,
     bootstrap_custom_op_env,
     check_kv_extra_config,
     enable_sfa_dcp_replicated_indexer,
-    get_ascend_device_type,
     is_moe_model,
     model_uses_sfa_sparse,
     refresh_block_size,
     update_cudagraph_capture_sizes,
-    is_310p,
     enable_sp,
 )
 
@@ -72,7 +75,7 @@ else:
 
 _CUSTOM_OP_REGISTERED = False
 # Delete after the driver is released; temporarily hard-coded to 4
-MAX_CAPTURE_SIZES_FOR_950 = 4
+MAX_REDUCED_CAPTURE_SIZES = 4
 
 
 class NPUPlatform(Platform):
@@ -226,7 +229,7 @@ class NPUPlatform(Platform):
             (True, True, False): "vllm_ascend.attention.sfa_v1.AscendSFABackend",
             (True, False, True): "vllm_ascend.attention.dsa_v1.AscendDSABackend",
         }
-        backend_map_310 = {
+        compatibility_backend_map = {
             (
                 False,
                 False,
@@ -236,8 +239,8 @@ class NPUPlatform(Platform):
             # (True, True):  "...AscendSFABackend310",
         }
 
-        if is_310p():
-            return backend_map_310.get(key, backend_map_310[(False, False)])
+        if get_current_hardware_profile().attention_backend_family is AttentionBackendFamily.COMPATIBILITY:
+            return compatibility_backend_map.get(key, compatibility_backend_map[(False, False)])
 
         return backend_map[(attn_selector_config.use_mla, attn_selector_config.use_sparse, use_compress)]
 
@@ -273,7 +276,7 @@ class NPUPlatform(Platform):
                 if ASCEND_QUANTIZATION_METHOD not in quant_action.choices:
                     quant_action.choices.append(ASCEND_QUANTIZATION_METHOD)
 
-        if not is_310p():
+        if get_current_hardware_profile().quantization_backend_family is QuantizationBackendFamily.STANDARD:
             from vllm_ascend.quantization import AscendCompressedTensorsConfig, AscendFp8Config, AscendModelSlimConfig  # noqa: F401
         else:
             from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
@@ -345,6 +348,8 @@ class NPUPlatform(Platform):
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         from vllm_ascend.quantization.utils import maybe_auto_detect_quantization
+
+        hardware_profile = get_current_hardware_profile()
 
         device_config = getattr(vllm_config, "device_config", None)
         if device_config is not None and getattr(device_config, "device_type", cls.device_type) != cls.device_type:
@@ -512,8 +517,8 @@ class NPUPlatform(Platform):
                 ]
             )
             # TODO(2026/7/15): Delete the reduced gear after the new driver is released.
-            if get_ascend_device_type() == AscendDeviceType.A5:
-                _prune_capture_sizes_for_950(vllm_config)
+            if hardware_profile.supports(HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES):
+                _prune_reduced_capture_sizes(vllm_config)
             ascend_config.ascend_compilation_config.enable_npugraph_ex = False
         elif compilation_config.cudagraph_mode.has_full_cudagraphs():
             # We don't want to have our FX graph split for the sake of static kernel feature,
@@ -545,18 +550,18 @@ class NPUPlatform(Platform):
             # TODO: this is a tricky way to disable `use_sequence_parallel_moe` in vllm.
             if not vllm_config.compilation_config.pass_config.enable_sp:
                 parallel_config.all2all_backend = "flashinfer_all2allv"
-            if is_310p():
-                parallel_config.worker_cls = "vllm_ascend._310p.worker_310p.NPUWorker310"
-            elif ascend_config.xlite_graph_config.enabled:
+            if ascend_config.xlite_graph_config.enabled and hardware_profile.supports(
+                HardwareCapability.STANDARD_WORKER_PATCHES
+            ):
                 logger.info("openEuler Xlite enabled. See: https://atomgit.com/openeuler/GVirt/tree/master/xlite")
                 parallel_config.worker_cls = "vllm_ascend.xlite.xlite_worker.XliteWorker"
             else:
-                parallel_config.worker_cls = "vllm_ascend.worker.worker.NPUWorker"
+                parallel_config.worker_cls = hardware_profile.default_worker_cls
 
         refresh_block_size(vllm_config)
 
-        # Activate custom ops for v1, except on 310P
-        if get_ascend_device_type() != AscendDeviceType._310P:
+        # Automatically activate all custom ops on profiles using the standard path.
+        if hardware_profile.supports(HardwareCapability.AUTO_ENABLE_CUSTOM_OPS):
             compilation_config.custom_ops = ["all"]
 
         scheduler_extension_config = ascend_config.scheduler_config
@@ -651,8 +656,10 @@ class NPUPlatform(Platform):
                     f"DCP for SFA is only supported when dcp_size({parallel_config.decode_context_parallel_size}) "
                     f"== tp_size({parallel_config.tensor_parallel_size})."
                 )
-            if get_ascend_device_type() == AscendDeviceType.A5:
-                raise NotImplementedError("SFA DCP with replicated indexer is not supported on A5 yet.")
+            if not hardware_profile.supports(HardwareCapability.SFA_DCP_REPLICATED_INDEXER):
+                raise NotImplementedError(
+                    "SFA DCP with replicated indexer is not supported by the current hardware profile."
+                )
 
         if (
             vllm_config.kv_transfer_config is not None
@@ -1230,14 +1237,14 @@ def _config_deprecated_logging():
     warnings_logger.propagate = False
 
 
-def _prune_capture_sizes_for_950(vllm_config):
+def _prune_reduced_capture_sizes(vllm_config):
     original_sizes = vllm_config.compilation_config.cudagraph_capture_sizes
     if not original_sizes:
         return
-    if len(original_sizes) <= MAX_CAPTURE_SIZES_FOR_950:
+    if len(original_sizes) <= MAX_REDUCED_CAPTURE_SIZES:
         return
-    step = (len(original_sizes) - 1) / (MAX_CAPTURE_SIZES_FOR_950 - 1)
-    indices = [round(i * step) for i in range(MAX_CAPTURE_SIZES_FOR_950)]
+    step = (len(original_sizes) - 1) / (MAX_REDUCED_CAPTURE_SIZES - 1)
+    indices = [round(i * step) for i in range(MAX_REDUCED_CAPTURE_SIZES)]
     indices[0], indices[-1] = 0, len(original_sizes) - 1
     sampled_sizes = [original_sizes[i] for i in indices]
     update_cudagraph_capture_sizes(vllm_config, sampled_sizes)
@@ -1245,7 +1252,7 @@ def _prune_capture_sizes_for_950(vllm_config):
         "Adjusted ACL graph batch sizes for model: %d → %d sizes due to HDK incompatibility"
         "and this warning will be cleared soon.",
         len(original_sizes),
-        MAX_CAPTURE_SIZES_FOR_950,
+        MAX_REDUCED_CAPTURE_SIZES,
     )
 
 

--- a/vllm_ascend/quantization/methods/kv_c8.py
+++ b/vllm_ascend/quantization/methods/kv_c8.py
@@ -3,7 +3,7 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 from vllm.logger import logger
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 from .base import AscendAttentionScheme
 from .registry import register_scheme
@@ -60,7 +60,7 @@ class AscendFAQuantAttentionMethod:
         fa_k_scale = torch.squeeze(layer.fa_k.scale).unsqueeze(0)
         layer.fak_descale_float = torch.nn.Parameter(fa_k_scale.to(torch.float), requires_grad=False)
         layer.fak_descale = torch.nn.Parameter(fa_k_scale, requires_grad=False)
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             layer.fak_descale_reciprocal = 1.0 / torch.nn.Parameter(fa_k_scale.to(torch.float), requires_grad=False)
         else:
             layer.fak_descale_reciprocal = 1.0 / torch.nn.Parameter(fa_k_scale, requires_grad=False)

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -41,11 +41,10 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.layers.vocab_parallel_embedding import UnquantizedEmbeddingMethod, VocabParallelEmbedding
 from vllm.model_executor.models.utils import WeightsMapper
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
-    AscendDeviceType,
     calc_split_factor,
-    get_ascend_device_type,
 )
 
 from .methods import get_scheme_class
@@ -780,7 +779,7 @@ class AscendModelSlimConfig(QuantizationConfig):
             and vllm_config.kv_transfer_config.is_kv_consumer
             and not vllm_config.kv_transfer_config.is_kv_producer
         )
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
             return self.is_fa_quant_layer(layer_name)
         else:
             return bool(is_decode_instance and self.is_fa_quant_layer(layer_name))
@@ -802,7 +801,11 @@ class AscendModelSlimConfig(QuantizationConfig):
     def get_kv_quant_dtype(self, layer_name, cache_dtype, model_config):
         if self.enable_fa_quant and self.is_fa_quant_layer(layer_name):
             ori_dtype = model_config.dtype
-            quant_dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+            quant_dtype = (
+                torch.float8_e4m3fn
+                if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
+                else torch.int8
+            )
             # For MLA models like deepseek, we only quantify K cache to ensure accuracy
             if model_config.use_mla:
                 return quant_dtype, ori_dtype

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -22,12 +22,11 @@ import torch_npu  # noqa: F401
 from vllm import envs
 from vllm.logger import logger
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
     FP8_METHOD,
-    AscendDeviceType,
-    get_ascend_device_type,
 )
 
 # TODO(zzzzzz198): Currently three formats(float8_e8m0fnu, float4_e2m1fn_x2, hifloat8) have to be
@@ -223,7 +222,7 @@ def maybe_auto_detect_quantization(vllm_config) -> None:
 
 def enable_fa_quant(vllm_config, layer_name=None) -> bool:
     is_kv_consumer = vllm_config.kv_transfer_config is not None and vllm_config.kv_transfer_config.is_kv_consumer
-    if not is_kv_consumer and get_ascend_device_type() != AscendDeviceType.A5:
+    if not is_kv_consumer and not get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
         return False
     if vllm_config.quant_config is not None and getattr(vllm_config.quant_config, "enable_fa_quant", False):
         if layer_name is not None:

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -9,8 +9,9 @@ from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.sample.penalties import apply_all_penalties
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, global_stream, npu_stream_switch
+from vllm_ascend.utils import global_stream, npu_stream_switch
 
 DEFAULT_LOGPROBS_MODE = "raw_logprobs"
 
@@ -266,6 +267,6 @@ def _apply_top_k_top_p_torch_npu(
 
 apply_top_k_top_p = (
     _apply_top_k_top_p_torch_npu
-    if get_ascend_device_type() in [AscendDeviceType.A2, AscendDeviceType.A3]
+    if get_current_hardware_profile().supports(HardwareCapability.NPU_TOP_K_TOP_P)
     else _apply_top_k_top_p_pytorch
 )

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -44,6 +44,7 @@ from vllm_ascend.device.device_config import (  # noqa: F401
     is_310p,
     is_950,
 )
+from vllm_ascend.device.hardware_profile import HardwareCapability, WeightLayoutPolicy, get_current_hardware_profile
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -154,7 +155,7 @@ def is_rc_device() -> bool:
     ``accelerators``.
     """
     global _IS_RC_DEVICE
-    if not is_310p():
+    if not get_current_hardware_profile().supports(HardwareCapability.RC_DEVICE_DISCOVERY):
         return False
     if _IS_RC_DEVICE is not None:
         return _IS_RC_DEVICE
@@ -257,8 +258,8 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if weight.is_meta:
         return False
 
-    # 310P always converts to NZ.
-    if is_310p():
+    # Some hardware profiles require NZ weight layout.
+    if get_current_hardware_profile().weight_layout_policy is WeightLayoutPolicy.FORCE_NZ:
         return True
 
     # Get config value instead of env
@@ -413,7 +414,7 @@ def enable_custom_op():
     # FIXME(linfeng): Currently custom op compilation and execution are partially available
     # in ASCEND950 chip, we temporarily disable all custom ops. Please refer to
     # https://github.com/vllm-project/vllm-ascend/issues/7157 for latest update about custom op.
-    if envs.VLLM_BATCH_INVARIANT or get_ascend_device_type() == AscendDeviceType.A5:
+    if envs.VLLM_BATCH_INVARIANT or not get_current_hardware_profile().supports(HardwareCapability.RUNTIME_CUSTOM_OPS):
         _CUSTOM_OP_ENABLED = False
         return _CUSTOM_OP_ENABLED
 
@@ -744,8 +745,8 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
         REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear
 
-    # 310P: override selected ops with 310P implementations (keep minimal changes outside _310p)
-    if is_310p():
+    # Override selected ops when the compatibility implementations are required.
+    if get_current_hardware_profile().supports(HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS):
         from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310, AscendRoutedExperts310
         from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
         from vllm_ascend._310p.ops.conv import AscendConv3dLayer310

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -132,6 +132,7 @@ from vllm_ascend.compilation.acl_graph import (
     set_graph_params,
     update_full_graph_params,
 )
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     apply_layerwise_kv_cache_plan,
 )
@@ -171,14 +172,12 @@ from vllm_ascend.spec_decode.utils import (
     update_num_computed_tokens_for_batch_change,
 )
 from vllm_ascend.utils import (
-    AscendDeviceType,
     calc_split_factor,
     check_gdn_layer,
     embedding_tp_enable,
     enable_sfa_dcp_replicated_indexer,
     enable_sp,
     enable_sp_by_pass,
-    get_ascend_device_type,
     get_c_env,
     global_stream,
     is_hidden_state_cache_spec,
@@ -379,7 +378,7 @@ class NPUModelRunner(GPUModelRunner):
         self.enable_sparse_sfa_c8 = self.ascend_config.enable_sparse_sfa_c8
         self.enable_sparse_li_c8 = self.ascend_config.enable_sparse_li_c8
         if self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8:
-            if get_ascend_device_type() == AscendDeviceType.A5:
+            if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
                 self.c8_k_cache_dtype = torch.float8_e4m3fn
                 self.c8_k_scale_cache_dtype = torch.float32
             else:
@@ -4207,7 +4206,7 @@ class NPUModelRunner(GPUModelRunner):
                                                 current_kv_cache_spec.num_kv_heads,
                                                 current_kv_cache_spec.scale_dim
                                                 )
-                        if get_ascend_device_type() in {AscendDeviceType.A5}:
+                        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
                             indexer_full_shape = self.attn_backend.get_kv_cache_shape(
                                 num_blocks, current_kv_cache_spec.block_size,
                                 current_kv_cache_spec.num_kv_heads,

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -47,8 +47,9 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendMLAAttentionSpec,
     AscendSlidingWindowMLASpec,
 )
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.quantization.utils import enable_fa_quant
-from vllm_ascend.utils import AscendDeviceType, calc_split_factor, get_ascend_device_type
+from vllm_ascend.utils import calc_split_factor
 
 
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
@@ -348,7 +349,7 @@ def _view_dsv4_cache(
         )
         cache_shapes.append(scale_shape)
         cache_dtypes.append(scale_dtype)
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
+        if get_current_hardware_profile().supports(HardwareCapability.DSV4_COMPRESSED_CACHE):
             full_shape = attn_backend.get_kv_cache_shape(
                 num_blocks,
                 kv_cache_spec.block_size,

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -59,6 +59,7 @@ import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
 from vllm_ascend.cpu_binding import bind_cpus
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
@@ -74,10 +75,8 @@ from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
-    AscendDeviceType,
     check_ascend_device_type,
     enable_sp,
-    get_ascend_device_type,
     register_ascend_customop,
     setup_ascend_local_comm_res,
 )
@@ -122,7 +121,7 @@ class NPUWorker(WorkerBase):
         from vllm_ascend import ops
 
         ops.register_dummy_fusion_op()
-        if get_ascend_device_type() != AscendDeviceType.A5:
+        if get_current_hardware_profile().supports(HardwareCapability.ATB_EXTENSIONS):
             _register_atb_extensions()
         register_ascend_customop(vllm_config)
         # init ascend config and soc version
@@ -412,7 +411,7 @@ class NPUWorker(WorkerBase):
         gc.collect()
         torch.npu.empty_cache()
 
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        if get_current_hardware_profile().supports(HardwareCapability.LOCAL_KV_COMM_RESOURCE):
             setup_ascend_local_comm_res(self.local_rank, self.vllm_config.kv_transfer_config)
 
         # take current memory snapshot
@@ -789,7 +788,7 @@ class NPUWorker(WorkerBase):
 
         # Call ATB matmul to warm up; otherwise, the first operation (ReshapeAndCache)
         # may cause performance degradation at runtime.
-        if get_ascend_device_type() != AscendDeviceType.A5:
+        if get_current_hardware_profile().supports(HardwareCapability.ATB_WARMUP):
             self._warm_up_atb()
         # Bind after warmup so hot allocations are already materialized on the
         # worker process before migratepages/taskset run.


### PR DESCRIPTION
### What this PR does / why we need it?

Migrates device-specific branches in business logic to semantic hardware
capabilities and strategies.

Device identity remains confined to the device detection and hardware profile
layers. Attention, quantization, MoE, distributed execution, worker and
platform code no longer need to know concrete Ascend device types.

### Does this PR introduce *any* user-facing change?

No. This is an internal architecture refactoring intended to preserve existing
behavior.

### How was this patch tested?

Relevant unit tests: 432 passed, 2 skipped.
 `/health` and `/v1/models` both returned HTTP 200.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
