### PR TITLE
[v0.26.0rc][BugFix][Frontend] Align DeepSeek V4 parser thinking default

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -2,6 +2,7 @@
 
 import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
 from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
 
@@ -10,6 +11,9 @@ class FakeTokenizer:
 
     def get_added_vocab(self):
         return {}
+
+    def get_vocab(self):
+        return {"<think>": 1, "</think>": 2}
 
     def encode(self, text, add_special_tokens=False, **kwargs):
         return text
@@ -107,6 +111,52 @@ def test_deepseek_v4_defaults_to_thinking_with_high_effort():
 
     assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum")
     assert prompt.endswith("<｜Assistant｜><think>")
+
+
+@pytest.mark.parametrize(
+    ("chat_template_kwargs", "expected_state"),
+    [
+        ({}, "REASONING"),
+        ({"thinking": True}, "REASONING"),
+        ({"enable_thinking": True}, "REASONING"),
+        ({"reasoning_effort": "high"}, "REASONING"),
+        ({"thinking": False}, "CONTENT"),
+        ({"enable_thinking": False}, "CONTENT"),
+        ({"enable_thinking": True, "reasoning_effort": "none"}, "CONTENT"),
+    ],
+)
+def test_parser_thinking_mode_matches_tokenizer_default(
+    chat_template_kwargs,
+    expected_state,
+):
+    parser = DeepSeekV4Parser(
+        FakeTokenizer(),
+        chat_template_kwargs=chat_template_kwargs,
+    )
+
+    assert parser.parser_engine_config.initial_state.name == expected_state
+
+
+@pytest.mark.parametrize("request_kwargs", [{}, {"reasoning_effort": "high"}])
+def test_parser_splits_implicit_start_reasoning(request_kwargs):
+    request = ChatCompletionRequest(
+        model="deepseek-v4",
+        messages=[{"role": "user", "content": "hi"}],
+        **request_kwargs,
+    )
+    params = request.build_chat_params(None, "auto")
+    parser = DeepSeekV4Parser(
+        FakeTokenizer(),
+        chat_template_kwargs=params.chat_template_kwargs,
+    )
+
+    reasoning, content = parser.extract_reasoning(
+        "reasoning text</think>answer text",
+        request,
+    )
+
+    assert reasoning == "reasoning text"
+    assert content == "answer text"
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -71,6 +71,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.tokenizers.deepseek_v4.get_deepseek_v4_tokenizer`
 #      `vllm.tokenizers.deepseek_v4_encoding.render_message`
+#      `vllm.parser.deepseek_v4.DeepSeekV4Parser.__init__`
 #    Why:
 #       DeepSeek-V4-Flash-0731 defines three reasoning effort levels: low has
 #       no prompt prefix, high uses the original "Absolute maximum" prefix,
@@ -80,11 +81,15 @@
 #       Monkey-patch tokenizer normalization so omitted options select
 #       thinking with high effort and compatibility aliases map to canonical
 #       low, high, or max. Wrap render_message to prepend the official 0731
-#       prompt before the first message in thinking mode.
+#       prompt before the first message in thinking mode. Align the parser's
+#       default state with the tokenizer so implicit thinking is extracted as
+#       reasoning instead of content.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/50580
+#       https://github.com/vllm-project/vllm/pull/51296
 #    Future Plan:
-#       Remove this patch once the supported vLLM version contains PR #50580.
+#       Remove this patch once the supported vLLM version contains PR #50580
+#       and PR #51296.
 #
 # ** 4. File: platform/patch_distributed.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import wraps
 from typing import Any
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
 from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
 REASONING_EFFORT_PROMPTS = {
@@ -47,6 +49,7 @@ DEFAULT_REASONING_EFFORT = "low"
 
 _original_render_message = deepseek_v4_encoding.render_message
 _original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
+_original_deepseek_v4_parser_init = DeepSeekV4Parser.__init__
 
 
 def _patched_render_message(
@@ -131,7 +134,24 @@ def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
     return dsv4_tokenizer
 
 
+@wraps(_original_deepseek_v4_parser_init)
+def _patched_deepseek_v4_parser_init(
+    self: DeepSeekV4Parser,
+    tokenizer: Any,
+    tools: list[Any] | None = None,
+    **kwargs: Any,
+) -> None:
+    chat_kwargs = kwargs.get("chat_template_kwargs") or {}
+    if "thinking" not in chat_kwargs and "enable_thinking" not in chat_kwargs:
+        chat_kwargs = dict(chat_kwargs)
+        chat_kwargs["enable_thinking"] = True
+        kwargs["chat_template_kwargs"] = chat_kwargs
+
+    _original_deepseek_v4_parser_init(self, tokenizer, tools, **kwargs)
+
+
 if not hasattr(deepseek_v4_encoding, "REASONING_EFFORT_PROMPTS"):
     deepseek_v4_encoding.REASONING_EFFORT_PROMPTS = REASONING_EFFORT_PROMPTS
     deepseek_v4_encoding.render_message = _patched_render_message
     deepseek_v4.get_deepseek_v4_tokenizer = _patched_get_deepseek_v4_tokenizer
+    DeepSeekV4Parser.__init__ = _patched_deepseek_v4_parser_init


### PR DESCRIPTION
### What this PR does / why we need it?

This backports the DeepSeek V4 reasoning parser behavior from
https://github.com/vllm-project/vllm/pull/51296 to the v0.26 release branch.

PR #13993 (commit `3fd0e217f`) already backported the tokenizer and renderer
behavior from https://github.com/vllm-project/vllm/pull/50580. As a result,
omitting both thinking controls selects thinking mode with high reasoning
effort. The vLLM v0.26 parser, however, still initializes in content mode
unless thinking is explicitly enabled.

The DeepSeek-V4-Flash-0731 prompt ends with `<think>`, so generated output may
start directly with reasoning and emit only the closing `</think>` marker. In
the default request case, the parser therefore returned reasoning text in
`content` and left `reasoning` empty, while an explicit high-effort request was
split correctly.

This patch initializes `DeepSeekV4Parser` with thinking enabled only when both
`thinking` and `enable_thinking` are omitted. Explicit enablement, explicit
disablement, and `reasoning_effort=none` keep their existing behavior. It also
adds a state matrix and a regression test for splitting implicit-start output
into reasoning and content.

### Does this PR introduce _any_ user-facing change?

Yes. For DeepSeek-V4-Flash-0731, a request that omits thinking controls now
returns reasoning text in the `reasoning` field and answer text in `content`,
matching an explicit thinking request with high reasoning effort. Explicit
thinking controls are unchanged.

### How was this patch tested?

- Based on the latest `releases/v0.26.0rc` commit
  `59a272bb5304d69183d5f8a1f0977b476daa9fc0`.
- Test machine: Linux 5.10 (`aarch64`), Python 3.12.13, with 8 Ascend NPU
  devices visible to `npu-smi`.
- `VLLM_VERSION=0.26.0 python -m pytest -q tests/ut/patch/platform/test_deepseek_v4_thinking.py`
  - Result: `31 passed`.
- `python -m py_compile` passed for all three changed Python files.
- `bash format.sh ci` passed all configured hooks, including ruff, codespell,
  typos, clang-format, markdownlint, Gitleaks, ShellCheck, and repository-local
  checks.
- `git diff --check` passed.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
