### PR TITLE
[v0.23.0][Performance] Backport terminal block hash from vLLM 25.0 and remove rehash in AscendStore

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -15,9 +15,8 @@
 # This file is a part of the vllm-ascend project.
 #
 
-import hashlib
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
@@ -31,21 +30,30 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     ReqMeta,
     RequestTracker,
     get_block_hashes,
+    resolve_request_hash_block_size,
 )
 
-_GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
-_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
 
+class TestRequestHashBlockSize(unittest.TestCase):
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store."
+        "config_data.kv_cache_utils.resolve_kv_cache_block_sizes"
+    )
+    def test_uses_vllm_resolver(self, resolver):
+        vllm_config = object()
+        kv_cache_config = object()
+        resolver.return_value = (128, 8)
 
-def _expected_grouped_hash(*block_hashes):
-    hasher = hashlib.sha256()
-    hasher.update(_GROUPED_BLOCK_HASH_DOMAIN)
-    hasher.update(len(block_hashes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
-    for block_hash in block_hashes:
-        hash_bytes = block_hash.encode("utf-8") if isinstance(block_hash, str) else bytes(block_hash)
-        hasher.update(len(hash_bytes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
-        hasher.update(hash_bytes)
-    return hasher.digest()
+        self.assertEqual(resolve_request_hash_block_size(vllm_config, kv_cache_config, 128), 8)
+        resolver.assert_called_once_with(kv_cache_config, vllm_config)
+
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store."
+        "config_data.kv_cache_utils.resolve_kv_cache_block_sizes"
+    )
+    def test_falls_back_without_kv_cache_config(self, resolver):
+        self.assertEqual(resolve_request_hash_block_size(object(), None, 128), 128)
+        resolver.assert_not_called()
 
 
 class TestKeyMetadata(unittest.TestCase):
@@ -186,12 +194,11 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         result = list(self.db.process_tokens(32, hashes))
         self.assertEqual(len(result), 2)
 
-    def test_process_tokens_rehashes_grouped_hashes(self):
+    def test_process_tokens_uses_terminal_grouped_hashes(self):
         db = ChunkedTokenDatabase([self.meta], block_size=[16], partitions=None, hash_block_size=8)
         result = list(db.process_tokens(32, ["a", "b", "c", "d"]))
         self.assertEqual(len(result), 2)
-        self.assertEqual(result[0][2].chunk_hash, _expected_grouped_hash("a", "b").hex())
-        self.assertEqual(len(result[0][2].chunk_hash), 64)
+        self.assertEqual([entry[2].chunk_hash for entry in result], ["b", "d"])
 
     def test_key_strings_match_pool_keys(self):
         hashes = ["aaa", "bbb", "ccc"]
@@ -253,15 +260,17 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         )
         self.assertEqual([(start, end, block_id) for start, end, _, _, block_id in result], [(32, 48, 12)])
 
-    def test_get_block_hashes_rehashes_groups(self):
+    def test_get_block_hashes_uses_terminal_hashes(self):
         for hashes in (["a", "b", "c", "d"], [b"a", b"b", b"c", b"d"]):
             with self.subTest(hash_type=type(hashes[0])):
                 result = get_block_hashes(hashes, group_block_size=32, hash_block_size=16)
-                expected = [
-                    _expected_grouped_hash(hashes[0], hashes[1]),
-                    _expected_grouped_hash(hashes[2], hashes[3]),
-                ]
-                self.assertEqual(list(result), expected)
+                self.assertEqual(list(result), [hashes[1], hashes[3]])
+
+    def test_get_block_hashes_uses_dsv4_compression_boundaries(self):
+        hashes = [bytes([idx % 251]) * 32 for idx in range(128)]
+
+        self.assertEqual(get_block_hashes(hashes, group_block_size=128 * 4, hash_block_size=128)[0], hashes[3])
+        self.assertEqual(get_block_hashes(hashes, group_block_size=128 * 128, hash_block_size=128)[0], hashes[127])
 
     def test_prepare_value(self):
         addr, size, block_id = self.db.prepare_value(0, 16, [5, 6, 7])

--- a/tests/ut/distributed/ascend_store/test_coordinator.py
+++ b/tests/ut/distributed/ascend_store/test_coordinator.py
@@ -113,32 +113,25 @@ class TestAscendStoreCoordinator(unittest.TestCase):
         db.cache_coordinator = coord
         grouped_hash_cache: config_data.GroupedBlockHashCache = {}
 
-        with patch.object(
-            config_data,
-            "_rehash_block_hash_group",
-            wraps=config_data._rehash_block_hash_group,
-        ) as rehash:
-            self.assertEqual(
-                db.load_mask(
-                    block_hashes,
-                    32,
-                    grouped_hash_cache=grouped_hash_cache,
-                ),
-                ([True, True],),
+        self.assertEqual(
+            db.load_mask(
+                block_hashes,
+                32,
+                grouped_hash_cache=grouped_hash_cache,
+            ),
+            ([True, True],),
+        )
+        keys = list(
+            db.process_token_key_strings_with_block_ids(
+                32,
+                block_hashes,
+                [10, 11],
+                grouped_hash_cache=grouped_hash_cache,
             )
-            self.assertEqual(rehash.call_count, 2)
-
-            keys = list(
-                db.process_token_key_strings_with_block_ids(
-                    32,
-                    block_hashes,
-                    [10, 11],
-                    grouped_hash_cache=grouped_hash_cache,
-                )
-            )
+        )
 
         self.assertEqual(len(keys), 2)
-        self.assertEqual(rehash.call_count, 2)
+        self.assertEqual([key[3] for key in keys], [block_hashes[1], block_hashes[3]])
 
     def test_compressed_group_hits_on_effective_granularity(self):
         block_hashes = _hashes(128)

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -17,13 +17,12 @@
 
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 # isort: off
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm.distributed.kv_events import BlockStored
 from vllm.v1.core.kv_cache_utils import maybe_convert_block_hash
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     ChunkedTokenDatabase,
     KeyMetadata,
@@ -276,15 +275,14 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         thread.add_stored_request("r1")
         thread.request_queue.put(request)
 
-        with patch.object(
-            config_data,
-            "_rehash_block_hash_group",
-            wraps=config_data._rehash_block_hash_group,
-        ) as rehash:
-            thread._handle_request(request)
+        thread._handle_request(request)
 
-        self.assertEqual(rehash.call_count, 2)
-        self.assertEqual(len(thread.get_kv_events()), 2)
+        events = thread.get_kv_events()
+        self.assertEqual(len(events), 2)
+        self.assertEqual(
+            [event.block_hashes for event in events],
+            [[maybe_convert_block_hash(b"h1")], [maybe_convert_block_hash(b"h3")]],
+        )
 
     def test_handle_request_consumer_role(self):
         t, store = self._make_thread([0], kv_role="kv_consumer")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -23,7 +23,6 @@ import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 import torch
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
 
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import config_data
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import (
     AscendConnectorMetadata,
     ChunkedTokenDatabase,
@@ -184,15 +183,11 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.m_store.exists.return_value = [1, 1]
         block_hashes = [b"h0", b"h1", b"h2", b"h3"]
 
-        with patch.object(
-            config_data,
-            "_rehash_block_hash_group",
-            wraps=config_data._rehash_block_hash_group,
-        ) as rehash:
-            hit = worker.lookup(32, block_hashes, [0])
+        hit = worker.lookup(32, block_hashes, [0])
 
         self.assertEqual(hit, 32)
-        self.assertEqual(rehash.call_count, 2)
+        keys = worker.m_store.exists.call_args.args[0]
+        self.assertEqual([key.rsplit("@", 1)[-1] for key in keys], [b"h1".hex(), b"h3".hex()])
 
     def test_registered_layer_layout_includes_mtp_multi_group_and_pp(self):
         cls = self._make_worker_class()

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 import torch
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHash, BlockHashListWithBlockSize
 from vllm.v1.core.single_type_kv_cache_manager import (
     SlidingWindowManager,
 )
@@ -101,12 +102,14 @@ def _make_vllm_config(
     dcp: int,
     pcp: int,
     block_size: int = 16,
+    kv_transfer_config: object | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         cache_config=SimpleNamespace(
             block_size=block_size,
             enable_prefix_caching=enable_prefix_caching,
         ),
+        kv_transfer_config=kv_transfer_config,
         parallel_config=SimpleNamespace(
             decode_context_parallel_size=dcp,
             prefill_context_parallel_size=pcp,
@@ -128,14 +131,16 @@ def _make_coordinator_for_effective_block_size(
 
 
 @pytest.mark.parametrize(
-    ("enable_prefix_caching", "expected_hash_block_size"),
+    ("enable_prefix_caching", "kv_transfer_config", "expected_hash_block_size"),
     [
-        pytest.param(False, math.lcm(16, 32) * 2 * 2, id="cp-without-prefix-caching"),
-        pytest.param(True, math.gcd(16, 32), id="cp-with-prefix-caching"),
+        pytest.param(False, None, math.lcm(16, 32) * 2 * 2, id="cp-without-hashing"),
+        pytest.param(False, object(), math.gcd(16, 32), id="cp-with-connector"),
+        pytest.param(True, None, math.gcd(16, 32), id="cp-with-prefix-caching"),
     ],
 )
 def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     enable_prefix_caching: bool,
+    kv_transfer_config: object | None,
     expected_hash_block_size: int,
 ) -> None:
     kv_cache_config = _make_hybrid_kv_cache_config(full_block_size=16, mamba_block_size=32)
@@ -143,6 +148,7 @@ def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
         enable_prefix_caching=enable_prefix_caching,
         dcp=2,
         pcp=2,
+        kv_transfer_config=kv_transfer_config,
     )
 
     scheduler_block_size, hash_block_size = _ascend_resolve_kv_cache_block_sizes(
@@ -153,6 +159,14 @@ def test_resolve_kv_cache_block_sizes_with_cp_hybrid_groups(
     expected_scheduler_block_size = math.lcm(16, 32) * 2 * 2
     assert scheduler_block_size == expected_scheduler_block_size
     assert hash_block_size == expected_hash_block_size
+
+
+def test_block_hash_list_uses_terminal_chained_hash() -> None:
+    block_hashes = [BlockHash(bytes([idx]) * 32) for idx in range(4)]
+
+    grouped_hashes = BlockHashListWithBlockSize(block_hashes, 8, 16)
+
+    assert list(grouped_hashes) == [block_hashes[1], block_hashes[3]]
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
-import hashlib
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any, cast
 
 import numpy as np
 import torch
+import vllm.v1.core.kv_cache_utils as kv_cache_utils
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata, KVConnectorWorkerMetadata
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
@@ -15,10 +15,14 @@ from vllm.v1.core.sched.output import NewRequestData
 
 from vllm_ascend.memcache_comm_fence import AttentionComputeStartGate
 
-_GROUPED_BLOCK_HASH_DOMAIN = b"vllm-ascend-grouped-block-hash-v1\0"
-_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES = 4
 # ponytail: each operation owns a fresh dict, so block size is the only cache key.
 GroupedBlockHashCache = dict[int, Sequence[BlockHash | str]]
+
+
+def resolve_request_hash_block_size(vllm_config: Any, kv_cache_config: Any | None, fallback: int) -> int:
+    if kv_cache_config is None:
+        return fallback
+    return kv_cache_utils.resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)[1]
 
 
 # Parameters related to the key
@@ -623,7 +627,7 @@ def get_block_hashes(
     return grouped_hash_cache[group_block_size]
 
 
-class _LazyGroupedBlockHashList(Sequence[BlockHash]):
+class _LazyGroupedBlockHashList(Sequence[BlockHash | str]):
     def __init__(
         self,
         block_hashes: Sequence[BlockHash | str],
@@ -632,7 +636,6 @@ class _LazyGroupedBlockHashList(Sequence[BlockHash]):
         self._block_hashes = block_hashes
         self._scale_factor = scale_factor
         self._length = len(block_hashes) // scale_factor
-        self._cache: dict[int, BlockHash] = {}
 
     def __len__(self) -> int:
         return self._length
@@ -644,23 +647,7 @@ class _LazyGroupedBlockHashList(Sequence[BlockHash]):
             index += self._length
         if index < 0 or index >= self._length:
             raise IndexError(index)
-        if index in self._cache:
-            return self._cache[index]
-        start = index * self._scale_factor
-        grouped_hash = _rehash_block_hash_group(self._block_hashes[start : start + self._scale_factor])
-        self._cache[index] = grouped_hash
-        return grouped_hash
-
-
-def _rehash_block_hash_group(block_hashes: Sequence[BlockHash | str]) -> BlockHash:
-    hasher = hashlib.sha256()
-    hasher.update(_GROUPED_BLOCK_HASH_DOMAIN)
-    hasher.update(len(block_hashes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
-    for block_hash in block_hashes:
-        hash_bytes = block_hash_to_bytes(block_hash)
-        hasher.update(len(hash_bytes).to_bytes(_GROUPED_BLOCK_HASH_LENGTH_PREFIX_BYTES, "big"))
-        hasher.update(hash_bytes)
-    return BlockHash(hasher.digest())
+        return self._block_hashes[(index + 1) * self._scale_factor - 1]
 
 
 def block_hash_to_str(block_hash: BlockHash | str) -> str:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -41,6 +41,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     infer_cache_family_ratio,
     infer_group_cache_families,
     normalize_block_ids_by_group,
+    resolve_request_hash_block_size,
 )
 
 
@@ -108,12 +109,11 @@ class KVPoolScheduler:
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
-        requested_hash_block_size = vllm_config.cache_config.hash_block_size
-        if not isinstance(requested_hash_block_size, int):
-            requested_hash_block_size = None
-        self.hash_block_size = (
-            requested_hash_block_size if requested_hash_block_size is not None else min(self.original_block_size)
-        ) * cp_scale
+        self.hash_block_size = resolve_request_hash_block_size(
+            vllm_config,
+            kv_cache_config,
+            self.grouped_block_size[0],
+        )
         for group_block_size in self.grouped_block_size:
             assert group_block_size % self.hash_block_size == 0, "block_size must be divisible by hash_block_size"
         self._block_size = self.grouped_block_size[0]

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -45,6 +45,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
     get_cache_family_granularity,
     infer_cache_family_ratio,
     infer_group_cache_families,
+    resolve_request_hash_block_size,
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.coordinator import (
     AscendStoreCoordinator,
@@ -144,12 +145,11 @@ class KVPoolWorker:
         self.original_block_size = self._infer_group_block_sizes(vllm_config, kv_cache_config)
         cp_scale = self.pcp_size * self.dcp_size
         self.grouped_block_size = [block_size * cp_scale for block_size in self.original_block_size]
-        requested_hash_block_size = vllm_config.cache_config.hash_block_size
-        if not isinstance(requested_hash_block_size, int):
-            requested_hash_block_size = None
-        self.hash_block_size = (
-            requested_hash_block_size if requested_hash_block_size is not None else min(self.original_block_size)
-        ) * cp_scale
+        self.hash_block_size = resolve_request_hash_block_size(
+            vllm_config,
+            kv_cache_config,
+            self.grouped_block_size[0],
+        )
         for group_block_size in self.grouped_block_size:
             assert group_block_size % self.hash_block_size == 0, "block_size must be divisible by hash_block_size"
         self.block_size = self.grouped_block_size[0]

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -205,20 +205,28 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes`
 #      `vllm.v1.engine.core.resolve_kv_cache_block_sizes`
+#      `vllm.v1.core.kv_cache_utils.BlockHashListWithBlockSize._get_value_at`
 #    Why:
 #       vLLM PR #40860 added a restriction that hybrid KV cache groups with
 #       multiple block sizes do not support context parallelism (dcp/pcp > 1).
 #       This restriction is correct for CUDA but not for Ascend, which
 #       implements context parallelism for MLA and SWA-MLA layers separately.
+#       KV connectors still need fine-grained request hashes when local prefix
+#       caching is disabled.
+#       vLLM v0.23.0 also concatenates fine-grained chained hashes when building
+#       a larger group-block view. vLLM PR #45939 instead reuses the terminal
+#       chained hash, which lets AscendStore avoid a separate rehash key space.
 #    How：
 #       Monkey-patch resolve_kv_cache_block_sizes to handle the multiple-groups
 #       + CP case by returning lcm(block_sizes) * dcp * pcp as scheduler_block_size
-#       instead of raising ValueError.
+#       instead of raising ValueError. On v0.23.0, patch the grouped hash view
+#       in place so existing BlockPool imports use the terminal chained hash.
 #    Related PR (if no, explain why):
 #       vLLM PR #40860 ([Feat] DeepSeek V4 Rebased).
+#       vLLM PR #45939 ([Core] add partial prefix cache primitives).
 #    Future Plan:
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
-#       non-CUDA backends, or exposes a platform hook for this behavior.
+#       non-CUDA backends and the supported version includes vLLM PR #45939.
 #
 # ** 10ab. File: worker/patch_v2/patch_attn_utils.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -6,7 +6,12 @@ from collections import defaultdict
 import vllm.v1.core.kv_cache_utils
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv, round_up
-from vllm.v1.core.kv_cache_utils import _approximate_gcd, may_override_num_blocks
+from vllm.v1.core.kv_cache_utils import (
+    BlockHash,
+    BlockHashListWithBlockSize,
+    _approximate_gcd,
+    may_override_num_blocks,
+)
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
@@ -20,6 +25,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm_ascend.utils import vllm_version_is
 
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
+
+
+def _get_terminal_block_hash(self: BlockHashListWithBlockSize, idx: int) -> BlockHash:
+    return self.block_hashes[(idx + 1) * self.scale_factor - 1]
 
 
 def _ascend_resolve_kv_cache_block_sizes(
@@ -52,7 +61,7 @@ def _ascend_resolve_kv_cache_block_sizes(
         # multiplied by the CP factors for proper alignment.
         group_block_sizes = [g.kv_cache_spec.block_size for g in groups]
         scheduler_block_size = math.lcm(*group_block_sizes) * dcp * pcp
-        if not cache_config.enable_prefix_caching:
+        if not (cache_config.enable_prefix_caching or vllm_config.kv_transfer_config is not None):
             return scheduler_block_size, scheduler_block_size
         hash_block_size = math.gcd(*group_block_sizes)
         return scheduler_block_size, hash_block_size
@@ -256,6 +265,7 @@ vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_
 # get_kv_cache_config_from_groups now calls _get_kv_cache_config_packed directly, bypassing
 # the alias patch above. Patch the canonical name so Ascend's non-packed layout is used.
 if vllm_version_is("0.23.0"):
+    BlockHashListWithBlockSize._get_value_at = _get_terminal_block_hash
     vllm.v1.core.kv_cache_utils._get_kv_cache_config_deepseek_v4 = _get_kv_cache_config_deepseek_v4
 else:
     vllm.v1.core.kv_cache_utils._get_kv_cache_config_packed = _get_kv_cache_config_deepseek_v4


### PR DESCRIPTION
### What this PR does / why we need it?

Backports the terminal chained-hash behavior from vLLM PR #45939 to the v0.23.0 integration and aligns AscendStore with that hash contract.

This change:

- patches vLLM v0.23.0's `BlockHashListWithBlockSize` in place so a larger cache-group block uses its terminal fine-grained chained hash;
- removes AscendStore's separate SHA-256 grouped-hash calculation;
- uses `resolve_kv_cache_block_sizes()` as the source of truth for scheduler and worker request-hash granularity;
- keeps fine-grained hashes enabled for hybrid CP when a KV connector is active and local prefix caching is disabled.

The implementation follows the relevant BlockHash adaptation from #12502 and the request hash-granularity alignment from #13201 without backporting newer partial-cache or coordinator APIs.

### Does this PR introduce _any_ user-facing change?

Yes. Multi-group AscendStore keys now use terminal chained hashes instead of AscendStore-specific rehashed values. Producer and consumer nodes must be upgraded together, and existing external KV Pool data should be cleared or isolated during rollout.

### How was this patch tested?

- AscendStore and prefix-cache patch unit tests: 235 passed, 10 skipped.
- Added explicit DeepSeek V4 C4 and C128 terminal-hash boundary coverage.
- Ran all pre-commit hooks on the changed files.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
