### PR TITLE
[Feature] Backport DeepSeek V4 MTP ACLGraph support to v0.21.0rc

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1124,6 +1124,9 @@ class TestEagleProposerPropose:
         mock_bd.num_tokens = 16
         self.runner.cudagraph_dispatcher.dispatch.return_value = (CUDAGraphMode.FULL, mock_bd)
         self.runner._pad_query_start_loc_for_fia.return_value = 4
+        self.proposer.query_start_loc = MagicMock()
+        self.proposer.query_start_loc.gpu = torch.tensor([0, 4, 8, 12, 16], device=torch.device("cpu"), dtype=torch.int32)
+        self.proposer.query_start_loc.cpu = torch.tensor([0, 4, 8, 12, 16], device=torch.device("cpu"), dtype=torch.int32)
         self.runner.query_start_loc.gpu = torch.tensor([0, 4, 8, 12, 16], device=torch.device("cpu"), dtype=torch.int32)
         self.runner.query_start_loc.cpu = torch.tensor([0, 4, 8, 12, 16], device=torch.device("cpu"), dtype=torch.int32)
         self.runner.seq_lens = seq_lens
@@ -1545,7 +1548,7 @@ class TestEagleProposerPropose:
         assert hasattr(RunnerCls, "_pad_query_start_loc_for_fia")
         sig = inspect.signature(RunnerCls._pad_query_start_loc_for_fia)
         sig_name = self.get_param_names(sig)
-        assert sig_name == ['self', 'num_tokens_padded', 'num_reqs_padded', 'num_reqs', 'cudagraph_runtime_mode', 'batch_desc_num_reqs']
+        assert sig_name == ['self', 'query_start_loc', 'num_tokens_padded', 'num_reqs_padded', 'num_reqs', 'cudagraph_runtime_mode', 'batch_desc_num_reqs']
 
 
         import vllm_ascend.spec_decode.llm_base_proposer

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -52,6 +52,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.utils import update_num_computed_tokens_for_batch_change
 from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ, lmhead_tp_enable
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN = 1
 _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
