### PR TITLE
[Misc][v0.26.0] Upgrade Triton Ascend(3.2.2)

### DIFF
--- a/.github/workflows/_build_csrc_cache.yaml
+++ b/.github/workflows/_build_csrc_cache.yaml
@@ -182,7 +182,7 @@ jobs:
           # Indexes for triton-ascend and the CPU PyTorch wheel come from
           # UV_EXTRA_INDEX_URL. Passing --extra-index-url here would replace it.
           uv pip install -r requirements-dev.txt
-          uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
+          uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
           uv pip install -e .
 
       - name: Verify csrc artifacts

--- a/.github/workflows/_build_csrc_cache.yaml
+++ b/.github/workflows/_build_csrc_cache.yaml
@@ -182,7 +182,7 @@ jobs:
           # Indexes for triton-ascend and the CPU PyTorch wheel come from
           # UV_EXTRA_INDEX_URL. Passing --extra-index-url here would replace it.
           uv pip install -r requirements-dev.txt
-          uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
+          uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           uv pip install -e .
 
       - name: Verify csrc artifacts

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -121,7 +121,7 @@ on:
         description: 'Triton Ascend package version'
         required: false
         type: string
-        default: '3.2.1'
+        default: '3.2.2'
       build_args:
         description: 'Additional build arguments for Docker build'
         required: false
@@ -349,7 +349,7 @@ jobs:
           TORCH_NPU_VERSION=${{ inputs.torch_npu_version || '26.1.0' }}
           TORCH_NPU_DATE=${{ inputs.torch_npu_date || '20260715.4' }}
           TRITON_ASCEND_VERSION=${{ inputs.triton_ascend_version || '' }}
-          TRITON_ASCEND_PACKAGE_VERSION=${{ inputs.triton_ascend_package_version || '3.2.1' }}
+          TRITON_ASCEND_PACKAGE_VERSION=${{ inputs.triton_ascend_package_version || '3.2.2' }}
           ${{ inputs.build_args }}
         provenance: false
         # To speed up the build, we use registry cache. The cache tag is determined by the suffix and architecture, and shared across different workflow runs.

--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -226,7 +226,7 @@ jobs:
           export MAX_JOBS=$(( ${{ matrix.group.num_npus }} * 23 ))
           pip install uc-manager
           uv pip install -r requirements-dev.txt
-          uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
+          uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
           # Preserve CI availability during the transition by compiling on the
           # NPU only when the new CPU-produced cache is unavailable.
           if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -226,7 +226,7 @@ jobs:
           export MAX_JOBS=$(( ${{ matrix.group.num_npus }} * 23 ))
           pip install uc-manager
           uv pip install -r requirements-dev.txt
-          uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
+          uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           # Preserve CI availability during the transition by compiling on the
           # NPU only when the new CPU-produced cache is unavailable.
           if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/_selected_tests_upstream.yaml
+++ b/.github/workflows/_selected_tests_upstream.yaml
@@ -216,7 +216,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/_selected_tests_upstream.yaml
+++ b/.github/workflows/_selected_tests_upstream.yaml
@@ -216,7 +216,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/schedule_e2e_upstream_test.yaml
+++ b/.github/workflows/schedule_e2e_upstream_test.yaml
@@ -169,7 +169,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then
@@ -307,7 +307,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then
@@ -437,7 +437,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/schedule_e2e_upstream_test.yaml
+++ b/.github/workflows/schedule_e2e_upstream_test.yaml
@@ -169,7 +169,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then
@@ -307,7 +307,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then
@@ -437,7 +437,7 @@ jobs:
               export MAX_JOBS=$(( ${{ matrix.num_npus }} * 23 ))
               pip install uc-manager
               uv pip install -r requirements-dev.txt
-              uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
+              uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
               # Preserve CI availability during the transition by compiling on
               # the NPU only when the CPU-produced cache is unavailable.
               if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -89,7 +89,7 @@ on:
       triton_ascend:
         description: 'Triton Ascend version and package version (JSON array: ["version", "package_version"])'
         required: false
-        default: '["", "3.2.1"]'
+        default: '["", "3.2.2"]'
         type: string
 
 permissions:
@@ -158,8 +158,8 @@ jobs:
         TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[1] }}
         ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[0]) || '' }}
         ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[1]) || '' }}
