### PR TITLE
[Test] Add MiniMax-M2.5 w8a8 QuaRot A3 PD 1P1D 200k case and deployment scripts

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -103,6 +103,10 @@ a3:
         config_file_path: DeepSeek-V4-Pro-w4a8-prefix-cache-PD.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 4
+      - name: MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k
+        config_file_path: MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
+        size: 2
   double_node:
     test_config:
       - name: multi-node-qwen3-dp

--- a/examples/external_online_dp/minimax_m2_pd/README.md
+++ b/examples/external_online_dp/minimax_m2_pd/README.md
@@ -1,0 +1,103 @@
+# MiniMax-M2.5 PD Separation (1P1D) Online Deployment
+
+Reference: [MiniMax-M2 tutorial, section 5.2 Multi-Node PD Separation Deployment](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/MiniMax-M2.html#52-multi-node-pd-separation-deployment)
+
+This example brings up a **1P1D** (1 Prefill + 1 Decode) MiniMax-M2.5 w8a8 QuaRot
+cluster with 200k context length:
+
+- **Hardware**: 2x Atlas 800 A3 (64GB x 16 NPUs), one node for Prefill, one for Decode
+- **Topology**: Prefill DP2/TP8/EP16, Decode DP2/TP8/EP16
+- **Context**: `--max-model-len 200000`
+- **KV transfer**: Mooncake (Ascend direct), prefill is `kv_producer`, decode is `kv_consumer`
+- **Decode acceleration**: EAGLE3 speculative decoding + `FULL_DECODE_ONLY` graph
+
+The same layout applies to MiniMax-M2.7 (swap the model/EAGLE3 weight paths).
+
+## 0. Prerequisites
+
+- Download the base weights and EAGLE3 weights (ModelScope) to a directory
+  reachable from both nodes (e.g. `/root/.cache/`):
+  - `MiniMax-M2.5-w8a8-QuaRot`
+  - `MiniMax-M2.5-eagle-model-0318`
+- Mooncake, jemalloc, and the CANN toolkit must be installed inside the container.
+
+## 1. Prepare scripts on each node
+
+`launch_online_dp.py` launches one `vllm serve` instance per local DP rank and
+always invokes `./run_dp_template.sh` relative to the working directory. Put the
+files together and copy the matching template to `run_dp_template.sh`:
+
+```bash
+cd examples/external_online_dp/minimax_m2_pd
+cp ../launch_online_dp.py .
+
+# Prefill node:
+cp run_dp_template_prefill.sh run_dp_template.sh
+
+# Decode node (different content!):
+cp run_dp_template_decode.sh run_dp_template.sh
+```
+
+Edit `NIC_NAME` and `LOCAL_IP` (or export them) in `run_dp_template.sh` on each
+node. Set `MODEL_PATH` / `EAGLE_MODEL_PATH` to your actual weight paths.
+
+## 2. Start the servers
+
+**Prefill node:**
+
+```bash
+python launch_online_dp.py \
+    --dp-size 2 --tp-size 8 \
+    --dp-size-local 2 --dp-rank-start 0 \
+    --dp-address <prefill_ip> --dp-rpc-port 12321 \
+    --vllm-start-port 7000
+```
+
+**Decode node:**
+
+```bash
+python launch_online_dp.py \
+    --dp-size 2 --tp-size 8 \
+    --dp-size-local 2 --dp-rank-start 0 \
+    --dp-address <decode_ip> --dp-rpc-port 12321 \
+    --vllm-start-port 7100
+```
+
+## 3. Start the load-balance proxy
+
+Run on any machine that can reach both nodes:
+
+```bash
+python ../../disaggregated_prefill_v1/load_balance_proxy_server_example.py \
+    --port 8009 \
+    --host <prefill_ip> \
+    --prefiller-hosts <prefill_ip> <prefill_ip> \
+    --prefiller-ports 7000 7001 \
+    --decoder-hosts <decode_ip> <decode_ip> \
+    --decoder-ports 7100 7101
+```
+
+The service is accessible at `http://<proxy_ip>:8009`. All requests go to the
+proxy; it forwards prefill to the Prefill node and decode to the Decode node.
+
+## 4. Verification
+
+The servers are launched with `--max-model-len 200000`, so the model context
+length is capped at 200k. A simple curl with a short prompt is enough to verify
+the PD pipeline end to end:
+
+```bash
+curl -sS http://<proxy_ip>:8009/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"model": "minimax",
+         "messages": [{"role": "user", "content": "What is deep learning?"}],
+         "max_tokens": 128}'
+```
+
+Note: the served model name is `minimax` (`--served-model-name minimax`).
+
+## 5. Automated nightly variant
+
+The same 1P1D 200k scenario is registered as a nightly A3 multi-node case:
+`tests/e2e/nightly/multi_node/external_dp/config/MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k.yaml`
+(see `nightly_config.yaml`, `a3.multi_node`).

--- a/examples/external_online_dp/minimax_m2_pd/run_dp_template_decode.sh
+++ b/examples/external_online_dp/minimax_m2_pd/run_dp_template_decode.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# MiniMax-M2.5 w8a8 QuaRot - PD separation DECODE node template.
+#
+# Called by launch_online_dp.py (../launch_online_dp.py), which passes:
+#   $1 visible_devices, $2 vllm port, $3 dp_size, $4 dp_rank,
+#   $5 dp_address, $6 dp_rpc_port, $7 tp_size
+#
+# Validated 1P1D configuration (2x Atlas 800 A3, 64GB x 16 each):
+#   decode: DP2/TP8/EP16, max-model-len 200000, Mooncake kv_consumer,
+#   EAGLE3 speculative decoding with FULL_DECODE_ONLY graph.
+# See docs/source/tutorials/models/MiniMax-M2.md section 5.2.
+
+set -euo pipefail
+
+unset http_proxy https_proxy ftp_proxy
+
+# ---- edit these for your environment ----
+MODEL_PATH="${MODEL_PATH:-/path/to/weight/MiniMax-M2.5-w8a8-QuaRot}"
+EAGLE_MODEL_PATH="${EAGLE_MODEL_PATH:-/path/to/weight/MiniMax-M2.5-eagle-model-0318}"
+NIC_NAME="${NIC_NAME:-<your_nic_name>}"
+LOCAL_IP="${LOCAL_IP:-<your_ip>}"
+
+export HCCL_IF_IP=$LOCAL_IP
+export GLOO_SOCKET_IFNAME=$NIC_NAME
+export TP_SOCKET_IFNAME=$NIC_NAME
+export HCCL_SOCKET_IFNAME=$NIC_NAME
+
+export HCCL_BUFFSIZE=2048
+export HCCL_OP_EXPANSION_MODE="AIV"
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export OMP_NUM_THREADS=1
+echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+sysctl -w vm.swappiness=0
+sysctl -w kernel.numa_balancing=0
+sysctl kernel.sched_migration_cost_ns=50000
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+
+export TASK_QUEUE_ENABLE=1
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=0
+export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+export PYTHONHASHSEED=0
+
+export ASCEND_RT_VISIBLE_DEVICES=$1
+
+vllm serve "$MODEL_PATH" \
+    --host 0.0.0.0 \
+    --port $2 \
+    --data-parallel-size $3 \
+    --data-parallel-rank $4 \
+    --data-parallel-address $5 \
+    --data-parallel-rpc-port $6 \
+    --tensor-parallel-size $7 \
+    --enable-expert-parallel \
+    --served-model-name minimax \
+    --max-model-len 200000 \
+    --max-num-batched-tokens 16384 \
+    --max-num-seqs 16 \
+    --trust-remote-code \
+    --no-enable-prefix-caching \
+    --gpu-memory-utilization 0.75 \
+    --quantization ascend \
+    --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+    --speculative_config "{\"method\": \"eagle3\", \"model\": \"$EAGLE_MODEL_PATH\", \"num_speculative_tokens\": 3}" \
+    --additional-config '{"enable_cpu_binding":true}' \
+    --kv-transfer-config \
+        '{"kv_connector": "MooncakeConnectorV1",
+        "kv_role": "kv_consumer",
+        "kv_port": "56900",
+        "engine_id": "1",
+        "kv_connector_extra_config": {
+             "use_ascend_direct": true,
+             "prefill": {"dp_size": 2, "tp_size": 8},
+             "decode":  {"dp_size": 2, "tp_size": 8}
+        }}'

