### PR TITLE
[Feature][MRV2] Support DSA prefill context parallelism

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -844,7 +844,7 @@ class TestAscendDSACompressedCacheRouting:
         state_cache = torch.empty(0)
 
         with patch.object(DeviceOperator, "dsa_kv_compress_scatter") as scatter:
-            actual = impl._update_compressed_caches_and_select_topk(
+            actual = impl._maybe_update_compressed_caches_and_select_topk(
                 layer_name="model.layers.0.self_attn.attn",
                 hidden_states=hidden_states,
                 qr=qr,
@@ -865,6 +865,7 @@ class TestAscendDSACompressedCacheRouting:
         assert indexer_call.kwargs["qr"] is qr
         assert indexer_call.kwargs["kv_cache"] is kv_cache
         assert indexer_call.kwargs["metadata"] is indexer_metadata
+        assert indexer_call.kwargs["write_cache"] is True
         assert isinstance(overlap_plan, IndexerOverlapPlan)
         assert overlap_plan.aux_stream is None
         impl.compressor.assert_called_once_with(
@@ -878,7 +879,8 @@ class TestAscendDSACompressedCacheRouting:
             compress_slot_mapping,
         )
 
-    def test_c128_delegates_directly_to_compressor(self):
+    @pytest.mark.parametrize("write_cache", [True, False], ids=["normal", "prepared"])
+    def test_c128_delegates_directly_to_compressor(self, write_cache: bool):
         impl = _make_impl()
         impl.compress_ratio = 128
         compressed_kv = torch.ones((1, 1, 4))
@@ -898,7 +900,7 @@ class TestAscendDSACompressedCacheRouting:
         compress_kv_cache = torch.empty(0)
 
         with patch.object(DeviceOperator, "dsa_kv_compress_scatter") as scatter:
-            actual = impl._update_compressed_caches_and_select_topk(
+            actual = impl._maybe_update_compressed_caches_and_select_topk(
                 layer_name="layer",
                 hidden_states=hidden_states,
                 qr=torch.ones((1, 4)),
@@ -907,23 +909,35 @@ class TestAscendDSACompressedCacheRouting:
                 qr_pertoken_scale=None,
                 compress_kv_cache=compress_kv_cache,
                 state_cache=state_cache,
+                write_cache=write_cache,
             )
 
         assert actual is None
-        impl.compressor.assert_called_once_with(
-            hidden_states=hidden_states,
-            state_cache=state_cache,
-            metadata=compressor_metadata,
-        )
-        scatter.assert_called_once_with(
-            compress_kv_cache,
-            compressed_kv,
-            compress_slot_mapping,
-        )
+        if write_cache:
+            impl.compressor.assert_called_once_with(
+                hidden_states=hidden_states,
+                state_cache=state_cache,
+                metadata=compressor_metadata,
+            )
+            scatter.assert_called_once_with(
+                compress_kv_cache,
+                compressed_kv,
+                compress_slot_mapping,
+            )
+        else:
+            impl.compressor.assert_not_called()
+            scatter.assert_not_called()
 
 
-@pytest.mark.parametrize("compress_ratio", [4, 128])
-def test_forward_attention_sets_compressed_kv_args(compress_ratio: int):
+@pytest.mark.parametrize(
+    ("compress_ratio", "cache_is_prepared"),
+    [(4, False), (128, False), (4, True)],
+    ids=["c4_normal", "c128_normal", "c4_prepared"],
+)
+def test_forward_attention_sets_compressed_kv_args(
+    compress_ratio: int,
+    cache_is_prepared: bool,
+):
     impl = _make_impl()
     impl.compress_ratio = compress_ratio
     impl.multistream_dsv4_dsa_overlap = False
@@ -989,10 +1003,10 @@ def test_forward_attention_sets_compressed_kv_args(compress_ratio: int):
             impl,
             "_mla_prolog_single_stream",
             return_value=(q, qr, None),
-        ),
+        ) as single_stream_prolog,
         patch.object(
             impl,
-            "_update_compressed_caches_and_select_topk",
+            "_maybe_update_compressed_caches_and_select_topk",
             return_value=topk_indices,
         ) as update_compressed_caches,
         patch.object(
@@ -1018,15 +1032,18 @@ def test_forward_attention_sets_compressed_kv_args(compress_ratio: int):
             hidden_states,
             (torch.empty(0),),
             layer_metadata,
+            cache_is_prepared,
         )
 
     assert actual is attention_output
+    assert single_stream_prolog.call_args.kwargs["write_swa_cache"] is not cache_is_prepared
     update_call = update_compressed_caches.call_args
     assert update_call.kwargs["layer_name"] == "layer"
     assert update_call.kwargs["hidden_states"] is hidden_states
     assert update_call.kwargs["layer_metadata"] is layer_metadata
     assert update_call.kwargs["compress_kv_cache"] is compress_kv_cache
     assert update_call.kwargs["state_cache"] is state_cache
+    assert update_call.kwargs["write_cache"] is not cache_is_prepared
     sparse_kwargs = sparse_attn_op.call_args.kwargs
     assert sparse_kwargs["cmp_kv"] is compress_kv_cache
     assert sparse_kwargs["cmp_block_table"] is common_req.block_table
@@ -1037,3 +1054,25 @@ def test_forward_attention_sets_compressed_kv_args(compress_ratio: int):
         assert sparse_kwargs["cmp_sparse_indices"] is topk_indices
     else:
         assert "cmp_sparse_indices" not in sparse_kwargs
+
+
+def test_prepared_cache_rejects_multistream_before_cache_access():
+    impl = _make_impl()
+    impl.multistream_dsv4_dsa_overlap = True
+
+    with (
+        patch.object(DeviceOperator, "unpack_dsa_forward_kv_cache") as unpack_cache,
+        pytest.raises(
+            RuntimeError,
+            match="Prepared DSA caches require single-stream attention",
+        ),
+    ):
+        impl._forward_attention(
+            "layer",
+            torch.empty((1, 4)),
+            (torch.empty(0),),
+            cast(Any, None),
+            True,
+        )
+
+    unpack_cache.assert_not_called()

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -17,11 +17,18 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 import torch
 
+from vllm_ascend.attention.context_parallel.dsa_cp import (
+    AscendDSAPCPImpl,
+    AscendDSAPCPMetadata,
+    AscendDSAPCPMetadataBuilder,
+)
 from vllm_ascend.attention.dsa_v1 import (
     DSA_METADATA_BUFFER_SIZE,
+    AscendDSABackend,
     AscendDSAImpl,
     AscendDSALayerMetadata,
     AscendDSAMetadata,
@@ -34,6 +41,7 @@ from vllm_ascend.models.deepseek_v4.indexer import (
     AscendIndexerMetadata,
     IndexerOverlapPlan,
 )
+from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 
 def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
@@ -557,7 +565,9 @@ def _make_req_metadata() -> AscendDSAReqMetadata:
     )
 
 
-def _make_impl() -> AscendDSAImpl:
+def _make_impl(
+    impl_cls: type[AscendDSAImpl] = AscendDSAImpl,
+) -> AscendDSAImpl:
     linear = MagicMock()
     with (
         patch(
@@ -569,7 +579,7 @@ def _make_impl() -> AscendDSAImpl:
             return_value=SimpleNamespace(multistream_dsv4_dsa_overlap=False),
         ),
     ):
-        return AscendDSAImpl(
+        return impl_cls(
             n_heads=1,
             scale=1.0,
             n_local_heads=1,
@@ -661,6 +671,7 @@ def test_forward_runs_mixed_prefill_and_decode_in_one_attention_call():
     assert torch.equal(call.args[1], hidden_states)
     assert call.args[3].attention is None
     assert call.args[3].swa is metadata
+    assert call.args[4] is False
     assert not call.kwargs
 
 
@@ -1076,3 +1087,284 @@ def test_prepared_cache_rejects_multistream_before_cache_access():
         )
 
     unpack_cache.assert_not_called()
+
+
+def test_dsa_backend_selects_pcp_and_rejects_legacy_cp():
+    with (
+        patch("vllm_ascend.attention.dsa_v1.enable_pcp", return_value=True),
+        patch("vllm_ascend.utils.enable_dsa_cp", return_value=False),
+    ):
+        assert AscendDSABackend.get_builder_cls() is AscendDSAPCPMetadataBuilder
+        assert AscendDSABackend.get_impl_cls() is AscendDSAPCPImpl
+
+    with (
+        patch("vllm_ascend.attention.dsa_v1.enable_pcp", return_value=True),
+        patch("vllm_ascend.utils.enable_dsa_cp", return_value=True),
+    ):
+        for get_backend_cls in (
+            AscendDSABackend.get_builder_cls,
+            AscendDSABackend.get_impl_cls,
+        ):
+            with pytest.raises(ValueError, match="cannot be enabled at the same time"):
+                get_backend_cls()
+
+
+def test_pcp_metadata_builds_from_manager_global_view():
+    """Build rank-local metadata from the manager's scheduler-global view."""
+    builder = AscendDSAPCPMetadataBuilder.__new__(AscendDSAPCPMetadataBuilder)
+    builder._pcp_world_size = 2
+    builder._pcp_rank = 1
+    builder.model_config = SimpleNamespace(get_head_size=lambda: 512)
+
+    raw_slot_mapping = torch.arange(6, dtype=torch.int64)
+    hidden_restore_idx = torch.arange(5, dtype=torch.int64)
+    global_batch = SimpleNamespace(
+        num_reqs=2,
+        num_tokens=5,
+        query_start_loc=torch.tensor([0, 2, 5], dtype=torch.int32),
+        query_start_loc_np=np.array([0, 2, 5], dtype=np.int32),
+        seq_lens=torch.tensor([4, 7], dtype=torch.int32),
+        seq_lens_np=np.array([4, 7], dtype=np.int32),
+        seq_lens_cpu_upper_bound=torch.tensor([8, 8], dtype=torch.int32),
+        num_computed_tokens_np=np.array([2, 4], dtype=np.int32),
+        num_scheduled_tokens=np.array([2, 3], dtype=np.int32),
+        dcp_local_seq_lens=None,
+        positions=torch.arange(5, dtype=torch.int64),
+        attn_state=object(),
+        is_prefilling_np=np.array([True, True]),
+        idx_mapping=torch.tensor([0, 1], dtype=torch.int32),
+        num_reqs_after_padding=2,
+    )
+    global_block_table = torch.tensor([[1], [2]], dtype=torch.int32)
+    global_block_tables = (torch.empty(0), global_block_table)
+    global_slot_mappings = torch.arange(14, dtype=torch.int64).view(2, 7)
+    global_slot_mapping = global_slot_mappings[1, : global_batch.num_tokens]
+    local_common = SimpleNamespace(
+        attn_state="local",
+        num_actual_tokens=2,
+    )
+    common_attn_metadata = SimpleNamespace(
+        num_actual_tokens=2,
+        slot_mapping=raw_slot_mapping,
+        max_seq_len=8,
+        causal=True,
+        replace=MagicMock(return_value=local_common),
+    )
+    gather_block_tables = MagicMock(return_value=global_block_tables)
+    pcp_manager = AscendPCPManager.__new__(AscendPCPManager)
+    pcp_manager._global_batch = global_batch
+    pcp_manager._block_tables = SimpleNamespace(
+        gather_block_tables=gather_block_tables,
+    )
+    pcp_manager._global_batch_slot_mappings = global_slot_mappings
+    pcp_manager._hidden_restore_idx = hidden_restore_idx
+    pcp_context = pcp_manager.build_attention_context(
+        SimpleNamespace(is_dummy=False, num_tokens_after_padding=3),
+        (),
+        torch.empty(0),
+    )
+    global_metadata = AscendDSAMetadata(
+        num_actual_tokens=5,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=2,
+    )
+    local_metadata = AscendDSAMetadata(
+        num_actual_tokens=2,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=1,
+    )
+    builder._global_metadata_builder = SimpleNamespace(
+        build=MagicMock(return_value=global_metadata),
+    )
+
+    with patch.object(
+        AscendDSAMetadataBuilder,
+        "build",
+        autospec=True,
+        return_value=local_metadata,
+    ) as build_local:
+        actual = builder.build(
+            0,
+            common_attn_metadata,
+            pcp_context=pcp_context,
+            pcp_cache_group_idx=1,
+            common_ratio_to_sas_metadata={"local": True},
+            num_reqs_actual=7,
+        )
+
+    assert isinstance(actual, AscendDSAPCPMetadata)
+    assert actual.num_actual_tokens == local_metadata.num_actual_tokens
+    assert actual.global_dsa_metadata is global_metadata
+    assert actual.hidden_restore_idx is hidden_restore_idx
+    assert actual.local_num_tokens_after_padding == 3
+    gather_block_tables.assert_called_once_with(
+        global_batch.idx_mapping,
+        global_batch.num_reqs_after_padding,
+    )
+    common_attn_metadata.replace.assert_called_once()
+    replace_kwargs = common_attn_metadata.replace.call_args.kwargs
+    assert torch.equal(replace_kwargs["slot_mapping"], raw_slot_mapping.view(2, 3)[1])
+    assert replace_kwargs["num_input_tokens"] == 3
+    global_call = builder._global_metadata_builder.build.call_args
+    global_common = global_call.args[1]
+    assert global_common.num_actual_tokens == global_batch.num_tokens
+    assert global_common.block_table_tensor is global_block_table
+    assert torch.equal(global_common.slot_mapping, global_slot_mapping)
+    assert global_common.attn_state is global_batch.attn_state
+    assert global_call.kwargs["num_reqs_actual"] == global_batch.num_reqs
+    assert global_call.kwargs["common_ratio_to_sas_metadata"] == {}
+    assert build_local.call_args.args[2] is local_common
+    assert build_local.call_args.kwargs["num_reqs_actual"] == 7
+
+
+@pytest.mark.parametrize("local_num_actual_tokens", [2, 0], ids=["local_tokens", "empty_rank"])
+def test_pcp_forward_updates_global_caches_before_local_attention(
+    local_num_actual_tokens: int,
+):
+    """Exercise batched cache preparation, local attention, and empty ranks."""
+    impl = _make_impl(AscendDSAPCPImpl)
+    impl.compress_ratio = 4
+    impl.compressor = SimpleNamespace(
+        state_cache=SimpleNamespace(prefix="compressor.state_cache"),
+    )
+    impl.indexer = SimpleNamespace(
+        skip_topk=False,
+        k_cache=SimpleNamespace(prefix="indexer.k_cache"),
+        compressor=SimpleNamespace(
+            state_cache=SimpleNamespace(prefix="indexer.compressor.state_cache"),
+        ),
+        update_cache=MagicMock(),
+    )
+
+    global_num_tokens = 2
+    restore_idx = torch.tensor([0, 5], dtype=torch.int64)
+    cache_prefixes = [
+        "layer",
+        "compressor.state_cache",
+        "indexer.compressor.state_cache",
+        "indexer.k_cache",
+        "swa_cache",
+    ]
+    global_dsa_metadata_by_prefix = {
+        cache_prefix: AscendDSAMetadata(
+            num_actual_tokens=global_num_tokens,
+            num_decodes=0,
+            num_decode_tokens=0,
+            num_prefills=1,
+        )
+        for cache_prefix in cache_prefixes
+    }
+    req_metadata = AscendDSAReqMetadata(
+        block_table=torch.tensor([[1]], dtype=torch.int32),
+        seq_lens=torch.tensor([2], dtype=torch.int32),
+        slot_mapping=None,
+        storage_block_size=32,
+        query_start_loc=torch.tensor([0, local_num_actual_tokens], dtype=torch.int32),
+        sin=cast(Any, {"layer": torch.zeros((4, 1, 1, 2))}),
+        cos=cast(Any, {"layer": torch.ones((4, 1, 1, 2))}),
+    )
+    attn_metadata = {
+        cache_prefix: AscendDSAPCPMetadata(
+            num_actual_tokens=local_num_actual_tokens,
+            num_decodes=0,
+            num_decode_tokens=0,
+            num_prefills=int(local_num_actual_tokens > 0),
+            req_metadata=req_metadata if local_num_actual_tokens else None,
+            local_num_tokens_after_padding=4,
+            hidden_restore_idx=restore_idx,
+            global_dsa_metadata=global_dsa_metadata_by_prefix[cache_prefix],
+        )
+        for cache_prefix in cache_prefixes
+    }
+    hidden_states = torch.arange(16, dtype=torch.float32).reshape(4, 4)
+    gathered_hidden_states = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+    attention_output = torch.arange(
+        local_num_actual_tokens * 2,
+        dtype=torch.float32,
+    ).reshape(local_num_actual_tokens, 1, 2)
+    output = torch.full((4, 2), -1.0)
+    captured_o_proj_inputs: list[torch.Tensor] = []
+    pcp_group = SimpleNamespace(
+        all_gather=MagicMock(return_value=gathered_hidden_states),
+    )
+
+    def fake_o_proj(o_proj_input: torch.Tensor, output_tensor: torch.Tensor) -> torch.Tensor:
+        captured_o_proj_inputs.append(o_proj_input.clone())
+        output_tensor[:local_num_actual_tokens].copy_(
+            o_proj_input[:local_num_actual_tokens].reshape(local_num_actual_tokens, 2)
+        )
+        return output_tensor
+
+    caches = tuple(torch.empty(0) for _ in range(6))
+    with (
+        patch.object(
+            torch.ops.vllm,
+            "maybe_all_gather_and_maybe_unpad",
+            create=True,
+            side_effect=lambda tensor, _: tensor,
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "inplace_partial_rotary_mul",
+            create=True,
+        ),
+        patch.object(
+            DeviceOperator,
+            "unpack_dsa_forward_kv_cache",
+            return_value=caches,
+        ),
+        patch("vllm_ascend.attention.context_parallel.dsa_cp.get_pcp_group", return_value=pcp_group),
+        patch.object(impl, "_update_global_swa_cache") as update_swa,
+        patch.object(impl, "_update_global_compressor_cache") as update_compressor,
+        patch.object(
+            impl,
+            "_forward_attention",
+            return_value=attention_output,
+        ) as forward_attention,
+        patch.object(impl, "_forward_o_proj", side_effect=fake_o_proj),
+        patch("vllm_ascend.attention.dsa_v1.wait_for_kv_layer_from_connector"),
+        patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
+        patch("vllm_ascend.attention.dsa_v1.maybe_save_kv_layer_to_connector"),
+    ):
+        actual = impl.forward(
+            layer_name="layer",
+            hidden_states=hidden_states,
+            kv_cache=caches,
+            attn_metadata=attn_metadata,
+            output=output,
+        )
+
+    assert actual is output
+    assert torch.equal(pcp_group.all_gather.call_args.args[0], hidden_states)
+    assert pcp_group.all_gather.call_args.kwargs == {"dim": 0}
+    update_swa.assert_called_once()
+    update_compressor.assert_called_once()
+    impl.indexer.update_cache.assert_called_once()
+    expected_global_hidden = gathered_hidden_states.index_select(0, restore_idx)
+    assert torch.equal(update_swa.call_args.args[1], expected_global_hidden)
+    assert torch.equal(update_compressor.call_args.args[0], expected_global_hidden)
+    update_indexer_call = impl.indexer.update_cache.call_args
+    assert torch.equal(
+        update_indexer_call.kwargs["hidden_states"],
+        expected_global_hidden,
+    )
+    assert update_indexer_call.kwargs["kv_cache"] is caches
+    if local_num_actual_tokens == 0:
+        forward_attention.assert_not_called()
+        assert not captured_o_proj_inputs
+        assert torch.count_nonzero(output) == 0
+    else:
+        assert torch.equal(
+            forward_attention.call_args.args[1],
+            hidden_states[:local_num_actual_tokens],
+        )
+        assert forward_attention.call_args.args[4] is True
+        assert not forward_attention.call_args.kwargs
+        assert len(captured_o_proj_inputs) == 1
+        assert torch.count_nonzero(captured_o_proj_inputs[0][local_num_actual_tokens:]) == 0
+        assert torch.equal(
+            output[:local_num_actual_tokens],
+            attention_output.view(local_num_actual_tokens, 2),
+        )

--- a/tests/ut/models/test_deepseek_v4_indexer.py
+++ b/tests/ut/models/test_deepseek_v4_indexer.py
@@ -118,6 +118,64 @@ def _make_forward_metadata() -> tuple[AscendIndexerMetadata, torch.Tensor, torch
     return metadata, cos, sin
 
 
+class TestIndexerCacheUpdate:
+    def test_updates_compressor_and_quantized_key_caches(self):
+        indexer = _make_indexer(None)
+        metadata, _, _ = _make_forward_metadata()
+        hidden_states = torch.ones((2, 4))
+        state_cache = torch.empty(0)
+        key_cache = torch.empty(0)
+        scale_cache = torch.empty(0)
+        full_cache = torch.empty(0)
+        kv_cache = (torch.empty(0),)
+        key = torch.ones((2, 1, 4))
+        rotated_key = torch.full_like(key, 2)
+        key_scale = torch.ones((2, 1))
+        slot_mapping = torch.zeros((2, 2), dtype=torch.int32)
+        compressor = MagicMock(return_value=(key, slot_mapping))
+        compressor.rotate = True
+        indexer.compressor = compressor
+        indexer.ops = SimpleNamespace(
+            unpack_dsa_indexer_kv_cache=MagicMock(
+                return_value=(
+                    state_cache,
+                    key_cache,
+                    scale_cache,
+                    full_cache,
+                )
+            ),
+            quantize_key_and_update_cache=MagicMock(
+                return_value=(None, key_scale),
+            ),
+            update_scale_cache=MagicMock(),
+        )
+
+        with patch(
+            "vllm_ascend.models.deepseek_v4.indexer.rotate_activation",
+            return_value=rotated_key,
+        ) as rotate:
+            indexer.update_cache(hidden_states, kv_cache, metadata)
+
+        indexer.ops.unpack_dsa_indexer_kv_cache.assert_called_once_with(kv_cache)
+        compressor.assert_called_once_with(
+            hidden_states=hidden_states,
+            state_cache=state_cache,
+            metadata=metadata.compressor,
+        )
+        rotate.assert_called_once_with(key, metadata.compressor.cache.hadamard)
+        indexer.ops.quantize_key_and_update_cache.assert_called_once_with(
+            rotated_key,
+            key_cache,
+            full_cache,
+            slot_mapping,
+        )
+        indexer.ops.update_scale_cache.assert_called_once_with(
+            key_scale,
+            scale_cache,
+            slot_mapping,
+        )
+
+
 class TestIndexerForward:
     @pytest.mark.parametrize("use_multistream", [False, True])
     def test_routes_serial_and_multistream_paths(self, use_multistream: bool):
@@ -128,7 +186,8 @@ class TestIndexerForward:
         topk_indices = torch.tensor([[[1, 2, 3]], [[4, 5, 6]]])
         indexer_q = torch.ones((2, 2, 4))
 
-        def select_serial(*args: Any) -> torch.Tensor:
+        def select_serial(*args: Any, **kwargs: Any) -> torch.Tensor:
+            assert kwargs == {"write_cache": True}
             execution_order.append("select")
             return topk_indices
 

--- a/tests/ut/models/test_deepseek_v4_indexer.py
+++ b/tests/ut/models/test_deepseek_v4_indexer.py
@@ -240,6 +240,74 @@ class TestIndexerForward:
         assert scatter.call_args.args[0] is compressed_kv
         assert scatter.call_args.args[1] is slot_mapping
 
+    def test_serial_prepared_cache_selects_topk_without_cache_writes(self):
+        indexer = _make_indexer(None)
+        indexer.skip_topk = False
+        indexer.use_index_cache = False
+        indexer.n_heads = 1
+        indexer.head_dim = 4
+        indexer.rope_head_dim = 2
+        indexer.softmax_scale = 1.0
+        indexer.wq_b = MagicMock(side_effect=lambda value: value)
+        indexer.weights_proj = MagicMock(return_value=torch.ones((2, 1)))
+        indexer.compressor = MagicMock()
+        indexer.ops = MagicMock()
+        key_cache = object()
+        scale_cache = object()
+        indexer.ops.unpack_dsa_indexer_kv_cache.return_value = (
+            object(),
+            key_cache,
+            scale_cache,
+            object(),
+        )
+        quantized_query = torch.ones((2, 1, 4), dtype=torch.int8)
+        query_scale = torch.ones((2, 1))
+        topk_indices = torch.tensor([[[1, 2, 3]], [[4, 5, 6]]])
+        indexer.ops.quantize_query.return_value = (quantized_query, query_scale)
+        indexer.ops.select_topk.return_value = topk_indices
+        metadata, _, _ = _make_forward_metadata()
+        compute = MagicMock()
+        scatter = MagicMock()
+
+        with (
+            patch(
+                "vllm_ascend.models.deepseek_v4.indexer._is_w8a8_dynamic",
+                return_value=False,
+            ),
+            patch.object(
+                torch.ops._C_ascend,
+                "inplace_partial_rotary_mul",
+                create=True,
+            ),
+        ):
+            actual = indexer(
+                layer_name="layer",
+                hidden_states=torch.ones((2, 4)),
+                qr=torch.ones((2, 4)),
+                kv_cache=(torch.empty(0),),
+                metadata=metadata,
+                overlap_plan=IndexerOverlapPlan(
+                    compute_attention_compressed_kv=compute,
+                    scatter_attention_compressed_kv=scatter,
+                    aux_stream=None,
+                ),
+                write_cache=False,
+            )
+
+        assert actual is topk_indices
+        indexer.compressor.assert_not_called()
+        indexer.ops.quantize_update_cache_and_select_topk.assert_not_called()
+        indexer.ops.quantize_query.assert_called_once()
+        select_args = indexer.ops.select_topk.call_args.args
+        assert select_args[0] is quantized_query
+        assert torch.equal(select_args[1], torch.ones((2, 1)))
+        assert select_args[2] is query_scale
+        assert select_args[3] is key_cache
+        assert select_args[4] is scale_cache
+        assert select_args[5] is metadata.compressor.cache.req_metadata
+        compute.assert_not_called()
+        scatter.assert_not_called()
+
 
 class TestIndexerOps:
     def test_quantize_scatter_then_select_topk(self):

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -188,6 +188,47 @@ def test_partition_batch_refreshes_local_ascend_input_batch_metadata():
     np.testing.assert_array_equal(args[4], np.array([3, 5], dtype=np.int32))
 
 
+def test_dummy_attention_context_uses_rank_local_identity_view():
+    manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager.pcp_world_size = 2
+    manager.pcp_rank = 1
+    manager.device = torch.device("cpu")
+    input_batch = _make_local_pcp_batch()
+    input_batch.is_dummy = True
+    block_tables = (
+        torch.tensor([[1]], dtype=torch.int32),
+        torch.tensor([[2]], dtype=torch.int32),
+    )
+    slot_mappings = torch.arange(
+        len(block_tables) * manager.pcp_world_size * input_batch.num_tokens,
+        dtype=torch.int64,
+    ).view(len(block_tables), -1)
+
+    actual = manager.build_attention_context(
+        input_batch,
+        block_tables,
+        slot_mappings,
+    )
+
+    expected_slot_mappings = slot_mappings.view(
+        len(block_tables),
+        manager.pcp_world_size,
+        input_batch.num_tokens,
+    )[:, manager.pcp_rank]
+    restore_start = manager.pcp_rank * input_batch.num_tokens
+    assert actual.global_batch is input_batch
+    assert actual.global_block_tables is block_tables
+    assert torch.equal(actual.global_slot_mappings, expected_slot_mappings)
+    assert torch.equal(
+        actual.hidden_restore_idx,
+        torch.arange(
+            restore_start,
+            restore_start + input_batch.num_tokens,
+        ),
+    )
+    assert actual.local_num_tokens_after_padding == input_batch.num_tokens
+
+
 def test_npu_model_runner_uses_ascend_pcp_manager() -> None:
     runner = NPUModelRunner.__new__(NPUModelRunner)
     assert runner.pcp_manager_cls is AscendPCPManager

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1,17 +1,18 @@
 import math
 from dataclasses import dataclass
-from typing import Any, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 import torch
 import torch.distributed as dist
 import torch.nn.functional as F
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tp_group
+from vllm.distributed import get_pcp_group, get_tp_group
 from vllm.triton_utils import HAS_TRITON, triton
 from vllm.v1.attention.backend import AttentionCGSupport, AttentionImplBase, AttentionMetadataBuilder
 from vllm.v1.kv_cache_interface import AttentionSpec
 
+from vllm_ascend.attention import dsa_v1
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import (
     build_dspark_swa_indices,
@@ -27,6 +28,8 @@ from vllm_ascend.attention.utils import (
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
+from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
+from vllm_ascend.models.deepseek_v4.indexer import AscendIndexerMetadata
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import RopeDataProxy, get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
 from vllm_ascend.ops.triton.dsa_cp import build_local_metadata_triton
@@ -38,6 +41,14 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     olora_tp_enable,
 )
+
+if TYPE_CHECKING:
+    from vllm_ascend.worker.v2.pcp_manager import AscendPCPAttentionContext
+
+
+# =============================================================================
+# Legacy DSA-CP implementation (TP/SP group)
+# =============================================================================
 
 
 def hadamard_transform_ref(
@@ -1908,3 +1919,381 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             return_value=False,
         )
         return topk_idxs
+
+
+# =============================================================================
+# MRV2 DSA-PCP implementation
+# =============================================================================
+
+
+@dataclass(kw_only=True)
+class AscendDSAPCPMetadata(dsa_v1.AscendDSAMetadata):
+    """Rank-local DSA metadata with its canonical cache-update view."""
+
+    local_num_tokens_after_padding: int
+    hidden_restore_idx: torch.Tensor
+    global_dsa_metadata: dsa_v1.AscendDSAMetadata
+
+    @classmethod
+    def from_local_metadata(
+        cls,
+        local_metadata: dsa_v1.AscendDSAMetadata,
+        local_num_tokens_after_padding: int,
+        hidden_restore_idx: torch.Tensor,
+        global_dsa_metadata: dsa_v1.AscendDSAMetadata,
+    ) -> "AscendDSAPCPMetadata":
+        return cls(
+            num_actual_tokens=local_metadata.num_actual_tokens,
+            num_decodes=local_metadata.num_decodes,
+            num_decode_tokens=local_metadata.num_decode_tokens,
+            num_prefills=local_metadata.num_prefills,
+            head_dim=local_metadata.head_dim,
+            attn_state=local_metadata.attn_state,
+            req_metadata=local_metadata.req_metadata,
+            reshape_cache_event=local_metadata.reshape_cache_event,
+            hadamard=local_metadata.hadamard,
+            local_num_tokens_after_padding=local_num_tokens_after_padding,
+            hidden_restore_idx=hidden_restore_idx,
+            global_dsa_metadata=global_dsa_metadata,
+        )
+
+
+class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
+    """Build rank-local attention and canonical global cache metadata."""
+
+    def __init__(
+        self,
+        kv_cache_spec: AscendMLAAttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+        )
+        # DualChunkSwap can expand each scheduler-global prefill request into
+        # two rank-local rows. Keep this in sync with PCPManager's local input
+        # buffers, which are sized to ``2 * max_num_seqs``. The canonical
+        # global builder below must retain the scheduler-global capacity.
+        max_num_local_reqs = 2 * vllm_config.scheduler_config.max_num_seqs
+        self.start_pos_prefill = self.start_pos_prefill.new_zeros(
+            max_num_local_reqs,
+        )
+        self._global_metadata_builder = dsa_v1.AscendDSAMetadataBuilder(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls=dsa_v1.AscendDSAMetadata,
+        )
+        self._pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self._pcp_rank = get_pcp_group().rank_in_group
+
+    @classmethod
+    def get_cudagraph_support(
+        cls: type["AscendDSAPCPMetadataBuilder"],
+        vllm_config: VllmConfig,
+        kv_cache_spec: AttentionSpec,
+    ) -> AttentionCGSupport:
+        return AttentionCGSupport.NEVER
+
+    @staticmethod
+    def _build_global_common_attn_metadata(
+        pcp_context: "AscendPCPAttentionContext",
+        cache_group_idx: int,
+        local_common_attn_metadata: AscendCommonAttentionMetadata,
+    ) -> AscendCommonAttentionMetadata:
+        global_batch = pcp_context.global_batch
+        num_reqs = global_batch.num_reqs
+        return AscendCommonAttentionMetadata(
+            query_start_loc=global_batch.query_start_loc,
+            query_start_loc_cpu=torch.from_numpy(global_batch.query_start_loc_np),
+            seq_lens=global_batch.seq_lens[:num_reqs],
+            seq_lens_cpu=torch.from_numpy(global_batch.seq_lens_np)[:num_reqs],
+            seq_lens_cpu_upper_bound=global_batch.seq_lens_cpu_upper_bound[:num_reqs],
+            num_computed_tokens_cpu=torch.from_numpy(global_batch.num_computed_tokens_np),
+            num_reqs=num_reqs,
+            num_actual_tokens=global_batch.num_tokens,
+            max_query_len=int(global_batch.num_scheduled_tokens.max()),
+            max_seq_len=local_common_attn_metadata.max_seq_len,
+            block_table_tensor=pcp_context.global_block_tables[cache_group_idx],
+            slot_mapping=pcp_context.global_slot_mappings[cache_group_idx],
+            causal=local_common_attn_metadata.causal,
+            dcp_local_seq_lens=global_batch.dcp_local_seq_lens,
+            positions=global_batch.positions,
+            attn_state=global_batch.attn_state,
+            num_input_tokens=global_batch.num_tokens,
+            is_prefilling=torch.from_numpy(global_batch.is_prefilling_np),
+        )
+
+    def _build_local_common_attn_metadata(
+        self,
+        pcp_context: "AscendPCPAttentionContext",
+        common_attn_metadata: AscendCommonAttentionMetadata,
+    ) -> AscendCommonAttentionMetadata:
+        num_local_padded_tokens = pcp_context.local_num_tokens_after_padding
+        gathered_slot_mapping = common_attn_metadata.slot_mapping
+        local_slot_mapping = gathered_slot_mapping.view(
+            self._pcp_world_size,
+            num_local_padded_tokens,
+        )[self._pcp_rank]
+        return common_attn_metadata.replace(
+            slot_mapping=local_slot_mapping,
+            num_input_tokens=num_local_padded_tokens,
+        )
+
+    def _build_local_dsa_metadata(
+        self,
+        common_prefix_len: int,
+        local_common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool,
+        **kwargs,
+    ) -> dsa_v1.AscendDSAMetadata:
+        if local_common_attn_metadata.num_actual_tokens > 0:
+            return super().build(
+                common_prefix_len,
+                local_common_attn_metadata,
+                fast_build,
+                **kwargs,
+            )
+
+        # Empty ranks still participate in the global cache update collectives.
+        self.common_ratio_to_sas_metadata = kwargs.get(
+            "common_ratio_to_sas_metadata",
+        )
+        return self.metadata_cls(  # type: ignore[call-arg]
+            num_actual_tokens=0,
+            head_dim=self.model_config.get_head_size(),
+            num_decodes=0,
+            num_decode_tokens=0,
+            num_prefills=0,
+            attn_state=local_common_attn_metadata.attn_state,
+            req_metadata=None,
+            hadamard=dsa_v1.AscendDSAMetadataBuilder.hadamard,
+        )
+
+    def _build_global_dsa_metadata(
+        self,
+        common_prefix_len: int,
+        global_common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool,
+        **kwargs,
+    ) -> dsa_v1.AscendDSAMetadata:
+        global_build_kwargs = {
+            **kwargs,
+            "common_ratio_to_sas_metadata": {},
+            "num_reqs_actual": global_common_attn_metadata.num_reqs,
+        }
+        return self._global_metadata_builder.build(
+            common_prefix_len,
+            global_common_attn_metadata,
+            fast_build,
+            **global_build_kwargs,
+        )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool = False,
+        pcp_context: "AscendPCPAttentionContext | None" = None,
+        pcp_cache_group_idx: int | None = None,
+        **kwargs,
+    ) -> AscendDSAPCPMetadata:
+        assert pcp_context is not None
+        assert pcp_cache_group_idx is not None
+        global_common_attn_metadata = self._build_global_common_attn_metadata(
+            pcp_context,
+            pcp_cache_group_idx,
+            common_attn_metadata,
+        )
+        global_dsa_metadata = self._build_global_dsa_metadata(
+            common_prefix_len,
+            global_common_attn_metadata,
+            fast_build,
+            **kwargs,
+        )
+        local_common_attn_metadata = self._build_local_common_attn_metadata(
+            pcp_context,
+            common_attn_metadata,
+        )
+        local_dsa_metadata = self._build_local_dsa_metadata(
+            common_prefix_len,
+            local_common_attn_metadata,
+            fast_build,
+            **kwargs,
+        )
+        return AscendDSAPCPMetadata.from_local_metadata(
+            local_dsa_metadata,
+            pcp_context.local_num_tokens_after_padding,
+            pcp_context.hidden_restore_idx,
+            global_dsa_metadata,
+        )
+
+
+class AscendDSAPCPImpl(dsa_v1.AscendDSAImpl):
+    """Run batched global DSA cache updates before rank-local PCP attention."""
+
+    supports_pcp: ClassVar[bool] = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # PCP prepares replicated caches before local attention, leaving no
+        # cache-update work for the auxiliary stream to overlap.
+        self.multistream_dsv4_dsa_overlap = False
+
+    def _gather_and_restore_hidden_states(
+        self,
+        hidden_states: torch.Tensor,
+        metadata: AscendDSAPCPMetadata,
+    ) -> torch.Tensor:
+        """All-gather one padded rank slice and restore scheduler token order."""
+        gathered_hidden_states = get_pcp_group().all_gather(
+            hidden_states.contiguous(),
+            dim=0,
+        )
+        return torch.index_select(
+            gathered_hidden_states,
+            0,
+            metadata.hidden_restore_idx,
+        )
+
+    def _update_global_swa_cache(
+        self,
+        layer_name: str,
+        global_hidden_states: torch.Tensor,
+        swa_kv_cache: torch.Tensor,
+        swa_metadata: dsa_v1.AscendDSAMetadata,
+    ) -> None:
+        """Update the replicated SWA cache from the canonical global batch."""
+        req_metadata = dsa_v1._require_req_metadata(swa_metadata)
+        assert req_metadata.slot_mapping is not None
+
+        kv = self.kv_norm(self.wkv(global_hidden_states))
+        assert self.rope_head_dim is not None
+        kv = kv.view(
+            -1,
+            1,
+            self.nope_head_dim + self.rope_head_dim,
+        )
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            kv.unsqueeze(1),
+            req_metadata.cos[layer_name],
+            req_metadata.sin[layer_name],
+            rotary_mode="interleave",
+            partial_slice=[self.nope_head_dim, self.head_dim],
+        )
+        DeviceOperator.dsa_kv_compress_scatter(
+            swa_kv_cache,
+            kv,
+            req_metadata.slot_mapping,
+        )
+
+    def _update_global_compressor_cache(
+        self,
+        global_hidden_states: torch.Tensor,
+        metadata: AscendCompressorMetadata,
+        compress_kv_cache: torch.Tensor,
+        state_cache: torch.Tensor,
+    ) -> None:
+        """Update the DSA compressor cache from the canonical global batch."""
+        assert self.compressor is not None
+        compressed_kv, compress_slot_mapping = self.compressor(
+            hidden_states=global_hidden_states,
+            state_cache=state_cache,
+            metadata=metadata,
+        )
+        if compressed_kv.shape[0] > 0:
+            DeviceOperator.dsa_kv_compress_scatter(
+                compress_kv_cache,
+                compressed_kv,
+                compress_slot_mapping,
+            )
+
+    def _update_global_indexer_cache(
+        self,
+        global_hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        metadata: AscendIndexerMetadata,
+    ) -> None:
+        """Update the Indexer cache from the canonical global batch."""
+        indexer = self.indexer
+        assert indexer is not None
+        if indexer.skip_topk:
+            return
+        indexer.update_cache(
+            hidden_states=global_hidden_states,
+            kv_cache=kv_cache,
+            metadata=metadata,
+        )
+
+    def _prepare_caches_before_attention(
+        self,
+        layer_name: str,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: dsa_v1.DSAMetadataDict,
+    ) -> bool:
+        """Restore one global batch and update each replicated cache once."""
+        pcp_metadata = next(iter(attn_metadata.values()))
+        assert isinstance(pcp_metadata, AscendDSAPCPMetadata)
+        global_hidden_states = self._gather_and_restore_hidden_states(
+            hidden_states,
+            pcp_metadata,
+        )
+
+        global_dsa_metadata_by_prefix = {}
+        for cache_prefix, metadata in attn_metadata.items():
+            assert isinstance(metadata, AscendDSAPCPMetadata)
+            global_dsa_metadata_by_prefix[cache_prefix] = metadata.global_dsa_metadata
+        global_layer_metadata = self._get_layer_metadata(
+            layer_name,
+            global_dsa_metadata_by_prefix,
+        )
+
+        cmp_kv, swa_kv, state_cache, _, _, _ = DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
+
+        self._update_global_swa_cache(
+            layer_name,
+            global_hidden_states,
+            swa_kv,
+            global_layer_metadata.swa,
+        )
+        if self.compress_ratio > 1:
+            compressor_metadata = global_layer_metadata.compressor
+            assert compressor_metadata is not None
+            assert cmp_kv is not None
+            assert state_cache is not None
+            self._update_global_compressor_cache(
+                global_hidden_states,
+                compressor_metadata,
+                cmp_kv,
+                state_cache,
+            )
+
+            if self.compress_ratio == 4:
+                indexer_metadata = global_layer_metadata.indexer
+                assert indexer_metadata is not None
+                self._update_global_indexer_cache(
+                    global_hidden_states,
+                    kv_cache,
+                    indexer_metadata,
+                )
+        return True
+
+    def _get_o_proj_input_shape(
+        self,
+        attn_metadata: dsa_v1.DSAMetadataDict | None,
+    ) -> tuple[int, int, int]:
+        if attn_metadata is None:
+            return super()._get_o_proj_input_shape(attn_metadata)
+        pcp_metadata = next(iter(attn_metadata.values()))
+        assert isinstance(pcp_metadata, AscendDSAPCPMetadata)
+        return (
+            pcp_metadata.local_num_tokens_after_padding,
+            self.n_local_heads,
+            self.head_dim,
+        )

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1239,7 +1239,15 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         return output_padded
 
-    def _mla_prolog_single_stream(self, hidden_states, cos, sin, swa_kv_cache, slot_mapping):
+    def _mla_prolog_single_stream(
+        self,
+        hidden_states,
+        cos,
+        sin,
+        swa_kv_cache,
+        slot_mapping,
+        write_swa_cache=True,
+    ):
         """Run the MLA prolog on the current stream."""
         share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
         if share_hs_quant:
@@ -1283,35 +1291,36 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         )
 
         # win kv & tok_dis
-        if share_hs_quant:
-            kv = torch_npu.npu_quant_matmul(
-                hs_int8,
-                self.wkv.weight,
-                self.wkv.weight_scale,
-                pertoken_scale=hs_pertoken_scale,
-                bias=self.wkv.bias,
-                output_dtype=hidden_states.dtype,
+        if write_swa_cache:
+            if share_hs_quant:
+                kv = torch_npu.npu_quant_matmul(
+                    hs_int8,
+                    self.wkv.weight,
+                    self.wkv.weight_scale,
+                    pertoken_scale=hs_pertoken_scale,
+                    bias=self.wkv.bias,
+                    output_dtype=hidden_states.dtype,
+                )
+            else:
+                kv = self.wkv(hidden_states)
+            kv = self.kv_norm(kv)
+            assert self.rope_head_dim is not None
+            kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
+
+            torch.ops._C_ascend.inplace_partial_rotary_mul(
+                kv.unsqueeze(1),
+                cos,
+                sin,
+                rotary_mode="interleave",
+                partial_slice=[self.nope_head_dim, self.head_dim],
             )
-        else:
-            kv = self.wkv(hidden_states)
-        kv = self.kv_norm(kv)
-        assert self.rope_head_dim is not None
-        kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
 
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
-            kv.unsqueeze(1),
-            cos,
-            sin,
-            rotary_mode="interleave",
-            partial_slice=[self.nope_head_dim, self.head_dim],
-        )
-
-        # swa exec kv
-        DeviceOperator.dsa_kv_compress_scatter(
-            swa_kv_cache,
-            kv,
-            slot_mapping,
-        )
+            # swa exec kv
+            DeviceOperator.dsa_kv_compress_scatter(
+                swa_kv_cache,
+                kv,
+                slot_mapping,
+            )
 
         return q, qr, qr_pertoken_scale
 
@@ -1412,7 +1421,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         return q, qr, qr_pertoken_scale
 
-    def _update_compressed_caches_and_select_topk(
+    def _maybe_update_compressed_caches_and_select_topk(
         self,
         layer_name: str,
         hidden_states: torch.Tensor,
@@ -1422,6 +1431,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         qr_pertoken_scale: torch.Tensor | None,
         compress_kv_cache: torch.Tensor,
         state_cache: torch.Tensor,
+        write_cache: bool = True,
     ) -> torch.Tensor | None:
         """Update compressed caches and return Indexer top-k indices."""
         compressor = self.compressor
@@ -1463,8 +1473,11 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 overlap_plan=overlap_plan,
                 layer_name=layer_name,
                 qr_pertoken_scale=qr_pertoken_scale,
+                write_cache=write_cache,
             )
 
+        if not write_cache:
+            return None
         compressed_kv, compress_slot_mapping = compressor(
             hidden_states=hidden_states,
             state_cache=state_cache,
@@ -1484,7 +1497,13 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         hidden_states: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
         layer_metadata: AscendDSALayerMetadata,
+        cache_is_prepared: bool = False,
     ) -> torch.Tensor:
+        # DSA PCP sets cache_is_prepared after global cache updates and forces
+        # single-stream attention because there is no local KV update to overlap.
+        if cache_is_prepared and self.multistream_dsv4_dsa_overlap:
+            raise RuntimeError("Prepared DSA caches require single-stream attention.")
+
         (
             compress_kv_cache,
             swa_kv_cache,
@@ -1526,6 +1545,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 sin,
                 swa_kv_cache,
                 swa_req_metadata.slot_mapping,
+                write_swa_cache=not cache_is_prepared,
             )
 
         compress_topk_idxs = None
@@ -1533,7 +1553,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         if self.compress_ratio > 1:
             compressor_metadata = layer_metadata.compressor
             assert compressor_metadata is not None
-            compress_topk_idxs = self._update_compressed_caches_and_select_topk(
+            compress_topk_idxs = self._maybe_update_compressed_caches_and_select_topk(
                 layer_name=layer_name,
                 hidden_states=hidden_states,
                 qr=qr,
@@ -1542,6 +1562,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 qr_pertoken_scale=qr_pertoken_scale,
                 compress_kv_cache=compress_kv_cache,
                 state_cache=state_cache,
+                write_cache=not cache_is_prepared,
             )
 
         notify_kv_cache_written(layer_name)

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -21,6 +21,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
+    enable_pcp,
     maybe_save_kv_layer_to_connector,
     notify_kv_cache_written,
     split_decodes_and_prefills,
@@ -90,10 +91,18 @@ class AscendDSABackend(AttentionBackend):
     def get_builder_cls():
         from vllm_ascend.utils import enable_dsa_cp
 
-        if enable_dsa_cp():
+        use_dsa_cp = enable_dsa_cp()
+        use_pcp = enable_pcp()
+        if use_dsa_cp and use_pcp:
+            raise ValueError("Legacy DSACP and PCP cannot be enabled at the same time.")
+        if use_dsa_cp:
             from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPMetadataBuilder
 
             return AscendDSACPMetadataBuilder
+        if use_pcp:
+            from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSAPCPMetadataBuilder
+
+            return AscendDSAPCPMetadataBuilder
         return AscendDSAMetadataBuilder
 
     @staticmethod
@@ -114,10 +123,18 @@ class AscendDSABackend(AttentionBackend):
     def get_impl_cls() -> type[AttentionImplBase[Any]]:
         from vllm_ascend.utils import enable_dsa_cp
 
-        if enable_dsa_cp():
+        use_dsa_cp = enable_dsa_cp()
+        use_pcp = enable_pcp()
+        if use_dsa_cp and use_pcp:
+            raise ValueError("Legacy DSACP and PCP cannot be enabled at the same time.")
+        if use_dsa_cp:
             from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
 
             return AscendDSACPImpl
+        if use_pcp:
+            from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSAPCPImpl
+
+            return AscendDSAPCPImpl
         return AscendDSAImpl
 
     @staticmethod
@@ -1181,6 +1198,26 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             output[...] = self.wo_b(o_proj_input)
         return output
 
+    def _prepare_caches_before_attention(
+        self,
+        layer_name: str,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: DSAMetadataDict,
+    ) -> bool:
+        """Prepare cache updates and report whether local writes can be skipped."""
+        return False
+
+    def _get_o_proj_input_shape(
+        self,
+        attn_metadata: DSAMetadataDict | None,
+    ) -> tuple[int, int, int]:
+        return (
+            _EXTRA_CTX.num_tokens,
+            self.n_local_heads,
+            self.head_dim,
+        )
+
     def forward(
         self,
         layer_name,
@@ -1191,16 +1228,12 @@ class AscendDSAImpl(AttentionImplBase[Any]):
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
         output_padded = output
-        o_proj_input_shape = (
-            _EXTRA_CTX.num_tokens,
-            self.n_local_heads,
-            self.head_dim,
-        )
+        o_proj_input_shape = self._get_o_proj_input_shape(attn_metadata)
         if attn_metadata is None:
             # Profiling run: run o_proj on zero input so HCCL collectives are
             # captured by the ACL graph.  Non-OTP just zeros the output.
             if oproj_tp_enable():
-                o_proj_input = torch.zeros(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+                o_proj_input = hidden_states.new_zeros(o_proj_input_shape)
                 self._forward_o_proj(o_proj_input, output)
             else:
                 output.fill_(0)
@@ -1211,30 +1244,42 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             common_attn_metadata = layer_metadata.swa
         actual_tokens = common_attn_metadata.num_actual_tokens
 
-        o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+        o_proj_input = hidden_states.new_zeros(o_proj_input_shape)
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
         wait_for_kv_layer_from_connector(layer_name)
+        cache_is_prepared = self._prepare_caches_before_attention(
+            layer_name,
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+        )
+        if actual_tokens == 0:
+            output.zero_()
+            notify_kv_cache_written(layer_name)
+            maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
+            return output
+
         req_metadata = _require_req_metadata(common_attn_metadata)
         o_proj_input[:actual_tokens] = self._forward_attention(
             layer_name,
             hidden_states[:actual_tokens],
             kv_cache,
             layer_metadata,
+            cache_is_prepared,
         )
         cos = req_metadata.cos[layer_name]
         sin = req_metadata.sin[layer_name]
 
         torch.ops._C_ascend.inplace_partial_rotary_mul(
-            o_proj_input.unsqueeze(1),
-            cos,
-            -sin,
+            o_proj_input[:actual_tokens].unsqueeze(1),
+            cos[:actual_tokens],
+            -sin[:actual_tokens],
             rotary_mode="interleave",
             partial_slice=[self.nope_head_dim, self.head_dim],
         )
 
         # o
         self._forward_o_proj(o_proj_input, output)
-
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
         return output_padded

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -325,6 +325,42 @@ class DeepseekV4Indexer(nn.Module):
         assert hadamard is not None
         return cache_req_metadata, hadamard
 
+    def update_cache(
+        self,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        metadata: AscendIndexerMetadata,
+    ) -> None:
+        """Update Indexer caches without projecting queries or selecting TopK."""
+        if hidden_states.shape[0] == 0:
+            return
+
+        state_cache, key_cache, scale_cache, full_cache = self.ops.unpack_dsa_indexer_kv_cache(kv_cache)
+        _, hadamard = self._get_indexer_cache_metadata(metadata)
+        compressor = self.compressor
+        assert compressor is not None
+        key, slot_mapping = compressor(
+            hidden_states=hidden_states,
+            state_cache=state_cache,
+            metadata=metadata.compressor,
+        )
+        if key.shape[0] == 0:
+            return
+        if compressor.rotate:
+            key = rotate_activation(key, hadamard)
+        _, key_scale = self.ops.quantize_key_and_update_cache(
+            key,
+            key_cache,
+            full_cache,
+            slot_mapping,
+        )
+        if key_scale is not None:
+            self.ops.update_scale_cache(
+                key_scale,
+                scale_cache,
+                slot_mapping,
+            )
+
     def _get_cached_topk_indices(self, num_tokens: int, offset: int = 0) -> torch.Tensor:
         if self.topk_indices_buffer is None:
             raise RuntimeError("topk_indices_buffer is required to read cached TopK indices")

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -356,6 +356,7 @@ class DeepseekV4Indexer(nn.Module):
         overlap_plan: IndexerOverlapPlan,
         *,
         qr_pertoken_scale: torch.Tensor | None = None,
+        write_cache: bool = True,
     ) -> torch.Tensor:
         num_tokens = hidden_states.shape[0]
         cache_metadata, _ = self._get_indexer_cache_metadata(metadata)
@@ -396,9 +397,10 @@ class DeepseekV4Indexer(nn.Module):
                 cos,
                 sin,
                 qr_pertoken_scale,
+                write_cache=write_cache,
             )
 
-        if self.skip_topk or aux_stream is None:
+        if write_cache and (self.skip_topk or aux_stream is None):
             compressed_kv, compress_slot_mapping = overlap_plan.compute_attention_compressed_kv()
             overlap_plan.scatter_attention_compressed_kv(compressed_kv, compress_slot_mapping)
 
@@ -571,6 +573,7 @@ class DeepseekV4Indexer(nn.Module):
         cos: torch.Tensor,
         sin: torch.Tensor,
         qr_pertoken_scale: torch.Tensor | None = None,
+        write_cache: bool = True,
     ):
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
             self.ops.unpack_dsa_indexer_kv_cache(kv_cache)
@@ -605,15 +608,18 @@ class DeepseekV4Indexer(nn.Module):
         )
 
         q = rotate_activation(q, hadamard)
