### PR TITLE
[Performance][Kimi K3] Overlap QKV packing with gate projections

### DIFF
--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -32,6 +32,8 @@ from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiGatedDeltaNetAttention,
     _load_a_log,
+    _resolve_kda_qkv_input,
+    _start_kda_qkv_concat,
     _zero_padded_spec_output,
 )
 
@@ -133,6 +135,109 @@ def test_load_a_log_preserves_exact_local_4d_checkpoint():
 def test_load_a_log_rejects_unsupported_layout():
     with pytest.raises(ValueError, match="must be 1-D or 4-D"):
         _load_a_log(torch.empty(1, 1, 2, 1), torch.empty(2, 2), num_heads=4)
+
+
+def test_start_kda_qkv_concat_cpu_packs_without_streams():
+    q = torch.randn(4, 2)
+    k = torch.randn(4, 3)
+    v = torch.randn(4, 5)
+
+    mixed_qkv, main_stream, concat_stream = _start_kda_qkv_concat(q, k, v)
+
+    torch.testing.assert_close(mixed_qkv, torch.cat((q, k, v), dim=-1))
+    assert main_stream is None
+    assert concat_stream is None
+
+
+def test_start_kda_qkv_concat_orders_streams_and_records_lifetimes():
+    q = MagicMock()
+    k = MagicMock()
+    v = MagicMock()
+    q.device = SimpleNamespace(type="npu")
+    main_stream = MagicMock()
+    concat_stream = MagicMock()
+    mixed_qkv = MagicMock()
+
+    with (
+        patch("vllm_ascend.ops.kimi_kda._kda_qkv_concat_stream", return_value=concat_stream),
+        patch.object(torch.npu, "current_stream", return_value=main_stream),
+        patch.object(torch.npu, "stream") as stream_context,
+        patch("vllm_ascend.ops.kimi_kda.torch.cat", return_value=mixed_qkv),
+    ):
+        result = _start_kda_qkv_concat(q, k, v)
+
+    q.record_stream.assert_called_once_with(concat_stream)
+    k.record_stream.assert_called_once_with(concat_stream)
+    v.record_stream.assert_called_once_with(concat_stream)
+    concat_stream.wait_stream.assert_called_once_with(main_stream)
+    stream_context.assert_called_once_with(concat_stream)
+    mixed_qkv.record_stream.assert_called_once_with(main_stream)
+    assert result == (mixed_qkv, main_stream, concat_stream)
+
+
+def test_resolve_kda_qkv_input_supports_packed_and_legacy_inputs():
+    q = torch.randn(4, 2)
+    k = torch.randn(4, 3)
+    v = torch.randn(4, 5)
+    packed = torch.cat((q, k, v), dim=-1)
+    sentinel = packed[:, :0]
+
+    resolved_packed = _resolve_kda_qkv_input(packed, sentinel, sentinel, 3)
+    resolved_legacy = _resolve_kda_qkv_input(q, k, v, 3)
+
+    torch.testing.assert_close(resolved_packed, packed[:3])
+    torch.testing.assert_close(resolved_legacy, packed[:3])
+
+
+def test_forward_passes_packed_qkv_sentinels_to_custom_op(monkeypatch):
+    attention = AscendKimiGatedDeltaNetAttention.__new__(AscendKimiGatedDeltaNetAttention)
+    nn.Module.__init__(attention)
+    attention.is_vl_first_layer = False
+    attention.use_full_rank_gate = True
+    attention.local_num_heads = 1
+    attention.head_dim = 2
+    attention.prefix = "model.layers.0.self_attn"
+
+    q = torch.randn(4, 2)
+    k = torch.randn(4, 2)
+    v = torch.randn(4, 2)
+
+    def fake_projection(result):
+        def project(_hidden_states):
+            return (result,)
+
+        return project
+
+    attention.q_proj = fake_projection(q)
+    attention.k_proj = fake_projection(k)
+    attention.v_proj = fake_projection(v)
+    attention.b_proj = fake_projection(torch.randn(4, 1))
+    attention.f_a_proj = fake_projection(torch.randn(4, 2))
+    attention.f_b_proj = fake_projection(torch.randn(4, 2))
+    attention.g_proj = fake_projection(torch.randn(4, 2))
+    attention.o_norm = lambda core_attn_out, output_gate: core_attn_out
+    attention.o_proj = fake_projection(q)
+
+    monkeypatch.setattr(
+        torch.ops.vllm,
+        "maybe_all_gather_and_maybe_unpad",
+        lambda hidden_states, enabled: hidden_states,
+    )
+
+    def fake_kda_attention(packed_qkv, k_sentinel, v_sentinel, raw_gate, beta, core_attn_out, prefix):
+        del raw_gate, beta
+        assert prefix == attention.prefix
+        assert packed_qkv.shape == (4, 6)
+        assert k_sentinel.shape == (4, 0)
+        assert v_sentinel.shape == (4, 0)
+        core_attn_out.copy_(packed_qkv[:, :2].reshape(1, 4, 1, 2))
+
+    monkeypatch.setattr(torch.ops.vllm, "kda_attention", fake_kda_attention)
+
+    output = torch.empty_like(q)
+    attention.forward(torch.randn(4, 8), torch.empty(0), output)
+
+    torch.testing.assert_close(output, q)
 
 
 def test_zero_padded_spec_output_clears_uninitialized_tail():

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -51,7 +51,54 @@ from vllm_ascend.ops.triton.kda.kda import fused_kda_gate
 from vllm_ascend.utils import is_vl_model, parse_layer_idx
 
 _KDA_CHUNK_SIZE = 64
