### PR TITLE
[Feature][Attention] Add UpdatableGraph FIA demo

### DIFF
--- a/vllm_ascend/attention/attention.py
+++ b/vllm_ascend/attention/attention.py
@@ -120,8 +120,8 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
 class FIARuntimeParameterProvider:
     layer_name: str
 
-    def resolve(self, forward_context) -> dict[str, Any]:
-        metadata = forward_context.attn_metadata[self.layer_name]
+    def resolve(self, attn_metadata) -> dict[str, Any]:
+        metadata = attn_metadata[self.layer_name]
         return {
             "actual_seq_lengths": metadata.query_start_loc,
             "actual_seq_lengths_kv": metadata.seq_lens,

--- a/vllm_ascend/attention/attention.py
+++ b/vllm_ascend/attention/attention.py
@@ -26,7 +26,13 @@ from vllm_ascend.attention.utils import (
 )
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
-from vllm_ascend.worker.v2.updatable_graph import register_task
+from vllm_ascend.worker.v2.updatable_graph import (
+    get_capture_resource,
+    register_task,
+)
+
+
+_FIA_WORKSPACE_KEY = "npu_fused_infer_attention_score.workspace"
 
 
 @dataclass
@@ -210,20 +216,23 @@ class AscendAttentionBackendImpl(AttentionImpl):
         value = value_cache.view(num_blocks, block_size, -1)
 
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
-        workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
-            query=query,
-            key=key,
-            value=value,
-            atten_mask=attn_metadata.attn_mask,
-            block_table=attn_metadata.block_table,
-            input_layout="TND",
-            block_size=block_size,
-            actual_seq_lengths=attn_metadata.query_start_loc,
-            actual_seq_lengths_kv=attn_metadata.seq_lens,
-            num_key_value_heads=self.num_kv_heads,
-            num_heads=self.num_heads,
-            scale=self.scale,
-            sparse_mode=3,
+        workspace = get_capture_resource(
+            _FIA_WORKSPACE_KEY,
+            lambda: torch_npu._npu_fused_infer_attention_score_get_max_workspace(
+                query=query,
+                key=key,
+                value=value,
+                atten_mask=attn_metadata.attn_mask,
+                block_table=attn_metadata.block_table,
+                input_layout="TND",
+                block_size=block_size,
+                actual_seq_lengths=attn_metadata.query_start_loc,
+                actual_seq_lengths_kv=attn_metadata.seq_lens,
+                num_key_value_heads=self.num_kv_heads,
+                num_heads=self.num_heads,
+                scale=self.scale,
+                sparse_mode=3,
+            ),
         )
         register_task(
             torch_npu.npu_fused_infer_attention_score.out,

--- a/vllm_ascend/attention/attention.py
+++ b/vllm_ascend/attention/attention.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+import torch
+import torch_npu
+from vllm.config import VllmConfig
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionImpl,
+    AttentionLayer,
+    AttentionMetadataBuilder,
+)
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_cache_interface import AttentionSpec
+
+from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
+from vllm_ascend.attention.utils import (
+    AscendCommonAttentionMetadata,
+    notify_kv_cache_written,
+)
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
+from vllm_ascend.worker.v2.updatable_graph import register_task
+
+
+@dataclass
+class AscendMetadata:
+    attn_mask: torch.Tensor | None = None
+    num_actual_tokens: int = 0
+    seq_lens: list[int] = None
+    query_start_loc: list[int] = None
+    block_table: torch.Tensor = None
+
+
+class AscendAttentionBackend(AttentionBackend):
+    accept_output_buffer = True
+    forward_includes_kv_cache_update = False
+
+    @staticmethod
+    def get_name() -> str:
+        return "CUSTOM"
+
+    @staticmethod
+    def get_impl_cls() -> type["AscendAttentionBackendImpl"]:
+        return AscendAttentionBackendImpl
+
+    @staticmethod
+    def get_builder_cls() -> type["AscendAttentionMetadataBuilder"]:
+        return AscendAttentionMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "",
+    ) -> tuple[int, ...]:
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        return [128]
+
+
+class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
+    reorder_batch_threshold = 1
+    metadata_cls = AscendMetadata
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.model_config = vllm_config.model_config
+        self.max_num_blocks_per_req = cdiv(
+            self.model_config.max_model_len,
+            AscendAttentionBackend.get_supported_kernel_block_sizes()[0],
+        )
+        self.attn_mask_builder = AttentionMaskBuilder(device)
+
+    @classmethod
+    def get_cudagraph_support(
+        cls,
+        vllm_config: VllmConfig,
+        kv_cache_spec: AttentionSpec,
+    ) -> AttentionCGSupport:
+        return AttentionCGSupport.ALWAYS
+
+    def reorder_batch(self, input_batch, scheduler_output: SchedulerOutput) -> bool:
+        return False
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> AscendMetadata:
+        return AscendMetadata(
+            attn_mask=self.attn_mask_builder.get_attention_mask(
+                common_attn_metadata.causal, self.model_config
+            ),
+            num_actual_tokens=common_attn_metadata.num_actual_tokens,
+            seq_lens=common_attn_metadata.seq_lens_list,
+            query_start_loc=common_attn_metadata.query_start_loc_list,
+            block_table=common_attn_metadata.block_table_tensor,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FIARuntimeParameterProvider:
+    layer_name: str
+
+    def resolve(self, forward_context) -> dict[str, Any]:
+        metadata = forward_context.attn_metadata[self.layer_name]
+        return {
+            "actual_seq_lengths": metadata.query_start_loc,
+            "actual_seq_lengths_kv": metadata.seq_lens,
+        }
+
+
+class AscendAttentionBackendImpl(AttentionImpl):
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None,
+        attn_type: str,
+        kv_sharing_target_layer_name: str | None,
+        **kwargs,
+    ) -> None:
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = float(scale)
+        self.num_kv_heads = num_heads if num_kv_heads is None else num_kv_heads
+        self.kv_cache_dtype = kv_cache_dtype
+        self.attn_type = attn_type
+        if alibi_slopes is not None:
+            self.alibi_slopes = torch.tensor(
+                alibi_slopes, dtype=torch.float32, device="npu"
+            )
+        else:
+            self.alibi_slopes = None
+
+    def do_kv_cache_update(
+        self,
+        layer: AttentionLayer,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        DeviceOperator.reshape_and_cache(
+            key=key,
+            value=value,
+            key_cache=kv_cache[0],
+            value_cache=kv_cache[1],
+            slot_mapping=slot_mapping,
+        )
+        notify_kv_cache_written()
+
+    def forward(
+        self,
+        layer: AttentionLayer,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: AscendMetadata | None,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        assert output is not None
+        assert output_scale is None and output_block_scale is None
+        if attn_metadata is None:
+            return output.fill_(0)
+
+        record_attention_compute_start()
+        query = query[: attn_metadata.num_actual_tokens]
+        output_view = output[: attn_metadata.num_actual_tokens]
+        key_cache, value_cache = kv_cache[0], kv_cache[1]
+        num_blocks, block_size, _, _ = key_cache.shape
+        key = key_cache.view(num_blocks, block_size, -1)
+        value = value_cache.view(num_blocks, block_size, -1)
+
+        softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
+        workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
+            query=query,
+            key=key,
+            value=value,
+            atten_mask=attn_metadata.attn_mask,
+            block_table=attn_metadata.block_table,
+            input_layout="TND",
+            block_size=block_size,
+            actual_seq_lengths=attn_metadata.query_start_loc,
+            actual_seq_lengths_kv=attn_metadata.seq_lens,
+            num_key_value_heads=self.num_kv_heads,
+            num_heads=self.num_heads,
+            scale=self.scale,
+            sparse_mode=3,
+        )
+        register_task(
+            torch_npu.npu_fused_infer_attention_score.out,
+            {
+                "query": query,
+                "key": key,
+                "value": value,
+                "atten_mask": attn_metadata.attn_mask,
+                "block_table": attn_metadata.block_table,
+                "input_layout": "TND",
+                "block_size": block_size,
+                "actual_seq_lengths": attn_metadata.query_start_loc,
+                "actual_seq_lengths_kv": attn_metadata.seq_lens,
+                "num_key_value_heads": self.num_kv_heads,
+                "num_heads": self.num_heads,
+                "scale": self.scale,
+                "sparse_mode": 3,
+                "workspace": workspace,
+                "out": [output_view, softmax_lse],
+            },
+            FIARuntimeParameterProvider(layer.layer_name),
+        )
+        return output

--- a/vllm_ascend/attention/attention.py
+++ b/vllm_ascend/attention/attention.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import torch
 import torch_npu
-from vllm.config import VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -81,6 +81,14 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         device: torch.device,
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
+        # FIA uses host-side sequence-length lists. Eager draft decode must
+        # rebuild metadata for every step, while full graphs update each
+        # captured FIA task through UpdatableGraph.
+        self.supports_draft_decode_metadata_update = (
+            cudagraph_mode is not None
+            and cudagraph_mode.decode_mode() == CUDAGraphMode.FULL
+        )
         self.model_config = vllm_config.model_config
         self.max_num_blocks_per_req = cdiv(
             self.model_config.max_model_len,
@@ -115,9 +123,12 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             block_table=common_attn_metadata.block_table_tensor,
         )
 
+    def update_draft_decode_metadata(self, metadata: AscendMetadata) -> None:
+        pass
+
 
 @dataclass(frozen=True, slots=True)
-class FIARuntimeParameterProvider:
+class FIAParamProvider:
     layer_name: str
 
     def resolve(self, attn_metadata) -> dict[str, Any]:
@@ -233,6 +244,6 @@ class AscendAttentionBackendImpl(AttentionImpl):
                 "workspace": workspace,
                 "out": [output_view, softmax_lse],
             },