-        kv, indexer_slot_mapping = compressor(
-            hidden_states=x,
-            state_cache=indexer_state_cache,
-            metadata=metadata.compressor,
-        )
-        if kv.numel() == 0:
-            kv = None
-        elif compressor.rotate:
-            kv = rotate_activation(kv, hadamard)
+        kv = None
+        indexer_slot_mapping = None
+        if write_cache:
+            kv, indexer_slot_mapping = compressor(
+                hidden_states=x,
+                state_cache=indexer_state_cache,
+                metadata=metadata.compressor,
+            )
+            if kv.numel() == 0:
+                kv = None
+            elif compressor.rotate:
+                kv = rotate_activation(kv, hadamard)
 
         return (
             q,
@@ -634,6 +640,7 @@ class DeepseekV4Indexer(nn.Module):
         cos: torch.Tensor,
         sin: torch.Tensor,
         qr_pertoken_scale: torch.Tensor | None = None,
+        write_cache: bool = True,
     ):
         q, kv, ik, isc, ifc, cache_metadata, indexer_slot_mapping = self._indexer_qkv_prepare(
             x,
@@ -643,17 +650,29 @@ class DeepseekV4Indexer(nn.Module):
             cos,
             sin,
             qr_pertoken_scale,
+            write_cache=write_cache,
         )
 
         weights = self.weights_proj(x) * (self.softmax_scale * self.n_heads**-0.5)
 
