### PR TITLE
feat: add custom ApplyTopKTopPWithSorted Ascend C operator from cann/…

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -269,6 +269,7 @@ add_subdirectory(common)
 if (NOT BUILD_OPS_RTY_KERNEL)
     add_subdirectory(mc2)
     add_subdirectory(posembedding)
+    add_subdirectory(sample)
 endif()
 
 if(NOT DEFINED COMPILED_OPS)

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -41,7 +41,8 @@ resolve_op_dir() {
         "${ROOT_DIR}/csrc/attention/${op_name}" \
         "${ROOT_DIR}/csrc/mc2/${op_name}" \
         "${ROOT_DIR}/csrc/ffn/${op_name}" \
-        "${ROOT_DIR}/csrc/posembedding/${op_name}"; do
+        "${ROOT_DIR}/csrc/posembedding/${op_name}" \
+        "${ROOT_DIR}/csrc/sample/${op_name}"; do
         if [[ -d "${candidate_dir}" ]]; then
             echo "${candidate_dir}"
             return 0
@@ -130,6 +131,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "store_kv_block"
         "store_kv_block_metadata"
         "sparse_attention_score"
+        "topk_topp"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
@@ -178,6 +180,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "store_kv_block"
         "store_kv_block_metadata"
         "sparse_attention_score"
+        "topk_topp"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"
@@ -212,6 +215,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
         "store_kv_block"
         "store_kv_block_metadata"
         "sparse_attention_score"
+        "topk_topp"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")

--- a/csrc/sample/topk_topp/CMakeLists.txt
+++ b/csrc/sample/topk_topp/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2025 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/sample/topk_topp/op_host/CMakeLists.txt
+++ b/csrc/sample/topk_topp/op_host/CMakeLists.txt
@@ -1,0 +1,21 @@
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+        apply_top_k_top_p_with_sorted_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+    OP_NAME ApplyTopKTopPWithSorted
+    OPTIONS
+        --cce-auto-sync=on
+        -Wno-deprecated-declarations
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE apply_top_k_top_p_with_sorted ACLNNTYPE aclnn)
+    target_include_directories(${OPHOST_NAME}_tiling_obj PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/csrc/sample/topk_topp/op_host/apply_top_k_top_p_with_sorted_def.cpp
+++ b/csrc/sample/topk_topp/op_host/apply_top_k_top_p_with_sorted_def.cpp
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_k_top_p_with_sorted_def.cpp
+ * \brief
+ */
+#include "register/op_def_registry.h"
+
+namespace ops {
+class ApplyTopKTopPWithSorted : public OpDef {
+public:
+    explicit ApplyTopKTopPWithSorted(const char* name) : OpDef(name)
+    {
+        this->Input("sorted_value")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("sorted_indices")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("p")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("k")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Input("logits")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+        this->Output("out")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16, ge::DT_BF16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        OpAICoreConfig aicore_config;
+        aicore_config.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(false)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true);
+        this->AICore().AddConfig("ascend910b");
+        this->AICore().AddConfig("ascend910_93");
+        this->AICore().AddConfig("ascend950");
+
+        OpAICoreConfig config_kirin = GetKirinCoreConfig();
+        this->AICore().AddConfig("kirinx90", config_kirin);
+        this->AICore().AddConfig("kirin9030", config_kirin);
+    }
+
+private:
+    OpAICoreConfig GetKirinCoreConfig() const
+    {
+        OpAICoreConfig config_kirin;
+        config_kirin.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true);
+        config_kirin.Input("sorted_value")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        config_kirin.Input("sorted_indices")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        config_kirin.Input("p")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        config_kirin.Input("k")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        config_kirin.Input("logits")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        config_kirin.Output("out")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+        return config_kirin;
+    }
+};
+
+OP_ADD(ApplyTopKTopPWithSorted);
+} // namespace ops

