### PR TITLE
[Refactor][SFA] Remove unused SFA state and redundant branches

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -790,7 +790,6 @@ class TestAscendSFAImpl(TestBase):
         mock_tp,
     ):
         mock_tp.world_size = 1
-        mock_tp.rank_in_group = 0
         mock_tp.device_group = MagicMock()
 
         mock_enable_sp.return_value = False

--- a/tests/ut/attention/test_sfa_o_proj_tp.py
+++ b/tests/ut/attention/test_sfa_o_proj_tp.py
@@ -144,13 +144,15 @@ class TestAscendSFAOProjTPParams(TestBase):
         impl._store_parallel_kv = MagicMock(return_value=(None, None, None))
         impl._get_indexcache_topk_indices = MagicMock(return_value=MagicMock())
         impl._execute_sparse_flash_attention_process = MagicMock(return_value=MagicMock())
-        impl._v_up_proj = MagicMock(return_value=MagicMock())
+        attn_output = MagicMock()
+        impl._v_up_proj = MagicMock(return_value=attn_output)
         impl.o_proj = MagicMock()
 
         output = MagicMock()
+        finalized_output = MagicMock()
         kv_cache = (MagicMock(), MagicMock())
         impl._compose_sfa_kv_cache = MagicMock(return_value=kv_cache)
-        impl._finalize_o_proj = MagicMock(return_value=output)
+        impl._finalize_o_proj = MagicMock(return_value=finalized_output)
 
         attn_metadata = MagicMock()
         attn_metadata.dcp_context = None
@@ -179,7 +181,8 @@ class TestAscendSFAOProjTPParams(TestBase):
                 output=output,
             )
 
-        self.assertIs(result, output)
+        self.assertIs(result, finalized_output)
+        impl._finalize_o_proj.assert_called_once_with(attn_output, output, True)
         record_gate.assert_called_once_with()
         save_layer.assert_called_once_with(impl.layer_name, list(kv_cache))
         impl.o_proj.assert_not_called()

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -63,6 +63,7 @@ from vllm_ascend.utils import (
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+
     from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 # token count limits within bmm_transpose operator

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -7,7 +7,7 @@ import scipy  # type: ignore
 import torch
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
-from vllm.distributed import get_tensor_model_parallel_world_size, get_tp_group
+from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import MLACommonMetadataBuilder
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
@@ -60,10 +60,10 @@ from vllm_ascend.utils import (
     get_ascend_device_type,
     maybe_trans_nz,
 )
-from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
+    from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 
 # token count limits within bmm_transpose operator
 BMM_TRANS_MAX_SUPPORTED_TOKENS = 1024
@@ -224,10 +224,8 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             supports_dcp_with_varlen,
         )
 
-        self.block_size = vllm_config.cache_config.block_size
         # Match the logical block size selected for BlockTable.
         self.kernel_block_size = select_common_block_size(kv_cache_spec.block_size, [AscendSFABackend])
-        self.max_blocks = (vllm_config.model_config.max_model_len + self.block_size - 1) // self.block_size
 
         self.speculative_config = vllm_config.speculative_config
         self.decode_threshold = 1
@@ -254,7 +252,6 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
             ]
         self.reorder_batch_threshold = self.decode_threshold
         self.attn_mask_builder = AttentionMaskBuilder(self.device)
-        self.rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
 
     def _prepare_parallel_metadata(
         self,
@@ -450,10 +447,8 @@ class AscendSFAImpl(MLAAttentionImpl):
         **kwargs,
     ) -> None:
         self.num_heads = num_heads
-        self.head_size = head_size
         self.scale = float(scale)
         self.num_kv_heads = num_kv_heads
-        self.kv_cache_dtype = kv_cache_dtype
 
         # MLA Args
         self.q_lora_rank = kwargs["q_lora_rank"]
@@ -462,7 +457,6 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.qk_rope_head_dim = kwargs["qk_rope_head_dim"]
         self.qk_head_dim = kwargs["qk_head_dim"]
         self.v_head_dim = kwargs["v_head_dim"]
-        self.rotary_emb = kwargs["rotary_emb"]
         self.q_proj = kwargs["q_proj"] if self.q_lora_rank is None else kwargs["q_b_proj"]
         self.fused_qkv_a_proj = kwargs.get("fused_qkv_a_proj")
         self.kv_b_proj = kwargs["kv_b_proj"]
@@ -471,10 +465,7 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.kv_a_proj_with_mqa = kwargs.get("kv_a_proj_with_mqa")
         self.kv_a_layernorm = kwargs.get("kv_a_layernorm")
         self.q_a_layernorm = kwargs.get("q_a_layernorm")
-        self.num_queries_per_kv = self.num_heads // self.num_kv_heads
         self.tp_size = get_tensor_model_parallel_world_size()
-        self.tp_rank = get_tp_group().rank_in_group
-        self.q_b_proj = kwargs["q_b_proj"]
         self.skip_topk = kwargs.get("skip_topk", False)
         self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
 
@@ -494,11 +485,11 @@ class AscendSFAImpl(MLAAttentionImpl):
         hf_config = self.vllm_config.model_config.hf_config
         hf_text_config = getattr(self.vllm_config.model_config, "hf_text_config", None)
         config_candidates = (hf_config, hf_text_config)
