### PR TITLE
[Feature][Ops] Add all-gather matmul fusion

### DIFF
--- a/tests/e2e/pull_request/four_card/test_all_gather_matmul_v2.py
+++ b/tests/e2e/pull_request/four_card/test_all_gather_matmul_v2.py
@@ -1,0 +1,220 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import socket
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+torch_npu = pytest.importorskip("torch_npu")
+
+WORLD_SIZE = 4
+LOCAL_M = 32
+K_SIZE = 6144
+N_SIZE = 1024
+UNQUANTIZED_N_SIZE = 256
+SEED = 2026
+TOLERANCE = 1e-2
+HCCL_SOCKET_PORT_RANGE_SIZE = 32
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _make_hccl_socket_port_range() -> str:
+    start = min(_find_free_port(), 65535 - HCCL_SOCKET_PORT_RANGE_SIZE)
+    end = start + HCCL_SOCKET_PORT_RANGE_SIZE - 1
+    return f"{start}-{end}"
+
+
+def _get_hccl_comm_name(rank: int) -> str:
+    from torch.distributed.distributed_c10d import _get_default_group
+
+    default_pg = _get_default_group()
+    return default_pg._get_backend(torch.device("npu")).get_hccl_comm_name(rank)
+
+
+def _all_gather_tensor(tensor: torch.Tensor) -> torch.Tensor:
+    outputs = [torch.empty_like(tensor) for _ in range(WORLD_SIZE)]
+    dist.all_gather(outputs, tensor)
+    return torch.cat(outputs, dim=0)
+
+
+def _run_all_gather_matmul_v2_quant(rank: int, master_port: int) -> None:
+    torch_npu.npu.set_device(rank)
+    dist.init_process_group(
+        backend="hccl",
+        rank=rank,
+        world_size=WORLD_SIZE,
+        init_method=f"tcp://127.0.0.1:{master_port}",
+    )
+
+    hcom = _get_hccl_comm_name(rank)
+    torch.manual_seed(SEED + rank)
+    input_fp = torch.randn((LOCAL_M, K_SIZE), device="npu", dtype=torch.bfloat16)
+    quantized_x, x1_scale = torch_npu.npu_dynamic_quant(input_fp, dst_type=torch.int8)
+    quantized_x = quantized_x.contiguous()
+    x1_scale = x1_scale.reshape(-1, 1).contiguous()
+
+    torch.manual_seed(SEED)
+    weight = torch.randint(
+        -16,
+        16,
+        (K_SIZE, N_SIZE),
+        device="npu",
+        dtype=torch.int8,
+    )
+    x2_scale = torch.ones((1, N_SIZE), device="npu", dtype=torch.float32)
+
+    output, gather_out = torch_npu.npu_all_gather_base_mm(
+        quantized_x,
+        weight,
+        hcom,
+        WORLD_SIZE,
+        bias=None,
+        x1_scale=x1_scale,
+        x2_scale=x2_scale,
+        gather_index=0,
+        gather_output=True,
+        comm_turn=0,
+        output_dtype=torch.bfloat16,
+        comm_mode="aiv",
+    )
+    torch.npu.synchronize()
+
+    gathered_x = _all_gather_tensor(quantized_x)
+    gathered_x1_scale = _all_gather_tensor(x1_scale)
+    expected = torch_npu.npu_quant_matmul(
+        gathered_x,
+        weight,
+        x2_scale.squeeze(0),
+        bias=None,
+        output_dtype=torch.bfloat16,
+    )
+    expected = (expected.float() * gathered_x1_scale).to(torch.bfloat16)
+    torch.npu.synchronize()
+
+    assert output.shape == (LOCAL_M * WORLD_SIZE, N_SIZE)
+    assert gather_out.shape == (LOCAL_M * WORLD_SIZE, K_SIZE)
+    torch.testing.assert_close(
+        output.float().cpu(),
+        expected.float().cpu(),
+        atol=TOLERANCE,
+        rtol=TOLERANCE,
+    )
+    torch.testing.assert_close(
+        gather_out.cpu(),
+        gathered_x.cpu(),
+        atol=0,
+        rtol=0,
+    )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def _run_all_gather_matmul_v2_unquantized(rank: int, master_port: int) -> None:
+    torch_npu.npu.set_device(rank)
+    dist.init_process_group(
+        backend="hccl",
+        rank=rank,
+        world_size=WORLD_SIZE,
+        init_method=f"tcp://127.0.0.1:{master_port}",
+    )
+
+    hcom = _get_hccl_comm_name(rank)
+    torch.manual_seed(SEED + rank)
+    input_fp = torch.randn((LOCAL_M, K_SIZE), device="npu", dtype=torch.bfloat16)
+
+    torch.manual_seed(SEED)
+    linear_weight = torch.randn(
+        (UNQUANTIZED_N_SIZE, K_SIZE),
+        device="npu",
+        dtype=torch.bfloat16,
+    )
+
+    output, gather_out = torch_npu.npu_all_gather_base_mm(
+        input_fp,
+        linear_weight.t(),
+        hcom,
+        WORLD_SIZE,
+        bias=None,
+        x1_scale=None,
+        x2_scale=None,
+        gather_index=0,
+        gather_output=True,
+        comm_turn=0,
+        output_dtype=torch.bfloat16,
+        comm_mode="aiv",
+    )
+    torch.npu.synchronize()
+
+    gathered_x = _all_gather_tensor(input_fp)
+    expected = torch.nn.functional.linear(gathered_x, linear_weight, bias=None)
+    torch.npu.synchronize()
+
+    assert output.shape == (LOCAL_M * WORLD_SIZE, UNQUANTIZED_N_SIZE)
+    assert gather_out.shape == (LOCAL_M * WORLD_SIZE, K_SIZE)
+    torch.testing.assert_close(
+        output.float().cpu(),
+        expected.float().cpu(),
+        atol=TOLERANCE,
+        rtol=TOLERANCE,
+    )
+    torch.testing.assert_close(
+        gather_out.cpu(),
+        gathered_x.cpu(),
+        atol=0,
+        rtol=0,
+    )
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "npu") or not torch.npu.is_available(),
+    reason="NPU is required for AllGatherMatmulV2 e2e test.",
+)
+@pytest.mark.skipif(
+    hasattr(torch, "npu") and torch.npu.device_count() < WORLD_SIZE,
+    reason="AllGatherMatmulV2 e2e test requires 4 visible NPUs.",
+)
+def test_all_gather_matmul_v2_dynamic_quant() -> None:
+    os.environ["HCCL_OP_EXPANSION_MODE"] = "AIV"
+    os.environ.setdefault("HCCL_NPU_SOCKET_PORT_RANGE", _make_hccl_socket_port_range())
+    mp.spawn(_run_all_gather_matmul_v2_quant, args=(_find_free_port(),), nprocs=WORLD_SIZE)
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "npu") or not torch.npu.is_available(),
+    reason="NPU is required for AllGatherMatmulV2 e2e test.",
+)
+@pytest.mark.skipif(
+    hasattr(torch, "npu") and torch.npu.device_count() < WORLD_SIZE,
+    reason="AllGatherMatmulV2 e2e test requires 4 visible NPUs.",
+)
+def test_all_gather_matmul_v2_unquantized() -> None:
+    os.environ["HCCL_OP_EXPANSION_MODE"] = "AIV"
+    os.environ.setdefault("HCCL_NPU_SOCKET_PORT_RANGE", _make_hccl_socket_port_range())
+    mp.spawn(_run_all_gather_matmul_v2_unquantized, args=(_find_free_port(),), nprocs=WORLD_SIZE)

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -209,6 +209,32 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
         self.assertIsNone(self._get_column_op("model.vision_model_proj.indexer_proj"))
         self.assertIsNone(self._get_column_op("model.vision_tower_encoder.qkv_proj"))
 
