### PR TITLE
[BugFix][Linear] Enable dynamic W8A8 mmrs fusion in eager mode

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -260,7 +260,8 @@ class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
         layer = MagicMock()
         layer.quant_method = AscendLinearMethod(quant_method)
         layer.weight = torch.randint(-8, 8, (8, 16), dtype=torch.int8)
-        layer.weight_scale = torch.randn(16, dtype=torch.float32)
+        layer.weight_scale = torch.randn(16, dtype=torch.bfloat16)
+        layer.weight_scale_fp32 = torch.randn(16, dtype=torch.float32)
         layer.tp_size = 2
         layer.tp_rank = 0
 
@@ -296,8 +297,10 @@ class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
         mock_dynamic_quant.assert_called_once_with(x, act_quant_type=quant_method.act_quant_type)
         mock_mmrs.assert_called_once()
         _, kwargs = mock_mmrs.call_args
-        self.assertIs(kwargs["x1_scale"], pertoken_scale)
-        self.assertIs(kwargs["x2_scale"], layer.weight_scale)
+        self.assertEqual(kwargs["x1_scale"].shape, (4, 1))
+        self.assertTrue(torch.equal(kwargs["x1_scale"].squeeze(dim=1), pertoken_scale))
+        self.assertEqual(kwargs["x2_scale"].shape, (1, 16))
+        self.assertTrue(torch.equal(kwargs["x2_scale"].squeeze(dim=0), layer.weight_scale_fp32))
         self.assertEqual(kwargs["output_dtype"], x.dtype)
 
 

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -171,11 +171,16 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
 
     def setUp(self):
         self.mock_layer = MagicMock()
+        self.mock_group = MagicMock()
+        self.mock_group.world_size = 2
+        self.mock_group.rank_in_group = 0
         self._patches = [
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=self.mock_group),
             patch("vllm_ascend.ops.linear_op.mlp_tp_enable", return_value=False),
             patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=False),
             patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
             patch("vllm_ascend.ops.linear_op.enable_sp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.is_310p", return_value=False),
             patch("vllm_ascend.ops.linear_op.is_moe_layer", return_value=False),
         ]
         for p in self._patches:
@@ -216,11 +221,16 @@ class TestRowParallelOpDispatch(unittest.TestCase):
 
     def setUp(self):
         self.mock_layer = MagicMock()
+        self.mock_group = MagicMock()
+        self.mock_group.world_size = 2
+        self.mock_group.rank_in_group = 0
         self._patches = [
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=self.mock_group),
             patch("vllm_ascend.ops.linear_op.mlp_tp_enable", return_value=False),
             patch("vllm_ascend.ops.linear_op.oproj_tp_enable", return_value=False),
             patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
             patch("vllm_ascend.ops.linear_op.enable_sp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.is_310p", return_value=False),
             patch("vllm_ascend.ops.linear_op.is_moe_layer", return_value=False),
         ]
         for p in self._patches:
@@ -249,8 +259,82 @@ class TestRowParallelOpDispatch(unittest.TestCase):
         self.assertIsNone(self._op("model.multi_modal_projector.down_proj"))
         self.assertIsNone(self._op("model.patch_merge_mlp.out_proj"))
 
+    def test_sequence_row_op_calls_tensor_mm_reduce_scatter_in_eager(self):
+        from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+
+        layer = MagicMock()
+        layer.prefix = "model.layers.0.mlp.down_proj"
+        layer.unique_prefix = "model.layers.0.mlp.down_proj"
+        layer.input_is_parallel = True
+        layer.reduce_results = True
+        layer.input_size_per_partition = 8
+        layer.skip_bias_add = False
+        layer.return_bias = True
+        layer.quant_method = AscendUnquantizedLinearMethod()
+        layer.weight = torch.nn.Parameter(torch.empty(16, 8, dtype=torch.float16), requires_grad=False)
+        layer.bias = None
+        output = torch.empty(2, 16, dtype=torch.float16)
+
+        op = SequenceRowParallelOp(layer)
+        op.update_attrs()
+        input_ = torch.empty(4, 8, dtype=torch.float16)
+        with patch.object(
+            torch.ops.vllm,
+            "unquantized_matmul_reduce_scatter",
+            return_value=output,
+            create=True,
+        ) as mock_fused:
+            result, output_bias = op.apply_impl(input_)
+
+        self.assertIs(result, output)
+        self.assertIsNone(output_bias)
+        mock_fused.assert_called_once_with(input_, layer.weight, None)
+
 
 class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
