### PR TITLE
[v0.23.0][BugFix][Worker] Reserve MTP draft slot mapping capacity

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1387,7 +1387,7 @@ class TestEagleProposerPropose:
             if model_type == 'deepseek':
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([11]))
                 assert captured_common_attn_metadata.max_seq_len == 9
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([138]), torch.full((8703,), -1)]))
+                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([138]), torch.full((9215,), -1)]))
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([11]))
                 assert captured_common_attn_metadata._seq_lens_cpu == torch.tensor([11])
                 assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([10, 1, 2, 3, 4, 5, 6, 7, 8] + [0]*(8704-9), dtype=torch.int64))
@@ -1396,14 +1396,14 @@ class TestEagleProposerPropose:
                 if flag_prefill_decode == 'prefill':
                     assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([15]))
                     assert captured_common_attn_metadata.max_seq_len == 13
-                    assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([142]), torch.full((8703,), -1)]))
+                    assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([142]), torch.full((9215,), -1)]))
                     assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([15]))
                     assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([14, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0]*(8704-13), dtype=torch.int64))
                     assert captured_common_attn_metadata.num_input_tokens == 13
                 if flag_prefill_decode == 'decode_and_prefill':
                     assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([19, 15, 15]))
                     assert captured_common_attn_metadata.max_seq_len == 0
-                    assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([146, 270, 398]), torch.full((8701,), -1)]))
+                    assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([146, 270, 398]), torch.full((9213,), -1)]))
                     assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([19, 15, 15]))
                     assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([18, 14, 14, 16, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
                                                                                               0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0]*(8704-30), dtype=torch.int64))
@@ -1440,17 +1440,17 @@ class TestEagleProposerPropose:
                     assert torch.equal(captured_common_attn_metadata.num_computed_tokens_cpu, torch.tensor([19, 15, 15]))
                     assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([20, 18, 18, 20, 13, 14, 15, 16, 13, 14, 15, 16, 8, 9, 10, 11, 12, 0, 1,
                                                                                             2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0]*(8704-30), dtype=torch.int64))
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([148, 274, 402]), torch.full((8701,), -1)]))
+                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([148, 274, 402]), torch.full((9213,), -1)]))
             if model_type == 'qwen_moe':
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([21, 19, 19]))
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([145, 272, 400]), torch.full((8701,), -1)]))
+                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([145, 272, 400]), torch.full((9213,), -1)]))
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([21, 19, 19]))
                 assert torch.equal(captured_common_attn_metadata.num_computed_tokens_cpu, torch.tensor([17, 15, 15]))
                 assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([17, 16, 16, 18, 13, 14, 15, 16, 13, 14, 15, 16, 8, 9, 10, 11, 12, 0, 1,
                                                                                           2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] + [0]*(8704-30), dtype=torch.int64))
             if model_type == 'deepseek':
                 assert torch.equal(captured_common_attn_metadata.seq_lens, torch.tensor([16, 15, 16]))
-                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([142, 268, 396]), torch.full((8701,), -1)]))
+                assert torch.equal(captured_common_attn_metadata.slot_mapping, torch.cat([torch.tensor([142, 268, 396]), torch.full((9213,), -1)]))
                 assert torch.equal(captured_common_attn_metadata.seq_lens_cpu, torch.tensor([16, 15, 16]))
                 assert torch.equal(captured_common_attn_metadata.num_computed_tokens_cpu, torch.tensor([12, 11, 12]))
                 assert torch.equal(captured_common_attn_metadata.positions, torch.tensor([14, 12, 12, 13, 9, 10, 11, 12, 10, 11, 12, 13, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9] + [0]*(8704-23), dtype=torch.int64))
@@ -1476,7 +1476,7 @@ class TestEagleProposerPropose:
                                                                                        266, 267, 268, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396]))
             assert torch.equal(self.proposer.slot_mapping_group[1][:3], torch.tensor([145, 269, 397]))
             assert torch.equal(self.proposer.slot_mapping_group[2][:3], torch.tensor([146, 270, 398]))
-            assert self.proposer.slot_mapping_group[0].shape == torch.Size([8704])
+            assert self.proposer.slot_mapping_group[0].shape == torch.Size([9216])
             assert torch.equal(self.proposer.seq_lens_group[0][:3], torch.tensor([17, 13, 13]))
             assert torch.equal(self.proposer.seq_lens_group[1][:3], torch.tensor([18, 14, 14]))
             assert torch.equal(self.proposer.seq_lens_group[2][:3], torch.tensor([19, 15, 15]))

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -44,7 +44,15 @@ class TestBlockTableComputeSlotMapping(TestBase):
         self.kernel_sizes = [128]
         self._skip_triton_kernel = True
 
-    def create_block_table(self, dcp_world_size, dcp_rank, pcp_world_size, pcp_rank, cp_kv_cache_interleave_size):
+    def create_block_table(
+        self,
+        dcp_world_size,
+        dcp_rank,
+        pcp_world_size,
+        pcp_rank,
+        cp_kv_cache_interleave_size,
+        num_speculative_tokens=0,
+    ):
         """Helper method to create BlockTable with mocked distributed groups"""
 
         with (
@@ -74,10 +82,34 @@ class TestBlockTableComputeSlotMapping(TestBase):
                 device=self.device,
                 kernel_sizes=self.kernel_sizes,
                 cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
-                num_speculative_tokens=0,
+                num_speculative_tokens=num_speculative_tokens,
             )
 
             return block_table
