### PR TITLE
[Refactor][Device][3/N] Extend hardware profile policies and capabilties

### DIFF
--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -9,51 +9,180 @@ import pytest
 from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    CPUBindingMode,
+    DeviceAdaptorFamily,
+    DeviceAddressingMode,
     HardwareCapability,
+    MoECommPolicy,
+    QuantizationBackendFamily,
     WeightLayoutPolicy,
     get_current_hardware_profile,
     get_hardware_profile,
 )
 
+_STANDARD_CAPABILITIES = frozenset(
+    {
+        HardwareCapability.ATB_EXTENSIONS,
+        HardwareCapability.ATB_WARMUP,
+        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+        HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+        HardwareCapability.GRAPH_MULS_ADD_FUSION,
+        HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+        HardwareCapability.IRQ_CPU_RESERVATION,
+        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX,
+        HardwareCapability.PAGED_ATTENTION,
+        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
+        HardwareCapability.STANDARD_MAMBA_PATCH,
+        HardwareCapability.STANDARD_WORKER_PATCHES,
+        HardwareCapability.TRITON_BATCH_MEMCPY,
+    }
+)
+
+_EXPECTED_CAPABILITIES = {
+    AscendDeviceType.A2: _STANDARD_CAPABILITIES
+    | {
+        HardwareCapability.NPU_TOP_K_TOP_P,
+        HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION,
+    },
+    AscendDeviceType.A3: _STANDARD_CAPABILITIES
+    | {
+        HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+        HardwareCapability.NPU_TOP_K_TOP_P,
+    },
+    AscendDeviceType._310P: frozenset(
+        {
+            HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
+            HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
+            HardwareCapability.FUSED_MOE_COMPATIBILITY,
+            HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+            HardwareCapability.GDN_COMPATIBILITY,
+            HardwareCapability.IRQ_CPU_RESERVATION,
+            HardwareCapability.RC_DEVICE_DISCOVERY,
+            HardwareCapability.RUNTIME_CUSTOM_OPS,
+        }
+    ),
+    AscendDeviceType.A5: frozenset(
+        {
+            HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+            HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
+            HardwareCapability.CLUSTER_CPU_TOPOLOGY,
+            HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+            HardwareCapability.DSA_O_PROJ_TP,
+            HardwareCapability.DSV4_COMPRESSED_CACHE,
+            HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+            HardwareCapability.FP8_ATTENTION,
+            HardwareCapability.GRAPH_MULS_ADD_FUSION,
+            HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+            HardwareCapability.LOCAL_KV_COMM_RESOURCE,
+            HardwareCapability.LORA_CUSTOM_OPS,
+            HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+            HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
+            HardwareCapability.NPUGRAPH_EX,
+            HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
+            HardwareCapability.STANDARD_MAMBA_PATCH,
+            HardwareCapability.STANDARD_WORKER_PATCHES,
+            HardwareCapability.TRITON_BATCH_MEMCPY,
+            HardwareCapability.UNRESTRICTED_MLAPO,
+        }
+    ),
+}
+
 
 @pytest.mark.parametrize(
-    ("device_type", "weight_layout_policy", "capabilities"),
+    (
+        "device_type",
+        "attention_backend_family",
+        "cpu_binding_mode",
+        "default_worker_cls",
+        "device_adaptor_family",
+        "device_addressing_mode",
+        "weight_layout_policy",
+        "moe_comm_policy",
+        "quantization_backend_family",
+    ),
     [
         (
             AscendDeviceType.A2,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.STANDARD,
+            DeviceAddressingMode.DIRECT,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+            MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
+            QuantizationBackendFamily.STANDARD,
         ),
         (
             AscendDeviceType.A3,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.GLOBAL_SLICE,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.STANDARD,
+            DeviceAddressingMode.DUAL_CHIP_CARD,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+            MoECommPolicy.FUSED_OR_CAPACITY,
+            QuantizationBackendFamily.STANDARD,
         ),
-        (AscendDeviceType._310P, WeightLayoutPolicy.FORCE_NZ, frozenset()),
+        (
+            AscendDeviceType._310P,
+            AttentionBackendFamily.COMPATIBILITY,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend._310p.worker_310p.NPUWorker310",
+            DeviceAdaptorFamily.COMPATIBILITY,
+            DeviceAddressingMode.DIRECT,
+            WeightLayoutPolicy.FORCE_NZ,
+            MoECommPolicy.ALLGATHER,
+            QuantizationBackendFamily.COMPATIBILITY,
+        ),
         (
             AscendDeviceType.A5,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.FP8_OPTIMIZED,
+            DeviceAddressingMode.DIRECT,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset(
-                {
-                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
-                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
-                }
-            ),
+            MoECommPolicy.CAPACITY_AND_WORLD_SIZE,
+            QuantizationBackendFamily.STANDARD,
         ),
     ],
 )