--- a/examples/external_online_dp/minimax_m2_pd/run_dp_template_prefill.sh
+++ b/examples/external_online_dp/minimax_m2_pd/run_dp_template_prefill.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# MiniMax-M2.5 w8a8 QuaRot - PD separation PREFILL node template.
+#
+# Called by launch_online_dp.py (../launch_online_dp.py), which passes:
+#   $1 visible_devices, $2 vllm port, $3 dp_size, $4 dp_rank,
+#   $5 dp_address, $6 dp_rpc_port, $7 tp_size
+#
+# Validated 1P1D configuration (2x Atlas 800 A3, 64GB x 16 each):
+#   prefill: DP2/TP8/EP16, max-model-len 200000, Mooncake kv_producer.
+# See docs/source/tutorials/models/MiniMax-M2.md section 5.2.
+
+set -euo pipefail
+
+unset http_proxy https_proxy ftp_proxy
+
+# ---- edit these for your environment ----
+MODEL_PATH="${MODEL_PATH:-/path/to/weight/MiniMax-M2.5-w8a8-QuaRot}"
+EAGLE_MODEL_PATH="${EAGLE_MODEL_PATH:-/path/to/weight/MiniMax-M2.5-eagle-model-0318}"
+NIC_NAME="${NIC_NAME:-<your_nic_name>}"
+LOCAL_IP="${LOCAL_IP:-<your_ip>}"
+
+export HCCL_IF_IP=$LOCAL_IP
+export GLOO_SOCKET_IFNAME=$NIC_NAME
+export TP_SOCKET_IFNAME=$NIC_NAME
+export HCCL_SOCKET_IFNAME=$NIC_NAME
+
+export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export OMP_NUM_THREADS=1
+echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
+sysctl -w vm.swappiness=0
+sysctl -w kernel.numa_balancing=0
+sysctl kernel.sched_migration_cost_ns=50000
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+
+export TASK_QUEUE_ENABLE=1
+export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+export PYTHONHASHSEED=0
+
+export ASCEND_RT_VISIBLE_DEVICES=$1
+
+vllm serve "$MODEL_PATH" \
+    --host 0.0.0.0 \
+    --port $2 \
+    --data-parallel-size $3 \
+    --data-parallel-rank $4 \
+    --data-parallel-address $5 \
+    --data-parallel-rpc-port $6 \
+    --tensor-parallel-size $7 \
+    --enable-expert-parallel \
+    --served-model-name minimax \
+    --max-model-len 200000 \
+    --max-num-batched-tokens 16384 \
+    --max-num-seqs 64 \
+    --trust-remote-code \
+    --gpu-memory-utilization 0.75 \
+    --quantization ascend \
+    --enforce-eager \
+    --speculative_config "{\"method\": \"eagle3\", \"model\": \"$EAGLE_MODEL_PATH\", \"num_speculative_tokens\": 1}" \
+    --additional-config '{"enable_cpu_binding":true}' \
+    --kv-transfer-config \
+        '{"kv_connector": "MooncakeConnectorV1",
+        "kv_role": "kv_producer",
+        "kv_port": "35880",
+        "engine_id": "0",
+        "kv_connector_extra_config": {
+             "use_ascend_direct": true,
+             "prefill": {"dp_size": 2, "tp_size": 8},
+             "decode":  {"dp_size": 2, "tp_size": 8}
+        }}'

