### PR TITLE
refactor: parameterize hardcoded registry URLs via ARGs

### DIFF
--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -82,7 +82,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: swr.cn-north-12.myhuaweicloud.com/modelfoundry/triton-ascend:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
+          tags: swr.cn-north-12.myhuaweicloud.com/modelfoundry/vllm-ascend:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
           build-args: |
             CANN_QUAY_URL=swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann
             APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
@@ -109,7 +109,7 @@ jobs:
 
       - name: Create multi-arch manifest
         env:
-          IMAGE: swr.cn-north-12.myhuaweicloud.com/modelfoundry/triton-ascend
+          IMAGE: swr.cn-north-12.myhuaweicloud.com/modelfoundry/vllm-ascend
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -1,0 +1,88 @@
+name: buildkit-dockerfile-test
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/buildkit-dockerfile-test.yaml'
+      - 'Dockerfile'
+      - 'Dockerfile.310p'
+      - 'Dockerfile.310p.openEuler'
+      - 'Dockerfile.a3'
+      - 'Dockerfile.a3.openEuler'
+      - 'Dockerfile.openEuler'
+      - 'Dockerfile.a5'
+      - 'Dockerfile.a5.openEuler'
+  workflow_dispatch:
+
+jobs:
+  build-test:
+    name: "${{ matrix.dockerfile }} (${{ matrix.runner_info.arch }})"
+    runs-on: ${{ matrix.runner_info.runner }}
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.0.0-a3-ubuntu22.04-py3.12
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile
+          - Dockerfile.310p
+          - Dockerfile.310p.openEuler
+          - Dockerfile.a3
+          - Dockerfile.a3.openEuler
+          - Dockerfile.openEuler
+          - Dockerfile.a5
+          - Dockerfile.a5.openEuler
+        runner_info:
+          - {runner: linux-aarch64-cpu-4, arch: arm64}
+          - {runner: linux-amd64-cpu-4, arch: amd64}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Determine SOC_VERSION
+        id: vars
+        run: |
+          case "${{ matrix.dockerfile }}" in
+            Dockerfile|Dockerfile.openEuler)
+              echo "soc_version=ascend910b1" >> $GITHUB_OUTPUT
+              ;;
+            Dockerfile.310p|Dockerfile.310p.openEuler)
+              echo "soc_version=ascend310p1" >> $GITHUB_OUTPUT
+              ;;
+            Dockerfile.a3|Dockerfile.a3.openEuler)
+              echo "soc_version=ascend910_9391" >> $GITHUB_OUTPUT
+              ;;
+            Dockerfile.a5|Dockerfile.a5.openEuler)
+              echo "soc_version=ascend950dt_9582" >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+      - name: Login to quay.io
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: quay.io/wjunlu/vllm-ascend-daily:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
+          build-args: |
+            APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
+            PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+            PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+            PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+            ASCEND_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/ascend/repos/pypi
+            GIT_PROXY=https://gh-proxy.test.osinfra.cn/
+            SOC_VERSION=${{ steps.vars.outputs.soc_version }}
+            COMPILE_CUSTOM_KERNELS=0
+          provenance: false

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -77,6 +77,7 @@ jobs:
           push: true
           tags: quay.io/wjunlu/vllm-ascend-daily:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
           build-args: |
+            CANN_QUAY_URL=swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann
             APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
             PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
             PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -62,12 +62,12 @@ jobs:
               ;;
           esac
 
-      - name: Login to quay.io
+      - name: Login to SWR
         uses: docker/login-action@v3
         with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          registry: swr.cn-north-12.myhuaweicloud.com