-        return self.ops.quantize_update_cache_and_select_topk(
+        if write_cache:
+            return self.ops.quantize_update_cache_and_select_topk(
+                q,
+                kv,
+                weights,
+                ik,
+                isc,
+                ifc,
+                indexer_slot_mapping,
+                cache_metadata,
+            )
+
+        q, q_scale = self.ops.quantize_query(q)
+        return self.ops.select_topk(
             q,
-            kv,
             weights,
+            q_scale,
             ik,
             isc,
-            ifc,
-            indexer_slot_mapping,
             cache_metadata,
         )

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -20,7 +20,7 @@
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -45,7 +45,10 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import AscendDSAMetadataBuilder
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, get_sfa_qsfa_packed_head_dim
+from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    get_sfa_qsfa_packed_head_dim,
+)
 from vllm_ascend.core.kv_cache_interface import (
     AscendMLAAttentionSpec,
     AscendSFAIndexerCacheSpec,
@@ -53,6 +56,9 @@ from vllm_ascend.core.kv_cache_interface import (
 )
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import AscendDeviceType, calc_split_factor, enable_sfa, get_ascend_device_type
+
+if TYPE_CHECKING:
+    from vllm_ascend.worker.v2.pcp_manager import AscendPCPAttentionContext
 
 
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
@@ -181,6 +187,7 @@ def build_attn_metadata(
     num_actual_tokens: int | None = None,
     num_input_tokens: int | None = None,
     is_prefilling: torch.Tensor | None = None,
+    pcp_context: "AscendPCPAttentionContext | None" = None,
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
     causal: bool | Mapping[int, bool] = True,
@@ -259,6 +266,11 @@ def build_attn_metadata(
                         num_reqs_actual=num_reqs,
                         common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                     )
+                    if pcp_context is not None:
+                        attn_metadata_extra_kwargs.update(
+                            pcp_context=pcp_context,
+                            pcp_cache_group_idx=i,
+                        )
                 metadata = attn_metadata_builder.build(
                     common_prefix_len=0,
                     common_attn_metadata=common_attn_metadata,

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -77,6 +77,7 @@ class AscendInputBatch(InputBatch):
         seq_lens_np: np.ndarray = None  # type: ignore[assignment, no-redef]
     # attn_state is used to build attention metadata.
     attn_state: AscendAttentionState | None = None
+    is_dummy: bool = False
 
     if vllm_version_is("0.27.1"):
 
@@ -104,6 +105,7 @@ class AscendInputBatch(InputBatch):
                 **asdict(input_batch),
                 seq_lens_np=seq_lens_np,
                 attn_state=AscendAttentionState.DecodeOnly,
+                is_dummy=True,
             )
 
     else:
@@ -134,4 +136,5 @@ class AscendInputBatch(InputBatch):
                 **asdict(input_batch),
                 seq_lens_np=seq_lens_np,
                 attn_state=AscendAttentionState.DecodeOnly,
+                is_dummy=True,
             )

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -168,7 +168,7 @@ class NPUModelRunner(GPUModelRunner):
             if self.pcp_manager is not None:
                 assert isinstance(self.pcp_manager, AscendPCPManager)
                 self.pcp_manager.vllm_config = self.vllm_config
-
+                self.model_state.pcp_manager = self.pcp_manager
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
 

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -17,7 +17,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch
 from vllm.config.compilation import CUDAGraphMode
@@ -28,9 +28,14 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 
+if TYPE_CHECKING:
+    from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+
 
 class AscendModelState(DefaultModelState):
     """Model state for Ascend NPUs."""
+
+    pcp_manager: "AscendPCPManager | None" = None
 
     def prepare_attn(
         self,
@@ -56,6 +61,15 @@ class AscendModelState(DefaultModelState):
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)
         max_query_len = input_batch.num_scheduled_tokens.max().item()
+        pcp_context = (
+            self.pcp_manager.build_attention_context(
+                input_batch,
+                block_tables,
+                slot_mappings,
+            )
+            if self.pcp_manager is not None
+            else None
+        )
         # attn_metadata is needed when update_full_graph_params, but no way can get it now.
         # Temporarily store it in model_state.
         self.attn_metadata = build_attn_metadata(
@@ -78,6 +92,7 @@ class AscendModelState(DefaultModelState):
             seq_lens_np=input_batch.seq_lens_np,
             positions=input_batch.positions,
             attn_state=input_batch.attn_state,
+            pcp_context=pcp_context,
             for_cudagraph_capture=for_capture,
         )
         return self.attn_metadata

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -17,6 +17,8 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from dataclasses import dataclass
+
 import torch
 from vllm.config import VllmConfig
 from vllm.v1.worker.gpu.block_table import BlockTables
@@ -25,6 +27,18 @@ from vllm.v1.worker.gpu.states import RequestState
 
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
+
+
+@dataclass(frozen=True)
+class AscendPCPAttentionContext:
+    """Canonical global PCP view for one attention step."""
+
+    # The global batch and its associated metadata, used to build DSA attention metadata.
+    global_batch: AscendInputBatch
+    global_block_tables: tuple[torch.Tensor, ...]
+    global_slot_mappings: torch.Tensor
+    hidden_restore_idx: torch.Tensor
+    local_num_tokens_after_padding: int
 
 
 class AscendPCPManager(PCPManager):
@@ -97,3 +111,41 @@ class AscendPCPManager(PCPManager):
             - (local_batch.num_draft_tokens_per_req if local_batch.num_draft_tokens_per_req is not None else 0),
         )
         return local_batch