-            FIARuntimeParameterProvider(layer.layer_name),
+            FIAParamProvider(layer.layer_name),
         )
         return output

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -32,10 +32,6 @@ from vllm.v1.attention.backend import (  # type: ignore
     AttentionMetadataBuilder,
     AttentionType,
 )
-from vllm.v1.attention.backends.registry import (  # type: ignore
-    AttentionBackendEnum,
-    register_backend,
-)
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import AttentionSpec, CrossAttentionSpec
 
@@ -68,7 +64,6 @@ SWA_INT_MAX = 2147483647
 _ATTN_KEYS_BUFFER = None
 
 
-@register_backend(AttentionBackendEnum.CUSTOM, "ASCEND")
 class AscendAttentionBackend(AttentionBackend):
     accept_output_buffer: bool = True
 

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -229,6 +229,9 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
     # E.g., [1, 1, 1, 128] for 3 decode tokens and 1 prefill with 128 tokens.
     actual_seq_lengths_q: list[int] = field(default_factory=list)
 
+    query_start_loc_list: list[int] = field(default_factory=list)
+    seq_lens_list: list[int] = field(default_factory=list)
+
     # NPU tensor of position indices for rotary embeddings computation.
     # E.g., tensor([0, 1, 2, ...]) indicating token positions in sequence.
     positions: torch.Tensor = None
@@ -277,6 +280,8 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
             slot_mapping=self.slot_mapping,
             causal=self.causal,
             actual_seq_lengths_q=self.actual_seq_lengths_q[:num_actual_tokens],
+            query_start_loc_list=self.query_start_loc_list[:num_actual_reqs],
+            seq_lens_list=self.seq_lens_list[:num_actual_reqs],
             positions=self.positions,
             positions_cpu=self.positions_cpu,
             attn_state=self.attn_state,

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -222,7 +222,7 @@ class NPUPlatform(Platform):
 
         backend_map = {
             (True, False, False): "vllm_ascend.attention.mla_v1.AscendMLABackend",
-            (False, False, False): "vllm_ascend.attention.attention_v1.AscendAttentionBackend",
+            (False, False, False): "vllm_ascend.attention.attention.AscendAttentionBackend",
             (True, True, False): "vllm_ascend.attention.sfa_v1.AscendSFABackend",
             (True, False, True): "vllm_ascend.attention.dsa_v1.AscendDSABackend",
         }

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -940,12 +940,10 @@ def weak_ref_tensor(tensor: Any) -> Any:
         return tensor
 
 
