### PR TITLE
[BugFix][LoRA][MoE] Handle rank-wide packed expand slices (replaces #13493)

### DIFF
--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -1,4 +1,5 @@
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from vllm_ascend.lora.fused_moe import (
     moe_lora_apply_w2,
     moe_lora_apply_w13,
 )
+from vllm_ascend.lora.lora_ops import bmm_expand_slice
 from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
 
 
@@ -121,3 +123,101 @@ def test_decode_metadata_refreshes_no_lora(index_mapping, expected_no_lora) -> N
     with patch.object(PunicaWrapperBase, "update_metadata"):
         wrapper.update_metadata(mapping, [], 2, 100)
     assert wrapper.no_lora is expected_no_lora
+
+
+@pytest.mark.parametrize(
+    ("rank", "slice_size", "expect_fallback"),
+    [(4, 8, False), (16, 8, True)],
+)
+def test_expand_slice_selects_fallback_from_tensor_shape(
+    rank: int,
+    slice_size: int,
+    expect_fallback: bool,
+) -> None:
+    wrapper: Any = SimpleNamespace(
+        no_lora=False,
+        _bmm_expand_slice=Mock(),
+        sgmv_expand_slice=Mock(),
+        prefill_metadata=("batches", "tokens", "indices"),
+    )
+    wrapper._requires_bmm_expand_slice = MethodType(PunicaWrapperNPU._requires_bmm_expand_slice, wrapper)
+    x = SimpleNamespace(shape=(2, rank))
+
+    PunicaWrapperNPU._expand_slice_prefill(
+        wrapper,
+        "y",
+        x,
+        "weights",
+        4,
+        slice_size,
+        True,
+    )
+
+    if expect_fallback:
+        wrapper._bmm_expand_slice.assert_called_once_with("y", x, "weights", 4, slice_size, True)
+        wrapper.sgmv_expand_slice.assert_not_called()
+    else:
+        wrapper._bmm_expand_slice.assert_not_called()
+        wrapper.sgmv_expand_slice.assert_called_once_with(
+            x,
+            "weights",
+            "y",
+            "batches",
+            "tokens",
+            "indices",
+            4,
+            slice_size,
+            True,
+        )
+
+
+@pytest.mark.parametrize("add_inputs", [False, True])
+def test_lora_bmm_expand_slice_fallback_matches_reference(add_inputs: bool) -> None:
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    weights = torch.tensor(
+        [
+            [[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]],
+            [[[2.0, 0.0], [0.0, 2.0], [1.0, -1.0]]],
+        ]
+    )
+    indices = torch.tensor([0, 1, -1], dtype=torch.long)
+    y = torch.ones((3, 5))
+
+    bmm_expand_slice(x, weights, y, indices, 1, 3, add_inputs)
+
+    delta = torch.stack(
+        [
+            x[0] @ weights[0, 0].T,
+            x[1] @ weights[1, 0].T,
+            torch.zeros(3),
+        ]
+    )
+    expected = torch.ones((3, 5))
+    expected[:, 1:4] = expected[:, 1:4] + delta if add_inputs else delta
+    torch.testing.assert_close(y, expected)
+
+
+@pytest.mark.parametrize(
+    ("x_shape", "weight_shape", "indices_shape", "y_shape", "slice_size", "message"),
+    [
+        ((3, 4), (2, 1, 5, 2), (3,), (3, 8), 5, "shrink rank"),
+        ((3, 2), (2, 1, 5, 2), (2,), (3, 8), 5, "same row count"),
+        ((3, 2), (2, 1, 5, 2), (3,), (2, 8), 5, "same row count"),
+        ((3, 2), (2, 1, 4, 2), (3,), (3, 8), 5, "destination slice"),
+    ],
+)
+def test_lora_bmm_expand_slice_rejects_incompatible_shapes(
+    x_shape,
+    weight_shape,
+    indices_shape,
+    y_shape,
+    slice_size,
+    message,
+) -> None:
+    x = torch.zeros(x_shape)
+    weights = torch.zeros(weight_shape)
+    indices = torch.zeros(indices_shape, dtype=torch.long)
+    y = torch.zeros(y_shape)
+
+    with pytest.raises(ValueError, match=message):
+        bmm_expand_slice(x, weights, y, indices, 1, slice_size, True)

--- a/vllm_ascend/lora/lora_ops.py
+++ b/vllm_ascend/lora/lora_ops.py
@@ -16,6 +16,99 @@
 import torch
 
 
+@torch.library.custom_op("vllm_ascend::lora_bmm_expand_slice", mutates_args={"output_tensor"})
+def _bmm_expand_slice_op(
+    output_tensor: torch.Tensor,
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool,
+) -> None:
+    if inputs.ndim != 2:
+        raise ValueError(f"Expected 2D LoRA shrink input, got shape {tuple(inputs.shape)}")
+    if output_tensor.ndim != 2:
+        raise ValueError(f"Expected 2D LoRA output, got shape {tuple(output_tensor.shape)}")
+    if lora_b_weights.ndim != 4 or lora_b_weights.shape[1] != 1:
+        raise ValueError(f"Expected LoRA-B shape [slots, 1, output_size, rank], got {tuple(lora_b_weights.shape)}")
+    if lora_indices_tensor.ndim != 1 or lora_indices_tensor.shape[0] != inputs.shape[0]:
+        raise ValueError(
+            "LoRA indices and shrink input must have the same row count, "
+            f"got indices={tuple(lora_indices_tensor.shape)} and inputs={tuple(inputs.shape)}"
+        )
+    if output_tensor.shape[0] != inputs.shape[0]:
+        raise ValueError(
+            "LoRA output and shrink input must have the same row count, "
+            f"got output={tuple(output_tensor.shape)} and inputs={tuple(inputs.shape)}"
+        )
+    if inputs.shape[-1] != lora_b_weights.shape[-1]:
+        raise ValueError(
+            "LoRA shrink rank must match LoRA-B input rank, "
+            f"got input rank={inputs.shape[-1]} and LoRA-B rank={lora_b_weights.shape[-1]}"
+        )
+    if lora_b_weights.shape[-2] != slice_size:
+        raise ValueError(
+            "LoRA-B output size must match the destination slice, "
+            f"got LoRA-B output={lora_b_weights.shape[-2]} and slice={slice_size}"
+        )
+    if slice_offset < 0 or slice_offset + slice_size > output_tensor.shape[-1]:
+        raise ValueError(
+            "LoRA destination slice is outside the output tensor, "
+            f"got offset={slice_offset}, size={slice_size}, output={output_tensor.shape[-1]}"
+        )
+
+    safe_indices = lora_indices_tensor.clamp(min=0).to(torch.long)
+    gathered_weights = lora_b_weights[safe_indices, 0].to(output_tensor.dtype)
+    if inputs.shape[0] == 0 or gathered_weights.shape[1] == 0:
+        return
+
+    delta = torch.bmm(gathered_weights, inputs.to(output_tensor.dtype).unsqueeze(-1)).squeeze(-1)
+    delta = torch.where(
+        (lora_indices_tensor >= 0).unsqueeze(-1),
+        delta,
+        torch.zeros_like(delta),
+    )
+    output_slice = output_tensor.narrow(1, slice_offset, slice_size)
+    if add_inputs:
+        output_slice.add_(delta)
+    else:
+        output_slice.copy_(delta)
+
+
+@_bmm_expand_slice_op.register_fake
+def _bmm_expand_slice_fake(
+    output_tensor: torch.Tensor,
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool,
+) -> None:
+    return None
+
+
+def bmm_expand_slice(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = True,
+) -> None:
+    _bmm_expand_slice_op(
+        output_tensor,
+        inputs,
+        lora_b_weights,
+        lora_indices_tensor,
+        slice_offset,
+        slice_size,
+        add_inputs,
+    )
+
+
 def bgmv_shrink(
     inputs: torch.Tensor,
     lora_a_weights: torch.Tensor,

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import torch
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
+from vllm_ascend.lora.lora_ops import bmm_expand_slice
 from vllm_ascend.lora.utils import refresh_all_lora_classes
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -67,6 +68,10 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         # PunicaWrapperBase computes this only for prefill. Decode must also
         # choose between the active-LoRA and base-only quantized MoE paths.
         self.no_lora = not any(lora_id > 0 for lora_id in mapping.index_mapping)
+
+    def _requires_bmm_expand_slice(self, x: torch.Tensor, y_slice_size: int) -> bool:
+        # Fused expand requires rank <= output slice size.
+        return x.shape[-1] > y_slice_size
 
     def _shrink_prefill(
         self,
@@ -134,6 +139,9 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         # No LoRA request, so return directly
         if self.no_lora:
             return
+        if self._requires_bmm_expand_slice(x, y_slice_size):
+            self._bmm_expand_slice(y, x, w_t_all, y_offset, y_slice_size, add_inputs)
+            return
         self.sgmv_expand_slice(
             x,
             w_t_all,
@@ -153,7 +161,30 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         y_slice_size: int,
         add_inputs: bool,
     ):
+        if self._requires_bmm_expand_slice(x, y_slice_size):
+            self._bmm_expand_slice(y, x, w_t_all, y_offset, y_slice_size, add_inputs)
+            return
         self.bgmv_expand_slice(
+            x,
+            w_t_all,
+            y,
+            self._get_token_lora_indices(x),
+            y_offset,
+            y_slice_size,
+            add_inputs,
+        )
+
+    def _bmm_expand_slice(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: torch.Tensor,
+        y_offset: int,
+        y_slice_size: int,
+        add_inputs: bool,
+    ):
+        """Run a graph-safe BMM fallback without padding or truncation."""
+        bmm_expand_slice(
             x,
             w_t_all,
             y,


### PR DESCRIPTION
## What this PR fixes

This PR fixes a remaining packed LoRA expand-slice case after #13365. The general shared-expert LoRA implementation is already provided by #13365 and is not duplicated here.

Some Qwen3.5 packed projections have a LoRA shrink rank larger than one destination output slice. For example, the valid matrix contract can be:

- shrink input: `[tokens, 16]`;
- LoRA-B: `[slots, 1, 8, 16]`;
- destination slice size: `8`.

The existing Ascend fused expand-slice kernel requires `rank <= slice_size`, so it cannot represent this valid `16 > 8` layout.

## Implementation

- Select an exact graph-safe BMM fallback only when `rank > slice_size`.
- Validate input rows, output rows, shrink rank, LoRA-B shape, adapter-index rows, and destination bounds before execution.
- Preserve base-token semantics for adapter index `-1`.
- Raise `ValueError` for incompatible dimensions.
- Never pad, truncate, clip, or silently reshape tensors.

The fallback computes the exact LoRA delta with `torch.bmm(gathered_weights, inputs.unsqueeze(-1)).squeeze(-1)` and writes only to the requested output slice.

## Scope

- Based on current main including #13365.
- No duplicate shared-expert wrapper or routing implementation.
- No vLLM source modification.
- No zero-LoRA-B projection skipping; that remains in #13494.

## Validation

- Ruff check and format: passed.
- mypy on Python 3.10/3.11/3.12: passed.
- Focused unit tests: 16 passed.
- Combined Dense + MoE integration tests: 50 passed.
- Direct A3 BMM/reference check for `[4, 16]` and `[2, 1, 8, 16]`: passed.
- Qwen3.5-35B-A3B BF16 TP4 FULL_DECODE_ONLY: 8/8 graphs captured.
- Mixed Base/LoRA C8: 80/80 successful requests.
- C1/C4/C8 performance traffic: 96/96 successful requests.
- LoRA throughput: 47.16/138.01/214.78 tok/s, within -0.34%/-0.71%/-0.55% of the previous validated stack.
- Runtime fatal errors: 0.

Replaces #13493 (closed due to #13365 overlap; the force-pushed head could not be reopened). The bugfix content is unchanged: 3 files, +225/-1, rebased onto main including #13365.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
