### PR TITLE
[BugFix][310P] Fix double-counting of external HBM in KV cache sizing

### DIFF
--- a/tests/ut/_310p/test_worker_310p.py
+++ b/tests/ut/_310p/test_worker_310p.py
@@ -1,0 +1,146 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from vllm.utils.mem_constants import GiB_bytes
+
+from tests.ut.base import TestBase
+
+
+class TestDetermineAvailableMemory310P(TestBase):
+    @staticmethod
+    def _make_worker(
+        requested_memory: float,
+        init_free_memory: int,
+        model_memory_usage: int,
+    ):
+        from vllm_ascend._310p.worker_310p import NPUWorker310
+
+        with patch.object(NPUWorker310, "__init__", lambda worker: None):
+            worker = NPUWorker310()
+
+        worker.init_snapshot = SimpleNamespace(free_memory=init_free_memory)
+        worker.requested_memory = requested_memory
+        worker.model_runner = MagicMock()
+        worker.model_runner.model_memory_usage = model_memory_usage
+        return worker
+
+    @staticmethod
+    def _make_profile_result(
+        free_memory_after: int,
+        non_kv_cache_memory: int,
+        non_torch_increase: int,
+        torch_peak_increase: int,
+    ):
+        return SimpleNamespace(
+            after_profile=SimpleNamespace(free_memory=free_memory_after),
+            non_kv_cache_memory=non_kv_cache_memory,
+            non_torch_increase=non_torch_increase,
+            torch_peak_increase=torch_peak_increase,
+        )
+
+    @staticmethod
+    def _mock_memory_profiling(profile_result):
+        context = MagicMock()
+        context.__enter__.return_value = profile_result
+        context.__exit__.return_value = False
+        return MagicMock(return_value=context)
+
+    def test_ep_ignores_pre_existing_process_memory(self):
+        total_memory = int(43.24 * GiB_bytes)
+        init_free_memory = int(23.45 * GiB_bytes)
+        requested_memory = total_memory * 0.5
+        model_memory_usage = int(1.43 * GiB_bytes)
+        non_torch_increase = int(0.06 * GiB_bytes)
+        torch_peak_increase = int(0.07 * GiB_bytes)
+        non_kv_cache_memory = int(1.71 * GiB_bytes)
+
+        worker = self._make_worker(
+            requested_memory=requested_memory,
+            init_free_memory=init_free_memory,
+            model_memory_usage=model_memory_usage,
+        )
+        profile_result = self._make_profile_result(
+            free_memory_after=init_free_memory - non_kv_cache_memory,
+            non_kv_cache_memory=non_kv_cache_memory,
+            non_torch_increase=non_torch_increase,
+            torch_peak_increase=torch_peak_increase,
+        )
+        mock_memory_profiling = self._mock_memory_profiling(profile_result)
+
+        with (
+            patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=False),
+            patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
+            patch(
+                "torch.npu.mem_get_info",
+                return_value=(profile_result.after_profile.free_memory, total_memory),
+            ),
+            patch("torch.npu.memory_reserved", return_value=int(1.50 * GiB_bytes)),
+        ):
+            result = worker.determine_available_memory()
+
+        expected = int((requested_memory - non_kv_cache_memory) // 2)
+        self.assertEqual(result, expected)
+        self.assertAlmostEqual(result / GiB_bytes, 9.95, delta=0.1)
+        self.assertEqual(worker.non_torch_memory, non_torch_increase)
+        self.assertEqual(worker.peak_activation_memory, torch_peak_increase)
+        worker.model_runner.profile_run.assert_called_once_with()
+        mock_memory_profiling.assert_called_once_with(
+            worker.init_snapshot,
+            weights_memory=model_memory_usage,
+        )
+
+    def test_rc_keeps_shared_host_memory_calculation(self):
+        requested_memory = 32 * GiB_bytes
+        init_free_memory = 48 * GiB_bytes
+        model_memory_usage = int(1.43 * GiB_bytes)
+        non_kv_cache_memory = int(1.71 * GiB_bytes)
+
+        worker = self._make_worker(
+            requested_memory=requested_memory,
+            init_free_memory=init_free_memory,
+            model_memory_usage=model_memory_usage,
+        )
+        profile_result = self._make_profile_result(
+            free_memory_after=init_free_memory - non_kv_cache_memory,
+            non_kv_cache_memory=non_kv_cache_memory,
+            non_torch_increase=int(0.06 * GiB_bytes),
+            torch_peak_increase=int(0.07 * GiB_bytes),
+        )
+        mock_memory_profiling = self._mock_memory_profiling(profile_result)
+        host_memory = SimpleNamespace(
+            total=64 * GiB_bytes,
+            available=48 * GiB_bytes,
+        )
+
+        with (
+            patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=True),
+            patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
+            patch("vllm_ascend._310p.worker_310p.psutil.virtual_memory", return_value=host_memory),
+            patch(
+                "torch.npu.mem_get_info",
+                return_value=(profile_result.after_profile.free_memory, host_memory.total),
+            ),
+            patch("torch.npu.memory_reserved", return_value=0),
+        ):
+            result = worker.determine_available_memory()
+
+        expected = int((requested_memory - (host_memory.total - host_memory.available)) // 2)
+        self.assertEqual(result, expected)
+        self.assertEqual(result, 8 * GiB_bytes)

--- a/tests/ut/_310p/test_worker_310p.py
+++ b/tests/ut/_310p/test_worker_310p.py
@@ -64,6 +64,8 @@ class TestDetermineAvailableMemory310P(TestBase):
 
     def test_ep_ignores_pre_existing_process_memory(self):
         total_memory = int(43.24 * GiB_bytes)
+        # Pre-existing device occupancy is reflected by init_free_memory and
+        # must not be subtracted from the per-instance KV cache budget.
         init_free_memory = int(23.45 * GiB_bytes)
         requested_memory = total_memory * 0.5
         model_memory_usage = int(1.43 * GiB_bytes)
@@ -87,11 +89,6 @@ class TestDetermineAvailableMemory310P(TestBase):
         with (
             patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=False),
             patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
-            patch(
-                "torch.npu.mem_get_info",
-                return_value=(profile_result.after_profile.free_memory, total_memory),
-            ),
-            patch("torch.npu.memory_reserved", return_value=int(1.50 * GiB_bytes)),
         ):
             result = worker.determine_available_memory()
 