-def weak_ref_tensors(
-    tensors: torch.Tensor | list[torch.Tensor] | tuple[torch.Tensor],
-) -> torch.Tensor | list[Any] | tuple[Any] | Any:
+def weak_ref_tensors(tensors: Any) -> Any:
     """
-    Convenience function to create weak references to tensors,
-    for single tensor, list of tensors or tuple of tensors.
+    Recursively replace tensors with weak references while preserving containers
+    and non-tensor values.
 
     This function should be used in the following scenario:
     When a tensor is created during graph capture, and it's held by a method
@@ -957,14 +955,16 @@ def weak_ref_tensors(
     if isinstance(tensors, torch.Tensor):
         return weak_ref_tensor(tensors)
     if isinstance(tensors, list):
-        return [weak_ref_tensor(t) for t in tensors]
+        return [weak_ref_tensors(tensor) for tensor in tensors]
     if isinstance(tensors, tuple):
-        return tuple(weak_ref_tensor(t) for t in tensors)
-    # For IntermediateTensors used in pipeline parallelism
+        return tuple(weak_ref_tensors(tensor) for tensor in tensors)
+    if isinstance(tensors, dict):
+        return {
+            key: weak_ref_tensors(tensor) for key, tensor in tensors.items()
+        }
     if isinstance(tensors, IntermediateTensors):
-        ret = IntermediateTensors({key: weak_ref_tensor(val) for key, val in tensors.tensors.items()})
-        return ret
-    raise ValueError("Invalid type for tensors")
+        return IntermediateTensors(weak_ref_tensors(tensors.tensors))
+    return tensors
 
 
 def npu_stream_switch(target_stream: torch.npu.Stream, *, enabled: bool = True):

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -36,7 +36,7 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.worker.v2.updatable_graph import UpdatableGraph
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -90,17 +90,10 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         self.model_runner = model_runner
         # Reuse the public update_stream from model_runner (shared with draft).
         self.update_stream = self.model_runner.update_stream
-        # The attention backend keys its per-size graph params by the actual
-        # captured token counts (rounded up to decode_query_len when using
-        # speculative decoding), so derive them from the capture descriptors
-        # instead of the raw config sizes.
-        self.capture_sizes = collect_sorted_captured_token_sizes(self._capture_descs)
-        # vllm-ascend need to update graph params of attention backend.
-        # so we need to set graph params before capture full graph.
-        if super().needs_capture():
-            set_graph_params(self.capture_sizes)
 
-    def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
+    def run_fullgraph(
+        self, desc: BatchExecutionDescriptor
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
         """Override run_fullgraph to update full graph params in run_fullgraph."""
         num_tokens = desc.num_tokens
         logger.info_once("run_fullgraph with num_tokens=%s", num_tokens)
@@ -108,8 +101,6 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 
-        # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
-        # calculate num_tokens_across_dp.
         num_tokens_across_dp = torch.full([self.model_runner.dp_size], num_tokens)
         with (
             set_current_vllm_config(self.vllm_config),
@@ -124,16 +115,9 @@ class ModelAclGraphManager(ModelCudaGraphManager):
             ),
         ):
             forward_context = get_forward_context()
-            attn_backend = _get_graph_update_backend(self.model_runner.attn_groups)
-            update_full_graph_params(
-                # FIXME(Ronald1995): support hybrid attn backend
-                attn_backend,
-                self.update_stream,
-                forward_context,
-                num_tokens,
-                self.vllm_config,
-                self.model_runner.speculative_config,
-            )
+            graph = self.graphs[desc]
+            assert isinstance(graph, UpdatableGraph)
+            graph.update(self.update_stream, forward_context)
         return ret
 
     def capture(

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -24,7 +24,6 @@ import torch
 import torch.nn as nn
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.config.compilation import CUDAGraphMode
-from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionBackend
@@ -94,30 +93,20 @@ class ModelAclGraphManager(ModelCudaGraphManager):
     def run_fullgraph(
         self, desc: BatchExecutionDescriptor
     ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]] | IntermediateTensors:
-        """Override run_fullgraph to update full graph params in run_fullgraph."""
+        """Replay a full graph and update its registered tasks."""
         num_tokens = desc.num_tokens
         logger.info_once("run_fullgraph with num_tokens=%s", num_tokens)
         assert self.update_stream is not None
+        graph = self.graphs[desc]
+        assert isinstance(graph, UpdatableGraph)
+        # Resolve every provider before replay so a provider failure cannot
+        # leave the graph blocked on an update event that will never be recorded.
+        resolved_tasks = graph.resolve_tasks(
+            self.model_runner.model_state.attn_metadata
+        )
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
-
-        num_tokens_across_dp = torch.full([self.model_runner.dp_size], num_tokens)
-        with (
-            set_current_vllm_config(self.vllm_config),
-            set_forward_context(
-                self.model_runner.model_state.attn_metadata,
-                self.vllm_config,
-                num_tokens=num_tokens,
-                cudagraph_runtime_mode=desc.cg_mode,
-                num_tokens_across_dp=num_tokens_across_dp,
-                batch_descriptor=None,  # Full graph model don't need batch_descriptor
-                slot_mapping=None,
-            ),
-        ):
-            forward_context = get_forward_context()
-            graph = self.graphs[desc]
-            assert isinstance(graph, UpdatableGraph)
-            graph.update(self.update_stream, forward_context)
+        graph.update(self.update_stream, resolved_tasks)
         return ret
 
     def capture(

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -35,7 +35,10 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.worker.v2.updatable_graph import UpdatableGraph
+from vllm_ascend.worker.v2.updatable_graph import (
+    ContextSource,
+    UpdatableGraph,
+)
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -102,7 +105,7 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         # Resolve every provider before replay so a provider failure cannot
         # leave the graph blocked on an update event that will never be recorded.
         resolved_tasks = graph.resolve_tasks(
-            self.model_runner.model_state.attn_metadata
+            ContextSource(self.model_runner.model_state.attn_metadata)
         )
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -172,6 +172,7 @@ def build_attn_metadata(
     kv_cache_config: KVCacheConfig,
     dcp_local_seq_lens: torch.Tensor | None = None,
     # extra attributes for ascend npus.
+    query_start_loc_np: np.ndarray | None = None,
     seq_lens_np: np.ndarray | None = None,
     seq_lens_cpu_upper_bound: torch.Tensor | None = None,
     num_computed_tokens_cpu: torch.Tensor | None = None,
@@ -194,6 +195,12 @@ def build_attn_metadata(
     seq_lens_cpu = torch.from_numpy(seq_lens_np)[:num_reqs]
     if seq_lens_cpu_upper_bound is None:
         seq_lens_cpu_upper_bound = seq_lens_cpu
+    query_start_loc_list = (
+        query_start_loc_np[1 : num_reqs + 1].tolist()
+        if query_start_loc_np is not None
+        else query_start_loc_cpu[1 : num_reqs + 1].tolist()
+    )
+    seq_lens_list = seq_lens_np[:num_reqs].tolist()
 
     # Upstream speculative-decoding callers do not provide Ascend's separate
     # scheduled-token and padded-input-token counts. Without these fields,
@@ -236,6 +243,8 @@ def build_attn_metadata(
             num_input_tokens=num_input_tokens,
             max_seq_len=max_seq_len,
             causal=group_causal,
+            query_start_loc_list=query_start_loc_list,
+            seq_lens_list=seq_lens_list,
             **common_attn_metadata_extra_kwargs,
         )
 

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -409,7 +409,7 @@ class NPUModelRunner(GPUModelRunner):
         seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
 
         # Pad for full CUDA graph mode.
-        self.input_buffers.seq_lens_np[num_reqs_padded:] = 0
+        self.input_buffers.seq_lens_np[num_reqs:] = 0
 
         # Some input token ids are directly read from the last sampled tokens
         # and draft tokens. Also, get the logits indices to sample tokens from.

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -73,6 +73,7 @@ class AscendModelState(DefaultModelState):
             kv_cache_config=kv_cache_config,
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
             # extra attributes for ascend npus.
+            query_start_loc_np=input_batch.query_start_loc_np,
             seq_lens_np=input_batch.seq_lens_np,
             positions=input_batch.positions,
             attn_state=input_batch.attn_state,

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -16,53 +16,21 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
-import logging
+
 from contextlib import contextmanager
-from copy import copy
-from typing import Any, cast
+from typing import Any
 
 import torch
-import vllm.v1.worker.gpu.spec_decode.speculator as vllm_speculator
-from vllm.config import VllmConfig, get_layers_from_vllm_config
+from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
-from vllm.v1.attention.backend import AttentionBackend
-from vllm.v1.kv_cache_interface import KVCacheConfig
-from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
-from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
-from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import AutoRegressiveSpeculator
-from vllm.v1.worker.utils import AttentionGroup
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
+    AutoRegressiveSpeculator,
+)
 
-from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
-from vllm_ascend.attention.dsa_v1 import AscendDSABackend
-from vllm_ascend.attention.mla_v1 import AscendMLABackend
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata_wrapper
 from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
-
-logger = logging.getLogger(__name__)
-
-
-@contextmanager
-def build_draft_attn_metadata_factory(positions, pad):
-    """Wrap build_attn_metadata to forward MLA rotary positions for the block.
-
-    MLA reads positions inside build_decode_metadata for cos/sin; the flat
-    super() path doesn't forward them. Must run inside build_attn_metadata_wrapper().
-    TODO:This field is removed when the external cos/sin solution is removed from the MLA.
-    """
-    raw = vllm_speculator.build_attn_metadata  # cache
-
-    def build_attn_metadata(*args, **kwargs):
-        kwargs["positions"] = positions[:pad]
-        return raw(*args, **kwargs)
-
-    try:
-        vllm_speculator.build_attn_metadata = build_attn_metadata
-        yield
-    finally:
-        vllm_speculator.build_attn_metadata = raw  # restore
 
 
 class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
@@ -78,7 +46,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
     and skips the generic MLA/GQA init and update logic.
     """
 
-    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+    def __init__(self, vllm_config: VllmConfig, device: torch.device) -> None:
         """Override the upstream __init__ for Ascend NPUs.
 
         Ascend attention-metadata building needs more information (e.g.
@@ -86,8 +54,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         AscendInputBuffers after super().__init__.
         """
         super().__init__(vllm_config, device)
-
-        self.attn_architecture: str | None = None
 
         del self.input_buffers
         # AscendInputBuffers has extra `seq_lens_cpu` attribute.
