### PR TITLE
[Feature][KV Transfer] Support layerwise buffer reuse for Prefill Offload and Mooncake Layerwise Connector

### DIFF
--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -295,7 +295,7 @@ class TestGVALayerTransferFailures(unittest.TestCase):
 
 
 class TestGVALayerReceivingTaskOwnership(unittest.TestCase):
-    def _make_thread(self):
+    def _make_thread(self, layerwise_reuse_waiter=None):
         store = MagicMock()
         store.store.batch_copy.return_value = 0
         load_finished = [threading.Event(), threading.Event()]
@@ -327,6 +327,7 @@ class TestGVALayerReceivingTaskOwnership(unittest.TestCase):
             sync_save_events=sync_events,
             num_layers=2,
             group_builders=[builder],
+            layerwise_reuse_waiter=layerwise_reuse_waiter,
         )
         return thread, load_finished, save_finished, sync_events
 
@@ -368,6 +369,48 @@ class TestGVALayerReceivingTaskOwnership(unittest.TestCase):
 
         sync_events[0].synchronize.assert_called_once_with()
         self.assertFalse(save_finished[0].is_set())
+        self.assertTrue(load_finished[1].is_set())
+
+    def test_h2d_waits_for_source_save_then_target_layer_reuse(self):
+        call_order = []
+        thread, _, save_finished, sync_events = self._make_thread(
+            layerwise_reuse_waiter=lambda layer_id: call_order.append(("reuse", layer_id))
+        )
+        save_finished[0].set()
+        sync_events[0].synchronize.side_effect = lambda: call_order.append(("save", 0))
+        thread._batch_copy_with_limits = MagicMock(side_effect=lambda *_args: call_order.append(("h2d", 1)) or 0)
+        task = LayerTransferTask(
+            layer_id=1,
+            block_ranges=[],
+            shared_block_data=SharedBlockData(
+                block_ids_arr=np.asarray([0]),
+                block_gvas_arr=np.asarray([100]),
+                req_ids=["r1"],
+                is_last_chunks=[False],
+            ),
+        )
+        load_task = LayerLoadTask(wait_for_save_layer=0, transfer_tasks=[task], layer_id=1)
+        thread.request_queue.put(load_task)
+
+        thread._handle_request(load_task)
+
+        self.assertEqual(call_order, [("save", 0), ("reuse", 1), ("h2d", 1)])
+
+    def test_empty_load_waits_for_target_layer_reuse_before_finish(self):
+        load_finished_observed = []
+        thread = None
+
+        def wait_for_reuse(layer_id):
+            assert thread is not None
+            load_finished_observed.append(thread.layer_load_finished_events[layer_id].is_set())
+
+        thread, load_finished, _, _ = self._make_thread(layerwise_reuse_waiter=wait_for_reuse)
+        load_task = LayerLoadTask(wait_for_save_layer=None, transfer_tasks=[], layer_id=1)
+        thread.request_queue.put(load_task)
+
+        thread._handle_request(load_task)
+
+        self.assertEqual(load_finished_observed, [False])
         self.assertTrue(load_finished[1].is_set())
 
 

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -15,6 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import threading
 import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -77,6 +78,22 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         cls = self._make_worker_class()
         result = cls.find_all_continuous_hit_positions([], [], 0, 48, 16)
         self.assertEqual(result, [])
+
+    def test_wait_for_layer_load_fallback_waits_for_reuse(self):
+        cls = self._make_worker_class()
+        worker = cls.__new__(cls)
+        worker.current_layer = 0
+        worker.num_layers = 1
+        worker.layer_load_tasks = [[]]
+        worker.prefetch_layer_map = {}
+        worker.layer_load_finished_events = [threading.Event()]
+        worker.kv_recv_thread = MagicMock()
+        worker.layerwise_reuse_waiter = MagicMock()
+        worker._submit_ready_layer_loads = MagicMock()
+
+        worker.wait_for_layer_load()
+
+        worker.layerwise_reuse_waiter.assert_called_once_with(0)
 
     def test_find_all_discontinuous_hit_positions_all_tp_hits(self):
         cls = self._make_worker_class()

--- a/tests/ut/kv_offload/test_ascend_multi_connector.py
+++ b/tests/ut/kv_offload/test_ascend_multi_connector.py
@@ -66,18 +66,19 @@ def test_update_state_after_alloc_forwards_observer_without_chosen_connector():
     )
 
 