+
+    def build_attention_context(
+        self,
+        input_batch: AscendInputBatch,
+        block_tables: tuple[torch.Tensor, ...],
+        slot_mappings: torch.Tensor,
+    ) -> AscendPCPAttentionContext:
+        """Build the PCP context consumed by attention metadata builders."""
+        if input_batch.is_dummy:
+            local_num_tokens_after_padding = input_batch.num_tokens
+            restore_start = self.pcp_rank * local_num_tokens_after_padding
+            return AscendPCPAttentionContext(
+                global_batch=input_batch,
+                global_block_tables=block_tables,
+                global_slot_mappings=slot_mappings.view(
+                    slot_mappings.shape[0],
+                    self.pcp_world_size,
+                    local_num_tokens_after_padding,
+                )[:, self.pcp_rank],
+                hidden_restore_idx=torch.arange(
+                    restore_start,
+                    restore_start + local_num_tokens_after_padding,
+                    device=self.device,
+                ),
+                local_num_tokens_after_padding=local_num_tokens_after_padding,
+            )
+
+        global_batch = self._global_batch
+        return AscendPCPAttentionContext(
+            global_batch=global_batch,
+            global_block_tables=self._block_tables.gather_block_tables(
+                global_batch.idx_mapping,
+                global_batch.num_reqs_after_padding,
+            ),
+            global_slot_mappings=self._global_batch_slot_mappings[:, : global_batch.num_tokens],
+            hidden_restore_idx=self._hidden_restore_idx,
+            local_num_tokens_after_padding=input_batch.num_tokens_after_padding,
+        )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds DeepSeek-V4 DSA prefill context parallelism support to
ModelRunner V2 while preserving the existing standalone DSA and legacy
DSACP paths.