+    def test_sequence_column_op_calls_tensor_all_gather_matmul_in_eager(self):
+        from vllm_ascend.ops.linear_op import SequenceColumnParallelOp
+
+        layer = MagicMock()
+        layer.prefix = "model.layers.1.mlp.gate_up_proj"
+        layer.gather_output = False
+        layer.skip_bias_add = False
+        layer.return_bias = True
+        layer.quant_method = AscendUnquantizedLinearMethod()
+        layer.weight = torch.nn.Parameter(torch.empty(16, 8, dtype=torch.float16), requires_grad=False)
+        layer.bias = None
+        output = torch.empty(4, 16, dtype=torch.float16)
+
+        op = SequenceColumnParallelOp(layer)
+        op.update_attrs()
+        input_ = torch.empty(2, 8, dtype=torch.float16)
+        with (
+            patch("vllm_ascend.ops.linear_op.is_vl_model", return_value=False),
+            patch.object(torch.ops.vllm, "all_gather_unquantized_matmul", return_value=output, create=True) as mock_fused,
+        ):
+            result, output_bias = op.apply_impl(input_)
+
+        self.assertIs(result, output)
+        self.assertIsNone(output_bias)
+        mock_fused.assert_called_once_with(input_, layer.weight, None)
+
 
 class TestRowParallelOpDispatch(unittest.TestCase):
     """Tests for _get_row_parallel_op — mtp_block, share_expert."""

