### PR TITLE
[Feature] Support per-channel W4A8 shared experts and mixed W8A8 fallback

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -16,6 +16,8 @@ from vllm_ascend.ops.fused_moe.fused_moe import (
     make_eplb_placement_config,
     use_multistage_eplb_load,
 )
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.quant_type import QuantType
 
 
@@ -438,7 +440,8 @@ def test_unquantized_shared_situ_uses_split_bf16_path(monkeypatch):
     runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
 
 
-def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
+@pytest.mark.parametrize("routed_quant_type", [QuantType.W8A8, QuantType.W4A8])
+def test_per_channel_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch, routed_quant_type):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)
     hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
@@ -452,15 +455,24 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     gate_up_proj.weight = torch.ones(4, 4, dtype=torch.int8)
     gate_up_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
     gate_up_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
+    gate_up_proj.quant_method = SimpleNamespace(
+        quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod)
+    )
     down_proj = MagicMock()
     down_proj.weight = torch.ones(2, 4, dtype=torch.int8)
     down_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
+    down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
+    down_proj.quant_method = SimpleNamespace(
+        quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod)
+    )
     runner._shared_experts = SimpleNamespace(
         gate_up_proj=gate_up_proj,
         down_proj=down_proj,
         act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
     )
-    runner.quant_type = QuantType.W4A8
+    # The routed MoE may remain W4A8 while the shared expert falls back to
+    # W8A8. Dispatch must follow the shared projections' concrete schemes.
+    runner.quant_type = routed_quant_type
     runner.multistream_overlap_shared_expert = False
     stream = MagicMock()
     events = fused_moe_module.FusedMoEEvents(
@@ -498,12 +510,154 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     down_proj.assert_not_called()
     fast_dynamic_quant.assert_called_once_with(hidden_states)
     assert fast_quant_matmul.call_count == 2
+    gate_up_call = fast_quant_matmul.call_args_list[0]
+    assert gate_up_call.args == (quantized_input, gate_up_proj.weight, gate_up_proj.weight_scale)
+    assert gate_up_call.kwargs["pertoken_scale"] is None
+    assert gate_up_call.kwargs["output_dtype"] == torch.int32
     situ_call = custom_ops.dequant_situ_quant.call_args.kwargs
     assert situ_call["x"] is gate_up
     assert situ_call["weight_scale"] is gate_up_proj.weight_scale_fp32
     assert situ_call["activation_scale"] is input_scale
     assert situ_call["beta"] == 4.0
     assert situ_call["linear_beta"] == 25.0
+    down_call = fast_quant_matmul.call_args_list[1]
+    assert down_call.args == (quantized_situ, down_proj.weight, down_proj.weight_scale)
+    assert down_call.kwargs["pertoken_scale"] is situ_scale
+    assert down_call.kwargs["output_dtype"] == hidden_states.dtype
+
+
+def test_per_channel_w4a8_shared_situ_uses_single_expert_gmm_fusion(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    quantized_input = torch.ones(2, 4, dtype=torch.int8)
+    input_scale = torch.ones(2, dtype=torch.float32)
+    quantized_situ = torch.ones(2, 4, dtype=torch.int8)
+    situ_scale = torch.ones(2, dtype=torch.float32)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up_proj = MagicMock(return_value=(gate_up, None))
+    gate_up_proj.weight_scale = torch.ones(8, dtype=torch.int64)
+    gate_up_proj.weight_scale_fp32 = torch.ones(8, dtype=torch.float32)
+    gate_up_proj.quant_method = SimpleNamespace(
+        quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod)
+    )
+    down_proj = MagicMock(return_value=(down_out, None))
+    down_proj.weight_scale = torch.ones(4, dtype=torch.int64)
+    down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
+    down_proj.quant_method = SimpleNamespace(
+        quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod)
+    )
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=gate_up_proj,
+        down_proj=down_proj,
+        act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
+    )
+    runner._shared_experts_part1 = MagicMock()
+    runner._shared_experts_part2 = MagicMock()
+    runner.quant_type = QuantType.W4A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        after_routed_experts=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    quant_matmul = MagicMock()
+    dynamic_quant = MagicMock(return_value=(quantized_input, input_scale))
+    custom_ops = SimpleNamespace(
+        dequant_situ_quant=MagicMock(return_value=(quantized_situ, situ_scale)),
+    )
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_quant_matmul", quant_matmul)
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_dynamic_quant", dynamic_quant, raising=False)
+    monkeypatch.setattr(fused_moe_module.torch.ops, "_C_ascend", custom_ops)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    assert output is down_out
+    dynamic_quant.assert_called_once_with(hidden_states)
+    gate_up_proj.assert_called_once()
+    gate_quantized, gate_scale = gate_up_proj.call_args.args[0]
+    assert gate_quantized is quantized_input
+    assert gate_scale is input_scale
+    situ_call = custom_ops.dequant_situ_quant.call_args.kwargs
+    assert situ_call["x"] is gate_up
+    assert situ_call["weight_scale"] is None
+    assert situ_call["activation_scale"] is None
+    assert situ_call["beta"] == 4.0
+    assert situ_call["linear_beta"] == 25.0
+    down_proj.assert_called_once()
+    down_quantized, down_scale = down_proj.call_args.args[0]
+    assert down_quantized is quantized_situ
+    assert down_scale is situ_scale
+    runner._shared_experts_part1.assert_not_called()
+    runner._shared_experts_part2.assert_not_called()
+    quant_matmul.assert_not_called()
+
+
+def test_per_group_w4a8_shared_experts_use_quantized_linear_path(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(weight_scale=torch.ones(1)),
+        down_proj=SimpleNamespace(weight_scale=torch.ones(1)),
+        act_fn=nn.Identity(),
+    )
+    runner._shared_experts_part1 = MagicMock(return_value=gate_up)
+    runner._shared_experts_part2 = MagicMock(return_value=down_out)
+    runner.quant_type = QuantType.W4A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    quant_matmul = MagicMock()
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_quant_matmul", quant_matmul)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    assert output is down_out
+    runner._shared_experts_part1.assert_called_once_with(hidden_states)
+    runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
+    quant_matmul.assert_not_called()
 
 
 @pytest.mark.parametrize("quant_type", [QuantType.W4A8MXFP, QuantType.W8A8MXFP])

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -455,16 +455,12 @@ def test_per_channel_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch, route
     gate_up_proj.weight = torch.ones(4, 4, dtype=torch.int8)
     gate_up_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
     gate_up_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
