### PR TITLE
[v0.25.1rc][BugFix][Frontend] Align DeepSeek V4 system tool rendering

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -98,6 +98,69 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(
     assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
 
 
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_effort"),
+    [
+        (None, "high"),
+        ("high", "high"),
+        ("low", "low"),
+    ],
+)
+def test_deepseek_v4_tokenizer_attaches_tools_to_existing_system(
+    monkeypatch,
+    reasoning_effort,
+    expected_effort,
+):
+    captured_messages = []
+    captured_kwargs = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_messages.append(messages)
+        captured_kwargs.append(kwargs)
+        return "prompt"
+
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "hi"},
+    ]
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    original_messages = [message.copy() for message in messages]
+    kwargs = {"reasoning_effort": reasoning_effort} if reasoning_effort is not None else {}
+
+    tokenizer.apply_chat_template(messages, tools=tools, tokenize=False, **kwargs)
+
+    assert captured_messages[-1] == [
+        {"role": "system", "content": "system prompt", "tools": tools},
+        {"role": "user", "content": "hi"},
+    ]
+    assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+    assert messages == original_messages
+
+
+def test_deepseek_v4_tokenizer_adds_system_for_tools_when_missing(monkeypatch):
+    captured_messages = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_messages.append(messages)
+        return "prompt"
+
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    messages = [{"role": "user", "content": "hi"}]
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    original_messages = [message.copy() for message in messages]
+
+    tokenizer.apply_chat_template(messages, tools=tools, tokenize=False)
+
+    assert captured_messages[-1] == [
+        {"role": "system", "tools": tools},
+        {"role": "user", "content": "hi"},
+    ]
+    assert messages == original_messages
+
+
 def test_deepseek_v4_defaults_to_thinking_with_high_effort():
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     prompt = tokenizer.apply_chat_template(

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -94,8 +94,16 @@ def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
         conversation = kwargs.get("conversation", messages)
         messages = conversation.copy()
         if tools is not None and len(tools) > 0:
-            messages.insert(0, {"role": "system"})
-            messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+            system_index = next(
+                (index for index, message in enumerate(messages) if message.get("role") == "system"),
+                None,
+            )
+            if system_index is None:
+                messages.insert(0, {"role": "system", "tools": tools})
+            else:
+                system_message = messages[system_index].copy()
+                system_message["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                messages[system_index] = system_message
 
         reasoning_effort = kwargs.get("reasoning_effort")
         if not isinstance(reasoning_effort, str):


### PR DESCRIPTION
### What this PR does / why we need it?

This is a follow-up to #13519. The v0.25.1 release monkey patch inherited an
upstream Python renderer mismatch reported in
https://github.com/vllm-project/vllm/issues/51829.

For DeepSeek V4 requests containing both an existing system message and
top-level tools, the Python wrapper always inserted a synthetic system message
and rendered the tools before the caller's system content. This differs from
both vLLM's Rust renderer and the DeepSeek-V4-Flash-0731 checkpoint reference.

This patch aligns the release Python path with those references:

- attach request-level tools to a shallow copy of the first existing system
  message;
- insert a synthetic system message only when no system message exists; and
- leave caller-owned message dictionaries unchanged.

The reasoning-effort normalization introduced by #13519 is unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek V4 requests with both a system message and top-level tools now
render the system content and tool schemas in the same order as the Rust and
checkpoint reference renderers. Requests without a system message keep the
existing synthetic-system behavior.

### How was this patch tested?

- Tested with vLLM `v0.25.1` at commit
  `752a3a504485790a2e8491cacbb35c137339ad34`.
- `VLLM_VERSION=0.25.1 python -m pytest -q tests/ut/patch/platform/test_deepseek_v4_thinking.py`
  - Result: `26 passed`.
  - Coverage includes existing-system tools, missing-system tools, caller input
    immutability, and default/high/low effort behavior.
- Tokenizer integration comparison against the checkpoint encoder for
  `system/no-system x low/high`:
  - all four rendered prompts matched exactly;
  - all four input-ID sequences matched exactly; and
  - caller messages remained unchanged in all four cases.
- `ruff check` and `ruff format --check` on both changed files passed.
- `git diff --check origin/releases/v0.25.1rc...HEAD` passed.

https://github.com/vllm-project/vllm/commit/752a3a504485790a2e8491cacbb35c137339ad34

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