--- a/vllm_ascend/compilation/graph_fusion_pass_manager.py
+++ b/vllm_ascend/compilation/graph_fusion_pass_manager.py
@@ -66,6 +66,11 @@ class GraphFusionPassManager:
 
             self.passes.append(MulsAddFusionPass(config))
 
+        if self.ascend_compilation_config.get("fuse_all_gather_matmul", True) and not is_310p():
+            from .passes.all_gather_matmul_pass import AllGatherMatmulFusionPass
+
+            self.passes.append(AllGatherMatmulFusionPass(config))
+
         if config.compilation_config.pass_config.enable_sp:
             from .passes.sequence_parallelism import SequenceParallelismPass
             from .passes.sequence_parallelism_moe import SequenceParallelismMoePass

--- a/vllm_ascend/compilation/passes/all_gather_matmul_pass.py
+++ b/vllm_ascend/compilation/passes/all_gather_matmul_pass.py
@@ -1,0 +1,162 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import torch
+from torch._inductor.pattern_matcher import PatternMatcherPass
+from vllm.compilation.passes.vllm_inductor_pass import VllmInductorPass
+from vllm.config import VllmConfig
+from vllm.config.compilation import Range
+from vllm.logger import logger
+
+from vllm_ascend.compilation.passes.base_pattern import BasePattern
+
+
+class AllGatherDynamicQuantMatmulPattern(BasePattern):
+    """
+    Match sequence-parallel all-gather followed by W8A8 dynamic quantized
+    matmul and replace it with the NPU all-gather-matmul primitive.
+    """
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        x = torch.randn(2, 256, device="npu", dtype=self.dtype)
+        weight = torch.randint(-8, 8, (256, 128), device="npu", dtype=torch.int8)
+        weight_scale = torch.ones(128, device="npu", dtype=torch.float32)
+        return [x, weight, weight_scale]
+
+    def get_pattern(self):
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ):
+            gathered = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(x, label=True)
+            quantized_x, pertoken_scale = torch.ops.npu.npu_dynamic_quant(gathered, dst_type=torch.int8)
+            return torch.ops.npu.npu_quant_matmul(
+                quantized_x,
+                weight,
+                weight_scale,
+                pertoken_scale=pertoken_scale,
+                bias=None,
+                output_dtype=self.dtype,
+            )
+
+        return pattern
+
+    def get_replacement(self):
+        def replacement(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            weight_scale: torch.Tensor,
+        ):
+            return torch.ops.vllm.all_gather_dynamic_quant_matmul(x, weight, weight_scale)
+
+        return replacement
+
+
+class AllGatherUnquantizedMatmulPattern(BasePattern):
+    """
+    Match sequence-parallel all-gather followed by an unquantized linear
+    matmul and replace it with AllGatherMatmulV2.
+    """
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        x = torch.randn(2, 256, device="npu", dtype=self.dtype)
+        weight = torch.randn(128, 256, device="npu", dtype=self.dtype)
+        return [x, weight]
+
+    def get_pattern(self):
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+        ):
+            gathered = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(x, label=True)
+            return torch.ops.vllm.unquantized_gemm(gathered, weight, None)
+
+        return pattern
+
+    def get_replacement(self):
+        def replacement(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+        ):
+            return torch.ops.vllm.all_gather_unquantized_matmul(x, weight, None)
+
+        return replacement
+
+
+class AllGatherUnquantizedMatmulWithBiasPattern(BasePattern):
+    """
+    Match sequence-parallel all-gather followed by an unquantized linear matmul
+    with bias and replace it with AllGatherMatmulV2.
+    """
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        x = torch.randn(2, 256, device="npu", dtype=self.dtype)
+        weight = torch.randn(128, 256, device="npu", dtype=self.dtype)
+        bias = torch.randn(128, device="npu", dtype=self.dtype)
+        return [x, weight, bias]
+
+    def get_pattern(self):
+        def pattern(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            bias: torch.Tensor,
+        ):
+            gathered = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(x, label=True)
+            return torch.ops.vllm.unquantized_gemm(gathered, weight, bias)
+
+        return pattern
+
+    def get_replacement(self):
+        def replacement(
+            x: torch.Tensor,
+            weight: torch.Tensor,
+            bias: torch.Tensor,
+        ):
+            return torch.ops.vllm.all_gather_unquantized_matmul(x, weight, bias)
+
+        return replacement
+
+
+class AllGatherMatmulFusionPass(VllmInductorPass):
+    """Fuse sequence-parallel all-gather + matmul for column-parallel layers."""
+
+    def __init__(self, vllm_config: VllmConfig):
+        super().__init__(vllm_config)
+        self.pattern_match_passes: PatternMatcherPass = PatternMatcherPass(
+            pass_name="all_gather_matmul_fusion_pass",
+        )
+
+        dtype = vllm_config.model_config.dtype
+        if dtype not in (torch.float16, torch.bfloat16):
+            logger.debug("AllGatherMatmul fusion not enabled: unsupported dtype %s", dtype)
+            return
+
+        AllGatherDynamicQuantMatmulPattern(vllm_config).register(self.pattern_match_passes)
+        AllGatherUnquantizedMatmulPattern(vllm_config).register(self.pattern_match_passes)
+        AllGatherUnquantizedMatmulWithBiasPattern(vllm_config).register(self.pattern_match_passes)
+
+    def __call__(self, graph: torch.fx.Graph) -> None:  # type: ignore[override]
+        self.begin()
+        self.matched_count = self.pattern_match_passes.apply(graph)
+        logger.debug("Fused %s all_gather_matmul patterns", self.matched_count)
+        self.end_and_log()
+
+    def is_applicable_for_range(self, compile_range: Range) -> bool:
+        return True

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -190,6 +190,37 @@ class BaseDeviceAdaptor:
         )
 
     @staticmethod