@@ -195,6 +196,7 @@ class NPUModelRunner310(NPUModelRunner):
 
     def _pad_query_start_loc_for_fia(
         self,
+        query_start_loc: Any,
         num_tokens_padded: int,
         num_reqs_padded: int,
         num_reqs: int,
@@ -211,8 +213,8 @@ class NPUModelRunner310(NPUModelRunner):
             # Uniform-batch case: num_reqs must be no greater than num_reqs_padded
             assert num_reqs <= num_reqs_padded
 
-            last_loc = self.query_start_loc.np[num_reqs]
-            self.query_start_loc.np[num_reqs + 1 : num_reqs_padded + 1] = (
+            last_loc = query_start_loc.np[num_reqs]
+            query_start_loc.np[num_reqs + 1 : num_reqs_padded + 1] = (
                 self.arange_np[1 : num_reqs_padded + 1 - num_reqs] * uniform_decode_query_len + last_loc
             )
         else:
@@ -220,10 +222,10 @@ class NPUModelRunner310(NPUModelRunner):
             assert num_reqs == num_reqs_padded
 
             # Insert a dummy request instead of setting query_start_loc[num_reqs] = num_tokens_padded directly
-            self.query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
+            query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
             num_reqs_padded = num_reqs_padded + 1
 
-        self.query_start_loc.copy_to_gpu()
+        copy_snapshot_to_gpu(query_start_loc)
         return num_reqs_padded
 
     def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1,6 +1,7 @@
 import math
+from contextlib import nullcontext  # For limit_core_num conditional context management
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, Callable, ClassVar, TypeAlias
 
 import torch
 import torch.nn.functional as F
@@ -46,6 +47,7 @@ BUILD_METADATA_STEP_PREFILL = 0
 BUILD_METADATA_STEP_DECODE = 1
 
 _DSV4_DSA_OVERLAP_STREAM = None
+_DSV4_DSA_COMPRESSOR_STREAM = None  # Dedicated stream for Compressor in multi-stream parallel optimization
 
 
 def dsv4_dsa_overlap_stream() -> torch.npu.Stream:
@@ -53,6 +55,43 @@ def dsv4_dsa_overlap_stream() -> torch.npu.Stream:
     if _DSV4_DSA_OVERLAP_STREAM is None:
         _DSV4_DSA_OVERLAP_STREAM = torch_npu.npu.Stream()
     return _DSV4_DSA_OVERLAP_STREAM
+
+
+# Get dedicated Compressor stream for CSA multi-stream parallelism
+def dsv4_dsa_compressor_stream() -> torch.npu.Stream:
+    global _DSV4_DSA_COMPRESSOR_STREAM
+    if _DSV4_DSA_COMPRESSOR_STREAM is None:
+        _DSV4_DSA_COMPRESSOR_STREAM = torch_npu.npu.Stream()
+    return _DSV4_DSA_COMPRESSOR_STREAM
+
+
+# Record event when the CSA stream path creates one.
+def record_event(event: torch.npu.Event | None) -> None:
+    if event is not None:
+        event.record()
+
+
+# Wait for event when the CSA stream path creates one.
+def wait_event(event: torch.npu.Event | None) -> None:
+    if event is not None:
+        torch.npu.current_stream().wait_event(event)
+
+
+# Record tensor ownership for memory safety in multi-stream scenarios.
+def record_stream(stream: torch.npu.Stream | None, *tensors: torch.Tensor | None) -> None:
+    if stream is None:
+        return
+    for tensor in tensors:
+        if tensor is not None:
+            tensor.record_stream(stream)
+
+
+# Conditionally limit core count for CSA multi-stream segments.
+def limit_core_num(enabled: bool, aic_num: int, aiv_num: int):
+    if not enabled:
+        return nullcontext()
+
+    return torch.npu.npugraph_ex.scope.limit_core_num(aic_num, aiv_num)
 
 
 # mypy: disable-error-code="has-type"
@@ -1382,6 +1421,13 @@ class AscendDSAImpl(DSAAttentionImpl):
     understand this class
     """
 
+    _CSA_TOTAL_AIC_NUM_BY_DEVICE: ClassVar[dict[AscendDeviceType, int]] = {
+        AscendDeviceType.A3: 24,
+        AscendDeviceType.A5: 32,
+    }
+    _CSA_COMPRESSOR_AIC_NUM: ClassVar[int] = 16
+    _CSA_AIV_TO_AIC_RATIO: ClassVar[int] = 2
+
     def __init__(
         self,
         n_heads: int,
@@ -1440,6 +1486,20 @@ class AscendDSAImpl(DSAAttentionImpl):
         self.multistream_dsv4_dsa_overlap = ascend_config.multistream_dsv4_dsa_overlap
         self.prefill_comm_compute_overlap = ascend_config.prefill_comm_compute_overlap
         self.vllm_config = get_current_vllm_config()
+        # CSA event dict for managing synchronization events between streams
+        self._csa_events: dict[str, torch.npu.Event] = {}
+        # CSA core-control profile. A3 and A5 share the same stream plan; A5
+        # differs only in total AIC count.
+        self._csa_total_aic_num = self._CSA_TOTAL_AIC_NUM_BY_DEVICE.get(get_ascend_device_type())
+        self._csa_aiv_to_aic_ratio = self._CSA_AIV_TO_AIC_RATIO
+        if self._csa_total_aic_num is None:
+            self._csa_compressor_aic_num = 0
+            self._csa_q_aic_num = 0
+            self._csa_kv_aic_num = 0
+        else:
+            self._csa_compressor_aic_num = self._CSA_COMPRESSOR_AIC_NUM
+            self._csa_q_aic_num = self._csa_total_aic_num - self._csa_compressor_aic_num
+            self._csa_kv_aic_num = self._csa_total_aic_num // 2
 
         # indexer param
         if self.indexer is not None:
@@ -1542,6 +1602,39 @@ class AscendDSAImpl(DSAAttentionImpl):
                     _ = self.weights_proj(hidden_states_dummy)
 
             torch.npu.current_stream().wait_stream(aux_stream)
+
+    # A3 and A5 share the same CSA stream ordering and core profile.
+    def _enable_csa_multistream(self, is_prefill: bool) -> bool:
+        return (
+            self.multistream_dsv4_dsa_overlap
+            and self.compress_ratio == 4
+            and not is_prefill
+            and not self.skip_topk
+            and self._csa_total_aic_num is not None
+        )
+
+    # Determine whether to enable CSA core limit.
+    def _enable_csa_limit_core(self, is_prefill: bool) -> bool:
+        return self._enable_csa_multistream(is_prefill)
+
+    # Get or create named event (for inter-stream synchronization)
+    def _csa_event(self, name: str) -> torch.npu.Event:
+        event = self._csa_events.get(name)
+        if event is None:
+            event = torch.npu.Event()
+            self._csa_events[name] = event
+        return event
+
+    def _compute_compressor_metadata(
+        self,
+        metadata: AscendDSAPrefillMetadata | AscendDSADecodeMetadata,
+        layer_name: str,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Read compressor metadata produced by the release-branch builder."""
+        assert metadata.compress_cos is not None
+        assert metadata.compress_sin is not None
+        assert metadata.slot_mapping is not None
+        return metadata.compress_cos[layer_name], metadata.compress_sin[layer_name], metadata.slot_mapping
 
     def _get_indexcache_topk_indices(self, num_tokens: int, offset: int = 0) -> torch.Tensor:
         if self.topk_indices_buffer is None:
@@ -1877,6 +1970,307 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         return q, qr, full_hidden_states
 
+    # Complete Q RMS Norm and RoPE operations.
+    def _finish_dsa_q(
+        self,
+        q: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        enable_limit_core: bool = False,
+    ) -> torch.Tensor:
+        with limit_core_num(
+            enable_limit_core,
+            self._csa_q_aic_num,
+            self._csa_q_aic_num * self._csa_aiv_to_aic_ratio,
+        ):
+            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+            torch.ops._C_ascend.inplace_partial_rotary_mul(
+                q.unsqueeze(1),
+                cos,
+                sin,
+                rotary_mode="interleave",
+                partial_slice=[self.nope_head_dim, self.head_dim],
+            )
+        return q
+
+    # CSA decode MLA prolog stage, implements Q/KV dual-stream parallel computation.
+    def _mla_prolog_csa_decode(
+        self,
+        hidden_states: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        swa_kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+        launch_after_q_b: Callable[[torch.Tensor, torch.Tensor | None, torch.npu.Stream, torch.npu.Stream], None],
+        enable_limit_core: bool = False,
+    ):
+        """CSA decode MLA prolog with a Q_b completion launch point.
+
+        The launch hook is invoked after Q_b matmul is submitted and before
+        Q RMS/RoPE, matching the CSA stream start point used by recipes.
+        """
+        main_stream = torch.npu.current_stream()
+        aux_stream = dsv4_dsa_overlap_stream()
+        kv_done_event = self._csa_event("kv_done")
+
+        is_w8a8 = _is_w8a8_dynamic(self.wq_b)
+
+        q_quant, q_pertoken_scale = self.cv_wq_a.quantize(hidden_states)
+        e_q_quant_done = main_stream.record_event()
+
+        record_stream(aux_stream, hidden_states)
+        with npu_stream_switch(aux_stream, enabled=True):
+            torch.npu.current_stream().wait_event(e_q_quant_done)
+            kv_quant, kv_pertoken_scale = self.cv_wkv.quantize(hidden_states)
+
+        wq_a_result = self.cv_wq_a.matmul(q_quant, q_pertoken_scale)
+        main_stream.wait_stream(aux_stream)
+
+        e_part2_start = main_stream.record_event()
+        with npu_stream_switch(aux_stream, enabled=True):
+            torch.npu.current_stream().wait_event(e_part2_start)
+            kv = self.cv_wkv.matmul(kv_quant, kv_pertoken_scale)
+
+        if is_w8a8:
+            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                wq_a_result, self.q_norm.weight, epsilon=self.eps
+            )
+            q_b_quant, q_b_scale = qr, qr_pertoken_scale
+        else:
+            qr = self.q_norm(wq_a_result)
+            qr_pertoken_scale = None
+            q_b_quant, q_b_scale = qr, None
+
+        main_stream.wait_stream(aux_stream)
+
+        e_part3_start = main_stream.record_event()
+        with npu_stream_switch(aux_stream, enabled=True):
+            torch.npu.current_stream().wait_event(e_part3_start)
+            with limit_core_num(
+                enable_limit_core,
+                self._csa_kv_aic_num,
+                self._csa_kv_aic_num * self._csa_aiv_to_aic_ratio,
+            ):
+                kv = self.kv_norm(kv)
+                assert self.rope_head_dim is not None
+                kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
+                torch.ops._C_ascend.inplace_partial_rotary_mul(
+                    kv.unsqueeze(1),
+                    cos,
+                    sin,
+                    rotary_mode="interleave",
+                    partial_slice=[self.nope_head_dim, self.head_dim],
+                )
+                DeviceOperator.dsa_kv_compress_scatter(swa_kv_cache, kv, slot_mapping)
+            record_event(kv_done_event)
+
+        if is_w8a8:
+            q = torch_npu.npu_quant_matmul(
+                q_b_quant,
+                self.wq_b.weight,
+                self.wq_b.weight_scale,
+                pertoken_scale=q_b_scale,
+                bias=self.wq_b.bias,
+                output_dtype=hidden_states.dtype,
+            ).unflatten(-1, (self.n_local_heads, self.head_dim))
+        else:
+            q = self.cv_wq_b.matmul(q_b_quant, q_b_scale).unflatten(-1, (self.n_local_heads, self.head_dim))
+
+        launch_after_q_b(qr, qr_pertoken_scale, main_stream, aux_stream)
+        q = self._finish_dsa_q(q, cos, sin, enable_limit_core)
+
+        return q, qr, qr_pertoken_scale, kv_done_event
+
+    # Launch C4A Compressor on independent stream (Compressor with compress ratio=4)
+    def _launch_csa_c4a_compressor(
+        self,
+        hidden_states: torch.Tensor,
+        compress_kv_cache: torch.Tensor,
+        state_cache: torch.Tensor,
+        compressor_state_block_table: torch.Tensor,
+        actual_seq_lengths_query: torch.Tensor,
+        start_pos: torch.Tensor,
+        compress_sin: torch.Tensor,
+        compress_cos: torch.Tensor,
+        compress_slot_mapping: torch.Tensor,
+        enable_limit_core: bool,
+    ) -> torch.npu.Event:
+        compressor_stream = dsv4_dsa_compressor_stream()
+        cmpr_start_event = self._csa_event("c4a_cmpr_start")
+        cmpr_done_event = self._csa_event("c4a_cmpr_done")
+        coff = 2 if self.compressor_overlap else 1
+
+        record_stream(compressor_stream, hidden_states)
+        record_event(cmpr_start_event)
+        with npu_stream_switch(compressor_stream, enabled=True):
+            wait_event(cmpr_start_event)
+            with limit_core_num(
+                enable_limit_core,
+                self._csa_compressor_aic_num,
+                self._csa_compressor_aic_num * self._csa_aiv_to_aic_ratio,
+            ):
+                compressed_kv = torch.ops._C_ascend.compressor(
+                    hidden_states,
+                    self.compressor_wkv.weight,
+                    self.compressor_wgate.weight,
+                    state_cache.squeeze(-2),
+                    self.compressor_ape,
+                    self.compressor_norm.weight,
+                    compress_sin.view(-1, compress_sin.shape[-1]),
+                    compress_cos.view(-1, compress_cos.shape[-1]),
+                    state_block_table=compressor_state_block_table,
+                    cu_seqlens=actual_seq_lengths_query,
+                    seqused=None,
+                    start_pos=start_pos,
+                    rope_head_dim=self.rope_head_dim,
+                    cmp_ratio=self.compress_ratio,
+                    coff=coff,
+                    norm_eps=self.compressor_norm_eps,
+                    rotary_mode=2,
+                    cache_mode=1,
+                )
+
+                if compressed_kv.shape[0] > 0:
+                    DeviceOperator.dsa_kv_compress_scatter(compress_kv_cache, compressed_kv, compress_slot_mapping)
+            record_event(cmpr_done_event)
+        return cmpr_done_event
+
+    # Launch Long-term Indexer query vector computation on auxiliary stream
+    def _launch_csa_li_query(
+        self,
+        qr: torch.Tensor,
+        qr_pertoken_scale: torch.Tensor | None,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        indexer_kv_scale_metadata,
+        cmpr_done_event: torch.npu.Event,  # Depends on Compressor completion
+        main_stream: torch.npu.Stream,
+        aux_stream: torch.npu.Stream,
+        enable_limit_core: bool,
+        output_dtype: torch.dtype,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.npu.Event]:
+        li_q_start_event = self._csa_event("li_q_start")
+        li_q_done_event = self._csa_event("li_q_done")
+        record_stream(aux_stream, qr, qr_pertoken_scale)
+        record_event(li_q_start_event)
+
+        q_quant = None
+        q_scale = None
+        with npu_stream_switch(aux_stream, enabled=True):
+            wait_event(li_q_start_event)
+            with limit_core_num(
+                enable_limit_core,
+                self._csa_q_aic_num,
+                self._csa_q_aic_num * self._csa_aiv_to_aic_ratio,
+            ):
+                if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
+                    q = torch_npu.npu_quant_matmul(
+                        qr,
+                        self.inderxer_wq_b.weight,
+                        self.inderxer_wq_b.weight_scale,
+                        pertoken_scale=qr_pertoken_scale,
+                        bias=self.inderxer_wq_b.bias,
+                        output_dtype=output_dtype,
+                    )
+                else:
+                    q = self.inderxer_wq_b(qr)
+                q = q.view(-1, self.indexer_heads, self.indexcom_head_dim)
+                torch.ops._C_ascend.inplace_partial_rotary_mul(
+                    q.unsqueeze(1),
+                    cos,
+                    sin,
+                    rotary_mode="interleave",
+                    partial_slice=[self.indexcom_head_dim - self.rope_head_dim, self.indexcom_head_dim],
+                )
+                q = rotate_activation(q, indexer_kv_scale_metadata.hadamard)
+
+            wait_event(cmpr_done_event)
+            with limit_core_num(
+                enable_limit_core,
+                self._csa_q_aic_num,
+                self._csa_q_aic_num * self._csa_aiv_to_aic_ratio,
+            ):
+                q_quant, q_scale = DeviceOperator.indexer_quantize_query(q)
+            record_stream(main_stream, q_quant, q_scale)
+            record_event(li_q_done_event)
+
+        assert q_quant is not None
+        assert q_scale is not None
+        return q_quant, q_scale, li_q_done_event
+
+    # Execute Long-term Indexer main decode path
+    def _run_csa_li_main_decode(
+        self,
+        hidden_states: torch.Tensor,
+        indexer_state_cache: torch.Tensor,
+        indexer_k_cache: torch.Tensor,
+        indexer_scale_cache: torch.Tensor,
+        indexer_full_cache: torch.Tensor | None,
+        indexer_kv_state_metadata,
+        indexer_kv_scale_metadata,
+        actual_seq_lengths_query: torch.Tensor,
+        enable_limit_core: bool,
+        layer_name: str,
+    ):
+        indexer_state_decode_metadata = _require_decode_metadata(indexer_kv_state_metadata)
+        indexer_scale_decode_metadata = _require_decode_metadata(indexer_kv_scale_metadata)
+        compressed_cos, compressed_sin, slot_mapping_indexer = self._compute_compressor_metadata(
+            indexer_scale_decode_metadata,
+            layer_name,
+        )
+        coff = 2 if self.compressor_overlap else 1
+
+        with limit_core_num(
+            enable_limit_core,
+            self._csa_compressor_aic_num,
+            self._csa_compressor_aic_num * self._csa_aiv_to_aic_ratio,
+        ):
+            # Calculate indexer weights
+            weights = self.weights_proj(hidden_states) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
+            # Run indexer Compressor to generate KV
+            kv = torch.ops._C_ascend.compressor(
+                hidden_states,
+                self.indexcom_wkv.weight,
+                self.indexcom_wgate.weight,
+                indexer_state_cache.squeeze(-2),
+                self.indexcom_ape,
+                self.indexcom_norm.weight,
+                compressed_sin.view(-1, compressed_sin.shape[-1]),
+                compressed_cos.view(-1, compressed_cos.shape[-1]),
+                state_block_table=indexer_state_decode_metadata.block_table,
+                cu_seqlens=actual_seq_lengths_query,
+                seqused=None,
+                start_pos=indexer_scale_decode_metadata.start_pos,
+                rope_head_dim=self.rope_head_dim,
+                cmp_ratio=self.compress_ratio,
+                coff=coff,
+                norm_eps=self.compressor_norm_eps,
+                rotary_mode=2,
+                cache_mode=1,
+            )
+
+            if kv.numel() == 0:
+                kv = None
+            elif self.indexcom_rotate:
+                kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
+
+            # Quantize and scatter to cache
+            if kv is not None:
+                _, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
+                    kv,
+                    indexer_k_cache,
+                    indexer_full_cache,
+                    slot_mapping_indexer,
+                )
+                if kv_scale is not None:
+                    DeviceOperator.dsa_indexer_scatter_scale_part3(
+                        kv_scale,
+                        indexer_scale_cache,
+                        slot_mapping_indexer,
+                    )
+
+        return weights, indexer_k_cache, indexer_scale_cache, indexer_kv_scale_metadata
+
     def _forward_prefill(
         self,
         layer_name,
@@ -2197,6 +2591,145 @@ class AscendDSAImpl(DSAAttentionImpl):
                 )[0]
         return attn_output
 