-        TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.1"]')[0] }}
-        TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.1"]')[1] }}
+        TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
+        TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
       
     secrets:
       quay_password: ${{ inputs.build_type == 'daily' && secrets.QUAY_DAILY_PASSWORD || secrets.QUAY_PASSWORD }}
@@ -225,8 +225,8 @@ jobs:
         TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[1] }}
         ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[0]) || '' }}
         ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.07.29"]')[1]) || '' }}
-        TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.1"]')[0] }}
-        TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.1"]')[1] }}
+        TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
+        TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
 
     secrets:
       quay_temp_password: ${{ inputs.build_type == 'daily' && secrets.QUAY_DAILY_TEMP_PASSWORD || secrets.QUAY_TEMP_PASSWORD }}

--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -428,7 +428,7 @@ jobs:
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
-          uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
+          uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
           # Preserve main2main availability during the transition by compiling
           # on the NPU only when the CPU-produced cache is unavailable.
           if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -428,7 +428,7 @@ jobs:
         run: |
           pip install uc-manager
           uv pip install -r requirements-dev.txt
-          uv pip install --force-reinstall --no-deps triton-ascend==3.2.2
+          uv pip install --force-reinstall --no-deps triton-ascend==3.2.1
           # Preserve main2main availability during the transition by compiling
           # on the NPU only when the CPU-produced cache is unavailable.
           if [ "$CSRC_CACHE_HIT" = "true" ]; then

--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 export ASCEND_LAUNCH_BLOCKING=1
+export ASCEND_SLOG_PRINT_TO_STDOUT=1
+export ASCEND_GLOBAL_LOG_LEVEL=0
 
 enable_coverage=false
 if [ "${ENABLE_COVERAGE:-}" = "true" ]; then

--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-export ASCEND_LAUNCH_BLOCKING=1
-export ASCEND_SLOG_PRINT_TO_STDOUT=1
-export ASCEND_GLOBAL_LOG_LEVEL=0
-
 enable_coverage=false
 if [ "${ENABLE_COVERAGE:-}" = "true" ]; then
   enable_coverage=true

--- a/.github/workflows/scripts/run_selected_tests.sh
+++ b/.github/workflows/scripts/run_selected_tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export ASCEND_LAUNCH_BLOCKING=1
+
 enable_coverage=false
 if [ "${ENABLE_COVERAGE:-}" = "true" ]; then
   enable_coverage=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -73,7 +73,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -73,7 +73,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -69,7 +69,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -69,7 +69,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -65,7 +65,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -65,7 +65,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -61,7 +61,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -61,7 +61,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -69,7 +69,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -69,7 +69,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/docs/hooks/macros_main.py
+++ b/docs/hooks/macros_main.py
@@ -56,7 +56,7 @@ def define_env(env):
     env.variables["main_pytorch_torch_npu_version"] = env.variables.get(
         "main_pytorch_torch_npu_version", "2.10.0 / 2.10.0.post4"
     )
-    env.variables["main_triton_ascend_version"] = env.variables.get("main_triton_ascend_version", "3.2.1")
+    env.variables["main_triton_ascend_version"] = env.variables.get("main_triton_ascend_version", "3.2.2")
     env.variables["main_vllm_commit"] = main_vllm_commit
     env.variables["main_vllm_tag"] = main_vllm_tag
 

--- a/docs/hooks/macros_main.py
+++ b/docs/hooks/macros_main.py
@@ -56,7 +56,7 @@ def define_env(env):
     env.variables["main_pytorch_torch_npu_version"] = env.variables.get(
         "main_pytorch_torch_npu_version", "2.10.0 / 2.10.0.post4"
     )
-    env.variables["main_triton_ascend_version"] = env.variables.get("main_triton_ascend_version", "3.2.2")
+    env.variables["main_triton_ascend_version"] = env.variables.get("main_triton_ascend_version", "3.2.1")
     env.variables["main_vllm_commit"] = main_vllm_commit
     env.variables["main_vllm_tag"] = main_vllm_tag
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -204,7 +204,7 @@ Then you can install `vllm` and `vllm-ascend` from a **pre-built wheel** using o
 
         To install `triton-ascend`, run:
 
-        pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+        pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 
         If you are installing via `uv`, make sure to install `triton-ascend` **last**, after all other packages have been installed, to avoid dependency resolution conflicts.
 
@@ -266,7 +266,7 @@ python -m pip install \
     torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
 python -m pip install \
     --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
