### PR TITLE
[Performance][Spec Decode] Replicate DSpark Markov head across TP ranks on Ascend

### DIFF
--- a/tests/ut/ops/test_vocab_parallel_embedding.py
+++ b/tests/ut/ops/test_vocab_parallel_embedding.py
@@ -75,9 +75,9 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         mock_group.rank_in_group = 0
         with (
             patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=mock_group),
-            patch("vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_rank", return_value=0),
+            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_rank", return_value=0),
             patch(
-                "vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_world_size",
+                "vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_world_size",
                 return_value=2,
             ),
             patch("vllm.model_executor.layers.vocab_parallel_embedding.pad_vocab_size", side_effect=lambda x, y: x + y),
@@ -254,8 +254,8 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         input_ = torch.tensor([1, 2, 3])
 
         with patch(
-            "torch.ops.vllm.maybe_pad_and_reduce",
-            side_effect=lambda x: x,
+            "torch.ops.vllm.all_reduce",
+            side_effect=lambda x, _: x,
         ) as mock_reduce:
             output = layer.forward(input_)
 
@@ -296,6 +296,8 @@ class TestAscendLogitsProcessor(unittest.TestCase):
             patch("vllm_ascend.ops.vocab_parallel_embedding.get_ascend_config", return_value=self.mock_ascend_config),
             patch("vllm_ascend.ops.vocab_parallel_embedding.get_lmhead_tp_group", return_value=self.mock_group),
             patch("vllm_ascend.ops.vocab_parallel_embedding.lmhead_tp_enable", return_value=True),