+    def npu_all_gather_base_mm(
+        x1: torch.Tensor,
+        x2: torch.Tensor,
+        hcom: str,
+        world_size: int,
+        *,
+        bias: torch.Tensor | None = None,
+        x1_scale: torch.Tensor | None = None,
+        x2_scale: torch.Tensor | None = None,
+        gather_index: int = 0,
+        gather_output: bool = False,
+        comm_turn: int = 0,
+        output_dtype: torch.dtype | None = None,
+        comm_mode: str = "aiv",
+    ):
+        return torch_npu.npu_all_gather_base_mm(
+            x1,
+            x2,
+            hcom,
+            world_size,
+            bias=bias,
+            x1_scale=x1_scale,
+            x2_scale=x2_scale,
+            gather_index=gather_index,
+            gather_output=gather_output,
+            comm_turn=comm_turn,
+            output_dtype=output_dtype,
+            comm_mode=comm_mode,
+        )
+
+    @staticmethod
     def npu_dynamic_quant(
         hidden_states: torch.Tensor,
         dynamic_scale: torch.Tensor | None = None,
@@ -1133,6 +1164,41 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
             comm_turn=comm_turn,
             x1_scale=x1_scale,
             x2_scale=x2_scale,
+            output_dtype=output_dtype,
+            comm_mode=comm_mode,
+        )
+
+    @staticmethod
+    def npu_all_gather_base_mm(
+        x1: torch.Tensor,
+        x2: torch.Tensor,
+        hcom: str,
+        world_size: int,
+        *,
+        bias: torch.Tensor | None = None,
+        x1_scale: torch.Tensor | None = None,
+        x2_scale: torch.Tensor | None = None,
+        gather_index: int = 0,
+        gather_output: bool = False,
+        comm_turn: int = 0,
+        output_dtype: torch.dtype | None = None,
+        comm_mode: str = "ai_cpu",
+    ):
+        expansion_mode = os.environ.get("HCCL_OP_EXPANSION_MODE")
+        if expansion_mode == "CCU_SCHED":
+            comm_mode = "ccu"
+
+        return torch_npu.npu_all_gather_base_mm(
+            x1,
+            x2,
+            hcom,
+            world_size,
+            bias=bias,
+            x1_scale=x1_scale,
+            x2_scale=x2_scale,
+            gather_index=gather_index,
+            gather_output=gather_output,
+            comm_turn=comm_turn,
             output_dtype=output_dtype,
             comm_mode=comm_mode,
         )

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -298,8 +298,10 @@ class SequenceColumnParallelOp(CustomColumnParallelOp):
         # Matrix multiply.
         assert self.quant_method is not None
         need_all_gather = not (extract_layer_index(self.layer.prefix) == 0 and is_vl_model() and "attn" in self.prefix)