@@ -97,21 +63,14 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             max_num_tokens=self.max_num_tokens,
             device=device,
         )
-
-        # add more attributes for `input_buffers` in graph mode
-        cudagraph_mode = self.vllm_config.compilation_config.cudagraph_mode
-        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
-            self.input_buffers.draft_seq_lens_cpus = [
-                torch.zeros(self.max_num_reqs, dtype=torch.int32, device="cpu")
-                for _ in range(self.num_speculative_steps - 1)
-            ]
-
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         super().init_cudagraph_manager(cudagraph_mode)
+        assert self.prefill_cudagraph_manager is not None
+        assert self.decode_cudagraph_manager is not None
         # The Ascend graph managers are patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.
         # They need this speculator to update full-graph params, so set it here.
@@ -145,8 +104,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         dummy_run: bool = False,
         skip_attn_for_dummy_run: bool = False,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
-        is_profile: Any = None,
-    ):
+        is_profile: bool = False,
+    ) -> torch.Tensor:
         """Override GPU EagleSpeculator.propose for Ascend NPUs,
         because npu attention metadata needs more information,
         we need to cache input_batch, so we can use it later in
@@ -175,293 +134,62 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 is_profile=is_profile,
             )
 
-    def set_attn(
-        self,
-        model_state: ModelState,
-        kv_cache_config: KVCacheConfig,
-        block_tables: BlockTables,
-        target_input_buffers: InputBuffers,
-        target_attn_groups: list[list[AttentionGroup]],
-    ) -> None:
-        super().set_attn(
-            model_state,
-            kv_cache_config,
-            block_tables,
-            target_input_buffers,
-            target_attn_groups,
-        )
-
-        # npu needs attn_backends to update graph params
-        attn_backends: dict[str, type[AttentionBackend]] = {}
-
-        active_layer_names = self.draft_attn_layer_names
-        for kv_cache_group_id, kv_cache_group_spec in enumerate(kv_cache_config.kv_cache_groups):
-            layer_names = kv_cache_group_spec.layer_names
-            if active_layer_names is not None:
-                layer_names = list(active_layer_names.intersection(layer_names))
-
-            layer_type = cast(type[Any], AttentionLayerBase)
-            attn_layers = get_layers_from_vllm_config(self.vllm_config, layer_type, layer_names)
-
-            for layer_name in layer_names:
-                attn_backend = attn_layers[layer_name].get_attn_backend()
-                attn_backends[layer_name] = attn_backend
-
-        self.attn_backends = attn_backends
-        first_attn_backend = list(self.attn_backends.values())[0]
-        if issubclass(first_attn_backend, AscendDSABackend):
-            self.attn_architecture = "DSA"
-        elif issubclass(first_attn_backend, AscendMLABackend):
-            self.attn_architecture = "MLA"
-        elif issubclass(first_attn_backend, AscendAttentionBackend):
-            self.attn_architecture = "GQA"
-        else:
-            raise ValueError(f"Unsupported attention backend: {first_attn_backend}")
-
-    def capture(self) -> None:
-        logger.info("Capturing model for speculator...")
-        # Reset indices to zeros to prevent stale values from prior
-        # dummy runs to cause out-of-bounds indexing during capture.
-        self.last_token_indices.zero_()
-
-        # Capture the prefill routine (model forward + compute_logits +
-        # sample).
-        # For FULL graphs, the entire routine is recorded as one graph.
-        # For PIECEWISE, only the model's compiled regions are captured
-        # and the rest (compute_logits, gumbel_sample) runs eagerly.
-        assert self.prefill_cudagraph_manager is not None
-        if self.prefill_cudagraph_manager.use_breakable_cg:
-            self.prefill_cudagraph_manager.init_breakable_cg_runner(self.model)
-        self.prefill_cudagraph_manager.capture(
-            self._prefill,
-            self.model_state,
-            self.target_input_buffers,
-            self.block_tables,
-            self.target_attn_groups,
-            self.kv_cache_config,
-            progress_bar_desc="Capturing prefill CUDA graphs",
-        )
-
-        if self.num_speculative_steps == 1:
-            return
-
-        # Capture all decode draft generation steps as a single graph.
-        assert self.decode_cudagraph_manager is not None
-        with build_attn_metadata_wrapper():
-            self.decode_cudagraph_manager.capture(
-                self._multi_step_decode,
-                self.model_state,
-                self.input_buffers,
-                self.block_tables,
-                self.attn_groups,
-                self.kv_cache_config,
-                progress_bar_desc="Capturing decode CUDA graphs",
-            )
-
-    @torch.inference_mode()
-    def _run_model(
-        self,
-        num_tokens: int,
-        attn_metadata: dict[str, Any] | None,
-        slot_mappings: dict[str, torch.Tensor] | None,
-        num_tokens_across_dp: torch.Tensor | None,
-        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-        mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
-    ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Override AutoRegressiveSpeculator._run_model for Ascend NPUs."""
-        last_hidden_states, hidden_states = super()._run_model(
-            num_tokens,
-            attn_metadata,
-            slot_mappings,
-            num_tokens_across_dp,
-            cudagraph_runtime_mode,
-            mm_inputs,
-        )
-        self._ascend_update_seq_lens(attn_metadata)
-        return last_hidden_states, hidden_states
-
-    def _generate_draft(
-        self,
-        num_reqs: int,
-        num_tokens_padded: int,
-        attn_metadata: dict[str, Any] | None,
-        slot_mappings: dict[str, torch.Tensor] | None,
-        num_tokens_across_dp: torch.Tensor | None,
-        cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
-    ) -> None:
-        """Thin override: delegate to upstream single-step ``_generate_draft``,
-        then apply Ascend-specific attention-metadata updates required by the
-        FIA operator."""
-        super()._generate_draft(
-            num_reqs,
-            num_tokens_padded,
-            attn_metadata,
-            slot_mappings,
-            num_tokens_across_dp,
-            cudagraph_runtime_mode,
-        )
-        if attn_metadata is not None:
-            self._update_decode_attn_metadata(attn_metadata, 1, num_reqs)
-
-    def _multi_step_decode(  # type: ignore[misc]
+    def _fused_multi_step_decode(
         self,
         num_reqs: int,
         skip_attn: bool,
         batch_desc: BatchExecutionDescriptor,
         num_tokens_across_dp: torch.Tensor | None,
-        seq_lens_cpu_upper_bound: torch.Tensor | None = None,
-    ) -> None:
-        """Minimal override to handle the merged multi-step graph in FULL mode.
-
-        In FULL mode the captured graph already contains all speculative
-        steps, so ``run_fullgraph`` is called once instead of once per
-        step.  For PIECEWISE / NONE modes we delegate to the upstream
-        ``_multi_step_decode`` which iterates over steps and calls
-        ``_generate_draft`` per step.
-        """
-        if batch_desc.cg_mode == CUDAGraphMode.FULL:
-            assert self.decode_cudagraph_manager is not None
-            self.decode_cudagraph_manager.run_fullgraph(batch_desc)
-            return
-        super()._multi_step_decode(num_reqs, skip_attn, batch_desc, num_tokens_across_dp, seq_lens_cpu_upper_bound)
-
-    def _build_draft_attn_metadata(  # type: ignore[misc]
-        self,
-        num_reqs: int,
-        num_reqs_padded: int,
-        num_tokens_padded: int,
         seq_lens_cpu_upper_bound: torch.Tensor,
-        step: int,
-        num_query_per_req: int = 1,
-        causal: bool = True,
-    ) -> dict[str, Any] | None:
-        with build_draft_attn_metadata_factory(self.input_buffers.positions, num_tokens_padded):
-            attn_metadata = super()._build_draft_attn_metadata(
-                num_reqs,
-                num_reqs_padded,
-                num_tokens_padded,
-                seq_lens_cpu_upper_bound,
-                step,
-                num_query_per_req,
-                causal,
-            )
-        if attn_metadata is not None:
-            # Ascend-specific: force DecodeOnly attention state for the draft model.
-            for metadata in attn_metadata.values():
-                metadata.attn_state = AscendAttentionState.DecodeOnly
-        return attn_metadata
+    ) -> None:
+        assert skip_attn or batch_desc.cg_mode == CUDAGraphMode.FULL, (
+            "Ascend fused draft decode requires a captured FULL graph, but "
+            f"got {batch_desc.cg_mode.name}. Ensure cudagraph_capture_sizes "
+            "covers this draft decode batch size."
+        )
+        super()._fused_multi_step_decode(
+            num_reqs,
+            skip_attn,
+            batch_desc,
+            num_tokens_across_dp,
+            seq_lens_cpu_upper_bound,
+        )
 
