### PR TITLE
[BugFix][Triton] Prevent zero-progress speculative decoding when recovery scores are NaN

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
@@ -31,6 +31,7 @@ def setup_device_properties():
     yield
 
 
+
 @torch.inference_mode()
 def test_expand_kernel():
     device = "npu"
@@ -145,6 +146,64 @@ def test_sample_recovered_tokens_kernel():
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("batch_size", [1, 8])
+@pytest.mark.parametrize("has_draft_probs", [False, True])
+@torch.inference_mode()
+def test_sample_recovered_tokens_all_nan(batch_size, has_draft_probs):
+    max_spec_len = 5
+    vocab_size = 17
+    num_tokens = batch_size * max_spec_len
+    cu_num_draft_tokens = torch.arange(
+        max_spec_len,
+        num_tokens + 1,
+        max_spec_len,
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    draft_token_ids = torch.ones(num_tokens, dtype=torch.int32, device=DEVICE)
+    draft_probs = None
+    if has_draft_probs:
+        draft_probs = torch.rand(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
+    target_probs = torch.full(
+        (num_tokens, vocab_size),
+        float("nan"),
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    q = torch.ones(batch_size, vocab_size, dtype=torch.float32, device=DEVICE)
+    output_token_ids = torch.full_like(draft_token_ids, -1)
+
+    reference_probs = target_probs.clone()
+    if draft_probs is None:
+        reference_probs[torch.arange(num_tokens, device=DEVICE), draft_token_ids.long()] = 0
+    else:
+        reference_probs = torch.clamp(reference_probs - draft_probs, min=0)
+    expected = torch.argmax(
+        reference_probs / q.repeat_interleave(max_spec_len, dim=0), dim=1
+    ).to(output_token_ids.dtype)
+
+    sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
+        output_token_ids,
+        cu_num_draft_tokens,
+        draft_token_ids,
+        draft_probs,
+        target_probs,
+        None,
+        q,
+        vocab_size,
+        vocab_size,
+        NO_DRAFT_PROBS=draft_probs is None,
+        ENABLE_REDUCE_SAMPLING=False,
+        SUB_BLOCK=16,
+        VOCAB_BLOCK_SIZE=8,
+        multibuffer=False,
+    )
+    torch.npu.synchronize()
+
+    assert torch.equal(output_token_ids, expected)
+    assert torch.all((output_token_ids >= 0) & (output_token_ids < vocab_size))
 
 
 @pytest.mark.parametrize("synthetic_mode", [False, True])

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -411,7 +411,7 @@ def sample_recovered_tokens_kernel(
         n_loop = tl.cdiv(C, VOCAB_BLOCK_SIZE)
 
         global_max_p = tl.full((), -float("inf"), tl.float32)
-        global_recovered_id = tl.full((), -1, tl.int64)
+        global_recovered_id = tl.full((), 0, tl.int64)
         draft_token_id = tl.load(draft_token_ids_ptr + token_idx).to(tl.int64)
 
         for li in range(n_loop):
@@ -448,27 +448,31 @@ def sample_recovered_tokens_kernel(
             global_max_p = tl.where(better, block_best_score, global_max_p)
             global_recovered_id = tl.where(better, block_best_global_id, global_recovered_id)
 
+        global_recovered_id = tl.maximum(0, tl.minimum(global_recovered_id, global_vocab_size - 1))
         tl.store(output_token_ids_ptr + token_idx, global_recovered_id)
     else:
         vocab_size = global_vocab_size
         loop = (vocab_size + SUB_BLOCK - 1) // SUB_BLOCK
-        global_recovered_id = -1
-        global_max_p = -1.0
+        global_recovered_id = 0
+        global_max_p = -float("inf")
         if NO_DRAFT_PROBS:
             draft_token_id = tl.load(draft_token_ids_ptr + start_idx + pos)
             for loop_i in range(loop):
                 vocab_start = loop_i * SUB_BLOCK
                 vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
+                vocab_mask = vocab_offset < vocab_size
                 prob = tl.load(
                     target_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
-                    mask=vocab_offset < vocab_size,
+                    mask=vocab_mask,
                     other=0,
                 )
                 prob = tl.where(vocab_offset == draft_token_id, 0.0, prob)
                 q = tl.load(
-                    q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_offset < vocab_size, other=float("-inf")
+                    q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_mask, other=float("-inf")
                 )
                 new_p = prob / q
+                # Padding must never win the argmax when valid scores are NaN.
+                new_p = tl.where(vocab_mask, new_p, float("-inf"))
                 recovered_id = tl.argmax(new_p, axis=-1)
                 max_p = get_element(new_p, (recovered_id,))
                 if max_p > global_max_p:
@@ -478,14 +482,15 @@ def sample_recovered_tokens_kernel(
             for loop_i in range(loop):
                 vocab_start = loop_i * SUB_BLOCK
                 vocab_offset = vocab_start + tl.arange(0, SUB_BLOCK)
+                vocab_mask = vocab_offset < vocab_size
                 draft_prob = tl.load(
                     draft_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
-                    mask=vocab_offset < vocab_size,
+                    mask=vocab_mask,
                     other=0,
                 )
                 target_prob = tl.load(
                     target_probs_ptr + (start_idx + pos) * vocab_size + vocab_offset,
-                    mask=vocab_offset < vocab_size,
+                    mask=vocab_mask,
                     other=0,
                 )
                 prob = tl.maximum(target_prob - draft_prob, 0)
@@ -493,15 +498,17 @@ def sample_recovered_tokens_kernel(
                 # `tl.argmax` will select the maximum value.
 
                 q = tl.load(
-                    q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_offset < vocab_size, other=float("-inf")
+                    q_ptr + req_idx * vocab_size + vocab_offset, mask=vocab_mask, other=float("-inf")
                 )
                 new_p = prob / q
+                new_p = tl.where(vocab_mask, new_p, float("-inf"))
                 recovered_id = tl.argmax(new_p, axis=-1)
                 max_p = get_element(new_p, (recovered_id,))
                 if max_p > global_max_p:
                     global_max_p = max_p
                     global_recovered_id = vocab_start + recovered_id
 
+        global_recovered_id = tl.maximum(0, tl.minimum(global_recovered_id, vocab_size - 1))
         tl.store(output_token_ids_ptr + start_idx + pos, global_recovered_id)
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR hardens the Ascend Triton `sample_recovered_tokens_kernel` against
invalid recovery scores that can otherwise leave speculative-decoding requests
permanently running without generating tokens.

This is the `main` counterpart of #14042, which targets
`releases/v0.25.1rc`.

#### Problem

The issue was reproduced with DeepSeek-V4-Flash-0731 W8A8 using DSpark,
PD disaggregation, Mooncake KV transfer, and a multi-rank Decode topology.
Under a high-concurrency long-context workload, some Decode ranks progressively
stopped producing tokens while:

- the API processes remained alive;
- `/health` continued to return HTTP 200;
- the affected requests remained in the `RUNNING` state;
- the affected ranks committed no new output tokens.

The active DSpark recovery path in the reproduced case was:

```text
ENABLE_REDUCE_SAMPLING=False
draft_probs=None
draft_token_ids.dtype=int32
```

Direct kernel testing showed that when `target_probs` was all NaN, the old
kernel returned `-1` for every recovered token across a range of batch sizes.

The failure chain was:

```text
all-NaN target probabilities
  -> no score compares greater than global_max_p
  -> recovered token ID remains -1, or tail padding wins argmax
  -> parse_output removes -1 as a speculative-decoding placeholder
  -> the speculative output row becomes empty
  -> the scheduler keeps the request RUNNING but commits zero tokens
  -> the Decode rank makes no generation progress while health stays responsive
```

For vocabulary sizes that are not divisible by `SUB_BLOCK`, the final Triton
tile also contains padding positions. Masking only the loads is insufficient:
padding must be excluded from the score passed to `argmax`, otherwise invalid
scores in the valid vocabulary region can allow a padding index to win and
produce an out-of-vocabulary token ID.

#### Fix

This PR makes the recovered-token contract explicit in both the reduced-vocab
and full-vocab paths:

- initialize the recovered token ID with valid token `0` instead of scheduler
  placeholder `-1`;
- initialize the full-vocab maximum score with `-inf`;
- mask tail-vocabulary padding scores to `-inf` before `argmax`;
- clamp every recovered token ID to the valid global vocabulary range before
  writing it to the output tensor.

The fallback matches the reproduced PyTorch recovery behavior and, more
importantly, prevents an internal scheduler placeholder or an OOV index from
escaping the Triton kernel as a model token.

This PR does not change the DSpark probability calculation or claim to remove
the upstream source of NaN values. It fixes the zero-progress failure at the
recovered-token boundary so invalid numerical input cannot wedge the scheduler.

### Does this PR introduce _any_ user-facing change?

Yes. A speculative-decoding request that encounters invalid recovered-token
scores no longer remains indefinitely `RUNNING` with zero token progress while
the service reports healthy.

There is no API, model-weight, quantization, deployment-topology, or serving
configuration change. Normal finite-score recovery remains unchanged.

### How was this patch tested?

#### Regression coverage

Added:

```text
tests/e2e/nightly/single_node/ops/singlecard_ops/triton/
test_rejection_sample.py::test_sample_recovered_tokens_all_nan
```

The test covers:

- batch sizes `1` and `8`;
- five speculative tokens per request;
- a vocabulary size that is not divisible by the Triton block size;
- recovery with `draft_probs=None`;
- recovery with explicit draft probabilities;
- equality with the PyTorch reference result;
- the invariant `0 <= recovered_token_id < vocab_size`.

#### Direct NPU kernel A/B

The kernel was tested with the production vocabulary size and a range of batch
sizes.

| Case | Old Triton kernel | Fixed Triton kernel |
|---|---:|---:|
| All-NaN target probabilities | `-1` for all positions | valid token ID for all positions |
| Out-of-vocabulary results | 100% | 0% |
| Mismatch versus PyTorch reference | not applicable because output is invalid | 0 |

Healthy random inputs were also compared with the PyTorch implementation for
both `draft_probs=None` and explicit draft probabilities. All tested batch sizes
had zero mismatches. The fixed Triton kernel latency remained in the
sub-millisecond range in the direct test.

#### End-to-end PD validation

Environment:

```text
Model: DeepSeek-V4-Flash-0731 W8A8
Serving: PD disaggregation with Mooncake
Speculative decoding: DSpark
Decode graph mode: FULL_DECODE_ONLY
Workload: high-concurrency long-context requests
```

The PyTorch recovery implementation was used only as a correctness and
performance control. The final implementation uses the fixed Triton kernel.

| Recovery implementation | Run | Successful | Failed | Output length | Output TPS | Mean TTFT | Mean TPOT | Duration |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| PyTorch control | 1 | 128/128 | 0 | 2,048 for every request | 630.62 tok/s | 13.25 s | 32.24 ms | 415.69 s |
| Fixed Triton | 1 | 128/128 | 0 | 2,048 for every request | 905.86 tok/s | 12.91 s | 18.65 ms | 289.39 s |

In the fixed-Triton validation run:

- `128/128` requests completed successfully;
- every request generated exactly `2,048` tokens;
- no request stalled, returned an empty output, or produced an OOV token;
- all Decode rank health endpoints remained HTTP 200 after the run;
- output throughput was `905.86 tok/s`, approximately 43.6% higher
  than the PyTorch control;
- Mean TPOT was `18.65 ms`, approximately 42.2% lower than the
  PyTorch control.

Additional checks:

```text
python -m compileall: passed for the changed kernel and regression test
git diff --check: passed
```

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