+            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_rank", return_value=0),
+            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_world_size", return_value=2),
             patch(
                 "vllm_ascend.ops.vocab_parallel_embedding.dist.all_to_all_single",
                 self.mock_all_to_all_single,

--- a/tests/ut/ops/test_vocab_parallel_embedding.py
+++ b/tests/ut/ops/test_vocab_parallel_embedding.py
@@ -146,7 +146,6 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         # Should just pass through without masking
         layer.quant_method.embedding.assert_called_once_with(layer, input_.long())
         self.assertEqual(output.shape, (3, layer.embedding_dim))
-
         mock_reduce_tp1.assert_not_called()
 
     def test_forward_with_tp(self):
@@ -225,6 +224,44 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
                     output = layer.forward(input_)
                 self.assertEqual(output.shape, expected_shape)
 
+    def test_disable_tp(self):
+        mock_group = MagicMock()
+        mock_group.world_size = 2
+        mock_group.rank_in_group = 0
+
+        with patch(
+            "vllm_ascend.ops.vocab_parallel_embedding.get_tp_group",
+            return_value=mock_group,
+        ) as mock_get_tp_group:
+            layer = AscendVocabParallelEmbedding(
+                num_embeddings=self.num_embeddings,
+                embedding_dim=self.embedding_dim,
+                org_num_embeddings=self.org_num_embeddings,
+                padding_size=self.padding_size,
+                quant_config=None,
+                prefix="",
+                disable_tp=True,
+            )
+
+        self.assertTrue(layer.disable_tp)
+        self.assertEqual(layer.tp_size, 1)
+        self.assertEqual(layer.tp_rank, 0)
+
+        # disable_tp=True should not depend on the TP communication group.
+        mock_get_tp_group.assert_not_called()
+
+        layer.quant_method.embedding = MagicMock(return_value=torch.randn(3, layer.embedding_dim))
+        input_ = torch.tensor([1, 2, 3])
+
+        with patch(
+            "torch.ops.vllm.maybe_pad_and_reduce",
+            side_effect=lambda x: x,
+        ) as mock_reduce:
+            output = layer.forward(input_)
+
+        mock_reduce.assert_not_called()
+        self.assertEqual(output.shape, (3, layer.embedding_dim))
+
 
 class TestAscendLogitsProcessor(unittest.TestCase):
     def setUp(self):
@@ -295,3 +332,59 @@ class TestAscendLogitsProcessor(unittest.TestCase):
         self.mock_all_to_all_single.assert_called_once()
         # [N/P, V] after redistribution, then truncated to org_vocab_size.
         self.assertEqual(logits.shape, (1, self.vocab_size))
+
+    def test_disable_tp_lm_head_skips_lmhead_tp_path(self):
+        processor = AscendLogitsProcessor(vocab_size=self.vocab_size)
+
+        lm_head = AscendParallelLMHead(
+            num_embeddings=self.num_embeddings,
+            embedding_dim=self.embedding_dim,
+            prefix="markov_head",
+            disable_tp=True,
+        )
+
+        hidden_states = torch.randn(1, self.embedding_dim)
+
+        with (
+            patch.object(
+                processor,
+                "_get_logits_lmheadtp",
+            ) as mock_lmhead_tp,
+            patch.object(
+                processor,
+                "_get_logits_normal",
+                return_value=torch.randn(1, self.vocab_size),
+            ) as mock_normal,
+        ):
+            processor._get_logits(hidden_states, lm_head)
+
+        mock_lmhead_tp.assert_not_called()
+        mock_normal.assert_called_once()
+
+    def test_disable_tp_lm_head_skips_logits_gather(self):
+        processor = AscendLogitsProcessor(vocab_size=self.vocab_size)
+
+        lm_head = AscendParallelLMHead(
+            num_embeddings=self.num_embeddings,
+            embedding_dim=self.embedding_dim,
+            prefix="markov_head",
+            disable_tp=True,
+        )
+
+        lm_head.quant_method = self.mock_quant_method
+
+        self.mock_ascend_config.enable_reduce_sample = False
+
+        hidden_states = torch.randn(1, self.embedding_dim)
+
+        with patch.object(
+            processor,
+            "_gather_logits",
+        ) as mock_gather:
+            processor._get_logits_normal(
+                hidden_states,
+                lm_head,
+                None,
+            )
+
+        mock_gather.assert_not_called()

--- a/tests/ut/ops/test_vocab_parallel_embedding.py
+++ b/tests/ut/ops/test_vocab_parallel_embedding.py
@@ -75,11 +75,6 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         mock_group.rank_in_group = 0
         with (
             patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=mock_group),
-            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_rank", return_value=0),
-            patch(
-                "vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_world_size",
-                return_value=2,
-            ),
             patch("vllm.model_executor.layers.vocab_parallel_embedding.pad_vocab_size", side_effect=lambda x, y: x + y),
             patch("vllm.model_executor.layers.vocab_parallel_embedding.divide", side_effect=lambda x, y: x // y),
         ):
@@ -225,42 +220,20 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
                 self.assertEqual(output.shape, expected_shape)
 
     def test_disable_tp(self):
-        mock_group = MagicMock()
-        mock_group.world_size = 2
-        mock_group.rank_in_group = 0
-
-        with patch(
-            "vllm_ascend.ops.vocab_parallel_embedding.get_tp_group",
-            return_value=mock_group,
-        ) as mock_get_tp_group:
-            layer = AscendVocabParallelEmbedding(
-                num_embeddings=self.num_embeddings,
-                embedding_dim=self.embedding_dim,
-                org_num_embeddings=self.org_num_embeddings,
-                padding_size=self.padding_size,
-                quant_config=None,
-                prefix="",
-                disable_tp=True,
-            )
+        layer = AscendVocabParallelEmbedding(
+            num_embeddings=self.num_embeddings,
+            embedding_dim=self.embedding_dim,
+            org_num_embeddings=self.org_num_embeddings,
+            padding_size=self.padding_size,
+            quant_config=None,
+            prefix="",
+            disable_tp=True,
+        )
 
         self.assertTrue(layer.disable_tp)
+        self.assertIsNone(layer.comm_group)
         self.assertEqual(layer.tp_size, 1)
         self.assertEqual(layer.tp_rank, 0)
-
-        # disable_tp=True should not depend on the TP communication group.
-        mock_get_tp_group.assert_not_called()
-
-        layer.quant_method.embedding = MagicMock(return_value=torch.randn(3, layer.embedding_dim))
-        input_ = torch.tensor([1, 2, 3])
-
-        with patch(
-            "torch.ops.vllm.all_reduce",
-            side_effect=lambda x, _: x,
-        ) as mock_reduce:
-            output = layer.forward(input_)
-
-        mock_reduce.assert_not_called()
-        self.assertEqual(output.shape, (3, layer.embedding_dim))
 
 
 class TestAscendLogitsProcessor(unittest.TestCase):
@@ -296,8 +269,6 @@ class TestAscendLogitsProcessor(unittest.TestCase):
             patch("vllm_ascend.ops.vocab_parallel_embedding.get_ascend_config", return_value=self.mock_ascend_config),
             patch("vllm_ascend.ops.vocab_parallel_embedding.get_lmhead_tp_group", return_value=self.mock_group),
             patch("vllm_ascend.ops.vocab_parallel_embedding.lmhead_tp_enable", return_value=True),
-            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_rank", return_value=0),
-            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tensor_model_parallel_world_size", return_value=2),
             patch(
                 "vllm_ascend.ops.vocab_parallel_embedding.dist.all_to_all_single",
                 self.mock_all_to_all_single,
@@ -334,59 +305,3 @@ class TestAscendLogitsProcessor(unittest.TestCase):
         self.mock_all_to_all_single.assert_called_once()
         # [N/P, V] after redistribution, then truncated to org_vocab_size.
         self.assertEqual(logits.shape, (1, self.vocab_size))
-
-    def test_disable_tp_lm_head_skips_lmhead_tp_path(self):
-        processor = AscendLogitsProcessor(vocab_size=self.vocab_size)
-
-        lm_head = AscendParallelLMHead(
-            num_embeddings=self.num_embeddings,
-            embedding_dim=self.embedding_dim,
-            prefix="markov_head",
-            disable_tp=True,
-        )
-
-        hidden_states = torch.randn(1, self.embedding_dim)
-
-        with (
-            patch.object(
-                processor,
-                "_get_logits_lmheadtp",
-            ) as mock_lmhead_tp,
-            patch.object(
-                processor,
-                "_get_logits_normal",
-                return_value=torch.randn(1, self.vocab_size),
-            ) as mock_normal,
-        ):
-            processor._get_logits(hidden_states, lm_head)
-
-        mock_lmhead_tp.assert_not_called()
-        mock_normal.assert_called_once()
-
-    def test_disable_tp_lm_head_skips_logits_gather(self):
-        processor = AscendLogitsProcessor(vocab_size=self.vocab_size)
-
-        lm_head = AscendParallelLMHead(
-            num_embeddings=self.num_embeddings,
-            embedding_dim=self.embedding_dim,
-            prefix="markov_head",
-            disable_tp=True,
-        )
-
-        lm_head.quant_method = self.mock_quant_method
-
-        self.mock_ascend_config.enable_reduce_sample = False
-
-        hidden_states = torch.randn(1, self.embedding_dim)
-
-        with patch.object(
-            processor,
-            "_gather_logits",
-        ) as mock_gather:
-            processor._get_logits_normal(
-                hidden_states,
-                lm_head,
-                None,
-            )
-
-        mock_gather.assert_not_called()

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -73,6 +73,7 @@ def _get_dspark_num_mtp_layers(config: PretrainedConfig) -> int:
 class DSparkMarkovHead(nn.Module):
     def __init__(self, config: PretrainedConfig, prefix: str) -> None:
         super().__init__()
+
         # Markov decoding runs serially for every draft position. Keep both
         # low-rank weights replicated so each step remains communication-free.
         self.markov_w1 = nn.Embedding(config.vocab_size, config.dspark_markov_rank)
@@ -82,6 +83,7 @@ class DSparkMarkovHead(nn.Module):
             bias=False,
             return_bias=False,
             prefix=f"{prefix}.markov_w2",
+            disable_tp=True,
         )
 
     def embed(self, token_ids: torch.Tensor) -> torch.Tensor:

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -35,7 +35,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.interfaces import SupportsEagle3
-from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
+from vllm.model_executor.models.qwen3_dspark import DSparkConfidenceHead, DSparkMarkovHead
 from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix, process_eagle_weight
 
 from vllm_ascend.models.common.ops.sequence_parallel import sp_padding_mask, sp_shard
@@ -45,7 +45,7 @@ from vllm_ascend.models.deepseek_v4.model import (
     DeepseekV4MoE,
 )
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
-from vllm_ascend.utils import enable_dsa_cp, vllm_version_is
+from vllm_ascend.utils import enable_dsa_cp
 
 
 def _apply_dsv4_rope(
@@ -136,25 +136,13 @@ class DeepseekV4DSparkModel(nn.Module):
                 f"layers.{last_layer_idx}.markov_head",
             ),
         )
