### PR TITLE
[v0.26.0rc][BugFix][Frontend] Support DeepSeek V4 0731 reasoning effort

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
-from vllm.tokenizers import deepseek_v4
+from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
 
 class FakeTokenizer:
@@ -51,7 +52,34 @@ def test_reasoning_effort_enables_thinking_unless_user_overrides():
     assert params.chat_template_kwargs["enable_thinking"] is False
 
 
-def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
+@pytest.mark.parametrize(
+    ("kwargs", "expected_mode", "expected_effort"),
+    [
+        ({}, "thinking", "high"),
+        ({"enable_thinking": True}, "thinking", "high"),
+        ({"enable_thinking": False}, "chat", None),
+        ({"thinking": False}, "chat", None),
+        ({"reasoning_effort": "none"}, "chat", None),
+        ({"reasoning_effort": "minimal"}, "thinking", "low"),
+        ({"reasoning_effort": "low"}, "thinking", "low"),
+        ({"reasoning_effort": "medium"}, "thinking", "low"),
+        ({"reasoning_effort": "high"}, "thinking", "high"),
+        ({"reasoning_effort": "xhigh"}, "thinking", "high"),
+        ({"reasoning_effort": "max"}, "thinking", "max"),
+        ({"reasoning_effort": "unexpected"}, "thinking", "high"),
+        (
+            {"enable_thinking": False, "reasoning_effort": "max"},
+            "chat",
+            "max",
+        ),
+    ],
+)
+def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(
+    monkeypatch,
+    kwargs,
+    expected_mode,
+    expected_effort,
+):
     captured_kwargs = []
 
     def fake_encode_messages(messages, **kwargs):
@@ -61,22 +89,80 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(monkeypatch):
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
 
-    cases = [
-        ("none", "chat", None),
-        ("minimal", "thinking", "high"),
-        ("low", "thinking", "high"),
-        ("medium", "thinking", "high"),
-        ("high", "thinking", "high"),
-        ("xhigh", "thinking", "max"),
-        ("max", "thinking", "max"),
-        ("unexpected", "thinking", "high"),
-    ]
-    for reasoning_effort, expected_mode, expected_effort in cases:
-        tokenizer.apply_chat_template(
+    tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+    assert captured_kwargs[-1]["thinking_mode"] == expected_mode
+    assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+
+
+def test_deepseek_v4_defaults_to_thinking_with_high_effort():
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+    )
+
+    assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum")
+    assert prompt.endswith("<｜Assistant｜><think>")
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"reasoning_effort": "none"},
+        {"enable_thinking": False, "reasoning_effort": "max"},
+    ],
+)
+def test_deepseek_v4_explicit_disable_overrides_reasoning_effort(kwargs):
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+
+    assert prompt == ("<｜begin▁of▁sentence｜><｜User｜>hi<｜Assistant｜></think>")
+
+
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_prefix"),
+    [
+        ("low", "<\uff5cbegin\u2581of\u2581sentence\uff5c><\uff5cUser\uff5c>hi"),
+        (
+            "high",
+            "<\uff5cbegin\u2581of\u2581sentence\uff5c>Reasoning Effort: Absolute maximum with no shortcuts permitted.",
+        ),
+        (
+            "max",
+            "<\uff5cbegin\u2581of\u2581sentence\uff5c>Reasoning Effort: "
+            "Beyond maximum \u2014 exhaustive, relentless, and uncompromising.",
+        ),
+    ],
+)
+def test_deepseek_v4_renders_0731_reasoning_effort_prompts(
+    reasoning_effort,
+    expected_prefix,
+):
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        enable_thinking=True,
+        reasoning_effort=reasoning_effort,
+    )
+
+    assert prompt.startswith(expected_prefix)
+    assert prompt.endswith("<\uff5cAssistant\uff5c><think>")
+
+
+def test_deepseek_v4_rejects_invalid_renderer_reasoning_effort():
+    with pytest.raises(ValueError, match="Invalid reasoning effort: unexpected"):
+        deepseek_v4_encoding.render_message(
+            0,
             [{"role": "user", "content": "hi"}],
-            tokenize=False,
-            enable_thinking=True,
-            reasoning_effort=reasoning_effort,
+            thinking_mode="thinking",
+            reasoning_effort="unexpected",
         )
-        assert captured_kwargs[-1]["thinking_mode"] == expected_mode
-        assert captured_kwargs[-1]["reasoning_effort"] == expected_effort

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -67,7 +67,26 @@
 #       Remove this patch if upstream exposes a platform allocator capability hook
 #       for sleep mode validation.
 #