-        input_ = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(input_, label=need_all_gather)
-        output_parallel = self.quant_method.apply(self.layer, input_, bias)
+        output_parallel = _apply_tensor_all_gather_matmul_if_supported(self.layer, input_, bias, need_all_gather)
+        if output_parallel is None:
+            input_ = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(input_, label=need_all_gather)
+            output_parallel = self.quant_method.apply(self.layer, input_, bias)
 
         if self.gather_output:
             # All-gather across the partitions.
@@ -450,6 +452,51 @@ _MULTIMODAL_ENCODER_PREFIX_PARTS = (
 
 def _should_skip_sp_for_multimodal_encoder(prefix: str) -> bool:
     return any(part in prefix for part in _MULTIMODAL_ENCODER_PREFIX_PARTS)
+
+
+_TENSOR_ALL_GATHER_MATMUL_DTYPES = {torch.float16, torch.bfloat16}
+
+
+def _get_weight_dtype(layer) -> torch.dtype | None:
+    weight = getattr(layer, "weight", None)
+    if weight is None:
+        return None
+    return getattr(weight, "dtype", getattr(getattr(weight, "data", None), "dtype", None))
+
+
+def _apply_tensor_all_gather_matmul_if_supported(
+    layer,
+    input_: torch.Tensor,
+    bias: torch.Tensor | None,
+    need_all_gather: bool,
+) -> torch.Tensor | None:
+    """Call the tensor all-gather-matmul custom op for supported column layers."""
+    if not need_all_gather:
+        return None
+
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+    from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
+
+    quant_method = getattr(layer, "quant_method", None)
+    if isinstance(quant_method, UnquantizedLinearMethod) and _get_weight_dtype(layer) in _TENSOR_ALL_GATHER_MATMUL_DTYPES:
+        return torch.ops.vllm.all_gather_unquantized_matmul(input_, layer.weight, bias)
+
+    chunk_size = getattr(layer, "_chunk_size", 0)
+    has_dynamic_weight_chunks = isinstance(chunk_size, int) and chunk_size > 0
+    if (
+        bias is None
+        and isinstance(quant_method, AscendLinearMethod)
+        and isinstance(quant_method.quant_method, AscendW8A8DynamicLinearMethod)
+        and hasattr(layer, "weight")
+        and hasattr(layer, "weight_scale")
+        and not has_dynamic_weight_chunks
+    ):
+        weight_scale = getattr(layer, "weight_scale_fp32", layer.weight_scale)
+        return torch.ops.vllm.all_gather_dynamic_quant_matmul(input_, layer.weight, weight_scale)
+
+    return None
 
 
 def _get_column_parallel_op(

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -10,10 +10,12 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.distributed.parallel_state import get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.ops.rotary_embedding import rope_forward_oot
 from vllm_ascend.ops.triton.muls_add import muls_add_triton
 from vllm_ascend.utils import enable_sp_by_pass, is_vl_model
@@ -172,6 +174,200 @@ def _quantize_impl_fake(
     return torch_npu.npu_quantize(in_tensor, input_scale_reciprocal, input_offset, torch.qint8, -1, False)
 
 
+def _dynamic_quant_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(input_, dst_type=torch.int8)
+    need_unsqueeze = False
+    if pertoken_scale.dim() == 2:
+        need_unsqueeze = True
+        quantized_x = quantized_x.squeeze(dim=1)
+        pertoken_scale = pertoken_scale.squeeze(dim=1)
+
+    output = torch_npu.npu_quant_matmul(
+        quantized_x,
+        weight,
+        weight_scale,
+        pertoken_scale=pertoken_scale,
+        bias=None,
+        output_dtype=input_.dtype,
+    )
+    if need_unsqueeze:
+        output = output.unsqueeze(dim=1)
+    return output
+
+
+def _all_gather_then_dynamic_quant_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    gathered = tensor_model_parallel_all_gather(input_, 0)
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        gathered = gathered[:-pad_size]
+    return _dynamic_quant_matmul(gathered, weight, weight_scale)
+
+
+def _all_gather_then_unquantized_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    gathered = tensor_model_parallel_all_gather(input_, 0)
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        gathered = gathered[:-pad_size]
+    return torch.ops.vllm.unquantized_gemm(gathered, weight, bias)
+
+
+def _is_tp_all_gather_enabled() -> bool:
+    try:
+        forward_context = get_forward_context()
+    except AssertionError:
+        return False
+
+    return bool(getattr(forward_context, "flash_comm_v1_enabled", False))
+
+
+def _all_gather_dynamic_quant_matmul_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    if not _is_tp_all_gather_enabled():
+        return _dynamic_quant_matmul(input_, weight, weight_scale)
+
+    if input_.dim() != 2:
+        return _all_gather_then_dynamic_quant_matmul(input_, weight, weight_scale)
+
+    tp_group = get_tp_group()
+    world_size = tp_group.world_size
+    if world_size == 1:
+        return _dynamic_quant_matmul(input_, weight, weight_scale)
+
+    hcom_name = tp_group.device_group._get_backend(torch.device("npu")).get_hccl_comm_name(
+        tp_group.rank_in_group,
+    )
+    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(input_, dst_type=torch.int8)
+    x1_scale = pertoken_scale.reshape(-1, 1).contiguous()
+    x2_scale = weight_scale.reshape(1, -1).to(torch.float32).contiguous()
+
+    output, _ = DeviceOperator.npu_all_gather_base_mm(
+        quantized_x,
+        weight,
+        hcom_name,
+        world_size,
+        bias=None,
+        x1_scale=x1_scale,
+        x2_scale=x2_scale,
+        gather_index=0,
+        gather_output=True,
+        comm_turn=0,
+        output_dtype=input_.dtype,
+        comm_mode="aiv",
+    )
+
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        output = output[:-pad_size]
+    return output
+
+
+def _all_gather_unquantized_matmul_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if not _is_tp_all_gather_enabled():
+        return torch.ops.vllm.unquantized_gemm(input_, weight, bias)
+
+    if input_.dim() != 2:
+        return _all_gather_then_unquantized_matmul(input_, weight, bias)
+
+    tp_group = get_tp_group()
+    world_size = tp_group.world_size
+    if world_size == 1:
+        return torch.ops.vllm.unquantized_gemm(input_, weight, bias)
+
+    hcom_name = tp_group.device_group._get_backend(torch.device("npu")).get_hccl_comm_name(
+        tp_group.rank_in_group,
+    )
+    output, _ = DeviceOperator.npu_all_gather_base_mm(
+        input_,
+        weight.t(),
+        hcom_name,
+        world_size,
+        bias=bias,
+        x1_scale=None,
+        x2_scale=None,
+        gather_index=0,
+        gather_output=True,
+        comm_turn=0,
+        output_dtype=input_.dtype,
+        comm_mode="aiv",
+    )
+
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        output = output[:-pad_size]
+    return output
+
+
+def _all_gather_dynamic_quant_matmul_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    try:
+        world_size = get_tensor_model_parallel_world_size()
+        pad_size = _EXTRA_CTX.pad_size
+    except Exception:
+        world_size = 1
+        pad_size = 0
+
+    if not _is_tp_all_gather_enabled():
+        world_size = 1
+        pad_size = 0
+
+    output_tokens = input_.shape[0] * world_size
+    if pad_size > 0:
+        output_tokens -= pad_size
+    return torch.empty(
+        (output_tokens, *input_.shape[1:-1], weight.shape[-1]),
+        device=input_.device,
+        dtype=input_.dtype,
+    )
+
+
+def _all_gather_unquantized_matmul_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    try:
+        world_size = get_tensor_model_parallel_world_size()
+        pad_size = _EXTRA_CTX.pad_size
+    except Exception:
+        world_size = 1
+        pad_size = 0
+
+    if not _is_tp_all_gather_enabled():
+        world_size = 1
+        pad_size = 0
+
+    output_tokens = input_.shape[0] * world_size
+    if pad_size > 0:
+        output_tokens -= pad_size
+    return torch.empty(
+        (output_tokens, *input_.shape[1:-1], weight.shape[0]),
+        device=input_.device,
+        dtype=input_.dtype,
+    )
+
+
 def _rope_forward_oot_impl_fake(
     positions: torch.Tensor,
     query: torch.Tensor,
@@ -236,6 +432,22 @@ direct_register_custom_op(
     op_name="quantize",
     op_func=_quantize_impl,
     fake_impl=_quantize_impl_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="all_gather_dynamic_quant_matmul",
+    op_func=_all_gather_dynamic_quant_matmul_impl,
+    fake_impl=_all_gather_dynamic_quant_matmul_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="all_gather_unquantized_matmul",
+    op_func=_all_gather_unquantized_matmul_impl,
+    fake_impl=_all_gather_unquantized_matmul_fake,
     mutates_args=[],
     dispatch_key="PrivateUse1",
 )


### PR DESCRIPTION
## What this PR does / why we need it?

  This PR adds all-gather matmul fusion for sequence-parallel column-parallel linear layers on Ascend.

  It includes:
  - Graph mode fusion for `maybe_all_gather_and_maybe_unpad + dynamic quant matmul`
  - Graph mode fusion for `maybe_all_gather_and_maybe_unpad + unquantized gemm`
  - Eager mode dispatch for supported unquantized and W8A8 dynamic column-parallel layers
  - `npu_all_gather_base_mm` device adaptor wrapper for Base and A5 devices
  - Custom vLLM ops:
    - `all_gather_dynamic_quant_matmul`
    - `all_gather_unquantized_matmul`
  - Four-card e2e coverage for dynamic quant and unquantized `AllGatherMatmulV2`

  ## Does this PR introduce _any_ user-facing change?

  No user-facing API change.

  This is a performance optimization for supported sequence-parallel TP paths when FlashComm is enabled. Unsupported paths fall back to the
  existing all-gather + matmul behavior.

  ## How was this patch tested?

  - `python -m py_compile vllm_ascend/compilation/passes/all_gather_matmul_pass.py vllm_ascend/ops/register_custom_ops.py vllm_ascend/ops/
  linear_op.py vllm_ascend/device/device_op.py tests/e2e/pull_request/four_card/test_all_gather_matmul_v2.py`
  - `git diff --check`
  - `TORCH_DEVICE_BACKEND_AUTOLOAD=0 pytest -q tests/ut/ops/
  test_linear.py::TestColumnParallelOpDispatch::test_sequence_column_op_calls_tensor_all_gather_matmul_in_eager`
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