--- a/tests/e2e/nightly/multi_node/external_dp/config/MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k.yaml
@@ -1,0 +1,152 @@
+# MiniMax-M2.5 w8a8 QuaRot, A3 PD disaggregation, 1 prefill + 1 decode node,
+# total context length 200k (--max-model-len 200000).
+#
+# Topology mirrors the Kimi-K2.6 PD case (prefill DP2/TP8, decode DP4/TP4 on
+# 16-NPU A3 nodes); serving args are inherited from the single-node case
+# tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A3.yaml.
+#
+# The case validates that the PD cluster boots with 200k context
+# (--max-model-len 200000) and the proxy is healthy. Functional verification
+# uses a normal short chat request via curl.
+
+test_name: "MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k"
+model: "Eco-Tech/MiniMax-M2.5-w8a8-QuaRot"
+num_nodes: 2
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0 ]
+    decoder: [ 1 ]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 2
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 4
+    dp_size_local: 4
+    dp_rank_start: 0
+    tp_size: 4
+    dp_address: "${NODE_1_IP}"
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  VLLM_RPC_TIMEOUT: "3600000"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+  HCCL_EXEC_TIMEOUT: "204"
+  HCCL_CONNECT_TIMEOUT: "120"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "10"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  TASK_QUEUE_ENABLE: "1"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  VLLM_ASCEND_ENABLE_NZ: "1"
+  VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+  VLLM_ASCEND_BALANCE_SCHEDULING: "1"
+  VLLM_SERVER_DEV_MODE: "1"
+env_prefill: &env_prefill
+  <<: *env_common
+  HCCL_BUFFSIZE: "512"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+env_decode: &env_decode
+  <<: *env_common
+  HCCL_BUFFSIZE: "800"
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --safetensors-load-strategy
+      - 'prefetch'
+      - --enable-expert-parallel
+      - --trust-remote-code
+      - --seed
+      - "1024"
+      - --quantization
+      - "ascend"
+      - --max-model-len
+      - "200000"
+      - --max-num-seqs
+      - "128"
+      - --max-num-batched-tokens
+      - "16384"
+      - --no-enable-prefix-caching
+      - --gpu-memory-utilization
+      - "0.85"
+      - --additional-config
+      - '{"enable_cpu_binding": true}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_producer","kv_port": "30000","engine_id": "0","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
+
+  - node_index: 1
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --safetensors-load-strategy
+      - 'prefetch'
+      - --enable-expert-parallel
+      - --trust-remote-code
+      - --seed
+      - "1024"
+      - --quantization
+      - "ascend"
+      - --max-model-len
+      - "200000"
+      - --max-num-seqs
+      - "128"
+      - --max-num-batched-tokens
+      - "256"
+      - --no-enable-prefix-caching
+      - --gpu-memory-utilization
+      - "0.9"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --speculative-config
+      - '{"method": "eagle3","model": "vllm-ascend/MiniMax-M2.5-eagle-model-0318","num_speculative_tokens": 3}'
+      - --additional-config
+      - '{"enable_cpu_binding": true}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
+
+benchmarks: {}


