### PR TITLE
[Feature] Warn when a deprecated env var conflicts with additional_config

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -401,6 +401,36 @@ class TestAscendConfig(TestBase):
         mock_info_once.assert_any_call("AscendConfig.weight_nz_mode is set from additional_config with value 1.")
 
     @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.logger.warning_once")
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_migrated_config_warns_when_env_conflicts(self, mock_fix_incompatible_config, mock_warning_once):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"weight_nz_mode": 0}
+        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"}, clear=True):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertEqual(ascend_config.weight_nz_mode, 0)
+        mock_warning_once.assert_any_call(
+            "AscendConfig.weight_nz_mode is set to 0 by additional_config, but environment variable "
+            "VLLM_ASCEND_ENABLE_NZ requests 1. additional_config takes precedence; unset VLLM_ASCEND_ENABLE_NZ "
+            "to silence this warning, because it will be removed in the next release."
+        )
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.logger.warning_once")
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_migrated_config_quiet_when_env_agrees(self, mock_fix_incompatible_config, mock_warning_once):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"weight_nz_mode": 1}
+        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "1"}, clear=True):
+            init_ascend_config(test_vllm_config)
+
+        conflict_logs = [
+            call.args[0] for call in mock_warning_once.call_args_list if "takes precedence" in call.args[0]
+        ]
+        self.assertEqual(conflict_logs, [])
+
+    @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     @patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_FLASHCOMM1": "1"}, clear=True)
     def test_enable_flashcomm1_config_overrides_disabled_env(self, mock_fix_incompatible_config):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -332,6 +332,15 @@ class AscendConfig:
         if config_key in additional_config:
             value = additional_config[config_key]
             logger.info_once(f"AscendConfig.{config_key} is set from additional_config with value {value}.")
+            # A half-finished migration is easy to miss: the env var is still
+            # exported somewhere (image, launch script) but silently loses to
+            # additional_config, so say which one won instead of dropping it.
+            if env_key in os.environ and value != env_value:
+                logger.warning_once(
+                    f"AscendConfig.{config_key} is set to {value} by additional_config, but environment variable "
+                    f"{env_key} requests {env_value}. additional_config takes precedence; unset {env_key} to "
+                    "silence this warning, because it will be removed in the next release."
+                )
             return value
         if env_key in os.environ:
             logger.info_once(


### PR DESCRIPTION
### What this PR does / why we need it?

#9064 set the precedence for the migrated options to `additional_config` > deprecated env var > default, and `_get_config_value` already logs when the env var is used as a fallback. The opposite case is silent: when both are set and they disagree, `additional_config` wins and the exported value disappears without a word.

That is the case people actually trip over, because the env var is usually not where they are looking — it is baked into an image or a launch script from before the migration. Adding `--additional-config '{"weight_nz_mode": 0}'` on top of an image that still exports `VLLM_ASCEND_ENABLE_NZ=1` does the right thing, but anyone reading the launch script concludes the opposite; and someone who sets only the env var expecting it to take effect gets no hint that something overrode it.

This logs a warning naming both values and which one wins, only when they disagree. No precedence change: the existing info log stays, and the quiet paths (values agree, or only one source is set) are untouched, so the existing migration tests pass unchanged.

Closes #14067. I wrote up the motivation there and asked whether this is wanted before sending code; opening the PR as well since that seems to be the usual entry point here. Happy to close it if you would rather not carry the extra log.

### Does this PR introduce _any_ user-facing change?

One additional warning line at startup, and only for setups where a deprecated env var and its `additional_config` replacement disagree. Behaviour is unchanged.

### How was this patch tested?

Two unit tests in `tests/ut/test_ascend_config.py`: one asserts the warning when `weight_nz_mode=0` meets `VLLM_ASCEND_ENABLE_NZ=1`, the other asserts nothing is logged when the two agree. The first fails without this change. `pytest -sv tests/ut/test_ascend_config.py` passes locally on CPU (42 tests). I don't have Ascend hardware, so I'm relying on the NPU CI for e2e coverage.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
