### PR TITLE
[Refactor][Device][3/N] Migrate core runtime selection to hardware profiles

### DIFF
--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -19,6 +19,8 @@ import torch
 
 from vllm_ascend import utils
 from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 def test_register_customop_overrides_mm_encoder_attention_for_310p():
@@ -27,7 +29,10 @@ def test_register_customop_overrides_mm_encoder_attention_for_310p():
         utils._ASCEND_CUSTOMOP_IS_REIGISTERED = False
         with (
             mock.patch("vllm.model_executor.custom_op.CustomOp.register_oot"),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType._310P),
+            ),
         ):
             utils.register_ascend_customop()
 

--- a/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_dynamic_310.py
@@ -22,6 +22,8 @@ from vllm_ascend._310p.quantization.methods.w8a8_dynamic import (
     AscendW8A8DynamicFusedMoEMethod310,
     AscendW8A8DynamicLinearMethod310,
 )
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 class TestAscendW8A8FusedMoEMethod310(TestBase):
@@ -121,7 +123,7 @@ class TestAscendW8A8DynamicLinearMethod310(TestBase):
 
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch("vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P))
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_is_310p):
         mock_npu_format_cast.side_effect = lambda x, fmt: x

--- a/tests/ut/_310p/quantization/test_w8a8_static_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_static_310.py
@@ -19,6 +19,8 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend._310p.quantization.methods.w8a8_static import AscendW8A8LinearMethod310
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 class TestAscendW8A8LinearMethod310(TestBase):
@@ -122,7 +124,7 @@ class TestAscendW8A8LinearMethod310(TestBase):
 
         self.assertTrue(torch.equal(output, expected_y_output))
 
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch("vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P))
     @patch("torch_npu.npu_format_cast")
     def test_process_weights_after_loading_calls_nz_format_cast_310p(self, mock_npu_format_cast, _mock_is_310p):
         mock_npu_format_cast.side_effect = lambda x, fmt: x

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -27,6 +27,7 @@ _STANDARD_CAPABILITIES = frozenset(
         HardwareCapability.BGMV_SGMV_META_REGISTRATION,
         HardwareCapability.IRQ_CPU_RESERVATION,
         HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.MC2_HIERARCHY_COMM,
         HardwareCapability.NPUGRAPH_EX,
         HardwareCapability.RUNTIME_CUSTOM_OPS,
         HardwareCapability.SFA_DCP_REPLICATED_INDEXER,

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -9,51 +9,140 @@ import pytest
 from vllm_ascend.device.device_config import DeviceConfig
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    CPUBindingMode,
+    DeviceAdaptorFamily,
+    DeviceAddressingMode,
     HardwareCapability,
+    QuantizationBackendFamily,
     WeightLayoutPolicy,
     get_current_hardware_profile,
     get_hardware_profile,
 )
 
+_STANDARD_CAPABILITIES = frozenset(
+    {
+        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+        HardwareCapability.IRQ_CPU_RESERVATION,
+        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX,
+        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
+        HardwareCapability.STANDARD_WORKER_PATCHES,
+    }
+)
+
+_EXPECTED_CAPABILITIES = {
+    AscendDeviceType.A2: _STANDARD_CAPABILITIES | {HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION},
+    AscendDeviceType.A3: _STANDARD_CAPABILITIES,
+    AscendDeviceType._310P: frozenset(
+        {
+            HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
+            HardwareCapability.IRQ_CPU_RESERVATION,
+            HardwareCapability.RC_DEVICE_DISCOVERY,
+            HardwareCapability.RUNTIME_CUSTOM_OPS,
+        }
+    ),
+    AscendDeviceType.A5: frozenset(
+        {
+            HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+            HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+            HardwareCapability.CLUSTER_CPU_TOPOLOGY,
+            HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+            HardwareCapability.LORA_CUSTOM_OPS,
+            HardwareCapability.NPUGRAPH_EX,
+            HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
+            HardwareCapability.STANDARD_WORKER_PATCHES,
+        }
+    ),
+}
+
 
 @pytest.mark.parametrize(
-    ("device_type", "weight_layout_policy", "capabilities"),
+    (
+        "device_type",
+        "attention_backend_family",
+        "cpu_binding_mode",
+        "default_worker_cls",
+        "device_adaptor_family",
+        "device_addressing_mode",
+        "weight_layout_policy",
+        "quantization_backend_family",
+    ),
     [
         (
             AscendDeviceType.A2,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.STANDARD,
+            DeviceAddressingMode.DIRECT,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+            QuantizationBackendFamily.STANDARD,
         ),
         (
             AscendDeviceType.A3,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.GLOBAL_SLICE,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.STANDARD,
+            DeviceAddressingMode.DUAL_CHIP_CARD,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS}),
+            QuantizationBackendFamily.STANDARD,
         ),
-        (AscendDeviceType._310P, WeightLayoutPolicy.FORCE_NZ, frozenset()),
+        (
+            AscendDeviceType._310P,
+            AttentionBackendFamily.COMPATIBILITY,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend._310p.worker_310p.NPUWorker310",
+            DeviceAdaptorFamily.COMPATIBILITY,
+            DeviceAddressingMode.DIRECT,
+            WeightLayoutPolicy.FORCE_NZ,
+            QuantizationBackendFamily.COMPATIBILITY,
+        ),
         (
             AscendDeviceType.A5,
+            AttentionBackendFamily.STANDARD,
+            CPUBindingMode.TOPO_AFFINITY,
+            "vllm_ascend.worker.worker.NPUWorker",
+            DeviceAdaptorFamily.FP8_OPTIMIZED,
+            DeviceAddressingMode.DIRECT,
             WeightLayoutPolicy.CONFIGURABLE,
-            frozenset(
-                {
-                    HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
-                    HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
-                }
-            ),
+            QuantizationBackendFamily.STANDARD,
         ),
     ],
 )