### PR DESCRIPTION
## Summary

Add an A3 PD-separation (1P1D) nightly test case and matching online deployment scripts for MiniMax-M2.5 w8a8 QuaRot with 200k context length.

- `tests/e2e/nightly/multi_node/external_dp/config/MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k.yaml`: external-DP disaggregated-prefill config, 2 nodes (prefill DP2/TP8, decode DP4/TP4 on 16-NPU A3), `--max-model-len 200000`, Mooncake KV transfer, EAGLE3 speculative decoding on the decode node. Mirrors the validated topology in the MiniMax-M2 tutorial (section 5.2).
- `.github/workflows/configs/nightly_config.yaml`: register the case under `a3.multi_node` (size 2) with the new `config_base_path` field.
- `examples/external_online_dp/minimax_m2_pd/`: `run_dp_template_prefill.sh` / `run_dp_template_decode.sh` (doc-faithful 1P1D launch templates) plus a README covering per-node launch, proxy startup, and a simple curl verification.

## Validation

- YAML syntax valid for the new config and nightly registration.
- `bash -n` passes for both template scripts.
- The case can be exercised before merge via `/nightly MiniMax-M2.5-w8a8-QuaRot-A3-PD-200k`.

## Notes

- Topology and serving args follow the MiniMax-M2 tutorial 1P1D configuration (prefill `--enforce-eager` + EAGLE3=1, decode `FULL_DECODE_ONLY` + EAGLE3=3); final tuning may need an A3 cluster run.
- Functional verification is a normal short chat request via curl; the service is launched with `--max-model-len 200000`.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