-# ** 3. File: platform/patch_distributed.py**
+# ** 3. File: platform/patch_deepseek_v4_thinking.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.tokenizers.deepseek_v4.get_deepseek_v4_tokenizer`
+#      `vllm.tokenizers.deepseek_v4_encoding.render_message`
+#    Why:
+#       DeepSeek-V4-Flash-0731 defines three reasoning effort levels: low has
+#       no prompt prefix, high uses the original "Absolute maximum" prefix,
+#       and max uses the new "Beyond maximum" prefix. The supported vLLM
+#       Python tokenizer predates this 0731 prompt mapping.
+#    How:
+#       Monkey-patch tokenizer normalization so omitted options select
+#       thinking with high effort and compatibility aliases map to canonical
+#       low, high, or max. Wrap render_message to prepend the official 0731
+#       prompt before the first message in thinking mode.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/50580
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #50580.
+#
+# ** 4. File: platform/patch_distributed.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.distributed.all_reduce`, `torch.distributed.broadcast`
 #    Why:
@@ -79,7 +98,7 @@
 #    Future Plan:
 #       Find a better way to support tensor alignment for 310p without this patch.
 #
-# ** 4. File: platform/patch_dp_device_ids.py**
+# ** 5. File: platform/patch_dp_device_ids.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.dp_utils.get_physical_gpu_ids_for_local_dp_rank`
 #    Why:
@@ -103,7 +122,7 @@
 #       handles a pre-sharded visible-devices env var, or vLLM-Ascend stops
 #       relying on application-level device slicing for DP.
 #
-# ** 5. File: platform/patch_fused_moe.py**
+# ** 6. File: platform/patch_fused_moe.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.layers.fused_moe.FusedMoE`
 #    Why:
@@ -139,7 +158,7 @@
 #    Future Plan:
 #       Remove this patch once both upstream fixes are in the supported vLLM.
 #
-# ** 6. File: platform/patch_kv_cache_coordinator.py**
+# ** 7. File: platform/patch_kv_cache_coordinator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_coordinator.HybridKVCacheCoordinator.find_longest_cache_hit_per_group`
 #    Why:
@@ -163,7 +182,7 @@
 #       Remove this patch when vLLM PR #42524 and #44243 is included in the supported
 #       upstream vLLM version.
 #
-# ** 7. File: platform/patch_kv_cache_utils.py**
+# ** 8. File: platform/patch_kv_cache_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
 #      `vllm.v1.engine.core.resolve_kv_cache_block_sizes`
@@ -182,7 +201,7 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
-# ** 8. File: platform/patch_mamba_config.py**
+# ** 9. File: platform/patch_mamba_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -194,7 +213,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM merges the PR.
 #
-# ** 9. File: platform/patch_mamba_config_310.py**
+# ** 10. File: platform/patch_mamba_config_310.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
 #    Why:
@@ -211,7 +230,7 @@
 #    Future Plan:
 #       Remove this patch once upstream supports 310P-aligned mamba block sizing.
 #
-# ** 10. File: platform/patch_mamba_manager.py**
+# ** 11. File: platform/patch_mamba_manager.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.single_type_kv_cache_manager.MambaManager`
 #    Why:
@@ -231,7 +250,7 @@
 #          hybrid prefix cache lookup for DCP.
 #       2. Remove this patch once upstream accept 46892 pr or fixed the bug by other pr.
 #
-# ** 11. File: platform/patch_media_connector.py**
+# ** 12. File: platform/patch_media_connector.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.multimodal.media.connector.MediaConnector`
 #      `vllm.multimodal.media.image.ImageMediaIO`
@@ -248,7 +267,7 @@
 #    Future Plan:
 #       Remove this patch when all supported vLLM releases contain PR #49159.
 #
-# ** 12. File: platform/patch_minimax_m2_config.py**
+# ** 13. File: platform/patch_minimax_m2_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.ModelConfig._verify_quantization`
 #    Why:
@@ -309,7 +328,7 @@
 #       Drop the alias once upstream registry includes it or the checkpoint
 #       standardizes architecture strings.
 #
-# ** 13. File: platform/patch_mla_prefill_backend.py**
+# ** 14. File: platform/patch_mla_prefill_backend.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.attention.backends.mla.common.get_mla_prefill_backend`
 #    Why:
@@ -331,7 +350,7 @@
 #       platform/device hook so Ascend can be selected (or skipped) without
 #       monkey-patching.
 #