+    def test_dynamic_w8a8_tensor_op_uses_mm_reduce_scatter_fusion(self):
+        from vllm_ascend.ops import register_custom_ops
+
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        weight = torch.randint(-8, 8, (8, 16), dtype=torch.int8)
+        weight_scale = torch.randn(16, dtype=torch.float32)
+        x_quant = torch.randint(-8, 8, (4, 8), dtype=torch.int8)
+        pertoken_scale = torch.randn(4, dtype=torch.float32)
+        fused_output = torch.randn(2, 16, dtype=torch.bfloat16)
+
+        tp_group = MagicMock()
+        tp_group.world_size = 2
+        tp_group.rank_in_group = 0
+        tp_group.device_group._get_backend.return_value.get_hccl_comm_name.return_value = "hccl_comm"
+
+        with (
+            patch(
+                "vllm_ascend.ops.register_custom_ops._EXTRA_CTX",
+                SimpleNamespace(flash_comm_v1_enabled=True, pad_size=0),
+            ),
+            patch("vllm_ascend.ops.register_custom_ops.get_forward_context", return_value=MagicMock()),
+            patch("vllm_ascend.ops.register_custom_ops.get_tp_group", return_value=tp_group),
+            patch(
+                "vllm_ascend.ops.register_custom_ops.DeviceOperator.npu_dynamic_quant",
+                return_value=(x_quant, pertoken_scale),
+            ) as mock_dynamic_quant,
+            patch(
+                "vllm_ascend.ops.register_custom_ops.DeviceOperator.npu_mm_reduce_scatter_base",
+                return_value=fused_output,
+            ) as mock_mmrs,
+        ):
+            output = register_custom_ops._dynamic_quant_matmul_reduce_scatter_impl(x, weight, weight_scale)
+
+        self.assertIs(output, fused_output)
+        mock_dynamic_quant.assert_called_once_with(x, act_quant_type=torch.int8)
+        mock_mmrs.assert_called_once()
+        _, kwargs = mock_mmrs.call_args
+        self.assertEqual(kwargs["x1_scale"].shape, (4, 1))
+        self.assertTrue(torch.equal(kwargs["x1_scale"].squeeze(dim=1), pertoken_scale))
+        self.assertEqual(kwargs["x2_scale"].shape, (1, 16))
+        self.assertTrue(torch.equal(kwargs["x2_scale"].squeeze(dim=0), weight_scale))
+        self.assertEqual(kwargs["output_dtype"], x.dtype)
+
     def test_dynamic_w8a8_uses_mm_reduce_scatter_fusion(self):
         from vllm_ascend.ops.linear_op import SequenceRowParallelOp
         from vllm_ascend.quantization.method_adapters import AscendLinearMethod

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -247,6 +248,57 @@ class TestRowParallelOpDispatch(unittest.TestCase):
         self._patches[-1].start()
         self.assertIsNone(self._op("model.multi_modal_projector.down_proj"))
         self.assertIsNone(self._op("model.patch_merge_mlp.out_proj"))
