### PR TITLE
fix(ocr2): restore Qwen2 decoder attention type

### DIFF
--- a/tests/ut/ops/test_qwen2_decoder.py
+++ b/tests/ut/ops/test_qwen2_decoder.py
@@ -1,0 +1,34 @@
+import pytest
+from transformers import Qwen2Config
+
+from vllm_ascend.ops.qwen2_decoder import AscendQwen2DecoderLayer
+
+
+@pytest.mark.parametrize("layer_idx", [0, 1])
+def test_qwen2_decoder_layer_uses_configured_attention_type(layer_idx: int):
+    config = Qwen2Config(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+    )
+
+    decoder_layer = AscendQwen2DecoderLayer(config, layer_idx)
+
+    assert decoder_layer.attention_type == config.layer_types[layer_idx]
+
+
+def test_qwen2_decoder_layer_defaults_to_full_attention_without_layer_types():
+    config = Qwen2Config(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+    )
+    del config.layer_types
+
+    decoder_layer = AscendQwen2DecoderLayer(config, 0)
+
+    assert decoder_layer.attention_type == "full_attention"

--- a/vllm_ascend/ops/qwen2_decoder.py
+++ b/vllm_ascend/ops/qwen2_decoder.py
@@ -249,6 +249,11 @@ class AscendQwen2Model(Qwen2Model):
 class AscendQwen2DecoderLayer(Qwen2DecoderLayer):
     def __init__(self, config: Qwen2Config, layer_idx: int):
         super().__init__(config, layer_idx)
+        # transformers>=5.5 no longer exposes attention_type on decoder layers.
+        if hasattr(config, "layer_types"):
+            self.attention_type = config.layer_types[layer_idx]
+        else:
+            self.attention_type = "full_attention"
         self.self_attn = AscendQwen2Attention(config=config, layer_idx=layer_idx)
         self.input_layernorm = AscendQwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = AscendQwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek-OCR-2 fails during the multimodal profile run with:

```text
AttributeError: 'AscendQwen2DecoderLayer' object has no attribute 'attention_type'

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
