### PR TITLE
[CI][Misc] Add Daily Regression pipeline for high-frequency broken-window detection

### DIFF
--- a/.github/TEST_README.md
+++ b/.github/TEST_README.md
@@ -10,9 +10,42 @@ This document describes the CI workflows for `vllm-ascend`, how to add tests, an
 | `_selected_tests.yaml` | Called by `pr_test.yaml` | Runs tests selected by `select_tests.py` |
 | `_parse_trigger.yaml` | PR comment `/e2e` | Parses comment to run specific E2E tests |
 | `_pre_commit.yml` | Called by `pr_test.yaml` | Lint and format checks |
-| `schedule_nightly_test_a2.yaml` | Cron | Nightly E2E on A2 runners |
-| `schedule_nightly_test_a3.yaml` | Cron | Nightly E2E on A3 runners |
+| `nightly_image_build.yaml` | Cron (12:00 UTC) + dispatch | Builds `nightly-ci-main-{a2,a3,310p}` images; daily build/compile gate |
+| `schedule_daily_regression.yaml` | Cron (4x/day) + dispatch | High-freq regression: build gate + A2/A3 PR E2E smoke + nightly high-freq subset |
+| `_e2e_daily_tests.yaml` | Called by `schedule_daily_regression.yaml` | Checks out main HEAD, reinstalls, runs curated pytest subset |
+| `schedule_nightly_test_a2.yaml` | `workflow_dispatch` / `/nightly` | Full nightly E2E on A2 runners |
+| `schedule_nightly_test_a3.yaml` | `workflow_dispatch` / `/nightly` | Full nightly E2E on A3 runners |
 | `schedule_weekly_test_a3.yaml` | Cron | Weekly E2E on A3 runners |
+
+## Daily Regression Pipeline
+
+`schedule_daily_regression.yaml` runs **4x/day** during daytime (01:00, 04:00, 07:00,
+10:00 UTC = 09:00, 12:00, 15:00, 18:00 Beijing) to catch "broken window" regressions on
+`main` within ~3h. Each slot executes the **same curated fast subset** so any breakage is
+surfaced quickly and consistently. The 09:00 Beijing slot verifies the overnight nightly-ci
+image; the 18:00 Beijing slot ends before the 20:00 Beijing nightly image build.
+
+| Stage | Workflow / Job | Cadence | Budget |
+|-------|----------------|---------|--------|
+| Build / compile gate | `nightly_image_build.yaml` (scheduled) + `verify-image` job | 1x/day image build + per-slot smoke import | ~10 min |
+| A2 PR E2E smoke | `_e2e_daily_tests.yaml` (1-card subset) | 4x/day | ~42 min |
+| A3 PR E2E smoke | `_e2e_daily_tests.yaml` (two-card + four-card subsets) | 4x/day | ~28 min |
+| Nightly high-freq subset | `_e2e_daily_tests.yaml` (A2 + A3 nightly high-freq cases) | 4x/day | ~5 min |
+| Failure notification | `notify-failure` job (one tracking issue per day, deduplicated) | on failure | -- |
+
+The fast subset is defined in `.github/workflows/configs/daily_config.yaml` and resolved via the
+existing `resolve_nightly_tests.py --mode=matrix`. All jobs use the SAME lightweight executor
+(`_e2e_daily_tests.yaml`): checkout main HEAD → reinstall → pytest. Test selection is driven by
+the real `estimated_times` in `test_config.yaml` so every slot stays under 90 min (tests + ~20 min
+checkout+install+compile overhead).
+
+**To tune the subset:** edit `daily_config.yaml` -- append/trim `- name:` entries under
+`daily.a2_pr_e2e` / `daily.a3_pr_e2e_two_card` / `daily.a3_pr_e2e_four_card` /
+`daily.a2_nightly_hf` / `daily.a3_nightly_hf`. No workflow edit required.
+
+**Resource note:** A3 pool is constrained (max 5*16 NPUs). A3 matrices use `max-parallel: 2`
+to avoid starving the nightly/PR pool. Reduce cron frequency in `schedule_daily_regression.yaml`
+if A3 contention rises.
 
 ## Selective Testing System
 
@@ -24,13 +57,9 @@ PR changed files
     ▼
 test_config.yaml ──► resolve base inheritance ──► match modules ──► collect test paths
                                                                          │