+
+
+class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
+    def test_dynamic_w8a8_uses_mm_reduce_scatter_fusion(self):
+        from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+        from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+        from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
+
+        quant_method = AscendW8A8DynamicLinearMethod()
+        layer = MagicMock()
+        layer.quant_method = AscendLinearMethod(quant_method)
+        layer.weight = torch.randint(-8, 8, (8, 16), dtype=torch.int8)
+        layer.weight_scale = torch.randn(16, dtype=torch.float32)
+        layer.tp_size = 2
+        layer.tp_rank = 0
+
+        op = SequenceRowParallelOp(layer)
+        op.quant_method = layer.quant_method
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        x_quant = torch.randint(-8, 8, (4, 8), dtype=torch.int8)
+        pertoken_scale = torch.randn(4, dtype=torch.float32)
+        fused_output = torch.randn(2, 16, dtype=torch.bfloat16)
+
+        tp_group = MagicMock()
+        tp_group.device_group._get_backend.return_value.get_hccl_comm_name.return_value = "hccl_comm"
+
+        with (
+            patch(
+                "vllm_ascend.ops.linear_op._EXTRA_CTX",
+                SimpleNamespace(flash_comm_v1_enabled=True, mmrs_fusion=True, pad_size=0),
+            ),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=tp_group),
+            patch(
+                "vllm_ascend.ops.linear_op.DeviceOperator.npu_dynamic_quant",
+                return_value=(x_quant, pertoken_scale),
+            ) as mock_dynamic_quant,
+            patch(
+                "vllm_ascend.ops.linear_op.DeviceOperator.npu_mm_reduce_scatter_base",
+                return_value=fused_output,
+            ) as mock_mmrs,
+        ):
+            output = op.matmul_and_reduce(x, bias_=None)
+
+        self.assertIs(output, fused_output)
+        mock_dynamic_quant.assert_called_once_with(x, act_quant_type=quant_method.act_quant_type)
+        mock_mmrs.assert_called_once()
+        _, kwargs = mock_mmrs.call_args
+        self.assertIs(kwargs["x1_scale"], pertoken_scale)
+        self.assertIs(kwargs["x2_scale"], layer.weight_scale)
+        self.assertEqual(kwargs["output_dtype"], x.dtype)
 
 
 class TestGetParallelOpShareExpert(unittest.TestCase):

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -388,6 +388,7 @@ class TestNPUPlatform(TestBase):
             )
 
         self.assertFalse(kwargs["in_profile_run"])
+        self.assertTrue(kwargs["mmrs_fusion"])
         self.assertEqual(kwargs["padded_num_tokens"], 8)
         self.assertIs(kwargs["moe_comm_method"], dummy_comm_method)
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -164,7 +164,6 @@ def set_ascend_forward_context(
         is_context_moe_model = is_drafter_moe_model(vllm_config) if is_draft_model else is_moe_model(vllm_config)
         if is_context_moe_model:
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None
-            mmrs_fusion = False
         elif is_draft_model:
             # TODO: for dense drafter, `sp` is redundant and is not compatible with `dp` and `graph`.
             # Disable it to avoid more problems.

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -364,7 +364,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
         from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 
         from vllm_ascend.quantization.method_adapters import AscendLinearMethod
-        from vllm_ascend.quantization.methods import AscendW8A8LinearMethod
+        from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod, AscendW8A8LinearMethod
 
         # For unquant
         if mmrs_fusion and isinstance(self.layer.quant_method, UnquantizedLinearMethod):
@@ -408,6 +408,36 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 output_dtype=output_dtype,
             )
             output = torch.add(output, torch.mul(quant_bias, deq_scale).to(self.layer.params_dtype))
