### PR TITLE
[BugFix][CI] Forward upload script stderr in nightly result postprocess

### DIFF
--- a/.github/workflows/schedule_e2e_upstream_test.yaml
+++ b/.github/workflows/schedule_e2e_upstream_test.yaml
@@ -73,7 +73,7 @@ jobs:
           image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.image_tag }}
           env:
             VLLM_LOGGING_LEVEL: ERROR
-            HF_HUB_OFFLINE: 1
+            HF_HUB_OFFLINE: 0
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v7

--- a/.github/workflows/schedule_e2e_upstream_test.yaml
+++ b/.github/workflows/schedule_e2e_upstream_test.yaml
@@ -73,7 +73,7 @@ jobs:
           image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:${{ matrix.image_tag }}
           env:
             VLLM_LOGGING_LEVEL: ERROR
-            HF_HUB_OFFLINE: 0
+            HF_HUB_OFFLINE: 1
         steps:
           - name: Checkout vllm-project/vllm-ascend repo
             uses: actions/checkout@v7

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -191,10 +191,7 @@ def _run_postprocess_script(script_path: Path, output_path: Path) -> None:
     if completed.stderr:
         print(completed.stderr.rstrip())
     if completed.returncode != 0:
-        print(
-            f"Warning: Postprocess script exited with code {completed.returncode} "
-            f"for {output_path}"
-        )
+        print(f"Warning: Postprocess script exited with code {completed.returncode} for {output_path}")
 
 
 def postprocess_one_benchmark(

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -133,6 +133,8 @@ def merge_postprocess_payload(
         test_env["Concurrency"] = case_config["batch_size"]
     if "num_prompts" in case_config:
         test_env["data_num"] = case_config["num_prompts"]
+    else:
+        test_env["data_num"] = ""
     test_env["data_set"] = _extract_dataset_name(case_config)
 
     testcase_info["extraTestEnv"] = {}

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -125,6 +125,7 @@ def merge_postprocess_payload(
         test_env = {}
         testcase_info["testEnv"] = test_env
 
+    test_env["yaml_name"] = testcase_name
     test_env["request_rate"] = case_config.get("request_rate", 0)
     if "max_out_len" in case_config:
         test_env["output_len"] = case_config["max_out_len"]

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -131,10 +131,7 @@ def merge_postprocess_payload(
         test_env["output_len"] = case_config["max_out_len"]
     if "batch_size" in case_config:
         test_env["Concurrency"] = case_config["batch_size"]
-    if "num_prompts" in case_config:
-        test_env["data_num"] = case_config["num_prompts"]
-    else:
-        test_env["data_num"] = ""
+    test_env["data_num"] = case_config.get("num_prompts", "")
     test_env["data_set"] = _extract_dataset_name(case_config)
 
     testcase_info["extraTestEnv"] = {}

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -185,13 +185,15 @@ def _run_postprocess_script(script_path: Path, output_path: Path) -> None:
     except OSError as exc:
         print(f"Warning: Failed to run postprocess script {script_path}: {exc}")
         return
+    # upload_to_openlibing uses logging (stderr); always forward both streams
     if completed.stdout:
         print(completed.stdout.rstrip())
+    if completed.stderr:
+        print(completed.stderr.rstrip())
     if completed.returncode != 0:
-        stderr = (completed.stderr or "").strip()
         print(
             f"Warning: Postprocess script exited with code {completed.returncode} "
-            f"for {output_path}" + (f": {stderr}" if stderr else "")
+            f"for {output_path}"
         )
 
 

--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -131,7 +131,8 @@ def merge_postprocess_payload(
         test_env["output_len"] = case_config["max_out_len"]
     if "batch_size" in case_config:
         test_env["Concurrency"] = case_config["batch_size"]
-    test_env["data_num"] = case_config.get("num_prompts", "")
+    if "num_prompts" in case_config:
+        test_env["data_num"] = case_config["num_prompts"]
     test_env["data_set"] = _extract_dataset_name(case_config)
 
     testcase_info["extraTestEnv"] = {}


### PR DESCRIPTION
### What this PR does / why we need it?

`upload_to_openlibing.py` uses Python `logging`, which writes to stderr. `_run_postprocess_script` captured both streams but only printed stdout on success, and only printed stderr when the exit code was non-zero.

As a result, after `OPENLIBING_SECRET` was configured and upload succeeded, CI only showed `Postprocess JSON written to ...` with no upload success/failure details, which made debugging difficult.

This PR always forwards stdout/stderr from the upload subprocess, and still prints a Warning when the exit code is non-zero. Upload failure continues to be best-effort and does not fail the benchmark test case.

### Does this PR introduce _any_ user-facing change?

No. CI-only logging improvement for nightly/weekly postprocess upload.

### How was this patch tested?

- Verified locally that success/failure logs from `upload_to_openlibing.py` are printed by `_run_postprocess_script`.
- Nightly debug runs for `qwen3-32b-int8` (e.g. Nightly-A2: https://github.com/vllm-project/vllm-ascend/actions/runs/31553200411) observed that without this fix, upload produced no logs after JSON write; this change addresses that. 
https://github.com/vllm-project/vllm-ascend/actions/runs/31561503582/job/94005553056


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
