### PR TITLE
[BugFix][Worker] Reserve MTP draft slot mapping capacity

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1090,6 +1090,16 @@ class TestEagleProposerPropose:
         set_current_vllm_config(None)
         clear_ascend_config()
 
+    def test_slot_mapping_group_reserves_mtp_draft_slots(self):
+        self.vllm_config.speculative_config.num_speculative_tokens = 5
+        self.vllm_config.speculative_config.speculative_token_tree = str([(i + 1) * (0,) for i in range(6)])
+
+        proposer = AscendEagleProposer(vllm_config=self.vllm_config, device=self.device, runner=self.runner)
+
+        expected_capacity = self.runner.max_num_tokens + 4 * self.runner.max_num_reqs
+        assert len(proposer.slot_mapping_group) == 5
+        assert all(slot_mapping.shape == torch.Size([expected_capacity]) for slot_mapping in proposer.slot_mapping_group)
+
     # config: prefill and decode, Qwen3-8B, tp1, enforce_eager, no_async_scheduling, eagle3, k=3, "disable_padded_drafter_batch": False
     @pytest.mark.parametrize(
         'flag_prefill_decode, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,' \

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -77,7 +77,7 @@ class TestBlockTableComputeSlotMapping(TestBase):
             return block_table
 
     def test_compute_slot_mapping_draft_reserves_mtp_slots(self):
-        """MTP5 draft slots can exceed the graph-padding-only capacity."""
+        """MTP5 draft slots can exceed the scheduler token capacity."""
         self.max_num_reqs = 12
         self.max_num_batched_tokens = 80
         block_table = self.create_block_table(
@@ -95,7 +95,7 @@ class TestBlockTableComputeSlotMapping(TestBase):
         positions = np.tile(np.arange(10, dtype=np.int64), num_active_reqs)
         block_table.compute_slot_mapping_draft(req_indices, positions)
 
-        self.assertEqual(block_table.slot_mapping.cpu.numel(), 152)
+        self.assertEqual(block_table.slot_mapping.cpu.numel(), 128)
         self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
 
     def setup_block_table_data(self, block_table, num_reqs=2):

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -44,7 +44,13 @@ class TestBlockTableComputeSlotMapping(TestBase):
         self.kernel_sizes = [128]
         self._skip_triton_kernel = True
 
-    def create_block_table(self, dcp_world_size, dcp_rank, cp_kv_cache_interleave_size):
+    def create_block_table(
+        self,
+        dcp_world_size,
+        dcp_rank,
+        cp_kv_cache_interleave_size,
+        num_speculative_tokens=0,
+    ):
         """Helper method to create BlockTable with mocked distributed groups"""
 
         with patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group:
@@ -65,10 +71,32 @@ class TestBlockTableComputeSlotMapping(TestBase):
                 device=self.device,
                 kernel_sizes=self.kernel_sizes,
                 cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
-                num_speculative_tokens=0,
+                num_speculative_tokens=num_speculative_tokens,
             )
 
             return block_table
+
+    def test_compute_slot_mapping_draft_reserves_mtp_slots(self):
+        """MTP5 draft slots can exceed the graph-padding-only capacity."""
+        self.max_num_reqs = 12
+        self.max_num_batched_tokens = 80
+        block_table = self.create_block_table(
+            dcp_world_size=4,
+            dcp_rank=0,
+            cp_kv_cache_interleave_size=1,
+            num_speculative_tokens=5,
+        )
+
+        num_active_reqs = 11
+        for req_idx in range(num_active_reqs):
+            block_table.add_row([req_idx], req_idx)
+
+        req_indices = np.repeat(np.arange(num_active_reqs, dtype=np.int32), 10)
+        positions = np.tile(np.arange(10, dtype=np.int64), num_active_reqs)
+        block_table.compute_slot_mapping_draft(req_indices, positions)
+
+        self.assertEqual(block_table.slot_mapping.cpu.numel(), 152)
+        self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
 
     def setup_block_table_data(self, block_table, num_reqs=2):
         """Helper method to populate block table with test data"""

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -207,9 +207,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample = torch.zeros(
             self.vllm_config.scheduler_config.max_num_batched_tokens, dtype=torch.int32, device=device
         )
-        # Graph capture appends two request-sized padding regions even when
-        # PCP is disabled in MRV1.
-        slot_mapping_lens = self.runner.max_num_tokens + 2 * self.runner.max_num_reqs
+        metadata_lens = self.runner.max_num_tokens + 2 * self.runner.max_num_reqs
+        num_mtp_draft_slots = max(self.num_speculative_tokens - 1, 0) * self.runner.max_num_reqs
+        slot_mapping_lens = self.runner.max_num_tokens + num_mtp_draft_slots
         self.slot_mapping_group = [
             torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
@@ -217,11 +217,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         # dsv32 needs seq_lens and query_start_loc persistent tensors for full graph mode
         self.seq_lens_group = [
-            torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
+            torch.zeros(metadata_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
         ]
         self.query_start_loc_group = [
-            torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
+            torch.zeros(metadata_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
         ]
 

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -97,10 +97,10 @@ class BlockTable:
         self.block_table = self._make_buffer(max_num_reqs * duplicate_size, logical_table_size, dtype=torch.int32)
         self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
         # MTP slot preparation appends up to num_speculative_tokens - 1
-        # draft positions for every request in addition to graph padding.
+        # draft positions for every request beyond the scheduler token limit.
         num_mtp_draft_slots = max(num_speculative_tokens - 1, 0) * self.max_num_reqs
         self.slot_mapping = self._make_buffer(
-            self.max_num_batched_tokens + 2 * self.max_num_reqs + num_mtp_draft_slots,
+            self.max_num_batched_tokens + num_mtp_draft_slots,
             dtype=torch.int32,
         )
 

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -96,7 +96,13 @@ class BlockTable:
             duplicate_size += num_speculative_tokens
         self.block_table = self._make_buffer(max_num_reqs * duplicate_size, logical_table_size, dtype=torch.int32)
         self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
-        self.slot_mapping = self._make_buffer(self.max_num_batched_tokens + 2 * self.max_num_reqs, dtype=torch.int32)
+        # MTP slot preparation appends up to num_speculative_tokens - 1
+        # draft positions for every request in addition to graph padding.
+        num_mtp_draft_slots = max(num_speculative_tokens - 1, 0) * self.max_num_reqs
+        self.slot_mapping = self._make_buffer(
+            self.max_num_batched_tokens + 2 * self.max_num_reqs + num_mtp_draft_slots,
+            dtype=torch.int32,
+        )
 
         self.kernel_sizes = kernel_sizes
         self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size


### PR DESCRIPTION
### What this PR does / why we need it?

This PR sizes both `BlockTable.slot_mapping` and the persistent proposer slot-mapping buffers from the scheduler token capacity plus the MTP draft capacity.

With DCP and MTP enabled, slot preparation appends up to `num_speculative_tokens - 1` positions per active request. The existing buffers only reserved `max_num_batched_tokens + 2 * max_num_reqs`, so an MTP5 batch could produce 110 slot mappings for a 104-element buffer and fail during the CPU assignment. The `2 * max_num_reqs` term was a PCP padding reserve left behind when PCP was removed from main; this PR removes that obsolete term from both BlockTable and proposer slot-mapping sizing.

The resulting capacity is `max_num_batched_tokens + max(num_speculative_tokens - 1, 0) * max_num_reqs`. The buffers remain statically allocated so graph-mode tensor addresses stay stable. Regression tests cover the reported DCP4, MTP5, `max_num_reqs=12`, 110-slot case and construct an MTP5 proposer to ensure the new formula is not masked by the MTP3 coincidence where `num_speculative_tokens - 1 == 2`.

The v0.23 backport CI also exposed why both sides must stay synchronized: BlockTable grew to 8208 while `AscendSpecDecodeBaseProposer.slot_mapping_group` remained 8200, causing `aclnnInplaceCopy` to fail during Eagle3 full-graph warmup.

### Does this PR introduce _any_ user-facing change?

Yes. DCP serving with MTP no longer crashes when expanded draft slot mappings exceed the scheduler token capacity, and speculative decode graph warmup no longer copies an expanded BlockTable mapping into a shorter proposer buffer. There is no API or configuration change.

### How was this patch tested?

- Added `test_compute_slot_mapping_draft_reserves_mtp_slots` in `tests/ut/worker/a2/test_block_table.py`.
- Added `test_slot_mapping_group_reserves_mtp_draft_slots` in `tests/ut/spec_decode/a2/test_eagle_proposer.py`.
- `ruff 0.14.0 check vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `ruff 0.14.0 format --check vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `python3 -m py_compile vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`

The targeted pytest and NPU serving matrix are left to CI/NPU validation because the local development host cannot execute the repository's torch/torch_npu tests.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