+        # For dynamic w8a8 quant
+        elif mmrs_fusion and (
+            isinstance(self.layer.quant_method, AscendLinearMethod)
+            and isinstance(self.layer.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
+            and hasattr(self.layer, "weight")
+            and hasattr(self.layer, "weight_scale")
+        ):
+            quant_method = self.layer.quant_method.quant_method
+            x_quant, pertoken_scale = DeviceOperator.npu_dynamic_quant(x, act_quant_type=quant_method.act_quant_type)
+            need_unsqueeze = False
+            if pertoken_scale.dim() == 2:
+                need_unsqueeze = True
+                x_quant = x_quant.squeeze(dim=1)
+                pertoken_scale = pertoken_scale.squeeze(dim=1)
+            output = DeviceOperator.npu_mm_reduce_scatter_base(
+                x_quant,
+                self.layer.weight,
+                hcom_name,
+                world_size,
+                reduce_op="sum",
+                bias=bias_ if quant_method.act_quant_type == torch.int8 else None,
+                comm_turn=0,
+                x1_scale=pertoken_scale,
+                x2_scale=self.layer.weight_scale,
+                output_dtype=x.dtype,
+            )
+            if need_unsqueeze:
+                output = output.unsqueeze(dim=1)
+            if bias_ is not None and quant_method.act_quant_type != torch.int8:
+                output = (output + bias_).to(x.dtype)
         else:
             output_parallel = self.layer.quant_method.apply(self.layer, x, bias=bias_)
             output = tensor_model_parallel_reduce_scatter(output_parallel, 0)

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -61,8 +61,10 @@ from vllm_ascend.distributed.parallel_state import (
     get_otp_group,
 )
 from vllm_ascend.utils import (
+    COMPRESSED_TENSORS_METHOD,
     enable_dsa_cp,
     enable_sp,
+    is_310p,
     is_vl_model,
     mlp_tp_enable,
     oproj_tp_enable,
@@ -314,6 +316,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
     def __init__(self, layer):
         super().__init__(layer)
         self.unique_prefix = None
+        self.use_tensor_mm_reduce_scatter_fusion = False
 
     def apply_impl(self, input_: torch.Tensor) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
         """Linear layer with column parallelism.
@@ -328,6 +331,8 @@ class SequenceRowParallelOp(CustomRowParallelOp):
 
         if self.tp_size == 1 or not self.reduce_results:
             output = self.quant_method.apply(self.layer, input_parallel, bias=bias_)
+        elif self.use_tensor_mm_reduce_scatter_fusion:
+            output = _apply_tensor_mm_reduce_scatter(self.layer, input_parallel, bias_)
         else:
             output = torch.ops.vllm.matmul_and_reduce(input_parallel, self.unique_prefix)
 
@@ -452,6 +457,15 @@ class SequenceRowParallelOp(CustomRowParallelOp):
         self.input_is_parallel = self.layer.input_is_parallel
         self.reduce_results = self.layer.reduce_results
         self.unique_prefix = self.layer.unique_prefix
+        try:
+            use_tensor_fusion = _supports_tensor_mm_reduce_scatter_fusion(
+                self.layer,
+                self.tp_size,
+                self.reduce_results,
+            )
+        except AssertionError:
+            use_tensor_fusion = False
+        self.use_tensor_mm_reduce_scatter_fusion = use_tensor_fusion
 
 
 class ShardedCPColumnParallelOp(CustomColumnParallelOp):
@@ -480,9 +494,121 @@ _MULTIMODAL_ENCODER_PREFIX_PARTS = (
     "patch_merge_mlp",
 )
 
+_SEQUENCE_ROW_PARALLEL_PREFIXES = (
+    "o_proj",  # attn output linear of most LLMs
+    "out_proj",  # attn output linear of Qwen3 Next
+    "down_proj",  # second MLP of most LLMs
+    "attention.dense",  # attn output linear of Bailing
+    "wo_b",  # attn output linear of v4
+)
+
+_TENSOR_MM_REDUCE_SCATTER_RANKS = {2, 4, 8}
+_TENSOR_MM_REDUCE_SCATTER_DTYPES = {torch.float16, torch.bfloat16}
+
 
 def _should_skip_sp_for_multimodal_encoder(prefix: str) -> bool:
     return any(part in prefix for part in _MULTIMODAL_ENCODER_PREFIX_PARTS)
+
+
+def _is_context_parallel_attention_output(prefix: str) -> bool:
+    if enable_dsa_cp() and ("o_proj" in prefix or "wo_b" in prefix):
+        return True
+    return False
+
+
+def _get_weight_dtype(layer) -> torch.dtype | None:
+    weight = getattr(layer, "weight", None)
+    if weight is None:
+        return None
+    return getattr(weight, "dtype", getattr(getattr(weight, "data", None), "dtype", None))
+
+
+def _supports_tensor_mm_reduce_scatter_quant_method(layer) -> bool:
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+    from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod, AscendW8A8LinearMethod
+
+    quant_method = getattr(layer, "quant_method", None)
+    if isinstance(quant_method, UnquantizedLinearMethod):
+        return _get_weight_dtype(layer) in _TENSOR_MM_REDUCE_SCATTER_DTYPES
+
+    if not isinstance(quant_method, AscendLinearMethod):
+        return False
+
+    inner_quant_method = quant_method.quant_method
+    if isinstance(inner_quant_method, AscendW8A8LinearMethod):
+        return all(
+            hasattr(layer, attr)
+            for attr in (
+                "weight",
+                "deq_scale",
+                "aclnn_input_scale",
+                "aclnn_input_scale_reciprocal",
+                "aclnn_input_offset",
+                "quant_bias",
+            )
+        )
+
+    chunk_size = getattr(layer, "_chunk_size", 0)
+    has_dynamic_weight_chunks = isinstance(chunk_size, int) and chunk_size > 0
+    return (
+        isinstance(inner_quant_method, AscendW8A8DynamicLinearMethod)
+        and hasattr(layer, "weight")
+        and hasattr(layer, "weight_scale")
+        and not has_dynamic_weight_chunks
+    )
+
+
+def _apply_tensor_mm_reduce_scatter(layer, input_: torch.Tensor, bias: torch.Tensor | None) -> torch.Tensor:
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+    from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod, AscendW8A8LinearMethod
+
+    quant_method = getattr(layer, "quant_method", None)
+    if isinstance(quant_method, UnquantizedLinearMethod):
+        return torch.ops.vllm.unquantized_matmul_reduce_scatter(input_, layer.weight, bias)
+
+    if isinstance(quant_method, AscendLinearMethod) and isinstance(quant_method.quant_method, AscendW8A8LinearMethod):
+        ascend_quant_method = getattr(layer, "ascend_quant_method", "")
+        quant_bias = bias if ascend_quant_method == COMPRESSED_TENSORS_METHOD else None
+        if quant_bias is None and get_tp_group().rank_in_group == 0:
+            quant_bias = layer.quant_bias
+        return torch.ops.vllm.quant_matmul_reduce_scatter(
+            input_,
+            layer.weight,
+            layer.deq_scale,
+            layer.aclnn_input_scale,
+            layer.aclnn_input_scale_reciprocal,
+            layer.aclnn_input_offset,
+            quant_bias,
+        )
+
+    if (
+        isinstance(quant_method, AscendLinearMethod)
+        and isinstance(quant_method.quant_method, AscendW8A8DynamicLinearMethod)
+        and hasattr(layer, "weight")
+        and hasattr(layer, "weight_scale")
+    ):
+        weight_scale = getattr(layer, "weight_scale_fp32", layer.weight_scale)
+        return torch.ops.vllm.dynamic_quant_matmul_reduce_scatter(input_, layer.weight, weight_scale, bias)
+
+    output_parallel = layer.quant_method.apply(layer, input_, bias=bias)
+    return torch.ops.vllm.maybe_pad_and_reduce(output_parallel)
+
+
+def _supports_tensor_mm_reduce_scatter_fusion(layer, tp_size: int, reduce_results: bool) -> bool:
+    prefix = getattr(layer, "prefix", "")
+    if not reduce_results or tp_size not in _TENSOR_MM_REDUCE_SCATTER_RANKS:
+        return False
+    if is_310p():
+        return False
+    if not any(row_prefix in prefix for row_prefix in _SEQUENCE_ROW_PARALLEL_PREFIXES):
+        return False
+    if _is_context_parallel_attention_output(prefix):
+        return False
+    return _supports_tensor_mm_reduce_scatter_quant_method(layer)
 
 
 def _get_column_parallel_op(
@@ -527,14 +653,7 @@ def _get_row_parallel_op(
         # "share_expert" added for Step3p5
         if "shared_expert" in prefix or "share_expert" in prefix:
             return None
-        sp_row_prefixes = [
-            "o_proj",  # attn output linear of most LLMs
-            "out_proj",  # attn output linear of Qwen3 Next
-            "down_proj",  # second MLP of most LLMs
-            "attention.dense",  # attn output linear of Bailing
-            "wo_b",  # attn output linear of v4
-        ]
-        for a_prefix in sp_row_prefixes:
+        for a_prefix in _SEQUENCE_ROW_PARALLEL_PREFIXES:
             if a_prefix in prefix:
                 return SequenceRowParallelOp(layer)
 

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -422,6 +422,9 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 need_unsqueeze = True
                 x_quant = x_quant.squeeze(dim=1)
                 pertoken_scale = pertoken_scale.squeeze(dim=1)
+            x1_scale = pertoken_scale.reshape(-1, 1).contiguous()
+            weight_scale = getattr(self.layer, "weight_scale_fp32", self.layer.weight_scale)
+            x2_scale = weight_scale.reshape(1, -1).contiguous()
             output = DeviceOperator.npu_mm_reduce_scatter_base(
                 x_quant,
                 self.layer.weight,
@@ -430,8 +433,8 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 reduce_op="sum",
                 bias=bias_ if quant_method.act_quant_type == torch.int8 else None,
                 comm_turn=0,
-                x1_scale=pertoken_scale,
-                x2_scale=self.layer.weight_scale,
+                x1_scale=x1_scale,
+                x2_scale=x2_scale,
                 output_dtype=x.dtype,
             )
             if need_unsqueeze:

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -10,10 +10,12 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.distributed.parallel_state import get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.rotary_embedding import rope_forward_oot
 from vllm_ascend.ops.triton.muls_add import muls_add_triton
 from vllm_ascend.utils import enable_sp_by_pass, is_vl_model
@@ -154,6 +156,241 @@ def _matmul_and_reduce_impl_fake(input_parallel: torch.Tensor, layer_name: str) 
     return output
 
 
+def _is_tp_mm_reduce_scatter_enabled() -> bool:
+    try:
+        get_forward_context()
+    except AssertionError:
+        return False
+
+    return bool(_EXTRA_CTX.flash_comm_v1_enabled)
+
+
+def _maybe_pad_input_for_mm_reduce_scatter(input_: torch.Tensor) -> torch.Tensor:
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size <= 0:
+        return input_
+    return F.pad(input_, (0, 0, 0, pad_size))
+
+
+def _fallback_dynamic_quant_matmul_reduce_scatter(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(input_, dst_type=torch.int8)
+    need_unsqueeze = False
+    if pertoken_scale.dim() == 2:
+        need_unsqueeze = True
+        quantized_x = quantized_x.squeeze(dim=1)
+        pertoken_scale = pertoken_scale.squeeze(dim=1)
+
+    output = torch_npu.npu_quant_matmul(
+        quantized_x,
+        weight,
+        weight_scale,
+        pertoken_scale=pertoken_scale,
+        bias=bias,
+        output_dtype=input_.dtype,
+    )
+    if need_unsqueeze:
+        output = output.unsqueeze(dim=1)
+    return torch.ops.vllm.maybe_pad_and_reduce(output)
+
+
+def _dynamic_quant_matmul_reduce_scatter_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if not _is_tp_mm_reduce_scatter_enabled() or input_.dim() != 2:
+        return _fallback_dynamic_quant_matmul_reduce_scatter(input_, weight, weight_scale, bias)
+
+    tp_group = get_tp_group()
+    world_size = tp_group.world_size
+    if world_size == 1 or world_size > 8:
+        return _fallback_dynamic_quant_matmul_reduce_scatter(input_, weight, weight_scale, bias)
+
+    hcom_name = tp_group.device_group._get_backend(torch.device("npu")).get_hccl_comm_name(
+        tp_group.rank_in_group,
+    )
+    x = _maybe_pad_input_for_mm_reduce_scatter(input_)
+    quantized_x, pertoken_scale = DeviceOperator.npu_dynamic_quant(x, act_quant_type=torch.int8)
+    need_unsqueeze = False
+    if pertoken_scale.dim() == 2:
+        need_unsqueeze = True
+        quantized_x = quantized_x.squeeze(dim=1)
+        pertoken_scale = pertoken_scale.squeeze(dim=1)
+    x1_scale = pertoken_scale.reshape(-1, 1).contiguous()
+    x2_scale = weight_scale.reshape(1, -1).to(torch.float32).contiguous()
+    output = DeviceOperator.npu_mm_reduce_scatter_base(
+        quantized_x,
+        weight,
+        hcom_name,
+        world_size,
+        reduce_op="sum",
+        bias=bias,
+        comm_turn=0,
+        x1_scale=x1_scale,
+        x2_scale=x2_scale,
+        output_dtype=input_.dtype,
+    )
+    if need_unsqueeze:
+        output = output.unsqueeze(dim=1)
+    return output
+
+
+def _fallback_quant_matmul_reduce_scatter(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    deq_scale: torch.Tensor,
+    input_scale: torch.Tensor,
+    input_scale_reciprocal: torch.Tensor,
+    input_offset: torch.Tensor,
+    quant_bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    quantized_x = torch.ops.vllm.quantize(input_, input_scale, input_scale_reciprocal, input_offset)
+    output = torch_npu.npu_quant_matmul(
+        quantized_x,
+        weight,
+        deq_scale,
+        bias=quant_bias,
+        output_dtype=input_.dtype,
+    )
+    return torch.ops.vllm.maybe_pad_and_reduce(output)
+
+
+def _quant_matmul_reduce_scatter_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    deq_scale: torch.Tensor,
+    input_scale: torch.Tensor,
+    input_scale_reciprocal: torch.Tensor,
+    input_offset: torch.Tensor,
+    quant_bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if not _is_tp_mm_reduce_scatter_enabled() or input_.dim() != 2:
+        return _fallback_quant_matmul_reduce_scatter(
+            input_, weight, deq_scale, input_scale, input_scale_reciprocal, input_offset, quant_bias
+        )
+
+    tp_group = get_tp_group()
+    world_size = tp_group.world_size
+    if world_size == 1 or world_size > 8:
+        return _fallback_quant_matmul_reduce_scatter(
+            input_, weight, deq_scale, input_scale, input_scale_reciprocal, input_offset, quant_bias
+        )
+
+    hcom_name = tp_group.device_group._get_backend(torch.device("npu")).get_hccl_comm_name(
+        tp_group.rank_in_group,
+    )
+    quantized_x = torch.ops.vllm.quantize(
+        _maybe_pad_input_for_mm_reduce_scatter(input_),
+        input_scale,
+        input_scale_reciprocal,
+        input_offset,
+    )
+    output = DeviceOperator.npu_mm_reduce_scatter_base(
+        quantized_x,
+        weight,
+        hcom_name,
+        world_size,
+        reduce_op="sum",
+        bias=None,
+        comm_turn=0,
+        x2_scale=deq_scale,
+        output_dtype=input_.dtype,
+    )
+    if quant_bias is not None:
+        output = torch.add(output, torch.mul(quant_bias, deq_scale).to(input_.dtype))
+    return output
+
+
+def _unquantized_matmul_reduce_scatter_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if not _is_tp_mm_reduce_scatter_enabled() or input_.dim() != 2:
+        output = torch.ops.vllm.unquantized_gemm(input_, weight, bias)
+        return torch.ops.vllm.maybe_pad_and_reduce(output)
+
+    tp_group = get_tp_group()
+    world_size = tp_group.world_size
+    if world_size == 1 or world_size > 8:
+        output = torch.ops.vllm.unquantized_gemm(input_, weight, bias)
+        return torch.ops.vllm.maybe_pad_and_reduce(output)
+
+    hcom_name = tp_group.device_group._get_backend(torch.device("npu")).get_hccl_comm_name(
+        tp_group.rank_in_group,
+    )
+    output = DeviceOperator.npu_mm_reduce_scatter_base(
+        _maybe_pad_input_for_mm_reduce_scatter(input_),
+        weight.t(),
+        hcom_name,
+        world_size,
+        reduce_op="sum",
+        bias=None,
+        comm_turn=0,
+    )
+    if bias is not None:
+        output.add_(bias)
+    return output
+
+
+def _matmul_reduce_scatter_tensor_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    *_args,
+) -> torch.Tensor:
+    try:
+        world_size = get_tensor_model_parallel_world_size()
+        pad_size = _EXTRA_CTX.pad_size
+    except Exception:
+        world_size = 1
+        pad_size = 0
+
+    if not _is_tp_mm_reduce_scatter_enabled():
+        world_size = 1
+        pad_size = 0
+
+    output_tokens = input_.shape[0]
+    if world_size > 1:
+        output_tokens = (output_tokens + pad_size) // world_size
+    return torch.empty(
+        (output_tokens, *input_.shape[1:-1], weight.shape[-1]),
+        device=input_.device,
+        dtype=input_.dtype,
+    )
+
+
+def _unquantized_matmul_reduce_scatter_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    *_args,
+) -> torch.Tensor:
+    try:
+        world_size = get_tensor_model_parallel_world_size()
+        pad_size = _EXTRA_CTX.pad_size
+    except Exception:
+        world_size = 1
+        pad_size = 0
+
+    if not _is_tp_mm_reduce_scatter_enabled():
+        world_size = 1
+        pad_size = 0
+
+    output_tokens = input_.shape[0]
+    if world_size > 1:
+        output_tokens = (output_tokens + pad_size) // world_size
+    return torch.empty(
+        (output_tokens, *input_.shape[1:-1], weight.shape[0]),
+        device=input_.device,
+        dtype=input_.dtype,
+    )
+
+
 # TODO(Angazenn): The reason why we use a custom op to encapsulate npu_quantize
 # is that aclnnAscendQuantV3(npu_quantize) use div_mode=False, while
 # aclnnAddRmsNormQuantV2(npu_add_rms_norm_quant) use div_moe=True. We have to
@@ -228,6 +465,30 @@ direct_register_custom_op(
     op_name="matmul_and_reduce",
     op_func=_matmul_and_reduce_impl,
     fake_impl=_matmul_and_reduce_impl_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="dynamic_quant_matmul_reduce_scatter",
+    op_func=_dynamic_quant_matmul_reduce_scatter_impl,
+    fake_impl=_matmul_reduce_scatter_tensor_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="quant_matmul_reduce_scatter",
+    op_func=_quant_matmul_reduce_scatter_impl,
+    fake_impl=_matmul_reduce_scatter_tensor_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="unquantized_matmul_reduce_scatter",
+    op_func=_unquantized_matmul_reduce_scatter_impl,
+    fake_impl=_unquantized_matmul_reduce_scatter_fake,
     mutates_args=[],
     dispatch_key="PrivateUse1",
 )

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -793,10 +793,11 @@ class NPUPlatform(Platform):
         # if the concurrency is below the threshold,
         # the performance may degrade due to the switching of
         # communication methods.
-        mmrs_fusion = True
+        # TODO: remove the TP-size guard when torch_npu.npu_mm_reduce_scatter_base
+        # supports tp_size >= 16.
+        mmrs_fusion = tp_world_size <= 8
         if is_moe_model(vllm_config):
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None
-            mmrs_fusion = False
         else:
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None and num_tokens > 1000
         pad_size = 0


### PR DESCRIPTION
  ### What this PR does / why we need it?

  This PR ports matmul reduce-scatter fusion support for dynamic W8A8 linear paths and enables the same fusion path in eager mode.

  The changes include:

  - Add dynamic W8A8 support in `SequenceRowParallelOp.matmul_and_reduce`
  - Reshape per-token and weight scales for `npu_mm_reduce_scatter_base`
  - Add tensor-level matmul reduce-scatter custom ops for eager execution:
    - `dynamic_quant_matmul_reduce_scatter`
    - `quant_matmul_reduce_scatter`
    - `unquantized_matmul_reduce_scatter`
  - Route supported sequence-parallel row linear eager paths through the fused mmrs tensor ops
  - Preserve fallback behavior for unsupported rank, shape, quantization method, or disabled FlashComm

  This intentionally does not include graph pass fusion or all-gather matmul eager fusion.

  ### Does this PR introduce _any_ user-facing change?

  No user-facing API change.

  For supported FlashComm/SP row-parallel linear paths, eager mode can now use matmul reduce-scatter fusion.

  ### How was this patch tested?

  - `python -m py_compile vllm_ascend/ops/linear_op.py vllm_ascend/ops/register_custom_ops.py tests/ut/ops/test_linear.py`
  - `git diff --check`
  - `TORCH_DEVICE_BACKEND_AUTOLOAD=0 pytest -sv tests/ut/ops/
  test_linear.py::TestRowParallelOpDispatch::test_sequence_row_op_calls_tensor_mm_reduce_scatter_in_eager tests/ut/ops/
  test_linear.py::TestSequenceRowParallelMatmulAndReduce::test_dynamic_w8a8_tensor_op_uses_mm_reduce_scatter_fusion tests/ut/ops/
  test_linear.py::TestSequenceRowParallelMatmulAndReduce::test_dynamic_w8a8_uses_mm_reduce_scatter_fusion`
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