-# ** 14. File: platform/patch_multiproc_executor.py**
+# ** 15. File: platform/patch_multiproc_executor.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.executor.multiproc_executor.MultiprocExecutor`
 #    Why:
@@ -344,7 +363,7 @@
 #    Future Plan:
 #       Remove this patch when vLLM fix the issue.
 #
-# ** 15. File: platform/patch_pp_mtp.py**
+# ** 16. File: platform/patch_pp_mtp.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.outputs.ModelRunnerOutput`
 #    Why:
@@ -434,7 +453,7 @@
 #       supports local drafter models with PP > 1, or moves the PP validation to a
 #       separate hook that can be overridden per-model-type.
 #
-# ** 16. File: platform/patch_profiling_chunk.py**
+# ** 17. File: platform/patch_profiling_chunk.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCore.__init__`
 #   2. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
@@ -462,7 +481,7 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
-# ** 17. File: platform/patch_speculative_config.py**
+# ** 18. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`
 #    Why:
@@ -485,7 +504,7 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
-# ** 18. File: platform/patch_structured_output.py**
+# ** 19. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
@@ -507,7 +526,7 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
-# ** 19. File: platform/patch_torch_accelerator.py**
+# ** 20. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,
 #      `torch.accelerator.reset_peak_memory_stats`, `torch.accelerator.get_memory_info`,
@@ -527,7 +546,7 @@
 #       Remove this patch once `torch.accelerator` correctly routes to the NPU
 #       backend for these memory APIs.
 #
-# ** 20. File: platform/patch_tool_choice_none_content.py**
+# ** 21. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
 #      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
@@ -543,7 +562,7 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #44105.
 #
-# ** 21. File: platform/patch_use_v2_model_runner.py**
+# ** 22. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
 #    Why:
@@ -568,7 +587,7 @@
 #       (model architecture, Triton, feature checks) without crashes or
 #       degraded functionality.
 #
-# ** 22. File: platform/patch_weight_transfer_engine.py**
+# ** 23. File: platform/patch_weight_transfer_engine.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.distributed.weight_transfer.factory.WeightTransferEngineFactory._registry["nccl"]`
 #    Why:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -17,6 +17,7 @@
 import os
 
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_glm_reasoning_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_kimi_k3_parsers  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -1,0 +1,137 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
+from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
+
+REASONING_EFFORT_PROMPTS = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively "
+        "decompose the problem to resolve the root cause, rigorously "
+        "stress-testing your logic against all potential paths, edge cases, "
+        "and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting "
+        "every intermediate step, considered alternative, and rejected "
+        "hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum \u2014 exhaustive, relentless, and "
+        "uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely "
+        "nothing to chance: exhaustively decompose the problem into its most "
+        "fundamental components, trace every causal chain to its root, and "
+        "resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the "
+        "solution from multiple angles and are certain that no assumption "
+        "remains unchecked and no error remains undiscovered.\n\n"
+    ),
+}
+DEFAULT_REASONING_EFFORT = "low"
+
+_original_render_message = deepseek_v4_encoding.render_message
+_original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
+
+
+def _patched_render_message(
+    index: int,
+    messages: list[dict[str, Any]],
+    thinking_mode: str,
+    drop_thinking: bool = True,
+    reasoning_effort: str | None = None,
+) -> str:
+    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
+    if reasoning_effort not in REASONING_EFFORT_PROMPTS:
+        raise ValueError(
+            f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
+        )
+
+    prompt = _original_render_message(
+        index,
+        messages,
+        thinking_mode,
+        drop_thinking,
+        reasoning_effort="high",
+    )
+    if index == 0 and thinking_mode == "thinking":
+        return REASONING_EFFORT_PROMPTS[reasoning_effort] + prompt
+    return prompt
+
+
+def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
+    dsv4_tokenizer = _original_get_deepseek_v4_tokenizer(tokenizer)
+    tokenizer_cls = type(dsv4_tokenizer)
+
+    def apply_chat_template(
+        self,
+        messages: list[ChatCompletionMessageParam],
+        tools: list[dict[str, Any]] | None = None,
+        **kwargs,
+    ) -> str | list[int]:
+        thinking = kwargs.get("thinking")
+        enable_thinking = kwargs.get("enable_thinking")
+        thinking_enabled = bool(thinking) or bool(enable_thinking)
+        if "thinking" not in kwargs and "enable_thinking" not in kwargs:
+            thinking_enabled = True
+        thinking_mode = "thinking" if thinking_enabled else "chat"
+
+        conversation = kwargs.get("conversation", messages)
+        messages = conversation.copy()
+        if tools is not None and len(tools) > 0:
+            messages.insert(0, {"role": "system"})
+            messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+
+        reasoning_effort = kwargs.get("reasoning_effort")
+        if not isinstance(reasoning_effort, str):
+            reasoning_effort = "high" if thinking_enabled else None
+        elif reasoning_effort == "none":
+            thinking_mode = "chat"
+            reasoning_effort = None
+        elif reasoning_effort == "max":
+            reasoning_effort = "max"
+        elif reasoning_effort in ("low", "minimal", "medium"):
+            reasoning_effort = "low"
+        else:
+            reasoning_effort = "high"
+
+        prompt_str = deepseek_v4.encode_messages(
+            messages,
+            thinking_mode=thinking_mode,
+            drop_thinking=kwargs.get("drop_thinking", True),
+            reasoning_effort=reasoning_effort,
+        )
+
+        if kwargs.get("tokenize", True):
+            tokenizer_kwargs = {key: kwargs[key] for key in ("truncation", "max_length") if key in kwargs}
+            return self.encode(
+                prompt_str,
+                add_special_tokens=False,
+                **tokenizer_kwargs,
+            )
+
+        return prompt_str
+
+    tokenizer_cls.apply_chat_template = apply_chat_template
+    return dsv4_tokenizer
+
+
+if not hasattr(deepseek_v4_encoding, "REASONING_EFFORT_PROMPTS"):
+    deepseek_v4_encoding.REASONING_EFFORT_PROMPTS = REASONING_EFFORT_PROMPTS
+    deepseek_v4_encoding.render_message = _patched_render_message
+    deepseek_v4.get_deepseek_v4_tokenizer = _patched_get_deepseek_v4_tokenizer


