### PR TITLE
[Feature][EPLB] Eplb supports Mega MoE

### DIFF
--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -205,18 +205,35 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
     ) -> torch.Tensor:
         topk_weights = topk_weights.to(x.dtype)
 
-        if self.use_expert_weight_list:
-            w1 = [i.view(torch.int32) for i in layer.w13_weight_list]
-            w1_scale = layer.w13_weight_scale_list
-            w2 = [i.view(torch.int32) for i in layer.w2_weight_list]
-            w2_scale = layer.w2_weight_scale_list
-            w1_scale_bias = layer.w13_scale_bias_list
-            w2_scale_bias = layer.w2_scale_bias_list
-        elif (
+        use_mega_moe = (
             _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2
             and get_ascend_config().enable_fused_mc2 == 1
             and _MEGA_MOE_SUPPORTED
-        ):
+        )
+
+        if self.use_expert_weight_list:
+            if use_mega_moe:
+                # EPLB rearranges these lists in place. MegaMoE must consume
+                # their original INT8/NZ tensors instead of the INT32 views
+                # used by the legacy dynamic-EPLB kernels.
+                w1 = layer.w13_weight_list
+                w1_scale = [t.reshape(-1) for t in layer.w13_weight_scale_list]
+                w2 = layer.w2_weight_list
+                w2_scale = [t.reshape(-1) for t in layer.w2_weight_scale_list]
+                w1_scale_bias = [
+                    t.reshape(-1).to(torch.float32) for t in layer.w13_scale_bias_list
+                ]
+                w2_scale_bias = [
+                    t.reshape(-1).to(torch.float32) for t in layer.w2_scale_bias_list
+                ]
+            else:
+                w1 = [i.view(torch.int32) for i in layer.w13_weight_list]
+                w1_scale = layer.w13_weight_scale_list
+                w2 = [i.view(torch.int32) for i in layer.w2_weight_list]
+                w2_scale = layer.w2_weight_scale_list
+                w1_scale_bias = layer.w13_scale_bias_list
+                w2_scale_bias = layer.w2_scale_bias_list
+        elif use_mega_moe:
             w1 = layer.cann_mega_moe_w13_weight_list
             w1_scale = layer.cann_mega_moe_w13_weight_scale_list
             w2 = layer.cann_mega_moe_w2_weight_list

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -222,8 +222,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w1_scale = [t.reshape(-1) for t in layer.w13_weight_scale_list]
                 w2 = layer.w2_weight_list
                 w2_scale = [t.reshape(-1) for t in layer.w2_weight_scale_list]
-                w1_scale_bias = [t.reshape(-1).to(torch.float32) for t in layer.w13_scale_bias_list]
-                w2_scale_bias = [t.reshape(-1).to(torch.float32) for t in layer.w2_scale_bias_list]
+                w1_scale_bias = [t.reshape(-1) for t in layer.w13_scale_bias_list]
+                w2_scale_bias = [t.reshape(-1) for t in layer.w2_scale_bias_list]
             else:
                 w1 = [i.view(torch.int32) for i in layer.w13_weight_list]
                 w1_scale = layer.w13_weight_scale_list
@@ -237,12 +237,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             w2 = layer.cann_mega_moe_w2_weight_list
             w2_scale = layer.cann_mega_moe_w2_weight_scale_list
 
-            def cast_bias_to_fp32(bias):
-                lst = bias if isinstance(bias, list) else [bias]
-                return [t if t.dtype == torch.float32 else t.to(torch.float32) for t in lst]
-
-            w1_scale_bias = cast_bias_to_fp32(layer.cann_mega_moe_w13_scale_bias_list)
-            w2_scale_bias = cast_bias_to_fp32(layer.cann_mega_moe_w2_scale_bias_list)
+            w1_scale_bias = layer.cann_mega_moe_w13_scale_bias_list
+            w2_scale_bias = layer.cann_mega_moe_w2_scale_bias_list
         else:
             w1 = [layer.w13_weight]
             w1_scale = [layer.w13_weight_scale]
@@ -357,7 +353,14 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         if self.use_expert_weight_list:
             for tensor_name in tensor_names:
                 tensor = getattr(layer, tensor_name)
-                setattr(layer, f"{tensor_name}_list", [expert.clone() for expert in tensor.data.unbind(dim=0)])
+                expert_list = [expert.clone() for expert in tensor.data.unbind(dim=0)]
+                if (
+                    tensor_name in ("w13_scale_bias", "w2_scale_bias")
+                    and get_ascend_config().enable_fused_mc2 == 1
+                    and _MEGA_MOE_SUPPORTED
+                ):
+                    expert_list = [expert.to(torch.float32) for expert in expert_list]
+                setattr(layer, f"{tensor_name}_list", expert_list)
                 delattr(layer, tensor_name)
         elif get_ascend_config().enable_fused_mc2 == 1 and _MEGA_MOE_SUPPORTED:
             layer.cann_mega_moe_w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
@@ -367,8 +370,12 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 t.reshape(-1) for t in layer.w13_weight_scale.data.unbind(dim=0)
             ]
             layer.cann_mega_moe_w2_weight_scale_list = [t.reshape(-1) for t in layer.w2_weight_scale.data.unbind(dim=0)]
