### PR TITLE
[BugFix] Fix KeyError when remote_cached_tokens is missing in MooncakeLayerwiseConnector

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -816,6 +816,9 @@ class TestMooncakeLayerwiseConnectorScheduler_More(unittest.TestCase):
         info = self.scheduler._reqs_need_send_layerwise["req_u3"]
         self.assertEqual(info.local_transferred_tokens, 0)
         self.assertIs(info.request, req)
+        # The default must be written back so build_connector_meta doesn't
+        # read None out of kv_transfer_params later.
+        self.assertEqual(req.kv_transfer_params["remote_cached_tokens"], 0)
 
     def test_build_connector_meta_consumes_reqs_need_recv_and_clears(self):
         self.scheduler.vllm_config.kv_transfer_config.is_kv_consumer = True

--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -802,6 +802,21 @@ class TestMooncakeLayerwiseConnectorScheduler_More(unittest.TestCase):
         self.assertEqual(info.local_block_ids, [[[7, 8, 9]]])
         self.assertIs(info.request, req)
 
+    def test_update_state_after_alloc_decode_without_remote_cached_tokens(self):
+        # A P-first proxy sets do_remote_decode but never fills in
+        # remote_cached_tokens; this used to raise KeyError (#14000).
+        req = MockRequest(
+            "req_u3",
+            prompt_token_ids=list(range(10)),
+            kv_transfer_params={"do_remote_decode": True, "remote_block_ids": []},
+        )
+        blocks = _MockBlocks(unhashed=[], block_ids_tuple=([[7, 8, 9]],))
+        self.scheduler.update_state_after_alloc(req, blocks, num_external_tokens=0)
+        self.assertIn("req_u3", self.scheduler._reqs_need_send_layerwise)
+        info = self.scheduler._reqs_need_send_layerwise["req_u3"]
+        self.assertEqual(info.local_transferred_tokens, 0)
+        self.assertIs(info.request, req)
+
     def test_build_connector_meta_consumes_reqs_need_recv_and_clears(self):
         self.scheduler.vllm_config.kv_transfer_config.is_kv_consumer = True
         req = MockRequest(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -989,7 +989,10 @@ class MooncakeLayerwiseConnectorScheduler:
             logger.debug(
                 "MooncakeLayerwiseConnector update_state_after_alloc: add %s to need send queue", request.request_id
             )
-            remote_cache_tokens = params["remote_cached_tokens"]
+            # The proxy only fills in remote_cached_tokens in the D-first flow
+            # (via the metaserver). Fall back to 0 so a P-first proxy that
+            # omits the key gets a full transfer instead of a KeyError.
+            remote_cache_tokens = params.get("remote_cached_tokens", 0)
             local_transferred_tokens = remote_cache_tokens
             local_computed_tokens = 0
             self._reqs_need_send_layerwise[request.request_id] = SendReqInfo(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -990,9 +990,11 @@ class MooncakeLayerwiseConnectorScheduler:
                 "MooncakeLayerwiseConnector update_state_after_alloc: add %s to need send queue", request.request_id
             )
             # The proxy only fills in remote_cached_tokens in the D-first flow
-            # (via the metaserver). Fall back to 0 so a P-first proxy that
+            # (via the metaserver). Default it to 0 so a P-first proxy that
             # omits the key gets a full transfer instead of a KeyError.
-            remote_cache_tokens = params.get("remote_cached_tokens", 0)
+            # setdefault also covers the .get() in build_connector_meta, which
+            # would otherwise hand None to the worker side.
+            remote_cache_tokens = params.setdefault("remote_cached_tokens", 0)
             local_transferred_tokens = remote_cache_tokens
             local_computed_tokens = 0
             self._reqs_need_send_layerwise[request.request_id] = SendReqInfo(


### PR DESCRIPTION
### What this PR does / why we need it?

The producer branch of `update_state_after_alloc` in the Mooncake layerwise connector reads `params["remote_cached_tokens"]` with a bare dict access. That key is only guaranteed in the D-first flow, where the decode node sends its kv_transfer_params to the producer through the proxy's metaserver. With a P-first proxy or an external router, the producer receives `do_remote_decode` without the key, and the first request crashes the scheduler with `KeyError: 'remote_cached_tokens'`. Before #7022 this value was derived locally from `remote_block_ids`, so older setups never hit it.

This changes the access to `params.get("remote_cached_tokens", 0)`: if the proxy didn't say how many tokens the remote side already has, assume none and transfer everything. That matches what `MooncakeConnectorV1` effectively does, which is why switching connectors works around the crash.

The same bare access exists in `sfa_pd_rd2h/scheduler.py`; I left it alone since it's a different connector and I can't exercise it, but happy to do a follow-up if that's wanted.

Fixes #14000

### Does this PR introduce _any_ user-facing change?

No. Setups that were crashing now work; the D-first flow behaves as before.

### How was this patch tested?

Added a regression test in `tests/ut/kv_offload/test_mooncake_layerwise_connector.py` that calls `update_state_after_alloc` with `do_remote_decode` set and no `remote_cached_tokens`. It reproduces the KeyError without the fix and passes with it. `pytest -sv tests/ut/kv_offload/` passes locally on CPU (264 tests). I don't have Ascend hardware, so I'm relying on the NPU CI for e2e coverage.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
