### PR TITLE
[Performance][KDA] Fuse Kimi K3 QKV projections into one quantized linear

### DIFF
--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -28,11 +28,40 @@ from vllm_ascend.transformers_utils.configs.kimi_k3 import (
 
 
 def test_kimi_k3_model_declares_checkpoint_packing_contract():
+    assert AscendKimiK3ForCausalLM.packed_modules_mapping["fused_qkv"] == [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+    ]
     assert AscendKimiK3ForCausalLM.packed_modules_mapping["experts"] == [
         "experts.0.w1",
         "experts.0.w3",
         "experts.0.w2",
     ]
+
+
+def test_kimi_k3_loads_qkv_checkpoint_shards_into_fused_linear():
+    model = KimiK3TextModel.__new__(KimiK3TextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(num_experts=0)
+    model.layers = nn.ModuleList([nn.Module()])
+    model.layers[0].self_attn = nn.Module()
+    model.layers[0].self_attn.fused_qkv = nn.Module()
+
+    fused_weight = nn.Parameter(torch.empty(1))
+    fused_weight.weight_loader = MagicMock()
+    model.layers[0].self_attn.fused_qkv.register_parameter("weight", fused_weight)
+    weights = [(f"layers.0.self_attn.{name}.weight", torch.empty(1)) for name in ("q_proj", "k_proj", "v_proj")]
+
+    with (
+        patch("vllm_ascend.models.kimi_k3.get_spec_layer_idx_from_weight_name", return_value=None),
+        patch("vllm_ascend.models.kimi_k3.fused_moe_make_expert_params_mapping", return_value=[]),
+        patch("vllm_ascend.models.kimi_k3.is_pp_missing_parameter", return_value=False),
+    ):
+        loaded = model.load_weights(weights)
+
+    assert [call.args[2] for call in fused_weight.weight_loader.call_args_list] == ["q", "k", "v"]
+    assert loaded == {"layers.0.self_attn.fused_qkv.weight"}
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -1154,6 +1154,9 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
         weights: Iterable[tuple[str, torch.Tensor] | tuple[str, torch.Tensor, dict[str, Any]]],
     ) -> set[str]:
         stacked_params_mapping = [
+            (".fused_qkv", ".q_proj", "q"),
+            (".fused_qkv", ".k_proj", "k"),
+            (".fused_qkv", ".v_proj", "v"),
             (".gate_up_proj", ".gate_proj", 0),
             (".gate_up_proj", ".up_proj", 1),
             (".fused_qkv_a_proj", ".q_a_proj", 0),
@@ -1223,6 +1226,7 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
 
 class AscendKimiK3ForCausalLM(nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid):
     packed_modules_mapping = {
+        "fused_qkv": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
         "experts": ["experts.0.w1", "experts.0.w3", "experts.0.w2"],
         "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -34,7 +34,7 @@ try:
     from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd  # type: ignore[import-not-found]
 except ModuleNotFoundError:
     from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
-from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear, QKVParallelLinear
 from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
     KimiGatedDeltaNetAttention,
 )
@@ -52,6 +52,7 @@ from vllm_ascend.utils import is_vl_model, parse_layer_idx
 
 _KDA_CHUNK_SIZE = 64
 _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
+_FUSED_QKV_NAME = "fused_qkv"
 
 
 def _zero_padded_spec_output(
@@ -156,6 +157,23 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         gate_lower_bound = kda_config.get("gate_lower_bound")
         self.gate_lower_bound = float(gate_lower_bound) if gate_lower_bound is not None else None
 
+        # KDA uses the same hidden states and TP head layout for Q, K, and V.
+        # Pack their checkpoint shards into one standard QKV linear so MXFP8
+        # performs one dynamic quantization and one quantized matmul.
+        fused_qkv = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.num_heads,
+            self.num_heads,
+            bias=False,
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.{_FUSED_QKV_NAME}",
+        )
+        del self.q_proj
+        del self.k_proj
+        del self.v_proj
+        self.fused_qkv = fused_qkv
+
         self.A_log.weight_loader = partial(
             _load_a_log,
             num_heads=self.num_heads,
@@ -221,18 +239,19 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
     ) -> None:
         del positions
         # KDA metadata and its recurrent state describe the complete sequence.
-        # Unlike Qwen GDN, Kimi's independent q/k/v/g projections do not match
-        # SequenceColumnParallelOp's prefix whitelist.  Gather the token shard
-        # once before all projections instead of gathering for every linear.
+        # KDA's gate projections do not match SequenceColumnParallelOp's prefix
+        # whitelist, so gather the token shard once before every projection.
+        # The fused module deliberately uses the ``fused_qkv`` prefix instead
+        # of ``qkv_proj`` to avoid a second automatic gather inside the linear.
         # The multimodal first layer is already full-sized and must not gather.
         hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
             hidden_states.contiguous(),
             not self.is_vl_first_layer,
         )
         num_tokens = hidden_states.size(0)
-        q = self.q_proj(hidden_states)[0]
-        k = self.k_proj(hidden_states)[0]
-        v = self.v_proj(hidden_states)[0]
+        qkv = self.fused_qkv(hidden_states)[0]
+        projection_size = self.local_num_heads * self.head_dim
+        q, k, v = qkv.split([projection_size] * 3, dim=-1)
 
         beta = self.b_proj(hidden_states)[0].float().sigmoid().unsqueeze(0)
         raw_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]


### PR DESCRIPTION
### What this PR does / why we need it

Kimi K3 KDA applies `q_proj`, `k_proj`, and `v_proj` to the same `hidden_states`. Under `W8A8_MXFP8`, the three independent linears execute three dynamic quantizations and three quantized matmuls.

This PR isolates the fused QKV optimization from #13727 into a focused change:

- replaces the independent KDA Q/K/V projections with the standard `QKVParallelLinear`;
- packs the existing `q_proj` / `k_proj` / `v_proj` checkpoint shards through the standard QKV weight loader;
- executes one fused QKV linear and splits its output back into Q, K, and V;
- preserves KDA's existing tensor-parallel head layout and sequence-parallel gather behavior.

For the MXFP8 path, the Q/K/V operator sequence is reduced from **3 DynamicMxQuant + 3 QuantMatmul** to **1 DynamicMxQuant + 1 QuantMatmul**.

This PR intentionally excludes the MLA head-padding and A5 MoE communication-selection changes that remain in #13727.

### Does this PR introduce any user-facing change?

No API or configuration change. This is a Kimi K3 KDA performance optimization.

### How was this patch tested?

- Added unit coverage for the model packing contract.
- Added unit coverage for loading the existing Q/K/V checkpoint shards into the fused parameter.
- The original isolated change was validated with:

  ```bash
  pytest -q tests/ut/ops/test_kimi_kda.py tests/ut/models/test_kimi_k3.py tests/ut/quantization/methods/test_w8a8_mxfp8.py
  ```

  Result: **50 passed** on the Ascend A5 feature environment.

- Ruff check, format check, and `git diff --check` passed for the changed files.

### Change scope

- 1 commit
- 3 changed files
- Base: `releases/v0.26.0rc`

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