+_KDA_QKV_CONCAT_STREAM: torch.npu.Stream | None = None
 _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
+
+
+def _kda_qkv_concat_stream() -> torch.npu.Stream:
+    """Return the process-local stream used to overlap KDA QKV packing."""
+    global _KDA_QKV_CONCAT_STREAM
+    if _KDA_QKV_CONCAT_STREAM is None:
+        _KDA_QKV_CONCAT_STREAM = torch.npu.Stream()
+    return _KDA_QKV_CONCAT_STREAM
+
+
+def _start_kda_qkv_concat(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> tuple[torch.Tensor, torch.npu.Stream | None, torch.npu.Stream | None]:
+    """Pack QKV while independent gate projections run on the main stream."""
+    if q.device.type != "npu":
+        return torch.cat((q, k, v), dim=-1), None, None
+
+    main_stream = torch.npu.current_stream()
+    concat_stream = _kda_qkv_concat_stream()
+    # The projection outputs originate on the main stream but remain live
+    # while the side stream reads them.
+    q.record_stream(concat_stream)
+    k.record_stream(concat_stream)
+    v.record_stream(concat_stream)
+    concat_stream.wait_stream(main_stream)
+    with torch.npu.stream(concat_stream):
+        mixed_qkv = torch.cat((q, k, v), dim=-1)
+    # The packed output is produced on the side stream and consumed by the
+    # main stream after its explicit wait below.
+    mixed_qkv.record_stream(main_stream)
+    return mixed_qkv, main_stream, concat_stream
+
+
+def _resolve_kda_qkv_input(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    num_actual_tokens: int,
+) -> torch.Tensor:
+    """Accept either legacy Q/K/V inputs or an already packed QKV tensor."""
+    q = q[:num_actual_tokens]
+    if k.numel() == 0 and v.numel() == 0:
+        return q
+    return torch.cat((q, k[:num_actual_tokens], v[:num_actual_tokens]), dim=-1)
 
 
 def _zero_padded_spec_output(
@@ -233,6 +280,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         q = self.q_proj(hidden_states)[0]
         k = self.k_proj(hidden_states)[0]
         v = self.v_proj(hidden_states)[0]
+        mixed_qkv, main_stream, qkv_concat_stream = _start_kda_qkv_concat(q, k, v)
 
         beta = self.b_proj(hidden_states)[0].float().sigmoid().unsqueeze(0)
         raw_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
@@ -249,10 +297,17 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
+        if qkv_concat_stream is not None:
+            assert main_stream is not None
+            main_stream.wait_stream(qkv_concat_stream)
+
+        # Keep the opaque custom-op boundary while avoiding a second concat in
+        # _forward. Empty K/V views mark the first argument as packed [Q|K|V].
+        packed_qkv_sentinel = mixed_qkv[:, :0]
         torch.ops.vllm.kda_attention(
-            q,
-            k,
-            v,
+            mixed_qkv,
+            packed_qkv_sentinel,
+            packed_qkv_sentinel,
             raw_gate,
             beta,
             core_attn_out,
@@ -492,14 +547,16 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         assert isinstance(attn_metadata, GDNAttentionMetadata)
 
         num_actual_tokens = attn_metadata.num_actual_tokens
-        q_proj_states = q_proj_states[:num_actual_tokens]
-        k_proj_states = k_proj_states[:num_actual_tokens]
-        v_proj_states = v_proj_states[:num_actual_tokens]
+        mixed_qkv = _resolve_kda_qkv_input(
+            q_proj_states,
+            k_proj_states,
+            v_proj_states,
+            num_actual_tokens,
+        )
         g1 = g1[:, :num_actual_tokens]
         beta = beta[:, :num_actual_tokens]
 
         conv_state, recurrent_state = self.kv_cache
-        mixed_qkv = torch.cat((q_proj_states, k_proj_states, v_proj_states), dim=-1)
         conv_weights_t = self._conv_weights_t()
 
         spec_masks = attn_metadata.spec_sequence_masks


### PR DESCRIPTION
### What this PR does / why we need it?

This PR ports the Kimi K3 QKV multi-stream optimization from [vllm-ascend/vllm-ascend-kimi-k3#58](https://github.com/vllm-ascend/vllm-ascend-kimi-k3/pull/58) to the vLLM Ascend 0.26 release branch.

- Run Q/K/V concatenation on a process-local NPU side stream.
- Overlap QKV packing with the independent beta, decay-gate, and output-gate projections.
- Pass the already packed QKV tensor through the existing custom-op boundary using empty K/V sentinel views.
- Preserve compatibility with legacy separate Q/K/V calls in the current KDA implementation.
- Register both producer and consumer streams for cross-stream tensor lifetimes to prevent allocator reuse before all consumers finish.

The change is limited to Kimi K3 KDA and does not alter other models or operators.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Kimi K3 inference uses the QKV packing overlap automatically on NPU.

### How was this patch tested?

- Added unit coverage for the CPU fallback path.
- Added unit coverage for NPU stream ordering and tensor lifetime registration.
- Added unit coverage for packed and legacy KDA input contracts.
- Added a forward-path regression test verifying packed-QKV sentinel dispatch.
- Ran Python bytecode compilation and `git diff --check` locally.
- Full pytest/pre-commit and Ascend NPU end-to-end validation were not run locally because this host does not contain the project test dependencies or Ascend NPU runtime; the PR is opened as a draft for CI and NPU validation.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
