### PR TITLE
[BugFix] Fix CopyInKv DMA flipping KV block order when physical address order mismatches logical token order

### DIFF
--- a/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_block_vector.h
+++ b/csrc/attention/sparse_attn_sharedkv/op_kernel/arch32/sparse_attn_sharedkv_scfa_block_vector.h
@@ -610,11 +610,15 @@ __aicore__ inline void SASVectorBlock<SAST>::CopyInKv(int64_t &mte2Size, int64_t
         keySrcStride = ((keyOffset1 > keyOffset2 ? (keyOffset1 - keyOffset2) :
 	                    (keyOffset2 - keyOffset1)) - constInfo.sparseBlockSize) * constInfo.headDim * sizeof(KV_T);
     }
+    // PA_ND (paged KV cache) only: check if physical address order
+    // is inconsistent with logical token order
+    constexpr bool isPagedLayout = (KV_LAYOUT_T == SAS_LAYOUT::PA_ND);
     if (unlikely(keySrcStride >= INT32_MAX || keySrcStride < 0 ||
         realS2Idx1 + constInfo.sparseBlockSize >= s2IdLimit ||
-        realS2Idx2 + constInfo.sparseBlockSize >= s2IdLimit)) {
-        // stride溢出、stride为负数、s2超长等异常场景，还原成2条搬运指令
-        // 因为需要拷贝两块
+        realS2Idx2 + constInfo.sparseBlockSize >= s2IdLimit ||
+        (isPagedLayout && keyOffset1 >= 0 && keyOffset2 >= 0 && keyOffset2 < keyOffset1))) {
+        // stride溢出、stride为负数、s2超长、或（PA_ND模式下）物理顺序与逻辑顺序不一致等异常场景，
+        // 还原成2条搬运指令以保持逻辑 token 顺序
         CopyInSingleKv(mte2Size, mte3Size, mergeMte3Idx, realS2Idx1, keyOffset1, s2IdLimit, runInfo);
         CopyInSingleKv(mte2Size, mte3Size, mergeMte3Idx, realS2Idx2, keyOffset2, s2IdLimit, runInfo);
     } else {

--- a/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_service_vector_mla.h
+++ b/csrc/attention/sparse_flash_attention/op_kernel/arch22/sparse_flash_attention_service_vector_mla.h
@@ -928,8 +928,10 @@ __aicore__ inline void SFAVectorService<SFAT>::CopyInKv(int64_t &mte2Size, int64
     if (unlikely(keySrcStride >= INT32_MAX || keySrcStride < 0 ||
         (!PAGE_ATTENTION && (keyRopeSrcStride >= INT32_MAX || keyRopeSrcStride < 0)) ||
         realS2Idx1 + constInfo.sparseBlockSize >= s2IdLimit ||
-        realS2Idx2 + constInfo.sparseBlockSize >= s2IdLimit)) {
-        // stride溢出、stride为负数、s2超长等异常场景，还原成2条搬运指令
+        realS2Idx2 + constInfo.sparseBlockSize >= s2IdLimit ||
+        (PAGE_ATTENTION && keyOffset1 >= 0 && keyOffset2 >= 0 && keyOffset2 < keyOffset1))) {
+        // stride溢出、stride为负数、s2超长、或（paged attention模式下）物理顺序与逻辑顺序不一致等异常场景，
+        // 还原成2条搬运指令以保持逻辑 token 顺序
         CopyInSingleKv(mte2Size, mte3Size, mergeMte3Idx, realS2Idx1, keyOffset1, s2IdLimit, runInfo);
         CopyInSingleKv(mte2Size, mte3Size, mergeMte3Idx, realS2Idx2, keyOffset2, s2IdLimit, runInfo);
     } else {


### PR DESCRIPTION
## Problem

In paged KV cache architecture, when two KV blocks' physical addresses are in reverse order compared to their logical token order (`keyOffset2 < keyOffset1`), the `CopyInKv` fast path DMA copies blocks starting from the lower physical address, which flips the block order in Unified Buffer. This causes sparse attention to read KV cache in wrong order, producing incorrect logits.

## Symptoms

- Intermittent (~2% rate) infinite token repetition in structured output
- Model enters a loop outputting the same token until `max_tokens` is hit
- `finish_reason: length` instead of `stop`
- More visible with structured output (xgrammar bitmask prevents model from breaking out of the loop by constraining token space)

## Root Cause

The fast path in `CopyInKv` merges two block DMAs into one strided copy. It starts from `min(keyOffset1, keyOffset2)` to ensure contiguous read. However, when `keyOffset2 < keyOffset1`, block2 lands before block1 in UB, reversing their logical order. The attention computation then reads KV in wrong sequence, corrupting the output.

## Fix

Add a physical/logical order consistency check to the fallback condition. When both blocks are valid and `keyOffset2 < keyOffset1` (physical order reversed), force the fallback path (two separate `CopyInSingleKv` calls) to preserve correct logical token order.

## Files Changed

- `sparse_attn_sharedkv_scfa_block_vector.h` (A2/910B, arch32)
- `sparse_flash_attention_service_vector_mla.h` (MLA variant, arch22)
- `kv_quant_sparse_attn_sharedkv_scfa_block_vector.h` (A3/910C, arch35)

## Verification

- Deployed dsv4-flash-w8a8-mtp on A2 pod (8x 910B2C, PD separation)
- **Before fix**: 1/50 requests reproduced (`finish_reason=length`, token 223 infinite repetition)
- **After fix**: 0/500 requests reproduced (all `finish_reason=stop`)
- Debug logs confirmed grammar constraint was working correctly; root cause was attention kernel reading wrong KV order

Related issue: #14013

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