-                                                                runner_mapping regex
-                                                                         │
-                                                               default partition
-                                                                         │
-                                                           pinned_routes (optional)
-                                                                         │
-                                                              partition runner_label
+                                                                Route by convention:
+                                                                 UT:  a2/, a2_2/, a3_2/, a3_4/, 310p/
+                                                                 E2E: one_card, two_card, four_card, *_310p.py
                                                                          │
                                                                 runner_label.json
                                                                          │
@@ -44,23 +73,6 @@ test_config.yaml ──► resolve base inheritance ──► match modules ─�
 | `.github/workflows/scripts/select_tests.py` | Matches changed files, scans tests, routes to runners |
 | `.github/workflows/scripts/test_config.yaml` | Maps source paths to UT/E2E tests |
 | `.github/workflows/scripts/runner_label.json` | Defines runner labels, chip types, NPU count, and image tags |
-
-`runner_mapping` maps test paths to default logical partitions such as
-`a3-2` or `a3-4`. After selection, skip filtering, and containment-aware
-deduplication, `pinned_routes` can move selected files into dedicated logical
-partitions without changing their technical directory structure. A file-level
-pin also applies when only one of its `::nodeid` targets is selected. If both a
-bare file and one of its nodeids are selected, the bare file wins to prevent
-duplicate execution. Each entry in `partition` selects an exact key from
-`runner_label.json` and sets the load-balanced group count.
-Logical partition names use display-ready labels such as `a3-2` and
-`a3-800i-2`; GitHub jobs render them as `a3-2 card-(part 1-3)` while the
-numeric `partition` value remains available for artifacts and load balancing.
-
-Workflows that temporarily reroute selected tests can use
-`--runner-label-override` with an exact label from `runner_label.json`. This
-override is applied after pinned routes, has the highest priority, and creates
-a transient single-shard partition for that invocation.
 
 ## `test_config.yaml` Tutorial
 