+    # Top-level orchestration function for CSA multi-stream decode.
+    def _forward_decode_csa_multistream(
+        self,
+        layer_name: str,
+        hidden_states: torch.Tensor,
+        compress_kv_cache: torch.Tensor,
+        swa_kv_cache: torch.Tensor,
+        state_cache: torch.Tensor,
+        indexer_state_cache: torch.Tensor,
+        indexer_k_cache: torch.Tensor,
+        indexer_scale_cache: torch.Tensor,
+        indexer_full_cache: torch.Tensor | None,
+        compressor_attn_metadata,
+        compressor_kv_state_metadata,
+        indexer_kv_state_metadata,
+        indexer_kv_scale_metadata,
+        swa_decode_metadata: AscendDSADecodeMetadata,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+    ):
+        """Overlap CSA decode prolog, compression, and indexer work across NPU streams."""
+        enable_limit_core = self._enable_csa_limit_core(is_prefill=False)
+        compressor_decode_metadata = _require_decode_metadata(compressor_attn_metadata)
+        compressor_state_decode_metadata = _require_decode_metadata(compressor_kv_state_metadata)
+        actual_seq_lengths_query = compressor_decode_metadata.query_start_loc
+        actual_seq_lengths_key = compressor_decode_metadata.seq_lens
+        compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(
+            compressor_decode_metadata,
+            layer_name,
+        )
+
+        cmpr_done_event: torch.npu.Event | None = None
+        li_q_quant: torch.Tensor | None = None
+        li_q_scale: torch.Tensor | None = None
+        li_q_done_event: torch.npu.Event | None = None
+        li_main_result = None
+
+        def launch_after_q_b(
+            qr: torch.Tensor,
+            qr_pertoken_scale: torch.Tensor | None,
+            main_stream: torch.npu.Stream,
+            aux_stream: torch.npu.Stream,
+        ) -> None:
+            nonlocal cmpr_done_event, li_q_quant, li_q_scale, li_q_done_event, li_main_result
+            cmpr_done_event = self._launch_csa_c4a_compressor(
+                hidden_states,
+                compress_kv_cache,
+                state_cache,
+                compressor_state_decode_metadata.block_table,
+                actual_seq_lengths_query,
+                compressor_decode_metadata.start_pos,
+                compress_sin,
+                compress_cos,
+                compress_slot_mapping,
+                enable_limit_core,
+            )
+            li_q_quant, li_q_scale, li_q_done_event = self._launch_csa_li_query(
+                qr,
+                qr_pertoken_scale,
+                cos,
+                sin,
+                indexer_kv_scale_metadata,
+                cmpr_done_event,
+                main_stream,
+                aux_stream,
+                enable_limit_core,
+                hidden_states.dtype,
+            )
+            li_main_result = self._run_csa_li_main_decode(
+                hidden_states,
+                indexer_state_cache,
+                indexer_k_cache,
+                indexer_scale_cache,
+                indexer_full_cache,
+                indexer_kv_state_metadata,
+                indexer_kv_scale_metadata,
+                actual_seq_lengths_query,
+                enable_limit_core,
+                layer_name,
+            )
+
+        q, _, _, kv_done_event = self._mla_prolog_csa_decode(
+            hidden_states,
+            cos,
+            sin,
+            swa_kv_cache,
+            swa_decode_metadata.slot_mapping,
+            launch_after_q_b=launch_after_q_b,
+            enable_limit_core=enable_limit_core,
+        )
+
+        assert cmpr_done_event is not None
+        assert li_q_quant is not None
+        assert li_q_scale is not None
+        assert li_q_done_event is not None
+        assert li_main_result is not None
+        weights, indexer_k_cache, indexer_scale_cache, indexer_kv_scale_metadata = li_main_result
+
+        wait_event(li_q_done_event)
+        compress_topk_idxs = self._indexer_qli(
+            li_q_quant,
+            weights,
+            li_q_scale,
+            indexer_k_cache,
+            indexer_scale_cache,
+            indexer_kv_scale_metadata,
+            with_prefill=False,
+        )
+
+        if self.use_index_cache:
+            self._update_indexcache_topk_indices(compress_topk_idxs, offset=0)
+
+        wait_event(cmpr_done_event)
+        wait_event(kv_done_event)
+
+        attn_op = DeviceOperator.get_dsa_sparse_attn_op()
+        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
+        return attn_op(
+            q,
+            ori_kv=swa_kv_cache,
+            cmp_kv=compress_kv_cache,
+            cmp_sparse_indices=compress_topk_idxs,
+            ori_block_table=swa_decode_metadata.block_table,
+            cmp_block_table=compressor_decode_metadata.block_table,
+            cu_seqlens_q=actual_seq_lengths_query,
+            seqused_kv=actual_seq_lengths_key,
+            sinks=self.attn_sink,
+            metadata=compressor_decode_metadata.sas_metadata,
+            softmax_scale=self.softmax_scale,
+            cmp_ratio=self.compress_ratio,
+            ori_mask_mode=4,
+            cmp_mask_mode=3,
+            ori_win_left=self.window_size - 1,
+            ori_win_right=0,
+            layout_q="TND",
+            layout_kv="PA_ND",
+            **extra_attn_kwargs,
+        )[0]
+
     def _forward_decode(
         self,
         layer_name,
@@ -2213,9 +2746,13 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         if self.compress_ratio == 4:
             # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
-            (compressor_attn_metadata, compressor_kv_state_metadata, _, indexer_kv_scale_metadata, swa_metadata) = (
-                attn_metadata
-            )
+            (
+                compressor_attn_metadata,
+                compressor_kv_state_metadata,
+                indexer_kv_state_metadata,
+                indexer_kv_scale_metadata,
+                swa_metadata,
+            ) = attn_metadata
             compress_common_attn_metadata = compressor_attn_metadata
         elif self.compress_ratio == 128:
             # sorted keys: [attn, compressor.state_cache, swa_cache]
@@ -2231,6 +2768,28 @@ class AscendDSAImpl(DSAAttentionImpl):
         sin = common_decode_metadata.sin[layer_name]
         actual_seq_lengths_query = common_decode_metadata.query_start_loc
         actual_seq_lengths_key = common_decode_metadata.seq_lens
+
+        # If CSA multi-stream optimization enabled, call dedicated path
+        if self._enable_csa_multistream(is_prefill=False):
+            indexer_state_cache, _, _, _ = DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
+            return self._forward_decode_csa_multistream(
+                layer_name,
+                hidden_states,
+                compress_kv_cache,
+                swa_kv_cache,
+                state_cache,
+                indexer_state_cache,
+                indexer_k_cache,
+                indexer_scale_cache,
+                indexer_full_cache,
+                compressor_attn_metadata,
+                compressor_kv_state_metadata,
+                indexer_kv_state_metadata,
+                indexer_kv_scale_metadata,
+                swa_decode_metadata,
+                cos,
+                sin,
+            )
 
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1485,6 +1485,19 @@ class AscendDSAImpl(DSAAttentionImpl):
             False,
         )
 
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # DSA graph metadata uses persistent tensors and has no extra params to update.
+        pass
+
     def dsa_warmup_with_multistream(self, hidden_states: torch.Tensor) -> None:
         """
         Warmup function for DSA profiling run.

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -2308,7 +2308,7 @@ class AscendDSAImpl(DSAAttentionImpl):
 
         if self.multistream_dsv4_dsa_overlap:
             # mla prolog: q + kv dual-stream parallel
-            q, qr, _ = self._mla_prolog_multistream(
+            q, qr, qr_pertoken_scale = self._mla_prolog_multistream(
                 hidden_states, cos, sin, swa_kv_cache, swa_prefill_metadata.slot_mapping, is_prefill=True
             )
         elif need_prefill_gather:
@@ -2500,6 +2500,7 @@ class AscendDSAImpl(DSAAttentionImpl):
                     weights_proj_output = self.weights_proj(hidden_states)
                 # Main stream: q_quant (between compressed_kv and kv_scatter)
                 q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
+                compress_topk_idxs = indexer_q
 
             DeviceOperator.dsa_kv_compress_scatter(
                 compress_kv_cache, compressed_kv, compressor_prefill_metadata.slot_mapping

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -387,6 +387,9 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
                 torch.zeros(self.slot_mapping_shape, dtype=torch.int32, device=self.device)
                 for _ in range(spec_token_num)
             ]
+            self.spec_sas_metadata = [
+                torch.zeros(1024, dtype=torch.int32, device=self.device) for _ in range(spec_token_num)
+            ]
             self.decode_threshold += spec_token_num
             assert self.decode_threshold <= 16, (
                 f"decode_threshold exceeded \
@@ -1137,9 +1140,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         if num_prefills:
             cos, sin = get_cos_and_sin_dsa(input_positions)
         else:
-            # disable use_cache, otherwise, draft_step>0 will override draft_step=0
-            # take care of this, if full graph is needed then rope cache is inevitable
-            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
+            cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, draft_index=draft_step)
 
         slot_mapping = common_attn_metadata.slot_mapping[:num_input_tokens]
         self.spec_slot_mapping[draft_step - 1][:num_input_tokens] = DeviceOperator.format_dsa_slot_mapping(  # type: ignore[index]
@@ -1285,9 +1286,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         max_seqlen_kv = torch.max(_seq_lens_cpu[:num_decodes]).item()
 
         input_positions = common_attn_metadata.positions[:num_decode_tokens_typed].long()
-        # disable use_cache, otherwise, draft_step>0 will override draft_step=0
-        # take care of this, if full graph is needed then rope cache is inevitable
-        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=False)
+        cos, sin = get_cos_and_sin_dsa(input_positions, use_cache=True, draft_index=draft_step)
 
         slot_mapping = self.spec_slot_mapping[draft_step - 1][:num_decode_tokens_typed]  # type: ignore[index]
         block_table = common_attn_metadata.block_table_tensor
@@ -1318,6 +1317,8 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             has_ori_kv=True,
             has_cmp_kv=False,
         )
+        self.spec_sas_metadata[draft_step - 1][:1024].copy_(decode_sas_metadata[:1024])
+        decode_sas_metadata = self.spec_sas_metadata[draft_step - 1]
 
         decode_metadata = AscendDSADecodeMetadata(
             input_positions=None,

--- a/vllm_ascend/ops/rope_dsv4.py
+++ b/vllm_ascend/ops/rope_dsv4.py
@@ -12,6 +12,7 @@ class RopeGlobalState:
     def __init__(self):
         self.static_cache: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
         self.runtime_buffer: dict[str, dict[str, tuple[torch.Tensor, torch.Tensor]]] = {}
+        self.spec_runtime_buffer: dict[str, dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]]] = {}
         self.layer_info: dict[str, tuple[str, list[str]]] = {}
         self.registry_summary: dict[str, set] = {}
 
@@ -58,7 +59,11 @@ class RopeDataProxy:
             return layer_result
 
 
-def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_cache: bool = False):
+def get_cos_and_sin_dsa(
+    positions: torch.Tensor | dict[str, torch.Tensor],
+    use_cache: bool = False,
+    draft_index: int | None = None,
+):
     if isinstance(positions, torch.Tensor):
         pos_map = {"default": positions}
     else:
@@ -81,7 +86,11 @@ def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_c
             curr_sin = static_sin[pos_tensor]
 
             if use_cache:
-                group_buffers = _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
+                group_buffers = (
+                    _ROPE_STATE.runtime_buffer.get(config_key, {}).get(group_name)
+                    if draft_index is None
+                    else _ROPE_STATE.spec_runtime_buffer.get(config_key, {}).get(group_name)
+                )
 
                 if group_buffers is None:
                     continue
@@ -89,10 +98,18 @@ def get_cos_and_sin_dsa(positions: torch.Tensor | dict[str, torch.Tensor], use_c
                 buf_cos, buf_sin = group_buffers
                 num_tokens = pos_tensor.size(0)
 
-                buf_cos[:num_tokens].copy_(curr_cos)
-                buf_sin[:num_tokens].copy_(curr_sin)
+                if draft_index is None:
+                    buf_cos[:num_tokens].copy_(curr_cos)
+                    buf_sin[:num_tokens].copy_(curr_sin)
 
-                batch_result[config_key][group_name] = (buf_cos[:num_tokens], buf_sin[:num_tokens])
+                    batch_result[config_key][group_name] = (buf_cos[:num_tokens], buf_sin[:num_tokens])
+                else:
+                    buf_cos[draft_index - 1][:num_tokens].copy_(curr_cos)
+                    buf_sin[draft_index - 1][:num_tokens].copy_(curr_sin)
+                    batch_result[config_key][group_name] = (
+                        buf_cos[draft_index - 1][:num_tokens],
+                        buf_sin[draft_index - 1][:num_tokens],
+                    )
             else:
                 batch_result[config_key][group_name] = (curr_cos, curr_sin)
 
@@ -147,8 +164,17 @@ class ComplexExpRotaryEmbedding(nn.Module):
 
             _ROPE_STATE.static_cache[config_key] = (cos.unsqueeze(1).unsqueeze(1), sin.unsqueeze(1).unsqueeze(1))
 
+        use_eagle = (
+            vllm_config is not None
+            and vllm_config.speculative_config is not None
+            and vllm_config.speculative_config.use_eagle()
+        )
+        num_speculative_tokens = vllm_config.speculative_config.num_speculative_tokens if use_eagle else None
+
         if config_key not in _ROPE_STATE.runtime_buffer:
             _ROPE_STATE.runtime_buffer[config_key] = {}
+        if num_speculative_tokens is not None and config_key not in _ROPE_STATE.spec_runtime_buffer:
+            _ROPE_STATE.spec_runtime_buffer[config_key] = {}
 
         target_device = current_platform.device_type
         max_batch_size = vllm_config.scheduler_config.max_num_batched_tokens
@@ -157,6 +183,16 @@ class ComplexExpRotaryEmbedding(nn.Module):
                 buf_cos = torch.ones(max_batch_size, 1, 1, rotary_dim, dtype=torch.float32, device=target_device)
                 buf_sin = torch.zeros(max_batch_size, 1, 1, rotary_dim, dtype=torch.float32, device=target_device)
                 _ROPE_STATE.runtime_buffer[config_key][grp] = (buf_cos, buf_sin)
+            if num_speculative_tokens is not None and grp not in _ROPE_STATE.spec_runtime_buffer[config_key]:
+                spec_buf_cos = [
+                    torch.ones(max_batch_size, 1, 1, rotary_dim, dtype=torch.float32, device=target_device)
+                    for _ in range(num_speculative_tokens)
+                ]
+                spec_buf_sin = [
+                    torch.zeros(max_batch_size, 1, 1, rotary_dim, dtype=torch.float32, device=target_device)
+                    for _ in range(num_speculative_tokens)
+                ]
+                _ROPE_STATE.spec_runtime_buffer[config_key][grp] = (spec_buf_cos, spec_buf_sin)
 
     @staticmethod
     def precompute_freqs_cis(dim, seqlen, original_seq_len, base, factor, beta_fast, beta_slow):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -53,6 +53,7 @@ from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.utils import enable_sp, lmhead_tp_enable, shared_expert_dp_enabled
+from vllm_ascend.worker.utils import copy_snapshot_to_gpu
 
 # Currently we will fix block size to a small one since `num_reqs` can't be too large
 _PREPARE_INPUTS_BLOCK_SIZE = 4
@@ -511,12 +512,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             # num_reqs is already the padded version
             self.query_start_loc.cpu[: num_reqs + 1].copy_(self.runner.query_start_loc.cpu[: num_reqs + 1])
-            self.query_start_loc.copy_to_gpu()
+            copy_snapshot_to_gpu(self.query_start_loc)
 
             common_attn_metadata = AscendCommonAttentionMetadata(
                 query_start_loc=self.query_start_loc.gpu[: num_reqs + 1],
                 query_start_loc_cpu=self.query_start_loc.cpu[: num_reqs + 1],
                 seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
+                _seq_lens_cpu=self.runner.optimistic_seq_lens_cpu,
                 seq_lens_cpu_upper_bound=self.runner.optimistic_seq_lens_cpu,
                 seq_lens=self.runner.seq_lens[:num_reqs],
                 num_reqs=num_reqs,
@@ -525,13 +527,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 max_query_len=self.num_speculative_tokens + 1,
                 num_computed_tokens_cpu=num_computed_tokens_cpu,
                 actual_seq_lengths_q=self.runner.actual_seq_lengths_q,
-                block_table_tensor=self.runner.input_batch.block_table[0].get_device_tensor()[:num_reqs],
+                block_table_tensor=self.runner.input_batch.block_table[self.kv_cache_gid].get_device_tensor()[
+                    :num_reqs
+                ],
                 # This is used to hold a position.
-                slot_mapping=self.runner.input_batch.block_table[0].slot_mapping.gpu,
-                slot_mapping_cpu=self.runner.input_batch.block_table[0].slot_mapping.cpu,
+                slot_mapping=self.runner.input_batch.block_table[self.kv_cache_gid].slot_mapping.gpu,
+                slot_mapping_cpu=self.runner.input_batch.block_table[self.kv_cache_gid].slot_mapping.cpu,
                 positions=self.runner.positions,
+                positions_cpu=self.runner._dsa_positions_cpu_buf if self.use_compress else None,
                 attn_state=self.runner.attn_state,
                 decode_token_per_req=self.runner.decode_token_per_req,
+                is_prefilling=torch.zeros(num_reqs, dtype=torch.bool),
                 max_seq_len=0,
             )
             if self.pcp_size * self.dcp_size > 1:
@@ -540,20 +546,46 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
             assert len(self.draft_attn_groups) > 0
             builder = self.draft_attn_groups[0].get_metadata_builder()
+            kv_cache_spec = self.draft_attn_groups[0].kv_cache_spec
             # update the tensor's address for each step.
             for draft_step in range(self.num_speculative_tokens):
                 common_attn_metadata = self.shallow_copy_metadata(common_attn_metadata)
+                extra_attn_metadata_args: dict = {}
+                if self.use_compress:
+                    extra_attn_metadata_args = dict(
+                        prefill_ratio_to_sas_metadata=dict(),
+                        decode_ratio_to_sas_metadata=dict(),
+                        common_ratio_to_sas_metadata=dict(),
+                        block_size=kv_cache_spec.block_size,
+                    )
                 # Set the real slot_mapping.
+                slot_mapping_lens = common_attn_metadata.slot_mapping.shape[0]
+                self.slot_mapping_group[draft_step][:slot_mapping_lens].copy_(common_attn_metadata.slot_mapping)
+                self.slot_mapping_group[draft_step][slot_mapping_lens:].fill_(PADDING_SLOT_ID)
                 common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_step]
+                self.seq_lens_group[draft_step][:num_reqs].copy_(common_attn_metadata.seq_lens)
+                self.seq_lens_group[draft_step][num_reqs:].fill_(0)
                 common_attn_metadata.seq_lens = self.seq_lens_group[draft_step][:num_reqs]
+                self.query_start_loc_group[draft_step][: num_reqs + 1].copy_(common_attn_metadata.query_start_loc)
+                self.query_start_loc_group[draft_step][num_reqs + 1 :].fill_(0)
                 common_attn_metadata.query_start_loc = self.query_start_loc_group[draft_step][: num_reqs + 1]
                 if self.pcp_size * self.dcp_size > 1 and draft_step > 0:
                     assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
                     common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:num_reqs]
-                attn_metadata_eagle = builder.build_for_graph_capture(
-                    common_attn_metadata,
-                    AscendAttentionState.SpecDecoding if self.method == "mtp" else AscendAttentionState.ChunkedPrefill,
-                )
+                if not self.use_compress or draft_step == 0:
+                    attn_metadata_eagle = builder.build_for_graph_capture(
+                        common_attn_metadata,
+                        AscendAttentionState.SpecDecoding
+                        if self.method == "mtp"
+                        else AscendAttentionState.ChunkedPrefill,
+                        **extra_attn_metadata_args,
+                    )
+                else:
+                    attn_metadata_eagle = builder.build_for_drafting(
+                        draft_step=draft_step,
+                        common_attn_metadata=common_attn_metadata,
+                        **extra_attn_metadata_args,
+                    )
                 per_layer_attn_metadata = dict()
                 for layer_name in self.attn_layer_names:
                     per_layer_attn_metadata[layer_name] = attn_metadata_eagle
@@ -703,7 +735,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # is run in eager mode currently, which means `_pad_query_start_loc_for_fia` is not called,
             # while draft model is run in graph model, which means we should pad the `query_start_loc`.
             # Need to be fixed in the future.
+            num_reqs = common_attn_metadata.query_start_loc.shape[0]
+            self.query_start_loc.gpu[:num_reqs].copy_(common_attn_metadata.query_start_loc)
+            self.query_start_loc.cpu[:num_reqs].copy_(common_attn_metadata.query_start_loc_cpu)
             num_reqs_padded = self.runner._pad_query_start_loc_for_fia(
+                self.query_start_loc,
                 num_input_tokens,
                 batch_descriptor.num_reqs if batch_descriptor.num_reqs is not None else common_attn_metadata.num_reqs,
                 common_attn_metadata.num_reqs,
@@ -711,8 +747,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 batch_descriptor.num_reqs,
             )
             common_attn_metadata.num_reqs = num_reqs_padded
-            common_attn_metadata.query_start_loc = self.runner.query_start_loc.gpu[: num_reqs_padded + 1]
-            common_attn_metadata.query_start_loc_cpu = self.runner.query_start_loc.cpu[: num_reqs_padded + 1]
+            common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
+            common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
             slicing_length = (
                 num_reqs_padded * self.decode_threshold if self.pcp_size * self.dcp_size > 1 else num_reqs_padded
             )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -161,7 +161,7 @@ from vllm_ascend.utils import (
 )
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.pcp_utils import PCPManager
-from vllm_ascend.worker.utils import AscendKVBlockZeroer
+from vllm_ascend.worker.utils import AscendKVBlockZeroer, copy_snapshot_to_gpu
 
 from vllm_ascend.ascend_forward_context import (  # isort: skip
     MoECommType,
@@ -699,6 +699,7 @@ class NPUModelRunner(GPUModelRunner):
 
     def _pad_query_start_loc_for_fia(
         self,
+        query_start_loc: Any,
         num_tokens_padded: int,
         num_reqs_padded: int,
         num_reqs: int,
@@ -727,8 +728,8 @@ class NPUModelRunner(GPUModelRunner):
             # Uniform-batch case: num_reqs must be no greater than num_reqs_padded
             assert num_reqs <= num_reqs_padded
 
-            last_loc = self.query_start_loc.np[num_reqs]
-            self.query_start_loc.np[num_reqs + 1 : num_reqs_padded + 1] = (
+            last_loc = query_start_loc.np[num_reqs]
+            query_start_loc.np[num_reqs + 1 : num_reqs_padded + 1] = (
                 self.arange_np[1 : num_reqs_padded + 1 - num_reqs] * self.uniform_decode_query_len + last_loc
             )
         else:
@@ -736,12 +737,12 @@ class NPUModelRunner(GPUModelRunner):
             assert num_reqs == num_reqs_padded
 
             # Do not insert if the last value already equals the num_tokens
-            if self.query_start_loc.np[num_reqs_padded] < num_tokens_padded:
+            if query_start_loc.np[num_reqs_padded] < num_tokens_padded:
                 # Insert a dummy request instead of change the last value directly
-                self.query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
+                query_start_loc.np[num_reqs_padded + 1] = num_tokens_padded
                 num_reqs_padded = num_reqs_padded + 1
 
-        self.query_start_loc.copy_to_gpu()
+        copy_snapshot_to_gpu(query_start_loc)
 
         return num_reqs_padded
 
@@ -2159,6 +2160,7 @@ class NPUModelRunner(GPUModelRunner):
                     # Another possible condition is num_tokens_padded != num_tokens_unpadded
                     # but this scope is way too big and the consequences are unpredictable
                     num_reqs_padded = self._pad_query_start_loc_for_fia(
+                        self.query_start_loc,
                         num_tokens_padded, num_reqs_padded, num_reqs, cudagraph_mode, batch_desc.num_reqs
                     )
 
@@ -3444,6 +3446,7 @@ class NPUModelRunner(GPUModelRunner):
 
             if not profile_cpp:
                 num_reqs_padded = self._pad_query_start_loc_for_fia(
+                    self.query_start_loc,
                     num_tokens_padded, num_reqs_padded, num_reqs, cudagraph_runtime_mode, batch_desc.num_reqs
                 )
 

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -13,9 +13,9 @@ from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
 def copy_snapshot_to_gpu(buffer: CpuGpuBuffer) -> torch.Tensor:
-    """Copy a pinned CPU snapshot so later host writes do not race the copy."""
-    cpu_snapshot = buffer.cpu.clone().pin_memory()
-    return buffer.gpu.copy_(cpu_snapshot, non_blocking=True)
+    """Copy a CPU snapshot so later host writes do not race the copy."""
+    cpu_snapshot = buffer.cpu.clone()
+    return buffer.gpu.copy_(cpu_snapshot, non_blocking=False)
 
 
 @triton.jit

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -6,9 +6,16 @@ import torch
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import largest_power_of_2_divisor
 from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+def copy_snapshot_to_gpu(buffer: CpuGpuBuffer) -> torch.Tensor:
+    """Copy a pinned CPU snapshot so later host writes do not race the copy."""
+    cpu_snapshot = buffer.cpu.clone().pin_memory()
+    return buffer.gpu.copy_(cpu_snapshot, non_blocking=True)
 
 
 @triton.jit


### PR DESCRIPTION
### What this PR does / why we need it?
Backports DeepSeek V4 MTP ACLGraph support from vllm-ascend v0.23.0 / PR #11062 into the `releases/v0.21.0rc` branch.

This fixes the draft-model full-graph path for DeepSeek V4 MTP by:
- isolating draft-side `query_start_loc` padding from the target runner buffer,
- adding capture-safe snapshot copies for graph padding,
- adding per-draft-step DSV4 rope runtime buffers,
- adding per-draft-step DSA SAS metadata buffers,
- and adding the missing no-op `AscendDSAImpl.update_graph_params()` hook required by ACLGraph updates.

This is not duplicating an existing open PR in this workspace; it is a direct backport of PR #11062 behavior to the older release branch.

### Does this PR introduce _any_ user-facing change?
Yes.

Users can run DeepSeek V4 MTP with ACLGraph enabled on `releases/v0.21.0rc` without the dummy-run/full-graph failure.
The request interface is unchanged, but the runtime behavior for MTP graph execution is fixed.

### How was this patch tested?
- `python -m py_compile vllm_ascend/worker/utils.py vllm_ascend/worker/model_runner_v1.py vllm_ascend/_310p/model_runner_310p.py vllm_ascend/spec_decode/llm_base_proposer.py vllm_ascend/ops/rope_dsv4.py vllm_ascend/attention/dsa_v1.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `git diff --check -- vllm_ascend/worker/utils.py vllm_ascend/worker/model_runner_v1.py vllm_ascend/_310p/model_runner_310p.py vllm_ascend/spec_decode/llm_base_proposer.py vllm_ascend/ops/rope_dsv4.py vllm_ascend/attention/dsa_v1.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- Both `mtp` graph and non-graph scenarios work normally after the fix.

- vLLM version: v0.21.0
- vLLM main: https://github.com/vllm-project/vllm/commit/9090368b650896bf5fc990c921df7eb4c20355a5