-            layer.cann_mega_moe_w13_scale_bias_list = [t.reshape(-1) for t in layer.w13_scale_bias.data.unbind(dim=0)]
-            layer.cann_mega_moe_w2_scale_bias_list = [t.reshape(-1) for t in layer.w2_scale_bias.data.unbind(dim=0)]
+            layer.cann_mega_moe_w13_scale_bias_list = [
+                t.reshape(-1).to(torch.float32) for t in layer.w13_scale_bias.data.unbind(dim=0)
+            ]
+            layer.cann_mega_moe_w2_scale_bias_list = [
+                t.reshape(-1).to(torch.float32) for t in layer.w2_scale_bias.data.unbind(dim=0)
+            ]
             for tensor_name in tensor_names:
                 delattr(layer, tensor_name)
         else:

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -210,6 +210,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             and get_ascend_config().enable_fused_mc2 == 1
             and _MEGA_MOE_SUPPORTED
         )
+        w1_scale_bias: list[torch.Tensor] | None
+        w2_scale_bias: list[torch.Tensor] | None
 
         if self.use_expert_weight_list:
             if use_mega_moe:
@@ -220,12 +222,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w1_scale = [t.reshape(-1) for t in layer.w13_weight_scale_list]
                 w2 = layer.w2_weight_list
                 w2_scale = [t.reshape(-1) for t in layer.w2_weight_scale_list]
-                w1_scale_bias = [
-                    t.reshape(-1).to(torch.float32) for t in layer.w13_scale_bias_list
-                ]
-                w2_scale_bias = [
-                    t.reshape(-1).to(torch.float32) for t in layer.w2_scale_bias_list
-                ]
+                w1_scale_bias = [t.reshape(-1).to(torch.float32) for t in layer.w13_scale_bias_list]
+                w2_scale_bias = [t.reshape(-1).to(torch.float32) for t in layer.w2_scale_bias_list]
             else:
                 w1 = [i.view(torch.int32) for i in layer.w13_weight_list]
                 w1_scale = layer.w13_weight_scale_list

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -243,15 +243,24 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             and get_ascend_config().enable_fused_mc2 == 1
             and act_name != "swigluoai_uninterleave"
         )
+        use_mega_moe = fused_scale_flag and _MEGA_MOE_SUPPORTED
         if self.use_expert_weight_list:
             w1 = layer.w13_weight_list
-            w1_scale = layer.fused_w1_scale_list if fused_scale_flag else layer.w13_weight_scale_fp32_list
             w2 = layer.w2_weight_list
-            w2_scale = layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
-            w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
-            w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            if use_mega_moe:
+                # EPLB rearranges these lists in place. MegaMoE consumes the
+                # original INT8/NZ weights and one flattened scale per expert.
+                w1_scale = [scale.reshape(-1) for scale in layer.fused_w1_scale_list]
+                w2_scale = [scale.reshape(-1) for scale in layer.fused_w2_scale_list]
+                w1_scale_bias = None
+                w2_scale_bias = None
+            else:
+                w1_scale = layer.fused_w1_scale_list if fused_scale_flag else layer.w13_weight_scale_fp32_list
+                w2_scale = layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
+                w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+                w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
 
-        elif fused_scale_flag and _MEGA_MOE_SUPPORTED:
+        elif use_mega_moe:
             w1 = layer.cann_mega_moe_w13_weight_list
             w1_scale = layer.cann_mega_moe_fused_w1_scale_list
             w2 = layer.cann_mega_moe_w2_weight_list

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -257,8 +257,8 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             else:
                 w1_scale = layer.fused_w1_scale_list if fused_scale_flag else layer.w13_weight_scale_fp32_list
                 w2_scale = layer.fused_w2_scale_list if fused_scale_flag else layer.w2_weight_scale_list
-                w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
-                w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+                w1_scale_bias = layer.fused_w1_scale_bias if fused_scale_flag else None
+                w2_scale_bias = layer.fused_w2_scale_bias if fused_scale_flag else None
 
         elif use_mega_moe:
             w1 = layer.cann_mega_moe_w13_weight_list
@@ -273,8 +273,8 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             w1_scale = [layer.fused_w1_scale] if fused_scale_flag else [layer.w13_weight_scale_fp32]
             w2 = [layer.w2_weight]
             w2_scale = [layer.fused_w2_scale] if fused_scale_flag else [layer.w2_weight_scale]
-            w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
-            w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
+            w1_scale_bias = layer.fused_w1_scale_bias if fused_scale_flag else None
+            w2_scale_bias = layer.fused_w2_scale_bias if fused_scale_flag else None
 
         final_hidden_states = moe_comm_method.fused_experts(
             fused_experts_input=build_fused_experts_input(
@@ -359,6 +359,8 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         if get_ascend_config().enable_fused_mc2 == 1:
             layer.fused_w1_scale = scale_from_float_to_int64(layer.w13_weight_scale.data)
             layer.fused_w2_scale = scale_from_float_to_int64(layer.w2_weight_scale.data)
+            layer.fused_w1_scale_bias = [torch.tensor([], dtype=torch.float32)]
+            layer.fused_w2_scale_bias = [torch.tensor([], dtype=torch.float32)]
 
         if self.use_expert_weight_list:
             layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the W4A8 quantization method to support MegaMoE when `use_expert_weight_list` is enabled. It ensures MegaMoE consumes the original INT8/NZ tensors and reshapes/casts the scale and bias lists, rather than using the INT32 views required by legacy dynamic-EPLB kernels.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
CI testing with MoE models.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
