### PR TITLE
[BugFix] Read migrated options from additional_config in RL and LoRA guards

### DIFF
--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -7,6 +7,7 @@ from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
 from vllm_ascend.lora.fused_moe import (
     AscendFusedMoEWithLoRA,
+    _assert_ascend_moe_lora_supported,
     _recover_moe_lora_routing_all2all,
     _recover_moe_lora_routing_allgather,
     has_lora,
@@ -121,3 +122,21 @@ def test_decode_metadata_refreshes_no_lora(index_mapping, expected_no_lora) -> N
     with patch.object(PunicaWrapperBase, "update_metadata"):
         wrapper.update_metadata(mapping, [], 2, 100)
     assert wrapper.no_lora is expected_no_lora
+
+
+def test_moe_lora_guard_reads_additional_config() -> None:
+    # additional_config disables fused MC2, so the guard must let LoRA through
+    # even when the deprecated env var is still set to 1.
+    base_layer = SimpleNamespace(dynamic_eplb=False, _shared_experts=None)
+
+    with (
+        patch("vllm_ascend.lora.fused_moe.get_ascend_config") as mock_config,
+        patch("vllm_ascend.envs.VLLM_ASCEND_ENABLE_FUSED_MC2", 1),
+    ):
+        mock_config.return_value.enable_fused_mc2 = 0
+        _assert_ascend_moe_lora_supported(base_layer)
+
+    with patch("vllm_ascend.lora.fused_moe.get_ascend_config") as mock_config:
+        mock_config.return_value.enable_fused_mc2 = 1
+        with pytest.raises(AssertionError, match="FusedMC2"):
+            _assert_ascend_moe_lora_supported(base_layer)

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -37,7 +37,7 @@ from vllm.lora.layers.base import BaseLayerWithLoRA
 from vllm.lora.layers.fused_moe import FusedMoE3DWithLoRA, FusedMoEWithLoRA
 from vllm.lora.layers.utils import _get_lora_device
 
-import vllm_ascend.envs as envs_ascend
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.ops.fused_moe.moe_utils import async_all_to_all
 
@@ -173,11 +173,11 @@ def _assert_ascend_moe_lora_supported(base_layer: nn.Module) -> None:
             "Ascend MoE LoRA is incompatible with dynamic EPLB "
             "(expert migration would break the per-expert LoRA layout)."
         )
-    if int(envs_ascend.VLLM_ASCEND_ENABLE_FUSED_MC2) != 0:
+    if int(get_ascend_config().enable_fused_mc2) != 0:
         raise AssertionError(
             "Ascend MoE LoRA cannot patch FusedMC2 path "
             "(dispatch_ffn_combine/mega_moe is a single fused C++ op). "
-            "Set VLLM_ASCEND_ENABLE_FUSED_MC2=0."
+            "Set enable_fused_mc2=0 via --additional-config."
         )
     if getattr(base_layer, "_shared_experts", None) is not None:
         logger.warning_once(

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -282,11 +282,11 @@ class NPUWorker(WorkerBase):
         self.weight_transfer_engine.init_transfer_engine(typed_init_info)
 
     def _check_nz_disabled(self) -> None:
-        if envs_ascend.VLLM_ASCEND_ENABLE_NZ:
+        if get_ascend_config().weight_nz_mode:
             raise ValueError(
                 "FRACTAL_NZ mode is enabled. This may cause model parameter "
                 "precision issues in the RL scenarios. Please set "
-                "VLLM_ASCEND_ENABLE_NZ=0."
+                "weight_nz_mode=0 via --additional-config."
             )
 
     def start_weight_update(self) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?

Two startup guards still read the deprecated environment variables directly instead of the migrated `additional_config` keys, so a user who followed the documented migration is rejected on a stale env value:

- `NPUWorker._check_nz_disabled()` reads `VLLM_ASCEND_ENABLE_NZ`, which defaults to `1`. Starting an RL run with `--additional-config '{"weight_nz_mode": 0}'` and no env var raises "FRACTAL_NZ mode is enabled" even though NZ is off, and the message asks for an env var that is being removed. `wake_up()` a few lines above in the same file already reads `weight_nz_mode` from `AscendConfig`.
- The MoE-LoRA guard reads `VLLM_ASCEND_ENABLE_FUSED_MC2`, while every other consumer of that switch (`moe_comm_method.py`, `routed_experts.py`) reads `enable_fused_mc2` from `AscendConfig`. With the env var exported in an image and `enable_fused_mc2: 0` in `additional_config`, fused MC2 is actually disabled everywhere but LoRA startup still aborts.

Both now read the config, and the error messages point at the supported option.

### Does this PR introduce _any_ user-facing change?

Configurations that were wrongly rejected now start. Setups that only set the environment variables are unaffected, since `AscendConfig` falls back to them.

### How was this patch tested?

Added a regression test in `tests/ut/lora/test_lora.py` covering both directions of the LoRA guard (config off + env on must pass, config on must raise); it fails without this change. `pytest -sv tests/ut/lora/` passes locally on CPU. The worker half has no unit test because this repo has no CPU UT harness for `worker/worker.py` today — happy to add one if you would like it in this PR. I don't have Ascend hardware, so I'm relying on the NPU CI for e2e coverage.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