-def test_layerwise_pd_completion_is_wired_and_provider_runs_first():
+def test_layerwise_reuse_completion_is_wired_and_provider_hooks_run_first():
     call_order = []
     provider = SimpleNamespace(
         is_producer=True,
         connector_worker=object(),
-        wait_for_layer_send=MagicMock(),
+        supports_layerwise_buffer_reuse=True,
+        wait_for_layer_reuse=MagicMock(),
         wait_for_layer_load=MagicMock(side_effect=lambda *_: call_order.append("pd-load")),
         save_kv_layer=MagicMock(side_effect=lambda *_args, **_kwargs: call_order.append("pd-save")),
         on_kv_cache_written=MagicMock(side_effect=lambda *_: call_order.append("pd-written")),
     )
     store = SimpleNamespace(
-        set_layerwise_pd_transfer_waiter=MagicMock(),
+        set_layerwise_reuse_waiter=MagicMock(return_value=True),
         wait_for_layer_load=MagicMock(side_effect=lambda *_: call_order.append("store-load")),
         save_kv_layer=MagicMock(side_effect=lambda *_args, **_kwargs: call_order.append("store-save")),
         on_kv_cache_written=MagicMock(side_effect=lambda *_: call_order.append("store-written")),
@@ -86,19 +87,62 @@ def test_layerwise_pd_completion_is_wired_and_provider_runs_first():
     # Put the store first to verify the dependency does not rely on config order.
     connector._connectors = [store, provider]
 
-    connector._configure_layerwise_pd_completion()
+    connector._configure_layerwise_reuse_completion()
 
-    waiter = store.set_layerwise_pd_transfer_waiter.call_args.args[0]
-    assert waiter == provider.wait_for_layer_send
+    waiter = store.set_layerwise_reuse_waiter.call_args.args[0]
+    waiter(7)
+    provider.wait_for_layer_reuse.assert_called_once_with(7)
 
     connector.wait_for_layer_load("model.layers.7.self_attn")
     connector.save_kv_layer("model.layers.7.self_attn", object(), object())
     connector.on_kv_cache_written("model.layers.7.self_attn")
     assert call_order == [
-        "pd-load",
         "store-load",
         "pd-save",
         "store-save",
         "pd-written",
         "store-written",
     ]
+    provider.wait_for_layer_load.assert_not_called()
+
+
+def test_layerwise_reuse_without_sink_keeps_provider_layer_entry_wait():
+    call_order = []
+    provider = SimpleNamespace(
+        is_producer=True,
+        connector_worker=object(),
+        supports_layerwise_buffer_reuse=True,
+        wait_for_layer_reuse=MagicMock(),
+        wait_for_layer_load=MagicMock(side_effect=lambda *_: call_order.append("provider")),
+    )
+    sibling = SimpleNamespace(
+        wait_for_layer_load=MagicMock(side_effect=lambda *_: call_order.append("sibling")),
+    )
+    connector = AscendMultiConnector.__new__(AscendMultiConnector)
+    connector._connectors = [sibling, provider]
+
+    connector._configure_layerwise_reuse_completion()
+    connector.wait_for_layer_load("model.layers.7.self_attn")
+
+    assert call_order == ["provider", "sibling"]
+
+
+def test_layerwise_reuse_waiter_joins_all_providers():
+    providers = [
+        SimpleNamespace(
+            is_producer=True,
+            connector_worker=object(),
+            supports_layerwise_buffer_reuse=True,
+            wait_for_layer_reuse=MagicMock(),
+        )
+        for _ in range(2)
+    ]
+    store = SimpleNamespace(set_layerwise_reuse_waiter=MagicMock(return_value=True))
+    connector = AscendMultiConnector.__new__(AscendMultiConnector)
+    connector._connectors = [providers[0], store, providers[1]]
+
+    connector._configure_layerwise_reuse_completion()
+    store.set_layerwise_reuse_waiter.call_args.args[0](4)
+
+    for provider in providers:
+        provider.wait_for_layer_reuse.assert_called_once_with(4)

--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -188,6 +188,18 @@ class TestKVCacheSendingLayerThread(unittest.TestCase):
             chunk_finish=False,
         )
 
+    def test_handle_request_completes_reuse_gate_on_error(self):
+        callback = MagicMock()
+        self.thread.reuse_completion_callback = callback
+        self.thread._transfer_kv_cache = MagicMock(side_effect=RuntimeError("write failed"))
+        task = SendTask(layer_idx=2)
+        self.thread.send_queue.put(task)
+
+        self.thread._handle_request(task)
+
+        callback.assert_called_once_with(2, "write failed")
+        self.assertEqual(self.thread.send_queue.unfinished_tasks, 0)
+
     @patch(
         "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.npu_stream_switch",
         side_effect=lambda *_args, **_kwargs: contextlib.nullcontext(),
@@ -306,6 +318,21 @@ class TestKVCacheSendingLayerThread(unittest.TestCase):
         )
         self.thread._transfer_kv_cache(send_task)
         self.engine.batch_transfer_sync_write.assert_not_called()