+
+    def test_compute_slot_mapping_draft_reserves_mtp_slots(self):
+        """MTP5 draft slots can exceed the graph-padding-only capacity."""
+        self.max_num_reqs = 12
+        self.max_num_batched_tokens = 80
+        block_table = self.create_block_table(
+            dcp_world_size=4,
+            dcp_rank=0,
+            pcp_world_size=1,
+            pcp_rank=0,
+            cp_kv_cache_interleave_size=1,
+            num_speculative_tokens=5,
+        )
+
+        num_active_reqs = 11
+        for req_idx in range(num_active_reqs):
+            block_table.add_row([req_idx], req_idx)
+
+        req_indices = np.repeat(np.arange(num_active_reqs, dtype=np.int32), 10)
+        positions = np.tile(np.arange(10, dtype=np.int64), num_active_reqs)
+        block_table.compute_slot_mapping_draft(req_indices, positions)
+
+        self.assertEqual(block_table.slot_mapping.cpu.numel(), 152)
+        self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
 
     def setup_block_table_data(self, block_table, num_reqs=2):
         """Helper method to populate block table with test data"""

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -241,7 +241,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample = torch.zeros(
             self.vllm_config.scheduler_config.max_num_batched_tokens, dtype=torch.int32, device=device
         )
-        slot_mapping_lens = self.runner.max_num_tokens + 2 * self.pcp_size * self.runner.max_num_reqs
+        metadata_lens = self.runner.max_num_tokens + 2 * self.pcp_size * self.runner.max_num_reqs
+        num_mtp_draft_slots = max(self.num_speculative_tokens - 1, 0) * self.runner.max_num_reqs
+        slot_mapping_lens = metadata_lens + num_mtp_draft_slots
         self.slot_mapping_group = [
             torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
@@ -249,11 +251,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         # dsv32 needs seq_lens and query_start_loc persistent tensors for full graph mode
         self.seq_lens_group = [
-            torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
+            torch.zeros(metadata_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
         ]
         self.query_start_loc_group = [
-            torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
+            torch.zeros(metadata_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
         ]
 

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -94,8 +94,12 @@ class BlockTable:
             duplicate_size += num_speculative_tokens
         self.block_table = self._make_buffer(max_num_reqs * duplicate_size, logical_table_size, dtype=torch.int32)
         self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
+        # MTP slot preparation appends up to num_speculative_tokens - 1
+        # draft positions for every request in addition to graph padding.
+        num_mtp_draft_slots = max(num_speculative_tokens - 1, 0) * self.max_num_reqs
         self.slot_mapping = self._make_buffer(
-            self.max_num_batched_tokens + 2 * self.pcp_world_size * self.max_num_reqs, dtype=torch.int32
+            self.max_num_batched_tokens + 2 * self.pcp_world_size * self.max_num_reqs + num_mtp_draft_slots,
+            dtype=torch.int32,
         )
 
         self.kernel_sizes = kernel_sizes


### PR DESCRIPTION
> [!NOTE]
> This PR is a cherry-pick of the main-branch fix in https://github.com/vllm-project/vllm-ascend/pull/14024.
> It was created with `git cherry-pick -x 6e83155b0a7b05dbc47df0fc9ba1d0efc7beda4b`; the release cherry-pick commit is `02b0c0a7d26eff4ab1c8865fae087f725ad42122`.
> Commit `7310f694d95a660d41471ee804660464594cae3f` is the v0.23 equivalent of the proposer synchronization now included in main PR #14024 as `31e2c40e3619dc9396fbe43dfd60221264d459c3`; it was prompted by this PR's CI.

### What this PR does / why we need it?

This PR backports the main-branch fix that reserves MTP draft slot mappings in `BlockTable` in addition to the existing graph/PCP-padding capacity.

With DCP and MTP enabled, slot preparation appends up to `num_speculative_tokens - 1` positions per active request. The existing v0.23 buffer only reserved `max_num_batched_tokens + 2 * pcp_world_size * max_num_reqs`, so an MTP5 batch could produce 110 slot mappings for a 104-element buffer and fail during the CPU assignment.

The cherry-pick conflict was limited to branch structure: v0.23 still carries PCP support in this class, while main has removed it. The resolution preserves the v0.23 PCP padding term and adds the same per-request MTP draft capacity from the main fix. A regression test covers the reported DCP4, PCP1, MTP5, `max_num_reqs=12`, 110-slot case.

### CI follow-up

The first CI run failed in `test_lora_with_spec_decode.py` during Eagle3 full-graph warmup:

```
RuntimeError: The size of tensor self [8200] must match the size of tensor src [8208].
```

`BlockTable.slot_mapping` had correctly grown to 8208, but `AscendSpecDecodeBaseProposer.slot_mapping_group` still used the old 8200-element formula. The follow-up applies the same `max(num_speculative_tokens - 1, 0) * max_num_reqs` allowance to the persistent proposer slot-mapping buffers. Step3.5's per-group buffers inherit the corrected capacity through `zeros_like`. Unrelated sequence-length, query-start, and block-table-clone buffers retain their existing sizes.

### Does this PR introduce _any_ user-facing change?

Yes. DCP serving with MTP no longer crashes when expanded draft slot mappings exceed the graph/PCP-padding-only capacity. Speculative decode graph warmup also no longer copies the expanded BlockTable slot mapping into a shorter proposer buffer. There is no API or configuration change.

### How was this patch tested?

- Added `test_compute_slot_mapping_draft_reserves_mtp_slots` in `tests/ut/worker/a2/test_block_table.py`.
- Updated `tests/ut/spec_decode/a2/test_eagle_proposer.py` to assert the proposer capacity includes MTP draft slots.
- `ruff 0.14.0 check vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `ruff 0.14.0 format --check vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `python3 -m py_compile vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`

The targeted pytest and NPU serving matrix are left to CI/NPU validation because the local development host cannot execute the repository's torch/torch_npu tests.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