+          username: ${{ secrets.SWR_USERNAME }}
+          password: ${{ secrets.SWR_PASSWORD }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -75,7 +75,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: quay.io/wjunlu/vllm-ascend-daily:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
+          tags: swr.cn-north-12.myhuaweicloud.com/modelfoundry/${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
           build-args: |
             CANN_QUAY_URL=swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann
             APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -34,8 +34,8 @@ jobs:
           - Dockerfile.a5
           - Dockerfile.a5.openEuler
         runner_info:
-          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
-          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
+          - {runner: linux-aarch64-cpu-4, arch: arm64}
+          - {runner: linux-amd64-cpu-4, arch: amd64}
 
     steps:
       - name: Checkout

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -94,3 +94,31 @@ jobs:
             SOC_VERSION=${{ steps.vars.outputs.soc_version }}
             COMPILE_CUSTOM_KERNELS=${{ steps.cache-csrc.outputs.cache-hit == 'true' && '0' || '1' }}
           provenance: false
+
+  merge-manifest:
+    name: Merge multi-arch manifest
+    runs-on: linux-amd64-cpu-4
+    needs: build-test
+    steps:
+      - name: Login to SWR
+        uses: docker/login-action@v3
+        with:
+          registry: swr.cn-north-12.myhuaweicloud.com
+          username: ${{ secrets.SWR_USERNAME }}
+          password: ${{ secrets.SWR_PASSWORD }}
+
+      - name: Create multi-arch manifest
+        env:
+          IMAGE: swr.cn-north-12.myhuaweicloud.com/modelfoundry/triton-ascend
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          for df in Dockerfile Dockerfile.310p Dockerfile.310p.openEuler \
+                    Dockerfile.a3 Dockerfile.a3.openEuler Dockerfile.openEuler \
+                    Dockerfile.a5 Dockerfile.a5.openEuler; do
+            echo "Merging ${df} into multi-arch manifest..."
+            docker buildx imagetools create \
+              -t "${IMAGE}:${df}-${SHA}" \
+              "${IMAGE}:${df}-arm64-${SHA}" \
+              "${IMAGE}:${df}-amd64-${SHA}"
+          done

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -62,6 +62,13 @@ jobs:
               ;;
           esac
 
+      - name: Cache csrc
+        id: cache-csrc
+        uses: actions/cache@v4
+        with:
+          path: csrc
+          key: csrc-${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ hashFiles('csrc/**') }}
+
       - name: Login to SWR
         uses: docker/login-action@v3
         with:
@@ -85,5 +92,5 @@ jobs:
             ASCEND_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/ascend/repos/pypi
             GIT_PROXY=https://gh-proxy.test.osinfra.cn/
             SOC_VERSION=${{ steps.vars.outputs.soc_version }}
-            COMPILE_CUSTOM_KERNELS=0
+            COMPILE_CUSTOM_KERNELS=${{ steps.cache-csrc.outputs.cache-hit == 'true' && '0' || '1' }}
           provenance: false

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -75,7 +75,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: swr.cn-north-12.myhuaweicloud.com/modelfoundry/${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
+          tags: swr.cn-north-12.myhuaweicloud.com/modelfoundry/triton-ascend:${{ matrix.dockerfile }}-${{ matrix.runner_info.arch }}-${{ github.sha }}
           build-args: |
             CANN_QUAY_URL=swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann
             APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081

--- a/.github/workflows/buildkit-dockerfile-test.yaml
+++ b/.github/workflows/buildkit-dockerfile-test.yaml
@@ -34,8 +34,8 @@ jobs:
           - Dockerfile.a5
           - Dockerfile.a5.openEuler
         runner_info:
-          - {runner: linux-aarch64-cpu-4, arch: arm64}
-          - {runner: linux-amd64-cpu-4, arch: amd64}
+          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
+          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,22 +20,32 @@ ARG BASE_OS="ubuntu22.04"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-910b-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
-RUN apt-get update -y && \
+RUN if [ -n "$APTMIRROR" ]; then \
+        sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
+    fi && \
+    apt-get update -y && \
     apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url https://mirrors.aliyun.com/pypi/web/simple && \
+    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
@@ -48,10 +58,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -64,13 +75,13 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -79,7 +79,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -79,7 +79,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -21,16 +21,26 @@ ARG BASE_OS="ubuntu22.04"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-310p-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
-RUN apt-get update -y && \
+RUN if [ -n "$APTMIRROR" ]; then \
+        sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
+    fi && \
+    apt-get update -y && \
     apt-get install -y python3-pip git vim wget net-tools gcc g++ cmake numactl libnuma-dev libjemalloc2 pciutils && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
@@ -43,10 +53,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -59,10 +70,10 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -57,7 +57,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -73,7 +73,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -57,7 +57,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -73,7 +73,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -21,6 +21,12 @@ ARG BASE_OS="openeuler24.03"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-310p-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
@@ -30,6 +36,7 @@ RUN yum update -y && \
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
@@ -42,10 +49,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -57,10 +65,10 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -53,7 +53,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -68,7 +68,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -53,7 +53,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -68,7 +68,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -21,6 +21,12 @@ ARG BASE_OS="ubuntu22.04"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-a3-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -28,17 +34,21 @@ WORKDIR /workspace
 
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
-RUN apt-get update -y && \
+RUN if [ -n "$APTMIRROR" ]; then \
+        sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
+    fi && \
+    apt-get update -y && \
     apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url https://mirrors.aliyun.com/pypi/web/simple && \
+    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
@@ -51,10 +61,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -67,13 +78,13 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -65,7 +65,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -82,7 +82,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -65,7 +65,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -82,7 +82,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -21,6 +21,12 @@ ARG BASE_OS="openeuler24.03"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-a3-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
@@ -31,11 +37,12 @@ ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
     yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url https://mirrors.aliyun.com/pypi/web/simple && \
+    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
@@ -48,10 +55,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -63,13 +71,13 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -59,7 +59,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -75,7 +75,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -59,7 +59,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -75,7 +75,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -58,7 +58,7 @@ ARG VLLM_TAG=v0.26.0
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -74,7 +74,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -58,7 +58,7 @@ ARG VLLM_TAG=v0.26.0
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -74,7 +74,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -21,6 +21,12 @@ ARG BASE_OS="ubuntu22.04"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-950-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -28,26 +34,31 @@ WORKDIR /workspace
 
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
-RUN apt-get update -y && \
+RUN if [ -n "$APTMIRROR" ]; then \
+        sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list; \
+    fi && \
+    apt-get update -y && \
     apt-get install -y git vim wget net-tools gcc g++ cmake numactl libnuma-dev libibverbs-dev libjemalloc2 libhiredis-dev clang-15 && \
     update-alternatives --install /usr/bin/clang clang /usr/bin/clang-15 20 && \
     update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-15 20 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url https://mirrors.aliyun.com/pypi/web/simple && \
+    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/apt/* && \
     rm -rf /var/lib/apt/lists/*
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.26.0
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
+    git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -60,12 +71,12 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -52,7 +52,7 @@ ARG VLLM_TAG=v0.26.0
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -67,7 +67,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -52,7 +52,7 @@ ARG VLLM_TAG=v0.26.0
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -67,7 +67,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -21,6 +21,12 @@ ARG BASE_OS="openeuler24.03"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-950-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
@@ -31,20 +37,22 @@ ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
     yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url https://mirrors.aliyun.com/pypi/web/simple && \
+    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
 # Install vLLM
 ARG VLLM_REPO=https://github.com/vllm-project/vllm.git
 ARG VLLM_TAG=v0.26.0
-RUN git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
+RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
+    git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -56,12 +64,12 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -21,6 +21,12 @@ ARG BASE_OS="openeuler24.03"
 FROM ${CANN_QUAY_URL}:${CANN_VERSION}-910b-${BASE_OS}-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
+ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
+ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
+ARG APTMIRROR=""
+ARG GIT_PROXY=""
+ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
@@ -31,11 +37,12 @@ ARG MOONCAKE_TAG=0.3.11.post1
 RUN yum update -y && \
     yum install -y git vim wget net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
-    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url https://mirrors.aliyun.com/pypi/web/simple && \
+    python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
+    if [ -n "$PIP_TRUSTED_HOST" ]; then pip config set global.trusted-host "$PIP_TRUSTED_HOST"; fi && \
     python3 -m pip install modelscope 'ray>=2.47.1,<=2.48.0' 'protobuf>3.20.0' && \
     python3 -m pip cache purge
 
@@ -48,10 +55,11 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git -C /vllm-workspace/vllm fetch --depth 1 $VLLM_REPO "$VLLM_COMMIT" && \
       git -C /vllm-workspace/vllm checkout FETCH_HEAD; \
     else \
+      if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -63,13 +71,13 @@ ENV SOC_VERSION=$SOC_VERSION \
     OMP_NUM_THREADS=1
 COPY . /vllm-workspace/vllm-ascend/
 
-RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi" && \
+RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url https://download.pytorch.org/whl/cpu/ && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
-    python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -59,7 +59,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -75,7 +75,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -59,7 +59,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -75,7 +75,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install -e /vllm-workspace/vllm-ascend/ $([ "$PYTORCH_INDEX_URL" != "https://download.pytorch.org/whl/cpu/" ] && echo "--find-links ${PYTORCH_INDEX_URL}/torch/ --find-links ${PYTORCH_INDEX_URL}/torchvision/" || echo "--extra-index-url ${PYTORCH_INDEX_URL}") && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip cache purge

--- a/docs/source/buildkit-guide.md
+++ b/docs/source/buildkit-guide.md
@@ -1,0 +1,166 @@
+# Buildkit CI User Guide
+
+## Overview
+
+The buildkit infrastructure provides **native** Docker image building for both `arm64` and `amd64` architectures. Each architecture runs on its own buildkitd daemon, so there is **no QEMU emulation** — builds are fast and native.
+
+## Runners
+
+Two self-hosted runners are available:
+
+| Runner | Target Architecture | Description |
+|---|---|---|
+| `linux-amd64-cpu-4-buildkit` | `amd64` (x86_64) | Native amd64 build |
+| `linux-aarch64-cpu-4-buildkit` | `arm64` (aarch64) | Native arm64 build |
+
+### Build for both architectures
+
+```yaml
+jobs:
+  build:
+    strategy:
+      matrix:
+        runner_info:
+          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
+          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
+    runs-on: ${{ matrix.runner_info.runner }}
+```
+
+### Build for a single architecture
+
+```yaml
+jobs:
+  build:
+    runs-on: linux-amd64-cpu-4-buildkit  # amd64 only
+```
+
+> **Important**: Do `NOT` use `--platform linux/amd64,linux/arm64` in `docker/build-push-action`. The runner architecture determines the target natively. Using `--platform` with a single runner unnecessarily triggers QEMU emulation.
+
+## Dockerfile
+
+The Dockerfiles are fully parameterized via `ARG` with sensible defaults. **You do not need to modify the Dockerfile.** The defaults work out of the box.
+
+### Available ARGs
+
+| ARG | Default | Description |
+|---|---|---|
+| `CANN_QUAY_URL` | `quay.io/ascend/cann` | CANN base image registry |
+| `CANN_VERSION` | `9.1.0` | CANN version |
+| `BASE_OS` | `ubuntu22.04` | Base OS |
+| `PIP_INDEX_URL` | `https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple` | PyPI mirror |
+| `MOONCAKE_INDEX_URL` | `https://mirrors.aliyun.com/pypi/web/simple` | Mooncake PyPI mirror |
+| `PYTORCH_INDEX_URL` | `https://download.pytorch.org/whl/cpu/` | PyTorch CPU wheel index |
+| `ASCEND_INDEX_URL` | `https://mirrors.huaweicloud.com/ascend/repos/pypi` | Ascend package index |
+| `APTMIRROR` | `""` (empty) | Apt cache/proxy mirror |
+| `GIT_PROXY` | `""` (empty) | Git proxy prefix |
+| `PIP_TRUSTED_HOST` | `""` (empty) | Trusted pip hosts |
+| `SOC_VERSION` | (per Dockerfile) | Ascend SOC version |
+| `COMPILE_CUSTOM_KERNELS` | `1` | Enable custom kernel compilation |
+
+### Override ARGs
+
+Override via `build-args` in the workflow:
+
+```yaml
+- name: Build and push
+  uses: docker/build-push-action@v7
+  with:
+    build-args: |
+      CANN_QUAY_URL=swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann
+      PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+      PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+```
+
+> The `PYTORCH_INDEX_URL` ARG is smart: when set to a non-default value (e.g., an internal cache service), it automatically uses `--find-links` instead of `--extra-index-url` to avoid slow index queries. With the default value (`https://download.pytorch.org/whl/cpu/`), it behaves exactly as before.
+
+## Authentication
+
+Use `docker/login-action` to authenticate with the registry:
+
+```yaml
+- name: Login to SWR
+  uses: docker/login-action@v3
+  with:
+    registry: swr.cn-north-12.myhuaweicloud.com
+    username: ${{ secrets.SWR_USERNAME }}
+    password: ${{ secrets.SWR_PASSWORD }}
+```
+
+> Configure `SWR_USERNAME` and `SWR_PASSWORD` as repository secrets in **Settings → Secrets and variables → Actions**.
+
+## Complete Workflow Example
+
+### Build + push for both architectures
+
+```yaml
+name: docker-build
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "build (${{ matrix.runner_info.arch }})"
+    runs-on: ${{ matrix.runner_info.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner_info:
+          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
+          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Login to SWR
+        uses: docker/login-action@v3
+        with:
+          registry: swr.cn-north-12.myhuaweicloud.com
+          username: ${{ secrets.SWR_USERNAME }}
+          password: ${{ secrets.SWR_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: swr.cn-north-12.myhuaweicloud.com/modelfoundry/my-image:${{ matrix.runner_info.arch }}-${{ github.sha }}
+          build-args: |
+            CANN_QUAY_URL=swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann
+            APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
+            PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
+            PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
+            PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
+            ASCEND_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/ascend/repos/pypi
+            GIT_PROXY=https://gh-proxy.test.osinfra.cn/
+          provenance: false
+```
+
+### Build only for amd64
+
+```yaml
+jobs:
+  build:
+    runs-on: linux-amd64-cpu-4-buildkit
+    # ... same steps as above
+```
+
+### Build only for arm64
+
+```yaml
+jobs:
+  build:
+    runs-on: linux-aarch64-cpu-4-buildkit
+    # ... same steps as above
+```
+
+## Key Rules
+
+1. **Do not use `--platform`** — the runner architecture is the target architecture. Use the matrix to select both architectures.
+2. **Do not modify the Dockerfile** — the defaults work for internal builds. Only override `build-args` if needed.
+3. **Always set `provenance: false`** — to avoid metadata push issues.
+4. **Always set `fail-fast: false`** — when building a matrix, so one architecture failure doesn't cancel the other.

--- a/docs/source/buildkit-guide.md
+++ b/docs/source/buildkit-guide.md
@@ -10,8 +10,8 @@ Two self-hosted runners are available:
 
 | Runner | Target Architecture | Description |
 |---|---|---|
-| `linux-amd64-cpu-4-buildkit` | `amd64` (x86_64) | Native amd64 build |
-| `linux-aarch64-cpu-4-buildkit` | `arm64` (aarch64) | Native arm64 build |
+| `linux-amd64-cpu-4` | `amd64` (x86_64) | Native amd64 build |
+| `linux-aarch64-cpu-4` | `arm64` (aarch64) | Native arm64 build |
 
 ### Build for both architectures
 
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         runner_info:
-          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
-          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
+          - {runner: linux-amd64-cpu-4, arch: amd64}
+          - {runner: linux-aarch64-cpu-4, arch: arm64}
     runs-on: ${{ matrix.runner_info.runner }}
 ```
 
@@ -31,7 +31,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    runs-on: linux-amd64-cpu-4-buildkit  # amd64 only
+    runs-on: linux-amd64-cpu-4  # amd64 only
 ```
 
 > **Important**: Do `NOT` use `--platform linux/amd64,linux/arm64` in `docker/build-push-action`. The runner architecture determines the target natively. Using `--platform` with a single runner unnecessarily triggers QEMU emulation.
@@ -109,8 +109,8 @@ jobs:
       fail-fast: false
       matrix:
         runner_info:
-          - {runner: linux-amd64-cpu-4-buildkit, arch: amd64}
-          - {runner: linux-aarch64-cpu-4-buildkit, arch: arm64}
+          - {runner: linux-amd64-cpu-4, arch: amd64}
+          - {runner: linux-aarch64-cpu-4, arch: arm64}
 
     steps:
       - uses: actions/checkout@v7
@@ -145,7 +145,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    runs-on: linux-amd64-cpu-4-buildkit
+    runs-on: linux-amd64-cpu-4
     # ... same steps as above
 ```
 
@@ -154,7 +154,7 @@ jobs:
 ```yaml
 jobs:
   build:
-    runs-on: linux-aarch64-cpu-4-buildkit
+    runs-on: linux-aarch64-cpu-4
     # ... same steps as above
 ```
 

--- a/docs/source/buildkit-guide.md
+++ b/docs/source/buildkit-guide.md
@@ -71,7 +71,7 @@ Override via `build-args` in the workflow:
       PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
 ```
 
-> The `PYTORCH_INDEX_URL` ARG is smart: when set to a non-default value (e.g., an internal cache service), it automatically uses `--find-links` instead of `--extra-index-url` to avoid slow index queries. With the default value (`https://download.pytorch.org/whl/cpu/`), it behaves exactly as before.
+> The `PYTORCH_INDEX_URL` ARG is used as `--extra-index-url`. The internal cache service (`cache-service.../whl/cpu`) whitelists PyTorch packages (`torch`, `torchvision`, `torchaudio`) and returns an instant empty index page for all other packages, so pip never hits the slow international `download.pytorch.org` for non-PyTorch dependencies. With the default value (`https://download.pytorch.org/whl/cpu/`), it behaves exactly as before.
 
 ## Authentication
 


### PR DESCRIPTION
## Summary

Replace hardcoded PyTorch, Mooncake, and Ascend registry URLs with ARG variables across 8 Dockerfiles. **All defaults are unchanged**, so builds behave identically when no build-args are passed.

## Changes (8 files)

`Dockerfile`, `Dockerfile.310p`, `Dockerfile.310p.openEuler`, `Dockerfile.a3`, `Dockerfile.a3.openEuler`, `Dockerfile.openEuler`, `Dockerfile.a5`, `Dockerfile.a5.openEuler`

| New ARG | Default (= original hardcoded value) |
|---|---|
| `PYTORCH_INDEX_URL` | `https://download.pytorch.org/whl/cpu/` |
| `MOONCAKE_INDEX_URL` | `https://mirrors.aliyun.com/pypi/web/simple` |
| `ASCEND_INDEX_URL` | `https://mirrors.huaweicloud.com/ascend/repos/pypi` |
| `APTMIRROR` | `""` (optional apt mirror substitution) |
| `GIT_PROXY` | `""` (optional git proxy prefix) |
| `PIP_TRUSTED_HOST` | `""` (optional pip trusted-host) |

## Behavior

- **No build-args** → identical to current behavior (defaults = original values)
- **With build-args** → override registry URLs / enable apt mirror / git proxy / pip trusted host (e.g. to use internal mirrors or caches)

## Not changed

- `FROM` base images, `CANN_VERSION`, `BASE_OS`, `VLLM_TAG`, all version numbers
- `BUILD_TYPE` conditional install logic, `CMD`/`ENTRYPOINT`, `COPY`
- Existing `CANN_QUAY_URL`, `PIP_INDEX_URL`, `VLLM_REPO` ARGs (still overridable via build-args)

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