@@ -133,11 +130,6 @@ class TestDetermineAvailableMemory310P(TestBase):
             patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=True),
             patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
             patch("vllm_ascend._310p.worker_310p.psutil.virtual_memory", return_value=host_memory),
-            patch(
-                "torch.npu.mem_get_info",
-                return_value=(profile_result.after_profile.free_memory, host_memory.total),
-            ),
-            patch("torch.npu.memory_reserved", return_value=0),
         ):
             result = worker.determine_available_memory()
 

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -77,17 +77,9 @@ class NPUWorker310(NPUWorker):
             weights_memory=int(self.model_runner.model_memory_usage),
         ) as profile_result:
             self.model_runner.profile_run()
-            free_memory, total_memory = torch.npu.mem_get_info()
-            # The host memory or device memory for RC devices refers to the available portion of memory
-            # which cannot be obtained via torch.npu.mem_get_info()
-            if is_rc_device():
-                free_memory = psutil.virtual_memory().available
-            torch_memory = torch.npu.memory_reserved()
-            non_torch_memory_before_empty_cache = total_memory - free_memory - torch_memory
 
         self.non_torch_memory = profile_result.non_torch_increase
         self.peak_activation_memory = profile_result.torch_peak_increase
-        non_torch_memory_cleared_by_empty_cache = non_torch_memory_before_empty_cache - self.non_torch_memory
 
         free_gpu_memory = profile_result.after_profile.free_memory
         assert self.init_snapshot.free_memory > free_gpu_memory, (
@@ -110,9 +102,8 @@ class NPUWorker310(NPUWorker):
             vm = psutil.virtual_memory()
             self.available_kv_cache_memory_bytes = (self.requested_memory - (vm.total - vm.available)) // 2
         else:
-            self.available_kv_cache_memory_bytes = (
-                self.requested_memory - profile_result.non_kv_cache_memory - non_torch_memory_cleared_by_empty_cache
-            ) // 2
+            # Existing allocations from other processes are already covered by the startup free-memory check.
+            self.available_kv_cache_memory_bytes = (self.requested_memory - profile_result.non_kv_cache_memory) // 2
 
         logger.debug(profile_result)
         logger.info_once(


### PR DESCRIPTION
## [BugFix][310P] 修复共享设备场景下 KV Cache 显存重复扣减

### What this PR does / why we need it?

修复 Ascend 310P 在 EP/独立 HBM 多服务场景下计算 KV Cache 时，重复扣除其他进程既有 HBM 占用的问题。

`NPUWorker310.determine_available_memory()` 原先会根据设备全局占用计算 `non_torch_memory_cleared_by_empty_cache`，再从当前实例的 `requested_memory` 中扣除。其他进程占用已经反映在启动时的空闲显存检查中，因此该计算会把 MindIE 或另一个 vLLM 实例占用的 HBM 再次计入当前实例，导致 KV Cache 过小或为负。

本 PR：

- 删除 310P profiling 阶段对设备全局 Non-Torch 占用的额外计算；
- EP 分支改为仅从当前实例预算中扣除 `profile_result.non_kv_cache_memory`；
- 保留 310P 的 `/ 2` workspace 预留；
- 保持启动空闲显存检查、profiling 一致性断言和 RC 分支行为不变；
- 增加 310P 专属单元测试，覆盖现场 EP 数值和 RC 分支保护。

现场环境中，Qwen3-0.6B 与占用约 19 GiB HBM 的 MindIE 共卡时，50% 实例预算只能得到约 `0.09 GiB` KV Cache。按修复后公式，同一预算预计可得到约 `9.95 GiB` KV Cache：

```text
(43.24 GiB * 0.5 - 1.71 GiB 当前实例 Non-KV) / 2
≈ 9.95 GiB
```

该修改与通用 Ascend worker 在 #7427 中采用的修复原则一致，只补齐 310P 专用 override 遗漏的 EP 路径。

Fixes #14004

### Does this PR introduce _any_ user-facing change?

是。

在 310P EP/独立 HBM 设备与其他服务共享 HBM 时，只要启动空闲显存检查可以通过，当前 vLLM 实例的 KV Cache 将按自身显存预算和自身 Non-KV 开销计算，不再被其他进程的既有占用重复压缩。

### How was this patch tested?

已完成：

- `python -m py_compile vllm_ascend/_310p/worker_310p.py tests/ut/_310p/test_worker_310p.py`
- `git diff --check`
- 使用标准库 AST 与现场数值执行公式检查，确认旧变量已移除，EP 结果约为 `9.95 GiB`
- 新增 `tests/ut/_310p/test_worker_310p.py`：
  - EP 场景验证其他进程既有占用不会进入当前实例 KV Cache 公式；
  - 验证 profiling、Non-Torch 和峰值激活统计仍被保留；
  - RC 场景验证共享主机内存公式保持不变。

当前开发机未安装 vLLM、torch-npu、pytest 和 pre-commit，也没有 Ascend NPU，因此以下检查未在本机完成，需由 CI/310P 环境验证：

- `pytest -sv tests/ut/_310p/test_worker_310p.py`
  - 本机结果：`No module named pytest`
- `bash format.sh ci`
  - 本机结果：`pre-commit is not installed`
- 310P EP 实机回归：Qwen3-0.6B、`gpu_memory_utilization=0.5`、`max_model_len=4096`，要求启动成功、至少一次非空推理成功且无 OOM。

---------

Signed-off-by: Binghao <3070362328@qq.com>


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