### PR DESCRIPTION
### What this PR does / why we need it?

This ports #13313 to the v0.26 release branch and follows the behavior already
merged for v0.25.1 in #13519.

The release branch is paired with vLLM `v0.26.0` at commit
`568afb3a13806beb53bb2e6bd518269357b237c0`, which predates
https://github.com/vllm-project/vllm/pull/50580. vLLM Ascend also does not use
the upstream Rust frontend renderer, so this PR adds the equivalent behavior
to the active Python tokenizer and renderer path:

- omitted thinking and effort select thinking with `high`
- `minimal`, `medium`, and `low` normalize to `low`
- `high`, `xhigh`, and unknown strings normalize to `high`
- `max` remains `max`
- `none` or explicit thinking disablement selects chat mode

The renderer accepts canonical `low`, `high`, and `max` values and emits the
exact DeepSeek-V4-Flash-0731 prompt prefixes. The patch is guarded and becomes
a no-op once the supported vLLM version contains the upstream implementation.

The latest vLLM main was also reviewed at commit
`a311916a291c1fed3dbfb72e60f74cd778c8419d`. Since the upstream merge, the only
Python tokenizer change is the unrelated vocab-size fix in
https://github.com/vllm-project/vllm/pull/51727; the reasoning-effort mapping
and prompt rendering remain unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. On the v0.26 release stack, DeepSeek-V4-Flash-0731 now defaults to
thinking with high effort, compatibility aliases match upstream vLLM, and
explicit thinking disablement continues to override the requested effort.

### How was this patch tested?

- Tested against the vLLM `v0.26.0` tag at commit
  `568afb3a13806beb53bb2e6bd518269357b237c0`.
- `VLLM_VERSION=0.26.0 python -m pytest -q tests/ut/patch/platform/test_deepseek_v4_thinking.py`
  - Result: `22 passed`
- `uvx --from pre-commit==4.0.1 pre-commit run --all-files --hook-stage manual`
  - Result: all configured hooks passed, including ruff, codespell, typos,
    markdownlint, gitleaks, and repository-local checks.
- `python -m py_compile` on all changed Python files and `git diff --check`
  passed.
- An isolated guard probe against vLLM main commit
  `a311916a291c1fed3dbfb72e60f74cd778c8419d` confirmed that both tokenizer and
  renderer function identities remain unchanged when upstream support exists.

Coverage includes omitted options, explicit thinking enable/disable, every
supported effort alias, unknown strings, canonical 0731 prompt prefixes, and
invalid direct renderer input.

The real checkpoint was not served through the OpenAI API in this validation,
so this PR does not claim real-weight NPU HTTP end-to-end sign-off.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