+
+    def test_transfer_negative_return_is_reuse_error(self):
+        self.engine.batch_transfer_sync_write.return_value = -1
+        send_task = SendTask(
+            send_request={"req2": self.req_meta_base},
+            wait_event=MagicMock(),
+            layer_idx=0,
+            layer_name="layer0",
+            group_rearrange_block_ids=[[5, 8]],
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "ret=-1"):
+            self.thread._transfer_kv_cache(send_task)
+
+        self.assertIn("req2", self.thread.failed_reqs)
 
     @patch(
         "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.group_concurrent_contiguous",
@@ -1046,6 +1073,49 @@ class TestMooncakeLayerwiseConnector(unittest.TestCase):
         request = MockRequest("req1")
         connector.request_finished(request, [1, 2, 3])
         mock_method.assert_called_once_with(request, [1, 2, 3])
+
+
+def test_layerwise_reuse_state_tracks_shared_physical_slots():
+    worker = MooncakeLayerwiseConnectorWorker.__new__(MooncakeLayerwiseConnectorWorker)
+    worker.index_to_name = {1: ["layer1"], 4: ["layer4"]}
+    worker.layer_metadata = {
+        "layer1": _make_layer_metadata(kv_caches_base_addr=[1000, 2000]),
+        "layer4": _make_layer_metadata(kv_caches_base_addr=[1000, 2000]),
+    }
+    worker._storage_send_errors = {}
+    worker._pending_reuse_layers = set()
+    worker._layerwise_reuse_lock = threading.Lock()
+    worker.kv_send_layer_thread = MagicMock()
+    worker.kv_send_layer_thread.is_alive.return_value = True
+
+    worker._init_layerwise_reuse_state()
+    worker._mark_layer_reuse_pending(1)
+
+    assert worker.layer_storage_slots[1] == worker.layer_storage_slots[4]
+    assert all(not event.is_set() for event in worker.storage_send_done_events)
+    worker._complete_layer_reuse(1, None)
+    worker.wait_for_layer_reuse(4)
+
+
+def test_layerwise_reuse_wait_propagates_mooncake_error():
+    worker = MooncakeLayerwiseConnectorWorker.__new__(MooncakeLayerwiseConnectorWorker)
+    worker.index_to_name = {1: ["layer1"], 4: ["layer4"]}
+    worker.layer_metadata = {
+        "layer1": _make_layer_metadata(kv_caches_base_addr=[1000, 2000]),
+        "layer4": _make_layer_metadata(kv_caches_base_addr=[1000, 2000]),
+    }
+    worker._storage_send_errors = {}
+    worker._pending_reuse_layers = set()
+    worker._layerwise_reuse_lock = threading.Lock()
+    worker.kv_send_layer_thread = MagicMock()
+    worker.kv_send_layer_thread.is_alive.return_value = True
+
+    worker._init_layerwise_reuse_state()
+    worker._mark_layer_reuse_pending(1)
+    worker._complete_layer_reuse(1, "write failed")
+
+    with unittest.TestCase().assertRaisesRegex(RuntimeError, "write failed"):
+        worker.wait_for_layer_reuse(4)
 
 
 class TestMooncakeLayerwiseConnectorWorker(unittest.TestCase):

--- a/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
+++ b/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
@@ -857,6 +857,15 @@ def test_pd_read_wait_propagates_read_failed():
         worker.wait_for_layer_send(0)
 
 
+def test_pd_read_wait_rejects_missing_layer_mapping():
+    worker = SFAPDRD2HProducerWorker.__new__(SFAPDRD2HProducerWorker)
+    worker.kv_send_layer_thread = MagicMock()
+    worker.layer_storage_slots = {0: (0,)}
+
+    with pytest.raises(RuntimeError, match="mapping is missing layer 1"):
+        worker.wait_for_layer_send(1)
+
+
 def test_save_kv_layer_requires_send_thread_without_marking_dispatched():
     worker = SFAPDRD2HProducerWorker.__new__(SFAPDRD2HProducerWorker)
     worker._backend = BACKEND_MEMFABRIC
@@ -1175,6 +1184,15 @@ def test_connector_shutdown_delegates_to_active_components():
 
     connector.connector_worker.shutdown.assert_called_once_with()
     connector.connector_scheduler.shutdown.assert_called_once_with()
+
+
+def test_connector_layerwise_reuse_wait_delegates_to_existing_gate():
+    connector = SfaRemoteD2HConnector.__new__(SfaRemoteD2HConnector)
+    connector.connector_worker = MagicMock()
+
+    connector.wait_for_layer_reuse(3)
+
+    connector.connector_worker.wait_for_layer_send.assert_called_once_with(3)
 
 
 # ---------------------------------------------------------------------------

--- a/vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/ascend_multi_connector.py
@@ -26,35 +26,44 @@ class AscendMultiConnector(MultiConnector, SupportsHMA):
         assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager or self._all_support_hma, (
             "HMA should not be enabled unless all sub-connectors support it"
         )
-        self._configure_layerwise_pd_completion()
+        self._configure_layerwise_reuse_completion()
 
-    def _configure_layerwise_pd_completion(self) -> None:
-        self._pd_completion_connector = next(
-            (
-                connector
-                for connector in self._connectors
-                if getattr(connector, "is_producer", False)
-                and getattr(connector, "connector_worker", None) is not None
-                and callable(getattr(connector, "wait_for_layer_send", None))
-            ),
-            None,
-        )
-        if self._pd_completion_connector is not None:
-            for connector in self._connectors:
-                set_waiter = getattr(connector, "set_layerwise_pd_transfer_waiter", None)
-                if callable(set_waiter):
-                    set_waiter(self._pd_completion_connector.wait_for_layer_send)
+    def _configure_layerwise_reuse_completion(self) -> None:
+        self._layerwise_reuse_providers = [
+            connector
+            for connector in self._connectors
+            if getattr(connector, "is_producer", False)
+            and getattr(connector, "connector_worker", None) is not None
+            and getattr(connector, "supports_layerwise_buffer_reuse", False)
+            and callable(getattr(connector, "wait_for_layer_reuse", None))
+        ]
+        self._layerwise_reuse_other_connectors = [
+            connector
+            for connector in self._connectors
+            if all(connector is not provider for provider in self._layerwise_reuse_providers)
+        ]
+        self._layerwise_reuse_sink_configured = False
+        if not self._layerwise_reuse_providers:
+            return
+        for connector in self._connectors:
+            set_waiter = getattr(connector, "set_layerwise_reuse_waiter", None)
+            if callable(set_waiter) and set_waiter(self._wait_for_layer_reuse) is not False:
+                self._layerwise_reuse_sink_configured = True
 
-    def _pd_connector_first(self):
-        provider = getattr(self, "_pd_completion_connector", None)
-        if provider is not None:
-            yield provider
-        yield from (connector for connector in self._connectors if connector is not provider)
+    def _wait_for_layer_reuse(self, layer_idx: int) -> None:
+        for provider in self._layerwise_reuse_providers:
+            provider.wait_for_layer_reuse(layer_idx)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
-        # Close the PD-reuse gate before a sibling connector can issue an H2D
-        # load into the shared buffer, regardless of connector config order.
-        for connector in self._pd_connector_first():
+        if getattr(self, "_layerwise_reuse_sink_configured", False):
+            # AscendStore owns the layer-entry reuse wait after accepting the
+            # composite waiter, so provider layer-entry waits are redundant.
+            connectors = self._layerwise_reuse_other_connectors
+        else:
+            # Without a sink, preserve the original protection by waiting on
+            # providers before any sibling connector can write shared slots.
+            connectors = [*self._layerwise_reuse_providers, *self._layerwise_reuse_other_connectors]
+        for connector in connectors:
             connector.wait_for_layer_load(layer_name)
 
     def save_kv_layer(
@@ -64,16 +73,21 @@ class AscendMultiConnector(MultiConnector, SupportsHMA):
         attn_metadata: Any,
         **kwargs,
     ) -> None:
-        # The producer clears the slot completion gate before AscendStore
-        # queues its asynchronous save, eliminating a publish/wait race.
-        for connector in self._pd_connector_first():
+        # Phase 1: providers must close any new slot gate before returning.
+        for connector in self._layerwise_reuse_providers:
+            connector.save_kv_layer(layer_name, kv_layer, attn_metadata, **kwargs)
+        # Phase 2: siblings may now publish work that can enable slot reuse.
+        for connector in self._layerwise_reuse_other_connectors:
             connector.save_kv_layer(layer_name, kv_layer, attn_metadata, **kwargs)
 
     def on_kv_cache_written(self, layer_name: str = "") -> None:
-        # PD-first ordering mirrors save_kv_layer: the PD hook clears the
-        # per-slot send-done gate before the AscendStore hook enqueues a save
-        # whose send thread later waits on that same gate.
-        for connector in self._pd_connector_first():
+        # Phase 1: providers close their gates at the earliest cache-write hook.
+        for connector in self._layerwise_reuse_providers:
+            hook = getattr(connector, "on_kv_cache_written", None)
+            if callable(hook):
+                hook(layer_name)
+        # Phase 2: only then may sibling hooks publish reuse-enabling work.
+        for connector in self._layerwise_reuse_other_connectors:
             hook = getattr(connector, "on_kv_cache_written", None)
             if callable(hook):
                 hook(layer_name)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
 
 DONE_SENDING_MSG = b"done_sending_msg"
 FAILED_SENDING_MSG = b"failed_sending_msg"
+LAYERWISE_REUSE_WAIT_LOG_INTERVAL_SECONDS = 10.0
 
 
 @dataclass
@@ -224,6 +225,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         enable_c8_quant: bool,
         resharding_stream: torch.npu.Stream,
         callback_func: Callable[..., None] = lambda x: None,
+        reuse_completion_callback: Callable[[int, str | None], None] | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheSendingLayerThread")
         self.engine = engine
@@ -262,6 +264,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         self.enable_c8_quant = enable_c8_quant
         self.ready_event = ready_event
         self.callback_func = callback_func
+        self.reuse_completion_callback = reuse_completion_callback
 
     def run(self):
         local_rank = get_world_group().local_rank
@@ -273,14 +276,20 @@ class KVCacheSendingLayerThread(threading.Thread):
             self._handle_request(send_task)
 
     def _handle_request(self, send_task: SendTask):
+        error: str | None = None
         try:
             self._transfer_kv_cache(send_task)
         except Exception as e:
+            error = str(e)
             logger.error(
                 "Failed to transfer KV cache. layer_idx=%s, error=%s. Check transfer engine and memory state.",
                 send_task.layer_idx,
                 e,
             )
+        finally:
+            if self.reuse_completion_callback is not None:
+                self.reuse_completion_callback(send_task.layer_idx, error)
+            self.send_queue.task_done()
 
     def get_transfer_meta(self, send_task: SendTask, req_id: str, req_meta: ReqMeta, layer_group_idx: int):
         src_list: list[int] = []
@@ -491,6 +500,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         elif self.pd_head_ratio > 1:
             self.resharding_stream.synchronize()
 
+        transfer_errors: list[str] = []
         for session_id, transfer_meta in session_meta.items():
             if len(transfer_meta.src) > 0:
                 req_start_time = time.perf_counter()
@@ -498,13 +508,11 @@ class KVCacheSendingLayerThread(threading.Thread):
                     session_id, transfer_meta.src, transfer_meta.dst, transfer_meta.length
                 )
                 if ret < 0:
-                    logger.error(
-                        "Mooncake transfer failed for send requests. req_ids=%s, destination=%s, ret=%d. ",
-                        transfer_meta.req_ids,
-                        session_id,
-                        ret,
+                    self.failed_reqs.update(transfer_meta.req_ids)
+                    transfer_errors.append(
+                        "Mooncake transfer failed for send requests. "
+                        f"req_ids={transfer_meta.req_ids}, destination={session_id}, ret={ret}"
                     )
-                    self.failed_reqs.add(req_id)
                 else:
                     req_end_time = time.perf_counter()
                     total_transfer_size = sum(transfer_meta.length) / 1024
@@ -525,6 +533,9 @@ class KVCacheSendingLayerThread(threading.Thread):
                                 self.failed_reqs.discard(req_id)
                             else:
                                 self.callback_func(req_id, req_meta, layer_group_idx, trans_flag=True)
+
+        if transfer_errors:
+            raise RuntimeError("; ".join(transfer_errors))
 
 
 class KVCacheRecvingLayerThread(threading.Thread):
@@ -696,11 +707,13 @@ class MooncakeLayerwiseConnectorMetadata(KVConnectorMetadata):
 
 class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
     requires_full_blocks_on_update_after_alloc = True
+    supports_layerwise_buffer_reuse = True
 
     def __init__(self, vllm_config: VllmConfig, role: KVConnectorRole, kv_cache_config: KVCacheConfig | None = None):
         super().__init__(vllm_config, role, kv_cache_config)
         assert vllm_config.kv_transfer_config is not None
         self._is_kv_producer = vllm_config.kv_transfer_config.is_kv_producer
+        self.is_producer = self._is_kv_producer
         self.engine_id = vllm_config.kv_transfer_config.engine_id
         self._connector_metadata = MooncakeLayerwiseConnectorMetadata()
 
@@ -775,6 +788,10 @@ class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_worker is not None
         assert isinstance(self._connector_metadata, MooncakeLayerwiseConnectorMetadata)
         self.connector_worker.wait_for_layer_load(layer_name)
+
+    def wait_for_layer_reuse(self, layer_idx: int) -> None:
+        assert self.connector_worker is not None
+        self.connector_worker.wait_for_layer_reuse(layer_idx)
 
     def save_kv_layer(
         self, layer_name: str, kv_layer: list[torch.Tensor], attn_metadata: "AttentionMetadata", **kwargs
@@ -1177,6 +1194,11 @@ class MooncakeLayerwiseConnectorWorker:
         # Background thread for sending or receiving KV caches.
         self.kv_recv_layer_thread: KVCacheRecvingLayerThread | None = None
         self.kv_send_layer_thread: KVCacheSendingLayerThread | None = None
+        self.layer_storage_slots: dict[int, tuple[int, ...]] = {}
+        self.storage_send_done_events: list[threading.Event] = []
+        self._storage_send_errors: dict[int, str] = {}
+        self._pending_reuse_layers: set[int] = set()
+        self._layerwise_reuse_lock = threading.Lock()
 
         self.block_size: list[int] = [spec.block_size for spec in self.kv_cache_specs]
         self.kernel_block_size_scale: list[int] = [1 for _ in range(self.num_kv_cache_groups)]
@@ -1215,6 +1237,62 @@ class MooncakeLayerwiseConnectorWorker:
         self.virtual_request: set[str] = set()
         self._invalid_block_ids: set[int] = set()
         self._recving_metadata: dict[str, ReqMeta] = {}
+
+    def _init_layerwise_reuse_state(self) -> None:
+        slot_by_addr: dict[int, int] = {}
+        layer_storage_slots: dict[int, tuple[int, ...]] = {}
+        for layer_idx, layer_names in self.index_to_name.items():
+            slots: list[int] = []
+            for layer_name in layer_names:
+                for addr in self.layer_metadata[layer_name].kv_caches_base_addr:
+                    slot_id = slot_by_addr.setdefault(addr, len(slot_by_addr))
+                    if slot_id not in slots:
+                        slots.append(slot_id)
+            layer_storage_slots[layer_idx] = tuple(slots)
+        self.layer_storage_slots = layer_storage_slots
+        self.storage_send_done_events = []
+        for _ in range(len(slot_by_addr)):
+            event = threading.Event()
+            event.set()
+            self.storage_send_done_events.append(event)
+
+    def _mark_layer_reuse_pending(self, layer_idx: int) -> None:
+        if layer_idx not in self.layer_storage_slots:
+            raise RuntimeError(f"Mooncake layerwise reuse mapping is missing layer {layer_idx}")
+        with self._layerwise_reuse_lock:
+            if layer_idx in self._pending_reuse_layers:
+                return
+            self._pending_reuse_layers.add(layer_idx)
+            for slot_id in self.layer_storage_slots[layer_idx]:
+                self._storage_send_errors.pop(slot_id, None)
+                self.storage_send_done_events[slot_id].clear()
+
+    def _complete_layer_reuse(self, layer_idx: int, error: str | None) -> None:
+        with self._layerwise_reuse_lock:
+            if layer_idx not in self._pending_reuse_layers:
+                return
+            self._pending_reuse_layers.remove(layer_idx)
+            for slot_id in self.layer_storage_slots[layer_idx]:
+                if error is not None:
+                    self._storage_send_errors[slot_id] = error
+                self.storage_send_done_events[slot_id].set()
+
+    def wait_for_layer_reuse(self, layer_idx: int) -> None:
+        send_thread = self.kv_send_layer_thread
+        if send_thread is None:
+            return
+        if layer_idx not in self.layer_storage_slots:
+            raise RuntimeError(f"Mooncake layerwise reuse mapping is missing layer {layer_idx}")
+        for slot_id in self.layer_storage_slots[layer_idx]:
+            event = self.storage_send_done_events[slot_id]
+            while not event.wait(timeout=LAYERWISE_REUSE_WAIT_LOG_INTERVAL_SECONDS):
+                if not send_thread.is_alive():
+                    raise RuntimeError("Mooncake send thread stopped while waiting for layerwise buffer reuse")
+                logger.info("Waiting for Mooncake transfer to release physical KV slot %d", slot_id)
+            with self._layerwise_reuse_lock:
+                error = self._storage_send_errors.get(slot_id)
+            if error is not None:
+                raise RuntimeError(f"Mooncake failed to transfer physical KV slot {slot_id}: {error}")
 
     def create_kv_buffer(self, first_kv_cache_tuple):
         alignment = 2 * 1024 * 1024
@@ -1354,6 +1432,8 @@ class MooncakeLayerwiseConnectorWorker:
         if self.total_layers < len(self.layer_metadata.keys()):
             self.total_layers = len(self.layer_metadata.keys())
 
+        self._init_layerwise_reuse_state()
+
         # After KV Caches registered, start the sending or receiving thread.
         metadata = MooncakeAgentMetadata(
             te_rpc_port=self.te_rpc_port,
@@ -1382,6 +1462,7 @@ class MooncakeLayerwiseConnectorWorker:
                 enable_c8_quant=self.enable_c8_quant,
                 resharding_stream=self.resharding_stream,
                 callback_func=self.send_done_send_signal,
+                reuse_completion_callback=self._complete_layer_reuse,
             )
             self.kv_send_layer_thread.start()
             ready_event.wait()
@@ -1836,7 +1917,21 @@ class MooncakeLayerwiseConnectorWorker:
                 logger.debug("Add request %s to kv send layer thread. req_meta_update=%r", req_id, req_meta_update)
                 layer_send_task.send_request[req_id] = req_meta_update
 
-            self.kv_send_layer_thread.send_queue.put(layer_send_task)
+            needs_reuse_gate = any(
+                len(req_meta.local_block_ids) > layer_group_idx and bool(req_meta.local_block_ids[layer_group_idx])
+                for req_meta in connector_metadata.requests.values()
+            )
+            if needs_reuse_gate:
+                # This must happen before AscendStore publishes StoreSaveDone.
+                # Otherwise its receiver may consume the previous set state
+                # and start H2D before this transfer is registered as pending.
+                self._mark_layer_reuse_pending(self.current_layer)
+            try:
+                self.kv_send_layer_thread.send_queue.put(layer_send_task)
+            except Exception as error:
+                if needs_reuse_gate:
+                    self._complete_layer_reuse(self.current_layer, str(error))
+                raise
             self.current_layer += 1
 
     # NOTE: Due to the FIA operator constraints, the expected kv cache is ND format, NZ shape,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/connector.py
@@ -51,6 +51,8 @@ class SfaRemoteD2HConnector(KVConnectorBase_V1, SupportsHMA):
       indexer/main split registration.
     """
 
+    supports_layerwise_buffer_reuse = True
+
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -236,3 +238,6 @@ class SfaRemoteD2HConnector(KVConnectorBase_V1, SupportsHMA):
         if worker is None or not hasattr(worker, "wait_for_layer_send"):
             return
         worker.wait_for_layer_send(layer_idx)
+
+    def wait_for_layer_reuse(self, layer_idx: int) -> None:
+        self.wait_for_layer_send(layer_idx)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/worker.py
@@ -839,7 +839,9 @@ class SFAPDRD2HProducerWorker:
         """
         if self.kv_send_layer_thread is None:
             return
-        storage_slots = self.layer_storage_slots.get(layer_idx, ())
+        if layer_idx not in self.layer_storage_slots:
+            raise RuntimeError(f"SFA layerwise reuse mapping is missing layer {layer_idx}")
+        storage_slots = self.layer_storage_slots[layer_idx]
         if storage_slots:
             for slot_id in storage_slots:
                 self._wait_for_pd_read_completion(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -1,5 +1,5 @@
 import threading
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -203,6 +203,12 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
     ############################################################
     # Worker Side Methods
     ############################################################
+    def set_layerwise_reuse_waiter(self, waiter: Callable[[int], None]) -> bool:
+        if not self.use_gva_layerwise or getattr(self, "connector_worker", None) is None:
+            return False
+        self.connector_worker.set_layerwise_reuse_waiter(waiter)
+        return True
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -5,6 +5,7 @@ import queue
 import threading
 import time
 from collections import defaultdict
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -1483,6 +1484,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         max_transfer_blocks: int = 0,
         max_transfer_bytes: int = 0,
         group_builders: list[LayerBatchBuilder] | None = None,
+        layerwise_reuse_waiter: Callable[[int], None] | None = None,
     ):
         super().__init__(
             m_store,
@@ -1502,6 +1504,7 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         self.h2d_stagger_us = h2d_stagger_us
         self.max_transfer_blocks = max_transfer_blocks
         self.max_transfer_bytes = max_transfer_bytes
+        self.layerwise_reuse_waiter = layerwise_reuse_waiter
         self.group_builders: list[LayerBatchBuilder] | None = group_builders
         if group_builders is not None:
             self.layer_batch_builder = group_builders[0]
@@ -1561,6 +1564,8 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
             self.layer_save_finished_events[wait_for_save].clear()
 
         if len(transfer_tasks) == 0:
+            if self.layerwise_reuse_waiter is not None:
+                self.layerwise_reuse_waiter(layer_id)
             assert not self.layer_load_finished_events[layer_id].is_set()
             logger.debug("Layer load event set: layer %d", layer_id)
             self.layer_load_finished_events[layer_id].set()
@@ -1580,6 +1585,8 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
                 task_metas.append((task, req_meta))
 
         if not task_metas:
+            if self.layerwise_reuse_waiter is not None:
+                self.layerwise_reuse_waiter(layer_id)
             assert not self.layer_load_finished_events[layer_id].is_set()
             logger.debug("Layer load event set: layer %d", layer_id)
             self.layer_load_finished_events[layer_id].set()
@@ -1611,6 +1618,8 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
         gvas_array = np.concatenate(all_gvas) if len(all_gvas) > 1 else all_gvas[0]
         addr_array = np.concatenate(all_addrs) if len(all_addrs) > 1 else all_addrs[0]
         size_array = np.concatenate(all_sizes) if len(all_sizes) > 1 else all_sizes[0]
+        if self.layerwise_reuse_waiter is not None:
+            self.layerwise_reuse_waiter(layer_id)
         res = self._batch_copy_with_limits(
             gvas_array,
             addr_array,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -4,7 +4,7 @@ import importlib
 import math
 import threading
 import time
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import Any
 
 import numpy as np
@@ -332,6 +332,7 @@ class KVPoolWorker:
         self.kv_send_thread: KVTransferThread | None = None
         self.kv_recv_thread: KVTransferThread | None = None
         self._transfer_threads_started = False
+        self.layerwise_reuse_waiter: Callable[[int], None] | None = None
         # Per-rank GVA cache: maps per-rank store key to its allocated GVA.
         # batch_alloc is non-idempotent (returns MMC_DUPLICATED_OBJECT for an
         # existing key without registering the blob), so the worker must track
@@ -453,6 +454,9 @@ class KVPoolWorker:
             )
         return builders
 
+    def set_layerwise_reuse_waiter(self, waiter: Callable[[int], None]) -> None:
+        self.layerwise_reuse_waiter = waiter
+
     def _start_kv_transfer_threads(self) -> None:
         if self._transfer_threads_started:
             return
@@ -525,6 +529,7 @@ class KVPoolWorker:
                     self.layerwise_max_transfer_blocks,
                     self.layerwise_max_transfer_bytes,
                     group_builders=self._build_group_layer_builders(),
+                    layerwise_reuse_waiter=self.layerwise_reuse_waiter,
                 )
             else:
                 self.kv_recv_thread = KVCacheStoreKeyLayerRecvingThread(
@@ -1709,6 +1714,8 @@ class KVPoolWorker:
         should_wait = bool(self.layer_load_tasks[self.current_layer]) or self.current_layer in self.prefetch_layer_map
         if not should_wait:
             self.layer_load_finished_events[self.current_layer].clear()
+            if self.layerwise_reuse_waiter is not None:
+                self.layerwise_reuse_waiter(self.current_layer)
             return
         while not self.layer_load_finished_events[self.current_layer].wait(timeout=10):
             self.kv_recv_thread.raise_if_failed()


### PR DESCRIPTION
### What this PR does / why we need it?

GVA layerwise KV cache pools can map multiple logical layers to the same physical KV buffer. AscendStore may prefetch a future layer into that shared buffer while the previous owner is still being consumed by either the Prefill Offload transfer path or Mooncake Layerwise Connector, which can overwrite live KV data.

This PR adds a common layerwise buffer-reuse completion contract and makes AscendStore the admission point for writes into reused physical slots:

- AscendMultiConnector wires the configured transfer provider's reuse waiter into GVA layerwise AscendStore and orders provider gate publication before sibling save hooks.
- AscendStore waits for the target physical slot to become reusable before H2D, empty-load completion, or the layer-entry fallback path.
- SfaRemoteD2HConnector exposes its existing READ_DONE-based completion gate through the common interface.
- MooncakeLayerwiseConnector tracks completion and failures per physical KV slot and releases reuse only after the synchronous layerwise transfer completes.
- Missing layer-to-slot mappings fail fast instead of silently allowing an unsafe overwrite.

Prefill Offload and Mooncake Layerwise Connector remain separate deployment paths; each is combined with AscendStore independently.

### Does this PR introduce _any_ user-facing change?

Yes. Layerwise KV cache reuse is now coordinated with Prefill Offload and Mooncake Layerwise transfers, preventing premature shared-buffer overwrites without disabling multi-layer prefetch.

No new configuration or public user API is introduced.

### How was this patch tested?

Added and updated unit coverage for:

- MultiConnector waiter wiring, ordering, and fallback behavior.
- AscendStore save completion, provider completion, and H2D ordering.
- Mooncake Layerwise physical-slot reuse, transfer errors, and send-queue bookkeeping.
- SFA reuse-wait aliasing and missing layer mappings.

Validation performed locally:

- `ruff check` on all changed Python files: passed.
- `ruff format --check` on all changed Python files: passed.
- `python -m compileall` on all changed Python files: passed.
- Focused pytest collection was attempted with the workspace vLLM source, but the local environment lacks the `cbor2` dependency and did not enter test execution.
- NPU end-to-end validation has not been run locally.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