-def test_hardware_profile_matrix(
+def test_hardware_profile_implementation_matrix(
     device_type: AscendDeviceType,
+    attention_backend_family: AttentionBackendFamily,
+    cpu_binding_mode: CPUBindingMode,
+    default_worker_cls: str,
+    device_adaptor_family: DeviceAdaptorFamily,
+    device_addressing_mode: DeviceAddressingMode,
     weight_layout_policy: WeightLayoutPolicy,
-    capabilities: frozenset[HardwareCapability],
+    quantization_backend_family: QuantizationBackendFamily,
 ) -> None:
     profile = get_hardware_profile(device_type)
 
     assert profile._device_type is device_type
+    assert profile.attention_backend_family is attention_backend_family
+    assert profile.cpu_binding_mode is cpu_binding_mode
+    assert profile.default_worker_cls == default_worker_cls
+    assert profile.device_adaptor_family is device_adaptor_family
+    assert profile.device_addressing_mode is device_addressing_mode
     assert profile.weight_layout_policy is weight_layout_policy
-    assert profile.capabilities == capabilities
+    assert profile.quantization_backend_family is quantization_backend_family
+
+
+@pytest.mark.parametrize("device_type", list(AscendDeviceType))
+def test_hardware_profile_capability_matrix(device_type: AscendDeviceType) -> None:
+    profile = get_hardware_profile(device_type)
+    expected_capabilities = _EXPECTED_CAPABILITIES[device_type]
+
+    assert profile.capabilities == expected_capabilities
     for capability in HardwareCapability:
-        assert profile.supports(capability) is (capability in capabilities)
+        assert profile.supports(capability) is (capability in expected_capabilities)
 
 
 def test_current_hardware_profile_uses_device_config(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -37,7 +37,7 @@ _STANDARD_CAPABILITIES = frozenset(
 
 _EXPECTED_CAPABILITIES = {
     AscendDeviceType.A2: _STANDARD_CAPABILITIES,
-    AscendDeviceType.A3: _STANDARD_CAPABILITIES,
+    AscendDeviceType.A3: _STANDARD_CAPABILITIES | {HardwareCapability.MC2_FULLMESH_V2_COMM},
     AscendDeviceType._310P: frozenset(
         {
             HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -152,7 +152,12 @@ def test_current_hardware_profile_uses_device_config() -> None:
     assert get_current_hardware_profile() is expected_profile
 
 
-def test_current_hardware_profile_is_dynamo_safe() -> None:
+def test_current_hardware_profile_is_dynamo_safe(monkeypatch: pytest.MonkeyPatch) -> None:
+    # CPU UTs expose a mocked NPU backend that is not importable as
+    # ``torch.npu``. Keep accelerator stream discovery out of this test so it
+    # only exercises hardware-profile tracing.
+    monkeypatch.setattr(torch.accelerator, "is_available", lambda: False)
+
     def use_profile_capability(value: torch.Tensor) -> torch.Tensor:
         if get_current_hardware_profile().supports(HardwareCapability.RUNTIME_CUSTOM_OPS):
             return value + 1

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -5,8 +5,9 @@
 from typing import cast
 
 import pytest
+import torch
 
-from vllm_ascend.device.device_config import DeviceConfig
+from vllm_ascend.device.device_config import get_device_config
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import (
     AttentionBackendFamily,
@@ -34,7 +35,7 @@ _STANDARD_CAPABILITIES = frozenset(
 )
 
 _EXPECTED_CAPABILITIES = {
-    AscendDeviceType.A2: _STANDARD_CAPABILITIES | {HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION},
+    AscendDeviceType.A2: _STANDARD_CAPABILITIES,
     AscendDeviceType.A3: _STANDARD_CAPABILITIES,
     AscendDeviceType._310P: frozenset(
         {
@@ -145,16 +146,23 @@ def test_hardware_profile_capability_matrix(device_type: AscendDeviceType) -> No
         assert profile.supports(capability) is (capability in expected_capabilities)
 
 
-def test_current_hardware_profile_uses_device_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    import vllm_ascend.device.hardware_profile as profile_module
+def test_current_hardware_profile_uses_device_config() -> None:
+    expected_profile = get_hardware_profile(get_device_config()._device_type)
 
-    monkeypatch.setattr(
-        profile_module,
-        "get_device_config",
-        lambda: DeviceConfig(_device_type=AscendDeviceType.A5),
-    )
+    assert get_current_hardware_profile() is expected_profile
 
-    assert get_current_hardware_profile() is get_hardware_profile(AscendDeviceType.A5)
+
+def test_current_hardware_profile_is_dynamo_safe() -> None:
+    def use_profile_capability(value: torch.Tensor) -> torch.Tensor:
+        if get_current_hardware_profile().supports(HardwareCapability.RUNTIME_CUSTOM_OPS):
+            return value + 1
+        return value
+
+    value = torch.ones(1)
+    expected = use_profile_capability(value)
+    compiled = torch.compile(use_profile_capability, backend="eager", fullgraph=True)
+
+    assert torch.equal(compiled(value), expected)
 
 
 def test_unknown_device_type_is_rejected() -> None:

--- a/tests/ut/device_allocator/test_cpu_binding.py
+++ b/tests/ut/device_allocator/test_cpu_binding.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, call, mock_open, patch
 
 import vllm_ascend.cpu_binding as cpu_binding_module
 from vllm_ascend.cpu_binding import CpuAlloc, DeviceInfo, bind_cpus, is_arm_cpu
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import AscendDeviceType
 
 
@@ -293,7 +294,10 @@ class TestCpuAlloc(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+        device_type_patcher = patch(
+            "vllm_ascend.cpu_binding.get_current_hardware_profile",
+            return_value=get_hardware_profile(AscendDeviceType.A2),
+        )
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 
@@ -326,18 +330,18 @@ class TestCpuAlloc(unittest.TestCase):
             },
         )
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     def test_binding_mode_table(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A2
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
         self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
-        mock_get_device_type.return_value = AscendDeviceType.A3
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A3)
         self.assertEqual(self.cpu_alloc._binding_mode(), "global_slice")
-        mock_get_device_type.return_value = AscendDeviceType.A5
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A5)
         self.assertEqual(self.cpu_alloc._binding_mode(), "topo_affinity")
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     def test_build_cpu_pools_fallback_to_global_slice(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A2
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A2)
         self.cpu_alloc.device_info.npu_affinity = {}
         with (
             patch.object(self.cpu_alloc, "build_cpu_node_map") as mock_build_cpu_node_map,
@@ -347,9 +351,9 @@ class TestCpuAlloc(unittest.TestCase):
         mock_build_cpu_node_map.assert_called_once()
         mock_build_global_slice_cpu_pool.assert_called_once()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     def test_build_cpu_pools_global_slice_mode(self, mock_get_device_type):
-        mock_get_device_type.return_value = AscendDeviceType.A3
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A3)
         with (
             patch.object(self.cpu_alloc, "build_cpu_node_map") as mock_build_cpu_node_map,
             patch.object(self.cpu_alloc, "build_global_slice_cpu_pool") as mock_build_global_slice_cpu_pool,
@@ -443,7 +447,9 @@ class TestCpuAlloc(unittest.TestCase):
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[0], [0, 1, 2, 3, 4, 5])
         self.assertEqual(self.cpu_alloc.npu_cpu_pool[1], [6, 7, 8, 9, 10, 11])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_global_slice_cpu_pool_raises_when_cpu_insufficient(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(8))
@@ -452,7 +458,9 @@ class TestCpuAlloc(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.build_global_slice_cpu_pool()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_build_global_slice_cpu_pool_allows_ascend_950_without_irq_reservation(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0, 1]
         self.cpu_alloc.device_info.allowed_cpus = list(range(6))
@@ -482,7 +490,9 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.build_global_slice_cpu_pool()
         self.assertEqual(self.cpu_alloc.npu_cpu_pool, {})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_allocate(self, _mock_execute_command, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0]
@@ -495,7 +505,9 @@ class TestCpuAlloc(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.cpu_alloc.allocate()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_allocate_ascend_950_assigns_cluster_to_main_only(self, _mock_get_device_type):
         self.cpu_alloc.device_info.running_npu_list = [0]
         self.cpu_alloc.npu_cpu_pool = {0: [0, 1, 2, 3, 4]}
@@ -526,7 +538,7 @@ class TestCpuAlloc(unittest.TestCase):
         self.cpu_alloc.bind_threads()
         mock_execute_command.assert_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type")
+    @patch("vllm_ascend.cpu_binding.get_current_hardware_profile")
     @patch("vllm_ascend.cpu_binding.os.listdir")
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which")
@@ -538,7 +550,7 @@ class TestCpuAlloc(unittest.TestCase):
         mock_access.return_value = True
         mock_which.return_value = None
         mock_listdir.side_effect = FileNotFoundError
-        mock_get_device_type.return_value = AscendDeviceType.A3
+        mock_get_device_type.return_value = get_hardware_profile(AscendDeviceType.A3)
         mock_execute_command.return_value = ("PCIe Bus Info 0000:03:00.0", 0)
         self.cpu_alloc.rank_id = 0
         self.cpu_alloc.device_info.running_npu_list = [3]
@@ -555,7 +567,10 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         visible_devices_patcher.start()
         self.addCleanup(visible_devices_patcher.stop)
 
-        device_type_patcher = patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+        device_type_patcher = patch(
+            "vllm_ascend.cpu_binding.get_current_hardware_profile",
+            return_value=get_hardware_profile(AscendDeviceType.A2),
+        )
         device_type_patcher.start()
         self.addCleanup(device_type_patcher.stop)
 
@@ -707,11 +722,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(cpu_alloc.cpu_node, {0: 0, 1: 1})
         self.assertEqual(cpu_alloc.numa_to_cpu_map, {0: [0], 1: [1]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value="unknown")
-    def test_binding_mode_defaults_to_topo_affinity_for_unknown_device(self, _mock_get_device_type):
-        self.assertEqual(CpuAlloc._binding_mode(), "topo_affinity")
-
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_raises_on_affinity_conflict(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.running_npu_list = [0]
@@ -721,7 +734,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         with patch.object(cpu_alloc, "build_cpu_node_map"), self.assertRaises(RuntimeError):
             cpu_alloc.build_cpu_pools()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_builds_and_splits_duplicate_groups(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1, 2]
@@ -737,7 +752,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [0, 1], 1: [2], 2: [3]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_skips_non_running_npu_without_cpuset_overlap(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1]
@@ -753,7 +770,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_excludes_non_running_npu_from_final_pool(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0, 1]
@@ -774,7 +793,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertEqual(cpu_alloc.npu_cpu_pool, {0: [192, 193, 194, 195, 196]})
         self.assertEqual(cpu_alloc.assign_main, {0: [194]})
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     def test_build_cpu_pools_topo_mode_splits_hidden_same_affinity_npus_across_processes(self, _mock_get_device_type):
         def build_single_card_process(visible_npu):
             cpu_alloc = make_cpu_alloc()
@@ -810,7 +831,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         self.assertFalse(set(npu0_process.assign_acl[0]) & set(npu2_process.assign_acl[2]))
         self.assertFalse(set(npu0_process.assign_rel[0]) & set(npu2_process.assign_rel[2]))
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_build_ascend_950_cpu_pools_assigns_hidden_global_clusters(self, _mock_get_device_type):
         def build_dp_process(visible_npus):
             cpu_alloc = make_cpu_alloc()
@@ -854,7 +877,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         dp1_cpus = set().union(*(set(cpus) for cpus in dp1_process.npu_cpu_pool.values()))
         self.assertFalse(dp0_cpus & dp1_cpus)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     def test_build_ascend_950_cpu_pools_skips_invalid_inputs(self, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
         cpu_alloc.device_info.all_logic_npus = [0]
@@ -883,7 +908,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         with patch.object(cpu_alloc, "get_ascend_950_cluster_size", return_value=16):
             self.assertFalse(cpu_alloc.build_ascend_950_cpu_pools())
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
@@ -897,7 +924,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertEqual(mock_logger_info.call_count, 2)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_uses_ascend_950_worker_log(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
@@ -917,7 +946,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
             ],
         )
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.logger.info")
     def test_print_plan_handles_non_empty_release_assignment(self, mock_logger_info, _mock_get_device_type):
         cpu_alloc = make_cpu_alloc()
@@ -1007,7 +1038,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         mock_bind.assert_called_once_with("1000", [1, 2, 3], True)
         mock_bind_memory.assert_called_once_with("1000", 0)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.access", return_value=False)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_returns_when_irq_path_not_writable(
@@ -1018,7 +1051,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A5)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A5)
+    )
     @patch("vllm_ascend.cpu_binding.os.access")
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_skips_on_ascend_950(self, mock_execute_command, mock_access, _mock_get_device_type):
@@ -1031,7 +1066,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         mock_access.assert_not_called()
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
     @patch("vllm_ascend.cpu_binding.execute_command")
     def test_bind_npu_irq_returns_when_current_npu_has_no_cpu_pool(
@@ -1045,7 +1082,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
@@ -1061,7 +1100,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_not_called()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
     @patch("vllm_ascend.cpu_binding.os.access", return_value=True)
@@ -1077,7 +1118,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         mock_execute_command.assert_called_once_with(["npu-smi", "info", "-t", "board", "-i", "0"])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["456", "457"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value=None)
@@ -1092,7 +1135,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         cpu_alloc.bind_npu_irq()
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
@@ -1118,7 +1163,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
         handle = mock_file()
         self.assertEqual(handle.write.call_args_list, [call("00000100"), call("00000200")])
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
@@ -1140,7 +1187,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertNotIn(call(["systemctl", "stop", "irqbalance"]), mock_execute_command.call_args_list)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch("builtins.open", new_callable=mock_open, read_data="123: 0 0 0 sq_send_trigger_irq\n")
     @patch("vllm_ascend.cpu_binding.shutil.which", return_value="/bin/systemctl")
@@ -1161,7 +1210,9 @@ class TestCpuBindingSupplemental(unittest.TestCase):
 
         self.assertNotIn(call(["systemctl", "is-active", "--quiet", "irqbalance"]), mock_execute_command.call_args_list)
 
-    @patch("vllm_ascend.cpu_binding.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    @patch(
+        "vllm_ascend.cpu_binding.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    )
     @patch("vllm_ascend.cpu_binding.os.listdir", return_value=["123", "124"])
     @patch(
         "builtins.open",

--- a/tests/ut/lora/test_punica_npu.py
+++ b/tests/ut/lora/test_punica_npu.py
@@ -20,6 +20,7 @@ import pytest
 import torch
 
 from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.lora import lora_ops
 from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
 
@@ -57,7 +58,10 @@ def _make_wrapper(*, is_prefill=False, no_lora=False) -> PunicaWrapperNPU:
 )
 def test_punica_init_selects_kernel_backend(device_type, max_lora_rank, expect_torch_ops) -> None:
     with (
-        patch("vllm_ascend.lora.punica_npu.get_ascend_device_type", return_value=device_type),
+        patch(
+            "vllm_ascend.lora.punica_npu.get_current_hardware_profile",
+            return_value=get_hardware_profile(device_type),
+        ),
         patch("vllm_ascend.lora.punica_npu.refresh_all_lora_classes") as refresh,
     ):
         wrapper = PunicaWrapperNPU(

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -921,8 +921,11 @@ class TestUpstreamConfigCompatibility(TestBase):
         self.assertTrue(AscendConfig._is_megamoe_supported_by_config(supported))
         self.assertFalse(AscendConfig._is_megamoe_supported_by_config(unsupported))
 
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A2)
-    def test_mc2_hierarchy_comm_rejects_more_than_512_experts(self, mock_device_type):
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A2),
+    )
+    def test_mc2_hierarchy_comm_rejects_more_than_512_experts(self, _mock_profile):
         config = AscendConfig(
             sparse_kv_offload_config=SimpleNamespace(enabled=False),
             mc2_comm_alg="hierarchy",
@@ -932,15 +935,18 @@ class TestUpstreamConfigCompatibility(TestBase):
         with self.assertRaisesRegex(ValueError, "supports at most 512 experts"):
             config._validate_mc2_comm_alg(vllm_config)
 
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A5)
-    def test_mc2_hierarchy_comm_rejects_unsupported_device(self, mock_device_type):
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
+    def test_mc2_hierarchy_comm_rejects_unsupported_device(self, _mock_profile):
         config = AscendConfig(
             sparse_kv_offload_config=SimpleNamespace(enabled=False),
             mc2_comm_alg="hierarchy",
         )
         vllm_config = SimpleNamespace(model_config=SimpleNamespace(get_num_experts=lambda: 1))
 
-        with self.assertRaisesRegex(NotImplementedError, "only supported on A2 and A3"):
+        with self.assertRaisesRegex(NotImplementedError, "not supported by the current hardware profile"):
             config._validate_mc2_comm_alg(vllm_config)
 
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -42,7 +42,9 @@ from vllm_ascend.ascend_config import (
     get_ascend_config,
     init_ascend_config,
 )
-from vllm_ascend.utils import AscendDeviceType, clear_enable_sp, enable_dsa_cp, enable_sp, shared_expert_dp_enabled
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
+from vllm_ascend.utils import clear_enable_sp, enable_dsa_cp, enable_sp, shared_expert_dp_enabled
 
 
 def test_config_modules_do_not_load_vllm_config():
@@ -400,7 +402,10 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.ascend_config.logger.warning")
-    @patch("vllm_ascend.utils.is_310p", return_value=True)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType._310P),
+    )
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     def test_init_ascend_config_disable_npugraph_ex_on_310p(
         self, mock_fix_incompatible_config, mock_is_310p, mock_warning
@@ -416,9 +421,9 @@ class TestAscendConfig(TestBase):
         self.assertFalse(ascend_compilation_config.enable_npugraph_ex)
         self.assertFalse(ascend_compilation_config.enable_static_kernel)
         warning_messages = [call.args[0] for call in mock_warning.call_args_list]
-        self.assertIn("npugraph_ex is not supported on Ascend 310P. Disabling it.", warning_messages)
+        self.assertIn("npugraph_ex is not supported by the current hardware profile. Disabling it.", warning_messages)
         self.assertIn(
-            "static kernel requires npugraph_ex, which is not supported on Ascend 310P. Disabling it.",
+            "static kernel requires npugraph_ex, which is not supported by the current hardware profile. Disabling it.",
             warning_messages,
         )
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -949,6 +949,31 @@ class TestUpstreamConfigCompatibility(TestBase):
         with self.assertRaisesRegex(NotImplementedError, "not supported by the current hardware profile"):
             config._validate_mc2_comm_alg(vllm_config)
 
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A5),
+    )
+    def test_mc2_fullmesh_v2_rejects_unsupported_device(self, _mock_profile):
+        config = AscendConfig(
+            sparse_kv_offload_config=SimpleNamespace(enabled=False),
+            mc2_comm_alg="fullmesh_v2",
+        )
+
+        with self.assertRaisesRegex(NotImplementedError, "not supported by the current hardware profile"):
+            config._validate_mc2_comm_alg(SimpleNamespace())
+
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
+    def test_mc2_fullmesh_uses_a3_operator_alias(self, _mock_profile):
+        config = AscendConfig(
+            sparse_kv_offload_config=SimpleNamespace(enabled=False),
+            mc2_comm_alg="fullmesh",
+        )
+
+        self.assertEqual(config.get_mc2_comm_alg(), "fullmesh_v1")
+
 
 class TestTopLevelSwitchTypeValidation(TestBase):
     """Verify @config migration gives top-level AscendConfig switches type validation.

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -11,6 +11,7 @@ from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.platform import (
     NPUPlatform,
     _setup_compile_backend,
@@ -417,7 +418,7 @@ class TestNPUPlatform(TestBase):
         self.assertIsNone(vllm_config.compilation_config.max_cudagraph_capture_size)
 
     @patch("vllm_ascend.platform.refresh_block_size")
-    @patch("vllm_ascend.platform.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.platform.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A3))
     @patch("vllm_ascend.platform.enable_sp", return_value=False)
     @patch("vllm_ascend.platform.init_ascend_config")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
@@ -466,7 +467,7 @@ class TestNPUPlatform(TestBase):
         self.assertIs(mock_setup.call_args.kwargs["enable_dsa_cp"], False)
 
     @patch("vllm_ascend.platform.refresh_block_size")
-    @patch("vllm_ascend.platform.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.platform.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A3))
     @patch("vllm_ascend.platform.enable_sp", return_value=True)
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
@@ -647,7 +648,10 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("os.environ", {})
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_basic_config_update(
@@ -676,7 +680,10 @@ class TestNPUPlatform(TestBase):
         mock_init_ascend.assert_called_once_with(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_no_model_config_warning(
@@ -705,7 +712,10 @@ class TestNPUPlatform(TestBase):
         self.assertTrue("Model config is missing" in cm.output[0])
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_enforce_eager_mode(
@@ -747,7 +757,10 @@ class TestNPUPlatform(TestBase):
         )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_unsupported_compilation_level(
@@ -788,7 +801,10 @@ class TestNPUPlatform(TestBase):
 
     @pytest.mark.skip("Revert me when vllm support setting cudagraph_mode on oot platform")
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_unsupported_cudagraph_mode(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -815,7 +831,10 @@ class TestNPUPlatform(TestBase):
             )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_cache_config_block_size(
@@ -840,7 +859,10 @@ class TestNPUPlatform(TestBase):
         self.assertEqual(vllm_config.cache_config.block_size, 128)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_no_kv_transfer(
@@ -872,7 +894,10 @@ class TestNPUPlatform(TestBase):
         mock_init_recompute.assert_not_called()
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_rejects_pd_mixed_kv_both(
@@ -905,7 +930,10 @@ class TestNPUPlatform(TestBase):
         mock_init_recompute.assert_not_called()
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_warns_and_disables_kv_producer(
@@ -947,7 +975,10 @@ class TestNPUPlatform(TestBase):
         )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_recompute_scheduler_accepts_kv_consumer(
@@ -1048,7 +1079,10 @@ class TestNPUPlatform(TestBase):
                 self.assertTrue(mock_ascend_config.scheduler_config.dyntra_lb_config.enabled)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_rejects_unsupported_combinations(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -1099,7 +1133,10 @@ class TestNPUPlatform(TestBase):
                     self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_accepts_standard_prefill_paths(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -1128,7 +1165,10 @@ class TestNPUPlatform(TestBase):
                 self.assertIsNone(vllm_config.scheduler_config.scheduler_cls)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_short_request_first_selects_async_scheduler(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -1161,7 +1201,10 @@ class TestNPUPlatform(TestBase):
                 )
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_short_request_first_survives_p_recompute_disable(
@@ -1202,7 +1245,10 @@ class TestNPUPlatform(TestBase):
             platform._validate_kv_load_failure_policy(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     def test_check_and_update_config_selects_dyntra_lb_scheduler(
         self, mock_init_ascend, mock_soc_version, mock_auto_detect
@@ -1363,7 +1409,10 @@ class TestNPUPlatform(TestBase):
             self.platform.check_and_update_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_balance_scheduler_rejects_pd_disaggregated_kv_consumer(
@@ -1451,7 +1500,10 @@ class TestNPUPlatform(TestBase):
         platform._validate_parallel_config(vllm_config)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
     @patch("vllm_ascend.ascend_config.init_ascend_config")
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_v1_worker_class_selection(
@@ -1488,7 +1540,10 @@ class TestNPUPlatform(TestBase):
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.ascend_config.init_ascend_config")
-    @patch("vllm_ascend.utils.get_ascend_device_type", return_value=AscendDeviceType._310P)
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType._310P),
+    )
     @patch("vllm_ascend.core.recompute_scheduler.RecomputeSchedulerConfig.initialize_from_config")
     def test_check_and_update_config_310p_no_custom_ops(
         self, mock_init_recompute, mock_soc_version, mock_init_ascend, mock_auto_detect

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -23,6 +23,8 @@ import torch
 
 from tests.ut.base import TestBase
 from vllm_ascend import utils
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.utils import REGISTERED_ASCEND_OPS
 
 
@@ -358,7 +360,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 0
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -370,7 +374,10 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 0
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType._310P),
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -382,7 +389,10 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType._310P),
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float32)
             result = utils.maybe_trans_nz(weight)
@@ -394,7 +404,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -406,7 +418,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 2
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.float16)
             result = utils.maybe_trans_nz(weight)
@@ -418,7 +432,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 2
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.randn(32, 64, dtype=torch.bfloat16)
             result = utils.maybe_trans_nz(weight)
@@ -430,7 +446,9 @@ class TestUtils(TestBase):
         mock_config.weight_nz_mode = 1
         with (
             mock.patch("vllm_ascend.utils.get_ascend_config", return_value=mock_config),
-            mock.patch("vllm_ascend.utils.is_310p", return_value=False),
+            mock.patch(
+                "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+            ),
         ):
             weight = torch.zeros(32, 64, dtype=torch.int8)
             result = utils.maybe_trans_nz(weight)
@@ -463,14 +481,18 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer():
 
 def test_is_rc_device_returns_false_on_non_310p():
     utils._IS_RC_DEVICE = None
-    with mock.patch("vllm_ascend.utils.is_310p", return_value=False):
+    with mock.patch(
+        "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType.A2)
+    ):
         assert utils.is_rc_device() is False
 
 
 def test_is_rc_device_detects_ep_from_lspci():
     utils._IS_RC_DEVICE = None
     with (
-        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch(
+            "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P)
+        ),
         mock.patch("subprocess.run") as mock_run,
     ):
         mock_run.return_value.stdout = "00:00.0 accelerators: Huawei Technologies Co., Ltd."
@@ -480,7 +502,9 @@ def test_is_rc_device_detects_ep_from_lspci():
 def test_is_rc_device_detects_rc_from_lspci():
     utils._IS_RC_DEVICE = None
     with (
-        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch(
+            "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P)
+        ),
         mock.patch("subprocess.run") as mock_run,
     ):
         mock_run.return_value.stdout = "00:00.0 PCI bridge: Huawei Technologies Co., Ltd."
@@ -490,7 +514,9 @@ def test_is_rc_device_detects_rc_from_lspci():
 def test_is_rc_device_defaults_to_ep_when_lspci_unavailable():
     utils._IS_RC_DEVICE = None
     with (
-        mock.patch("vllm_ascend.utils.is_310p", return_value=True),
+        mock.patch(
+            "vllm_ascend.utils.get_current_hardware_profile", return_value=get_hardware_profile(AscendDeviceType._310P)
+        ),
         mock.patch("subprocess.run", side_effect=FileNotFoundError),
     ):
         assert utils.is_rc_device() is False

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -535,21 +535,18 @@ class AscendConfig:
         return self
 
     def _validate_mc2_comm_alg(self, vllm_config: VllmConfig) -> None:
-        if self.mc2_comm_alg == "fullmesh_v2":
-            from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+        from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
-            device_type = get_ascend_device_type()
-            if device_type != AscendDeviceType.A3:
-                raise NotImplementedError(
-                    f"mc2_comm_alg == 'fullmesh_v2' is only supported on A3, but got {device_type.name}."
-                )
+        hardware_profile = get_current_hardware_profile()
+        if self.mc2_comm_alg == "fullmesh_v2" and not hardware_profile.supports(
+            HardwareCapability.MC2_FULLMESH_V2_COMM
+        ):
+            raise NotImplementedError("mc2_comm_alg == 'fullmesh_v2' is not supported by the current hardware profile.")
 
         if self.mc2_comm_alg != "hierarchy":
             return
 
-        from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
-
-        if not get_current_hardware_profile().supports(HardwareCapability.MC2_HIERARCHY_COMM):
+        if not hardware_profile.supports(HardwareCapability.MC2_HIERARCHY_COMM):
             raise NotImplementedError("mc2_comm_alg == 'hierarchy' is not supported by the current hardware profile.")
 
         num_logical_experts = vllm_config.model_config.get_num_experts()
@@ -733,11 +730,13 @@ class AscendConfig:
         return
 
     def get_mc2_comm_alg(self) -> str:
-        from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+        from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
         # When A3 and comm_alg == "fullmesh", dispatch/combine op need pass in "fullmesh_v1" instead of "fullmesh"
         # TODO(zzzzwwjj): Remove it when op's param is uniformed between A2/A3/A5.
-        if self.mc2_comm_alg == "fullmesh" and get_ascend_device_type() == AscendDeviceType.A3:
+        if self.mc2_comm_alg == "fullmesh" and get_current_hardware_profile().supports(
+            HardwareCapability.MC2_FULLMESH_V2_COMM
+        ):
             return "fullmesh_v1"
         return self.mc2_comm_alg
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -535,22 +535,22 @@ class AscendConfig:
         return self
 
     def _validate_mc2_comm_alg(self, vllm_config: VllmConfig) -> None:
-        from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+        if self.mc2_comm_alg == "fullmesh_v2":
+            from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
-        device_type = get_ascend_device_type()
-
-        if self.mc2_comm_alg == "fullmesh_v2" and device_type != AscendDeviceType.A3:
-            raise NotImplementedError(
-                f"mc2_comm_alg == 'fullmesh_v2' is only supported on A3, but got {device_type.name}."
-            )
+            device_type = get_ascend_device_type()
+            if device_type != AscendDeviceType.A3:
+                raise NotImplementedError(
+                    f"mc2_comm_alg == 'fullmesh_v2' is only supported on A3, but got {device_type.name}."
+                )
 
         if self.mc2_comm_alg != "hierarchy":
             return
 
-        if device_type not in (AscendDeviceType.A2, AscendDeviceType.A3):
-            raise NotImplementedError(
-                f"mc2_comm_alg == 'hierarchy' is only supported on A2 and A3, but got {device_type.name}."
-            )
+        from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+
+        if not get_current_hardware_profile().supports(HardwareCapability.MC2_HIERARCHY_COMM):
+            raise NotImplementedError("mc2_comm_alg == 'hierarchy' is not supported by the current hardware profile.")
 
         num_logical_experts = vllm_config.model_config.get_num_experts()
         num_redundant_experts = self.eplb_config.num_redundant_experts if self.eplb_config.dynamic_eplb else 0

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -46,9 +46,10 @@ def validate_additional_config_bool(value: Any, path: str) -> bool:
 class AscendCompilationConfig:
     """Configuration for controlling the behavior of Ascend graph optimization.
 
-    Migrated to ``@config`` (pydantic dataclass). The 310P runtime downgrade
-    (disable npugraph_ex / static_kernel) and the static_kernel→npugraph_ex
-    dependency check are applied in an ``after`` model_validator.
+    Migrated to ``@config`` (pydantic dataclass). Hardware-profile runtime
+    downgrades (disable npugraph_ex / static_kernel) and the
+    static_kernel→npugraph_ex dependency check are applied in an ``after``
+    model_validator.
     """
 
     enable_npugraph_ex: bool = True
@@ -58,15 +59,16 @@ class AscendCompilationConfig:
     fuse_muls_add: bool = True
 
     @model_validator(mode="after")
-    def _apply_310p_downgrade_and_static_kernel_check(self):
-        from vllm_ascend.utils import is_310p
+    def _apply_unsupported_hardware_downgrade_and_static_kernel_check(self):
+        from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
-        if is_310p():
+        if not get_current_hardware_profile().supports(HardwareCapability.NPUGRAPH_EX):
             if self.enable_npugraph_ex:
-                logger.warning("npugraph_ex is not supported on Ascend 310P. Disabling it.")
+                logger.warning("npugraph_ex is not supported by the current hardware profile. Disabling it.")
             if self.enable_static_kernel:
                 logger.warning(
-                    "static kernel requires npugraph_ex, which is not supported on Ascend 310P. Disabling it."
+                    "static kernel requires npugraph_ex, which is not supported by the current hardware profile. "
+                    "Disabling it."
                 )
             self.enable_npugraph_ex = False
             self.enable_static_kernel = False

--- a/vllm_ascend/cpu_binding.py
+++ b/vllm_ascend/cpu_binding.py
@@ -10,25 +10,22 @@ import psutil
 import regex as re
 from vllm.logger import logger
 
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+from vllm_ascend.device.hardware_profile import (
+    CPUBindingMode,
+    DeviceAddressingMode,
+    HardwareCapability,
+    get_current_hardware_profile,
+)
 
 MASK_BIT = 32  # Number of bits in a CPU affinity mask group
 MIN_CPUS_PER_NPU = 5  # 2(IRQ) + 1(main, at least 1 CPU) + 1(acl) + 1(release) = 5 CPUs per NPU
 MIN_CPUS_PER_NPU_WITHOUT_IRQ = 3  # 1(main, at least 1 CPU) + 1(acl) + 1(release)
-ASCEND_950_PHYSICAL_CPUS_PER_CLUSTER = 8
+PHYSICAL_CPUS_PER_CLUSTER = 8
 ALLOWED_CPUS_PATH = "/proc/self/status"
 ASCEND_RT_VISIBLE_DEVICES = os.getenv("ASCEND_RT_VISIBLE_DEVICES")
 
-TOPO_AFFINITY_MODE = "topo_affinity"
-GLOBAL_SLICE_MODE = "global_slice"
-
-DEVICE_BINDING_MODE: dict["AscendDeviceType", str] = {
-    AscendDeviceType.A2: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A3: GLOBAL_SLICE_MODE,
-    AscendDeviceType._310P: TOPO_AFFINITY_MODE,
-    AscendDeviceType.A5: TOPO_AFFINITY_MODE,
-}
-NO_IRQ_BINDING_DEVICE_TYPES = {AscendDeviceType.A5}
+TOPO_AFFINITY_MODE = CPUBindingMode.TOPO_AFFINITY.value
+GLOBAL_SLICE_MODE = CPUBindingMode.GLOBAL_SLICE.value
 
 
 def is_arm_cpu() -> bool:
@@ -325,7 +322,7 @@ class CpuAlloc:
                 threads_per_core,
             )
             return None
-        return ASCEND_950_PHYSICAL_CPUS_PER_CLUSTER * threads_per_core
+        return PHYSICAL_CPUS_PER_CLUSTER * threads_per_core
 
     def get_single_numa_node(self, cpu_list: list[int]) -> int | None:
         if not cpu_list:
@@ -518,16 +515,15 @@ class CpuAlloc:
 
     @staticmethod
     def _binding_mode() -> str:
-        device_type = get_ascend_device_type()
-        return DEVICE_BINDING_MODE.get(device_type, TOPO_AFFINITY_MODE)
+        return get_current_hardware_profile().cpu_binding_mode.value
 
     @staticmethod
-    def _is_ascend_950() -> bool:
-        return get_ascend_device_type() == AscendDeviceType.A5
+    def _uses_cluster_cpu_topology() -> bool:
+        return get_current_hardware_profile().supports(HardwareCapability.CLUSTER_CPU_TOPOLOGY)
 
     @staticmethod
     def _reserve_irq_cpus() -> bool:
-        return get_ascend_device_type() not in NO_IRQ_BINDING_DEVICE_TYPES
+        return get_current_hardware_profile().supports(HardwareCapability.IRQ_CPU_RESERVATION)
 
     @staticmethod
     def _min_cpus_per_npu() -> int:
@@ -542,7 +538,7 @@ class CpuAlloc:
         logger.info(
             "[cpu_bind_mode] mode=%s rank=%s visible_npus=%s", mode, self.rank_id, self.device_info.running_npu_list
         )
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self.bind_uvb_poll_window_threads()
             return self.build_ascend_950_cpu_pools()
 
@@ -593,7 +589,7 @@ class CpuAlloc:
         self.npu_cpu_pool = {npu: final[npu] for npu in self.device_info.running_npu_list}
 
     def allocate(self) -> None:
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self._allocate_ascend_950_roles()
             return
         self._allocate_default_roles()
@@ -625,7 +621,7 @@ class CpuAlloc:
     def print_plan(self) -> None:
         logger.info("The CPU allocation plan is as follows:")
         current_npu = self.device_info.running_npu_list[self.rank_id]
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self._print_ascend_950_plan(current_npu)
             return
         self._print_default_plan(current_npu)
@@ -675,7 +671,7 @@ class CpuAlloc:
         )
 
     def bind_threads(self) -> None:
-        if self._is_ascend_950():
+        if self._uses_cluster_cpu_topology():
             self.bind_ascend_950_threads()
             return
         self._bind_default_threads()
@@ -743,14 +739,13 @@ class CpuAlloc:
         sq_cpu, cq_cpu = cpus[0], cpus[1]  # Reserved for IRQ binding
         pci_addr = ""
 
-        device_type = get_ascend_device_type()
-        if device_type == AscendDeviceType.A3:
-            # A3: logical npu_id = card_id*2 + chip_id
+        if get_current_hardware_profile().device_addressing_mode is DeviceAddressingMode.DUAL_CHIP_CARD:
+            # Dual-chip cards address each logical NPU by card and chip id.
             card_id = npu // 2
             chip_id = npu % 2
             info, _ = execute_command(["npu-smi", "info", "-t", "board", "-i", str(card_id), "-c", str(chip_id)])
         else:
-            # A2 / others: logical npu_id is card id
+            # Direct addressing uses the logical NPU id as the card id.
             info, _ = execute_command(["npu-smi", "info", "-t", "board", "-i", str(npu)])
 
         for line in info.splitlines():

--- a/vllm_ascend/device/__init__.py
+++ b/vllm_ascend/device/__init__.py
@@ -1,16 +1,26 @@
 from vllm_ascend.device.device_config import DeviceConfig, get_device_config
 from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    CPUBindingMode,
+    DeviceAdaptorFamily,
+    DeviceAddressingMode,
     HardwareCapability,
     HardwareProfile,
+    QuantizationBackendFamily,
     WeightLayoutPolicy,
     get_current_hardware_profile,
     get_hardware_profile,
 )
 
 __all__ = [
+    "AttentionBackendFamily",
+    "CPUBindingMode",
+    "DeviceAdaptorFamily",
+    "DeviceAddressingMode",
     "DeviceConfig",
     "HardwareCapability",
     "HardwareProfile",
+    "QuantizationBackendFamily",
     "WeightLayoutPolicy",
     "get_current_hardware_profile",
     "get_device_config",

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -24,12 +24,12 @@ import torch_npu
 from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.device import utils as device_utils
+from vllm_ascend.device.hardware_profile import DeviceAdaptorFamily, get_current_hardware_profile
 from vllm_ascend.ops.triton.fla.chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd_kernel
 from vllm_ascend.ops.triton.fla.solve_tril import solve_tril_16x16_kernel
 from vllm_ascend.ops.triton.fused_gdn_gating import fused_gdn_gating_patch
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.quantization.utils import QUANT_DTYPES, SCALE_DTYPES, get_dynamic_mx_quant_scale_alg
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 DSA_COMPRESSOR_SLOT_MAPPING_FLAT = 1
 DSA_COMPRESSOR_SLOT_MAPPING_BLOCK_OFFSET = 2
@@ -1683,12 +1683,12 @@ class Ascend310PDeviceAdaptor(BaseDeviceAdaptor):
 
 
 def get_device_adaptor() -> type["BaseDeviceAdaptor"]:
-    ascend_device_type = get_ascend_device_type()
-    if ascend_device_type == AscendDeviceType.A5:
-        return A5DeviceAdaptor
-    if ascend_device_type == AscendDeviceType._310P:
-        return Ascend310PDeviceAdaptor
-    return BaseDeviceAdaptor
+    adaptor_by_family = {
+        DeviceAdaptorFamily.STANDARD: BaseDeviceAdaptor,
+        DeviceAdaptorFamily.FP8_OPTIMIZED: A5DeviceAdaptor,
+        DeviceAdaptorFamily.COMPATIBILITY: Ascend310PDeviceAdaptor,
+    }
+    return adaptor_by_family[get_current_hardware_profile().device_adaptor_family]
 
 
 DeviceOperator: type["BaseDeviceAdaptor"] = get_device_adaptor()

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -28,7 +28,6 @@ class HardwareCapability(Enum):
     REDUCED_CUDAGRAPH_CAPTURE_SIZES = auto()
     RUNTIME_CUSTOM_OPS = auto()
     SFA_DCP_REPLICATED_INDEXER = auto()
-    SKIP_REMOTE_H2D_BUFFER_REGISTRATION = auto()
     STANDARD_WORKER_PATCHES = auto()
 
 
@@ -119,7 +118,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
             device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
             quantization_backend_family=QuantizationBackendFamily.STANDARD,
-            capabilities=_STANDARD_CAPABILITIES | {HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION},
+            capabilities=_STANDARD_CAPABILITIES,
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,
@@ -185,7 +184,10 @@ def get_hardware_profile(device_type: AscendDeviceType) -> HardwareProfile:
         raise RuntimeError(f"No hardware profile is registered for device type: {device_type}.") from exc
 
 
+_CURRENT_HARDWARE_PROFILE = get_hardware_profile(get_device_config()._device_type)
+
+
 def get_current_hardware_profile() -> HardwareProfile:
     """Return the profile selected by the current device configuration."""
 
-    return get_hardware_profile(get_device_config()._device_type)
+    return _CURRENT_HARDWARE_PROFILE

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -23,6 +23,7 @@ class HardwareCapability(Enum):
     DYNAMIC_MX_QUANT_FUSION = auto()
     IRQ_CPU_RESERVATION = auto()
     LORA_CUSTOM_OPS = auto()
+    MC2_FULLMESH_V2_COMM = auto()
     MC2_HIERARCHY_COMM = auto()
     NPUGRAPH_EX = auto()
     RC_DEVICE_DISCOVERY = auto()
@@ -108,6 +109,7 @@ _STANDARD_CAPABILITIES = frozenset(
         HardwareCapability.STANDARD_WORKER_PATCHES,
     }
 )
+_A3_CAPABILITIES = _STANDARD_CAPABILITIES | {HardwareCapability.MC2_FULLMESH_V2_COMM}
 _DEFAULT_WORKER_CLS = "vllm_ascend.worker.worker.NPUWorker"
 _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
     {
@@ -131,7 +133,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
             device_addressing_mode=DeviceAddressingMode.DUAL_CHIP_CARD,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
             quantization_backend_family=QuantizationBackendFamily.STANDARD,
-            capabilities=_STANDARD_CAPABILITIES,
+            capabilities=_A3_CAPABILITIES,
         ),
         AscendDeviceType._310P: HardwareProfile(
             _device_type=AscendDeviceType._310P,

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -23,6 +23,7 @@ class HardwareCapability(Enum):
     DYNAMIC_MX_QUANT_FUSION = auto()
     IRQ_CPU_RESERVATION = auto()
     LORA_CUSTOM_OPS = auto()
+    MC2_HIERARCHY_COMM = auto()
     NPUGRAPH_EX = auto()
     RC_DEVICE_DISCOVERY = auto()
     REDUCED_CUDAGRAPH_CAPTURE_SIZES = auto()
@@ -100,6 +101,7 @@ _STANDARD_CAPABILITIES = frozenset(
         HardwareCapability.BGMV_SGMV_META_REGISTRATION,
         HardwareCapability.IRQ_CPU_RESERVATION,
         HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.MC2_HIERARCHY_COMM,
         HardwareCapability.NPUGRAPH_EX,
         HardwareCapability.RUNTIME_CUSTOM_OPS,
         HardwareCapability.SFA_DCP_REPLICATED_INDEXER,

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -17,7 +17,55 @@ class HardwareCapability(Enum):
     """Independent SoC capabilities consumed by shared business logic."""
 
     AUTO_ENABLE_CUSTOM_OPS = auto()
+    BGMV_SGMV_META_REGISTRATION = auto()
+    CLUSTER_CPU_TOPOLOGY = auto()
+    COMPATIBILITY_OP_IMPLEMENTATIONS = auto()
     DYNAMIC_MX_QUANT_FUSION = auto()
+    IRQ_CPU_RESERVATION = auto()
+    LORA_CUSTOM_OPS = auto()
+    NPUGRAPH_EX = auto()
+    RC_DEVICE_DISCOVERY = auto()
+    REDUCED_CUDAGRAPH_CAPTURE_SIZES = auto()
+    RUNTIME_CUSTOM_OPS = auto()
+    SFA_DCP_REPLICATED_INDEXER = auto()
+    SKIP_REMOTE_H2D_BUFFER_REGISTRATION = auto()
+    STANDARD_WORKER_PATCHES = auto()
+
+
+class AttentionBackendFamily(Enum):
+    """Attention backend implementation families selected by the platform."""
+
+    STANDARD = auto()
+    COMPATIBILITY = auto()
+
+
+class CPUBindingMode(Enum):
+    """CPU binding policies selected for worker processes."""
+
+    TOPO_AFFINITY = "topo_affinity"
+    GLOBAL_SLICE = "global_slice"
+
+
+class DeviceAdaptorFamily(Enum):
+    """Device operation adaptor implementation families."""
+
+    STANDARD = auto()
+    FP8_OPTIMIZED = auto()
+    COMPATIBILITY = auto()
+
+
+class DeviceAddressingMode(Enum):
+    """PCIe device addressing policies used by CPU binding."""
+
+    DIRECT = auto()
+    DUAL_CHIP_CARD = auto()
+
+
+class QuantizationBackendFamily(Enum):
+    """Quantization configuration implementation families."""
+
+    STANDARD = auto()
+    COMPATIBILITY = auto()
 
 
 class WeightLayoutPolicy(Enum):
@@ -32,7 +80,13 @@ class HardwareProfile:
     """Immutable capabilities and implementation choices for one SoC family."""
 
     _device_type: AscendDeviceType
+    attention_backend_family: AttentionBackendFamily
+    cpu_binding_mode: CPUBindingMode
+    default_worker_cls: str
+    device_adaptor_family: DeviceAdaptorFamily
+    device_addressing_mode: DeviceAddressingMode
     weight_layout_policy: WeightLayoutPolicy
+    quantization_backend_family: QuantizationBackendFamily
     capabilities: frozenset[HardwareCapability]
 
     def supports(self, capability: HardwareCapability) -> bool:
@@ -41,31 +95,80 @@ class HardwareProfile:
         return capability in self.capabilities
 
 
-_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES = frozenset({HardwareCapability.AUTO_ENABLE_CUSTOM_OPS})
+_STANDARD_CAPABILITIES = frozenset(
+    {
+        HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+        HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+        HardwareCapability.IRQ_CPU_RESERVATION,
+        HardwareCapability.LORA_CUSTOM_OPS,
+        HardwareCapability.NPUGRAPH_EX,
+        HardwareCapability.RUNTIME_CUSTOM_OPS,
+        HardwareCapability.SFA_DCP_REPLICATED_INDEXER,
+        HardwareCapability.STANDARD_WORKER_PATCHES,
+    }
+)
+_DEFAULT_WORKER_CLS = "vllm_ascend.worker.worker.NPUWorker"
 _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
     {
         AscendDeviceType.A2: HardwareProfile(
             _device_type=AscendDeviceType.A2,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
+            capabilities=_STANDARD_CAPABILITIES | {HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION},
         ),
         AscendDeviceType.A3: HardwareProfile(
             _device_type=AscendDeviceType.A3,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.GLOBAL_SLICE,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.STANDARD,
+            device_addressing_mode=DeviceAddressingMode.DUAL_CHIP_CARD,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
-            capabilities=_AUTO_ENABLE_CUSTOM_OP_CAPABILITIES,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
+            capabilities=_STANDARD_CAPABILITIES,
         ),
         AscendDeviceType._310P: HardwareProfile(
             _device_type=AscendDeviceType._310P,
+            attention_backend_family=AttentionBackendFamily.COMPATIBILITY,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls="vllm_ascend._310p.worker_310p.NPUWorker310",
+            device_adaptor_family=DeviceAdaptorFamily.COMPATIBILITY,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.FORCE_NZ,
-            capabilities=frozenset(),
+            quantization_backend_family=QuantizationBackendFamily.COMPATIBILITY,
+            capabilities=frozenset(
+                {
+                    HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS,
+                    HardwareCapability.IRQ_CPU_RESERVATION,
+                    HardwareCapability.RC_DEVICE_DISCOVERY,
+                    HardwareCapability.RUNTIME_CUSTOM_OPS,
+                }
+            ),
         ),
         AscendDeviceType.A5: HardwareProfile(
             _device_type=AscendDeviceType.A5,
+            attention_backend_family=AttentionBackendFamily.STANDARD,
+            cpu_binding_mode=CPUBindingMode.TOPO_AFFINITY,
+            default_worker_cls=_DEFAULT_WORKER_CLS,
+            device_adaptor_family=DeviceAdaptorFamily.FP8_OPTIMIZED,
+            device_addressing_mode=DeviceAddressingMode.DIRECT,
             weight_layout_policy=WeightLayoutPolicy.CONFIGURABLE,
+            quantization_backend_family=QuantizationBackendFamily.STANDARD,
             capabilities=frozenset(
                 {
                     HardwareCapability.AUTO_ENABLE_CUSTOM_OPS,
+                    HardwareCapability.BGMV_SGMV_META_REGISTRATION,
+                    HardwareCapability.CLUSTER_CPU_TOPOLOGY,
                     HardwareCapability.DYNAMIC_MX_QUANT_FUSION,
+                    HardwareCapability.LORA_CUSTOM_OPS,
+                    HardwareCapability.NPUGRAPH_EX,
+                    HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES,
+                    HardwareCapability.STANDARD_WORKER_PATCHES,
                 }
             ),
         ),

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -8,6 +8,7 @@ from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import split_host_port
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
 
 
@@ -85,6 +86,7 @@ class YuanrongBackend(Backend):
             and self.config.remote_h2d_transport_backend == "HIXL"
             and not self.config.enable_fabric_mem
             and self.config.enable_dev_mem_pregister
+            and not get_current_hardware_profile().supports(HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION)
         )
         self._registered_buffers: tuple[list[int], list[int]] | None = None
         self._buffers_registered = False

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -8,7 +8,6 @@ from vllm.distributed.parallel_state import get_world_group
 from vllm.logger import logger
 from vllm.utils.network_utils import split_host_port
 
-from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
 
 
@@ -86,7 +85,6 @@ class YuanrongBackend(Backend):
             and self.config.remote_h2d_transport_backend == "HIXL"
             and not self.config.enable_fabric_mem
             and self.config.enable_dev_mem_pregister
-            and not get_current_hardware_profile().supports(HardwareCapability.SKIP_REMOTE_H2D_BUFFER_REGISTRATION)
         )
         self._registered_buffers: tuple[list[int], list[int]] | None = None
         self._buffers_registered = False

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -5,8 +5,8 @@ from collections.abc import Callable
 import torch
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.lora.utils import refresh_all_lora_classes
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 # The platforms that are compatible with the PyTorch-native implementation can
@@ -22,7 +22,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches, device)
         refresh_all_lora_classes()
         self.lora_config = kwargs.get("lora_config")
-        if get_ascend_device_type() == AscendDeviceType._310P or (
+        if not get_current_hardware_profile().supports(HardwareCapability.LORA_CUSTOM_OPS) or (
             self.lora_config is not None and self.lora_config.max_lora_rank >= 128
         ):
             from vllm.lora.ops.torch_ops import (

--- a/vllm_ascend/meta_registration.py
+++ b/vllm_ascend/meta_registration.py
@@ -1,7 +1,7 @@
 import torch
 from torch.library import Library
 
-from vllm_ascend.utils import is_310p
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 
 # This file provides a template and registration utilities for writing "meta" implementations
 # of custom operators in Python for the vllm_ascend project.
@@ -72,6 +72,6 @@ def sgmv_expand_meta(
     return y_out
 
 
-if not is_310p():
+if get_current_hardware_profile().supports(HardwareCapability.BGMV_SGMV_META_REGISTRATION):
     register_meta_if_necessary("_C_ascend", "bgmv_expand", bgmv_expand_meta)
     register_meta_if_necessary("_C_ascend", "sgmv_expand", sgmv_expand_meta)

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -40,12 +40,10 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
 
+from vllm_ascend.device.hardware_profile import HardwareCapability, WeightLayoutPolicy, get_current_hardware_profile
 from vllm_ascend.ops.linear_op import get_parallel_op, get_replicated_op
 from vllm_ascend.quantization.tp_weight_switch import TPWeightGatherSpec, TPWeightSwitchMixin
 from vllm_ascend.utils import (
-    AscendDeviceType,
-    get_ascend_device_type,
-    is_310p,
     maybe_trans_nz,
 )
 
@@ -76,8 +74,12 @@ direct_register_custom_op(
 )
 
 
-def _should_keep_nd_for_310p_weight(weight: torch.Tensor) -> bool:
-    return is_310p() and weight.ndim >= 2 and (weight.shape[-1] == 1 or weight.shape[-2] == 1)
+def _should_keep_nd_for_compatibility_weight(weight: torch.Tensor) -> bool:
+    return (
+        get_current_hardware_profile().weight_layout_policy is WeightLayoutPolicy.FORCE_NZ
+        and weight.ndim >= 2
+        and (weight.shape[-1] == 1 or weight.shape[-2] == 1)
+    )
 
 
 class AscendUnquantizedLinearMethod(TPWeightSwitchMixin, UnquantizedLinearMethod):
@@ -89,7 +91,7 @@ class AscendUnquantizedLinearMethod(TPWeightSwitchMixin, UnquantizedLinearMethod
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         super().process_weights_after_loading(layer)
-        keep_nd_weight = _should_keep_nd_for_310p_weight(layer.weight.data)
+        keep_nd_weight = _should_keep_nd_for_compatibility_weight(layer.weight.data)
         # must use fp32 to avoid accuracy degradation in dsv4.
         if getattr(layer, "precast_fp32_weight", False):
             weight_fp32 = layer.weight.data.to(torch.float32)
@@ -456,7 +458,9 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
         return super().forward(input_)
 
     def weight_loader(self, param: Parameter, loaded_weight: torch.Tensor):
-        if "wo_a" in self.prefix and get_ascend_device_type() != AscendDeviceType.A5:
+        if "wo_a" in self.prefix and not get_current_hardware_profile().supports(
+            HardwareCapability.DYNAMIC_MX_QUANT_FUSION
+        ):
             if self.weight.ndim == 2:
                 super().weight_loader(param, loaded_weight)
                 self.weight.data = (

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -31,7 +31,14 @@ from vllm.platforms import Platform, PlatformEnum
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
+
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.device.hardware_profile import (
+    AttentionBackendFamily,
+    HardwareCapability,
+    QuantizationBackendFamily,
+    get_current_hardware_profile,
+)
 
 # isort: off
 from vllm_ascend.utils import (
@@ -39,16 +46,13 @@ from vllm_ascend.utils import (
     COMPILATION_PASS_KEY,
     COMPRESSED_TENSORS_METHOD,
     FP8_METHOD,
-    AscendDeviceType,
     bootstrap_custom_op_env,
     check_kv_extra_config,
     enable_sfa_dcp_replicated_indexer,
-    get_ascend_device_type,
     is_moe_model,
     model_uses_sfa_sparse,
     refresh_block_size,
     update_cudagraph_capture_sizes,
-    is_310p,
     enable_sp,
 )
 
@@ -71,7 +75,7 @@ logger.info_once(
 
 _CUSTOM_OP_REGISTERED = False
 # Delete after the driver is released; temporarily hard-coded to 4
-MAX_CAPTURE_SIZES_FOR_950 = 4
+MAX_REDUCED_CAPTURE_SIZES = 4
 
 
 class NPUPlatform(Platform):
@@ -227,7 +231,7 @@ class NPUPlatform(Platform):
             (True, True, False): "vllm_ascend.attention.sfa_v1.AscendSFABackend",
             (True, False, True): "vllm_ascend.attention.dsa_v1.AscendDSABackend",
         }
-        backend_map_310 = {
+        compatibility_backend_map = {
             (
                 False,
                 False,
@@ -237,8 +241,8 @@ class NPUPlatform(Platform):
             # (True, True):  "...AscendSFABackend310",
         }
 
-        if is_310p():
-            return backend_map_310.get(key, backend_map_310[(False, False)])
+        if get_current_hardware_profile().attention_backend_family is AttentionBackendFamily.COMPATIBILITY:
+            return compatibility_backend_map.get(key, compatibility_backend_map[(False, False)])
 
         return backend_map[(attn_selector_config.use_mla, attn_selector_config.use_sparse, use_compress)]
 
@@ -274,15 +278,15 @@ class NPUPlatform(Platform):
                 if ASCEND_QUANTIZATION_METHOD not in quant_action.choices:
                     quant_action.choices.append(ASCEND_QUANTIZATION_METHOD)
 
-        if is_310p():
-            from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
-        else:
+        if get_current_hardware_profile().quantization_backend_family is QuantizationBackendFamily.STANDARD:
             from vllm_ascend.quantization import (  # noqa: F401
                 AscendCompressedTensorsConfig,
                 AscendFp8Config,
                 AscendModelOptMxFp8Config,
                 AscendModelSlimConfig,
             )
+        else:
+            from vllm_ascend._310p.quantization import AscendModelSlimConfig310  # noqa: F401
 
         _config_deprecated_logging()
 
@@ -1156,8 +1160,8 @@ def _setup_compile_backend(
             ]
         )
         # TODO(2026/7/15): Delete the reduced gear after the new driver is released.
-        if get_ascend_device_type() == AscendDeviceType.A5:
-            _prune_capture_sizes_for_950(vllm_config)
+        if get_current_hardware_profile().supports(HardwareCapability.REDUCED_CUDAGRAPH_CAPTURE_SIZES):
+            _prune_reduced_capture_sizes(vllm_config)
         additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
         additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
     elif compilation_config.cudagraph_mode.has_full_cudagraphs():
@@ -1191,18 +1195,19 @@ def _setup_worker_and_scheduler(
         additional_config = vllm_config.additional_config or {}
         if ("enable_flashcomm1" not in additional_config) and (not os.getenv("VLLM_ASCEND_ENABLE_FLASHCOMM1")):
             parallel_config.all2all_backend = "flashinfer_all2allv"  # a trikky way to disable SP moe.
-        if is_310p():
-            parallel_config.worker_cls = "vllm_ascend._310p.worker_310p.NPUWorker310"
-        elif ascend_config.xlite_graph_config.enabled:
+        hardware_profile = get_current_hardware_profile()
+        if ascend_config.xlite_graph_config.enabled and hardware_profile.supports(
+            HardwareCapability.STANDARD_WORKER_PATCHES
+        ):
             logger.info("openEuler Xlite enabled. See: https://atomgit.com/openeuler/GVirt/tree/master/xlite")
             parallel_config.worker_cls = "vllm_ascend.xlite.xlite_worker.XliteWorker"
         else:
-            parallel_config.worker_cls = "vllm_ascend.worker.worker.NPUWorker"
+            parallel_config.worker_cls = hardware_profile.default_worker_cls
 
     refresh_block_size(vllm_config)
 
-    # Activate custom ops, except on 310P
-    if get_ascend_device_type() != AscendDeviceType._310P:
+    # Automatically activate all custom ops on profiles using the standard path.
+    if get_current_hardware_profile().supports(HardwareCapability.AUTO_ENABLE_CUSTOM_OPS):
         vllm_config.compilation_config.custom_ops = ["all"]
 
     # Select specialized scheduler class
@@ -1400,14 +1405,14 @@ def _config_deprecated_logging():
     warnings_logger.propagate = False
 
 
-def _prune_capture_sizes_for_950(vllm_config):
+def _prune_reduced_capture_sizes(vllm_config):
     original_sizes = vllm_config.compilation_config.cudagraph_capture_sizes
     if not original_sizes:
         return
-    if len(original_sizes) <= MAX_CAPTURE_SIZES_FOR_950:
+    if len(original_sizes) <= MAX_REDUCED_CAPTURE_SIZES:
         return
-    step = (len(original_sizes) - 1) / (MAX_CAPTURE_SIZES_FOR_950 - 1)
-    indices = [round(i * step) for i in range(MAX_CAPTURE_SIZES_FOR_950)]
+    step = (len(original_sizes) - 1) / (MAX_REDUCED_CAPTURE_SIZES - 1)
+    indices = [round(i * step) for i in range(MAX_REDUCED_CAPTURE_SIZES)]
     indices[0], indices[-1] = 0, len(original_sizes) - 1
     sampled_sizes = [original_sizes[i] for i in indices]
     update_cudagraph_capture_sizes(vllm_config, sampled_sizes)
@@ -1415,7 +1420,7 @@ def _prune_capture_sizes_for_950(vllm_config):
         "Adjusted ACL graph batch sizes for model: %d → %d sizes due to HDK incompatibility"
         "and this warning will be cleared soon.",
         len(original_sizes),
-        MAX_CAPTURE_SIZES_FOR_950,
+        MAX_REDUCED_CAPTURE_SIZES,
     )
 
 
@@ -1455,8 +1460,10 @@ def _validate_parallel_config(vllm_config: VllmConfig) -> None:
                 f"DCP for SFA is only supported when dcp_size({parallel_config.decode_context_parallel_size}) "
                 f"== tp_size({parallel_config.tensor_parallel_size})."
             )
-        if get_ascend_device_type() == AscendDeviceType.A5:
-            raise NotImplementedError("SFA DCP with replicated indexer is not supported on A5 yet.")
+        if not get_current_hardware_profile().supports(HardwareCapability.SFA_DCP_REPLICATED_INDEXER):
+            raise NotImplementedError(
+                "SFA DCP with replicated indexer is not supported by the current hardware profile."
+            )
 
 
 def _validate_draft_decode_context_parallel_config(vllm_config: VllmConfig) -> None:

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -44,6 +44,7 @@ from vllm_ascend.device.device_config import (  # noqa: F401
     is_310p,
     is_950,
 )
+from vllm_ascend.device.hardware_profile import HardwareCapability, WeightLayoutPolicy, get_current_hardware_profile
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -152,7 +153,7 @@ def is_rc_device() -> bool:
     ``accelerators``.
     """
     global _IS_RC_DEVICE
-    if not is_310p():
+    if not get_current_hardware_profile().supports(HardwareCapability.RC_DEVICE_DISCOVERY):
         return False
     if _IS_RC_DEVICE is not None:
         return _IS_RC_DEVICE
@@ -255,8 +256,8 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
     if weight.is_meta:
         return False
 
-    # 310P always converts to NZ.
-    if is_310p():
+    # Some hardware profiles require NZ weight layout.
+    if get_current_hardware_profile().weight_layout_policy is WeightLayoutPolicy.FORCE_NZ:
         return True
 
     # Get config value instead of env
@@ -411,7 +412,7 @@ def enable_custom_op():
     # FIXME(linfeng): Currently custom op compilation and execution are partially available
     # in ASCEND950 chip, we temporarily disable all custom ops. Please refer to
     # https://github.com/vllm-project/vllm-ascend/issues/7157 for latest update about custom op.
-    if envs.VLLM_BATCH_INVARIANT or get_ascend_device_type() == AscendDeviceType.A5:
+    if envs.VLLM_BATCH_INVARIANT or not get_current_hardware_profile().supports(HardwareCapability.RUNTIME_CUSTOM_OPS):
         _CUSTOM_OP_ENABLED = False
         return _CUSTOM_OP_ENABLED
 
@@ -743,8 +744,8 @@ def register_ascend_customop(vllm_config: VllmConfig | None = None):
 
         REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear
 
-    # 310P: override selected ops with 310P implementations (keep minimal changes outside _310p)
-    if is_310p():
+    # Override selected ops when the compatibility implementations are required.
+    if get_current_hardware_profile().supports(HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS):
         from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310, AscendRoutedExperts310
         from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
         from vllm_ascend._310p.ops.conv import AscendConv3dLayer310


### PR DESCRIPTION
### What this PR does / why we need it?

Introduces the hardware capabilities and policies required by this module,
and migrates the corresponding device-specific branches to hardware profiles.

This keeps capability definitions close to their first consumers instead of
declaring all future hardware capabilities upfront.

### Does this PR introduce *any* user-facing change?

No. Existing hardware behavior is preserved.

### How was this patch tested?
UT

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
