### PR TITLE
[BugFix][Triton] fix rejection sampler when target_logits are NaN

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -230,10 +230,11 @@ class AscendRejectionSampler(RejectionSampler):
         if torch.isinf(target_logits).any():
             target_logits[target_logits == torch.inf] = info.max
             target_logits[target_logits == -torch.inf] = info.min
+            logger.warning("[sample/rejection_sampler] target_logits have infinite values.")
         nan_mask = torch.isnan(target_logits)
         if nan_mask.any():
             target_logits[nan_mask] = 0
-            logger.warning_once("[sample/rejection_sampler] target_logits have NaN.")
+            logger.warning("[sample/rejection_sampler] target_logits have NaN.")
 
         target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
         # [num_tokens, vocab_size]

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -225,6 +225,16 @@ class AscendRejectionSampler(RejectionSampler):
             # the original raw logits for logprobs computation, since
             # apply_logits_processors modifies the tensor in-place.
             target_logits = target_logits.clone()
+
+        info = torch.finfo(target_logits.dtype)
+        if torch.isinf(target_logits).any():
+            target_logits[target_logits == torch.inf] = info.max
+            target_logits[target_logits == -torch.inf] = info.min
+        nan_mask = torch.isnan(target_logits)
+        if nan_mask.any():
+            target_logits[nan_mask] = 0
+            logger.warning_once("[sample/rejection_sampler] target_logits have NaN.")
+
         target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -226,15 +226,17 @@ class AscendRejectionSampler(RejectionSampler):
             # apply_logits_processors modifies the tensor in-place.
             target_logits = target_logits.clone()
 
+        # Clean NaN/inf without introducing CPU sync.
+        # torch.nan_to_num is a pure element-wise op that replaces
+        # NaN/±inf in a single pass, avoiding the .any()/.item() sync
+        # triggered by `if tensor.any()` branches. No-op when clean.
         info = torch.finfo(target_logits.dtype)
-        if torch.isinf(target_logits).any():
-            target_logits[target_logits == torch.inf] = info.max
-            target_logits[target_logits == -torch.inf] = info.min
-            logger.warning("[sample/rejection_sampler] target_logits have infinite values.")
-        nan_mask = torch.isnan(target_logits)
-        if nan_mask.any():
-            target_logits[nan_mask] = 0
-            logger.warning("[sample/rejection_sampler] target_logits have NaN.")
+        target_logits = torch.nan_to_num(
+            target_logits,
+            nan=0.0,
+            posinf=info.max,
+            neginf=info.min,
+        )
 
         target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
         # [num_tokens, vocab_size]


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes an issue in the rejection sampler where `target_logits` containing `NaN` or `Inf` values could cause errors or incorrect sampling. It cleans up `NaN` and `Inf` values in `target_logits` before applying logits processors.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