-    torch-npu==2.10.0.post4 triton-ascend==3.2.2
+    torch-npu==2.10.0.post4 triton-ascend==3.2.1
 python -m pip install \
     --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
     -r requirements.txt

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -204,7 +204,7 @@ Then you can install `vllm` and `vllm-ascend` from a **pre-built wheel** using o
 
         To install `triton-ascend`, run:
 
-        pip install triton-ascend==3.2.1 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
+        pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi
 
         If you are installing via `uv`, make sure to install `triton-ascend` **last**, after all other packages have been installed, to avoid dependency resolution conflicts.
 
@@ -266,7 +266,7 @@ python -m pip install \
     torch==2.10.0 torchvision==0.25.0 torchaudio==2.10.0
 python -m pip install \
     --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
-    torch-npu==2.10.0.post4 triton-ascend==3.2.1
+    torch-npu==2.10.0.post4 triton-ascend==3.2.2
 python -m pip install \
     --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi \
     -r requirements.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,7 +165,7 @@ extra:
   main_python_version: ">= 3.10, < 3.13"
   main_cann_version: "9.1.0"
   main_pytorch_torch_npu_version: "2.10.0 / 2.10.0.post4"
-  main_triton_ascend_version: "3.2.1"
+  main_triton_ascend_version: "3.2.2"
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/vllm-project/vllm-ascend

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -165,7 +165,7 @@ extra:
   main_python_version: ">= 3.10, < 3.13"
   main_cann_version: "9.1.0"
   main_pytorch_torch_npu_version: "2.10.0 / 2.10.0.post4"