--- a/csrc/sample/topk_topp/op_host/apply_top_k_top_p_with_sorted_tiling.cpp
+++ b/csrc/sample/topk_topp/op_host/apply_top_k_top_p_with_sorted_tiling.cpp
@@ -1,0 +1,349 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_k_top_p_with_sorted_tiling.cpp
+ * \brief
+ */
+
+#include <iostream>
+#include <map>
+#include "log/log.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "platform/platform_infos_def.h"
+#include "register/op_def_registry.h"
+#include "register/op_impl_registry.h"
+#include "tiling/tiling_api.h"
+#include "apply_top_k_top_p_with_sorted_tiling.h"
+#include "platform/soc_spec.h"
+
+namespace {
+constexpr uint32_t SYS_RESERVED_UB = uint32_t(16 * 1024);
+constexpr uint32_t SELECT_RESERVED_UB = uint32_t(8 * 1024);
+constexpr uint32_t DIM_ONE = 1;
+constexpr uint32_t DIM_TWO = 2;
+constexpr int32_t SORTED_VALUE_INPUT_INDEX = 0;
+constexpr int32_t SORTED_INDICES_INPUT_INDEX = 1;
+constexpr int32_t P_INPUT_INDEX = 2;
+constexpr int32_t K_INPUT_INDEX = 3;
+constexpr int32_t LOGITS_INPUT_INDEX = 4;
+constexpr uint32_t DIM_INDEX0 = 0;
+constexpr uint32_t FLOAT_BYTES = 4;
+static std::map<ge::DataType, uint32_t> DTYPE_MAP = {{ge::DT_BF16, 2}, {ge::DT_FLOAT16, 1}, {ge::DT_FLOAT, 0}};
+static std::map<ge::DataType, uint32_t> DATATYPE_LEN_MAP = {{ge::DT_FLOAT16, 2}, {ge::DT_BF16, 2}, {ge::DT_FLOAT, 4}};
+const static uint32_t SYS_WORKSPACESIZE = uint32_t(16 * 1024 * 1024);
+
+constexpr uint32_t DATA_PER_BLOCK_B32 = 8;
+constexpr uint32_t BYTES_B32 = 4;
+constexpr uint32_t BLOCK_BYTES = 32;
+constexpr uint32_t K_VALUE_MAX = 1024;
+constexpr uint32_t ONLY_TOP_P_KEY = 2;
+constexpr uint32_t OPT_TOP_K_TOP_P_KEY = 3;
+constexpr uint32_t OPT_TOP_K_KEY = 4;
+constexpr uint32_t OPT_TOP_P_KEY = 5;
+constexpr uint32_t ONLY_TOP_K_KEY = 1;
+constexpr uint32_t BATCH_MODE = 1;
+constexpr uint32_t ONLY_TOP_950_MAX_CORENUM = 48;
+constexpr uint32_t BRCB_VOCAB_MIN = 256;
+constexpr uint32_t BRCB_B1_VOCAB_MAX = 12000;
+constexpr uint32_t BRCB_B2_VOCAB_MAX = 12048;
+constexpr uint32_t BRCB_B16_VOCAB_MIN = 512;
+constexpr uint32_t BRCB_B16_VOCAB_MAX = 1024;
+} // namespace
+
+namespace optiling {
+class ApplyTopKTopPWithSortedTiling {
+public:
+    explicit ApplyTopKTopPWithSortedTiling(gert::TilingContext* context) : tilingcontext(context) {};
+    ge::graphStatus Init();
+    ge::graphStatus RunKernelTiling();
+
+private:
+    ApplyTopKTopPWithSortedTilingData tilingData;
+    gert::TilingContext* tilingcontext = nullptr;
+    ge::graphStatus CheckShape();
+    void SetTilingKey();
+    void GetUsedCore();
+    void CalDataPerCore();
+    void FillTilingData();
+    void PrintTilingData();
+    template <typename T1>
+    inline auto CeilAlign(T1 a, T1 b) const -> T1
+    {
+        return b == 0 ? a : (a + b - 1) / b * b;
+    }
+    template <typename T1>
+    inline auto FloorAlign(T1 a, T1 b) const -> T1
+    {
+        return b == 0 ? a : a / b * b;
+    }
+
+    const char* opName_ = nullptr;
+    uint32_t coreNum_ = 0;
+    uint32_t calUbSize_ = 0;
+    uint32_t batchSize_ = 0;
+    uint32_t vocabSize_ = 0;
+    uint32_t tilingKey_ = 0;
+    uint32_t usedCoreNum_ = 0;
+    uint32_t batchPerCore_ = 1;
+    uint32_t tailBatch_ = 0;
+    uint32_t dataNumInit_ = 0;
+    uint32_t dataNumInitAligned_ = 0;
+    uint32_t ubFactorElement_ = 0;
+    uint32_t ubFactorElementAligned_ = 0;
+    uint32_t tailUbFactorElement_ = 0;
+    uint32_t tailUbFactorElementAligned_ = 0;
+    uint32_t iterateTimes_ = 0;
+    uint32_t onlyTopK_ = 0;
+    uint32_t onlyTopP_ = 0;
+    uint64_t platformUbSize_ = 0;
+    NpuArch socVersion_;
+};
+
+ge::graphStatus ApplyTopKTopPWithSortedTiling::CheckShape()
+{
+    auto sortedValueShapePtr = tilingcontext->GetInputShape(SORTED_VALUE_INPUT_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(tilingcontext, sortedValueShapePtr);
+    auto sortedValueShape = sortedValueShapePtr->GetStorageShape();
+    if (sortedValueShape.GetDimNum() != DIM_TWO) {
+        OP_LOGE(opName_, "the dimNum of sorted_value should be 2, but got %u.", sortedValueShape.GetDimNum());
+        return ge::GRAPH_FAILED;
+    }
+    auto sortedIndicesShapePtr = tilingcontext->GetInputShape(SORTED_INDICES_INPUT_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(tilingcontext, sortedIndicesShapePtr);
+    auto sortedIndicesShape = sortedIndicesShapePtr->GetStorageShape();
+    if (sortedIndicesShape.GetDimNum() != DIM_TWO) {
+        OP_LOGE(opName_, "the dimNum of sorted_indices should be 2, but got %u.", sortedIndicesShape.GetDimNum());
+        return ge::GRAPH_FAILED;
+    }
+    batchSize_ = sortedValueShape.GetDim(DIM_INDEX0);
+    vocabSize_ = sortedValueShape.GetDim(DIM_ONE);
+    if (sortedIndicesShape.GetDim(DIM_INDEX0) != batchSize_ || sortedIndicesShape.GetDim(DIM_ONE) != vocabSize_) {
+        OP_LOGE(opName_, "the shape of sorted_indices should be equal to sorted_value.");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto pShapePtr = tilingcontext->GetOptionalInputShape(P_INPUT_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(tilingcontext, pShapePtr);
+    auto pShape = pShapePtr->GetStorageShape();
+    auto pDimNum = pShape.GetDimNum();
+    if (pDimNum != DIM_ONE && pDimNum != 0) {
+        OP_LOGE(opName_, "the dimNum of p should be 1 or 0, but got %u.", pDimNum);
+        return ge::GRAPH_FAILED;
+    }
+    if (pDimNum != 0 && batchSize_ != pShape.GetDim(DIM_INDEX0)) {
+        OP_LOGE(opName_, "p.shape[0] should be equal to logits.shape[0].");
+        return ge::GRAPH_FAILED;
+    }
+
+    auto kShapePtr = tilingcontext->GetOptionalInputShape(K_INPUT_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(tilingcontext, kShapePtr);
+    auto kShape = kShapePtr->GetStorageShape();
+    auto kDimNum = kShape.GetDimNum();
+    if (kDimNum != DIM_ONE && kDimNum != 0) {
+        OP_LOGE(opName_, "the dimNum of k should be 1 or 0, but got %u.", kShape.GetDimNum());
+        return ge::GRAPH_FAILED;
+    }
+    if (kDimNum != 0 && batchSize_ != kShape.GetDim(DIM_INDEX0)) {
+        OP_LOGE(opName_, "k.shape[0] should be equal to logits.shape[0].");
+        return ge::GRAPH_FAILED;
+    }
+    if (kDimNum == 0 && pDimNum == 0) {
+        OP_LOGE(opName_, "the dimNum of q and k should be 0 at the same time.");
+        return ge::GRAPH_FAILED;
+    }
+    onlyTopK_ = (kDimNum != 0 && pDimNum == 0) ? ONLY_TOP_K_KEY : 0;
+    onlyTopP_ = (pDimNum != 0 && kDimNum == 0) ? ONLY_TOP_P_KEY : 0;
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus ApplyTopKTopPWithSortedTiling::Init()
+{
+    opName_ = tilingcontext->GetNodeName();
+    OP_LOGD(opName_, "TilingForApplyTopKTopPWithSorted init.");
+    auto platformInfo = platform_ascendc::PlatformAscendC(tilingcontext->GetPlatformInfo());
+    coreNum_ = platformInfo.GetCoreNumAiv();
+    socVersion_ = platformInfo.GetCurNpuArch();
+    platformInfo.GetCoreMemSize(platform_ascendc::CoreMemType::UB, platformUbSize_);
+    OP_LOGD(opName_, "platformUbSize: %lu.", platformUbSize_);
+    uint32_t avaliableUb = static_cast<uint32_t>(platformUbSize_) - SYS_RESERVED_UB - SELECT_RESERVED_UB;
+    calUbSize_ = FloorAlign(avaliableUb, BLOCK_BYTES);
+    if (CheckShape() == ge::GRAPH_FAILED) {
+        OP_LOGE(opName_, "check shape failed.");
+        return ge::GRAPH_FAILED;
+    }
+    uint32_t tempValue = 1;
+    while (tempValue < vocabSize_) {
+        tempValue <<= 1;
+        iterateTimes_++;
+    } // ceil(log2(vocabSize_))
+    return ge::GRAPH_SUCCESS;
+}
+
+void ApplyTopKTopPWithSortedTiling::SetTilingKey()
+{
+    tilingKey_ += onlyTopK_;
+    tilingKey_ += onlyTopP_;
+    tilingcontext->SetTilingKey(tilingKey_);
+    tilingcontext->SetScheduleMode(BATCH_MODE);
+}
+
+void ApplyTopKTopPWithSortedTiling::GetUsedCore()
+{
+    if (socVersion_ == NpuArch::DAV_3510 && tilingKey_ == ONLY_TOP_P_KEY) {
+        coreNum_ = coreNum_ > ONLY_TOP_950_MAX_CORENUM ? ONLY_TOP_950_MAX_CORENUM : coreNum_;
+    }
+    if (coreNum_ > 0) {
+        batchPerCore_ = batchSize_ / coreNum_;
+        tailBatch_ = batchSize_ % coreNum_;
+        usedCoreNum_ = coreNum_;
+    }
+}
+
+void ApplyTopKTopPWithSortedTiling::CalDataPerCore()
+{
+    uint32_t inputDataTypeByte = DATATYPE_LEN_MAP[tilingcontext->GetInputDesc(SORTED_VALUE_INPUT_INDEX)->GetDataType()];
+    uint32_t dataPerBlock = BLOCK_BYTES / inputDataTypeByte;
+    dataNumInit_ = vocabSize_ < K_VALUE_MAX ? vocabSize_ : K_VALUE_MAX;
+    dataNumInitAligned_ = vocabSize_ < K_VALUE_MAX ? vocabSize_ : K_VALUE_MAX;
+    ubFactorElement_ = vocabSize_ < K_VALUE_MAX ? vocabSize_ : K_VALUE_MAX;
+    ubFactorElementAligned_ = CeilAlign(ubFactorElement_, dataPerBlock);
+    tailUbFactorElement_ = vocabSize_ % ubFactorElement_;
+    tailUbFactorElement_ = tailUbFactorElement_ == uint32_t(0) ? ubFactorElement_ : tailUbFactorElement_;
+    tailUbFactorElementAligned_ = CeilAlign(tailUbFactorElement_, dataPerBlock);
+
+    uint32_t sortedValueBytes = ubFactorElementAligned_ * inputDataTypeByte + K_VALUE_MAX * inputDataTypeByte;
+    uint32_t sortedIndicesBytes = ubFactorElementAligned_ * BYTES_B32 + K_VALUE_MAX * BYTES_B32;
+    uint32_t pBytes = dataPerBlock * inputDataTypeByte;
+    uint32_t kBytes = DATA_PER_BLOCK_B32 * BYTES_B32;
+    uint32_t outTensorBytes = ubFactorElementAligned_ * inputDataTypeByte;
+
+    calUbSize_ = calUbSize_ - sortedValueBytes - sortedIndicesBytes - pBytes - kBytes - outTensorBytes;
+    if (onlyTopP_ > 0) {
+        calUbSize_ = static_cast<uint32_t>(platformUbSize_);
+    }
+}
+
+void ApplyTopKTopPWithSortedTiling::FillTilingData()
+{
+    tilingData.set_batchSize(batchSize_);
+    tilingData.set_vocabSize(vocabSize_);
+    tilingData.set_batchPerCore(batchPerCore_);
+    tilingData.set_tailBatch(tailBatch_);
+    tilingData.set_blockNum(usedCoreNum_);
+    tilingData.set_dataNumInit(dataNumInit_);
+    tilingData.set_dataNumInitAligned(dataNumInitAligned_);
+    tilingData.set_ubFactorElement(ubFactorElement_);
+    tilingData.set_ubFactorElementAligned(ubFactorElementAligned_);
+    tilingData.set_tailUbFactorElement(tailUbFactorElement_);
+    tilingData.set_tailUbFactorElementAligned(tailUbFactorElementAligned_);
+    tilingData.set_calUbSize(calUbSize_);
+    tilingData.set_iterateTimes(iterateTimes_);
+}
+
+void ApplyTopKTopPWithSortedTiling::PrintTilingData()
+{
+    OP_LOGD(opName_, "batchSize: %u.", tilingData.get_batchSize());
+    OP_LOGD(opName_, "vocabSize: %u.", tilingData.get_vocabSize());
+    OP_LOGD(opName_, "batchPerCore: %u.", tilingData.get_batchPerCore());
+    OP_LOGD(opName_, "tailBatch: %u.", tilingData.get_tailBatch());
+    OP_LOGD(opName_, "usedCoreNum: %u.", tilingData.get_blockNum());
+    OP_LOGD(opName_, "dataNumInit_: %u.", tilingData.get_dataNumInit());
+    OP_LOGD(opName_, "dataNumInitAligned_: %u.", tilingData.get_dataNumInitAligned());
+    OP_LOGD(opName_, "ubFactorElement: %u.", tilingData.get_ubFactorElement());
+    OP_LOGD(opName_, "ubFactorElementAligned: %u.", tilingData.get_ubFactorElementAligned());
+    OP_LOGD(opName_, "tailUbFactorElement: %u.", tilingData.get_tailUbFactorElement());
+    OP_LOGD(opName_, "tailUbFactorElementAligned: %u.", tilingData.get_tailUbFactorElementAligned());
+    OP_LOGD(opName_, "calUbSize: %u.", tilingData.get_calUbSize());
+    OP_LOGD(opName_, "iterateTimes: %u.", tilingData.get_iterateTimes());
+}
+
+ge::graphStatus ApplyTopKTopPWithSortedTiling::RunKernelTiling()
+{
+    OP_LOGD(opName_, "TilingForApplyTopKTopPWithSorted start.");
+
+    SetTilingKey();
+    GetUsedCore();
+    CalDataPerCore();
+
+    auto logitsShapePtr = tilingcontext->GetOptionalInputShape(LOGITS_INPUT_INDEX);
+    bool logitsAvailable = (logitsShapePtr != nullptr && logitsShapePtr->GetStorageShape().GetDimNum() > 0);
+    if (logitsAvailable && batchSize_ > 0 && vocabSize_ > 0) {
+        if (onlyTopP_ > 0) {
+            tilingKey_ = OPT_TOP_P_KEY;
+        } else if (onlyTopK_ > 0) {
+            tilingKey_ = OPT_TOP_K_KEY;
+        } else {
+            tilingKey_ = OPT_TOP_K_TOP_P_KEY;
+        }
+        tilingcontext->SetTilingKey(tilingKey_);
+        calUbSize_ = static_cast<uint32_t>(platformUbSize_);
+    }
+
+    FillTilingData();
+    PrintTilingData();
+
+    uint32_t syncWorkspaceSize = SYS_WORKSPACESIZE;
+    size_t* currentWorkspace = tilingcontext->GetWorkspaceSizes(1);
+    if (tilingKey_ == OPT_TOP_P_KEY || tilingKey_ == ONLY_TOP_P_KEY || tilingKey_ == OPT_TOP_K_TOP_P_KEY) {
+        currentWorkspace[0] = syncWorkspaceSize + batchSize_ * vocabSize_ * FLOAT_BYTES;
+    } else {
+        currentWorkspace[0] = syncWorkspaceSize + batchSize_ * FLOAT_BYTES;
+    }
+
+    tilingData.SaveToBuffer(tilingcontext->GetRawTilingData()->GetData(),
+                            tilingcontext->GetRawTilingData()->GetCapacity());
+    tilingcontext->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
+    tilingcontext->SetBlockDim(usedCoreNum_);
+
+    OP_LOGD(opName_, "tilingKey: %u.", tilingKey_);
+    OP_LOGD(opName_, "TilingForApplyTopKTopPWithSorted end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus TilingForApplyTopKTopPWithSorted(gert::TilingContext* context)
+{
+    ApplyTopKTopPWithSortedTiling tilingObject(context);
+    auto ret = tilingObject.Init();
+    if (ret != ge::GRAPH_SUCCESS) {
+        OP_LOGE(context->GetNodeName(), "tiling Init failed.");
+        return ge::GRAPH_FAILED;
+    }
+    ret = tilingObject.RunKernelTiling();
+    OP_LOGD(context->GetNodeName(), "TilingForApplyTopKTopPWithSorted end.");
+    return ret;
+}
+
+static ge::graphStatus TilingPrepareForApplyTopKTopPWithSorted(gert::TilingParseContext* context)
+{
+    OP_LOGD(context->GetNodeName(), "TilingPrepareForApplyTopKTopPWithSorted start");
+    auto compileInfo = context->GetCompiledInfo<TilingForApplyTopKTopPWithSortedCompileInfo>();
+    OP_CHECK_NULL_WITH_CONTEXT(context, compileInfo);
+    auto platformInfo = context->GetPlatformInfo();
+    OP_CHECK_NULL_WITH_CONTEXT(context, platformInfo);
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(platformInfo);
+    compileInfo->totalCoreNum = ascendcPlatform.GetCoreNumAiv();
+    uint64_t ubSizePlatForm;
+    ascendcPlatform.GetCoreMemSize(platform_ascendc::CoreMemType::UB, ubSizePlatForm);
+    compileInfo->ubSizePlatForm = static_cast<int64_t>(ubSizePlatForm);
+    OP_CHECK_IF(compileInfo->ubSizePlatForm <= 0, OP_LOGE(context->GetNodeName(), "Failed to get ub size"),
+                return ge::GRAPH_FAILED);
+    OP_LOGD(context->GetNodeName(), "ub_size_platform is %lu", compileInfo->ubSizePlatForm);
+    uint64_t totalUbSize = 0;
+    platformInfo->GetLocalMemSize(fe::LocalMemType::UB, totalUbSize);
+    OP_LOGD(context->GetNodeName(), "total ub size is %lu", totalUbSize);
+    OP_LOGD(context->GetNodeName(), "TilingPrepareForApplyTopKTopPWithSorted end");
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(ApplyTopKTopPWithSorted)
+    .Tiling(TilingForApplyTopKTopPWithSorted)
+    .TilingParse<TilingForApplyTopKTopPWithSortedCompileInfo>(TilingPrepareForApplyTopKTopPWithSorted);
+} // namespace optiling

--- a/csrc/sample/topk_topp/op_host/apply_top_k_top_p_with_sorted_tiling.h
+++ b/csrc/sample/topk_topp/op_host/apply_top_k_top_p_with_sorted_tiling.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_k_top_p_with_sorted_tiling.h
+ * \brief
+ * ATTENTION: MAKE SURE 'BEGIN_TILING_DATA_DEF' STAY IN THE SAME LINE (28) USING BLANK LINES.
+ *
+ *
+ *
+ *
+ *
+ */
+#ifndef __APPLY_TOP_K_TOP_P_WITH_SORTED_TILINGDATA_H__
+#define __APPLY_TOP_K_TOP_P_WITH_SORTED_TILINGDATA_H__
+
+#include "register/tilingdata_base.h"
+
+namespace optiling {
+
+BEGIN_TILING_DATA_DEF(ApplyTopKTopPWithSortedTilingData)
+TILING_DATA_FIELD_DEF(uint32_t, batchSize);
+TILING_DATA_FIELD_DEF(uint32_t, vocabSize);
+TILING_DATA_FIELD_DEF(uint32_t, batchPerCore);
+TILING_DATA_FIELD_DEF(uint32_t, tailBatch);
+TILING_DATA_FIELD_DEF(uint32_t, blockNum);
+TILING_DATA_FIELD_DEF(uint32_t, dataNumInit);
+TILING_DATA_FIELD_DEF(uint32_t, dataNumInitAligned);
+TILING_DATA_FIELD_DEF(uint32_t, ubFactorElement);
+TILING_DATA_FIELD_DEF(uint32_t, ubFactorElementAligned);
+TILING_DATA_FIELD_DEF(uint32_t, tailUbFactorElement);
+TILING_DATA_FIELD_DEF(uint32_t, tailUbFactorElementAligned);
+TILING_DATA_FIELD_DEF(uint32_t, calUbSize);
+TILING_DATA_FIELD_DEF(uint32_t, iterateTimes);
+END_TILING_DATA_DEF;
+REGISTER_TILING_DATA_CLASS(ApplyTopKTopPWithSorted, ApplyTopKTopPWithSortedTilingData)
+
+struct TilingForApplyTopKTopPWithSortedCompileInfo {
+    uint32_t totalCoreNum = 0;
+    uint64_t ubSizePlatForm = 0;
+};
+
+} // namespace optiling
+#endif // __APPLY_TOP_K_TOP_P_WITH_SORTED_TILINGDATA_H__

--- a/csrc/sample/topk_topp/op_host/op_api/aclnn_apply_top_k_top_p.cpp
+++ b/csrc/sample/topk_topp/op_host/op_api/aclnn_apply_top_k_top_p.cpp
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file aclnn_apply_top_k_top_p.cpp
+ * \brief
+ */
+#include "aclnn_apply_top_k_top_p.h"
+#include "apply_top_k_top_p_with_sorted.h"
+#include "level0/sort.h"
+#include "aclnn_kernels/contiguous.h"
+#include "aclnn_kernels/common/op_error_check.h"
+#include "aclnn/aclnn_base.h"
+#include "opdev/common_types.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/format_utils.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/tensor_view_utils.h"
+#include "opdev/shape_utils.h"
+#include "opdev/platform.h"
+
+using namespace op;
+#ifdef __cplusplus
+extern "C" {
+#endif
+namespace {
+static const int64_t EXPECTED_DIM_ONE = 1;
+static const int64_t EXPECTED_DIM_TWO = 2;
+static constexpr size_t DIM_ONE = 1;
+
+// 根据API定义，需要列出所能支持的所有dtype
+static const std::initializer_list<op::DataType> DTYPE_SUPPORT_LIST = {op::DataType::DT_FLOAT, op::DataType::DT_FLOAT16,
+                                                                       op::DataType::DT_BF16};
+
+static const std::initializer_list<op::DataType> INT_DTYPE_SUPPORT_LIST = {op::DataType::DT_INT32};
+
+static bool CheckNotNull(const aclTensor* logits, const aclTensor* p, const aclTensor* k, const aclTensor* out)
+{
+    OP_CHECK_NULL(logits, return false);
+    if (p == nullptr && k == nullptr) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "The inputs, p and k, should not be nullptr at the same time.");
+    }
+    OP_CHECK_NULL(out, return false);
+    return true;
+}
+
+static bool CheckDtypeValid(const aclTensor* logits, const aclTensor* p, const aclTensor* k, const aclTensor* out)
+{
+    // 检查数据类型是否在支持列表内
+    OP_CHECK_DTYPE_NOT_SUPPORT(logits, DTYPE_SUPPORT_LIST, return false);
+    if (p != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(p, DTYPE_SUPPORT_LIST, return false);
+    }
+    if (k != nullptr) {
+        OP_CHECK_DTYPE_NOT_SUPPORT(k, INT_DTYPE_SUPPORT_LIST, return false);
+    }
+    OP_CHECK_DTYPE_NOT_SUPPORT(out, DTYPE_SUPPORT_LIST, return false);
+
+    // 检查数据类型是否相同
+    if (p != nullptr) {
+        OP_CHECK_DTYPE_NOT_MATCH(p, logits->GetDataType(), return false);
+    }
+    OP_CHECK_DTYPE_NOT_MATCH(out, logits->GetDataType(), return false);
+    return true;
+}
+
+static bool CheckShapeValid(const aclTensor* logits, const aclTensor* p, const aclTensor* k, const aclTensor* out)
+{
+    OP_CHECK_WRONG_DIMENSION(logits, EXPECTED_DIM_TWO, return false);
+    OP_CHECK_SHAPE_NOT_EQUAL(out, logits, return false);
+    if (p != nullptr) {
+        OP_CHECK_WRONG_DIMENSION(p, EXPECTED_DIM_ONE, return false);
+    }
+    if (k != nullptr) {
+        OP_CHECK_WRONG_DIMENSION(k, EXPECTED_DIM_ONE, return false);
+    }
+    if (p != nullptr && p->GetViewShape().GetDim(0) != logits->GetViewShape().GetDim(0)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "expected p.size(0) is equal to logits.size(0), but got %ld.",
+                p->GetViewShape().GetDim(0));
+        return false;
+    }
+    if (k != nullptr && k->GetViewShape().GetDim(0) != logits->GetViewShape().GetDim(0)) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "expected k.size(0) is equal to logits.size(0), but got %ld.",
+                k->GetViewShape().GetDim(0));
+        return false;
+    }
+    return true;
+}
+
+static bool CheckFormatValid(const aclTensor* logits, const aclTensor* p, const aclTensor* k, const aclTensor* out)
+{
+    if (logits->GetStorageFormat() != Format::FORMAT_ND) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "logits format only support ND");
+        return false;
+    }
+    if (p != nullptr && p->GetStorageFormat() != Format::FORMAT_ND) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "p format only support ND");
+        return false;
+    }
+    if (k != nullptr && k->GetStorageFormat() != Format::FORMAT_ND) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "k format only support ND");
+        return false;
+    }
+    if (out->GetStorageFormat() != Format::FORMAT_ND) {
+        OP_LOGE(ACLNN_ERR_PARAM_INVALID, "out format only support ND");
+        return false;
+    }
+    return true;
+}
+
+static aclnnStatus CheckParams(const aclTensor* logits, const aclTensor* p, const aclTensor* k, const aclTensor* out)
+{
+    // 错误码等DFX方案细化后刷新，错误日志在check接口内打印
+    // 1. 检查参数是否为空指针
+    CHECK_RET(CheckNotNull(logits, p, k, out), ACLNN_ERR_PARAM_NULLPTR);
+
+    // 2. 检查输入的数据类型是否在API支持的数据类型范围之内，需要根据api定义校验
+    CHECK_RET(CheckDtypeValid(logits, p, k, out), ACLNN_ERR_PARAM_INVALID);
+
+    // 3. 检查shape是否满足约束
+    CHECK_RET(CheckShapeValid(logits, p, k, out), ACLNN_ERR_PARAM_INVALID);
+
+    // 4. 检查format是否满足约束
+    CHECK_RET(CheckFormatValid(logits, p, k, out), ACLNN_ERR_PARAM_INVALID);
+
+    return ACLNN_SUCCESS;
+}
+} // namespace
+
+aclnnStatus aclnnApplyTopKTopPGetWorkspaceSize(const aclTensor* logits, const aclTensor* p, const aclTensor* k,
+                                               aclTensor* out, uint64_t* workspaceSize, aclOpExecutor** executor)
+{
+    OP_CHECK_COMM_INPUT(workspaceSize, executor);
+    L2_DFX_PHASE_1(aclnnApplyTopKTopP, DFX_IN(logits, p, k), DFX_OUT(out));
+    // 固定写法，创建OpExecutor
+    auto uniqueExecutor = CREATE_EXECUTOR();
+    CHECK_RET(uniqueExecutor.get() != nullptr, ACLNN_ERR_INNER_CREATE_EXECUTOR);
+
+    // 固定写法，参数检查
+    auto ret = CheckParams(logits, p, k, out);
+    CHECK_RET(ret == ACLNN_SUCCESS, ret);
+    bool pIsEmpty = false;
+    bool kIsEmpty = false;
+    if (p != nullptr) {
+        pIsEmpty = p->IsEmpty();
+    }
+    if (k != nullptr) {
+        kIsEmpty = k->IsEmpty();
+    }
+    if (logits->IsEmpty() || pIsEmpty || kIsEmpty) {
+        // 根据实际支持情况补充
+        *workspaceSize = 0;
+        uniqueExecutor.ReleaseTo(executor);
+        return ACLNN_SUCCESS;
+    }
+    // 固定写法，将输入selfRef转换成连续的tensor
+    auto logitsContiguous = l0op::Contiguous(logits, uniqueExecutor.get());
+    CHECK_RET(logitsContiguous != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    const aclTensor* pContiguous = nullptr;
+    const aclTensor* kContiguous = nullptr;
+    if (p != nullptr) {
+        pContiguous = l0op::Contiguous(p, uniqueExecutor.get());
+        CHECK_RET(pContiguous != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+    if (k != nullptr) {
+        kContiguous = l0op::Contiguous(k, uniqueExecutor.get());
+        CHECK_RET(kContiguous != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+    bool isLastDimSizeOne = logits->GetViewShape()[DIM_ONE] == 1;
+    auto viewCopyResult = logitsContiguous;
+    if (isLastDimSizeOne) {
+        viewCopyResult = l0op::ViewCopy(logitsContiguous, out, uniqueExecutor.get());
+    } else {
+        auto sortResult = l0op::Sort(logitsContiguous, -1, false, true, op::DataType::DT_INT32, uniqueExecutor.get());
+        const aclTensor* sortedValue = std::get<0>(sortResult);
+        CHECK_RET(sortedValue != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        const aclTensor* sortedIndices = std::get<1>(sortResult);
+        CHECK_RET(sortedIndices != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        auto res = l0op::ApplyTopKTopPWithSorted(sortedValue, sortedIndices, pContiguous, kContiguous, logitsContiguous,
+                                                 uniqueExecutor.get());
+        CHECK_RET(res != nullptr, ACLNN_ERR_INNER_NULLPTR);
+        // 固定写法，将计算结果拷贝到输出out上，out可能是非连续的tensor
+        viewCopyResult = l0op::ViewCopy(res, out, uniqueExecutor.get());
+    }
+    CHECK_RET(viewCopyResult != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    // 固定写法，获取计算过程中需要使用的workspace大小
+    *workspaceSize = uniqueExecutor->GetWorkspaceSize();
+    uniqueExecutor.ReleaseTo(executor); // 需要把 uniqueExecutor持有executor转移给executor
+    return ACLNN_SUCCESS;
+}
+
+aclnnStatus aclnnApplyTopKTopP(void* workspace, uint64_t workspaceSize, aclOpExecutor* executor, aclrtStream stream)
+{
+    L2_DFX_PHASE_2(aclnnApplyTopKTopP);
+    // 固定写法，调用框架能力，完成计算
+    return CommonOpExecutorRun(workspace, workspaceSize, executor, stream);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/csrc/sample/topk_topp/op_host/op_api/aclnn_apply_top_k_top_p.h
+++ b/csrc/sample/topk_topp/op_host/op_api/aclnn_apply_top_k_top_p.h
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file aclnn_apply_top_k_top_p.h
+ * \brief
+ */
+#ifndef OP_API_INC_APPLY_TOP_K_TOP_P_H_
+#define OP_API_INC_APPLY_TOP_K_TOP_P_H_
+
+#include "aclnn/aclnn_base.h"
+#include "aclnn_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief aclnnApplyTopKTopP的第一段接口，根据具体的计算流程，计算workspace大小。
+ * @domain aclnn_ops_infer
+ * @param [in] logits: npu
+ * device侧的aclTensor，数据类型支持FLOAT、FLOAT16、BFLOAT16，支持非连续的Tensor，数据格式支持ND。
+ * @param [in] p: npu device侧的aclTensor，数据类型支持FLOAT、FLOAT16、BFLOAT16，支持非连续的Tensor，数据格式支持ND。
+ * @param [in] k: npu device侧的aclTensor，数据类型支持INT32，支持非连续的Tensor，数据格式支持ND。
+ * @param [in] out: npu device侧的aclTensor，数据类型支持FLOAT、FLOAT16、BFLOAT16，支持非连续的Tensor，数据格式支持ND。
+ * @param [out] workspaceSize: 返回用户需要在npu device侧申请的workspace大小。
+ * @param [out] executor: 返回op执行器，包含算子计算流程。
+ * @return aclnnStatus: 返回状态码。
+ */
+ACLNN_API aclnnStatus aclnnApplyTopKTopPGetWorkspaceSize(const aclTensor* logits, const aclTensor* p,
+                                                         const aclTensor* k, aclTensor* out, uint64_t* workspaceSize,
+                                                         aclOpExecutor** executor);
+
+/**
+ * @brief aclnnApplyTopKTopP的第二段接口，用于执行计算。
+ * @param [in] workspace: 在npu device侧申请的workspace内存起址。
+ * @param [in] workspaceSize: 在npu device侧申请的workspace大小，由第一段接口aclnnApplyTopKTopPGetWorkspaceSize获取。
+ * @param [in] stream: acl stream流。
+ * @param [in] executor: op执行器，包含了算子计算流程。
+ * @return aclnnStatus: 返回状态码。
+ */
+ACLNN_API aclnnStatus aclnnApplyTopKTopP(void* workspace, uint64_t workspaceSize, aclOpExecutor* executor,
+                                         aclrtStream stream);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OP_API_INC_APPLY_TOP_K_TOP_P_H_

--- a/csrc/sample/topk_topp/op_host/op_api/apply_top_k_top_p_with_sorted.cpp
+++ b/csrc/sample/topk_topp/op_host/op_api/apply_top_k_top_p_with_sorted.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_k_top_p_with_sorted.cpp
+ * \brief
+ */
+#include "apply_top_k_top_p_with_sorted.h"
+#include "opdev/data_type_utils.h"
+#include "opdev/format_utils.h"
+#include "opdev/make_op_executor.h"
+#include "opdev/op_def.h"
+#include "opdev/op_dfx.h"
+#include "opdev/op_executor.h"
+#include "opdev/op_log.h"
+#include "opdev/shape_utils.h"
+using namespace op;
+
+namespace l0op {
+
+OP_TYPE_REGISTER(ApplyTopKTopPWithSorted);
+
+const aclTensor* ApplyTopKTopPWithSorted(const aclTensor* sortedValue, const aclTensor* sortedIndices,
+                                         const aclTensor* p, const aclTensor* k, const aclTensor* logits,
+                                         aclOpExecutor* executor)
+{
+    L0_DFX(ApplyTopKTopPWithSorted, sortedValue, sortedIndices, p, k, logits);
+    auto output = executor->AllocTensor(sortedValue->GetViewShape(), sortedValue->GetDataType());
+    if (p == nullptr) {
+        p = executor->AllocTensor(sortedValue->GetDataType(), Format::FORMAT_ND, Format::FORMAT_ND);
+    }
+    if (k == nullptr) {
+        k = executor->AllocTensor(DataType::DT_INT32, Format::FORMAT_ND, Format::FORMAT_ND);
+    }
+    if (logits == nullptr) {
+        logits = executor->AllocTensor(sortedValue->GetDataType(), Format::FORMAT_ND, Format::FORMAT_ND);
+    }
+    ADD_TO_LAUNCHER_LIST_AICORE(ApplyTopKTopPWithSorted, OP_INPUT(sortedValue, sortedIndices, p, k, logits),
+                                OP_OUTPUT(output));
+
+    return output;
+}
+} // namespace l0op

--- a/csrc/sample/topk_topp/op_host/op_api/apply_top_k_top_p_with_sorted.h
+++ b/csrc/sample/topk_topp/op_host/op_api/apply_top_k_top_p_with_sorted.h
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_k_top_p_with_sorted.h
+ * \brief
+ */
+#ifndef OP_API_INC_LEVEL0_OP_APPLY_TOP_K_TOP_P_WITH_SORTED_OP_H_
+#define OP_API_INC_LEVEL0_OP_APPLY_TOP_K_TOP_P_WITH_SORTED_OP_H_
+
+#include "opdev/op_executor.h"
+
+namespace l0op {
+const aclTensor* ApplyTopKTopPWithSorted(const aclTensor* sortedValue, const aclTensor* sortedIndices,
+                                         const aclTensor* p, const aclTensor* k, const aclTensor* logits,
+                                         aclOpExecutor* executor);
+}
+#endif // OP_API_INC_LEVEL0_OP_APPLY_TOP_K_TOP_P_WITH_SORTED_OP_H_

--- a/csrc/sample/topk_topp/op_kernel/apply_top_k_top_p_opt.h
+++ b/csrc/sample/topk_topp/op_kernel/apply_top_k_top_p_opt.h
@@ -1,0 +1,1166 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef APPLY_TOP_K_TOP_P_OPT_H_KERNEL
+#define APPLY_TOP_K_TOP_P_OPT_H_KERNEL
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+namespace ApplyTopKTopPOptOp {
+constexpr uint16_t FLOAT16_NEG_INF = 0xFC00;
+constexpr uint16_t BF16_NEG_INF = 0xFF80;
+constexpr int32_t FLOAT32_NEG_INF = 0xFF800000;
+
+constexpr uint32_t BLOCK_BYTES = 32;
+constexpr uint32_t RESERVED_UB = 1024;
+constexpr uint32_t FLOAT_BYTES = 4;
+constexpr uint32_t SOFTMAX_UB_NUM = 2;
+constexpr uint32_t CMP_ALIGN_BYTES = 256;
+constexpr uint32_t SCATTER_PART_LENGTH = 1024;
+
+template <typename inputT, typename calT, typename outputT>
+class ApplyTopKTopPOpt {
+public:
+    __aicore__ inline ApplyTopKTopPOpt(){};
+    __aicore__ inline void InitTilingData(const ApplyTopKTopPWithSortedTilingData& __restrict tilingData,
+                                          GM_ADDR sorted_value, GM_ADDR sorted_indices, GM_ADDR p, GM_ADDR k,
+                                          GM_ADDR logits, GM_ADDR out, GM_ADDR workspace);
+    __aicore__ inline void InitBuffer(TPipe* inputPipe);
+    __aicore__ inline void ProcessTopKTopPOpt();
+    __aicore__ inline void ProcessTopKOpt();
+    __aicore__ inline void ProcessTopPOpt();
+
+private:
+    __aicore__ inline void GetMaxValue(int64_t baseGmIdx);
+    __aicore__ inline void ComputeSoftmaxSum(int64_t baseGmIdx, float kthVal, uint32_t kthStartIdx);
+    __aicore__ inline void WriteSoftmaxToGm(int64_t baseGmIdx, uint32_t kthStartIdx);
+    __aicore__ inline void CumsumKoggleStone(int64_t baseGmIdx);
+    __aicore__ inline void FindFirstIndex(int64_t baseGmIdx, uint32_t& firstIdx);
+    __aicore__ inline void CompareSelectOnLogits(int64_t batchGmBase, inputT thresholdVal, bool useGE);
+    __aicore__ inline void ScatterBoundary(int64_t batchGmBase, int64_t sortedBase, uint32_t firstIdx,
+                                           inputT thresholdVal);
+    __aicore__ inline void CopyOutLast(int64_t batchGmBase, int64_t sortedBase);
+    __aicore__ inline void FillNegInfAndScatterTopK(int64_t batchGmBase, int64_t sortedBase, uint32_t kthStartIdx);
+    __aicore__ inline uint32_t FindKthStartIdx(int64_t sortedBase, int32_t kValue);
+    __aicore__ inline uint32_t CeilDiv(uint32_t x, uint32_t y) { return y == 0 ? x : (x + y - 1) / y; }
+
+    __aicore__ inline void SToMTE3Sync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_MTE3));
+        SetFlag<HardEvent::S_MTE3>(id);
+        WaitFlag<HardEvent::S_MTE3>(id);
+    }
+    __aicore__ inline void VToMTE3Sync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE3));
+        SetFlag<HardEvent::V_MTE3>(id);
+        WaitFlag<HardEvent::V_MTE3>(id);
+    }
+    __aicore__ inline void MTE2ToVSync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
+        SetFlag<HardEvent::MTE2_V>(id);
+        WaitFlag<HardEvent::MTE2_V>(id);
+    }
+    __aicore__ inline void VToMTE2Sync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE2));
+        SetFlag<HardEvent::V_MTE2>(id);
+        WaitFlag<HardEvent::V_MTE2>(id);
+    }
+    __aicore__ inline void MTE2ToSSync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_S));
+        SetFlag<HardEvent::MTE2_S>(id);
+        WaitFlag<HardEvent::MTE2_S>(id);
+    }
+    __aicore__ inline void MTE3ToSSync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_S));
+        SetFlag<HardEvent::MTE3_S>(id);
+        WaitFlag<HardEvent::MTE3_S>(id);
+    }
+    __aicore__ inline void MTE3ToMTE2Sync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_MTE2));
+        SetFlag<HardEvent::MTE3_MTE2>(id);
+        WaitFlag<HardEvent::MTE3_MTE2>(id);
+    }
+    __aicore__ inline void VToSSync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+        SetFlag<HardEvent::V_S>(id);
+        WaitFlag<HardEvent::V_S>(id);
+    }
+    __aicore__ inline void SToVSync()
+    {
+        event_t id = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_V));
+        SetFlag<HardEvent::S_V>(id);
+        WaitFlag<HardEvent::S_V>(id);
+    }
+
+private:
+    TPipe* pipe_;
+    TBuf<TPosition::VECCALC> calBuf_;
+
+    uint32_t batchSize_ = 0;
+    uint32_t vocabSize_ = 0;
+    uint32_t batchPerCore_ = 0;
+    uint32_t tailBatch_ = 0;
+    uint32_t blockNum_ = 0;
+    uint32_t calUbSize_ = 0;
+    uint32_t blockIdx_ = 0;
+    uint32_t loopBatch_ = 0;
+    uint32_t batchOffset_ = 0;
+
+    uint32_t softmaxLength = 1;
+    uint32_t lineSfLoopTimes = 1;
+    uint32_t softmaxLengthTail = 1;
+    uint32_t cmpSelTileLength = 0;
+    uint32_t scatterLength = 1;
+    uint32_t iterateTimes = 0;
+
+    GlobalTensor<inputT> mGmSortedValue_;
+    GlobalTensor<int32_t> mGmSortedIndices_;
+    GlobalTensor<inputT> mGmP_;
+    GlobalTensor<int32_t> mGmK_;
+    GlobalTensor<inputT> mGmLogits_;
+    GlobalTensor<outputT> mGmOut_;
+    GlobalTensor<float> softMaxGm;
+
+    LocalTensor<uint8_t> totalUb;
+    LocalTensor<float> sfLocalFp32;
+    LocalTensor<inputT> sfLocalInput;
+    LocalTensor<float> sfResLocal;
+    LocalTensor<float> reduceLocal;
+
+    LocalTensor<inputT> cmpLogitsLocal;
+    LocalTensor<inputT> cmpNegInfLocal;
+    LocalTensor<float> cmpFp32Local;
+    LocalTensor<uint8_t> cmpMaskLocal;
+
+    LocalTensor<inputT> scatterValLocal;
+    LocalTensor<int32_t> scatterIdxLocal;
+    LocalTensor<inputT> scatterAlignedLocal;
+    LocalTensor<float> cumsumLocal;
+
+    float maxValue = 0;
+    float pValue = 0;
+    float kthValue_ = 0;
+    float reduceSumValue = 0;
+    float reduceSumValueInvert = 0;
+};
+
+// --- InitTilingData ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::InitTilingData(
+    const ApplyTopKTopPWithSortedTilingData& __restrict tilingData, GM_ADDR sorted_value, GM_ADDR sorted_indices,
+    GM_ADDR p, GM_ADDR k, GM_ADDR logits, GM_ADDR out, GM_ADDR workspace)
+{
+    batchSize_ = tilingData.batchSize;
+    vocabSize_ = tilingData.vocabSize;
+    batchPerCore_ = tilingData.batchPerCore;
+    tailBatch_ = tilingData.tailBatch;
+    blockNum_ = tilingData.blockNum;
+    calUbSize_ = static_cast<uint32_t>(tilingData.calUbSize);
+    blockIdx_ = GetBlockIdx();
+    if (blockIdx_ < tailBatch_) {
+        loopBatch_ = batchPerCore_ + 1;
+        batchOffset_ = blockIdx_ * loopBatch_;
+    } else {
+        loopBatch_ = batchPerCore_;
+        batchOffset_ = blockIdx_ * batchPerCore_ + tailBatch_;
+    }
+    uint32_t maxSfLen = (calUbSize_ - RESERVED_UB) / SOFTMAX_UB_NUM / FLOAT_BYTES;
+    softmaxLength = maxSfLen < vocabSize_ ? maxSfLen : vocabSize_;
+    lineSfLoopTimes = CeilDiv(vocabSize_, softmaxLength);
+    softmaxLengthTail = vocabSize_ - (lineSfLoopTimes - 1) * softmaxLength;
+    scatterLength = (calUbSize_ - RESERVED_UB - BLOCK_BYTES) /
+                    (SOFTMAX_UB_NUM * FLOAT_BYTES + sizeof(inputT) + BLOCK_BYTES) / SCATTER_PART_LENGTH *
+                    SCATTER_PART_LENGTH;
+
+    mGmSortedValue_.SetGlobalBuffer(reinterpret_cast<__gm__ inputT*>(sorted_value));
+    mGmSortedIndices_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(sorted_indices));
+    mGmP_.SetGlobalBuffer(reinterpret_cast<__gm__ inputT*>(p));
+    mGmK_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(k));
+    mGmLogits_.SetGlobalBuffer(reinterpret_cast<__gm__ inputT*>(logits));
+    mGmOut_.SetGlobalBuffer(reinterpret_cast<__gm__ outputT*>(out));
+    softMaxGm.SetGlobalBuffer((__gm__ float*)workspace, batchSize_ * vocabSize_);
+    iterateTimes = tilingData.iterateTimes;
+}
+
+// --- InitBuffer ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::InitBuffer(TPipe* inputPipe)
+{
+    pipe_ = inputPipe;
+    pipe_->InitBuffer(calBuf_, calUbSize_);
+    totalUb = calBuf_.Get<uint8_t>();
+
+    uint32_t sfLenAligned = CeilDiv(softmaxLength, BLOCK_BYTES / sizeof(inputT)) * (BLOCK_BYTES / sizeof(inputT));
+    sfLocalFp32 = totalUb.ReinterpretCast<float>();
+    sfLocalInput = totalUb[sfLenAligned * sizeof(inputT)].ReinterpretCast<inputT>();
+    sfResLocal = totalUb[sfLenAligned * sizeof(float)].ReinterpretCast<float>();
+    reduceLocal = totalUb[sfLenAligned * sizeof(float) * 2].ReinterpretCast<float>();
+
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+    scatterLength = (calUbSize_ - RESERVED_UB - BLOCK_BYTES) /
+                    (SOFTMAX_UB_NUM * FLOAT_BYTES + sizeof(inputT) + BLOCK_BYTES) / SCATTER_PART_LENGTH *
+                    SCATTER_PART_LENGTH;
+    scatterValLocal = totalUb[0].ReinterpretCast<inputT>();
+    scatterIdxLocal = totalUb[scatterLength * sizeof(inputT)].ReinterpretCast<int32_t>();
+    cumsumLocal = totalUb[scatterLength * (FLOAT_BYTES + sizeof(inputT))].ReinterpretCast<float>();
+    uint32_t alignedOff = scatterLength * (SOFTMAX_UB_NUM * FLOAT_BYTES + sizeof(inputT));
+    scatterAlignedLocal = totalUb[alignedOff].ReinterpretCast<inputT>();
+
+    constexpr uint32_t CMP_ALIGN_ELEMS = CMP_ALIGN_BYTES / sizeof(inputT);
+    uint32_t cmpAvail = calUbSize_ - RESERVED_UB - BLOCK_BYTES;
+    if constexpr (IsSameType<inputT, float>::value || IsSameType<inputT, half>::value) {
+        cmpSelTileLength = cmpAvail / (2 * sizeof(inputT) + 1) / CMP_ALIGN_ELEMS * CMP_ALIGN_ELEMS;
+        cmpLogitsLocal = totalUb[0].ReinterpretCast<inputT>();
+        cmpNegInfLocal = totalUb[cmpSelTileLength * sizeof(inputT)].ReinterpretCast<inputT>();
+        cmpMaskLocal = totalUb[cmpSelTileLength * 2 * sizeof(inputT)];
+    } else {
+        cmpSelTileLength = cmpAvail / (2 * sizeof(inputT) + sizeof(float) + 1) / CMP_ALIGN_ELEMS * CMP_ALIGN_ELEMS;
+        cmpLogitsLocal = totalUb[0].ReinterpretCast<inputT>();
+        cmpNegInfLocal = totalUb[cmpSelTileLength * sizeof(inputT)].ReinterpretCast<inputT>();
+        cmpFp32Local = totalUb[cmpSelTileLength * 2 * sizeof(inputT)].ReinterpretCast<float>();
+        cmpMaskLocal = totalUb[cmpSelTileLength * (2 * sizeof(inputT) + sizeof(float))];
+    }
+}
+
+// --- GetMaxValue: get max from valid elements (>= kthValue, excluding +inf) ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::GetMaxValue(int64_t baseGmIdx)
+{
+    int64_t idx = baseGmIdx + vocabSize_ - 1;
+    if constexpr (IsSameType<inputT, float>::value) {
+        maxValue = -mGmSortedValue_[idx].GetValue(0);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        maxValue = -static_cast<float>(mGmSortedValue_[idx].GetValue(0));
+    } else {
+        maxValue = -ToFloat(mGmSortedValue_[idx].GetValue(0));
+    }
+}
+
+// --- ComputeSoftmaxSum: tile-by-tile exp sum with TopK filtering ---
+// For partial tile: only load valid data (from kthStartIdx); UB is pre-cleared by prior Duplicate.
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::ComputeSoftmaxSum(int64_t baseGmIdx, float kthVal,
+                                                                                  uint32_t kthStartIdx)
+{
+    reduceSumValue = 0;
+    uint32_t loopDataNum = softmaxLength;
+    for (uint32_t loopInner = 0; loopInner < lineSfLoopTimes; loopInner++) {
+        uint32_t tileStart = loopInner * softmaxLength;
+        int64_t gmIdx = baseGmIdx + tileStart;
+        if (loopInner == lineSfLoopTimes - 1)
+            loopDataNum = softmaxLengthTail;
+        uint32_t tileEnd = tileStart + loopDataNum;
+
+        if (tileEnd <= kthStartIdx) {
+            continue;
+        }
+
+        if (tileStart >= kthStartIdx) {
+            if constexpr (!IsSameType<inputT, float>::value) {
+                DataCopyPad(sfLocalInput, mGmSortedValue_[gmIdx],
+                            {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+                Cast(sfLocalFp32, sfLocalInput, RoundMode::CAST_NONE, loopDataNum);
+                PipeBarrier<PIPE_V>();
+            } else {
+                DataCopyPad(sfLocalFp32, mGmSortedValue_[gmIdx],
+                            {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+            }
+        } else {
+            uint32_t localOffset = kthStartIdx - tileStart;
+            if constexpr (!IsSameType<inputT, float>::value) {
+                DataCopyPad(sfLocalInput, mGmSortedValue_[gmIdx],
+                            {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+                Cast(sfLocalFp32, sfLocalInput, RoundMode::CAST_NONE, loopDataNum);
+                PipeBarrier<PIPE_V>();
+            } else {
+                DataCopyPad(sfLocalFp32, mGmSortedValue_[gmIdx],
+                            {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+            }
+            Duplicate(sfLocalFp32, -1.0e30f, localOffset);
+            PipeBarrier<PIPE_V>();
+        }
+
+        Adds(sfResLocal, sfLocalFp32, maxValue, loopDataNum);
+        PipeBarrier<PIPE_V>();
+        Exp(sfResLocal, sfResLocal, loopDataNum);
+        PipeBarrier<PIPE_V>();
+        ReduceSum(reduceLocal, sfResLocal, reduceLocal, loopDataNum);
+        VToSSync();
+        reduceSumValue += reduceLocal.GetValue(0);
+        SToVSync();
+    }
+    reduceSumValueInvert = (reduceSumValue > 0.0f) ? (1.0f / reduceSumValue) : 0.0f;
+}
+
+// --- WriteSoftmaxToGm: compute normalized probabilities with TopK masking, write to softMaxGm ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::WriteSoftmaxToGm(int64_t baseGmIdx,
+                                                                                 uint32_t kthStartIdx)
+{
+    uint32_t loopDataNum = softmaxLength;
+    for (uint32_t loopInner = 0; loopInner < lineSfLoopTimes; loopInner++) {
+        uint32_t tileStart = loopInner * softmaxLength;
+        int64_t gmIdx = baseGmIdx + tileStart;
+        if (loopInner == lineSfLoopTimes - 1)
+            loopDataNum = softmaxLengthTail;
+        uint32_t tileEnd = tileStart + loopDataNum;
+
+        if (tileEnd <= kthStartIdx) {
+            Duplicate(sfResLocal, 0.0f, loopDataNum);
+            VToMTE3Sync();
+            DataCopyPad(softMaxGm[gmIdx], sfResLocal, {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+            MTE3ToMTE2Sync();
+            continue;
+        }
+
+        if constexpr (!IsSameType<inputT, float>::value) {
+            DataCopyPad(sfLocalInput, mGmSortedValue_[gmIdx],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            Cast(sfLocalFp32, sfLocalInput, RoundMode::CAST_NONE, loopDataNum);
+            PipeBarrier<PIPE_V>();
+        } else {
+            DataCopyPad(sfLocalFp32, mGmSortedValue_[gmIdx],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+        }
+
+        if (tileStart < kthStartIdx) {
+            uint32_t localOffset = kthStartIdx - tileStart;
+            Duplicate(sfLocalFp32, -1.0e30f, localOffset);
+            PipeBarrier<PIPE_V>();
+        }
+
+        Adds(sfResLocal, sfLocalFp32, maxValue, loopDataNum);
+        PipeBarrier<PIPE_V>();
+        Exp(sfResLocal, sfResLocal, loopDataNum);
+        PipeBarrier<PIPE_V>();
+        Muls(sfResLocal, sfResLocal, reduceSumValueInvert, loopDataNum);
+        VToMTE3Sync();
+        DataCopyPad(softMaxGm[gmIdx], sfResLocal, {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+        MTE3ToMTE2Sync();
+    }
+}
+
+// --- CumsumKoggleStone: iterative parallel prefix sum on softMaxGm ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::CumsumKoggleStone(int64_t baseGmIdx)
+{
+    int64_t iteratOffset = 1;
+    for (uint32_t iterateTime = 0; iterateTime < iterateTimes; iterateTime++) {
+        uint32_t addLength = vocabSize_ - static_cast<uint32_t>(iteratOffset);
+        uint32_t innerLoopNum = addLength / softmaxLength;
+        uint32_t dataTail = addLength - innerLoopNum * softmaxLength;
+        uint32_t loopDataNum = softmaxLength;
+        for (uint32_t innerLoopIdx = 0; innerLoopIdx < innerLoopNum; innerLoopIdx++) {
+            int64_t loopInnerOffset = dataTail + (innerLoopNum - 1 - innerLoopIdx) * softmaxLength;
+            DataCopyPad(sfLocalFp32, softMaxGm[baseGmIdx + loopInnerOffset],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            DataCopyPad(sfResLocal, softMaxGm[baseGmIdx + loopInnerOffset + iteratOffset],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            Add(sfLocalFp32, sfLocalFp32, sfResLocal, loopDataNum);
+            VToMTE3Sync();
+            DataCopyPad(softMaxGm[baseGmIdx + loopInnerOffset + iteratOffset], sfLocalFp32,
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+            MTE3ToMTE2Sync();
+        }
+        if (dataTail > 0) {
+            loopDataNum = dataTail;
+            DataCopyPad(sfLocalFp32, softMaxGm[baseGmIdx],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            DataCopyPad(sfResLocal, softMaxGm[baseGmIdx + iteratOffset],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            Add(sfLocalFp32, sfLocalFp32, sfResLocal, loopDataNum);
+            VToMTE3Sync();
+            DataCopyPad(softMaxGm[baseGmIdx + iteratOffset], sfLocalFp32,
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+            MTE3ToMTE2Sync();
+        }
+        iteratOffset *= 2;
+    }
+}
+
+// --- FindFirstIndex: read cumsum from softMaxGm to find threshold crossing ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::FindFirstIndex(int64_t baseGmIdx, uint32_t& firstIdx)
+{
+    firstIdx = vocabSize_;
+    bool found = false;
+    uint32_t searchTimes = CeilDiv(vocabSize_, scatterLength);
+    uint32_t searchTail = vocabSize_ - (searchTimes - 1) * scatterLength;
+    for (uint32_t sIdx = 0; sIdx < searchTimes && !found; sIdx++) {
+        uint32_t curLen = (sIdx == searchTimes - 1) ? searchTail : scatterLength;
+        int64_t gmOff = baseGmIdx + sIdx * scatterLength;
+        DataCopyPad(cumsumLocal, softMaxGm[gmOff], {1, static_cast<uint32_t>(curLen * sizeof(float)), 0, 0, 0},
+                    {false, 0, 0, 0});
+        MTE2ToSSync();
+        if (cumsumLocal.GetValue(curLen - 1) <= pValue) {
+            continue;
+        }
+        uint32_t scatterLoop = CeilDiv(curLen, SCATTER_PART_LENGTH);
+        uint32_t scatterNumsTail = curLen - (scatterLoop - 1) * SCATTER_PART_LENGTH;
+        for (uint32_t si = 0; si < scatterLoop && !found; si++) {
+            uint32_t curNums = (si == scatterLoop - 1) ? scatterNumsTail : SCATTER_PART_LENGTH;
+            if (cumsumLocal.GetValue(si * SCATTER_PART_LENGTH + curNums - 1) <= pValue) {
+                continue;
+            }
+            for (uint32_t i = 0; i < curNums; i++) {
+                uint32_t off = si * SCATTER_PART_LENGTH + i;
+                if (cumsumLocal.GetValue(off) > pValue) {
+                    firstIdx = sIdx * scatterLength + off;
+                    found = true;
+                    break;
+                }
+            }
+        }
+    }
+}
+
+// --- CompareSelectOnLogits: vectorized compare + select on original logits ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::CompareSelectOnLogits(int64_t batchGmBase,
+                                                                                      inputT thresholdVal, bool useGE)
+{
+    constexpr uint32_t CMP_ALIGN_ELEMS = CMP_ALIGN_BYTES / sizeof(inputT);
+    uint32_t tileTimes = CeilDiv(vocabSize_, cmpSelTileLength);
+    uint32_t tileTail = vocabSize_ - (tileTimes - 1) * cmpSelTileLength;
+
+    for (uint32_t tIdx = 0; tIdx < tileTimes; tIdx++) {
+        uint32_t curLen = (tIdx == tileTimes - 1) ? tileTail : cmpSelTileLength;
+        uint32_t curLenAligned = CeilDiv(curLen, CMP_ALIGN_ELEMS) * CMP_ALIGN_ELEMS;
+        int64_t gmOff = batchGmBase + static_cast<int64_t>(tIdx) * cmpSelTileLength;
+
+        DataCopyPad(cmpLogitsLocal, mGmLogits_[gmOff], {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0},
+                    {false, 0, 0, 0});
+        MTE2ToVSync();
+
+        if constexpr (IsSameType<inputT, float>::value) {
+            Duplicate(cmpNegInfLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, curLenAligned);
+            PipeBarrier<PIPE_V>();
+            CMPMODE cmpMode = useGE ? CMPMODE::GE : CMPMODE::GT;
+            Compares(cmpMaskLocal, cmpLogitsLocal, thresholdVal, cmpMode, curLenAligned);
+            PipeBarrier<PIPE_V>();
+            Select(cmpLogitsLocal, cmpMaskLocal, cmpLogitsLocal, cmpNegInfLocal, SELMODE::VSEL_TENSOR_TENSOR_MODE,
+                   curLenAligned);
+        } else if constexpr (IsSameType<inputT, half>::value) {
+            Duplicate(cmpNegInfLocal.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, curLenAligned);
+            PipeBarrier<PIPE_V>();
+            CMPMODE cmpMode = useGE ? CMPMODE::GE : CMPMODE::GT;
+            Compares(cmpMaskLocal, cmpLogitsLocal, thresholdVal, cmpMode, curLenAligned);
+            PipeBarrier<PIPE_V>();
+            Select(cmpLogitsLocal, cmpMaskLocal, cmpLogitsLocal, cmpNegInfLocal, SELMODE::VSEL_TENSOR_TENSOR_MODE,
+                   curLenAligned);
+        } else {
+            Duplicate(cmpNegInfLocal.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, curLenAligned);
+            PipeBarrier<PIPE_V>();
+            Cast(cmpFp32Local, cmpLogitsLocal, RoundMode::CAST_NONE, curLenAligned);
+            PipeBarrier<PIPE_V>();
+            float threshFp32 = ToFloat(thresholdVal);
+            CMPMODE cmpMode = useGE ? CMPMODE::GE : CMPMODE::GT;
+            Compares(cmpMaskLocal, cmpFp32Local, threshFp32, cmpMode, curLenAligned);
+            PipeBarrier<PIPE_V>();
+            Select(cmpLogitsLocal.template ReinterpretCast<half>(), cmpMaskLocal,
+                   cmpLogitsLocal.template ReinterpretCast<half>(), cmpNegInfLocal.template ReinterpretCast<half>(),
+                   SELMODE::VSEL_TENSOR_TENSOR_MODE, curLenAligned);
+        }
+        VToMTE3Sync();
+        DataCopyPad(mGmOut_[gmOff], cmpLogitsLocal, {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0});
+        MTE3ToMTE2Sync();
+    }
+}
+
+// --- ScatterBoundary: scatter elements == threshold at sorted positions >= firstIndex ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::ScatterBoundary(int64_t batchGmBase, int64_t sortedBase,
+                                                                                uint32_t firstIdx, inputT thresholdVal)
+{
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ELEM_PER_REP = 8;
+    constexpr uint32_t BRCB_SRC_ALIGN = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ALIGN_REPEATS = BRCB_SRC_ALIGN / BRCB_ELEM_PER_REP;
+    constexpr uint32_t MAX_BRCB_REPEAT = 255;
+    constexpr uint32_t ALIGNED_MAX_REPEAT = (MAX_BRCB_REPEAT / BRCB_ALIGN_REPEATS) * BRCB_ALIGN_REPEATS;
+
+    float threshFloat;
+    if constexpr (IsSameType<inputT, float>::value) {
+        threshFloat = thresholdVal;
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        threshFloat = static_cast<float>(thresholdVal);
+    } else {
+        threshFloat = ToFloat(thresholdVal);
+    }
+
+    uint32_t equalCount = 0;
+    for (uint32_t ei = firstIdx; ei < vocabSize_; ei++) {
+        float val;
+        if constexpr (IsSameType<inputT, float>::value) {
+            val = mGmSortedValue_[sortedBase + ei].GetValue(0);
+        } else if constexpr (IsSameType<inputT, half>::value) {
+            val = static_cast<float>(mGmSortedValue_[sortedBase + ei].GetValue(0));
+        } else {
+            val = ToFloat(mGmSortedValue_[sortedBase + ei].GetValue(0));
+        }
+        if (val != threshFloat)
+            break;
+        equalCount++;
+    }
+    if (equalCount == 0)
+        return;
+
+    uint32_t copyTimes = CeilDiv(equalCount, scatterLength);
+    uint32_t copyTail = equalCount - (copyTimes - 1) * scatterLength;
+    for (uint32_t ci = 0; ci < copyTimes; ci++) {
+        uint32_t curLen = (ci == copyTimes - 1) ? copyTail : scatterLength;
+        int64_t gmOff = sortedBase + firstIdx + ci * scatterLength;
+        DataCopyPad(scatterIdxLocal, mGmSortedIndices_[gmOff],
+                    {1, static_cast<uint32_t>(curLen * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+        DataCopyPad(scatterValLocal, mGmSortedValue_[gmOff],
+                    {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        MTE2ToVSync();
+        MTE2ToSSync();
+
+        uint32_t totalRepeat = CeilDiv(curLen, BRCB_ELEM_PER_REP);
+        uint32_t brcbDone = 0;
+        while (brcbDone < totalRepeat) {
+            uint32_t remaining = totalRepeat - brcbDone;
+            uint32_t curRepeat = remaining > ALIGNED_MAX_REPEAT ?
+                                     ALIGNED_MAX_REPEAT :
+                                     (remaining + BRCB_ALIGN_REPEATS - 1) / BRCB_ALIGN_REPEATS * BRCB_ALIGN_REPEATS;
+            Brcb(scatterAlignedLocal[brcbDone * BRCB_ELEM_PER_REP * DATA_PER_BLOCK],
+                 scatterValLocal[brcbDone * BRCB_ELEM_PER_REP], curRepeat, {1, 8});
+            brcbDone += curRepeat;
+        }
+        VToMTE3Sync();
+
+        for (uint32_t idx = 0; idx < curLen; idx++) {
+            int32_t lineIndex = scatterIdxLocal.GetValue(idx);
+            DataCopyPad(mGmOut_[batchGmBase + lineIndex], scatterAlignedLocal[idx * DATA_PER_BLOCK],
+                        {1, (uint32_t)(sizeof(outputT)), 0, 0, 0});
+        }
+        MTE3ToSSync();
+    }
+}
+
+// --- CopyOutLast: unconditionally output the last sorted element ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::CopyOutLast(int64_t batchGmBase, int64_t sortedBase)
+{
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+    int64_t lastOff = sortedBase + vocabSize_ - 1;
+    DataCopyPad(scatterAlignedLocal, mGmSortedValue_[lastOff], {1, static_cast<uint32_t>(sizeof(inputT)), 0, 0, 0},
+                {false, 0, 0, 0});
+    int32_t lineIndex = mGmSortedIndices_.GetValue(lastOff);
+    MTE2ToSSync();
+    SToMTE3Sync();
+    DataCopyPad(mGmOut_[batchGmBase + lineIndex], scatterAlignedLocal.template ReinterpretCast<outputT>(),
+                {1, (uint32_t)(sizeof(outputT)), 0, 0, 0});
+    MTE3ToSSync();
+}
+
+// --- FindKthStartIdx: find actual start index by searching backward for boundary ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline uint32_t ApplyTopKTopPOpt<inputT, calT, outputT>::FindKthStartIdx(int64_t sortedBase, int32_t kValue)
+{
+    int64_t kthIdx = sortedBase + vocabSize_ - kValue;
+    float kthFloat;
+    if constexpr (IsSameType<inputT, float>::value) {
+        kthFloat = mGmSortedValue_[kthIdx].GetValue(0);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        kthFloat = static_cast<float>(mGmSortedValue_[kthIdx].GetValue(0));
+    } else {
+        kthFloat = ToFloat(mGmSortedValue_[kthIdx].GetValue(0));
+    }
+
+    uint32_t kthStartIdx = vocabSize_ - static_cast<uint32_t>(kValue);
+    while (kthStartIdx > 0) {
+        uint32_t chunkLen = (kthStartIdx > scatterLength) ? scatterLength : kthStartIdx;
+        uint32_t chunkStart = kthStartIdx - chunkLen;
+        DataCopyPad(scatterValLocal, mGmSortedValue_[sortedBase + chunkStart],
+                    {1, static_cast<uint32_t>(chunkLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        MTE2ToSSync();
+        bool foundBoundary = false;
+        for (int32_t i = static_cast<int32_t>(chunkLen) - 1; i >= 0; i--) {
+            float prevVal;
+            if constexpr (IsSameType<inputT, float>::value) {
+                prevVal = scatterValLocal.GetValue(i);
+            } else if constexpr (IsSameType<inputT, half>::value) {
+                prevVal = static_cast<float>(scatterValLocal.GetValue(i));
+            } else {
+                prevVal = ToFloat(scatterValLocal.GetValue(i));
+            }
+            if (prevVal < kthFloat) {
+                kthStartIdx = chunkStart + static_cast<uint32_t>(i) + 1;
+                foundBoundary = true;
+                break;
+            }
+        }
+        if (foundBoundary)
+            break;
+        kthStartIdx = chunkStart;
+    }
+    return kthStartIdx;
+}
+
+// --- FillNegInfAndScatterTopK: fill output with -inf, then Brcb scatter elements from kthStartIdx ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::FillNegInfAndScatterTopK(int64_t batchGmBase,
+                                                                                         int64_t sortedBase,
+                                                                                         uint32_t kthStartIdx)
+{
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ELEM_PER_REP = 8;
+    constexpr uint32_t BRCB_SRC_ALIGN = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ALIGN_REPEATS = BRCB_SRC_ALIGN / BRCB_ELEM_PER_REP;
+    constexpr uint32_t MAX_BRCB_REPEAT = 255;
+    constexpr uint32_t ALIGNED_MAX_REPEAT = (MAX_BRCB_REPEAT / BRCB_ALIGN_REPEATS) * BRCB_ALIGN_REPEATS;
+
+    uint32_t tileTimes = CeilDiv(vocabSize_, cmpSelTileLength);
+    uint32_t tileTail = vocabSize_ - (tileTimes - 1) * cmpSelTileLength;
+    for (uint32_t tIdx = 0; tIdx < tileTimes; tIdx++) {
+        uint32_t curLen = (tIdx == tileTimes - 1) ? tileTail : cmpSelTileLength;
+        int64_t gmOff = batchGmBase + static_cast<int64_t>(tIdx) * cmpSelTileLength;
+        if constexpr (IsSameType<inputT, float>::value) {
+            Duplicate(cmpLogitsLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, curLen);
+        } else if constexpr (IsSameType<inputT, half>::value) {
+            Duplicate(cmpLogitsLocal.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, curLen);
+        } else {
+            Duplicate(cmpLogitsLocal.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, curLen);
+        }
+        VToMTE3Sync();
+        DataCopyPad(mGmOut_[gmOff], cmpLogitsLocal, {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0});
+        MTE3ToMTE2Sync();
+    }
+
+    uint32_t topKCount = vocabSize_ - kthStartIdx;
+    int64_t topKStart = sortedBase + kthStartIdx;
+
+    uint32_t copyTimes = CeilDiv(topKCount, scatterLength);
+    uint32_t copyTail = topKCount - (copyTimes - 1) * scatterLength;
+    for (uint32_t ci = 0; ci < copyTimes; ci++) {
+        uint32_t curLen = (ci == copyTimes - 1) ? copyTail : scatterLength;
+        int64_t gmOff = topKStart + ci * scatterLength;
+        DataCopyPad(scatterValLocal, mGmSortedValue_[gmOff],
+                    {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        DataCopyPad(scatterIdxLocal, mGmSortedIndices_[gmOff],
+                    {1, static_cast<uint32_t>(curLen * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+        MTE2ToVSync();
+        MTE2ToSSync();
+
+        uint32_t totalRepeat = CeilDiv(curLen, BRCB_ELEM_PER_REP);
+        uint32_t brcbDone = 0;
+        while (brcbDone < totalRepeat) {
+            uint32_t remaining = totalRepeat - brcbDone;
+            uint32_t curRepeat = remaining > ALIGNED_MAX_REPEAT ?
+                                     ALIGNED_MAX_REPEAT :
+                                     (remaining + BRCB_ALIGN_REPEATS - 1) / BRCB_ALIGN_REPEATS * BRCB_ALIGN_REPEATS;
+            Brcb(scatterAlignedLocal[brcbDone * BRCB_ELEM_PER_REP * DATA_PER_BLOCK],
+                 scatterValLocal[brcbDone * BRCB_ELEM_PER_REP], curRepeat, {1, 8});
+            brcbDone += curRepeat;
+        }
+        VToMTE3Sync();
+
+        for (uint32_t idx = 0; idx < curLen; idx++) {
+            int32_t lineIndex = scatterIdxLocal.GetValue(idx);
+            DataCopyPad(mGmOut_[batchGmBase + lineIndex], scatterAlignedLocal[idx * DATA_PER_BLOCK],
+                        {1, (uint32_t)(sizeof(outputT)), 0, 0, 0});
+        }
+        MTE3ToSSync();
+    }
+}
+
+// --- ProcessTopKTopPOpt: main entry for optimized TopKTopP ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::ProcessTopKTopPOpt()
+{
+    for (uint32_t loopBatch = 0; loopBatch < loopBatch_; loopBatch++) {
+        int64_t sortedBase = (batchOffset_ + loopBatch) * vocabSize_;
+        int64_t batchGmBase = sortedBase;
+
+        int32_t kValue = mGmK_.GetValue(batchOffset_ + loopBatch);
+
+        if constexpr (IsSameType<inputT, float>::value) {
+            pValue = 1.0f - mGmP_[batchOffset_ + loopBatch].GetValue(0);
+        } else if constexpr (IsSameType<inputT, half>::value) {
+            pValue = 1.0f - static_cast<float>(mGmP_[batchOffset_ + loopBatch].GetValue(0));
+        } else {
+            pValue = 1.0f - ToFloat(mGmP_[batchOffset_ + loopBatch].GetValue(0));
+        }
+
+        GetMaxValue(sortedBase);
+
+        if (*reinterpret_cast<int32_t*>(&maxValue) == FLOAT32_NEG_INF) {
+            if (kValue <= 0 || static_cast<uint32_t>(kValue) >= vocabSize_) {
+                uint32_t tileTimes = CeilDiv(vocabSize_, cmpSelTileLength);
+                uint32_t tileTail = vocabSize_ - (tileTimes - 1) * cmpSelTileLength;
+                for (uint32_t tIdx = 0; tIdx < tileTimes; tIdx++) {
+                    uint32_t curLen = (tIdx == tileTimes - 1) ? tileTail : cmpSelTileLength;
+                    int64_t gmOff = batchGmBase + static_cast<int64_t>(tIdx) * cmpSelTileLength;
+                    DataCopyPad(cmpLogitsLocal, mGmLogits_[gmOff],
+                                {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                    MTE2ToVSync();
+                    VToMTE3Sync();
+                    DataCopyPad(mGmOut_[gmOff], cmpLogitsLocal,
+                                {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0});
+                    MTE3ToMTE2Sync();
+                }
+            } else {
+                uint32_t kthStart = FindKthStartIdx(sortedBase, kValue);
+                uint32_t actualTopKCount = vocabSize_ - kthStart;
+                if (actualTopKCount <= scatterLength) {
+                    FillNegInfAndScatterTopK(batchGmBase, sortedBase, kthStart);
+                } else {
+                    int64_t kthIdx = sortedBase + kthStart;
+                    inputT kthValRaw = mGmSortedValue_[kthIdx].GetValue(0);
+                    CompareSelectOnLogits(batchGmBase, kthValRaw, true);
+                    CopyOutLast(batchGmBase, sortedBase);
+                }
+            }
+            continue;
+        }
+
+        uint32_t kthStartIdx = 0;
+        float kthVal = 0;
+        if (kValue > 0 && static_cast<uint32_t>(kValue) < vocabSize_) {
+            kthStartIdx = FindKthStartIdx(sortedBase, kValue);
+            int64_t kthIdx = sortedBase + kthStartIdx;
+            if constexpr (IsSameType<inputT, float>::value) {
+                kthVal = mGmSortedValue_[kthIdx].GetValue(0);
+            } else if constexpr (IsSameType<inputT, half>::value) {
+                kthVal = static_cast<float>(mGmSortedValue_[kthIdx].GetValue(0));
+            } else {
+                kthVal = ToFloat(mGmSortedValue_[kthIdx].GetValue(0));
+            }
+            kthValue_ = kthVal;
+        }
+
+        if (kValue > 0 && (vocabSize_ - kthStartIdx) <= scatterLength && (vocabSize_ - kthStartIdx) <= softmaxLength) {
+            constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+            constexpr uint32_t BRCB_ELEM_PER_REP = 8;
+            constexpr uint32_t BRCB_SRC_ALIGN = BLOCK_BYTES / sizeof(inputT);
+            constexpr uint32_t BRCB_ALIGN_REPEATS = BRCB_SRC_ALIGN / BRCB_ELEM_PER_REP;
+            constexpr uint32_t MAX_BRCB_REPEAT = 255;
+            constexpr uint32_t ALIGNED_MAX_REPEAT = (MAX_BRCB_REPEAT / BRCB_ALIGN_REPEATS) * BRCB_ALIGN_REPEATS;
+
+            uint32_t topKActual = vocabSize_ - kthStartIdx;
+            int64_t topKStart = sortedBase + kthStartIdx;
+
+            if constexpr (!IsSameType<inputT, float>::value) {
+                DataCopyPad(sfLocalInput, mGmSortedValue_[topKStart],
+                            {1, static_cast<uint32_t>(topKActual * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+                Cast(sfLocalFp32, sfLocalInput, RoundMode::CAST_NONE, topKActual);
+                PipeBarrier<PIPE_V>();
+            } else {
+                DataCopyPad(sfLocalFp32, mGmSortedValue_[topKStart],
+                            {1, static_cast<uint32_t>(topKActual * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+            }
+            Adds(sfResLocal, sfLocalFp32, maxValue, topKActual);
+            PipeBarrier<PIPE_V>();
+            Exp(sfResLocal, sfResLocal, topKActual);
+            PipeBarrier<PIPE_V>();
+            ReduceSum(reduceLocal, sfResLocal, reduceLocal, topKActual);
+            VToSSync();
+            float localReduceSum = reduceLocal.GetValue(0);
+            float localReduceSumInv = (localReduceSum > 0.0f) ? (1.0f / localReduceSum) : 0.0f;
+            SToVSync();
+
+            Muls(sfResLocal, sfResLocal, localReduceSumInv, topKActual);
+            VToSSync();
+
+            float cumVal = 0.0f;
+            uint32_t firstScatterIdx = topKActual - 1;
+            for (uint32_t ci = 0; ci < topKActual; ci++) {
+                cumVal += sfResLocal.GetValue(ci);
+                if (cumVal > pValue) {
+                    firstScatterIdx = ci;
+                    break;
+                }
+            }
+
+            uint32_t scatterCount = topKActual - firstScatterIdx;
+            int64_t scatterGmStart = topKStart + firstScatterIdx;
+
+            uint32_t tileTimes = CeilDiv(vocabSize_, cmpSelTileLength);
+            uint32_t tileTail = vocabSize_ - (tileTimes - 1) * cmpSelTileLength;
+            for (uint32_t tIdx = 0; tIdx < tileTimes; tIdx++) {
+                uint32_t curLen = (tIdx == tileTimes - 1) ? tileTail : cmpSelTileLength;
+                int64_t gmOff = batchGmBase + static_cast<int64_t>(tIdx) * cmpSelTileLength;
+                if constexpr (IsSameType<inputT, float>::value) {
+                    Duplicate(cmpLogitsLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, curLen);
+                } else if constexpr (IsSameType<inputT, half>::value) {
+                    Duplicate(cmpLogitsLocal.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, curLen);
+                } else {
+                    Duplicate(cmpLogitsLocal.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, curLen);
+                }
+                VToMTE3Sync();
+                DataCopyPad(mGmOut_[gmOff], cmpLogitsLocal,
+                            {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0});
+                MTE3ToMTE2Sync();
+            }
+
+            uint32_t scCopyTimes = CeilDiv(scatterCount, scatterLength);
+            uint32_t scCopyTail = scatterCount - (scCopyTimes - 1) * scatterLength;
+            for (uint32_t sci = 0; sci < scCopyTimes; sci++) {
+                uint32_t curScLen = (sci == scCopyTimes - 1) ? scCopyTail : scatterLength;
+                int64_t scGmOff = scatterGmStart + sci * scatterLength;
+
+                DataCopyPad(scatterValLocal, mGmSortedValue_[scGmOff],
+                            {1, static_cast<uint32_t>(curScLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                DataCopyPad(scatterIdxLocal, mGmSortedIndices_[scGmOff],
+                            {1, static_cast<uint32_t>(curScLen * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+                MTE2ToSSync();
+
+                uint32_t totalRepeat = CeilDiv(curScLen, BRCB_ELEM_PER_REP);
+                uint32_t brcbDone = 0;
+                while (brcbDone < totalRepeat) {
+                    uint32_t remaining = totalRepeat - brcbDone;
+                    uint32_t curRepeat = remaining > ALIGNED_MAX_REPEAT ? ALIGNED_MAX_REPEAT :
+                                                                          (remaining + BRCB_ALIGN_REPEATS - 1) /
+                                                                              BRCB_ALIGN_REPEATS * BRCB_ALIGN_REPEATS;
+                    Brcb(scatterAlignedLocal[brcbDone * BRCB_ELEM_PER_REP * DATA_PER_BLOCK],
+                         scatterValLocal[brcbDone * BRCB_ELEM_PER_REP], curRepeat, {1, 8});
+                    brcbDone += curRepeat;
+                }
+                VToMTE3Sync();
+
+                for (uint32_t idx = 0; idx < curScLen; idx++) {
+                    int32_t lineIndex = scatterIdxLocal.GetValue(idx);
+                    DataCopyPad(mGmOut_[batchGmBase + lineIndex], scatterAlignedLocal[idx * DATA_PER_BLOCK],
+                                {1, (uint32_t)(sizeof(outputT)), 0, 0, 0});
+                }
+                MTE3ToSSync();
+            }
+            continue;
+        }
+
+        ComputeSoftmaxSum(sortedBase, kthVal, kthStartIdx);
+        WriteSoftmaxToGm(sortedBase, kthStartIdx);
+        CumsumKoggleStone(sortedBase);
+
+        uint32_t firstIdx = vocabSize_;
+        FindFirstIndex(sortedBase, firstIdx);
+        if (firstIdx >= vocabSize_)
+            firstIdx = vocabSize_ - 1;
+
+        inputT thresholdVal = mGmSortedValue_[sortedBase + firstIdx].GetValue(0);
+
+        // Always use GE compare (keeps all elements >= threshold)
+        CompareSelectOnLogits(batchGmBase, thresholdVal, true);
+
+        // Exclude elements == threshold at sorted positions BEFORE firstIdx
+        // These were incorrectly kept by GE, need to write -inf back
+        float threshFloat;
+        if constexpr (IsSameType<inputT, float>::value) {
+            threshFloat = thresholdVal;
+        } else if constexpr (IsSameType<inputT, half>::value) {
+            threshFloat = static_cast<float>(thresholdVal);
+        } else {
+            threshFloat = ToFloat(thresholdVal);
+        }
+
+        uint32_t excludeCount = 0;
+        if (firstIdx > 0) {
+            uint32_t searchPos = firstIdx;
+            bool exDone = false;
+            while (searchPos > 0 && !exDone) {
+                uint32_t chunkLen = (searchPos > scatterLength) ? scatterLength : searchPos;
+                uint32_t chunkStart = searchPos - chunkLen;
+                DataCopyPad(scatterValLocal, mGmSortedValue_[sortedBase + chunkStart],
+                            {1, static_cast<uint32_t>(chunkLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToSSync();
+                for (int32_t i = static_cast<int32_t>(chunkLen) - 1; i >= 0; i--) {
+                    float val;
+                    if constexpr (IsSameType<inputT, float>::value) {
+                        val = scatterValLocal.GetValue(i);
+                    } else if constexpr (IsSameType<inputT, half>::value) {
+                        val = static_cast<float>(scatterValLocal.GetValue(i));
+                    } else {
+                        val = ToFloat(scatterValLocal.GetValue(i));
+                    }
+                    if (val != threshFloat) {
+                        exDone = true;
+                        break;
+                    }
+                    excludeCount++;
+                }
+                searchPos = chunkStart;
+            }
+        }
+
+        if (excludeCount > 0) {
+            uint32_t excludeStart = firstIdx - excludeCount;
+            uint32_t writeTimes = CeilDiv(excludeCount, scatterLength);
+            uint32_t writeTail = excludeCount - (writeTimes - 1) * scatterLength;
+            for (uint32_t wi = 0; wi < writeTimes; wi++) {
+                uint32_t curLen = (wi == writeTimes - 1) ? writeTail : scatterLength;
+                int64_t idxGmOff = sortedBase + excludeStart + wi * scatterLength;
+                DataCopyPad(scatterIdxLocal, mGmSortedIndices_[idxGmOff],
+                            {1, static_cast<uint32_t>(curLen * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToSSync();
+                if constexpr (IsSameType<inputT, float>::value) {
+                    scatterAlignedLocal.template ReinterpretCast<int32_t>().SetValue(0, FLOAT32_NEG_INF);
+                } else if constexpr (IsSameType<inputT, half>::value) {
+                    scatterAlignedLocal.template ReinterpretCast<uint16_t>().SetValue(0, FLOAT16_NEG_INF);
+                } else {
+                    scatterAlignedLocal.template ReinterpretCast<uint16_t>().SetValue(0, BF16_NEG_INF);
+                }
+                SToMTE3Sync();
+                for (uint32_t ei = 0; ei < curLen; ei++) {
+                    int32_t lineIndex = scatterIdxLocal.GetValue(ei);
+                    DataCopyPad(mGmOut_[batchGmBase + lineIndex],
+                                scatterAlignedLocal.template ReinterpretCast<outputT>(),
+                                {1, (uint32_t)(sizeof(outputT)), 0, 0, 0});
+                }
+                MTE3ToSSync();
+            }
+        }
+        CopyOutLast(batchGmBase, sortedBase);
+    }
+}
+
+// --- ProcessTopKOpt: main entry for optimized TopK-only ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::ProcessTopKOpt()
+{
+    for (uint32_t loopBatch = 0; loopBatch < loopBatch_; loopBatch++) {
+        int64_t sortedBase = (batchOffset_ + loopBatch) * vocabSize_;
+        int64_t batchGmBase = sortedBase;
+
+        int32_t kValue = mGmK_.GetValue(batchOffset_ + loopBatch);
+
+        if (kValue <= 0 || static_cast<uint32_t>(kValue) >= vocabSize_) {
+            uint32_t tileTimes = CeilDiv(vocabSize_, cmpSelTileLength);
+            uint32_t tileTail = vocabSize_ - (tileTimes - 1) * cmpSelTileLength;
+            for (uint32_t tIdx = 0; tIdx < tileTimes; tIdx++) {
+                uint32_t curLen = (tIdx == tileTimes - 1) ? tileTail : cmpSelTileLength;
+                int64_t gmOff = batchGmBase + static_cast<int64_t>(tIdx) * cmpSelTileLength;
+                DataCopyPad(cmpLogitsLocal, mGmLogits_[gmOff],
+                            {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+                VToMTE3Sync();
+                DataCopyPad(mGmOut_[gmOff], cmpLogitsLocal,
+                            {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0});
+                MTE3ToMTE2Sync();
+            }
+            continue;
+        }
+
+        uint32_t kthStart = FindKthStartIdx(sortedBase, kValue);
+        uint32_t actualTopKCount = vocabSize_ - kthStart;
+
+        if (actualTopKCount <= scatterLength) {
+            FillNegInfAndScatterTopK(batchGmBase, sortedBase, kthStart);
+            continue;
+        }
+        int64_t kthIdx = sortedBase + kthStart;
+        inputT kthValRaw = mGmSortedValue_[kthIdx].GetValue(0);
+
+        CompareSelectOnLogits(batchGmBase, kthValRaw, true);
+        CopyOutLast(batchGmBase, sortedBase);
+    }
+}
+
+// --- ProcessTopPOpt: main entry for optimized TopP-only (with logits) ---
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPOpt<inputT, calT, outputT>::ProcessTopPOpt()
+{
+    for (uint32_t loopBatch = 0; loopBatch < loopBatch_; loopBatch++) {
+        int64_t sortedBase = (batchOffset_ + loopBatch) * vocabSize_;
+        int64_t batchGmBase = sortedBase;
+
+        GetMaxValue(sortedBase);
+
+        if (*reinterpret_cast<int32_t*>(&maxValue) == FLOAT32_NEG_INF) {
+            uint32_t tileTimes = CeilDiv(vocabSize_, cmpSelTileLength);
+            uint32_t tileTail = vocabSize_ - (tileTimes - 1) * cmpSelTileLength;
+            for (uint32_t tIdx = 0; tIdx < tileTimes; tIdx++) {
+                uint32_t curLen = (tIdx == tileTimes - 1) ? tileTail : cmpSelTileLength;
+                int64_t gmOff = batchGmBase + static_cast<int64_t>(tIdx) * cmpSelTileLength;
+                DataCopyPad(cmpLogitsLocal, mGmLogits_[gmOff],
+                            {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+                VToMTE3Sync();
+                DataCopyPad(mGmOut_[gmOff], cmpLogitsLocal,
+                            {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0});
+                MTE3ToMTE2Sync();
+            }
+            continue;
+        }
+
+        ComputeSoftmaxSum(sortedBase, 0, 0);
+        WriteSoftmaxToGm(sortedBase, 0);
+        CumsumKoggleStone(sortedBase);
+
+        if constexpr (IsSameType<inputT, float>::value) {
+            pValue = 1.0f - mGmP_[batchOffset_ + loopBatch].GetValue(0);
+        } else if constexpr (IsSameType<inputT, half>::value) {
+            pValue = 1.0f - static_cast<float>(mGmP_[batchOffset_ + loopBatch].GetValue(0));
+        } else {
+            pValue = 1.0f - ToFloat(mGmP_[batchOffset_ + loopBatch].GetValue(0));
+        }
+
+        uint32_t firstIdx = vocabSize_;
+        FindFirstIndex(sortedBase, firstIdx);
+        if (firstIdx >= vocabSize_)
+            firstIdx = vocabSize_ - 1;
+
+        uint32_t survivorCount = vocabSize_ - firstIdx;
+
+        if (survivorCount <= scatterLength) {
+            constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+            constexpr uint32_t BRCB_ELEM_PER_REP = 8;
+            constexpr uint32_t BRCB_SRC_ALIGN = BLOCK_BYTES / sizeof(inputT);
+            constexpr uint32_t BRCB_ALIGN_REPEATS = BRCB_SRC_ALIGN / BRCB_ELEM_PER_REP;
+            constexpr uint32_t MAX_BRCB_REPEAT = 255;
+            constexpr uint32_t ALIGNED_MAX_REPEAT = (MAX_BRCB_REPEAT / BRCB_ALIGN_REPEATS) * BRCB_ALIGN_REPEATS;
+
+            uint32_t tileTimes = CeilDiv(vocabSize_, cmpSelTileLength);
+            uint32_t tileTail = vocabSize_ - (tileTimes - 1) * cmpSelTileLength;
+            for (uint32_t tIdx = 0; tIdx < tileTimes; tIdx++) {
+                uint32_t curLen = (tIdx == tileTimes - 1) ? tileTail : cmpSelTileLength;
+                int64_t gmOff = batchGmBase + static_cast<int64_t>(tIdx) * cmpSelTileLength;
+                if constexpr (IsSameType<inputT, float>::value) {
+                    Duplicate(cmpLogitsLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, curLen);
+                } else if constexpr (IsSameType<inputT, half>::value) {
+                    Duplicate(cmpLogitsLocal.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, curLen);
+                } else {
+                    Duplicate(cmpLogitsLocal.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, curLen);
+                }
+                VToMTE3Sync();
+                DataCopyPad(mGmOut_[gmOff], cmpLogitsLocal,
+                            {1, static_cast<uint32_t>(curLen * sizeof(inputT)), 0, 0, 0});
+                MTE3ToMTE2Sync();
+            }
+
+            int64_t scatterGmStart = sortedBase + firstIdx;
+            uint32_t scCopyTimes = CeilDiv(survivorCount, scatterLength);
+            uint32_t scCopyTail = survivorCount - (scCopyTimes - 1) * scatterLength;
+            for (uint32_t sci = 0; sci < scCopyTimes; sci++) {
+                uint32_t curScLen = (sci == scCopyTimes - 1) ? scCopyTail : scatterLength;
+                int64_t scGmOff = scatterGmStart + sci * scatterLength;
+                DataCopyPad(scatterValLocal, mGmSortedValue_[scGmOff],
+                            {1, static_cast<uint32_t>(curScLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                DataCopyPad(scatterIdxLocal, mGmSortedIndices_[scGmOff],
+                            {1, static_cast<uint32_t>(curScLen * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+                MTE2ToVSync();
+                MTE2ToSSync();
+
+                uint32_t totalRepeat = CeilDiv(curScLen, BRCB_ELEM_PER_REP);
+                uint32_t brcbDone = 0;
+                while (brcbDone < totalRepeat) {
+                    uint32_t remaining = totalRepeat - brcbDone;
+                    uint32_t curRepeat = remaining > ALIGNED_MAX_REPEAT ? ALIGNED_MAX_REPEAT :
+                                                                          (remaining + BRCB_ALIGN_REPEATS - 1) /
+                                                                              BRCB_ALIGN_REPEATS * BRCB_ALIGN_REPEATS;
+                    Brcb(scatterAlignedLocal[brcbDone * BRCB_ELEM_PER_REP * DATA_PER_BLOCK],
+                         scatterValLocal[brcbDone * BRCB_ELEM_PER_REP], curRepeat, {1, 8});
+                    brcbDone += curRepeat;
+                }
+                VToMTE3Sync();
+
+                for (uint32_t idx = 0; idx < curScLen; idx++) {
+                    int32_t lineIndex = scatterIdxLocal.GetValue(idx);
+                    DataCopyPad(mGmOut_[batchGmBase + lineIndex], scatterAlignedLocal[idx * DATA_PER_BLOCK],
+                                {1, (uint32_t)(sizeof(outputT)), 0, 0, 0});
+                }
+                MTE3ToSSync();
+            }
+        } else {
+            inputT thresholdVal = mGmSortedValue_[sortedBase + firstIdx].GetValue(0);
+            CompareSelectOnLogits(batchGmBase, thresholdVal, true);
+
+            float threshFloat;
+            if constexpr (IsSameType<inputT, float>::value) {
+                threshFloat = thresholdVal;
+            } else if constexpr (IsSameType<inputT, half>::value) {
+                threshFloat = static_cast<float>(thresholdVal);
+            } else {
+                threshFloat = ToFloat(thresholdVal);
+            }
+
+            uint32_t excludeCount = 0;
+            if (firstIdx > 0) {
+                uint32_t searchPos = firstIdx;
+                bool exDone = false;
+                while (searchPos > 0 && !exDone) {
+                    uint32_t chunkLen = (searchPos > scatterLength) ? scatterLength : searchPos;
+                    uint32_t chunkStart = searchPos - chunkLen;
+                    DataCopyPad(scatterValLocal, mGmSortedValue_[sortedBase + chunkStart],
+                                {1, static_cast<uint32_t>(chunkLen * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+                    MTE2ToSSync();
+                    for (int32_t i = static_cast<int32_t>(chunkLen) - 1; i >= 0; i--) {
+                        float val;
+                        if constexpr (IsSameType<inputT, float>::value) {
+                            val = scatterValLocal.GetValue(i);
+                        } else if constexpr (IsSameType<inputT, half>::value) {
+                            val = static_cast<float>(scatterValLocal.GetValue(i));
+                        } else {
+                            val = ToFloat(scatterValLocal.GetValue(i));
+                        }
+                        if (val != threshFloat) {
+                            exDone = true;
+                            break;
+                        }
+                        excludeCount++;
+                    }
+                    searchPos = chunkStart;
+                }
+            }
+
+            if (excludeCount > 0) {
+                uint32_t excludeStart = firstIdx - excludeCount;
+                uint32_t writeTimes = CeilDiv(excludeCount, scatterLength);
+                uint32_t writeTail = excludeCount - (writeTimes - 1) * scatterLength;
+                for (uint32_t wi = 0; wi < writeTimes; wi++) {
+                    uint32_t curLen = (wi == writeTimes - 1) ? writeTail : scatterLength;
+                    int64_t idxGmOff = sortedBase + excludeStart + wi * scatterLength;
+                    DataCopyPad(scatterIdxLocal, mGmSortedIndices_[idxGmOff],
+                                {1, static_cast<uint32_t>(curLen * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+                    MTE2ToSSync();
+                    if constexpr (IsSameType<inputT, float>::value) {
+                        scatterAlignedLocal.template ReinterpretCast<int32_t>().SetValue(0, FLOAT32_NEG_INF);
+                    } else if constexpr (IsSameType<inputT, half>::value) {
+                        scatterAlignedLocal.template ReinterpretCast<uint16_t>().SetValue(0, FLOAT16_NEG_INF);
+                    } else {
+                        scatterAlignedLocal.template ReinterpretCast<uint16_t>().SetValue(0, BF16_NEG_INF);
+                    }
+                    SToMTE3Sync();
+                    for (uint32_t ei = 0; ei < curLen; ei++) {
+                        int32_t lineIndex = scatterIdxLocal.GetValue(ei);
+                        DataCopyPad(mGmOut_[batchGmBase + lineIndex],
+                                    scatterAlignedLocal.template ReinterpretCast<outputT>(),
+                                    {1, (uint32_t)(sizeof(outputT)), 0, 0, 0});
+                    }
+                    MTE3ToSSync();
+                }
+            }
+            CopyOutLast(batchGmBase, sortedBase);
+        }
+    }
+}
+
+} // namespace ApplyTopKTopPOptOp
+#endif

--- a/csrc/sample/topk_topp/op_kernel/apply_top_k_top_p_with_sorted.cpp
+++ b/csrc/sample/topk_topp/op_kernel/apply_top_k_top_p_with_sorted.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_k_top_p_with_sorted.cpp
+ * \brief
+ */
+
+#include "apply_top_k_top_p_with_sorted.h"
+#include "apply_top_p_with_sorted.h"
+#include "apply_top_k_top_p_opt.h"
+using namespace AscendC;
+using namespace ApplyTopKTopPWithSortedOp;
+using namespace ApplyTopPWithSortedOp;
+using namespace ApplyTopKTopPOptOp;
+
+extern "C" __global__ __aicore__ void apply_top_k_top_p_with_sorted(GM_ADDR sorted_value, GM_ADDR sorted_indices,
+                                                                    GM_ADDR p, GM_ADDR k, GM_ADDR logits, GM_ADDR out,
+                                                                    GM_ADDR workSpace, GM_ADDR tiling)
+{
+    TPipe pipe;
+    GET_TILING_DATA(tilingData, tiling);
+    if (TILING_KEY_IS(0)) {
+        ApplyTopKTopPWithSortedOp::ApplyTopKTopPWithSorted<DTYPE_OUT, float, DTYPE_OUT> op;
+        op.InitTilingData(tilingData, sorted_value, sorted_indices, p, k, out, workSpace);
+        op.InitBuffer(&pipe);
+        op.Process();
+    } else if (TILING_KEY_IS(1)) {
+        ApplyTopKTopPWithSortedOp::ApplyTopKTopPWithSorted<DTYPE_OUT, float, DTYPE_OUT> op;
+        op.InitTilingData(tilingData, sorted_value, sorted_indices, p, k, out, workSpace);
+        op.InitBuffer(&pipe);
+        op.ProcessTopK();
+    } else if (TILING_KEY_IS(2)) {
+        ApplyTopPWithSortedOp::ApplyTopPWithSorted<DTYPE_OUT, float, DTYPE_OUT> op;
+        op.InitTilingData(tilingData, sorted_value, sorted_indices, p, k, logits, out, workSpace);
+        op.InitBuffer(&pipe);
+        op.ProcessTopP();
+    } else if (TILING_KEY_IS(3)) {
+        ApplyTopKTopPOptOp::ApplyTopKTopPOpt<DTYPE_OUT, float, DTYPE_OUT> op;
+        op.InitTilingData(tilingData, sorted_value, sorted_indices, p, k, logits, out, workSpace);
+        op.InitBuffer(&pipe);
+        op.ProcessTopKTopPOpt();
+    } else if (TILING_KEY_IS(4)) {
+        ApplyTopKTopPOptOp::ApplyTopKTopPOpt<DTYPE_OUT, float, DTYPE_OUT> op;
+        op.InitTilingData(tilingData, sorted_value, sorted_indices, p, k, logits, out, workSpace);
+        op.InitBuffer(&pipe);
+        op.ProcessTopKOpt();
+    } else if (TILING_KEY_IS(5)) {
+        ApplyTopKTopPOptOp::ApplyTopKTopPOpt<DTYPE_OUT, float, DTYPE_OUT> op;
+        op.InitTilingData(tilingData, sorted_value, sorted_indices, p, k, logits, out, workSpace);
+        op.InitBuffer(&pipe);
+        op.ProcessTopPOpt();
+    }
+}

--- a/csrc/sample/topk_topp/op_kernel/apply_top_k_top_p_with_sorted.h
+++ b/csrc/sample/topk_topp/op_kernel/apply_top_k_top_p_with_sorted.h
@@ -1,0 +1,963 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_k_top_p_with_sorted.h
+ * \brief
+ */
+#ifndef APPLY_TOP_K_TOP_P_WITH_SORTED_H_KERNEL
+#define APPLY_TOP_K_TOP_P_WITH_SORTED_H_KERNEL
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+namespace ApplyTopKTopPWithSortedOp {
+constexpr uint32_t BUFFER_NUM = 1;
+constexpr uint16_t FLOAT16_NEG_INF = 0xFC00;    // -inf 64512
+constexpr uint16_t BF16_NEG_INF = 0xFF80;       // -inf 65408
+constexpr int32_t FLOAT32_NEG_INF = 0xFF800000; // -inf -2139095040
+
+constexpr uint32_t BLOCK_BYTES = 32;
+constexpr uint32_t DATA_PER_BLOCK_B32 = 8;
+constexpr uint32_t DATA_PER_REPEAT_B32 = 64;
+constexpr uint32_t K_MAX = 1024;
+constexpr uint64_t MASK_64 = 64;
+constexpr uint32_t RESERVE_CAL_BUFFER_SIZE = 1024;
+constexpr CumSumConfig CUMSUM_CONFIG{true, true, false};
+
+template <typename inputT, typename calT, typename outputT>
+class ApplyTopKTopPWithSorted {
+public:
+    __aicore__ inline ApplyTopKTopPWithSorted(){};
+    __aicore__ inline void InitTilingData(const ApplyTopKTopPWithSortedTilingData& __restrict tilingData,
+                                          GM_ADDR sorted_value, GM_ADDR sorted_indices, GM_ADDR p, GM_ADDR k,
+                                          GM_ADDR out, GM_ADDR workSpace);
+    __aicore__ inline void InitBuffer(TPipe* inputPipe);
+    __aicore__ inline void Process();
+    __aicore__ inline void ProcessTopK();
+
+private:
+    __aicore__ inline void InitCopyIn(uint32_t loopBatch, int64_t currentGmIdx);
+    __aicore__ inline void InitProcess(uint32_t loopBatch);
+    __aicore__ inline void ProcessKLtKMax(uint32_t loopBatch);
+    __aicore__ inline void ScatterCumtomImpl(uint32_t loopBatch, uint32_t loopProbNum, uint32_t offset);
+    __aicore__ inline void ProcessRemain(uint32_t loopBatch);
+    __aicore__ inline void GetKthResult(uint32_t loopBatch, uint32_t offset, uint8_t repeatTimes);
+    __aicore__ inline void GetFirstKLoop(uint32_t loopBatch, int32_t& firstKLoop);
+    __aicore__ inline void ScatterFromFirstKLoop(uint32_t loopBatch, int32_t firstKLoop, float& cumsumData);
+    __aicore__ inline void ReduceSumWithAddsAndExpImpl(uint32_t offset, uint32_t loopDataNum);
+    __aicore__ inline void CumSumWithAddsAndExpImpl(uint32_t offset, uint32_t loopDataNum, uint32_t cumsumInner,
+                                                    float cumsumData);
+    __aicore__ inline void SetCumsumGTIndex(uint32_t loopBatch, int32_t index);
+    __aicore__ inline void ProcessScatter();
+    __aicore__ inline void ProcessResScatter();
+    // topk func
+    __aicore__ inline void InitProcessTopK(uint32_t loopBatch);
+    __aicore__ inline void ProcessKLtKMaxTopK(uint32_t loopBatch);
+    __aicore__ inline void ProcessRemainTopK(uint32_t loopBatch);
+    __aicore__ inline void GetFirstKLoopTopK(uint32_t loopBatch, int32_t& firstKLoop);
+    __aicore__ inline void ScatterFromFirstKLoopTopK(uint32_t loopBatch, int32_t firstKLoop);
+    __aicore__ inline void ScatterCumtomImplTopK(uint32_t loopBatch, uint32_t loopProbNum, uint32_t offset);
+    __aicore__ inline void SToMTE3Sync()
+    {
+        event_t eventIDSToMTE3 = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_MTE3));
+        SetFlag<HardEvent::S_MTE3>(eventIDSToMTE3);
+        WaitFlag<HardEvent::S_MTE3>(eventIDSToMTE3);
+    }
+    __aicore__ inline void MTE3ToSSync()
+    {
+        event_t eventIDMTE3ToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_S));
+        SetFlag<HardEvent::MTE3_S>(eventIDMTE3ToS);
+        WaitFlag<HardEvent::MTE3_S>(eventIDMTE3ToS);
+    }
+    __aicore__ inline void VToSSync()
+    {
+        event_t eventIdVToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+        SetFlag<HardEvent::V_S>(eventIdVToS);
+        WaitFlag<HardEvent::V_S>(eventIdVToS);
+    }
+    __aicore__ inline void MTE2ToVSync()
+    {
+        event_t eventIdMte2ToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
+        SetFlag<HardEvent::MTE2_V>(eventIdMte2ToV);
+        WaitFlag<HardEvent::MTE2_V>(eventIdMte2ToV);
+    }
+    __aicore__ inline void MTE2ToSSync()
+    {
+        event_t eventIdMte2ToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_S));
+        SetFlag<HardEvent::MTE2_S>(eventIdMte2ToS);
+        WaitFlag<HardEvent::MTE2_S>(eventIdMte2ToS);
+    }
+    __aicore__ inline void MTE3ToVSync()
+    {
+        event_t eventIdMte3ToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_V));
+        SetFlag<HardEvent::MTE3_V>(eventIdMte3ToV);
+        WaitFlag<HardEvent::MTE3_V>(eventIdMte3ToV);
+    }
+    __aicore__ inline void SToMTE2Sync()
+    {
+        event_t eventIDSToMTE2 = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_MTE2));
+        SetFlag<HardEvent::S_MTE2>(eventIDSToMTE2);
+        WaitFlag<HardEvent::S_MTE2>(eventIDSToMTE2);
+    }
+    __aicore__ inline void VToMTE3Sync()
+    {
+        event_t eventIDVToMTE3 = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE3));
+        SetFlag<HardEvent::V_MTE3>(eventIDVToMTE3);
+        WaitFlag<HardEvent::V_MTE3>(eventIDVToMTE3);
+    }
+    __aicore__ inline void SToVSync()
+    {
+        event_t eventIdSToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_V));
+        SetFlag<HardEvent::S_V>(eventIdSToV);
+        WaitFlag<HardEvent::S_V>(eventIdSToV);
+    }
+    template <typename T>
+    __aicore__ inline T Min(T a, T b)
+    {
+        return a > b ? b : a;
+    }
+
+    template <typename T>
+    __aicore__ inline T Max(T a, T b)
+    {
+        return a > b ? a : b;
+    }
+
+private:
+    TPipe* pipe_;
+    // create queues for input, in this case depth is equal to buffer num
+    TQue<QuePosition::VECIN, BUFFER_NUM> sortedValueInQueue_;
+    TQue<QuePosition::VECIN, BUFFER_NUM> sortedIndicesInQueue_;
+    TQue<QuePosition::VECIN, BUFFER_NUM> pInQueue_;
+    TQue<QuePosition::VECIN, BUFFER_NUM> kInQueue_;
+    TQue<QuePosition::VECOUT, BUFFER_NUM> outQueue_;
+    TBuf<TPosition::VECCALC> calBuf_;
+
+    // tilingData
+    uint32_t batchSize_ = 0;
+    uint32_t vocabSize_ = 0;
+    uint32_t batchPerCore_ = 0;
+    uint32_t tailBatch_ = 0;
+    uint32_t blockNum_ = 0;
+    uint32_t dataNumInit_ = 0;
+    uint32_t dataNumInitAligned_ = 0;
+    uint32_t ubFactorElement_ = 0;
+    uint32_t ubFactorElementAligned_ = 0;
+    uint32_t tailUbFactorElement_ = 0;
+    uint32_t tailUbFactorElementAligned_ = 0;
+    uint32_t calUbSize_ = 0;
+
+    uint32_t blockIdx_ = 0;
+    uint32_t loopBatch_ = 0;
+    uint32_t batchOffset_ = 0;
+    uint32_t bufOffsetLoop = 0;
+    uint32_t loopInner_ = 0;
+    uint32_t loopInnerOnlyP_ = 0;
+    int64_t baseGmIdx_ = 0;
+
+    GlobalTensor<inputT> mGmSortedValue_;
+    GlobalTensor<int32_t> mGmSortedIndices_;
+    GlobalTensor<inputT> mGmP_;
+    GlobalTensor<int32_t> mGmK_;
+    GlobalTensor<outputT> mGmOut_;
+    GlobalTensor<int32_t> mGmCumsumGTIndex;
+
+    LocalTensor<int32_t> kLocal;
+    LocalTensor<inputT> pLocal;
+    LocalTensor<outputT> outTensor;
+    LocalTensor<inputT> sortedValueLocal;
+    LocalTensor<int32_t> sortedIndicesLocal;
+
+    LocalTensor<float> sortedValueLocalFp32;
+    LocalTensor<float> negInfLocal;
+
+    LocalTensor<float> calLocalFp32;
+    LocalTensor<float> kthValueLocal;
+    LocalTensor<float> tmpLocal;
+    LocalTensor<float> cumSumRes;
+    LocalTensor<float> cumSumTmp;
+    LocalTensor<float> reduceLocal;
+    LocalTensor<float> softMaxRes;
+    LocalTensor<inputT> scatterTensor;
+    LocalTensor<uint8_t> sharedTmpBuffer;
+
+    LocalTensor<int32_t> scatterIdxTensor;
+    LocalTensor<inputT> scatterSortedValueLocal;
+    LocalTensor<int32_t> scatterSortedIndicesLocal;
+    LocalTensor<inputT> scatterValueTensor;
+    LocalTensor<inputT> scatterBrcbLocal;
+
+    float kthValue = 0;
+    float pValue = 0;
+    float maxValue = 0;
+    float reduceSumValueInvert = 0;
+    float reduceSumValue = 0;
+    inputT kthTopKValue = 0;
+    bool hadGreaterCumsumP = false;
+    bool hadGreaterK = false;
+    bool hadGreaterKFirstLoop = false;
+    uint32_t scatterTensorNums_ = 1;
+    BinaryRepeatParams repeatParams = {1, 0, 1, 8, 0, 8};
+    DataCopyExtParams scatterCopyParams{1, (uint32_t)(sizeof(outputT)), 0, 0, 0};
+};
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::InitTilingData(
+    const ApplyTopKTopPWithSortedTilingData& __restrict tilingData, GM_ADDR sorted_value, GM_ADDR sorted_indices,
+    GM_ADDR p, GM_ADDR k, GM_ADDR out, GM_ADDR workSpace)
+{
+    batchSize_ = tilingData.batchSize;
+    vocabSize_ = tilingData.vocabSize;
+    batchPerCore_ = tilingData.batchPerCore;
+    tailBatch_ = tilingData.tailBatch;
+    blockNum_ = tilingData.blockNum;
+    dataNumInit_ = tilingData.dataNumInit;
+    dataNumInitAligned_ = AscendC::AlignUp(dataNumInit_, DATA_PER_BLOCK_B32);
+    ubFactorElement_ = tilingData.ubFactorElement;
+    ubFactorElementAligned_ = tilingData.ubFactorElementAligned;
+    tailUbFactorElement_ = tilingData.tailUbFactorElement;
+    tailUbFactorElementAligned_ = tilingData.tailUbFactorElementAligned;
+    calUbSize_ = tilingData.calUbSize;
+    blockIdx_ = GetBlockIdx();
+
+    if (blockIdx_ < tailBatch_) {
+        loopBatch_ = batchPerCore_ + 1;
+        batchOffset_ = blockIdx_ * loopBatch_;
+    } else {
+        loopBatch_ = batchPerCore_;
+        batchOffset_ = blockIdx_ * batchPerCore_ + tailBatch_;
+    }
+    loopInner_ = (vocabSize_ - dataNumInit_ + ubFactorElementAligned_ - 1) / ubFactorElementAligned_;
+    loopInnerOnlyP_ = (vocabSize_ + ubFactorElementAligned_ - 1) / ubFactorElementAligned_;
+    mGmSortedValue_.SetGlobalBuffer(reinterpret_cast<__gm__ inputT*>(sorted_value));
+    mGmSortedIndices_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(sorted_indices));
+    mGmP_.SetGlobalBuffer(reinterpret_cast<__gm__ inputT*>(p));
+    mGmK_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(k));
+    mGmOut_.SetGlobalBuffer(reinterpret_cast<__gm__ outputT*>(out));
+    mGmCumsumGTIndex.SetGlobalBuffer((__gm__ int32_t*)workSpace, batchSize_);
+}
+
+// init used buffer
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::InitBuffer(TPipe* inputPipe)
+{
+    pipe_ = inputPipe;
+    pipe_->InitBuffer(sortedValueInQueue_, BUFFER_NUM, sizeof(inputT) * (ubFactorElementAligned_ + K_MAX));
+    pipe_->InitBuffer(sortedIndicesInQueue_, BUFFER_NUM, sizeof(int32_t) * (ubFactorElementAligned_ + K_MAX));
+    pipe_->InitBuffer(pInQueue_, BUFFER_NUM, BLOCK_BYTES);
+    pipe_->InitBuffer(kInQueue_, BUFFER_NUM, BLOCK_BYTES);
+    pipe_->InitBuffer(outQueue_, BUFFER_NUM, sizeof(outputT) * ubFactorElementAligned_);
+    pipe_->InitBuffer(calBuf_, calUbSize_);
+    if constexpr (!IsSameType<inputT, float>::value) {
+        sortedValueLocalFp32 = calBuf_.GetWithOffset<float>(ubFactorElementAligned_ + K_MAX, bufOffsetLoop);
+        bufOffsetLoop = bufOffsetLoop + (ubFactorElementAligned_ + K_MAX) * sizeof(float);
+    }
+    kthValueLocal = calBuf_.GetWithOffset<float>(DATA_PER_BLOCK_B32, bufOffsetLoop);
+    bufOffsetLoop = bufOffsetLoop + BLOCK_BYTES;
+
+    negInfLocal = calBuf_.GetWithOffset<float>(DATA_PER_BLOCK_B32, bufOffsetLoop);
+    bufOffsetLoop = bufOffsetLoop + BLOCK_BYTES;
+
+    tmpLocal = calBuf_.GetWithOffset<float>(ubFactorElementAligned_, bufOffsetLoop);
+    bufOffsetLoop = bufOffsetLoop + ubFactorElementAligned_ * sizeof(float);
+    cumSumRes = calBuf_.GetWithOffset<float>(ubFactorElementAligned_, bufOffsetLoop);
+    bufOffsetLoop = bufOffsetLoop + ubFactorElementAligned_ * sizeof(float);
+    cumSumTmp = calBuf_.GetWithOffset<float>(ubFactorElementAligned_, bufOffsetLoop);
+    bufOffsetLoop = bufOffsetLoop + ubFactorElementAligned_ * sizeof(float);
+    reduceLocal = calBuf_.GetWithOffset<float>(ubFactorElementAligned_ * BLOCK_BYTES, bufOffsetLoop);
+    bufOffsetLoop = bufOffsetLoop + ubFactorElementAligned_ * BLOCK_BYTES * sizeof(float);
+
+    softMaxRes = tmpLocal.template ReinterpretCast<float>();
+    scatterTensor = reduceLocal.template ReinterpretCast<inputT>();
+    sharedTmpBuffer = reduceLocal.template ReinterpretCast<uint8_t>();
+
+    scatterIdxTensor = scatterTensor.template ReinterpretCast<int32_t>();
+    scatterTensorNums_ = (calUbSize_ - RESERVE_CAL_BUFFER_SIZE) / (sizeof(inputT) + sizeof(int32_t) + BLOCK_BYTES) /
+                         BLOCK_BYTES * BLOCK_BYTES;
+    scatterSortedValueLocal = calBuf_.GetWithOffset<inputT>(scatterTensorNums_, 0);
+    scatterSortedIndicesLocal = calBuf_.GetWithOffset<int32_t>(scatterTensorNums_, scatterTensorNums_ * sizeof(inputT));
+    uint32_t brcbOffset = scatterTensorNums_ * (sizeof(inputT) + sizeof(int32_t));
+    scatterBrcbLocal = calBuf_.GetWithOffset<inputT>(scatterTensorNums_ * (BLOCK_BYTES / sizeof(inputT)), brcbOffset);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::Process()
+{
+    kLocal = kInQueue_.AllocTensor<int32_t>();
+    pLocal = pInQueue_.AllocTensor<inputT>();
+    outTensor = outQueue_.AllocTensor<outputT>();
+    sortedValueLocal = sortedValueInQueue_.AllocTensor<inputT>();
+    sortedIndicesLocal = sortedIndicesInQueue_.AllocTensor<int32_t>();
+    Duplicate(negInfLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, DATA_PER_BLOCK_B32);
+    if constexpr (IsSameType<inputT, float>::value) {
+        calLocalFp32 = sortedValueLocal;
+        Duplicate(outTensor.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, ubFactorElementAligned_);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        calLocalFp32 = sortedValueLocalFp32;
+        Duplicate(outTensor.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, ubFactorElementAligned_);
+    } else {
+        calLocalFp32 = sortedValueLocalFp32;
+        Duplicate(outTensor.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, ubFactorElementAligned_);
+    }
+    VToMTE3Sync();
+    for (uint32_t loopBatch = 0; loopBatch < loopBatch_; loopBatch++) {
+        baseGmIdx_ = batchOffset_ * vocabSize_ + loopBatch * vocabSize_;
+        hadGreaterKFirstLoop = false;
+        hadGreaterK = false;
+        hadGreaterCumsumP = false;
+        InitProcess(loopBatch);
+        if (calLocalFp32.GetValue(ubFactorElementAligned_) < kthValue) {
+            ProcessKLtKMax(loopBatch);
+        } else {
+            ProcessRemain(loopBatch);
+        }
+    }
+    SyncAll();
+    ProcessScatter();
+    kInQueue_.FreeTensor(kLocal);
+    pInQueue_.FreeTensor(pLocal);
+    sortedValueInQueue_.FreeTensor(sortedValueLocal);
+    sortedIndicesInQueue_.FreeTensor(sortedIndicesLocal);
+    outQueue_.FreeTensor(outTensor);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ProcessScatter()
+{
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ELEM_PER_REP = 8;
+    constexpr uint32_t BRCB_SRC_ALIGN = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ALIGN_REPEATS = BRCB_SRC_ALIGN / BRCB_ELEM_PER_REP;
+    constexpr uint32_t MAX_BRCB_REPEAT = 255;
+    constexpr uint32_t ALIGNED_MAX_REPEAT = (MAX_BRCB_REPEAT / BRCB_ALIGN_REPEATS) * BRCB_ALIGN_REPEATS;
+
+    uint32_t batchBlocks = batchSize_ / blockNum_;
+    for (uint32_t count = 0; count < batchBlocks; count++) {
+        int64_t currentBatch = static_cast<int64_t>(blockIdx_) * batchBlocks + count;
+        int32_t cumsumGTIndex = mGmCumsumGTIndex.GetValue(currentBatch);
+        int64_t currentBatchIdx = currentBatch * vocabSize_;
+        int64_t currentBatchEndIdx = currentBatchIdx + vocabSize_ - 1;
+        int32_t scatterLength = currentBatchEndIdx - (currentBatchIdx + cumsumGTIndex) + 1;
+        if (scatterLength <= 0) {
+            continue;
+        }
+
+        int32_t scatterLengthBlocks = (scatterLength + scatterTensorNums_ - 1) / scatterTensorNums_;
+        int32_t resScatterLength = scatterLength - (scatterLengthBlocks - 1) * scatterTensorNums_;
+        for (int32_t scatterLengthCount = 0; scatterLengthCount < scatterLengthBlocks; scatterLengthCount++) {
+            int64_t currentGmIdx = currentBatchIdx + cumsumGTIndex + scatterLengthCount * scatterTensorNums_;
+            int32_t dataNums = scatterTensorNums_;
+            if (scatterLengthCount == scatterLengthBlocks - 1) {
+                dataNums = resScatterLength;
+            }
+            DataCopyPad(scatterSortedValueLocal, mGmSortedValue_[currentGmIdx],
+                        {1, static_cast<uint32_t>(dataNums * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+            DataCopyPad(scatterSortedIndicesLocal, mGmSortedIndices_[currentGmIdx],
+                        {1, static_cast<uint32_t>(dataNums * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            MTE2ToSSync();
+
+            uint32_t totalRepeat = (static_cast<uint32_t>(dataNums) + BRCB_ELEM_PER_REP - 1) / BRCB_ELEM_PER_REP;
+            uint32_t brcbDone = 0;
+            while (brcbDone < totalRepeat) {
+                uint32_t remaining = totalRepeat - brcbDone;
+                uint32_t curRepeat = remaining > ALIGNED_MAX_REPEAT ?
+                                         ALIGNED_MAX_REPEAT :
+                                         (remaining + BRCB_ALIGN_REPEATS - 1) / BRCB_ALIGN_REPEATS * BRCB_ALIGN_REPEATS;
+                Brcb(scatterBrcbLocal[brcbDone * BRCB_ELEM_PER_REP * DATA_PER_BLOCK],
+                     scatterSortedValueLocal[brcbDone * BRCB_ELEM_PER_REP], curRepeat, {1, 8});
+                brcbDone += curRepeat;
+            }
+            VToMTE3Sync();
+
+            for (int32_t loopProb = 0; loopProb < dataNums; loopProb++) {
+                int32_t gmIndex = scatterSortedIndicesLocal.GetValue(loopProb);
+                DataCopyPad(mGmOut_[currentBatchIdx + gmIndex], scatterBrcbLocal[loopProb * DATA_PER_BLOCK],
+                            {1, (uint32_t)(1 * sizeof(outputT)), 0, 0, 0});
+            }
+            MTE3ToSSync();
+        }
+    }
+    ProcessResScatter();
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ProcessResScatter()
+{
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ELEM_PER_REP = 8;
+    constexpr uint32_t BRCB_SRC_ALIGN = BLOCK_BYTES / sizeof(inputT);
+    constexpr uint32_t BRCB_ALIGN_REPEATS = BRCB_SRC_ALIGN / BRCB_ELEM_PER_REP;
+    constexpr uint32_t MAX_BRCB_REPEAT = 255;
+    constexpr uint32_t ALIGNED_MAX_REPEAT = (MAX_BRCB_REPEAT / BRCB_ALIGN_REPEATS) * BRCB_ALIGN_REPEATS;
+
+    uint32_t batchBlocks = batchSize_ / blockNum_;
+    uint32_t resbatch = batchSize_ % blockNum_;
+    if (resbatch == 0) {
+        return;
+    }
+    uint32_t batchCoreNum = blockNum_ / resbatch;
+    if (blockIdx_ > batchCoreNum * resbatch - 1) {
+        return;
+    }
+    int64_t currentBatch = static_cast<int64_t>(batchBlocks) * blockNum_ + blockIdx_ / batchCoreNum;
+    int64_t currentBatchIdx = currentBatch * vocabSize_;
+    int64_t currentBatchEndIdx = currentBatchIdx + vocabSize_ - 1;
+    int32_t cumsumGTIndex = mGmCumsumGTIndex.GetValue(currentBatch);
+    uint32_t batchCoreIdx = blockIdx_ % batchCoreNum;
+    int32_t scatterLength = currentBatchEndIdx - (currentBatchIdx + cumsumGTIndex) + 1;
+    int32_t scatterCoreLength = (scatterLength + batchCoreNum - 1) / batchCoreNum;
+    int64_t currentCoreStartIdx = currentBatchIdx + cumsumGTIndex + scatterCoreLength * batchCoreIdx;
+    currentCoreStartIdx = Max(currentCoreStartIdx, currentBatchIdx + cumsumGTIndex + batchCoreIdx);
+    scatterCoreLength = Min(scatterCoreLength, static_cast<int32_t>(currentBatchEndIdx - currentCoreStartIdx + 1));
+    if (scatterLength <= 0 || currentCoreStartIdx > currentBatchEndIdx) {
+        return;
+    }
+
+    int32_t scatterLengthBlocks = (scatterCoreLength + scatterTensorNums_ - 1) / scatterTensorNums_;
+    int32_t resScatterLength = scatterCoreLength - (scatterLengthBlocks - 1) * scatterTensorNums_;
+    for (int32_t scatterLengthCount = 0; scatterLengthCount < scatterLengthBlocks; scatterLengthCount++) {
+        int64_t currentGmIdx = currentCoreStartIdx + scatterLengthCount * scatterTensorNums_;
+        int32_t dataNums = scatterTensorNums_;
+        if (scatterLengthCount == scatterLengthBlocks - 1) {
+            dataNums = resScatterLength;
+        }
+        DataCopyPad(scatterSortedValueLocal, mGmSortedValue_[currentGmIdx],
+                    {1, static_cast<uint32_t>(dataNums * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        DataCopyPad(scatterSortedIndicesLocal, mGmSortedIndices_[currentGmIdx],
+                    {1, static_cast<uint32_t>(dataNums * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+        MTE2ToVSync();
+        MTE2ToSSync();
+
+        uint32_t totalRepeat = (static_cast<uint32_t>(dataNums) + BRCB_ELEM_PER_REP - 1) / BRCB_ELEM_PER_REP;
+        uint32_t brcbDone = 0;
+        while (brcbDone < totalRepeat) {
+            uint32_t remaining = totalRepeat - brcbDone;
+            uint32_t curRepeat = remaining > ALIGNED_MAX_REPEAT ?
+                                     ALIGNED_MAX_REPEAT :
+                                     (remaining + BRCB_ALIGN_REPEATS - 1) / BRCB_ALIGN_REPEATS * BRCB_ALIGN_REPEATS;
+            Brcb(scatterBrcbLocal[brcbDone * BRCB_ELEM_PER_REP * DATA_PER_BLOCK],
+                 scatterSortedValueLocal[brcbDone * BRCB_ELEM_PER_REP], curRepeat, {1, 8});
+            brcbDone += curRepeat;
+        }
+        VToMTE3Sync();
+
+        for (int32_t loopProb = 0; loopProb < dataNums; loopProb++) {
+            int32_t gmIndex = scatterSortedIndicesLocal.GetValue(loopProb);
+            DataCopyPad(mGmOut_[currentBatchIdx + gmIndex], scatterBrcbLocal[loopProb * DATA_PER_BLOCK],
+                        {1, (uint32_t)(1 * sizeof(outputT)), 0, 0, 0});
+        }
+        MTE3ToSSync();
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::InitCopyIn(uint32_t loopBatch,
+                                                                                  int64_t currentGmIdx)
+{
+    scatterIdxTensor.SetValue(0, static_cast<int32_t>(vocabSize_));
+    SToMTE3Sync();
+    DataCopyPad(mGmCumsumGTIndex[batchOffset_ + loopBatch], scatterIdxTensor,
+                {1, static_cast<uint32_t>(sizeof(int32_t)), 0, 0, 0});
+    MTE3ToSSync();
+    DataCopyPad(mGmOut_[currentGmIdx], outTensor, {1, (uint32_t)(dataNumInit_ * sizeof(outputT)), 0, 0, 0});
+    DataCopyPad(sortedValueLocal[ubFactorElementAligned_], mGmSortedValue_[currentGmIdx],
+                {1, static_cast<uint32_t>(dataNumInit_ * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+    DataCopyPad(pLocal, mGmP_[batchOffset_ + loopBatch], {1, static_cast<uint32_t>(sizeof(inputT)), 0, 0, 0},
+                {false, 0, 0, 0});
+    if constexpr (!IsSameType<inputT, float>::value) {
+        MTE2ToVSync();
+        Cast(sortedValueLocalFp32[ubFactorElementAligned_], sortedValueLocal[ubFactorElementAligned_],
+             RoundMode::CAST_NONE, dataNumInit_);
+        Cast(tmpLocal, pLocal, RoundMode::CAST_NONE, DATA_PER_BLOCK_B32);
+    }
+    DataCopyPad(sortedIndicesLocal[ubFactorElementAligned_], mGmSortedIndices_[currentGmIdx],
+                {1, static_cast<uint32_t>(dataNumInit_ * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+    DataCopyPad(kLocal, mGmK_[batchOffset_ + loopBatch], {1, static_cast<uint32_t>(sizeof(int32_t)), 0, 0, 0},
+                {false, 0, 0, 0});
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::GetKthResult(uint32_t loopBatch, uint32_t offset,
+                                                                                    uint8_t repeatTimes)
+{
+    Compare(tmpLocal.template ReinterpretCast<uint8_t>(), kthValueLocal, calLocalFp32[offset], CMPMODE::GT, MASK_64,
+            repeatTimes, repeatParams);
+    PipeBarrier<PIPE_V>();
+    Select(calLocalFp32[offset], tmpLocal.template ReinterpretCast<uint8_t>(), negInfLocal, calLocalFp32[offset],
+           SELMODE::VSEL_TENSOR_TENSOR_MODE, MASK_64, repeatTimes, repeatParams);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ReduceSumWithAddsAndExpImpl(uint32_t offset,
+                                                                                                   uint32_t loopDataNum)
+{
+    Adds(softMaxRes, calLocalFp32[offset], maxValue, loopDataNum);
+    PipeBarrier<PIPE_V>();
+    Exp(softMaxRes, softMaxRes, loopDataNum);
+    PipeBarrier<PIPE_V>();
+    ReduceSum(reduceLocal, softMaxRes, reduceLocal, loopDataNum);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::InitProcess(uint32_t loopBatch)
+{
+    int64_t initGmIdx = baseGmIdx_ + vocabSize_ - dataNumInit_;
+    InitCopyIn(loopBatch, initGmIdx);
+    MTE2ToSSync();
+
+    int32_t kValue = kLocal.GetValue(0);
+    if constexpr (IsSameType<inputT, float>::value) {
+        pValue = float(1.0) - pLocal.GetValue(0);
+    } else {
+        pValue = float(1.0) - tmpLocal.GetValue(0);
+    }
+    maxValue = -calLocalFp32[ubFactorElementAligned_].GetValue(dataNumInit_ - 1);
+    if constexpr (IsSameType<inputT, float>::value) {
+        kthValue = mGmSortedValue_[baseGmIdx_ + vocabSize_ - kValue].GetValue(0);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        kthValue = static_cast<float>(mGmSortedValue_[baseGmIdx_ + vocabSize_ - kValue].GetValue(0));
+    } else {
+        kthValue = ToFloat(mGmSortedValue_[baseGmIdx_ + vocabSize_ - kValue].GetValue(0));
+    }
+    Duplicate(kthValueLocal, kthValue, 8);
+    PipeBarrier<PIPE_V>();
+
+    uint8_t repeatTimes = (dataNumInit_ + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+    GetKthResult(loopBatch, ubFactorElementAligned_, repeatTimes);
+    PipeBarrier<PIPE_V>();
+    DataCopyExtParams copyParams{1, (uint32_t)(ubFactorElementAligned_ * sizeof(outputT)), 0, 0, 0};
+
+    ReduceSumWithAddsAndExpImpl(ubFactorElementAligned_, dataNumInit_);
+    VToSSync();
+    reduceSumValue = reduceLocal.GetValue(0);
+    reduceSumValueInvert = 1 / reduceSumValue;
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ProcessKLtKMax(uint32_t loopBatch)
+{
+    DataCopyExtParams copyParams{1, (uint32_t)(ubFactorElementAligned_ * sizeof(outputT)), 0, 0, 0};
+    for (int32_t loopInner = 0; loopInner < loopInner_; loopInner++) {
+        int64_t currentGmIdxInner = baseGmIdx_ + loopInner * ubFactorElementAligned_;
+        if (loopInner == loopInner_ - 1) {
+            DataCopyPad(mGmOut_[currentGmIdxInner], outTensor,
+                        {1, (uint32_t)(tailUbFactorElement_ * sizeof(outputT)), 0, 0, 0});
+        } else {
+            DataCopyPad(mGmOut_[currentGmIdxInner], outTensor, copyParams);
+        }
+    }
+    Muls(softMaxRes, softMaxRes, reduceSumValueInvert, dataNumInit_);
+    PipeBarrier<PIPE_V>();
+    const CumSumInfo cumSumInfo{1, dataNumInitAligned_};
+    CumSum<float, CUMSUM_CONFIG>(cumSumRes, cumSumTmp, softMaxRes, sharedTmpBuffer, cumSumInfo);
+    VToSSync();
+    int32_t loopProb = dataNumInit_ - 1;
+    scatterTensor.SetValue(0, sortedValueLocal[ubFactorElementAligned_].GetValue(loopProb));
+    SToMTE3Sync();
+    int32_t gmIndex = sortedIndicesLocal[ubFactorElementAligned_].GetValue(loopProb);
+    PipeBarrier<PIPE_MTE3>();
+    DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(), scatterCopyParams);
+    MTE3ToSSync();
+    loopProb = loopProb - 1;
+    for (; loopProb >= 0; loopProb--) {
+        float cumsumData = cumSumRes.GetValue(loopProb);
+        if (cumsumData <= pValue) {
+            break;
+        }
+        scatterTensor.SetValue(0, sortedValueLocal[ubFactorElementAligned_].GetValue(loopProb));
+        gmIndex = sortedIndicesLocal[ubFactorElementAligned_].GetValue(loopProb);
+        SToMTE3Sync();
+        DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(),
+                    scatterCopyParams);
+        MTE3ToSSync();
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ScatterCumtomImpl(uint32_t loopBatch,
+                                                                                         uint32_t loopProbNum,
+                                                                                         uint32_t offset)
+{
+    for (int32_t loopProb = 0; loopProb < static_cast<int32_t>(loopProbNum); loopProb++) {
+        float cumsumDataTmp = cumSumRes.GetValue(loopProb);
+        if (cumsumDataTmp <= pValue && !hadGreaterCumsumP) {
+            continue;
+        }
+        scatterTensor.SetValue(0, sortedValueLocal[offset].GetValue(loopProb));
+        int32_t gmIndex = sortedIndicesLocal[offset].GetValue(loopProb);
+        SToMTE3Sync();
+        DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(),
+                    {1, (uint32_t)(1 * sizeof(outputT)), 0, 0, 0});
+        MTE3ToSSync();
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::GetFirstKLoop(uint32_t loopBatch,
+                                                                                     int32_t& firstKLoop)
+{
+    uint8_t repeatTimes = (dataNumInit_ + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+    uint32_t loopDataNum = ubFactorElementAligned_;
+    for (int32_t loopInner = 0; loopInner < loopInner_; loopInner++) {
+        int64_t currentGmIdx = baseGmIdx_ + loopInner * ubFactorElementAligned_;
+        if (loopInner == (loopInner_ - 1)) {
+            repeatTimes = ((tailUbFactorElement_) + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+            loopDataNum = tailUbFactorElement_;
+        }
+        DataCopyPad(mGmOut_[currentGmIdx], outTensor, {1, (uint32_t)(loopDataNum * sizeof(outputT)), 0, 0, 0});
+        DataCopyPad(sortedValueLocal.template ReinterpretCast<inputT>(), mGmSortedValue_[currentGmIdx],
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        if constexpr (!IsSameType<inputT, float>::value) {
+            MTE2ToVSync();
+            Cast(sortedValueLocalFp32, sortedValueLocal, RoundMode::CAST_NONE, loopDataNum);
+            VToSSync();
+        } else {
+            MTE2ToSSync();
+        }
+        if (calLocalFp32.GetValue(loopDataNum - 1) < kthValue) {
+            firstKLoop += 1;
+            continue;
+        }
+        SToVSync();
+        if (!hadGreaterKFirstLoop) {
+            GetKthResult(loopBatch, 0, repeatTimes);
+            PipeBarrier<PIPE_V>();
+            hadGreaterKFirstLoop = true;
+        }
+        ReduceSumWithAddsAndExpImpl(0, loopDataNum);
+        VToSSync();
+        reduceSumValue += reduceLocal.GetValue(0);
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::CumSumWithAddsAndExpImpl(uint32_t offset,
+                                                                                                uint32_t loopDataNum,
+                                                                                                uint32_t cumsumInner,
+                                                                                                float cumsumData)
+{
+    Adds(softMaxRes, calLocalFp32[offset], maxValue, loopDataNum);
+    PipeBarrier<PIPE_V>();
+    Exp(softMaxRes, softMaxRes, loopDataNum);
+    PipeBarrier<PIPE_V>();
+    Muls(softMaxRes, softMaxRes, reduceSumValueInvert, loopDataNum);
+    PipeBarrier<PIPE_V>();
+    const CumSumInfo cumSumInfo{1, cumsumInner};
+    CumSum<float, CUMSUM_CONFIG>(cumSumRes, cumSumTmp, softMaxRes, sharedTmpBuffer, cumSumInfo);
+    PipeBarrier<PIPE_V>();
+    Adds(cumSumRes, cumSumRes, cumsumData, loopDataNum);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ProcessRemain(uint32_t loopBatch)
+{
+    int32_t firstKLoop = 0;
+    GetFirstKLoop(loopBatch, firstKLoop);
+    reduceSumValueInvert = 1 / reduceSumValue;
+    float cumsumData = 0;
+    ScatterFromFirstKLoop(loopBatch, firstKLoop, cumsumData);
+    uint32_t loopProb = dataNumInit_ - 1;
+    scatterTensor.SetValue(0, sortedValueLocal[ubFactorElementAligned_].GetValue(loopProb));
+    int32_t gmIndex = sortedIndicesLocal[ubFactorElementAligned_].GetValue(loopProb);
+    SToMTE3Sync();
+    DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(), scatterCopyParams);
+    MTE3ToVSync();
+    if (hadGreaterCumsumP) {
+        return;
+    }
+    CumSumWithAddsAndExpImpl(ubFactorElementAligned_, dataNumInit_, dataNumInitAligned_, cumsumData);
+    VToSSync();
+    ScatterCumtomImpl(loopBatch, dataNumInit_ - 1, ubFactorElementAligned_);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ScatterFromFirstKLoop(uint32_t loopBatch,
+                                                                                             int32_t firstKLoop,
+                                                                                             float& cumsumData)
+{
+    uint32_t loopDataNum = ubFactorElementAligned_;
+    uint32_t cumsumInner = ubFactorElementAligned_;
+    uint8_t repeatTimes = ((ubFactorElementAligned_) + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+    for (int32_t loopInner = firstKLoop; loopInner < loopInner_; loopInner++) {
+        int64_t currentGmIdx = baseGmIdx_ + loopInner * ubFactorElementAligned_;
+        if (loopInner == (loopInner_ - 1)) {
+            repeatTimes = (tailUbFactorElement_ + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+            loopDataNum = tailUbFactorElement_;
+            cumsumInner = tailUbFactorElementAligned_;
+        }
+        DataCopyPad(sortedValueLocal.template ReinterpretCast<inputT>(), mGmSortedValue_[currentGmIdx],
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        DataCopyPad(sortedIndicesLocal, mGmSortedIndices_[currentGmIdx],
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+        if constexpr (!IsSameType<inputT, float>::value) {
+            MTE2ToVSync();
+            Cast(sortedValueLocalFp32, sortedValueLocal, RoundMode::CAST_NONE, loopDataNum);
+            PipeBarrier<PIPE_V>();
+        } else {
+            MTE2ToVSync();
+        }
+
+        if (!hadGreaterK) {
+            GetKthResult(loopBatch, 0, repeatTimes);
+            PipeBarrier<PIPE_V>();
+            hadGreaterK = true;
+        }
+
+        if (!hadGreaterCumsumP) {
+            CumSumWithAddsAndExpImpl(0, loopDataNum, cumsumInner, cumsumData);
+            VToSSync();
+            float cumsumDataTmp = cumSumRes.GetValue(loopDataNum - 1);
+            cumsumData = cumsumDataTmp;
+            if (cumsumDataTmp <= pValue) {
+                continue;
+            }
+            SetCumsumGTIndex(loopBatch, static_cast<int32_t>(loopInner * ubFactorElementAligned_ + loopDataNum));
+        }
+        ScatterCumtomImpl(loopBatch, loopDataNum, 0);
+        hadGreaterCumsumP = true;
+        break;
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::SetCumsumGTIndex(uint32_t loopBatch,
+                                                                                        int32_t index)
+{
+    scatterIdxTensor.SetValue(0, index);
+    SToMTE3Sync();
+    DataCopyPad(mGmCumsumGTIndex[batchOffset_ + loopBatch], scatterIdxTensor,
+                {1, static_cast<uint32_t>(sizeof(int32_t)), 0, 0, 0});
+    MTE3ToSSync();
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ProcessTopK()
+{
+    kLocal = kInQueue_.AllocTensor<int32_t>();
+    outTensor = outQueue_.AllocTensor<outputT>();
+    sortedValueLocal = sortedValueInQueue_.AllocTensor<inputT>();
+    sortedIndicesLocal = sortedIndicesInQueue_.AllocTensor<int32_t>();
+    Duplicate(negInfLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, DATA_PER_BLOCK_B32);
+    if constexpr (IsSameType<inputT, float>::value) {
+        calLocalFp32 = sortedValueLocal;
+        Duplicate(outTensor.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, ubFactorElementAligned_);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        calLocalFp32 = sortedValueLocalFp32;
+        Duplicate(outTensor.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, ubFactorElementAligned_);
+    } else {
+        calLocalFp32 = sortedValueLocalFp32;
+        Duplicate(outTensor.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, ubFactorElementAligned_);
+    }
+    VToMTE3Sync();
+    for (uint32_t loopBatch = 0; loopBatch < loopBatch_; loopBatch++) {
+        baseGmIdx_ = batchOffset_ * vocabSize_ + loopBatch * vocabSize_;
+        hadGreaterKFirstLoop = false;
+        hadGreaterK = false;
+        InitProcessTopK(loopBatch);
+        /* The difference lies in that for the max branch, some data is less than the kthvalue,
+        so part of the data can be filtered out in advance;
+        while for the remain branch, all data must undergo the topk calculation.*/
+        if (calLocalFp32.GetValue(ubFactorElementAligned_) < kthValue) {
+            ProcessKLtKMaxTopK(loopBatch);
+        } else {
+            ProcessRemainTopK(loopBatch);
+        }
+    }
+    SyncAll();
+    ProcessScatter();
+    kInQueue_.FreeTensor(kLocal);
+    sortedValueInQueue_.FreeTensor(sortedValueLocal);
+    sortedIndicesInQueue_.FreeTensor(sortedIndicesLocal);
+    outQueue_.FreeTensor(outTensor);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ProcessRemainTopK(uint32_t loopBatch)
+{
+    int32_t firstKLoop = 0;
+    GetFirstKLoopTopK(loopBatch, firstKLoop);
+    // Start the scatter calculation from the first loop in the row where the value is ≥ kthValue.
+    ScatterFromFirstKLoopTopK(loopBatch, firstKLoop);
+    /* Perform scatter calculation on the maximum number of ubFactorElementAligned_,
+       which does not overlap with the previous ones.*/
+    uint32_t loopProb = dataNumInit_ - 1;
+    scatterTensor.SetValue(0, sortedValueLocal[ubFactorElementAligned_].GetValue(loopProb));
+    SToMTE3Sync();
+    int32_t gmIndex = sortedIndicesLocal[ubFactorElementAligned_].GetValue(loopProb);
+    DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(), scatterCopyParams);
+    MTE3ToSSync();
+    if (hadGreaterK) {
+        return;
+    }
+    ScatterCumtomImplTopK(loopBatch, dataNumInit_ - 1, ubFactorElementAligned_);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::GetFirstKLoopTopK(uint32_t loopBatch,
+                                                                                         int32_t& firstKLoop)
+{
+    uint8_t repeatTimes = (dataNumInit_ + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+    uint32_t loopDataNum = ubFactorElementAligned_;
+    for (int32_t loopInner = 0; loopInner < loopInner_; loopInner++) {
+        int64_t currentGmIdx = baseGmIdx_ + loopInner * ubFactorElementAligned_;
+        if (loopInner == (loopInner_ - 1)) {
+            repeatTimes = ((tailUbFactorElement_) + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+            loopDataNum = tailUbFactorElement_;
+        }
+        DataCopyPad(mGmOut_[currentGmIdx], outTensor, {1, (uint32_t)(loopDataNum * sizeof(outputT)), 0, 0, 0});
+        if (hadGreaterKFirstLoop) {
+            continue;
+        }
+        DataCopyPad(sortedValueLocal.template ReinterpretCast<inputT>(), mGmSortedValue_[currentGmIdx],
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        MTE2ToSSync();
+        float rightVlaue = 0;
+        // Make a judgment on the rightmost value of each loop to filter the data.
+        if constexpr (IsSameType<inputT, bfloat16_t>::value) {
+            rightVlaue = ToFloat(sortedValueLocal.GetValue(loopDataNum - 1));
+        } else {
+            rightVlaue = static_cast<float>(sortedValueLocal.GetValue(loopDataNum - 1));
+        }
+        SToMTE2Sync();
+        if (rightVlaue < kthValue) {
+            firstKLoop += 1;
+            continue;
+        }
+        hadGreaterKFirstLoop = true;
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ScatterFromFirstKLoopTopK(uint32_t loopBatch,
+                                                                                                 int32_t firstKLoop)
+{
+    uint32_t loopDataNum = ubFactorElementAligned_;
+    uint32_t cumsumInner = ubFactorElementAligned_;
+    uint8_t repeatTimes = ((ubFactorElementAligned_) + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+    for (int32_t loopInner = firstKLoop; loopInner < loopInner_; loopInner++) {
+        int64_t currentGmIdx = baseGmIdx_ + loopInner * ubFactorElementAligned_;
+        if (loopInner == (loopInner_ - 1)) {
+            repeatTimes = (tailUbFactorElement_ + DATA_PER_REPEAT_B32 - 1) / DATA_PER_REPEAT_B32;
+            loopDataNum = tailUbFactorElement_;
+            cumsumInner = tailUbFactorElementAligned_;
+        }
+        DataCopyPad(sortedValueLocal.template ReinterpretCast<inputT>(), mGmSortedValue_[currentGmIdx],
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        if constexpr (!IsSameType<inputT, float>::value) {
+            MTE2ToVSync();
+            Cast(sortedValueLocalFp32, sortedValueLocal, RoundMode::CAST_NONE, loopDataNum);
+            VToSSync();
+        }
+        DataCopyPad(sortedIndicesLocal, mGmSortedIndices_[currentGmIdx],
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+        MTE2ToSSync();
+
+        SetCumsumGTIndex(loopBatch, static_cast<int32_t>(loopInner * ubFactorElementAligned_ + loopDataNum));
+        ScatterCumtomImplTopK(loopBatch, loopDataNum, 0);
+        hadGreaterK = true;
+        break;
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ScatterCumtomImplTopK(uint32_t loopBatch,
+                                                                                             uint32_t loopProbNum,
+                                                                                             uint32_t offset)
+{
+    // Reverse traversal, returning early to improve performance.
+    for (int32_t loopProb = static_cast<int32_t>(loopProbNum) - 1; loopProb >= 0; loopProb--) {
+        float curValue = calLocalFp32[offset].GetValue(loopProb);
+        if (curValue < kthValue) {
+            break;
+        }
+        scatterTensor.SetValue(0, sortedValueLocal[offset].GetValue(loopProb));
+        int32_t gmIndex = sortedIndicesLocal[offset].GetValue(loopProb);
+        SToMTE3Sync();
+        DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(),
+                    {1, (uint32_t)(1 * sizeof(outputT)), 0, 0, 0});
+        MTE3ToSSync();
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::InitProcessTopK(uint32_t loopBatch)
+{
+    scatterIdxTensor.SetValue(0, static_cast<int32_t>(vocabSize_));
+    SToMTE3Sync();
+    DataCopyPad(mGmCumsumGTIndex[batchOffset_ + loopBatch], scatterIdxTensor,
+                {1, static_cast<uint32_t>(sizeof(int32_t)), 0, 0, 0});
+    MTE3ToSSync();
+    int64_t initGmIdx = baseGmIdx_ + vocabSize_ - dataNumInit_;
+    DataCopyPad(mGmOut_[initGmIdx], outTensor, {1, (uint32_t)(dataNumInit_ * sizeof(outputT)), 0, 0, 0});
+    DataCopyPad(sortedValueLocal[ubFactorElementAligned_], mGmSortedValue_[initGmIdx],
+                {1, static_cast<uint32_t>(dataNumInit_ * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+    if constexpr (!IsSameType<inputT, float>::value) {
+        MTE2ToVSync();
+        Cast(sortedValueLocalFp32[ubFactorElementAligned_], sortedValueLocal[ubFactorElementAligned_],
+             RoundMode::CAST_NONE, dataNumInit_);
+    }
+    DataCopyPad(sortedIndicesLocal[ubFactorElementAligned_], mGmSortedIndices_[initGmIdx],
+                {1, static_cast<uint32_t>(dataNumInit_ * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+    DataCopyPad(kLocal, mGmK_[batchOffset_ + loopBatch], {1, static_cast<uint32_t>(sizeof(int32_t)), 0, 0, 0},
+                {false, 0, 0, 0});
+    MTE2ToSSync();
+    int32_t kValue = mGmK_.GetValue(batchOffset_ + loopBatch);
+    maxValue = -calLocalFp32[ubFactorElementAligned_].GetValue(dataNumInit_ - 1);
+    if constexpr (IsSameType<inputT, float>::value) {
+        kthValue = mGmSortedValue_[baseGmIdx_ + vocabSize_ - kValue].GetValue(0);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        kthValue = static_cast<float>(mGmSortedValue_[baseGmIdx_ + vocabSize_ - kValue].GetValue(0));
+    } else {
+        kthValue = ToFloat(mGmSortedValue_[baseGmIdx_ + vocabSize_ - kValue].GetValue(0));
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopKTopPWithSorted<inputT, calT, outputT>::ProcessKLtKMaxTopK(uint32_t loopBatch)
+{
+    DataCopyExtParams copyParams{1, (uint32_t)(ubFactorElementAligned_ * sizeof(outputT)), 0, 0, 0};
+    // Move out -infinity to fill GM
+    for (int32_t loopInner = 0; loopInner < loopInner_; loopInner++) {
+        int64_t currentGmIdxInner = baseGmIdx_ + loopInner * ubFactorElementAligned_;
+        if (loopInner == loopInner_ - 1) {
+            DataCopyPad(mGmOut_[currentGmIdxInner], outTensor,
+                        {1, (uint32_t)(tailUbFactorElement_ * sizeof(outputT)), 0, 0, 0});
+        } else {
+            DataCopyPad(mGmOut_[currentGmIdxInner], outTensor, copyParams);
+        }
+    }
+    // Scatter calculation
+    int32_t loopProb = dataNumInit_ - 1;
+    scatterTensor.SetValue(0, sortedValueLocal[ubFactorElementAligned_].GetValue(loopProb));
+    int32_t gmIndex = sortedIndicesLocal[ubFactorElementAligned_].GetValue(loopProb);
+    SToMTE3Sync();
+    PipeBarrier<PIPE_MTE3>();
+    DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(), scatterCopyParams);
+    loopProb = loopProb - 1;
+
+    for (; loopProb >= 0; loopProb--) {
+        float curValue = calLocalFp32[ubFactorElementAligned_].GetValue(loopProb);
+        if (curValue < kthValue) {
+            break;
+        }
+        MTE3ToSSync();
+        scatterTensor.SetValue(0, sortedValueLocal[ubFactorElementAligned_].GetValue(loopProb));
+        gmIndex = sortedIndicesLocal[ubFactorElementAligned_].GetValue(loopProb);
+        SToMTE3Sync();
+        DataCopyPad(mGmOut_[baseGmIdx_ + gmIndex], scatterTensor.template ReinterpretCast<outputT>(),
+                    scatterCopyParams);
+    }
+}
+
+} // namespace ApplyTopKTopPWithSortedOp
+
+#endif // APPLY_TOP_K_TOP_P_WITH_SORTED_H_KERNEL

--- a/csrc/sample/topk_topp/op_kernel/apply_top_p_with_sorted.h
+++ b/csrc/sample/topk_topp/op_kernel/apply_top_p_with_sorted.h
@@ -1,0 +1,562 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file apply_top_p_with_sorted.h
+ * \brief
+ */
+#ifndef APPLY_TOP_P_WITH_SORTED_H_KERNEL
+#define APPLY_TOP_P_WITH_SORTED_H_KERNEL
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+namespace ApplyTopPWithSortedOp {
+constexpr uint16_t FLOAT16_NEG_INF = 0xFC00;    // -inf 64512
+constexpr uint16_t BF16_NEG_INF = 0xFF80;       // -inf 65408
+constexpr int32_t FLOAT32_NEG_INF = 0xFF800000; // -inf -2139095040
+
+constexpr uint32_t BLOCK_BYTES = 32;
+constexpr uint32_t DATA_PER_BLOCK_B32 = 8;
+constexpr uint32_t DATA_PER_REPEAT_B32 = 64;
+constexpr uint32_t SCATTER_PART_LENGTH = 1024;
+constexpr uint32_t RESERVED_UB = 1024;
+constexpr uint32_t FLOAT_BYTES = 4;
+constexpr uint32_t SOFTMAX_UB_NUM = 2;
+
+template <typename inputT, typename calT, typename outputT>
+class ApplyTopPWithSorted {
+public:
+    __aicore__ inline ApplyTopPWithSorted(){};
+    __aicore__ inline void InitTilingData(const ApplyTopKTopPWithSortedTilingData& __restrict tilingData,
+                                          GM_ADDR sorted_value, GM_ADDR sorted_indices, GM_ADDR p, GM_ADDR k,
+                                          GM_ADDR logits, GM_ADDR out, GM_ADDR workspace);
+    __aicore__ inline void InitBuffer(TPipe* inputPipe);
+    __aicore__ inline void ProcessTopP();
+
+private:
+    __aicore__ inline void ReduceSumWithAddsAndExpImpl(uint32_t loopDataNum);
+    // topp func
+    __aicore__ inline void ProcessPreSingleBatch(uint32_t loopBatch);
+    __aicore__ inline void GetSoftmaxSum(uint32_t loopBatch);
+    __aicore__ inline void CumsumKoggleStone(uint32_t loopBatch);
+    __aicore__ inline void CopyOutLastValue(uint32_t loopBatch);
+    __aicore__ inline void GetPValue(uint32_t batchOffset);
+    __aicore__ inline void CumsumParamCompute(uint32_t iterateTime);
+    __aicore__ inline void GetMaxValue(int64_t baseGmIdx);
+    __aicore__ inline void GetSoftMaxRes(uint32_t loopBatch);
+    __aicore__ inline void ScatterSingleTask(uint32_t taskIndex);
+
+    __aicore__ inline void SToMTE3Sync()
+    {
+        event_t eventIDSToMTE3 = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_MTE3));
+        SetFlag<HardEvent::S_MTE3>(eventIDSToMTE3);
+        WaitFlag<HardEvent::S_MTE3>(eventIDSToMTE3);
+    }
+    __aicore__ inline void VToMTE3Sync()
+    {
+        event_t eventIDVToMTE3 = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE3));
+        SetFlag<HardEvent::V_MTE3>(eventIDVToMTE3);
+        WaitFlag<HardEvent::V_MTE3>(eventIDVToMTE3);
+    }
+    __aicore__ inline void VToMTE2Sync()
+    {
+        event_t eventIDVToMTE2 = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_MTE2));
+        SetFlag<HardEvent::V_MTE2>(eventIDVToMTE2);
+        WaitFlag<HardEvent::V_MTE2>(eventIDVToMTE2);
+    }
+    __aicore__ inline void MTE3ToSSync()
+    {
+        event_t eventIDMTE3ToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_S));
+        SetFlag<HardEvent::MTE3_S>(eventIDMTE3ToS);
+        WaitFlag<HardEvent::MTE3_S>(eventIDMTE3ToS);
+    }
+    __aicore__ inline void VToSSync()
+    {
+        event_t eventIdVToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::V_S));
+        SetFlag<HardEvent::V_S>(eventIdVToS);
+        WaitFlag<HardEvent::V_S>(eventIdVToS);
+    }
+    __aicore__ inline void SToVSync()
+    {
+        event_t eventIdSToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::S_V));
+        SetFlag<HardEvent::S_V>(eventIdSToV);
+        WaitFlag<HardEvent::S_V>(eventIdSToV);
+    }
+    __aicore__ inline void MTE2ToVSync()
+    {
+        event_t eventIdMte2ToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_V));
+        SetFlag<HardEvent::MTE2_V>(eventIdMte2ToV);
+        WaitFlag<HardEvent::MTE2_V>(eventIdMte2ToV);
+    }
+    __aicore__ inline void MTE2ToSSync()
+    {
+        event_t eventIdMte2ToS = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE2_S));
+        SetFlag<HardEvent::MTE2_S>(eventIdMte2ToS);
+        WaitFlag<HardEvent::MTE2_S>(eventIdMte2ToS);
+    }
+
+    __aicore__ inline void MTE3ToMTE2Sync()
+    {
+        event_t eventIdMte3ToMte2 = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_MTE2));
+        SetFlag<HardEvent::MTE3_MTE2>(eventIdMte3ToMte2);
+        WaitFlag<HardEvent::MTE3_MTE2>(eventIdMte3ToMte2);
+    }
+
+    __aicore__ inline void MTE3ToVSync()
+    {
+        event_t eventIdMte3ToV = static_cast<event_t>(GetTPipePtr()->FetchEventID(HardEvent::MTE3_V));
+        SetFlag<HardEvent::MTE3_V>(eventIdMte3ToV);
+        WaitFlag<HardEvent::MTE3_V>(eventIdMte3ToV);
+    }
+
+    __aicore__ inline uint32_t CeilDiv(uint32_t x, uint32_t y) { return y == 0 ? x : (x + y - 1) / y; }
+
+private:
+    TPipe* pipe_;
+    TBuf<TPosition::VECCALC> calBuf_;
+
+    // tilingData
+    uint32_t batchSize_ = 0;
+    uint32_t vocabSize_ = 0;
+    uint32_t batchPerCore_ = 0;
+    uint32_t tailBatch_ = 0;
+    uint32_t blockNum_ = 0;
+    uint32_t dataNumInitAligned_ = 0;
+    uint32_t calUbSize_ = 0;
+    uint32_t blockIdx_ = 0;
+    uint32_t loopBatch_ = 0;
+    uint32_t batchOffset_ = 0;
+    uint32_t bufOffsetLoop = 0;
+    int64_t baseGmIdx_ = 0;
+
+    // topp scalar
+    uint32_t maxSoftmaxLength = 1;
+    uint32_t softmaxLength = 1;
+    uint32_t lineSfLoopTimes = 1;
+    uint32_t softmaxLengthTail = 1;
+    uint32_t scatterLength = 1;
+
+    uint32_t vCnt = 0;
+    uint32_t bCnt = 0;
+    uint32_t singleCoreV = 1;
+    uint32_t singleCoreVTail = 1;
+    uint32_t iterateTimes = 1;
+
+    GlobalTensor<inputT> mGmSortedValue_;
+    GlobalTensor<int32_t> mGmSortedIndices_;
+    GlobalTensor<inputT> mGmP_;
+    GlobalTensor<int32_t> mGmK_;
+    GlobalTensor<outputT> mGmOut_;
+    GlobalTensor<float> softMaxGm;
+
+    LocalTensor<uint8_t> totalUb;
+
+    // softmax tensor
+    LocalTensor<float> softMaxLocalFp32;
+    LocalTensor<inputT> softMaxLocal;
+    LocalTensor<float> softMaxResLocal;
+    LocalTensor<float> reduceLocal;
+    LocalTensor<inputT> outInfLocal;
+
+    // cumsum tensor
+    LocalTensor<float> cumSumInput1Local;
+    LocalTensor<float> cumSumInput2Local;
+
+    // scatter tensor
+    LocalTensor<inputT> sortedValueLocal;
+    LocalTensor<int32_t> sortedIndicesLocal;
+    LocalTensor<float> cumsumLocal;
+
+    // batch scatter tensor: scatterAlignedLocal stores Brcb output for DataCopyPad
+    LocalTensor<inputT> scatterAlignedLocal;
+
+    float pValue = 0;
+    float maxValue = 0;
+    float reduceSumValueInvert = 0;
+    float reduceSumValue = 0;
+    BinaryRepeatParams repeatParams = {1, 0, 1, 8, 0, 8};
+};
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::InitTilingData(
+    const ApplyTopKTopPWithSortedTilingData& __restrict tilingData, GM_ADDR sorted_value, GM_ADDR sorted_indices,
+    GM_ADDR p, GM_ADDR k, GM_ADDR logits, GM_ADDR out, GM_ADDR workspace)
+{
+    batchSize_ = tilingData.batchSize;
+    vocabSize_ = tilingData.vocabSize;
+    batchPerCore_ = tilingData.batchPerCore;
+    tailBatch_ = tilingData.tailBatch;
+    blockNum_ = tilingData.blockNum;
+    calUbSize_ = tilingData.calUbSize;
+    iterateTimes = tilingData.iterateTimes;
+    blockIdx_ = GetBlockIdx();
+    if (blockIdx_ < tailBatch_) {
+        loopBatch_ = batchPerCore_ + 1;
+        batchOffset_ = blockIdx_ * loopBatch_;
+    } else {
+        loopBatch_ = batchPerCore_;
+        batchOffset_ = blockIdx_ * batchPerCore_ + tailBatch_;
+    }
+    maxSoftmaxLength = (calUbSize_ - RESERVED_UB) / SOFTMAX_UB_NUM / FLOAT_BYTES;
+    softmaxLength = maxSoftmaxLength < vocabSize_ ? maxSoftmaxLength : vocabSize_;
+
+    lineSfLoopTimes = (vocabSize_ + softmaxLength - 1) / softmaxLength;
+    softmaxLengthTail = vocabSize_ - (lineSfLoopTimes - 1) * softmaxLength;
+    scatterLength = (calUbSize_ - RESERVED_UB - BLOCK_BYTES) / (SOFTMAX_UB_NUM * FLOAT_BYTES + sizeof(inputT)) /
+                    SCATTER_PART_LENGTH * SCATTER_PART_LENGTH;
+    vCnt = batchSize_ < blockNum_ ? blockNum_ / batchSize_ : 1;
+    bCnt = batchSize_;
+    singleCoreV = vocabSize_ / vCnt;
+    singleCoreVTail = vocabSize_ - vCnt * singleCoreV;
+    mGmSortedValue_.SetGlobalBuffer(reinterpret_cast<__gm__ inputT*>(sorted_value));
+    mGmSortedIndices_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(sorted_indices));
+    mGmP_.SetGlobalBuffer(reinterpret_cast<__gm__ inputT*>(p));
+    mGmK_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t*>(k));
+    mGmOut_.SetGlobalBuffer(reinterpret_cast<__gm__ outputT*>(out));
+    softMaxGm.SetGlobalBuffer((__gm__ float*)workspace, batchSize_ * vocabSize_);
+}
+
+// init used buffer
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::InitBuffer(TPipe* inputPipe)
+{
+    pipe_ = inputPipe;
+    pipe_->InitBuffer(calBuf_, calUbSize_);
+    totalUb = calBuf_.Get<uint8_t>();
+    // softmax ub
+    uint32_t softmaxLengthAligned = CeilDiv(softmaxLength, BLOCK_BYTES / sizeof(inputT)) * BLOCK_BYTES / sizeof(inputT);
+    softMaxLocalFp32 = totalUb.ReinterpretCast<float>();
+    softMaxLocal = totalUb[softmaxLengthAligned * sizeof(inputT)].ReinterpretCast<inputT>();
+    softMaxResLocal = totalUb[softmaxLengthAligned * sizeof(float)].ReinterpretCast<float>();
+    reduceLocal = totalUb[softmaxLengthAligned * sizeof(float) * 2].ReinterpretCast<float>(); // 32 bytes
+    outInfLocal = totalUb.ReinterpretCast<inputT>();                                          // Take softmax ub
+
+    // cumsum ub
+    cumSumInput1Local = totalUb.ReinterpretCast<float>();                                       // Take softmax local
+    cumSumInput2Local = totalUb[softmaxLengthAligned * sizeof(float)].ReinterpretCast<float>(); // Take softmax res ub
+
+    // scatter ub: layout = sortedValueLocal | sortedIndicesLocal | cumsumLocal | scatterAlignedLocal
+    // scatterAlignedLocal stores Brcb output: each value in its own 32B-aligned datablock
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+    scatterLength = (calUbSize_ - RESERVED_UB - BLOCK_BYTES) /
+                    (SOFTMAX_UB_NUM * FLOAT_BYTES + sizeof(inputT) + BLOCK_BYTES) / SCATTER_PART_LENGTH *
+                    SCATTER_PART_LENGTH;
+    sortedValueLocal = totalUb[0].ReinterpretCast<inputT>();
+    sortedIndicesLocal = totalUb[scatterLength * sizeof(inputT)].ReinterpretCast<int32_t>();
+    cumsumLocal = totalUb[scatterLength * (FLOAT_BYTES + sizeof(inputT))].ReinterpretCast<float>();
+    uint32_t alignedAreaOffset = scatterLength * (SOFTMAX_UB_NUM * FLOAT_BYTES + sizeof(inputT));
+    scatterAlignedLocal = totalUb[alignedAreaOffset].ReinterpretCast<inputT>();
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::GetMaxValue(int64_t baseGmIdx)
+{
+    int64_t initGmIdx = baseGmIdx + vocabSize_ - 1;
+    if constexpr (IsSameType<inputT, float>::value) {
+        maxValue = -mGmSortedValue_[initGmIdx].GetValue(0);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        maxValue = -static_cast<float>(mGmSortedValue_[initGmIdx].GetValue(0));
+    } else {
+        maxValue = -ToFloat(mGmSortedValue_[initGmIdx].GetValue(0));
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::GetPValue(uint32_t batchOffset)
+{
+    if constexpr (IsSameType<inputT, float>::value) {
+        pValue = float(1.0) - mGmP_[batchOffset].GetValue(0);
+    } else if constexpr (IsSameType<inputT, half>::value) {
+        pValue = float(1.0) - static_cast<float>(mGmP_[batchOffset].GetValue(0));
+    } else {
+        pValue = float(1.0) - ToFloat(mGmP_[batchOffset].GetValue(0));
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::ProcessPreSingleBatch(uint32_t loopBatch)
+{
+    reduceSumValue = 0;
+    GetSoftmaxSum(loopBatch);
+    GetSoftMaxRes(loopBatch);
+    CumsumKoggleStone(loopBatch);
+    CopyOutLastValue(loopBatch);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::ProcessTopP()
+{
+    for (uint32_t loopBatch = 0; loopBatch < loopBatch_; loopBatch++) {
+        baseGmIdx_ = batchOffset_ * vocabSize_ + loopBatch * vocabSize_;
+        GetMaxValue(baseGmIdx_); // Get max value in softmax.
+
+        if (*reinterpret_cast<int32_t*>(&maxValue) == FLOAT32_NEG_INF) {
+            uint32_t loopDataNum = softmaxLength;
+            for (uint32_t loopInner = 0; loopInner < lineSfLoopTimes; loopInner++) {
+                int64_t currentGmIdx = baseGmIdx_ + loopInner * softmaxLength;
+                if (loopInner == (lineSfLoopTimes - 1))
+                    loopDataNum = softmaxLengthTail;
+                if constexpr (IsSameType<inputT, float>::value) {
+                    Duplicate(outInfLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, loopDataNum);
+                } else if constexpr (IsSameType<inputT, half>::value) {
+                    Duplicate(outInfLocal.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, loopDataNum);
+                } else {
+                    Duplicate(outInfLocal.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, loopDataNum);
+                }
+                VToMTE3Sync();
+                DataCopyPad(mGmOut_[currentGmIdx], outInfLocal,
+                            {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0});
+                MTE3ToMTE2Sync();
+                Duplicate(softMaxResLocal, 2.0f, loopDataNum);
+                VToMTE3Sync();
+                DataCopyPad(softMaxGm[currentGmIdx], softMaxResLocal,
+                            {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+                MTE3ToMTE2Sync();
+            }
+            CopyOutLastValue(loopBatch);
+            continue;
+        }
+
+        ProcessPreSingleBatch(loopBatch); // Softmax and cumsum.
+    }
+    SyncAll();
+    for (uint32_t batchIdx = blockIdx_; batchIdx < bCnt; batchIdx += blockNum_) {
+        ScatterSingleTask(batchIdx);
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::ScatterSingleTask(uint32_t batchIdx)
+{
+    uint32_t copyTimes = CeilDiv(vocabSize_, scatterLength);
+    uint32_t copyLength = scatterLength;
+    uint32_t copyLengthTail = vocabSize_ - (copyTimes - 1) * scatterLength;
+    GetPValue(batchIdx);
+    constexpr uint32_t DATA_PER_BLOCK = BLOCK_BYTES / sizeof(inputT);
+
+    bool thresholdCrossed = false;
+    for (uint32_t cpIndex = 0; cpIndex < copyTimes; cpIndex++) {
+        uint32_t curCopyLength = cpIndex == (copyTimes - 1) ? copyLengthTail : copyLength;
+        int64_t gmOffset = static_cast<int64_t>(batchIdx) * vocabSize_ + cpIndex * copyLength;
+        if (!thresholdCrossed) {
+            DataCopyPad(cumsumLocal, softMaxGm[gmOffset],
+                        {1, static_cast<uint32_t>(curCopyLength * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToSSync();
+            if (cumsumLocal.GetValue(curCopyLength - 1) <= pValue) {
+                continue;
+            }
+        }
+        DataCopyPad(sortedIndicesLocal, mGmSortedIndices_[gmOffset],
+                    {1, static_cast<uint32_t>(curCopyLength * sizeof(int32_t)), 0, 0, 0}, {false, 0, 0, 0});
+        DataCopyPad(sortedValueLocal, mGmSortedValue_[gmOffset],
+                    {1, static_cast<uint32_t>(curCopyLength * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+        MTE2ToVSync();
+        MTE2ToSSync();
+
+        uint32_t startIdx = 0;
+        if (!thresholdCrossed) {
+            uint32_t scatterLoop = CeilDiv(curCopyLength, SCATTER_PART_LENGTH);
+            uint32_t scatterNumsTail = curCopyLength - (scatterLoop - 1) * SCATTER_PART_LENGTH;
+            for (uint32_t scatterLoopIndex = 0; scatterLoopIndex < scatterLoop; scatterLoopIndex++) {
+                uint32_t curScatterNums = scatterLoopIndex == (scatterLoop - 1) ? scatterNumsTail : SCATTER_PART_LENGTH;
+                uint32_t blockEndIdx = scatterLoopIndex * SCATTER_PART_LENGTH + curScatterNums - 1;
+                if (cumsumLocal.GetValue(blockEndIdx) <= pValue) {
+                    continue;
+                }
+                for (uint32_t i = 0; i < curScatterNums; i++) {
+                    uint32_t offset = scatterLoopIndex * SCATTER_PART_LENGTH + i;
+                    if (cumsumLocal.GetValue(offset) > pValue) {
+                        startIdx = offset;
+                        thresholdCrossed = true;
+                        break;
+                    }
+                }
+                if (thresholdCrossed) {
+                    break;
+                }
+            }
+            if (!thresholdCrossed) {
+                continue;
+            }
+        }
+
+        uint32_t collectCount = curCopyLength - startIdx;
+        constexpr uint32_t BRCB_ELEM_PER_REP = 8;
+        constexpr uint32_t BRCB_SRC_ALIGN = BLOCK_BYTES / sizeof(inputT);
+        constexpr uint32_t BRCB_ALIGN_REPEATS = BRCB_SRC_ALIGN / BRCB_ELEM_PER_REP;
+        constexpr uint32_t MAX_BRCB_REPEAT = 255;
+        constexpr uint32_t ALIGNED_MAX_REPEAT = (MAX_BRCB_REPEAT / BRCB_ALIGN_REPEATS) * BRCB_ALIGN_REPEATS;
+        uint32_t brcbAlignedStart = (startIdx / BRCB_SRC_ALIGN) * BRCB_SRC_ALIGN;
+        uint32_t brcbSrcCount = collectCount + (startIdx - brcbAlignedStart);
+        uint32_t totalRepeat = CeilDiv(brcbSrcCount, BRCB_ELEM_PER_REP);
+        MTE3ToVSync();
+
+        uint32_t brcbDone = 0;
+        while (brcbDone < totalRepeat) {
+            uint32_t remaining = totalRepeat - brcbDone;
+            uint32_t curRepeat = remaining > ALIGNED_MAX_REPEAT ?
+                                     ALIGNED_MAX_REPEAT :
+                                     (remaining + BRCB_ALIGN_REPEATS - 1) / BRCB_ALIGN_REPEATS * BRCB_ALIGN_REPEATS;
+            Brcb(scatterAlignedLocal[brcbDone * BRCB_ELEM_PER_REP * DATA_PER_BLOCK],
+                 sortedValueLocal[brcbAlignedStart + brcbDone * BRCB_ELEM_PER_REP], curRepeat, {1, 8});
+            brcbDone += curRepeat;
+        }
+        VToMTE3Sync();
+
+        uint32_t brcbValueOffset = startIdx - brcbAlignedStart;
+        for (uint32_t idx = 0; idx < collectCount; idx++) {
+            int32_t lineIndex = sortedIndicesLocal.GetValue(startIdx + idx);
+            DataCopyPad(mGmOut_[batchIdx * vocabSize_ + lineIndex],
+                        scatterAlignedLocal[(brcbValueOffset + idx) * DATA_PER_BLOCK],
+                        {1, (uint32_t)(1 * sizeof(outputT)), 0, 0, 0});
+        }
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::GetSoftMaxRes(uint32_t loopBatch)
+{
+    uint32_t loopDataNum = softmaxLength;
+    for (int32_t loopInner = 0; loopInner < lineSfLoopTimes; loopInner++) {
+        int64_t currentGmIdx = baseGmIdx_ + loopInner * softmaxLength;
+        if (loopInner == (lineSfLoopTimes - 1)) {
+            loopDataNum = softmaxLengthTail;
+        }
+        if constexpr (!IsSameType<inputT, float>::value) {
+            DataCopyPad(softMaxLocal, mGmSortedValue_[currentGmIdx],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            Cast(softMaxLocalFp32, softMaxLocal, RoundMode::CAST_NONE, loopDataNum);
+            PipeBarrier<PIPE_V>();
+        } else {
+            DataCopyPad(softMaxLocalFp32, mGmSortedValue_[currentGmIdx],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+        }
+        Adds(softMaxResLocal, softMaxLocalFp32, maxValue, loopDataNum);
+        VToMTE2Sync();
+        PipeBarrier<PIPE_V>();
+        Exp(softMaxResLocal, softMaxResLocal, loopDataNum);
+        PipeBarrier<PIPE_V>();
+        Muls(softMaxResLocal, softMaxResLocal, reduceSumValueInvert, loopDataNum);
+        VToMTE3Sync();
+        DataCopyPad(softMaxGm[currentGmIdx], softMaxResLocal,
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+        MTE3ToMTE2Sync();
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::CumsumKoggleStone(uint32_t loopBatch)
+{
+    int64_t iteratOffset = 1; // 2^0 = 1, doubles each iteration
+    for (uint32_t iterateTime = 0; iterateTime < iterateTimes; iterateTime++) {
+        uint32_t addLength = vocabSize_ - static_cast<uint32_t>(iteratOffset);
+        uint32_t innerLoopNum = addLength / softmaxLength;
+        uint32_t dataTail = addLength - innerLoopNum * softmaxLength;
+        uint32_t loopDataNum = softmaxLength;
+        for (uint32_t innerLoopIdx = 0; innerLoopIdx < innerLoopNum; innerLoopIdx++) {
+            // Copy data from right
+            int64_t loopInnerOffset = dataTail + (innerLoopNum - 1 - innerLoopIdx) * softmaxLength;
+            DataCopyPad(cumSumInput1Local, softMaxGm[baseGmIdx_ + loopInnerOffset],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            DataCopyPad(cumSumInput2Local, softMaxGm[baseGmIdx_ + loopInnerOffset + iteratOffset],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            Add(cumSumInput1Local, cumSumInput1Local, cumSumInput2Local, loopDataNum);
+            VToMTE3Sync();
+            DataCopyPad(softMaxGm[baseGmIdx_ + loopInnerOffset + iteratOffset], cumSumInput1Local,
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+            MTE3ToMTE2Sync();
+        }
+        if (dataTail > 0) {
+            loopDataNum = dataTail;
+            DataCopyPad(cumSumInput1Local, softMaxGm[baseGmIdx_],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            DataCopyPad(cumSumInput2Local, softMaxGm[baseGmIdx_ + iteratOffset],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            Add(cumSumInput1Local, cumSumInput1Local, cumSumInput2Local, loopDataNum);
+            VToMTE3Sync();
+            DataCopyPad(softMaxGm[baseGmIdx_ + iteratOffset], cumSumInput1Local,
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(float)), 0, 0, 0});
+            MTE3ToMTE2Sync();
+        }
+        iteratOffset *= 2; // 2^(iterateTime+1)
+    }
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::CopyOutLastValue(uint32_t loopBatch)
+{
+    int64_t lastValueOffset = (static_cast<int64_t>(batchOffset_) + loopBatch + 1) * vocabSize_ - 1;
+    DataCopyPad(scatterAlignedLocal, mGmSortedValue_[lastValueOffset],
+                {1, static_cast<uint32_t>(sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+    int32_t lineIndex = mGmSortedIndices_.GetValue(lastValueOffset);
+    MTE2ToSSync();
+    DataCopyPad(mGmOut_[(static_cast<int64_t>(batchOffset_) + loopBatch) * vocabSize_ + lineIndex],
+                scatterAlignedLocal.template ReinterpretCast<outputT>(), {1, (uint32_t)(1 * sizeof(outputT)), 0, 0, 0});
+    MTE3ToVSync();
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::ReduceSumWithAddsAndExpImpl(uint32_t loopDataNum)
+{
+    Adds(softMaxResLocal, softMaxLocalFp32, maxValue, loopDataNum);
+    PipeBarrier<PIPE_V>();
+    Exp(softMaxResLocal, softMaxResLocal, loopDataNum);
+    PipeBarrier<PIPE_V>();
+    ReduceSum(reduceLocal, softMaxResLocal, reduceLocal, loopDataNum);
+}
+
+template <typename inputT, typename calT, typename outputT>
+__aicore__ inline void ApplyTopPWithSorted<inputT, calT, outputT>::GetSoftmaxSum(uint32_t loopBatch)
+{
+    uint32_t loopDataNum = softmaxLength;
+    for (int32_t loopInner = 0; loopInner < lineSfLoopTimes; loopInner++) {
+        int64_t currentGmIdx = baseGmIdx_ + loopInner * softmaxLength;
+        if (loopInner == (lineSfLoopTimes - 1)) {
+            loopDataNum = softmaxLengthTail;
+        }
+        if constexpr (IsSameType<inputT, float>::value) {
+            Duplicate(outInfLocal.template ReinterpretCast<int32_t>(), FLOAT32_NEG_INF, loopDataNum);
+        } else if constexpr (IsSameType<inputT, half>::value) {
+            Duplicate(outInfLocal.template ReinterpretCast<uint16_t>(), FLOAT16_NEG_INF, loopDataNum);
+        } else {
+            Duplicate(outInfLocal.template ReinterpretCast<uint16_t>(), BF16_NEG_INF, loopDataNum);
+        }
+        VToMTE3Sync();
+        DataCopyPad(mGmOut_[currentGmIdx], outInfLocal,
+                    {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0});
+        MTE3ToMTE2Sync();
+        if constexpr (!IsSameType<inputT, float>::value) {
+            DataCopyPad(softMaxLocal, mGmSortedValue_[currentGmIdx],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+            Cast(softMaxLocalFp32, softMaxLocal, RoundMode::CAST_NONE, loopDataNum);
+            PipeBarrier<PIPE_V>();
+        } else {
+            DataCopyPad(softMaxLocalFp32, mGmSortedValue_[currentGmIdx],
+                        {1, static_cast<uint32_t>(loopDataNum * sizeof(inputT)), 0, 0, 0}, {false, 0, 0, 0});
+            MTE2ToVSync();
+        }
+
+        ReduceSumWithAddsAndExpImpl(loopDataNum);
+        VToSSync();
+        reduceSumValue += reduceLocal.GetValue(0);
+        SToVSync();
+    }
+    reduceSumValueInvert = 1 / reduceSumValue;
+    SToVSync();
+}
+} // namespace ApplyTopPWithSortedOp
+
+#endif // APPLY_TOP_P_WITH_SORTED_H_KERNEL


### PR DESCRIPTION
…ops-nn PR #8469

Integrate the optimized ApplyTopKTopPWithSorted operator from cann/ops-nn PR #8469 as a custom ACLNN operator in vllm-ascend.

Key changes:
- Add csrc/sample/topk_topp/ with full operator source:
  - op_kernel: apply_top_k_top_p_opt.h (1166 lines, optimized kernel), apply_top_k_top_p_with_sorted.h/cpp (kernel entry with tiling key routing 0-5), apply_top_p_with_sorted.h (Kogge-Stone top-p kernel)
  - op_host: operator definition (with optional logits input for optimization), tiling logic (auto-detect logits to upgrade tiling key 0/1/2 -> 3/4/5), ACLNN API layer
- Register topk_topp in build_aclnn.sh for ascend910b/910_93/950
- Add sample/ subdirectory to csrc/CMakeLists.txt
- Add csrc/sample/ to resolve_op_dir() search path

The custom operator replaces the system ApplyTopKTopPWithSorted via ASCEND_CUSTOM_OPP_PATH priority. No Python-layer changes needed as torch_npu.npu_top_k_top_p API remains unchanged.

Source: https://gitcode.com/cann/ops-nn/pull/8469

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