--- a/.github/workflows/_e2e_daily_tests.yaml
+++ b/.github/workflows/_e2e_daily_tests.yaml
@@ -1,0 +1,167 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (The "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# Daily E2E test executor -- tests main HEAD, NOT the baked image.
+#
+# Each scheduled slot must test the latest main HEAD so that regressions are
+# surfaced within ~3h (the inter-slot gap). To achieve this the executor:
+#   1. Starts from the prebuilt nightly-ci image (CANN + vllm + build deps).
+#   2. Checks out main HEAD into $GITHUB_WORKSPACE.
+#   3. Uninstalls the image's baked vllm-ascend and reinstalls from the
+#      checkout (editable, full compile -- NOT COMPILE_CUSTOM_KERNELS=0, which
+#      would skip all C extensions and break E2E on NPU).
+#   4. Runs the curated pytest subset from the checkout directory.
+#
+# Incremental cost vs. image-only mode: ~15-20 min (install+compile). Total
+# per-slot budget stays well under 90 min (~20min install + ~42min tests).
+
+name: 'Daily E2E tests'
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+        description: 'Self-hosted runner label (e.g. linux-aarch64-a2b3-1).'
+      image:
+        required: true
+        type: string
+        description: 'Prebuilt nightly-ci image (provides CANN + vllm + build deps).'
+      tests:
+        required: true
+        type: string
+        description: 'Space-separated pytest paths/files to run against main HEAD.'
+      name:
+        required: false
+        type: string
+        default: ''
+        description: 'Display name used in the job name and log artifact.'
+      vllm_ascend_branch:
+        required: false
+        type: string
+        default: 'main'
+        description: 'Branch/ref to checkout and test (default: main).'
+      timeout_minutes:
+        required: false
+        type: string
+        default: '60'
+        description: 'Per-job hard timeout. Default 60 min guards the 90 min daily budget.'
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be
+# explicitly declared as "shell: bash -el {0}" on steps that need to be
+# properly activated. It activates the ascend-toolkit environment variables.
+defaults:
+  run:
+    shell: bash -el {0}
+
+jobs:
+  daily-e2e:
+    name: ${{ inputs.name || inputs.tests }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
+    container:
+      image: ${{ inputs.image }}
+      env:
+        HF_HUB_OFFLINE: 1
+        VLLM_USE_MODELSCOPE: True
+        VLLM_LOGGING_LEVEL: ERROR
+        VLLM_WORKER_MULTIPROC_METHOD: spawn
+        VLLM_CI_RUNNER: ${{ inputs.runner }}
+    steps:
+      - name: Check NPU and CANN info
+        run: |
+          npu-smi info || true
+          cat /usr/local/Ascend/ascend-toolkit/latest/"$(uname -i)"-linux/ascend_toolkit_install.info || true
+
+      - name: Show image-baked vLLM version
+        working-directory: /vllm-workspace
+        run: |
+          . /usr/local/Ascend/ascend-toolkit/set_env.sh || true
+          echo "=== Image-baked vLLM packages ==="
+          pip list | grep -i vllm || echo "No vllm packages found."
+
+      - name: Checkout main HEAD
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.vllm_ascend_branch }}
+          fetch-depth: 1
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set MAX_JOBS and SOC_VERSION based on runner
+        run: |
+          CARDS=$(echo "${{ inputs.runner }}" | grep -oE '[0-9]+$')
+          echo "MAX_JOBS=$((CARDS * 23))" >> $GITHUB_ENV
+          # Set SOC_VERSION if not already set by the image (setup.py:141-154
+          # calls npu-smi to auto-detect chip type, which can fail in containers
+          # without device access -- e.g. when pip install runs in the metadata
+          # phase before any NPU init). The nightly-ci base image sets it via
+          # Dockerfile ENV, but guard against missing env here.
+          if [ -z "${SOC_VERSION:-}" ]; then
+            RUNNER="${{ inputs.runner }}"
+            if echo "$RUNNER" | grep -q "a2b3"; then
+              echo "SOC_VERSION=ascend910b1" >> $GITHUB_ENV
+            elif echo "$RUNNER" | grep -q "a3-"; then
+              echo "SOC_VERSION=ascend910_9391" >> $GITHUB_ENV
+            elif echo "$RUNNER" | grep -q "310p"; then
+              echo "SOC_VERSION=ascend310p1" >> $GITHUB_ENV
+            fi
+            echo "SOC_VERSION was not set in image, auto-detected: ${SOC_VERSION}"
+          fi
+
+      - name: Install vllm-ascend from main HEAD
+        working-directory: ${{ github.workspace }}
+        run: |
+          . /usr/local/Ascend/ascend-toolkit/set_env.sh || true
+          echo "=== Uninstalling image-baked vllm-ascend ==="
+          pip uninstall -y vllm-ascend 2>/dev/null || true
+          echo "=== Installing from checkout (main HEAD, full compile) ==="
+          # Normal compile (NOT COMPILE_CUSTOM_KERNELS=0) -- the nightly-ci image
+          # has cmake/pybind11/CANN build deps. COMPILE_CUSTOM_KERNELS=0 would skip
+          # all C extensions (setup.py:434 ext_modules=[]), leaving vllm_ascend_C.so
+          # missing and causing E2E failures on NPU (see worker.py:110 warning).
+          pip install -e . --no-build-isolation 2>&1 | tee /tmp/install.log
+          echo "=== Verify C extension ==="
+          python3 -c "import vllm_ascend.vllm_ascend_C; print('vllm_ascend_C OK')"
+          echo "=== main HEAD under test ==="
+          git log -1 --format='%H %s'
+
+      - name: Run pytest subset
+        working-directory: ${{ github.workspace }}
+        env:
+          DAILY_TESTS: ${{ inputs.tests }}
+        run: |
+          . /usr/local/Ascend/ascend-toolkit/set_env.sh || true
+          export LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH:-}
+          mkdir -p /tmp/test-logs
+          set -o pipefail
+          echo "Running pytest subset against main HEAD:"
+          printf '  %s\n' $DAILY_TESTS
+          pytest -sv $DAILY_TESTS 2>&1 | tee /tmp/test-logs/pytest.log
+
+      - name: Upload test logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: daily-logs-${{ inputs.name }}
+          path: /tmp/test-logs/
+          if-no-files-found: ignore
+          retention-days: 7
+          compression-level: 0