-    def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
-        """Build draft_attn_metadatas for partial-merged draft graph."""
-        attn_metadata = self.model_state.attn_metadata
-        attn_metadata = {
-            name: metadata for name, metadata in attn_metadata.items() if name in self.draft_attn_layer_names
-        }
-
+    def build_fia_params(
+        self,
+        num_reqs_padded: int,
+        is_draft_model_prefill: bool,
+    ) -> list[dict[str, Any]]:
         if is_draft_model_prefill:
-            return [attn_metadata]
-
-        draft_attn_metadatas = self._init_decode_draft_attn_metadatas(attn_metadata, num_reqs_padded)
-
-        for i, per_step_attn_metadata in enumerate(draft_attn_metadatas):
-            step = i + 1
-            assert self.input_batch is not None
-            self._update_decode_attn_metadata(per_step_attn_metadata, step, self.input_batch.num_reqs)
-
-        return draft_attn_metadatas
-
-    def _ascend_update_seq_lens(self, attn_metadata: dict[str, Any] | None) -> None:
-        if attn_metadata is not None:
-            for attn_meta in attn_metadata.values():
-                attn_meta.seq_lens = attn_meta.seq_lens + 1
-                attn_meta.seq_len_list = attn_meta.seq_lens.tolist()
-
-    def _init_decode_draft_attn_metadatas(self, attn_metadata: dict[str, Any] | None, num_reqs_padded: int):
-        """Initialize per-step decode attention metadata for graph mode."""
-        if attn_metadata is None:
-            return
-
-        # DSA owns its per-step slot mapping, SAS, and QLI state in the DSA
-        # metadata builder and does not use draft graph metadata updates.
-        if self.attn_architecture == "DSA":
-            return []
-
-        # TODO: _build_draft_attn_metadata pulls data (seq_lens, block_table,
-        # ...) from input_buffers internally; future may pass these as CPU
-        # params directly to build_attn_metadata, decoupling from input_buffers.
-        if self.attn_architecture == "MLA":
-            assert self.input_batch is not None
-            attn_metadata = self._build_draft_attn_metadata(  # type: ignore[call-arg]
-                num_reqs=self.input_batch.num_reqs,
-                num_reqs_padded=num_reqs_padded,
-                num_tokens_padded=num_reqs_padded,  # decode: 1 token/req
-                seq_lens_cpu_upper_bound=self.input_batch.seq_lens_cpu_upper_bound,
-                step=1,
+            metadata = next(
+                metadata
+                for layer_name, metadata in self.model_state.attn_metadata.items()
+                if layer_name in self.draft_attn_layer_names
             )
-            if attn_metadata is None:
-                return
+            return [
+                {
+                    "actual_seq_lengths": metadata.query_start_loc,
+                    "actual_seq_lengths_kv": metadata.seq_lens,
+                }
+            ]
 
-        attn_state = AscendAttentionState.DecodeOnly
-
-        draft_attn_metadatas = []
-        # attn_metadata is build in vllm's super class.
-        # We need to update attn_state for each layer's metadata.
-        for seq_lens_cpu in self.input_buffers.draft_seq_lens_cpus:
-            per_step_attn_metadata = {k: copy(v) for k, v in attn_metadata.items()}
-
-            seq_lens_cpu = seq_lens_cpu[:num_reqs_padded]
-            for metadata in per_step_attn_metadata.values():
-                metadata.attn_state = attn_state
-                metadata.seq_lens_cpu = seq_lens_cpu
-                if self.attn_architecture == "MLA":
-                    # clone .decode so per-step seq_lens_list writes don't alias.
-                    metadata.decode = copy(metadata.decode)
-            draft_attn_metadatas.append(per_step_attn_metadata)
-
-        return draft_attn_metadatas
-
-    def _update_decode_attn_metadata(
-        self, attn_metadata: dict[str, Any] | None, step: int, num_reqs: int | None = None
-    ):
-        """Update per-step decode attention metadata on Ascend."""
-        if attn_metadata is None:
-            return
-
-        if self.attn_architecture == "DSA":
-            return
-
-        attn_meta = next(iter(attn_metadata.values()))
-        num_reqs_padded = attn_meta.seq_lens_cpu.shape[0]
-        seq_lens_cpu = self._get_seq_lens_cpu()[:num_reqs_padded]
-        if num_reqs is None:
-            num_reqs = num_reqs_padded
-        next_seq_lens_cpu = self._calc_next_seq_lens_cpu(seq_lens_cpu, num_reqs, num_reqs_padded, step)
-
-        query_lens_list = [i for i in range(1, num_reqs_padded + 1)]
-        seq_lens_list = next_seq_lens_cpu.tolist()
-        for metadata in attn_metadata.values():
-            if self.attn_architecture == "MLA":
-                decode_metadata = metadata.decode
-            else:
-                decode_metadata = metadata
-            decode_metadata.seq_lens_list = seq_lens_list
-            decode_metadata.actual_seq_lengths_q = query_lens_list
-            metadata.seq_lens_cpu.copy_(next_seq_lens_cpu)
-
-    def _calc_next_seq_lens_cpu(self, seq_lens_cpu, num_reqs, num_reqs_padded, step):
-        # NOTE(drslark) to achieve fully alignment with vllm, `num_rejected` should be subtracted from `seq_lens`
-        # to avoid extra sync overhead, `v2` is currently aligned with NPU `v1` only
-
-        # follows the logic in `prepare_eagle_decode` and `update_eagle_inputs`
-        next_seqs_cpu = torch.clamp(seq_lens_cpu[:num_reqs_padded] + step, max=self.max_model_len)
-        next_seqs_cpu[num_reqs:].fill_(0)
-        return next_seqs_cpu
-
-    def _get_seq_lens_cpu(self) -> torch.Tensor:
-        """Get seq_lens_cpu from input_batch."""
         assert self.input_batch is not None
-        seq_lens_cpu = torch.from_numpy(self.input_batch.seq_lens_np)
-        return seq_lens_cpu
+        num_reqs = self.input_batch.num_reqs
+        query_start_loc = list(range(1, num_reqs_padded + 1))
+        fia_params: list[dict[str, Any]] = []
+        for step in range(1, self.num_speculative_steps):
+            seq_lens = [
+                min(int(seq_len) + step, self.max_model_len)
+                for seq_len in self.input_batch.seq_lens_np[:num_reqs]
+            ]
+            seq_lens.extend([0] * (num_reqs_padded - num_reqs))
+            fia_params.append(
+                {
+                    "actual_seq_lengths": query_start_loc,
+                    "actual_seq_lengths_kv": seq_lens,
+                }
+            )
+        return fia_params
 
 
 # TODO Remove this patch when cann fix the gather bug.

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -1,32 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
 from collections.abc import Callable
 from typing import Any
 
 import torch
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.forward_context import get_forward_context, set_forward_context
-from vllm.logger import logger
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cudagraph_utils import (
-    BatchExecutionDescriptor,
-    CudaGraphManager,
-    prepare_inputs_to_capture,
-)
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import SpeculatorCudaGraphManager
+from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
+    SpeculatorCudaGraphManager,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.compilation.acl_graph import (
-    set_draft_graph_params,
-    set_draft_graph_prefill_params,
-    update_full_graph_params,
+from vllm_ascend.worker.v2.aclgraph_utils import model_capture_wrapper
+from vllm_ascend.worker.v2.updatable_graph import (
+    SharedSource,
+    UpdatableGraph,
 )
-from vllm_ascend.worker.v2.aclgraph_utils import collect_sorted_captured_token_sizes, model_capture_wrapper
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -40,7 +35,7 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
         cudagraph_mode: CUDAGraphMode,
         decode_query_len: int,
         lora_capture_cases: list[int] | None = None,
-    ):
+    ) -> None:
         super().__init__(
             vllm_config,
             device,
@@ -53,20 +48,7 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
         # when call `run_fullgraph` method in CudaGraphManager,
         # then we don't need to # copy `propose` method in `AscendEagleSpeculator` class.
         self.speculator: Any = None
-        # The attention backend keys its per-size graph params by the actual
-        # captured token counts (rounded up to decode_query_len when using
-        # speculative decoding), so derive them from the capture descriptors
-        # instead of the raw config sizes.
-        self.capture_sizes = collect_sorted_captured_token_sizes(self._capture_descs)
-        # vllm-ascend need to update draft graph params of attention backend.
-        # so we need to set draft graph params before capture full graph.
-        # `prefill` graph and `decodes` graph are different, `decode_query_len` can be used to distinguish them
         self.is_draft_model_prefill = decode_query_len > 1
-        if super().needs_capture():
-            if self.is_draft_model_prefill:
-                set_draft_graph_prefill_params(self.capture_sizes)
-            else:
-                set_draft_graph_params(self.capture_sizes)
 
     def capture(
         self,
@@ -80,87 +62,35 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
     ) -> None:
         """Capture ACL graphs for Eagle."""
 
-        with communicator_switch(), model_capture_wrapper(self.speculator, self.is_draft_model_prefill):
-            if self.is_draft_model_prefill:
-                super().capture(
-                    forward_fn,
-                    model_state,
-                    input_buffers,
-                    block_tables,
-                    attn_groups,
-                    kv_cache_config,
-                    progress_bar_desc=progress_bar_desc,
-                )
-                return
-
-            def create_forward_fn(desc: BatchExecutionDescriptor, warmup: bool):
-                num_tokens = desc.num_tokens
-                num_reqs = desc.num_reqs or min(num_tokens, self.max_num_reqs)
-                num_tokens_across_dp = (
-                    torch.full((self.dp_size,), num_tokens, dtype=torch.int32, device="cpu")
-                    if self.dp_size > 1
-                    else None
-                )
-                prepare_inputs_to_capture(
-                    num_reqs,
-                    num_tokens,
-                    model_state,
-                    input_buffers,
-                    block_tables,
-                    attn_groups,
-                    kv_cache_config,
-                    full_cudagraph=(desc.cg_mode == CUDAGraphMode.FULL),
-                )
-                seq_lens_cpu_upper_bound = input_buffers.seq_lens_cpu[:num_reqs]
-                return lambda cg_mode: forward_fn(
-                    num_reqs,
-                    cg_mode == CUDAGraphMode.PIECEWISE,
-                    BatchExecutionDescriptor(cg_mode=cg_mode, num_tokens=num_tokens, num_reqs=num_reqs),
-                    num_tokens_across_dp,
-                    seq_lens_cpu_upper_bound,
-                )
-
-            CudaGraphManager.capture(self, create_forward_fn, progress_bar_desc=progress_bar_desc)
-
-    def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
-        """Override run_fullgraph to update full graph params in run_fullgraph."""
-        num_tokens = desc.num_tokens
-        if self.is_draft_model_prefill:
-            logger.info_once("PrefillEagleAclGraphManager: draft prefill run_fullgraph with num_tokens=%s", num_tokens)
-        else:
-            logger.info_once("DecodeEagleAclGraphManager: draft run_fullgraph with num_tokens=%s", num_tokens)
-
-        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(desc.num_reqs, self.is_draft_model_prefill)
-        self.update_stream.wait_stream(torch.npu.current_stream())
-        ret = super().run_fullgraph(desc)
-
-        # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
-        # calculate num_tokens_across_dp.
-        num_tokens_across_dp = torch.full([self.speculator.dp_size], num_tokens)
-        with set_forward_context(
-            self.speculator.model_state.attn_metadata,
-            self.vllm_config,
-            num_tokens=num_tokens,
-            cudagraph_runtime_mode=desc.cg_mode,
-            num_tokens_across_dp=num_tokens_across_dp,
-            batch_descriptor=None,  # Full graph model don't need batch_descriptor
-            slot_mapping=None,
+        with communicator_switch(), model_capture_wrapper(
+            self.speculator,
+            self.is_draft_model_prefill,
         ):
-            # decide to update draft graph params
-            _EXTRA_CTX.is_draft_model = True
-
-            # decide to run `prefill` graph or `decodes` graph
-            _EXTRA_CTX.is_draft_model_prefill = self.is_draft_model_prefill
-
-            forward_context = get_forward_context()
-            update_full_graph_params(
-                # FIXME(Ronald1995): support hybrid attn backend
-                list(self.speculator.attn_backends.values())[0],
-                self.update_stream,
-                forward_context,
-                num_tokens,
-                self.vllm_config,
-                self.speculator.speculative_config,
-                draft_attn_metadatas=draft_attn_metadatas,
+            super().capture(
+                forward_fn,
+                model_state,
+                input_buffers,
+                block_tables,
+                attn_groups,
+                kv_cache_config,
+                progress_bar_desc=progress_bar_desc,
             )
-        return ret
+
+    def run_fullgraph(
+        self,
+        desc: BatchExecutionDescriptor,
+    ) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
+        """Override run_fullgraph to update full graph params in run_fullgraph."""
+        graph = self.graphs[desc]
+        assert isinstance(graph, UpdatableGraph)
+        fia_params = self.speculator.build_fia_params(
+            desc.num_reqs,
+            self.is_draft_model_prefill,
+        )
+        resolved_tasks = graph.resolve_tasks(SharedSource(fia_params))
+
+        assert self.update_stream is not None
+        self.update_stream.wait_stream(torch.npu.current_stream())
+        output = super().run_fullgraph(desc)
+        graph.update(self.update_stream, resolved_tasks)
+        return output

--- a/vllm_ascend/worker/v2/updatable_graph.py
+++ b/vllm_ascend/worker/v2/updatable_graph.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
@@ -11,8 +11,40 @@ import torch
 from vllm_ascend.utils import weak_ref_tensors
 
 
-class RuntimeParameterProvider(Protocol):
-    def resolve(self, runtime_context) -> dict[str, Any]: ...
+Params = dict[str, Any]
+
+
+class ParamProvider(Protocol):
+    def resolve(self, context) -> Params: ...
+
+
+class ParamSource(Protocol):
+    def get(
+        self,
+        provider: ParamProvider,
+    ) -> Sequence[Params]: ...
+
+
+@dataclass(frozen=True, slots=True)
+class ContextSource:
+    context: Any
+
+    def get(
+        self,
+        provider: ParamProvider,
+    ) -> Sequence[Params]:
+        return (provider.resolve(self.context),)
+
+
+@dataclass(frozen=True, slots=True)
+class SharedSource:
+    params: Sequence[Params]
+
+    def get(
+        self,
+        _provider: ParamProvider,
+    ) -> Sequence[Params]:
+        return self.params
 
 
 _ACTIVE_GRAPH: ContextVar["UpdatableGraph | None"] = ContextVar(
@@ -24,12 +56,13 @@ _ACTIVE_GRAPH: ContextVar["UpdatableGraph | None"] = ContextVar(
 class GraphUpdateTask:
     operation: Callable[..., Any]
     kwargs: dict[str, Any]
-    provider: RuntimeParameterProvider
+    provider: ParamProvider
+    provider_index: int
     handle: Any
     event: Any
 
-    def resolve(self, runtime_context) -> "GraphUpdateTask":
-        runtime_kwargs = {**self.kwargs, **self.provider.resolve(runtime_context)}
+    def bind(self, params: Params) -> "GraphUpdateTask":
+        runtime_kwargs = {**self.kwargs, **params}
         return replace(self, kwargs=runtime_kwargs)
 
     def apply(self, update_stream) -> None:
@@ -43,6 +76,7 @@ class UpdatableGraph(torch.npu.NPUGraph):
     def __init__(self) -> None:
         super().__init__()
         self.tasks: list[GraphUpdateTask] = []
+        self.provider_sizes: dict[ParamProvider, int] = {}
         self.capture_token: Token[UpdatableGraph | None] | None = None
 
     def capture_begin(self, pool=None, capture_error_mode: str = "global") -> None:
@@ -62,7 +96,7 @@ class UpdatableGraph(torch.npu.NPUGraph):
         self,
         operation: Callable[..., Any],
         kwargs: dict[str, Any],
-        provider: RuntimeParameterProvider,
+        provider: ParamProvider,
     ) -> None:
         stream = torch.npu.current_stream()
         event = torch.npu.ExternalEvent()
@@ -72,12 +106,32 @@ class UpdatableGraph(torch.npu.NPUGraph):
         operation(**kwargs)
         handle = torch.npu.graph_task_group_end(stream)
         weak_kwargs = weak_ref_tensors(kwargs)
+        provider_index = self.provider_sizes.get(provider, 0)
+        self.provider_sizes[provider] = provider_index + 1
         self.tasks.append(
-            GraphUpdateTask(operation, weak_kwargs, provider, handle, event)
+            GraphUpdateTask(
+                operation,
+                weak_kwargs,
+                provider,
+                provider_index,
+                handle,
+                event,
+            )
         )
 
-    def resolve_tasks(self, runtime_context) -> tuple[GraphUpdateTask, ...]:
-        return tuple(task.resolve(runtime_context) for task in self.tasks)
+    def resolve_tasks(
+        self,
+        source: ParamSource,
+    ) -> tuple[GraphUpdateTask, ...]:
+        params_by_provider = {
+            provider: source.get(provider) for provider in self.provider_sizes
+        }
+        for provider, size in self.provider_sizes.items():
+            assert len(params_by_provider[provider]) == size
+        return tuple(
+            task.bind(params_by_provider[task.provider][task.provider_index])
+            for task in self.tasks
+        )
 
     def update(
         self,
@@ -92,7 +146,7 @@ class UpdatableGraph(torch.npu.NPUGraph):
 def register_task(
     operation: Callable[..., Any],
     kwargs: dict[str, Any],
-    provider: RuntimeParameterProvider,
+    provider: ParamProvider,
 ) -> None:
     graph = _ACTIVE_GRAPH.get()
     if graph is None:

--- a/vllm_ascend/worker/v2/updatable_graph.py
+++ b/vllm_ascend/worker/v2/updatable_graph.py
@@ -2,9 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 from collections.abc import Callable
-from contextlib import contextmanager
-from contextvars import ContextVar
-from dataclasses import dataclass
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, replace
 from typing import Any, Protocol
 
 import torch
@@ -13,7 +12,7 @@ from vllm_ascend.utils import weak_ref_tensors
 
 
 class RuntimeParameterProvider(Protocol):
-    def resolve(self, forward_context) -> dict[str, Any]: ...
+    def resolve(self, runtime_context) -> dict[str, Any]: ...
 
 
 _ACTIVE_GRAPH: ContextVar["UpdatableGraph | None"] = ContextVar(
@@ -29,10 +28,13 @@ class GraphUpdateTask:
     handle: Any
     event: Any
 
-    def update(self, update_stream, forward_context) -> None:
-        runtime_kwargs = {**self.kwargs, **self.provider.resolve(forward_context)}
+    def resolve(self, runtime_context) -> "GraphUpdateTask":
+        runtime_kwargs = {**self.kwargs, **self.provider.resolve(runtime_context)}
+        return replace(self, kwargs=runtime_kwargs)
+
+    def apply(self, update_stream) -> None:
         torch.npu.graph_task_update_begin(update_stream, self.handle)
-        self.operation(**runtime_kwargs)
+        self.operation(**self.kwargs)
         torch.npu.graph_task_update_end(update_stream)
         self.event.record(update_stream)
 
@@ -40,7 +42,21 @@ class GraphUpdateTask:
 class UpdatableGraph(torch.npu.NPUGraph):
     def __init__(self) -> None:
         super().__init__()
-        self.update_tasks: list[GraphUpdateTask] = []
+        self.tasks: list[GraphUpdateTask] = []
+        self.capture_token: Token[UpdatableGraph | None] | None = None
+
+    def capture_begin(self, pool=None, capture_error_mode: str = "global") -> None:
+        super().capture_begin(pool=pool, capture_error_mode=capture_error_mode)
+        assert self.capture_token is None
+        self.capture_token = _ACTIVE_GRAPH.set(self)
+
+    def capture_end(self) -> None:
+        try:
+            super().capture_end()
+        finally:
+            assert self.capture_token is not None
+            _ACTIVE_GRAPH.reset(self.capture_token)
+            self.capture_token = None
 
     def register_task(
         self,
@@ -56,23 +72,21 @@ class UpdatableGraph(torch.npu.NPUGraph):
         operation(**kwargs)
         handle = torch.npu.graph_task_group_end(stream)
         weak_kwargs = weak_ref_tensors(kwargs)
-        self.update_tasks.append(
+        self.tasks.append(
             GraphUpdateTask(operation, weak_kwargs, provider, handle, event)
         )
 
-    def update(self, update_stream, forward_context) -> None:
+    def resolve_tasks(self, runtime_context) -> tuple[GraphUpdateTask, ...]:
+        return tuple(task.resolve(runtime_context) for task in self.tasks)
+
+    def update(
+        self,
+        update_stream,
+        resolved_tasks: tuple[GraphUpdateTask, ...],
+    ) -> None:
         with torch.npu.stream(update_stream):
-            for task in self.update_tasks:
-                task.update(update_stream, forward_context)
-
-
-@contextmanager
-def capture_updatable_graph(graph: UpdatableGraph):
-    token = _ACTIVE_GRAPH.set(graph)
-    try:
-        yield
-    finally:
-        _ACTIVE_GRAPH.reset(token)
+            for task in resolved_tasks:
+                task.apply(update_stream)
 
 
 def register_task(

--- a/vllm_ascend/worker/v2/updatable_graph.py
+++ b/vllm_ascend/worker/v2/updatable_graph.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+import torch
+
+from vllm_ascend.utils import weak_ref_tensors
+
+
+class RuntimeParameterProvider(Protocol):
+    def resolve(self, forward_context) -> dict[str, Any]: ...
+
+
+_ACTIVE_GRAPH: ContextVar["UpdatableGraph | None"] = ContextVar(
+    "capturing_updatable_graph", default=None
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GraphUpdateTask:
+    operation: Callable[..., Any]
+    kwargs: dict[str, Any]
+    provider: RuntimeParameterProvider
+    handle: Any
+    event: Any
+
+    def update(self, update_stream, forward_context) -> None:
+        runtime_kwargs = {**self.kwargs, **self.provider.resolve(forward_context)}
+        torch.npu.graph_task_update_begin(update_stream, self.handle)
+        self.operation(**runtime_kwargs)
+        torch.npu.graph_task_update_end(update_stream)
+        self.event.record(update_stream)
+
+
+class UpdatableGraph(torch.npu.NPUGraph):
+    def __init__(self) -> None:
+        super().__init__()
+        self.update_tasks: list[GraphUpdateTask] = []
+
+    def register_task(
+        self,
+        operation: Callable[..., Any],
+        kwargs: dict[str, Any],
+        provider: RuntimeParameterProvider,
+    ) -> None:
+        stream = torch.npu.current_stream()
+        event = torch.npu.ExternalEvent()
+        event.wait(stream)
+        event.reset(stream)
+        torch.npu.graph_task_group_begin(stream)
+        operation(**kwargs)
+        handle = torch.npu.graph_task_group_end(stream)
+        weak_kwargs = weak_ref_tensors(kwargs)
+        self.update_tasks.append(
+            GraphUpdateTask(operation, weak_kwargs, provider, handle, event)
+        )
+
+    def update(self, update_stream, forward_context) -> None:
+        with torch.npu.stream(update_stream):
+            for task in self.update_tasks:
+                task.update(update_stream, forward_context)
+
+
+@contextmanager
+def capture_updatable_graph(graph: UpdatableGraph):
+    token = _ACTIVE_GRAPH.set(graph)
+    try:
+        yield
+    finally:
+        _ACTIVE_GRAPH.reset(token)
+
+
+def register_task(
+    operation: Callable[..., Any],
+    kwargs: dict[str, Any],
+    provider: RuntimeParameterProvider,
+) -> None:
+    graph = _ACTIVE_GRAPH.get()
+    if graph is None:
+        operation(**kwargs)
+    else:
+        graph.register_task(operation, kwargs, provider)

--- a/vllm_ascend/worker/v2/updatable_graph.py
+++ b/vllm_ascend/worker/v2/updatable_graph.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Hashable, Sequence
 from contextvars import ContextVar, Token
 from dataclasses import dataclass, replace
 from typing import Any, Protocol
@@ -77,6 +77,7 @@ class UpdatableGraph(torch.npu.NPUGraph):
         super().__init__()
         self.tasks: list[GraphUpdateTask] = []
         self.provider_sizes: dict[ParamProvider, int] = {}
+        self.capture_resources: dict[Hashable, Any] = {}
         self.capture_token: Token[UpdatableGraph | None] | None = None
 
     def capture_begin(self, pool=None, capture_error_mode: str = "global") -> None:
@@ -91,6 +92,16 @@ class UpdatableGraph(torch.npu.NPUGraph):
             assert self.capture_token is not None
             _ACTIVE_GRAPH.reset(self.capture_token)
             self.capture_token = None
+            self.capture_resources = weak_ref_tensors(self.capture_resources)
+
+    def get_capture_resource(
+        self,
+        key: Hashable,
+        factory: Callable[[], Any],
+    ) -> Any:
+        if key not in self.capture_resources:
+            self.capture_resources[key] = factory()
+        return self.capture_resources[key]
 
     def register_task(
         self,
@@ -153,3 +164,13 @@ def register_task(
         operation(**kwargs)
     else:
         graph.register_task(operation, kwargs, provider)
+
+
+def get_capture_resource(
+    key: Hashable,
+    factory: Callable[[], Any],
+) -> Any:
+    graph = _ACTIVE_GRAPH.get()
+    if graph is None:
+        return factory()
+    return graph.get_capture_resource(key, factory)

--- a/vllm_ascend/worker/v2/utils.py
+++ b/vllm_ascend/worker/v2/utils.py
@@ -4,7 +4,7 @@ import torch
 from vllm.logger import logger
 
 from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params, weak_ref_workspaces
-from vllm_ascend.worker.v2.updatable_graph import UpdatableGraph, capture_updatable_graph
+from vllm_ascend.worker.v2.updatable_graph import UpdatableGraph
 
 
 @contextmanager
@@ -51,10 +51,8 @@ def torch_npu_graph_wrapper(*args, **kwargs):
     # manager's exit to weak-ref graph workspaces after each capture,
     # without adding another upstream monkey patch.
     try:
-        graph = args[0]
-        with capture_updatable_graph(graph):
-            with torch.npu.graph(*args, **kwargs):
-                yield
+        with torch.npu.graph(*args, **kwargs):
+            yield
     finally:
         weak_ref_workspaces(get_graph_params())
         weak_ref_workspaces(get_draft_graph_params())

--- a/vllm_ascend/worker/v2/utils.py
+++ b/vllm_ascend/worker/v2/utils.py
@@ -4,6 +4,7 @@ import torch
 from vllm.logger import logger
 
 from vllm_ascend.compilation.acl_graph import get_draft_graph_params, get_graph_params, weak_ref_workspaces
+from vllm_ascend.worker.v2.updatable_graph import UpdatableGraph, capture_updatable_graph
 
 
 @contextmanager
@@ -15,7 +16,7 @@ def torch_cuda_wrapper():
         torch.cuda.default_stream = torch.npu.default_stream
         torch.cuda.current_stream = torch.npu.current_stream
         torch.cuda.graph_pool_handle = torch.npu.graph_pool_handle
-        torch.cuda.CUDAGraph = torch.npu.NPUGraph
+        torch.cuda.CUDAGraph = UpdatableGraph
         torch.cuda.graph = torch_npu_graph_wrapper
         torch.cuda.synchronize = torch.npu.synchronize
         torch.cuda.set_stream = torch.npu.set_stream
@@ -50,8 +51,10 @@ def torch_npu_graph_wrapper(*args, **kwargs):
     # manager's exit to weak-ref graph workspaces after each capture,
     # without adding another upstream monkey patch.
     try:
-        with torch.npu.graph(*args, **kwargs):
-            yield
+        graph = args[0]
+        with capture_updatable_graph(graph):
+            with torch.npu.graph(*args, **kwargs):
+                yield
     finally:
         weak_ref_workspaces(get_graph_params())
         weak_ref_workspaces(get_draft_graph_params())


### PR DESCRIPTION
### What this PR does / why we need it?

Implements a Qwen3-0.6B-only MRV2 demo for the UpdatableGraph design discussed in #13058.

- Adds a standalone FIA backend.
- Registers FIA capture/update tasks on UpdatableGraph.
- Reuses the upstream full-graph replay flow.

This is an experimental demo, not a formal or general-purpose solution.

### Does this PR introduce _any_ user-facing change?

No. The implementation is intentionally limited to the demo scope.

### How was this patch tested?

Static validation only: Python syntax compilation and diff checks. Runtime inference was not tested because the environment is still being installed; no tests were added for this demo.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