-def test_hardware_profile_matrix(
+def test_hardware_profile_implementation_matrix(
     device_type: AscendDeviceType,
+    attention_backend_family: AttentionBackendFamily,
+    cpu_binding_mode: CPUBindingMode,
+    default_worker_cls: str,
+    device_adaptor_family: DeviceAdaptorFamily,
+    device_addressing_mode: DeviceAddressingMode,
     weight_layout_policy: WeightLayoutPolicy,
-    capabilities: frozenset[HardwareCapability],
+    moe_comm_policy: MoECommPolicy,
+    quantization_backend_family: QuantizationBackendFamily,
 ) -> None:
     profile = get_hardware_profile(device_type)
 
     assert profile._device_type is device_type
+    assert profile.attention_backend_family is attention_backend_family
+    assert profile.cpu_binding_mode is cpu_binding_mode
+    assert profile.default_worker_cls == default_worker_cls
+    assert profile.device_adaptor_family is device_adaptor_family
+    assert profile.device_addressing_mode is device_addressing_mode
     assert profile.weight_layout_policy is weight_layout_policy
-    assert profile.capabilities == capabilities
+    assert profile.moe_comm_policy is moe_comm_policy
+    assert profile.quantization_backend_family is quantization_backend_family
+
+
+@pytest.mark.parametrize("device_type", list(AscendDeviceType))
+def test_hardware_profile_capability_matrix(device_type: AscendDeviceType) -> None:
+    profile = get_hardware_profile(device_type)
+    expected_capabilities = _EXPECTED_CAPABILITIES[device_type]
+
+    assert profile.capabilities == expected_capabilities
     for capability in HardwareCapability:
-        assert profile.supports(capability) is (capability in capabilities)
+        assert profile.supports(capability) is (capability in expected_capabilities)
 
 
 def test_current_hardware_profile_uses_device_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/vllm_ascend/device/__init__.py
+++ b/vllm_ascend/device/__init__.py
@@ -1,17 +1,29 @@
 from vllm_ascend.device.device_config import DeviceConfig, get_device_config
 from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    CPUBindingMode,
+    DeviceAdaptorFamily,
+    DeviceAddressingMode,
     HardwareCapability,
     HardwareProfile,
+    MoECommPolicy,
+    QuantizationBackendFamily,
     WeightLayoutPolicy,
     get_current_hardware_profile,
     get_hardware_profile,
 )
 
 __all__ = [
+    "AttentionBackendFamily",
+    "CPUBindingMode",
+    "DeviceAdaptorFamily",
+    "DeviceAddressingMode",
     "DeviceConfig",
     "HardwareCapability",
     "HardwareProfile",
     "WeightLayoutPolicy",
+    "MoECommPolicy",
+    "QuantizationBackendFamily",
     "get_current_hardware_profile",
     "get_device_config",
     "get_hardware_profile",

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -16,8 +16,85 @@ from vllm_ascend.device.hardware import AscendDeviceType
 class HardwareCapability(Enum):
     """Independent SoC capabilities consumed by shared business logic."""
 
+    ATB_EXTENSIONS = auto()
+    ATB_WARMUP = auto()
+    BGMV_SGMV_META_REGISTRATION = auto()
+    CHUNKED_PREFILL_PHASE_SPLIT = auto()
+    CLUSTER_CPU_TOPOLOGY = auto()
+    COMPATIBILITY_OP_IMPLEMENTATIONS = auto()
     AUTO_ENABLE_CUSTOM_OPS = auto()
+    DISTRIBUTED_COMMUNICATION_ADAPTATION = auto()
+    DSA_O_PROJ_TP = auto()
+    DSV4_COMPRESSED_CACHE = auto()
     DYNAMIC_MX_QUANT_FUSION = auto()
+    FP8_ATTENTION = auto()
+    FUSED_MOE_COMPATIBILITY = auto()
+    FUSED_SWIGLU_TUNING_ARGS = auto()
+    GDN_COMPATIBILITY = auto()
+    GRAPH_MULS_ADD_FUSION = auto()
+    GRAPH_NORM_QUANT_FUSION = auto()
+    IRQ_CPU_RESERVATION = auto()
+    LOCAL_KV_COMM_RESOURCE = auto()
+    LORA_CUSTOM_OPS = auto()
+    MOE_DISPATCH_EXTRA_ARGS = auto()
+    MOE_DISPATCH_SHARED_EXPERT_ARGS = auto()
+    NPUGRAPH_EX = auto()
+    NPU_TOP_K_TOP_P = auto()
+    PAGED_ATTENTION = auto()
+    RC_DEVICE_DISCOVERY = auto()
+    REDUCED_CUDAGRAPH_CAPTURE_SIZES = auto()
+    SKIP_REMOTE_H2D_BUFFER_REGISTRATION = auto()
+    RUNTIME_CUSTOM_OPS = auto()
+    SFA_DCP_REPLICATED_INDEXER = auto()
+    STANDARD_MAMBA_PATCH = auto()
+    STANDARD_WORKER_PATCHES = auto()
+    TRITON_BATCH_MEMCPY = auto()
+    UNRESTRICTED_MLAPO = auto()
+
+
+class AttentionBackendFamily(Enum):
+    """Attention backend implementation families."""
+
+    STANDARD = auto()
+    COMPATIBILITY = auto()
+
+
+class CPUBindingMode(Enum):
+    """CPU binding policies selected for worker processes."""
+
+    TOPO_AFFINITY = "topo_affinity"
+    GLOBAL_SLICE = "global_slice"
+
+
+class DeviceAdaptorFamily(Enum):
+    """Device operation adaptor implementation families."""
+
+    STANDARD = auto()
+    FP8_OPTIMIZED = auto()
+    COMPATIBILITY = auto()
+
+
+class DeviceAddressingMode(Enum):
+    """PCIe device addressing policies used by CPU binding."""
+
+    DIRECT = auto()
+    DUAL_CHIP_CARD = auto()
+
+
+class MoECommPolicy(Enum):
+    """MoE communication selection policies."""
+
+    CAPACITY_AND_EXPERT_DENSITY = auto()
+    FUSED_OR_CAPACITY = auto()
+    CAPACITY_AND_WORLD_SIZE = auto()
+    ALLGATHER = auto()
+
+
+class QuantizationBackendFamily(Enum):
+    """Quantization configuration implementation families."""
+
+    STANDARD = auto()
+    COMPATIBILITY = auto()
 
 
 class WeightLayoutPolicy(Enum):
@@ -32,7 +109,14 @@ class HardwareProfile:
     """Immutable capabilities and implementation choices for one SoC family."""
 
     _device_type: AscendDeviceType
+    attention_backend_family: AttentionBackendFamily
+    cpu_binding_mode: CPUBindingMode
+    default_worker_cls: str
+    device_adaptor_family: DeviceAdaptorFamily
+    device_addressing_mode: DeviceAddressingMode
     weight_layout_policy: WeightLayoutPolicy
+    moe_comm_policy: MoECommPolicy
+    quantization_backend_family: QuantizationBackendFamily
     capabilities: frozenset[HardwareCapability]
 
     def supports(self, capability: HardwareCapability) -> bool:
@@ -41,31 +125,116 @@ class HardwareProfile:
         return capability in self.capabilities
 
 
-_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES = frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS})
+_STANDARD_CAPABILITIES = frozenset(
+    {
+        HardwareCapability.ATB_EXTENSIONS,
+        HardwareCapability.ATB_WARMUP,
+        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+        HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+        HardwareCapability.GRAPH_MULS_ADD_FUSION,
+        HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+        HardwareCapability.IRQ_CPU_RESERVATION,
+        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX,
+        HardwareCapability.PAGED_ATTENTION,
+        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
+        HardwareCapability.STANDARD_MAMBA_PATCH,
+        HardwareCapability.STANDARD_WORKER_PATCHES,
+        HardwareCapability.TRITON_BATCH_MEMCPY,
+    }
+)
+_DEFAULT_WORKER_CLS = "vllm_ascend.worker.worker.NPUWorker"
 _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
     {
         AscendDeviceType.A2: HardwareProfile(
             _device_type=AscendDeviceType.A2,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+            moe_comm_policy=MoECommPolicy.CAPACITY_AND_EXPERT_DENSITY,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
+            capabilities=_STANDARD_CAPABILITIES
+            | {
+                HardwareCapability.NPU_TOP_K_TOP_P,
+                HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION,
+            },
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.GLOBAL_SLICE,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_addressing_mode=DeviceAddressingMode.DUAL_CHIP_CARD,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+            moe_comm_policy=MoECommPolicy.FUSED_OR_CAPACITY,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
+            capabilities=_STANDARD_CAPABILITIES
+            | {
+                HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+                HardwareCapability.NPU_TOP_K_TOP_P,
+            },
         ),
         AscendDeviceType._310P: HardwareProfile(
             _device_type=AscendDeviceType._310P,
+            attention_backend_family=AttentionBackendFamily.COMPATIBILITY,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls="vllm_ascend._310p.worker_310p.NPUWorker310",
+            device_adaptor_family=DeviceAdaptorFamily.COMPATIBILITY,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.FORCE_NZ,
-            capabilities=frozenset(),
+            moe_comm_policy=MoECommPolicy.ALLGATHER,
+            quantization_backend_family=QuantizationBackendFamily.COMPATIBILITY,
+            capabilities=frozenset(
+                {
+                    HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
+                    HardwareCapability.DISTRIBUTED_COMMUNICATION_ADAPTATION,
+                    HardwareCapability.FUSED_MOE_COMPATIBILITY,
+                    HardwareCapability.FUSED_SWIGLU_TUNING_ARGS,
+                    HardwareCapability.GDN_COMPATIBILITY,
+                    HardwareCapability.IRQ_CPU_RESERVATION,
+                    HardwareCapability.RC_DEVICE_DISCOVERY,
+                    HardwareCapability.RUNTIME_CUSTOM_OPS,
+                }
+            ),
         ),
         AscendDeviceType.A5: HardwareProfile(
             _device_type=AscendDeviceType.A5,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.FP8_OPTIMIZED,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            moe_comm_policy=MoECommPolicy.CAPACITY_AND_WORLD_SIZE,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
             capabilities=frozenset(
                 {
+                    HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+                    HardwareCapability.CHUNKED_PREFILL_PHASE_SPLIT,
+                    HardwareCapability.CLUSTER_CPU_TOPOLOGY,
                     HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+                    HardwareCapability.DSA_O_PROJ_TP,
+                    HardwareCapability.DSV4_COMPRESSED_CACHE,
                     HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+                    HardwareCapability.FP8_ATTENTION,
+                    HardwareCapability.GRAPH_MULS_ADD_FUSION,
+                    HardwareCapability.GRAPH_NORM_QUANT_FUSION,
+                    HardwareCapability.LOCAL_KV_COMM_RESOURCE,
+                    HardwareCapability.LORA_CUSTOM_OPS,
+                    HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
+                    HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
+                    HardwareCapability.NPUGRAPH_EX,
+                    HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
+                    HardwareCapability.STANDARD_MAMBA_PATCH,
+                    HardwareCapability.STANDARD_WORKER_PATCHES,
+                    HardwareCapability.TRITON_BATCH_MEMCPY,
+                    HardwareCapability.UNRESTRICTED_MLAPO,
                 }
             ),
         ),


### PR DESCRIPTION
### What this PR does / why we need it?

Extends the hardware profile abstraction with semantic capabilities and policy enums, and centralizes the capability matrix for supported Ascend hardware families.

This allows subsequent business logic to select behavior by capability or policy instead of branching on concrete device identities.

### Does this PR introduce *any* user-facing change?

No.

### How was this patch tested?

UT

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
