### PR TITLE
[BugFix][Kimi K3] Fix corrupted output for 384n+1 input lengths

### DIFF
--- a/vllm_ascend/ops/gdn_attn_builder.py
+++ b/vllm_ascend/ops/gdn_attn_builder.py
@@ -51,6 +51,31 @@ def _stable_argsort_for_npu(tensor: torch.Tensor) -> torch.Tensor:
     return torch.argsort(tensor, stable=True)
 
 
+def _treat_single_token_prefills_with_state_as_decodes(
+    common_attn_metadata: CommonAttentionMetadata,
+) -> CommonAttentionMetadata:
+    """Treat stateful one-token prefill tails as decode rows.
+
+    Full-graph selection is shape based, so a final one-token prompt chunk can
+    replay the same graph as an ordinary decode. Once a request has recurrent
+    state, both cases must construct identical GDN metadata. A prompt's first
+    token remains on the prefill path because it has no prior state to update.
+    """
+    is_prefilling = common_attn_metadata.is_prefilling
+    seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
+    if is_prefilling is None or seq_lens_cpu is None:
+        return common_attn_metadata
+
+    query_lens_cpu = torch.diff(common_attn_metadata.query_start_loc_cpu)
+    prefill_to_decode = is_prefilling & (query_lens_cpu == 1) & (seq_lens_cpu > 1)
+    if not torch.any(prefill_to_decode).item():
+        return common_attn_metadata
+
+    is_prefilling = is_prefilling.clone()
+    is_prefilling[prefill_to_decode] = False
+    return common_attn_metadata.replace(is_prefilling=is_prefilling)
+
+
 @dataclass
 class GDNChunkedPrefillMetadata:
     cu_seqlens_host: tuple[int, ...]
@@ -416,7 +441,7 @@ class AscendGDNAttentionMetadataBuilder(GDNAttentionMetadataBuilder):
         num_decode_draft_tokens_cpu: torch.Tensor | None = None,
         fast_build: bool = False,
     ) -> GDNAttentionMetadata:
-        m = common_attn_metadata
+        m = _treat_single_token_prefills_with_state_as_decodes(common_attn_metadata)
 
         query_start_loc = m.query_start_loc
         query_start_loc_cpu = m.query_start_loc_cpu


### PR DESCRIPTION
## What this PR does / why we need it?

This PR ports the stateful single-token prefill handling from #12255 to the `releases/v0.26.0rc` branch.

For Kimi K3 requests whose input length is `384 * n + 1`, the final prompt chunk contains one token while the request already has recurrent state. This chunk may reuse the same captured graph as a decode step, but it is still classified as prefill when constructing GDN attention metadata.

The inconsistent metadata can cause stale recurrent state to be used and lead to corrupted output, such as repeated exclamation marks.

This PR treats a one-token prefill as decode only when the sequence already has state:

- `query_len == 1`
- `seq_len > 1`
- the row is currently classified as prefill

The first token of a request remains on the normal prefill path.

This PR only includes the `384 * n + 1` fix. It does not include the separate speculative-decoding handling for `num_speculative_tokens + 1`.

## Does this PR introduce any user-facing change?

Yes. Kimi K3 requests with `384 * n + 1` input lengths no longer produce corrupted repeated-exclamation-mark output due to inconsistent GDN metadata.

No new configuration or startup parameter is required.

## How was this patch tested?

- Verified that the modified Python file compiles successfully.
- Verified the patch with `git diff --check`.
- Ascend NPU end-to-end validation is pending.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