-    gate_up_proj.quant_method = SimpleNamespace(
-        quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod)
-    )
+    gate_up_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod))
     down_proj = MagicMock()
     down_proj.weight = torch.ones(2, 4, dtype=torch.int8)
     down_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
     down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
-    down_proj.quant_method = SimpleNamespace(
-        quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod)
-    )
+    down_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod))
     runner._shared_experts = SimpleNamespace(
         gate_up_proj=gate_up_proj,
         down_proj=down_proj,
@@ -539,15 +535,11 @@ def test_per_channel_w4a8_shared_situ_uses_single_expert_gmm_fusion(monkeypatch)
     gate_up_proj = MagicMock(return_value=(gate_up, None))
     gate_up_proj.weight_scale = torch.ones(8, dtype=torch.int64)
     gate_up_proj.weight_scale_fp32 = torch.ones(8, dtype=torch.float32)
-    gate_up_proj.quant_method = SimpleNamespace(
-        quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod)
-    )
+    gate_up_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod))
     down_proj = MagicMock(return_value=(down_out, None))
     down_proj.weight_scale = torch.ones(4, dtype=torch.int64)
     down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
-    down_proj.quant_method = SimpleNamespace(
-        quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod)
-    )
+    down_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod))
     runner._shared_experts = SimpleNamespace(
         gate_up_proj=gate_up_proj,
         down_proj=down_proj,

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import regex as re

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import regex as re
@@ -53,6 +54,183 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         params = self.method.get_pergroup_param(8, 32, torch.bfloat16, layer_type="row")
         self.assertEqual(params["scale_bias"].dtype, torch.float32)
         self.assertEqual(params["scale_bias"].shape, (32, 16))
+
+    def test_per_channel_weight_uses_only_first_level_scale(self):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16)
+
+        self.assertEqual(params["weight_scale"].shape, (32, 1))
+        self.assertEqual(params["weight_offset"].shape, (32, 1))
+        self.assertNotIn("weight_scale_second", params)
+        self.assertNotIn("weight_offset_second", params)
+        self.assertEqual(params["scale_bias"].shape, (32, 1))
+
+    @patch("torch_npu.npu_quant_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_weight_uses_per_token_activation_scale(self, mock_dynamic_quant, mock_matmul):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(8, 4, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.bfloat16), requires_grad=False)
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        mock_dynamic_quant.return_value = (quantized_x, pertoken_scale)
+        mock_matmul.return_value = torch.empty(2, 8, dtype=torch.bfloat16)
+
+        self.method.apply(layer, x)
+
+        mock_dynamic_quant.assert_called_once_with(x)
+        self.assertEqual(mock_matmul.call_args.args, (quantized_x, layer.weight, layer.weight_scale))
+        self.assertIs(mock_matmul.call_args.kwargs["pertoken_scale"], pertoken_scale)
+        self.assertEqual(mock_matmul.call_args.kwargs["output_dtype"], x.dtype)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_shared_expert_uses_w4a8_grouped_matmul(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.is_per_channel_weight = True
+        self.method.enable_shared_expert_grouped_matmul()
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.arange(8, dtype=torch.float32), requires_grad=False)
+        x = torch.randn(2, 1, 4, dtype=torch.bfloat16)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        expected_2d = torch.empty(2, 8, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (quantized_x, pertoken_scale)
+        mock_grouped_matmul.return_value = [expected_2d]
+
+        # A host-backed ``torch.tensor(..., device="npu")`` is illegal during
+        # ACL Graph capture. Keep this unit test sensitive to that regression;
+        # the implementation should create group_list with a device fill op.
+        with patch(
+            "torch.tensor",
+            side_effect=AssertionError("host tensor construction is not graph-safe"),
+        ):
+            output = self.method.apply(layer, x)
+
+        self.assertEqual(output.shape, (2, 1, 8))
+        mock_dynamic_quant.assert_called_once()
+        torch.testing.assert_close(mock_dynamic_quant.call_args.args[0], x.reshape(2, 4))
+        mock_grouped_matmul.assert_called_once()
+        call = mock_grouped_matmul.call_args.kwargs
+        self.assertIs(call["x"][0], quantized_x)
+        self.assertIs(call["weight"][0], layer.weight)
+        torch.testing.assert_close(call["scale"][0], layer.weight_scale.reshape(1, 1, -1))
+        torch.testing.assert_close(call["bias"][0], layer.scale_bias.reshape(1, -1))
+        self.assertIs(call["per_token_scale"][0], pertoken_scale)
+        torch.testing.assert_close(call["group_list"], torch.tensor([2]))
+        self.assertEqual(call["split_item"], 2)
+        self.assertEqual(call["group_type"], 0)
+        self.assertEqual(call["group_list_type"], 1)
+        self.assertEqual(call["output_dtype"], x.dtype)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_shared_expert_reuses_quantized_input(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.is_per_channel_weight = True
+        self.method.enable_shared_expert_grouped_matmul()
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.arange(8, dtype=torch.float32), requires_grad=False)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        expected = torch.empty(2, 8, dtype=torch.bfloat16)
+        mock_grouped_matmul.return_value = [expected]
+
+        output = self.method.apply(layer, (quantized_x, pertoken_scale))
+
+        self.assertEqual(output.shape, expected.shape)
+        torch.testing.assert_close(output, expected)
+        mock_dynamic_quant.assert_not_called()
+        call = mock_grouped_matmul.call_args.kwargs
+        self.assertIs(call["x"][0], quantized_x)
+        self.assertIs(call["per_token_scale"][0], pertoken_scale)
+        self.assertEqual(call["output_dtype"], torch.bfloat16)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_shared_expert_sums_owned_tp_scale_bias(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.is_per_channel_weight = True
+        self.method.enable_shared_expert_grouped_matmul()
+        layer = torch.nn.Module()
+        layer.tp_size = 4
+        layer.tp_rank = 3
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(
+            torch.arange(8 * 16, dtype=torch.float32).reshape(8, 16),
+            requires_grad=False,
+        )
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (
+            torch.ones(2, 4, dtype=torch.int8),
+            torch.ones(2, dtype=torch.float32),
+        )
+        mock_grouped_matmul.return_value = [torch.empty(2, 8)]
+
+        self.method.apply(layer, x, tp_rank=3)
+
+        grouped_bias = mock_grouped_matmul.call_args.kwargs["bias"][0]
+        torch.testing.assert_close(grouped_bias, layer.scale_bias[:, 12:16].sum(dim=1).reshape(1, -1))
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_shared_expert_tp1_sums_all_scale_bias(self, mock_dynamic_quant, mock_grouped_matmul):
+        self.method.is_per_channel_weight = True
+        self.method.enable_shared_expert_grouped_matmul()
+        layer = torch.nn.Module()
+        layer.tp_size = 1
+        layer.tp_rank = 0
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(
+            torch.arange(8 * 16, dtype=torch.float32).reshape(8, 16),
+            requires_grad=False,
+        )
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (
+            torch.ones(2, 4, dtype=torch.int8),
+            torch.ones(2, dtype=torch.float32),
+        )
+        mock_grouped_matmul.return_value = [torch.empty(2, 8)]
+
+        self.method.apply(layer, x)
+
+        grouped_bias = mock_grouped_matmul.call_args.kwargs["bias"][0]
+        torch.testing.assert_close(grouped_bias, layer.scale_bias.sum(dim=1).reshape(1, -1))
+
+    def test_shared_expert_grouped_matmul_rejects_per_group_weights(self):
+        self.method.is_per_channel_weight = False
+
+        with self.assertRaisesRegex(ValueError, "requires per-channel W4A8 weights"):
+            self.method.enable_shared_expert_grouped_matmul()
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
+    def test_process_per_channel_weight_without_second_level_scale(self, _mock_maybe_trans_nz):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.empty((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.weight.data.shape, (8, 4))
+        self.assertEqual(layer.weight_scale.data.shape, (32,))
+        self.assertEqual(layer.weight_scale.dtype, torch.bfloat16)
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        torch.testing.assert_close(layer.weight_scale_fp32, layer.weight_scale.data.float())
+        self.assertFalse(hasattr(layer, "weight_scale_second"))
 
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_convert_weight_to_int4pack")
@@ -126,6 +304,68 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
             patch.object(self.method, "process_scale_second", return_value=(torch.ones((2, 20)), None)),
             self.assertRaisesRegex(AssertionError, re.escape(expected_message)),
         ):
+            self.method.process_weights_after_loading(layer)
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    @patch("torch_npu.npu_convert_weight_to_int4pack")
+    def test_process_shared_expert_prepares_grouped_nz_weight(self, mock_int4pack, mock_maybe_trans_nz):
+        self.method.is_per_channel_weight = True
+        self.method.enable_shared_expert_grouped_matmul()
+        self.method.new_quant_version = True
+        mock_maybe_trans_nz.side_effect = identity
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(
+            torch.tensor([[1.0], [2.0]] + [[1.0]] * 30, dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        mock_int4pack.assert_not_called()
+        mock_maybe_trans_nz.assert_called_once()
+        nz_input = mock_maybe_trans_nz.call_args.args[0]
+        self.assertEqual(nz_input.shape, torch.Size([1, 8, 16]))
+        self.assertEqual(nz_input.dtype, torch.int8)
+        self.assertEqual(layer.weight.shape, torch.Size([1, 8, 4]))
+        self.assertEqual(layer.weight.dtype, torch.int32)
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        self.assertEqual(layer.weight_scale_fp32.shape, torch.Size([32]))
+        self.assertEqual(layer.weight_scale.dtype, torch.int64)
+        expected_scale_bits = layer.weight_scale_fp32.numpy().view("uint32").astype("int64")
+        torch.testing.assert_close(layer.weight_scale, torch.from_numpy(expected_scale_bits))
+        self.assertEqual(layer.scale_bias.shape, torch.Size([32]))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
+    def test_process_shared_expert_tp1_sums_down_scale_bias(self, _mock_maybe_trans_nz):
+        self.method.is_per_channel_weight = True
+        self.method.enable_shared_expert_grouped_matmul()
+        self.method.new_quant_version = True
+        layer = torch.nn.Module()
+        layer.tp_size = 1
+        layer.tp_rank = 0
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        original_bias = torch.arange(32 * 16, dtype=torch.float32).reshape(32, 16)
+        layer.scale_bias = torch.nn.Parameter(original_bias.clone(), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        torch.testing.assert_close(layer.scale_bias, original_bias.sum(dim=1))
+
+    def test_process_shared_expert_rejects_old_quant_version(self):
+        self.method.is_per_channel_weight = True
+        self.method.enable_shared_expert_grouped_matmul()
+        self.method.new_quant_version = False
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((32, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        with self.assertRaisesRegex(ValueError, "requires W4A8 quantization version 1.0.0"):
             self.method.process_weights_after_loading(layer)
 
 

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -13,13 +13,13 @@ from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
     AscendModelSlimConfig,
     get_linear_quant_type,
     get_packed_modules_mapping,
 )
-from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD
 
 

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -19,6 +19,7 @@ from vllm_ascend.quantization.modelslim_config import (
     get_linear_quant_type,
     get_packed_modules_mapping,
 )
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD
 
 
@@ -191,6 +192,66 @@ class TestAscendModelSlimConfig(TestBase):
             "experts.0.up_proj",
             "experts.0.down_proj",
         ]
+
+    def test_per_channel_w4a8_shared_expert_enables_grouped_matmul(self):
+        prefix = "model.layers.0.mlp.shared_experts.gate_up_proj"
+        config = AscendModelSlimConfig(
+            {
+                "group_size": 0,
+                f"{prefix}.weight": "W4A8_DYNAMIC",
+            }
+        )
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "future_moe"
+        vllm_config.model_config.hf_text_config = MagicMock()
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+        scheme.is_per_channel_weight = True
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_shared_expert_grouped_matmul.assert_called_once_with()
+
+    def test_per_group_w4a8_shared_expert_does_not_enable_grouped_matmul(self):
+        prefix = "model.layers.0.block_sparse_moe.shared_expert.down_proj"
+        config = AscendModelSlimConfig(
+            {
+                "group_size": 256,
+                f"{prefix}.weight": "W4A8_DYNAMIC",
+            }
+        )
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "future_moe"
+        vllm_config.model_config.hf_text_config = MagicMock()
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+        scheme.is_per_channel_weight = False
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_shared_expert_grouped_matmul.assert_not_called()
 
     def test_missing_linear_weight_without_gate_capability_does_not_fall_back(self):
         config = AscendModelSlimConfig({})

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -46,6 +46,8 @@ from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_expe
 from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult, setup_moe_comm_method
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
 from vllm_ascend.quantization.methods.base import get_moe_num_logical_experts
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_NZ,
@@ -54,6 +56,13 @@ from vllm_ascend.utils import (
     shared_expert_dp_enabled,
     shared_experts_calculation_stream,
 )
+
+
+def _linear_uses_quant_method(linear: torch.nn.Module, method_type: type) -> bool:
+    """Check a linear's concrete scheme, unwrapping AscendLinearMethod."""
+    quant_method = getattr(linear, "quant_method", None)
+    quant_method = getattr(quant_method, "quant_method", quant_method)
+    return isinstance(quant_method, method_type)
 
 
 def get_compressed_expert_map(expert_map: torch.Tensor) -> str:
@@ -781,29 +790,56 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 self._shared_experts.down_proj, "weight_scale"
             )
             shared_uses_situ = isinstance(self._shared_experts.act_fn, AscendSituAndMul)
-            if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+            # Per-channel W4A8 shared-expert Linear methods expose floating-
+            # point scales after converting INT4 weights to the single-expert
+            # GMM layout. Reuse those methods with already-quantized
+            # activations, avoiding the incompatible QuantMatmul WeightNZ ABI.
+            shared_is_w4a8 = all(
+                _linear_uses_quant_method(proj, AscendW4A8DynamicLinearMethod)
+                for proj in (self._shared_experts.gate_up_proj, self._shared_experts.down_proj)
+            )
+            shared_is_w8a8 = all(
+                _linear_uses_quant_method(proj, AscendW8A8DynamicLinearMethod)
+                for proj in (self._shared_experts.gate_up_proj, self._shared_experts.down_proj)
+            )
+            has_per_channel_w4a8_situ_shared = (
+                shared_is_w4a8
+                and shared_uses_situ
+                and all(
+                    hasattr(proj, "weight_scale_fp32")
+                    for proj in (self._shared_experts.gate_up_proj, self._shared_experts.down_proj)
+                )
+            )
+            if has_quantized_shared and (shared_is_w8a8 or has_per_channel_w4a8_situ_shared):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.after_routed_experts)
-                hidden_states = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.gate_up_proj.weight,
-                    self._shared_experts.gate_up_proj.weight_scale,
-                    pertoken_scale=None,
-                    bias=None,
-                    output_dtype=torch.int32,
-                )
+                if has_per_channel_w4a8_situ_shared:
+                    hidden_states = self._shared_experts.gate_up_proj((quantized_x, pertoken_scale))[0]
+                else:
+                    hidden_states = torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        self._shared_experts.gate_up_proj.weight,
+                        self._shared_experts.gate_up_proj.weight_scale,
+                        pertoken_scale=None,
+                        bias=None,
+                        output_dtype=torch.int32,
+                    )
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 if shared_uses_situ:
                     quantized_x, swiglu_out_scale = torch.ops._C_ascend.dequant_situ_quant(
                         x=hidden_states,
-                        weight_scale=self._shared_experts.gate_up_proj.weight_scale_fp32,
-                        activation_scale=pertoken_scale,
+                        weight_scale=(
+                            None
+                            if has_per_channel_w4a8_situ_shared
+                            else self._shared_experts.gate_up_proj.weight_scale_fp32
+                        ),
+                        activation_scale=None if has_per_channel_w4a8_situ_shared else pertoken_scale,
                         bias=None,
                         quant_scale=None,
                         quant_offset=None,
@@ -832,14 +868,17 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 # Execute the down projection concurrently with the combine
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self._shared_experts.down_proj.weight,
-                    self._shared_experts.down_proj.weight_scale,
-                    pertoken_scale=swiglu_out_scale,
-                    bias=None,
-                    output_dtype=original_dtype,
-                )
+                if has_per_channel_w4a8_situ_shared:
+                    shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
+                else:
+                    shared_out = torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        self._shared_experts.down_proj.weight,
+                        self._shared_experts.down_proj.weight_scale,
+                        pertoken_scale=swiglu_out_scale,
+                        bias=None,
+                        output_dtype=original_dtype,
+                    )
             elif has_quantized_shared and self.quant_type in (QuantType.W8A8MXFP, QuantType.W4A8MXFP):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
@@ -878,6 +917,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = self._shared_experts.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
+                # Per-group W4A8 shared experts use this path. Per-channel
+                # W4A8 shared experts take the fused branch above.
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -140,8 +140,7 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         num_offline_shards = scale_bias.shape[1]
         if tp_size <= 0 or num_offline_shards % tp_size != 0:
             raise ValueError(
-                f"scale_bias width {num_offline_shards} must be divisible by "
-                f"the projection TP size {tp_size}"
+                f"scale_bias width {num_offline_shards} must be divisible by the projection TP size {tp_size}"
             )
         if rank < 0 or rank >= tp_size:
             raise ValueError(f"tp_rank {rank} exceeds projection TP size {tp_size}")

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -278,6 +278,8 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
                 if bias is not None:
                     output = output + bias
                 return output.reshape(*input_shape[:-1], output.shape[-1])
+            if isinstance(x, tuple):
+                raise TypeError("pre-quantized input requires shared-expert grouped matmul")
             quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x)
             need_unsqueeze = pertoken_scale.dim() == 2
             if need_unsqueeze:
@@ -295,6 +297,8 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
             return output.unsqueeze(dim=1) if need_unsqueeze else output
 
         # Per-group INT4 weights use the weight-only quantized operator.
+        if isinstance(x, tuple):
+            raise TypeError("pre-quantized input is not supported for per-group W4A8 weights")
         return torch_npu.npu_weight_quant_batchmatmul(
             x,
             layer.weight,

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -48,7 +48,8 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     The names below use ``linear`` as the checkpoint prefix of a linear layer,
     ``input_size`` as the logical input dimension, ``output_size`` as the
     logical output dimension, and ``group_size`` as the number of input
-    channels per weight quantization group.
+    channels per weight quantization group. A ``group_size`` of ``0`` selects
+    per-channel weight quantization.
 
     For ``quant_version != "1.0.0"``, the original linear weights are:
 
@@ -56,10 +57,11 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
       Each int8 element stores one 4-bit weight value.
     - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
     - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
-    - ``linear.weight_scale_second``: ``params_dtype``,
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
       ``[output_size, input_size // group_size]``.
-    - ``linear.weight_offset_second``: ``torch.int64``,
-      ``[output_size, input_size // group_size]``.
+    - For per-channel quantization, ``weight_scale`` and ``weight_offset``
+      are the only scale tensors; no second-level tensors are present.
 
     For ``quant_version == "1.0.0"``, the original linear weights are:
 
@@ -68,10 +70,10 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
       dimension.
     - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
     - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
-    - ``linear.weight_scale_second``: ``params_dtype``,
-      ``[output_size, input_size // group_size]``.
-    - ``linear.weight_offset_second``: ``torch.int64``,
-      ``[output_size, input_size // group_size]``.
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
+      ``[output_size, input_size // group_size]``. Per-channel quantization
+      does not store second-level scale or offset tensors.
     - ``linear.scale_bias``: ``torch.float32``, ``[output_size, 1]`` for
       column-parallel linear layers and ``[output_size, 16]`` for
       row-parallel linear layers.
@@ -83,20 +85,70 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     already packed as int4 pairs in int8 storage and are reinterpreted as int32
     by grouping four int8 values.
 
-    After processing, ``torch_npu.npu_weight_quant_batchmatmul`` is called with
-    ``weight`` as ``torch.int32`` in the operator-required packed layout
-    with shape ``[input_size, output_size // 8]`` and
-    ``antiquant_scale`` as ``weight_scale * weight_scale_second`` converted to
-    ``x.dtype`` with shape ``[input_size // group_size, output_size]``.
+    Per-group linear weights use ``torch_npu.npu_weight_quant_batchmatmul``.
+    Generic per-channel linear weights use ``torch_npu.npu_quant_matmul``.
+    Per-channel W4A8 shared experts use a grouped-matmul path: activations are
+    dynamically quantized to int8, packed int4 weights are converted to NZ,
+    and the projection is evaluated as a single expert by
+    ``torch_npu.npu_grouped_matmul``. This avoids silently degrading shared
+    experts to W4A16.
+
+    The generic linear operators consume ``weight`` as ``torch.int32`` with
+    shape ``[input_size, output_size // 8]``. The shared-expert grouped
+    operator consumes a leading singleton expert dimension, with shape
+    ``[1, input_size, output_size // 8]``.
     """
 
     def __init__(self):
         vllm_config = get_current_vllm_config()
         self.group_size = vllm_config.quant_config.quant_description.get("group_size", 256)
+        self.is_per_channel_weight = self.group_size == 0
         quant_version = vllm_config.quant_config.quant_description.get("version", "0")
         self.new_quant_version = quant_version == "1.0.0"
+        self._use_shared_expert_grouped_matmul = False
 
         self.tp_size = get_tensor_model_parallel_world_size()
+
+    def enable_shared_expert_grouped_matmul(self) -> None:
+        """Select the single-expert GMM ABI for a shared projection.
+
+        Model selection belongs to the quantization config layer. This method
+        only validates and records operator capabilities on this scheme
+        instance, so any model with a per-channel W4A8 shared expert can use
+        the same execution path.
+        """
+        if not self.is_per_channel_weight:
+            raise ValueError("shared-expert grouped matmul requires per-channel W4A8 weights")
+        self._use_shared_expert_grouped_matmul = True
+
+    def _local_scale_bias(self, layer: torch.nn.Module, tp_rank: int | None = None) -> torch.Tensor:
+        """Combine the offline scale-bias shards owned by this projection.
+
+        ModelSlim stores row-parallel ``scale_bias`` with 16 columns, one for
+        each offline input shard.  A runtime TP rank may own more than one of
+        those shards (all 16 when shared-expert DP disables TP), so selecting a
+        single column is only correct for TP16.
+        """
+        scale_bias = layer.scale_bias
+        if scale_bias.dim() != 2:
+            return scale_bias
+        if scale_bias.shape[1] == 1:
+            return scale_bias.flatten()
+
+        tp_size = getattr(layer, "tp_size", self.tp_size)
+        rank = getattr(layer, "tp_rank", tp_rank if tp_rank is not None else 0)
+        num_offline_shards = scale_bias.shape[1]
+        if tp_size <= 0 or num_offline_shards % tp_size != 0:
+            raise ValueError(
+                f"scale_bias width {num_offline_shards} must be divisible by "
+                f"the projection TP size {tp_size}"
+            )
+        if rank < 0 or rank >= tp_size:
+            raise ValueError(f"tp_rank {rank} exceeds projection TP size {tp_size}")
+
+        shards_per_rank = num_offline_shards // tp_size
+        start = rank * shards_per_rank
+        return scale_bias[:, start : start + shards_per_rank].sum(dim=1)
 
     def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
         """Create weight parameters.
@@ -127,10 +179,13 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         params_dict = {}
         params_dict["weight_scale"] = torch.empty(output_size, 1, dtype=params_dtype)
         params_dict["weight_offset"] = torch.empty(output_size, 1, dtype=params_dtype)
-        params_dict["weight_scale_second"] = torch.empty(output_size, input_size // self.group_size, dtype=params_dtype)
-        params_dict["weight_offset_second"] = torch.empty(
-            output_size, input_size // self.group_size, dtype=params_dtype
-        )
+        if not self.is_per_channel_weight:
+            params_dict["weight_scale_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
+            params_dict["weight_offset_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
 
         # NOTE: In w4a8 quantization implementation,
         #       for down_proj and o_proj(layer_type == "row") scale_bias shape is [output_size, 16],
@@ -178,11 +233,69 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
     def apply(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
         bias: torch.Tensor | None = None,
         tp_rank: int | None = None,
     ) -> torch.Tensor:
-        # NOTE: activation `x` is not quantized
+        if self.is_per_channel_weight:
+            if self._use_shared_expert_grouped_matmul:
+                # QuantMatmul cannot consume the A3 per-channel INT4 WeightNZ
+                # representation. Model this projection as one grouped expert
+                # instead, which keeps both the int8 activation and int4 weight.
+                if isinstance(x, tuple):
+                    quantized_x, pertoken_scale = x
+                    input_shape = quantized_x.shape
+                    output_dtype = torch.bfloat16
+                else:
+                    input_shape = x.shape
+                    x_2d = x.reshape(-1, input_shape[-1])
+                    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x_2d)
+                    output_dtype = x.dtype
+                # Construct the single-group token count directly on the
+                # device. ``torch.tensor([count], device=x.device)`` performs
+                # a synchronous host-to-device copy, which is forbidden while
+                # ACL Graph is capturing in GLOBAL mode.
+                group_list = torch.full(
+                    (1,),
+                    quantized_x.shape[0],
+                    dtype=torch.int64,
+                    device=quantized_x.device,
+                )
+
+                scale_bias = self._local_scale_bias(layer, tp_rank)
+
+                output = torch_npu.npu_grouped_matmul(
+                    x=[quantized_x],
+                    weight=[layer.weight],
+                    scale=[layer.weight_scale.reshape(1, 1, -1)],
+                    bias=[scale_bias.reshape(1, -1)],
+                    per_token_scale=[pertoken_scale],
+                    split_item=2,
+                    group_list=group_list,
+                    group_type=0,
+                    group_list_type=1,
+                    output_dtype=output_dtype,
+                )[0]
+                if bias is not None:
+                    output = output + bias
+                return output.reshape(*input_shape[:-1], output.shape[-1])
+            quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x)
+            need_unsqueeze = pertoken_scale.dim() == 2
+            if need_unsqueeze:
+                quantized_x = quantized_x.squeeze(dim=1)
+                pertoken_scale = pertoken_scale.squeeze(dim=1)
+
+            output = torch_npu.npu_quant_matmul(
+                quantized_x,
+                layer.weight,
+                layer.weight_scale,
+                pertoken_scale=pertoken_scale,
+                bias=bias,
+                output_dtype=x.dtype,
+            )
+            return output.unsqueeze(dim=1) if need_unsqueeze else output
+
+        # Per-group INT4 weights use the weight-only quantized operator.
         return torch_npu.npu_weight_quant_batchmatmul(
             x,
             layer.weight,
@@ -192,15 +305,48 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
 
     def process_weights_after_loading(self, layer: torch.nn.Module):
         layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
-        layer.weight.data = maybe_trans_nz(layer.weight.data)
-        layer.weight_scale.data = layer.weight_scale.data.flatten().to(torch.float32)
+        layer.weight_scale.data = layer.weight_scale.data.flatten()
         layer.weight_offset.data = layer.weight_offset.data.flatten()
-        layer.weight_scale_second.data, scale_bias = self.process_scale_second(
-            layer.weight.data,
-            layer.weight_scale.data,
-            layer.weight_scale_second.data.transpose(0, 1).contiguous(),
-            is_new_quant=self.new_quant_version,
-        )
+
+        if self._use_shared_expert_grouped_matmul:
+            if not self.new_quant_version:
+                raise ValueError("shared-expert grouped matmul requires W4A8 quantization version 1.0.0")
+
+            # Preserve the floating-point scale for the fused SiTU path, then
+            # bit-cast it to the int64 representation required by grouped
+            # matmul. Each int64 element stores one FP32 scale bit pattern.
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+            scale_np = layer.weight_scale_fp32.contiguous().cpu().numpy()
+            scale_np.dtype = np.uint32
+            layer.weight_scale.data = torch.from_numpy(scale_np.astype(np.int64)).to(layer.weight_scale.device)
+
+            if not hasattr(layer, "scale_bias"):
+                raise ValueError("shared-expert grouped matmul requires scale_bias")
+            layer.scale_bias.data = self._local_scale_bias(layer).contiguous()
+
+            # Treat the shared projection as one grouped expert. Keep packed
+            # int4 bytes while converting to NZ, then expose groups of four
+            # bytes as the int32 storage expected by the GMM interface.
+            assert layer.weight.data.shape[-1] % 4 == 0, (
+                f"the last dim of weight needs to be divided by 4 but got shape {layer.weight.data.shape}"
+            )
+            layer.weight.data = maybe_trans_nz(layer.weight.data.unsqueeze(0)).view(torch.int32).contiguous()
+            return
+
+        layer.weight.data = maybe_trans_nz(layer.weight.data)
+        if self.is_per_channel_weight:
+            # QuantMatmul consumes the checkpoint dtype, while the fused SiTU
+            # dequantization step requires an FP32 copy of the same scale.
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+        scale_bias = None
+        if not self.is_per_channel_weight:
+            layer.weight_scale.data = layer.weight_scale.data.to(torch.float32)
+            layer.weight_scale_second.data, scale_bias = self.process_scale_second(
+                layer.weight.data,
+                layer.weight_scale.data,
+                layer.weight_scale_second.data.transpose(0, 1).contiguous(),
+                is_new_quant=self.new_quant_version,
+            )
 
         if self.new_quant_version:
             # Process the loaded data based on layer type
@@ -209,22 +355,19 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
                     layer.scale_bias.data = layer.scale_bias.data.flatten()
                 else:
                     layer.scale_bias.data = layer.scale_bias.data.contiguous()
-        else:
-            if scale_bias is not None:
-                param = torch.nn.Parameter(scale_bias, requires_grad=False)
-                layer.register_parameter("weight_scale_bias", param)
+        elif scale_bias is not None:
+            param = torch.nn.Parameter(scale_bias, requires_grad=False)
+            layer.register_parameter("weight_scale_bias", param)
 
-        # Convert to NPU-specific int4pack format
+        # Convert to NPU-specific int4pack format.
         if self.new_quant_version:
-            # weights on disk are already in packed int4 format
-            # pack 4 int8(int4*2) to int32
+            # Weights on disk are already in packed int4 format; group four
+            # int8 bytes into one int32 storage element.
             assert layer.weight.data.shape[-1] % 4 == 0, (
                 f"the last dim of weight needs to be divided by 4 but got shape {layer.weight.data.shape}"
             )
             layer.weight.data = layer.weight.data.view(torch.int32).contiguous()
         else:
-            # weights are not compressed
-            # need to be packed via npu_convert_weight_to_int4pack
             layer.weight.data = torch_npu.npu_convert_weight_to_int4pack(layer.weight.data.to(torch.int32))
 
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -713,6 +713,15 @@ class AscendModelSlimConfig(QuantizationConfig):
                 logger.debug("Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
                 return AscendUnquantizedLinearMethod()
             scheme = create_scheme_for_layer(self.quant_description, prefix, "linear", self.packed_modules_mapping)
+            prefix_parts = prefix.split(".")
+            is_shared_expert = any(part in {"shared_expert", "shared_experts"} for part in prefix_parts)
+            if is_shared_expert:
+                # Select the single-expert GMM ABI from quantization
+                # capabilities and the layer role, not from a model name.
+                from .methods.w4a8 import AscendW4A8DynamicLinearMethod
+
+                if isinstance(scheme, AscendW4A8DynamicLinearMethod) and scheme.is_per_channel_weight:
+                    scheme.enable_shared_expert_grouped_matmul()
             logger.debug("Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
             return AscendLinearMethod(scheme)
         elif isinstance(layer, AttentionLayerBase) and (


### PR DESCRIPTION
## What this PR does

Adds model-agnostic shared-expert quantization support:

- supports per-channel W4A8 shared-expert weights with a single-expert grouped-matmul ABI;
- keeps the selection capability-driven: a W4A8 scheme with `group_size == 0` plus a `shared_expert(s)` layer role enables the path, with no model-name checks;
- dynamically quantizes shared-expert activations, converts packed INT4 weights to the required NZ layout, and aggregates row-parallel `scale_bias` over the runtime TP-owned offline shards;
- keeps group-list construction safe for ACL Graph capture;
- dispatches W4A8 and W8A8 shared experts from each projection's concrete quantization method rather than the routed MoE runner's global quantization type.

Kimi-K3 is the first validated consumer, but the implementation does not import, identify, or branch on Kimi-specific model configuration. Future MoE models can reuse it by expressing the same quantization metadata and shared-expert layer role.

## Root cause

Two concerns were conflated with model identity:

1. The per-channel W4A8 shared projection needs a grouped-matmul weight layout and ABI, while a normal per-channel linear uses quantized matmul.
2. The routed experts and shared experts can use different quantization schemes. Inferring the shared ABI from the routed MoE runner's global `quant_type` misclassified a W8A8 shared expert as W4A8 and passed a `(quantized_x, pertoken_scale)` tuple into its tensor-only `apply` method.

The fix separates layer-role selection from operator capability and inspects the concrete quantization method at execution time.

## Scope

The PR contains only six shared-expert and quantization files. It does not include C8 KV-cache, MLA, KDA, or serving changes from #13225.

## Validation

- `tests/ut/ops/test_fused_moe.py`
- `tests/ut/quantization/methods/a2/test_w4a8.py`
- `tests/ut/quantization/test_modelslim_config.py`

Result on Ascend A3 with vLLM v0.26.0: **112 passed**.

The tests include a non-Kimi `future_moe` configuration to verify that per-channel W4A8 shared experts enable the grouped-matmul path based only on metadata and layer role, while per-group shared experts do not.

Also passed Python compile checks and `git diff --check`.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
