### PR TITLE
[BugFix] correct MiniMax-M3 index query normalization head dimension

### DIFF
--- a/vllm_ascend/models/minimax_m3/minimax_m3.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3.py
@@ -391,7 +391,7 @@ class MiniMaxM3SparseAttention(nn.Module, AttentionLayerBase):
     def _index_qk_norm(self, idx_q: torch.Tensor, idx_k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         idx_q_shape = idx_q.shape
         idx_k_shape = idx_k.shape
-        idx_q = idx_q.reshape(-1, self.index_q_size)
+        idx_q = idx_q.reshape(-1, self.idx_head_dim)
         idx_k = idx_k.reshape(-1, self.idx_head_dim)
         idx_q = self.index_q_norm(idx_q).reshape(idx_q_shape)
         idx_k = self.index_k_norm(idx_k).reshape(idx_k_shape)


### PR DESCRIPTION
### What this PR does / why we need it?
Fixes the reshape dimension used for index_q before index Q/K normalization in MiniMax-M3 sparse attention. index_q is now reshaped by idx_head_dim, matching the index-head layout and the corresponding index_k handling.
### Does this PR introduce any user-facing change?
No direct user-facing API or interface change. This fixes MiniMax-M3 sparse-attention runtime behavior.

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