- Deduplicate the Q projection, SWA cache update, and multistream QLI
  completion shared by DSA prefill and decode.
- Add a cache-prepared execution mode that separates global SWA,
  compressor, and indexer cache updates from rank-local attention.
- Add a PCP-specific DSA backend and metadata builder that derive a
  canonical global token layout, gather fixed-shape hidden states, and
  replay the main and indexer compressors in the same order on every PCP
  rank.
- Run attention on rank-local tokens after cache preparation and restore
  rank-local outputs, while rejecting unsupported PCP combinations.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek-V4 DSA models running with ModelRunner V2 can use prefill
context parallelism through the existing PCP configuration. This PR does
not add new CLI arguments or configuration fields.

### How was this patch tested?

DeepSeek-V4 Flash W4A8, 128K prefill (131072 input tokens + 1 output token),
16 NPUs, DP2:

| Global batch | TP8 baseline | DSACP | PCP8 | PCP8 vs DSACP |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 7.88k tok/s | 12.49k tok/s | 15.12k tok/s | +21.05% |
| 2 | 14.60k tok/s | 22.50k tok/s | 24.37k tok/s | +8.32% |
| 4 | 15.28k tok/s | 23.86k tok/s | 26.01k tok/s | +8.98% |
| 8 | 15.77k tok/s | 25.22k tok/s | 27.35k tok/s | +8.44% |

GPQA Diamond first 100 samples, 8 NPUs, DP1: PCP8 accuracy is **62%**,
compared with **60%** for the TP8 baseline (**+2 pp**); both completed
100/100 requests successfully.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