-        self.confidence_head: nn.Module
-        if vllm_version_is("0.27.1"):
-            from vllm_ascend.models.qwen3_dspark import DSparkConfidenceHead as CompatDSparkConfidenceHead
 
-            self.confidence_head = CompatDSparkConfidenceHead(
-                input_dim=config.hidden_size + config.dspark_markov_rank,
-                prefix=maybe_prefix(prefix, "confidence_head"),
-                bias=False,
-                with_markov=True,
-            )
-        else:
-            from vllm.model_executor.models.qwen3_dspark import DSparkConfidenceHead
-
-            self.confidence_head = DSparkConfidenceHead(
-                input_dim=config.hidden_size + config.dspark_markov_rank,
-                prefix=maybe_prefix(prefix, "confidence_head"),
-                bias=False,
-                with_markov=True,
-            )
+        self.confidence_head = DSparkConfidenceHead(
+            input_dim=config.hidden_size + config.dspark_markov_rank,
+            prefix=maybe_prefix(prefix, "confidence_head"),
+            bias=False,
+            with_markov=True,
+        )
         hc_dim = self.hc_mult * config.hidden_size
         self.hc_head_fn = nn.Parameter(
             torch.empty(self.hc_mult, hc_dim, dtype=torch.float32),

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -27,7 +27,7 @@ from vllm.forward_context import get_forward_context, is_forward_context_availab
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ColumnParallelLinear, ReplicatedLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -35,6 +35,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 )
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.interfaces import SupportsEagle3
+from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix, process_eagle_weight
 
 from vllm_ascend.models.common.ops.sequence_parallel import sp_padding_mask, sp_shard