-        self.index_cache_enabled = _get_config_bool(
+        index_cache_enabled = _get_config_bool(
             config_candidates,
             "use_index_cache",
         ) or _has_shared_indexer_layers(config_candidates)
-        self.use_index_cache = self.skip_topk or self.index_cache_enabled
+        self.use_index_cache = self.skip_topk or index_cache_enabled
         self.has_indexer = self.indexer is not None
         if not self.has_indexer and not self.skip_topk:
             raise ValueError(
@@ -524,7 +515,6 @@ class AscendSFAImpl(MLAAttentionImpl):
             self.wq_b = None
             self.wk_weights_proj = None
             self.k_norm = None
-        self.cp_size = 1
         self.is_rope_neox_style = True
         self.use_torch_npu_lightning_indexer = False
         if self.vllm_config.model_config.hf_config.model_type in ["glm_moe_dsa"]:
@@ -1503,7 +1493,6 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         # Inputs and outputs may be padded for CUDA graphs
         num_input_tokens = attn_metadata.num_input_tokens
-        output_padded = output
         parallel_context = self._get_parallel_forward_context(
             attn_metadata,
             num_input_tokens,
@@ -1620,10 +1609,10 @@ class AscendSFAImpl(MLAAttentionImpl):
                 parallel_context.gather_full_o_proj,
             )
 
-        if kv_cache is not None and self.is_kv_producer:
+        if self.is_kv_producer:
             attn_metadata.reshape_cache_event = torch.npu.Event()
 
-        if kv_cache is not None and self.has_indexer:
+        if self.has_indexer:
             assert k_li is not None
             use_li_c8_reshape_optim = self._use_li_c8_reshape_optim()
             dsa_k_cache_idx = self.kv_cache_indexer_k_idx
@@ -1646,27 +1635,26 @@ class AscendSFAImpl(MLAAttentionImpl):
                 )  # b, s, n, d
             if self.enable_sparse_li_c8:
                 assert len(kv_cache) == (3 if self.enable_sparse_sfa_c8 else 4)
-                if k_li_scale is not None:
-                    if use_li_c8_reshape_optim:
-                        torch.ops._C_ascend.store_kv_block(
-                            k_li_scale,
-                            kv_cache[dsa_k_scale_cache_idx],
-                            attn_metadata.group_len,
-                            attn_metadata.group_key_idx,
-                            attn_metadata.group_key_cache_idx,
-                            attn_metadata.block_size,
-                        )
-                    else:
-                        torch_npu.npu_scatter_nd_update_(
-                            kv_cache[dsa_k_scale_cache_idx].view(-1, k_li_scale.shape[-1]),
-                            slot_mapping.view(-1, 1),
-                            k_li_scale.view(-1, k_li_scale.shape[-1]),
-                        )
+                assert k_li_scale is not None
+                if use_li_c8_reshape_optim:
+                    torch.ops._C_ascend.store_kv_block(
+                        k_li_scale,
+                        kv_cache[dsa_k_scale_cache_idx],
+                        attn_metadata.group_len,
+                        attn_metadata.group_key_idx,
+                        attn_metadata.group_key_cache_idx,
+                        attn_metadata.block_size,
+                    )
+                else:
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[dsa_k_scale_cache_idx].view(-1, k_li_scale.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        k_li_scale.view(-1, k_li_scale.shape[-1]),
+                    )
         # Notify for every layer that wrote the cache, not just indexer layers:
         # by this point all of the layer's KV (main + indexer) has been
         # scattered, so the connector can dispatch the PD pull immediately.
-        if kv_cache is not None:
-            notify_kv_cache_written(self.layer_name or "")
+        notify_kv_cache_written(self.layer_name or "")
 
         # Open the prefetch gate for every SFA layer. Some GLM-5.2 layers
         # reuse cached top-k indices and have no indexer, so recording this
@@ -1712,7 +1700,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
-        return output_padded
+        return output
 
 
 def custom_kv_rmsnorm_rope(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes dead state and redundant control flow from the Ascend SFA implementation:

- removes unused metadata-builder state (`block_size`, `max_blocks`, and `rope_dim`);
- stops retaining unused implementation attributes while preserving the `MLAAttentionImpl` constructor contract;
- avoids the unused tensor-parallel rank lookup and moves the type-only `NPUInputBatch` import behind `TYPE_CHECKING`;
- simplifies KV-cache branches after the composed cache has already been asserted non-null;
- replaces the unreachable nullable LI C8 scale branch with an explicit invariant assertion;
- removes the redundant output alias and returns the result of `_finalize_o_proj` directly;
- updates SFA unit tests to remove the obsolete TP-rank mock and verify that `forward` propagates the finalized output.

These changes reduce stale state and make the existing SFA invariants and output contract explicit without changing the attention computation.

### Does this PR introduce _any_ user-facing change?

No. This is an internal refactor with no API, configuration, or inference behavior change.

### How was this patch tested?

- `git diff --check upstream/main...HEAD`
- `python -m py_compile vllm_ascend/attention/sfa_v1.py tests/ut/attention/a2/test_sfa_v1.py tests/ut/attention/test_sfa_o_proj_tp.py`

The NPU-dependent unit tests were not run locally because this workspace requires an Ascend remote container for `torch_npu` execution. The affected UT was updated to cover `_finalize_o_proj` return-value propagation.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