--- a/.github/workflows/configs/daily_config.yaml
+++ b/.github/workflows/configs/daily_config.yaml
@@ -1,0 +1,64 @@
+# Single source of truth for the Daily Regression pipeline (schedule_daily_regression.yaml).
+#
+# Goal: high-frequency "broken window" detection on main. Each scheduled run
+# executes the SAME fast subset so any breakage is surfaced within ~3h.
+# All tests are pytest paths curated from tests/e2e/pull_request/ (PR E2E
+# smoke) and tests/e2e/nightly/single_node/ops/ (nightly high-freq subset).
+# Durations are taken from the real `estimated_times` in test_config.yaml so
+# every slot stays well under 90 min (tests + ~20 min checkout+install+compile overhead).
+#
+# -- Maintenance model --------------------------------------------------
+# This file is a LIVING config maintained by build engineers. The test
+# selection is NOT fixed -- it should be regularly refreshed based on:
+#   1. Recent high-frequency failure cases (regression-prone tests that
+#      break repeatedly on main should be promoted here for tight gating).
+#   2. Hot-path coverage of actively-developed modules (attention, ops,
+#      distributed, spec-decode, quant, MoE routing).
+#   3. Per-slot runtime budget (<90 min). Trim when a slot overruns; the
+#      `estimated_times` in test_config.yaml are the source of truth.
+#
+# Cadence: review biweekly (or after any major regression) and trim/append
+# entries below. Adding a `- name:` entry automatically adds a matrix job
+# in the next daily run -- no workflow edit needed.
+# -----------------------------------------------------------------------
+
+daily:
+  # --- A2: PR E2E one-card smoke (pytest-driven, runs on a2b3-1) ---
+  # One representative example: attention/fa3 core hot-path.
+  a2_pr_e2e:
+    - name: a2-one-card-smoke
+      os: linux-aarch64-a2b3-1
+      tests: >-
+        tests/e2e/pull_request/one_card/test_attention_fa3.py
+
+  # --- A3: PR E2E two-card smoke (pytest-driven, runs on a3-2) ---
+  # One representative example: flashcomm distributed correctness.
+  a3_pr_e2e_two_card:
+    - name: a3-two-card-smoke
+      os: linux-aarch64-a3-2
+      tests: >-
+        tests/e2e/pull_request/two_card/test_flashcomm_distributed.py
+
+  # --- A3: PR E2E four-card smoke (pytest-driven, runs on a3-4) ---
+  # One representative example: DP-TP2 distributed correctness.
+  a3_pr_e2e_four_card:
+    - name: a3-four-card-smoke
+      os: linux-aarch64-a3-4
+      tests: >-
+        tests/e2e/pull_request/four_card/test_data_parallel_tp2.py
+
+  # --- A2: nightly high-freq subset (pytest-driven, runs on a2b3-1) ---
+  # One representative example: fused_moe (singlecard ops).
+  a2_nightly_hf:
+    - name: a2-nightly-hf
+      os: linux-aarch64-a2b3-1
+      tests: >-
+        tests/e2e/nightly/single_node/ops/singlecard_ops/test_fused_moe.py
+
+  # --- A3: nightly high-freq subset (pytest-driven, runs on a3-2) ---
+  # One representative example: dispatch_ffn_combine (FP path).
+  a3_nightly_hf:
+    # - name: a3-nightly-hf
+    #   os: linux-aarch64-a3-2
+    #   tests: >-
+    #     tests/e2e/nightly/single_node/ops/multicard_ops_a3/test_dispatch_ffn_combine.py

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -18,9 +18,20 @@
 # This workflow builds nightly images as a layer-cache warm-up at 20:00 Beijing time.
 # The nightly test workflows (Nightly-A2, Nightly-A3) each rebuild the image fresh
 # before running tests, so this schedule only serves to pre-populate the build cache.
+#
+# The scheduled run (12:00 UTC = 20:00 Beijing) also acts as the Daily Regression
+# pipeline's build/compile gate: a successful build produces fresh
+# nightly-ci-main-{a2,a3,310p} images that schedule_daily_regression.yaml reuses
+# for high-frequency PR E2E + nightly high-freq testing (no inline rebuild).
 name: Nightly Image Build Schedule
 
 on:
+  schedule:
+    # 12:00 UTC = 20:00 Beijing time. Build finishes ~14:00 UTC (22:00 Beijing).
+    # The fresh nightly-ci image is then available for the next morning's Daily
+    # Regression slot (01:00 UTC = 09:00 Beijing). A failed build here surfaces
+    # as a broken compile on main within the day.
+    - cron: '0 12 * * *'
   workflow_dispatch:
     inputs:
       vllm_ascend_branch:

--- a/.github/workflows/schedule_daily_regression.yaml
+++ b/.github/workflows/schedule_daily_regression.yaml
@@ -1,0 +1,362 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (The "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# Daily Regression pipeline -- high-frequency "broken window" detection on main.
+#
+# Runs 4x/day during daytime (Beijing 09:00/12:00/15:00/18:00) to cover the
+# PR-merge peak window (09:00-20:00 Beijing). Each slot executes the SAME
+# curated fast subset defined in .github/workflows/configs/daily_config.yaml
+# so any breakage on main is surfaced within ~3h. Per-slot runtime < 90 min.
+#
+# The 09:00 Beijing (01:00 UTC) morning slot verifies the overnight nightly-ci
+# image (built at 20:00 Beijing / 12:00 UTC the night before) and surfaces any
+# regression introduced by the nightly build. The 18:00 Beijing (10:00 UTC)
+# slot ends by ~19:30 Beijing, leaving the 20:00 Beijing nightly image build
+# slot clear.
+#
+# Coverage per slot (all jobs test main HEAD via _e2e_daily_tests.yaml):
+#   - Build/compile gate: verify-image pulls the nightly-ci image and smoke-
+#     imports vllm_ascend + vllm + custom ops. The image itself is rebuilt daily
+#     by the scheduled nightly_image_build.yaml (compile gate).
+#   - PR E2E: A2 one_card + A3 two_card/four_card curated smoke subsets.
+#   - Nightly high-freq subset: curated high-frequency failure cases from
+#     tests/e2e/nightly/single_node/ops/ (A2 + A3, as pytest paths).
+#
+# All test jobs use the SAME lightweight executor (_e2e_daily_tests.yaml):
+# checkout main HEAD -> reinstall -> pytest. No nightly executor, no aisbench,
+# no AOP hooks, no config_file_path -- daily is self-contained.
+#
+# On failure a tracking GitHub issue is opened (one per day, deduplicated) and
+# the Actions run status is red -- combining the two for fast triage.
+
+name: Daily
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+    branches:
+      - 'main'
+      - '*-dev'
+      - 'releases/v*'
+  schedule:
+    # 01:00, 04:00, 07:00, 10:00 UTC = 09:00, 12:00, 15:00, 18:00 Beijing.
+    # 4 runs/day during the PR-merge peak window (09:00-20:00 Beijing), every 3h.
+    # The 09:00 Beijing (01:00 UTC) slot uses the overnight nightly-ci image
+    # (built at 12:00 UTC = 20:00 Beijing the night before). The 18:00 Beijing
+    # (10:00 UTC) slot ends by ~19:10 Beijing, clear of the 20:00 nightly build.
+    #
+    # Timing note: the 10:00 UTC slot's worst-case timeout is 85min (ends 11:25
+    # UTC), leaving a 35min gap before the 12:00 UTC nightly image build. In
+    # practice the slot runs ~72min (ends 11:12 UTC, 48min gap). Even if they
+    # overlap, daily tests use NPU runners while nightly_image_build uses ARM
+    # CPU runners -- no resource contention.
+    - cron: '0 1,4,7,10 * * *'
+  workflow_dispatch:
+    inputs:
+      skip_notify:
+        description: 'Skip opening a tracking issue on failure (useful for manual dry-runs)'
+        required: false
+        default: 'false'
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+  actions: read
+
+# Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be
+# explicitly declared as "shell: bash -el {0}" to activate ascend-toolkit env.
+defaults:
+  run:
+    shell: bash -el {0}
+
+# Cancel a still-running previous slot -- slots are 3h apart and each is <90min,
+# so overlap only happens on a stuck run; cancelling it keeps feedback fast.
+concurrency:
+  group: daily-regression-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Prebuilt images produced by nightly_image_build.yaml (scheduled at 12:00 UTC).
+  A2_IMAGE: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-main-a2'
+  A3_IMAGE: 'swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend:nightly-ci-main-a3'
+  DAILY_CONFIG: '.github/workflows/configs/daily_config.yaml'
+
+jobs:
+  setup-vars:
+    name: Resolve daily test matrix
+    runs-on: linux-aarch64-a2b3-0
+    outputs:
+      a2_image: ${{ steps.export.outputs.a2_image }}
+      a3_image: ${{ steps.export.outputs.a3_image }}
+      a2_pr_e2e: ${{ steps.set-matrix.outputs.a2_pr_e2e }}
+      a3_pr_e2e_two_card: ${{ steps.set-matrix.outputs.a3_pr_e2e_two_card }}
+      a3_pr_e2e_four_card: ${{ steps.set-matrix.outputs.a3_pr_e2e_four_card }}
+      a2_nightly_hf: ${{ steps.set-matrix.outputs.a2_nightly_hf }}
+      a3_nightly_hf: ${{ steps.set-matrix.outputs.a3_nightly_hf }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Export image refs
+        id: export
+        run: |
+          {
+            echo "a2_image=${{ env.A2_IMAGE }}"
+            echo "a3_image=${{ env.A3_IMAGE }}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Read daily test matrix config
+        id: set-matrix
+        env:
+          MATRIX_FILE: ${{ env.DAILY_CONFIG }}
+          MATRIX_OUTPUTS: '{"a2_pr_e2e":"daily.a2_pr_e2e","a3_pr_e2e_two_card":"daily.a3_pr_e2e_two_card","a3_pr_e2e_four_card":"daily.a3_pr_e2e_four_card","a2_nightly_hf":"daily.a2_nightly_hf","a3_nightly_hf":"daily.a3_nightly_hf"}'
+        run: |
+          python3 -m pip install pyyaml -q
+          python3 .github/workflows/scripts/resolve_nightly_tests.py --mode=matrix
+
+  verify-image:
+    name: Verify nightly-ci image (build gate)
+    needs: [setup-vars]
+    runs-on: linux-aarch64-a2b3-1
+    timeout-minutes: 10
+    container:
+      image: ${{ needs.setup-vars.outputs.a2_image }}
+    steps:
+      - name: Smoke import vllm-ascend and vllm
+        run: |
+          . /usr/local/Ascend/ascend-toolkit/set_env.sh || true
+          python3 -c "import vllm_ascend, vllm; print('import OK ->', vllm_ascend.__file__)"
+      - name: Verify custom ops loadable
+        run: |
+          . /usr/local/Ascend/ascend-toolkit/set_env.sh || true
+          python3 -c "import vllm_ascend.vllm_ascend_C; print('custom ops OK -> vllm_ascend_C loaded')"
+      - name: Report image build provenance
+        run: |
+          echo "Image: ${{ needs.setup-vars.outputs.a2_image }}"
+          echo "=== vllm-ascend ==="
+          (cd /vllm-workspace/vllm-ascend && git log -1 --format='%H %s' 2>/dev/null) || echo "(no git info)"
+          echo "=== vllm ==="
+          (cd /vllm-workspace/vllm && git log -1 --format='%H %s' 2>/dev/null) || echo "(no git info)"
+
+  a2-pr-e2e:
+    name: A2 one-card PR E2E
+    needs: [setup-vars, verify-image]
+    if: always() && needs.verify-image.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        test_config: ${{ fromJson(needs.setup-vars.outputs.a2_pr_e2e) }}
+    uses: ./.github/workflows/_e2e_daily_tests.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      image: ${{ needs.setup-vars.outputs.a2_image }}
+      tests: ${{ matrix.test_config.tests }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_branch: main
+      timeout_minutes: '75'
+
+  a3-pr-e2e-two-card:
+    name: A3 two-card PR E2E
+    needs: [setup-vars, verify-image]
+    if: always() && needs.verify-image.result == 'success'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        test_config: ${{ fromJson(needs.setup-vars.outputs.a3_pr_e2e_two_card) }}
+    uses: ./.github/workflows/_e2e_daily_tests.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      image: ${{ needs.setup-vars.outputs.a3_image }}
+      tests: ${{ matrix.test_config.tests }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_branch: main
+      timeout_minutes: '60'
+
+  a3-pr-e2e-four-card:
+    name: A3 four-card PR E2E
+    needs: [setup-vars, verify-image]
+    if: always() && needs.verify-image.result == 'success'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        test_config: ${{ fromJson(needs.setup-vars.outputs.a3_pr_e2e_four_card) }}
+    uses: ./.github/workflows/_e2e_daily_tests.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      image: ${{ needs.setup-vars.outputs.a3_image }}
+      tests: ${{ matrix.test_config.tests }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_branch: main
+      timeout_minutes: '60'
+
+  a2-nightly-hf:
+    name: A2 nightly high-freq
+    needs: [setup-vars, verify-image]
+    if: always() && needs.verify-image.result == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        test_config: ${{ fromJson(needs.setup-vars.outputs.a2_nightly_hf) }}
+    uses: ./.github/workflows/_e2e_daily_tests.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      image: ${{ needs.setup-vars.outputs.a2_image }}
+      tests: ${{ matrix.test_config.tests }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_branch: main
+      timeout_minutes: '45'
+
+  a3-nightly-hf:
+    name: A3 nightly high-freq
+    needs: [setup-vars, verify-image]
+    if: always() && needs.verify-image.result == 'success'
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        test_config: ${{ fromJson(needs.setup-vars.outputs.a3_nightly_hf) }}
+    uses: ./.github/workflows/_e2e_daily_tests.yaml
+    with:
+      runner: ${{ matrix.test_config.os }}
+      image: ${{ needs.setup-vars.outputs.a3_image }}
+      tests: ${{ matrix.test_config.tests }}
+      name: ${{ matrix.test_config.name }}
+      vllm_ascend_branch: main
+      timeout_minutes: '45'
+
+  daily-gate:
+    name: Daily gate
+    needs:
+      - verify-image
+      - a2-pr-e2e
+      - a3-pr-e2e-two-card
+      - a3-pr-e2e-four-card
+      - a2-nightly-hf
+      - a3-nightly-hf
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate job results
+        env:
+          VERIFY: ${{ needs.verify-image.result }}
+          A2_PR: ${{ needs.a2-pr-e2e.result }}
+          A3_TWO: ${{ needs.a3-pr-e2e-two-card.result }}
+          A3_FOUR: ${{ needs.a3-pr-e2e-four-card.result }}
+          A2_HF: ${{ needs.a2-nightly-hf.result }}
+          A3_HF: ${{ needs.a3-nightly-hf.result }}
+        run: |
+          echo "=== Daily Gate Summary ==="
+          printf 'verify-image:          %s\n' "$VERIFY"
+          printf 'a2-pr-e2e:             %s\n' "$A2_PR"
+          printf 'a3-pr-e2e-two-card:    %s\n' "$A3_TWO"
+          printf 'a3-pr-e2e-four-card:   %s\n' "$A3_FOUR"
+          printf 'a2-nightly-hf:         %s\n' "$A2_HF"
+          printf 'a3-nightly-hf:         %s\n' "$A3_HF"
+          echo "========================="
+
+          # Build gate is mandatory -- a broken/missing image is a hard fail.
+          if [ "$VERIFY" != "success" ]; then
+            echo "::error::verify-image (build gate) did not succeed (result: $VERIFY)"
+            exit 1
+          fi
+
+          # Any non-skipped test job that did not succeed is a regression.
+          for r in "$A2_PR" "$A3_TWO" "$A3_FOUR" "$A2_HF" "$A3_HF"; do
+            if [ "$r" != "success" ] && [ "$r" != "skipped" ]; then
+              echo "::error::test job failed (result: $r)"
+              exit 1
+            fi
+          done
+
+          echo "=== Daily Gate: PASSED ==="
+
+  notify-failure:
+    name: Open tracking issue on failure
+    needs: [daily-gate]
+    if: >-
+      always() &&
+      needs.daily-gate.result == 'failure' &&
+      github.event_name != 'pull_request' &&
+      !(github.event_name == 'workflow_dispatch' && inputs.skip_notify == 'true')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Open or update daily tracking issue
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          TITLE="Daily Regression Failure ($DATE)"
+          LABEL="daily-regression-failure"
+
+          # Ensure the label exists (idempotent). Keep stderr visible for
+          # diagnostics (e.g. permission errors) but don't fail the step if the
+          # label already exists.
+          gh label create "$LABEL" --color B60205 --description "Daily regression pipeline failure" || true
+
+          # Find an open tracking issue for today (dedup -- one issue per day).
+          ISSUE_NUMBER=$(gh issue list \
+            --label "$LABEL" \
+            --state open \
+            --search "in:title $TITLE" \
+            --json number,title \
+            --jq ".[] | select(.title==\"$TITLE\") | .number" | head -n1 || true)
+
+          BODY="## Daily Regression Failure
+
+          - **Date (UTC):** $DATE
+          - **Run:** [$RUN_URL]($RUN_URL)
+          - **Trigger:** ${{ github.event_name }}
+
+          ### What to do
+
+          1. Open the run link above and locate the first failing job.
+          2. If \`verify-image\` failed -> the nightly-ci image build is broken; check [Nightly Image Build Schedule](../actions/workflows/nightly_image_build.yaml).
+          3. If a test job failed -> fetch its \`daily-logs-*\` artifact and triage the pytest log.
+          4. Comment with the root cause and link the fixing PR; close this issue once main is green again on the next daily slot.
+
+          _This issue is auto-generated by the Daily-Regression workflow. It will not be recreated for the same day._
+          "
+
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "Appending comment to existing issue #$ISSUE_NUMBER"
+            gh issue comment "$ISSUE_NUMBER" --body "### Slot $(date -u +%H:%M) UTC also failed
+
+          - Run: $RUN_URL
+
+          $BODY"
+          else
+            echo "Creating new tracking issue: $TITLE"
+            gh issue create --title "$TITLE" --body "$BODY" --label "$LABEL"
+          fi


### PR DESCRIPTION
### What this PR does / why we need it?

vllm-ascend's CI is tiered as PR CI -> Nightly -> Weekly, but `main` lacks **high-frequency daytime regression** coverage: a regression introduced after a PR merge may take up to ~24h to surface (until the next nightly). This PR adds a **Daily Regression pipeline** that runs 4x/day during daytime (09:00/12:00/15:00/18:00 Beijing) to catch "broken window" regressions on `main` within ~3h.

**Key design:**
- Each slot tests `main` HEAD (checkout + full compile + pytest), NOT the baked nightly-ci image -- critical for the ~3h detection goal
- All test jobs use a single lightweight executor (`_e2e_daily_tests.yaml`): checkout main HEAD -> reinstall -> pytest. Self-contained, no nightly executor / aisbench / AOP hooks
- Test list curated in `daily_config.yaml` (single source of truth) from `tests/e2e/pull_request/` (PR E2E smoke) + `tests/e2e/nightly/single_node/ops/` (nightly high-freq subset)
- `verify-image` build gate: smoke import vllm_ascend + vllm + custom ops (`vllm_ascend_C`)
- `notify-failure`: auto-open tracking issue (deduplicated per day) with run link + triage guidance

**Files:**
- `schedule_daily_regression.yaml` (new) -- main workflow: cron trigger, matrix generation, 5 test jobs, verify-image gate, daily-gate, notify-failure
- `_e2e_daily_tests.yaml` (new) -- lightweight executor: checkout main HEAD -> full compile reinstall -> pytest -> upload logs
- `configs/daily_config.yaml` (new) -- test matrix single source of truth (a3_nightly_hf temporarily commented out pending a3-2 verification)
- `nightly_image_build.yaml` (modified) -- add schedule cron `0 12 * * *` (20:00 Beijing daily build of nightly-ci image) as the Daily pipeline's build/compile gate
- `TEST_README.md` (modified) -- document Daily pipeline in CI overview

Closes #13953

### Does this PR introduce _any_ user-facing change?

No. This is a CI-only change. No user-facing API, CLI, or behavior changes.

### How was this patch tested?

- **Static verification**: YAML syntax (PyYAML), actionlint, matrix resolution (`resolve_nightly_tests.py --mode=matrix`), job dependency graph, reusable workflow refs, test path existence, non-ASCII / trailing-whitespace checks -- all pass
- **Fork dry-run** ([run 31592952346](https://github.com/winson-00178005/vllm-benchmarks/actions/runs/31592952346)): 5/5 jobs PASS on `ubuntu-latest` (YAML syntax, test paths, matrix resolution, gate aggregation)
- **NPU verify-image gate** ([run 31699959737](https://github.com/vllm-project/vllm-ascend/actions/runs/31699959737) via test PR [#14230](https://github.com/vllm-project/vllm-ascend/pull/14230)): smoke import + custom ops `vllm_ascend_C` loadable on `linux-aarch64-a2b3-1`
- **PR-level Daily run**: `pull_request` trigger added (matching [#14458](https://github.com/vllm-project/vllm-ascend/pull/14458)) to run the full Daily pipeline on PR; matrix resolution passed, downstream jobs queued for NPU runner

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3