-  main_triton_ascend_version: "3.2.2"
+  main_triton_ascend_version: "3.2.1"
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/vllm-project/vllm-ascend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires = [
     "fastapi<0.124.0",
     "compressed_tensors>=0.11.0",
     "arctic-inference==0.1.1",
-    "triton-ascend==3.2.1"
+    "triton-ascend==3.2.2"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires = [
     "fastapi<0.124.0",
     "compressed_tensors>=0.11.0",
     "arctic-inference==0.1.1",
-    "triton-ascend==3.2.2"
+    "triton-ascend==3.2.1"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ torch==2.10.0
 torch-npu==2.10.0.post4
 torchvision==0.25.0
 torchaudio==2.10.0
-triton-ascend==3.2.2
+triton-ascend==3.2.1
 wheel
 xgrammar>=0.1.30
 pandas-stubs

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ torch==2.10.0
 torch-npu==2.10.0.post4
 torchvision==0.25.0
 torchaudio==2.10.0
-triton-ascend==3.2.1
+triton-ascend==3.2.2
 wheel
 xgrammar>=0.1.30
 pandas-stubs

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -68,7 +68,8 @@ DEEPSEEK_V4_PROMPTS = [
     "What is the meaning of life?",
 ]
 
-DEEPSEEK_V4_GOLDEN = ["Hello, my name is {name} and I", 'What is the meaning of life?",\n    "What is']
+# The routed-expert SwiGLU clamp changes the second continuation (#14397).
+DEEPSEEK_V4_GOLDEN = ["Hello, my name is {name} and I", "What is the meaning of life?', 'What is the"]
 
 
 @dataclass(frozen=True)

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -266,6 +266,9 @@ def test_full_checkpoint_reload_refreshes_packed_weight_in_place():
 
 def test_repack_waits_until_all_source_weights_are_materialized():
     attention = _make_conv_pack_attention()
+    source_convs = (attention.q_conv1d, attention.k_conv1d, attention.v_conv1d)
+    for value, conv in enumerate(source_convs, start=1):
+        conv.weight.data.fill_(value)
     packed = attention._conv_weights_t()
     packed.data.fill_(-1)
     before = packed.clone()

--- a/vllm_ascend/patch/worker/patch_v2/patch_uva.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_uva.py
@@ -28,18 +28,17 @@ from vllm.logger import logger
 
 def check_triton_ascend_version_valid() -> bool:
     """
-    Check triton-ascend version and warn about UVA feature disablement in 3.2.1.
-    If version isn't 3.2.1, return True.
+    Check triton-ascend version and warn about UVA feature disablement.
+    If the installed version isn't affected by the UVA issue, return True.
     """
-    # Target version that disables UVA feature
-    DISABLE_UVA_VERSION = "3.2.1"
+    # Triton Ascend versions affected by the UVA pointer validation issue.
+    UVA_INCOMPATIBLE_VERSIONS = ("3.2.1", "3.2.2")
     installed_version = version("triton-ascend")
-    # Check if current version is the one with UVA disabled
-    if installed_version == DISABLE_UVA_VERSION:
+    if installed_version in UVA_INCOMPATIBLE_VERSIONS:
         logger.warning(
             "triton-ascend %s disables the UVA feature.\n"
             "Related bug issue: https://github.com/triton-lang/triton-ascend/issues/783",
-            DISABLE_UVA_VERSION,
+            installed_version,
         )
         return False
     return True
@@ -47,8 +46,8 @@ def check_triton_ascend_version_valid() -> bool:
 
 def is_uva_available() -> bool:
     """check if uva feature is supported in this environment"""
-    # FIXME(chenboxun): There is an issue with using the UVA feature alongside triton-ascend3.2.1.
-    # Thus UVA feature is disabled when using version 3.2.1
+    # FIXME(chenboxun): Some triton-ascend versions reject pinned CPU tensors.
+    # Thus UVA is disabled for affected versions.
     # (Related bug issue link: https://github.com/triton-lang/triton-ascend/issues/783)
     return (
         "pinned_mem_register:True" in os.environ.get("PYTORCH_NPU_ALLOC_CONF", {})

--- a/vllm_ascend/patch/worker/patch_v2/patch_uva.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_uva.py
@@ -28,17 +28,18 @@ from vllm.logger import logger
 
 def check_triton_ascend_version_valid() -> bool:
     """
-    Check triton-ascend version and warn about UVA feature disablement.
-    If the installed version isn't affected by the UVA issue, return True.
+    Check triton-ascend version and warn about UVA feature disablement in 3.2.1.
+    If version isn't 3.2.1, return True.
     """
-    # Triton Ascend versions affected by the UVA pointer validation issue.
-    UVA_INCOMPATIBLE_VERSIONS = ("3.2.1", "3.2.2")
+    # Target version that disables UVA feature
+    DISABLE_UVA_VERSION = "3.2.1"
     installed_version = version("triton-ascend")
-    if installed_version in UVA_INCOMPATIBLE_VERSIONS:
+    # Check if current version is the one with UVA disabled
+    if installed_version == DISABLE_UVA_VERSION:
         logger.warning(
             "triton-ascend %s disables the UVA feature.\n"
             "Related bug issue: https://github.com/triton-lang/triton-ascend/issues/783",
-            installed_version,
+            DISABLE_UVA_VERSION,
         )
         return False
     return True
@@ -46,8 +47,8 @@ def check_triton_ascend_version_valid() -> bool:
 
 def is_uva_available() -> bool:
     """check if uva feature is supported in this environment"""
-    # FIXME(chenboxun): Some triton-ascend versions reject pinned CPU tensors.
-    # Thus UVA is disabled for affected versions.
+    # FIXME(chenboxun): There is an issue with using the UVA feature alongside triton-ascend3.2.1.
+    # Thus UVA feature is disabled when using version 3.2.1
     # (Related bug issue link: https://github.com/triton-lang/triton-ascend/issues/783)
     return (
         "pinned_mem_register:True" in os.environ.get("PYTORCH_NPU_ALLOC_CONF", {})


### PR DESCRIPTION
### What this PR does / why we need it?
This PR upgrades the software stack for the `releases/v0.26.0rc` branch:

- Upgrade Triton Ascend from 3.2.1 to 3.2.2.


#### CI follow-up fixes

- Stabilized `test_kimi_kda.py` by initializing q/k/v weights before testing the meta-parameter guard. The original test used uninitialized `torch.empty` values, making the result allocator- and test-order-dependent and occasionally introducing NaNs.  
  [Failing CI](https://github.com/vllm-project/vllm-ascend/actions/runs/31584371888/job/94077498904#step:18:4652)

- Updated the DeepSeek-V4 context-parallel golden output. PR [#14397](https://github.com/vllm-project/vllm-ascend/pull/14397) correctly enabled the configured SwiGLU clamp for routed experts, which intentionally changed the generated continuation; therefore, the stale golden output was refreshed.  
  [Failing CI](https://github.com/vllm-project/vllm-ascend/actions/runs/32012766676/job/95439003808#step:17:1751)

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
