### PR TITLE
[Doc] GLM deployment on A3 over RoCE

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -839,6 +839,44 @@ Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single
 
 Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.
 
+##### 5.1.1.4 Multi-Node Deployment over RoCE
+
+This section describes the additional configuration for A3 deployments that use RoCE between physical nodes, such as deployments across SuperPods. Apply these settings in addition to the corresponding A3 deployment commands above.
+
+1. **Logical SuperPod configuration**
+
+    Set a unique `HCCL_LOGIC_SUPERPOD_ID` for each physical node. All vLLM processes on the same physical node must use the same value.
+
+2. **Expert Parallel communication configuration**
+
+    The supported MC2 communication mode depends on whether the Expert Parallel (EP) communication domain spans physical nodes:
+
+    - If the EP communication domain is contained within a physical node, no change to the existing configuration is required. Fused MC2 remains supported.
+    - If the EP communication domain spans physical nodes, Fused MC2 is not supported. Hierarchical MC2 communication over RoCE is required and must be enabled by adding `"enable_mc2_hierarchy_comm": true` to `--additional-config`.
+
+**Example**
+
+For the 1P1D (2+2) scenario, configure the logical SuperPod ID as follows:
+
+| Physical node | Configuration |
+|---------------|---------------|
+| Prefill node 0 | `export HCCL_LOGIC_SUPERPOD_ID=0` |
+| Prefill node 1 | `export HCCL_LOGIC_SUPERPOD_ID=1` |
+| Decode node 0 | `export HCCL_LOGIC_SUPERPOD_ID=2` |
+| Decode node 1 | `export HCCL_LOGIC_SUPERPOD_ID=3` |
+
+Apply the following Fused MC2 setting on every node:
+
+```shell
+export VLLM_ASCEND_ENABLE_FUSED_MC2=0
+```
+
+Merge `"enable_mc2_hierarchy_comm": true` into the existing `--additional-config` JSON object. The following pattern uses `...` to represent the existing fields:
+
+```text
+--additional-config '{..., "enable_mc2_hierarchy_comm": true}'
+```
+
 #### 5.1.2 Atlas 800 A2
 
 ##### 5.1.2.1 Multi-Node Co-Located Deployment


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a new section "5.1.1.4 Multi-Node Deployment over RoCE" to the GLM-5.2 deployment tutorial. It details the additional configuration required for Atlas 800 A3 deployments using RoCE between physical nodes, including logical SuperPod configuration (`HCCL_LOGIC_SUPERPOD_ID`) and Expert Parallel communication configuration (`enable_mc2_hierarchy_comm`).

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation-only updates do not require functional testing.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