@@ -44,7 +45,7 @@ from vllm_ascend.models.deepseek_v4.model import (
     DeepseekV4MoE,
 )
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa
-from vllm_ascend.utils import enable_dsa_cp
+from vllm_ascend.utils import enable_dsa_cp, vllm_version_is
 
 
 def _apply_dsv4_rope(
@@ -68,52 +69,6 @@ def _get_dspark_num_mtp_layers(config: PretrainedConfig) -> int:
     if num_layers is None:
         num_layers = getattr(config, "dspark_num_mtp_layers", 3)
     return int(num_layers or 3)
-
-
-class DSparkMarkovHead(nn.Module):
-    def __init__(self, config: PretrainedConfig, prefix: str) -> None:
-        super().__init__()
-
-        # Markov decoding runs serially for every draft position. Keep both
-        # low-rank weights replicated so each step remains communication-free.
-        self.markov_w1 = nn.Embedding(config.vocab_size, config.dspark_markov_rank)
-        self.markov_w2 = ReplicatedLinear(
-            config.dspark_markov_rank,
-            config.vocab_size,
-            bias=False,
-            return_bias=False,
-            prefix=f"{prefix}.markov_w2",
-            disable_tp=True,
-        )
-
-    def embed(self, token_ids: torch.Tensor) -> torch.Tensor:
-        return self.markov_w1(token_ids)
-
-    def bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.markov_w2(markov_embed)
-
-
-class DSparkConfidenceHead(nn.Module):
-    def __init__(self, config: PretrainedConfig, prefix: str) -> None:
-        super().__init__()
-
-        input_dim = config.hidden_size + config.dspark_markov_rank
-
-        self.proj = ReplicatedLinear(
-            input_dim,
-            1,
-            bias=False,
-            return_bias=False,
-            prefix=maybe_prefix(prefix, "proj"),
-        )
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        markov_embed: torch.Tensor,
-    ) -> torch.Tensor:
-        features = torch.cat([hidden_states, markov_embed.to(dtype=hidden_states.dtype)], dim=-1)
-        return self.proj(features).squeeze(-1)
 
 
 class DeepseekV4DSparkModel(nn.Module):
@@ -171,11 +126,35 @@ class DeepseekV4DSparkModel(nn.Module):
 
         self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         last_layer_idx = self.mtp_start_layer_idx + self.num_dspark_layers - 1
+        draft_vocab_size = getattr(config, "draft_vocab_size", None) or config.vocab_size
         self.markov_head = DSparkMarkovHead(
-            config,
-            maybe_prefix(prefix, f"layers.{last_layer_idx}.markov_head"),
+            config.vocab_size,
+            draft_vocab_size,
+            config.dspark_markov_rank,
+            prefix=maybe_prefix(
+                prefix,
+                f"layers.{last_layer_idx}.markov_head",
+            ),
         )
-        self.confidence_head = DSparkConfidenceHead(config, maybe_prefix(prefix, "confidence_head"))
+        self.confidence_head: nn.Module
+        if vllm_version_is("0.27.1"):
+            from vllm_ascend.models.qwen3_dspark import DSparkConfidenceHead as CompatDSparkConfidenceHead
+
+            self.confidence_head = CompatDSparkConfidenceHead(
+                input_dim=config.hidden_size + config.dspark_markov_rank,
+                prefix=maybe_prefix(prefix, "confidence_head"),
+                bias=False,
+                with_markov=True,
+            )
+        else:
+            from vllm.model_executor.models.qwen3_dspark import DSparkConfidenceHead
+
+            self.confidence_head = DSparkConfidenceHead(
+                input_dim=config.hidden_size + config.dspark_markov_rank,
+                prefix=maybe_prefix(prefix, "confidence_head"),
+                bias=False,
+                with_markov=True,
+            )
         hc_dim = self.hc_mult * config.hidden_size
         self.hc_head_fn = nn.Parameter(
             torch.empty(self.hc_mult, hc_dim, dtype=torch.float32),
@@ -306,8 +285,8 @@ class DeepseekV4DSparkModel(nn.Module):
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_head.embed(token_ids)
 
-    def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.markov_head.bias(markov_embed)
+    def markov_bias(self, markov_embed: torch.Tensor, logits_processor: LogitsProcessor) -> torch.Tensor:
+        return self.markov_head.bias(markov_embed, logits_processor)
 
     def compute_logits(
         self,
@@ -405,7 +384,7 @@ class DSparkDeepseekV4ForCausalLM(nn.Module, DeepseekV2MixtureOfExperts, Support
         return self.model.markov_embed(token_ids)
 
     def markov_bias(self, markov_embed: torch.Tensor) -> torch.Tensor:
-        return self.model.markov_bias(markov_embed)
+        return self.model.markov_bias(markov_embed, self.logits_processor)
 
     def compute_confidence(self, head_hidden: torch.Tensor, markov_embed: torch.Tensor) -> torch.Tensor:
         """Per-position acceptance probability for each drafted token."""

--- a/vllm_ascend/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/ops/vocab_parallel_embedding.py
@@ -20,7 +20,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.nn.parameter import Parameter
-from vllm.distributed import divide
+from vllm.distributed import divide, get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import (
@@ -72,19 +72,19 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
 
         elif lmhead_tp_enable() and "head" in prefix:
             self.comm_group = get_lmhead_tp_group()
-            self.tp_size = self.comm_group.world_size
-            self.tp_rank = self.comm_group.rank_in_group
+            self.tp_size = get_tensor_model_parallel_world_size()
+            self.tp_rank = get_tensor_model_parallel_rank()
 
         elif embedding_tp_enable() and "embed_tokens" in prefix:
             self.comm_group = get_embed_tp_group()
             self.forward_type = "embed_tp"
-            self.tp_size = self.comm_group.world_size
-            self.tp_rank = self.comm_group.rank_in_group
+            self.tp_size = get_tensor_model_parallel_world_size()
+            self.tp_rank = get_tensor_model_parallel_rank()
 
         else:
             self.comm_group = get_tp_group()
-            self.tp_size = self.comm_group.world_size
-            self.tp_rank = self.comm_group.rank_in_group
+            self.tp_size = get_tensor_model_parallel_world_size()
+            self.tp_rank = get_tensor_model_parallel_rank()
 
         self.num_embeddings = num_embeddings
         self.padding_size = padding_size

--- a/vllm_ascend/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/ops/vocab_parallel_embedding.py
@@ -58,19 +58,33 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
         padding_size: int = DEFAULT_VOCAB_PADDING_SIZE,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        *,
+        disable_tp: bool = False,
     ):
         nn.Module.__init__(self)
         self.forward_type = None
-        if lmhead_tp_enable() and "head" in prefix:
+        self.disable_tp = disable_tp
+
+        if disable_tp:
+            self.comm_group = None
+            self.tp_size = 1
+            self.tp_rank = 0
+
+        elif lmhead_tp_enable() and "head" in prefix:
             self.comm_group = get_lmhead_tp_group()
+            self.tp_size = self.comm_group.world_size
+            self.tp_rank = self.comm_group.rank_in_group
+
         elif embedding_tp_enable() and "embed_tokens" in prefix:
             self.comm_group = get_embed_tp_group()
             self.forward_type = "embed_tp"
+            self.tp_size = self.comm_group.world_size
+            self.tp_rank = self.comm_group.rank_in_group
+
         else:
             self.comm_group = get_tp_group()
-
-        self.tp_size = self.comm_group.world_size
-        self.tp_rank = self.comm_group.rank_in_group
+            self.tp_size = self.comm_group.world_size
+            self.tp_rank = self.comm_group.rank_in_group
 
         self.num_embeddings = num_embeddings
         self.padding_size = padding_size
@@ -134,6 +148,8 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
             weight_loader=self.weight_loader,
         )
 
+        self.update_param_tp_status()
+
     def _mask_input_for_vocab_range(
         self,
         input_: torch.Tensor,
@@ -164,10 +180,10 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
     def forward(self, input_):
         if self.forward_type == "embed_tp":
             return self._forward_embed_tp(input_)
-        else:
-            return self._forward_origin(input_)
+        return self._forward_origin(input_)
 
     def _forward_embed_tp(self, input_):
+        assert self.comm_group is not None
         num_tokens = input_.shape[0]
 
         # potential_max_tokens is computed once in the model runner __init__, so
@@ -244,6 +260,9 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
         # Mask the output embedding.
         if self.tp_size > 1:
             output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
+        else:
+            return output_parallel
+
         # Reduce across all the model parallel GPUs.
         tp_group = get_tp_group()
         if tp_group.world_size == 1:
@@ -261,7 +280,7 @@ class AscendParallelLMHead(ParallelLMHead):
     """
     Register ParallelLMHead as a custom op for Ascend."""
 
-    def __init__(  # type: ignore[misc]
+    def __init__(
         self,
         num_embeddings: int,
         embedding_dim: int,
@@ -274,8 +293,6 @@ class AscendParallelLMHead(ParallelLMHead):
         *,
         disable_tp: bool = False,
     ):
-        self.disable_tp = disable_tp
-
         AscendVocabParallelEmbedding.__init__(
             self,
             num_embeddings,
@@ -285,8 +302,8 @@ class AscendParallelLMHead(ParallelLMHead):
             padding_size,
             quant_config,
             prefix,
+            disable_tp=disable_tp,
         )
-
         self.quant_config = quant_config
         if bias:
             self.bias = Parameter(torch.empty(self.num_embeddings_per_partition, dtype=params_dtype))
@@ -365,11 +382,12 @@ class AscendLogitsProcessor(LogitsProcessor):
         embedding_bias: torch.Tensor | None = None,
         skip_gather: bool = False,
     ) -> torch.Tensor | None:
+
         # vLLM #50465 added skip_gather; when set, upstream returns the
         # untruncated apply_head result for spec-decode/top-k callers.
         if skip_gather:
             return self._apply_head(lm_head, hidden_states, embedding_bias)
-        if lmhead_tp_enable():
+        if lmhead_tp_enable() and not lm_head.disable_tp:
             return self._get_logits_lmheadtp(hidden_states, lm_head, embedding_bias)
         else:
             return self._get_logits_normal(hidden_states, lm_head, embedding_bias)
@@ -403,7 +421,7 @@ class AscendLogitsProcessor(LogitsProcessor):
     ) -> torch.Tensor | None:
         logits = self._apply_head(lm_head, hidden_states, embedding_bias)
         # Gather logits for tensor parallel
-        if not get_ascend_config().enable_reduce_sample:
+        if not get_ascend_config().enable_reduce_sample and lm_head.tp_size > 1:
             logits = self._gather_logits(logits)
 
         # Remove paddings in vocab (if any)

--- a/vllm_ascend/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/ops/vocab_parallel_embedding.py
@@ -20,7 +20,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 from torch.nn.parameter import Parameter
-from vllm.distributed import divide, get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+from vllm.distributed import divide
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization.base_config import (
@@ -67,24 +67,20 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
 
         if disable_tp:
             self.comm_group = None
-            self.tp_size = 1
-            self.tp_rank = 0
-
         elif lmhead_tp_enable() and "head" in prefix:
             self.comm_group = get_lmhead_tp_group()
-            self.tp_size = get_tensor_model_parallel_world_size()
-            self.tp_rank = get_tensor_model_parallel_rank()
-
         elif embedding_tp_enable() and "embed_tokens" in prefix:
             self.comm_group = get_embed_tp_group()
             self.forward_type = "embed_tp"
-            self.tp_size = get_tensor_model_parallel_world_size()
-            self.tp_rank = get_tensor_model_parallel_rank()
-
         else:
             self.comm_group = get_tp_group()
-            self.tp_size = get_tensor_model_parallel_world_size()
-            self.tp_rank = get_tensor_model_parallel_rank()
+
+        if self.comm_group:
+            self.tp_size = self.comm_group.world_size
+            self.tp_rank = self.comm_group.rank_in_group
+        else:
+            self.tp_size = 1
+            self.tp_rank = 0
 
         self.num_embeddings = num_embeddings
         self.padding_size = padding_size
@@ -382,7 +378,6 @@ class AscendLogitsProcessor(LogitsProcessor):
         embedding_bias: torch.Tensor | None = None,
         skip_gather: bool = False,
     ) -> torch.Tensor | None:
-
         # vLLM #50465 added skip_gather; when set, upstream returns the
         # untruncated apply_head result for spec-decode/top-k callers.
         if skip_gather:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR ports the optimization from [vLLM #49731](https://github.com/vllm-project/vllm/pull/49731) to vLLM-Ascend.

The main idea is to **replicate the lightweight DSpark Markov head computation on each TP rank instead of sharding it across ranks**, reducing the communication overhead in the Markov head path.

I tested this change on **8 x Ascend 910B**, using **DeepSeek-V4-Flash-DSpark-w4a8-test** with **TP=8**.

In a random benchmark with 500 requests, the output token throughput improved from **175.11 tok/s** to **178.70 tok/s**, which is about **+2.05%**. The speculative decoding acceptance rate was slightly lower in this run.

I also collected MindStudio profiles before and after the change. The Markov head path shows a clear latency reduction after removing the related TP communication.

---

## Related PRs

### vLLM #49731

[vLLM #49731](https://github.com/vllm-project/vllm/pull/49731) is the upstream PR that this PR mainly follows.

It replicates the DSpark Markov embedding and projection across TP ranks, avoiding an all-reduce and a full-vocabulary gather for every draft position.

The upstream benchmark reported:

- TP=2: **+3.3%**
- TP=4: **+3.8%**

### vLLM-Ascend #13358

[vLLM-Ascend #13358](https://github.com/vllm-project/vllm-ascend/pull/13358) synced the upstream `disable_tp` interface into vLLM-Ascend.

However, it mainly provides compatibility with the upstream interface. The DSpark Markov head itself is still not switched to the replicated implementation, so the optimization from vLLM #49731 is not actually enabled on Ascend.

### vLLM-Ascend #13724

[vLLM-Ascend #13724](https://github.com/vllm-project/vllm-ascend/pull/13724) also tries to reduce communication overhead in the DSpark Markov head, but takes a different approach.

#13724 keeps the Markov head vocabulary sharded across TP ranks. `compute_logits` and `markov_bias` operate on local vocabulary logits, and `greedy_sample` reduces the local top-1 results across TP ranks.

This PR instead follows the upstream #49731 approach: since the Markov head itself is relatively lightweight, its computation is replicated on each TP rank to directly avoid the corresponding TP communication.

Both approaches aim to reduce communication overhead, but from different directions.

---

## Why this optimization helps

The Markov head computation is relatively lightweight compared with the main model forward.

For this kind of small computation, the benefit of tensor parallelism can be smaller than the communication overhead introduced by tensor parallelism itself.

For the DSpark Markov head, TP sharding introduces communication repeatedly during draft token generation. Since multiple speculative tokens are generated sequentially, this communication is repeated for every draft position.

Because the Markov head is small, using a small amount of additional computation and memory on every TP rank to remove these communication operations is a reasonable trade-off.

In short:

> A small amount of redundant computation and memory is exchanged for less TP communication.

This is also the basic motivation behind upstream vLLM #49731.

---

## Benchmark

### Environment

- Hardware: **8 x Ascend 910B**
- Model: **DeepSeek-V4-Flash-DSpark-w4a8-test**
- Tensor Parallel Size: **8**
- Data Parallel Size: **1**
- Speculative decoding method: **DSpark**
- Number of speculative tokens: **7**
- Draft sampling: **greedy**
- Benchmark: random benchmark
- Number of prompts: **500**
- Max concurrency: **6**
- Warmup: one relatively long request before the benchmark

### Server command

```bash
export OMP_NUM_THREADS=10
export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
export HCCL_BUFFSIZE=1024
export TASK_QUEUE_ENABLE=1
export HCCL_OP_EXPANSION_MODE="AIV"

vllm serve /data/models/DeepSeek-V4-Flash-DSpark-w4a8-test/ \
    --max-num-batched-tokens 16384 \
    --max-model-len 262144 \
    --served-model-name illm \
    --gpu-memory-utilization 0.92 \
    --max-num-seqs 10 \
    --data-parallel-size 1 \
    --tensor-parallel-size 8 \
    --enable-expert-parallel \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --enable-auto-tool-choice \
    --reasoning-parser deepseek_v4 \
    --model-loader-extra-config='{"enable_multithread_load": true, "num_threads": 128}' \
    --quantization ascend \
    --port 8080 \
    --host 0.0.0.0 \
    --block-size 32 \
    --cudagraph-metrics \
    --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
    --speculative-config '{"num_speculative_tokens": 7, "method": "dspark", "enforce_eager": true, "draft_sample_method": "greedy"}' \
    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
```

### Result summary

| Version | TP | Output token throughput (tok/s) | Improvement |
| --- | ---: | ---: | ---: |
| Before | 8 | 175.11 | - |
| After | 8 | 178.70 | **+2.05%** |

The random benchmark has relatively large randomness in speculative decoding acceptance rate, so the acceptance rate from this workload should not be treated as a very meaningful model-quality metric.

In this test, the acceptance rate changed from **19.19%** to **18.75%**, while output token throughput increased by **2.05%**.

This means the throughput improvement was still observed even with a slightly lower speculative acceptance rate in this run.

For reference, upstream vLLM #49731 reported **+3.3% with TP=2** and **+3.8% with TP=4** on its Qwen3-14B DSpark benchmark.

### Raw result before

```text
============ Serving Benchmark Result ============
Successful requests:                     500
Failed requests:                         0
Maximum request concurrency:             6
Benchmark duration (s):                  999.38
Total input tokens:                      25002000
Total generated tokens:                  175000
Request throughput (req/s):              0.50
Output token throughput (tok/s):         175.11
Peak output token throughput (tok/s):    133.00
Peak concurrent requests:                9.00
Total token throughput (tok/s):          25192.64

---------------Time to First Token----------------
Mean TTFT (ms):                          1585.20
Median TTFT (ms):                        1185.48
P50 TTFT (ms):                           1185.48
P95 TTFT (ms):                           2309.79
P99 TTFT (ms):                           14904.88

-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.53
Median TPOT (ms):                        28.78
P50 TPOT (ms):                           28.78
P95 TPOT (ms):                           51.83
P99 TPOT (ms):                           62.69

---------------Inter-token Latency----------------
Mean ITL (ms):                           69.65
Median ITL (ms):                         49.99
P50 ITL (ms):                            49.99
P95 ITL (ms):                            61.53
P99 ITL (ms):                            708.67

----------------End-to-end Latency----------------
Mean E2EL (ms):                          11890.94
Median E2EL (ms):                        11389.11
P50 E2EL (ms):                           11389.11
P95 E2EL (ms):                           19433.92
P99 E2EL (ms):                           34241.37

---------------Speculative Decoding---------------
Acceptance rate (%):                     19.19
Acceptance length:                       2.34
Drafts:                                  74844
Draft tokens:                            523908
Accepted tokens:                         100514

Per-position acceptance (%):
  Position 0:                            51.73
  Position 1:                            29.62
  Position 2:                            19.78
  Position 3:                            12.91
  Position 4:                            9.33
  Position 5:                            6.53
  Position 6:                            4.40

==================================================
```

### Raw result after

```text
============ Serving Benchmark Result ============
Successful requests:                     500
Failed requests:                         0
Maximum request concurrency:             6
Benchmark duration (s):                  979.28
Total input tokens:                      25002000
Total generated tokens:                  175000
Request throughput (req/s):              0.51
Output token throughput (tok/s):         178.70
Peak output token throughput (tok/s):    130.00
Peak concurrent requests:                10.00
Total token throughput (tok/s):          25709.67

---------------Time to First Token----------------
Mean TTFT (ms):                          1394.94
Median TTFT (ms):                        1173.95
P50 TTFT (ms):                           1173.95
P95 TTFT (ms):                           2160.12
P99 TTFT (ms):                           8670.11

-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          29.53
Median TPOT (ms):                        28.79
P50 TPOT (ms):                           28.79
P95 TPOT (ms):                           52.87
P99 TPOT (ms):                           66.75

---------------Inter-token Latency----------------
Mean ITL (ms):                           68.81
Median ITL (ms):                         50.32
P50 ITL (ms):                            50.32
P95 ITL (ms):                            62.19
P99 ITL (ms):                            713.37

----------------End-to-end Latency----------------
Mean E2EL (ms):                          11701.42
Median E2EL (ms):                        11469.16
P50 E2EL (ms):                           11469.16
P95 E2EL (ms):                           20019.70
P99 E2EL (ms):                           24464.25

---------------Speculative Decoding---------------
Acceptance rate (%):                     18.75
Acceptance length:                       2.31
Drafts:                                  75814
Draft tokens:                            530698
Accepted tokens:                         99523

Per-position acceptance (%):
  Position 0:                            50.97
  Position 1:                            29.14
  Position 2:                            19.32
  Position 3:                            12.49
  Position 4:                            9.02
  Position 5:                            6.18
  Position 6:                            4.16

==================================================
```

---

## MindStudio Profile

I collected MindStudio profiles with the same configuration before and after this change.

The profile comparison shows a clear reduction in the time spent on the Markov head path after removing the corresponding TP communication.

### Before

![Markov head profile before optimization](https://github.com/user-attachments/assets/7a6fa551-0ea9-4c4f-a81e-c901e9c850bc)

### After

![Markov head profile after optimization](https://github.com/user-attachments/assets/1e460624-b5c1-4915-99c7-3c81c8e1a7e8)

---

### Does this PR introduce _any_ user-facing change?

No.

This PR only changes the internal DSpark Markov head execution strategy to reduce TP communication. The DSpark user-facing configuration and behavior remain unchanged.

---

### How was this patch tested?

Performance testing:

- 8 x Ascend 910B
- DeepSeek-V4-Flash-DSpark-w4a8-test
- TP=8
- DP=1
- DSpark with 7 speculative tokens
- Random benchmark with 500 prompts
- Max concurrency=6
- Long request warmup before benchmark

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
