### PR TITLE
[BugFix] Fix KeyError when remote_cached_tokens is missing in SFA PD RD2H producer

### DIFF
--- a/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
+++ b/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
@@ -762,6 +762,30 @@ def test_producer_scheduler_resolves_batch_metadata_by_external_request_id():
     assert send_req_info.local_block_ids == [[1, 2], [3]]
 
 
+def test_producer_scheduler_defaults_missing_remote_cached_tokens_to_zero():
+    scheduler = SFAPDRD2HProducerScheduler.__new__(SFAPDRD2HProducerScheduler)
+    scheduler._reqs_need_send_layerwise = {}
+    # A P-first proxy sends do_remote_decode without remote_cached_tokens;
+    # only the D-first metaserver rendezvous fills that key in.
+    request = SimpleNamespace(
+        request_id="req-0",
+        kv_transfer_params={
+            "do_remote_decode": True,
+            "remote_host": "decode-1",
+            "remote_port": 1234,
+        },
+    )
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = ([1, 2], [3])
+
+    scheduler.update_state_after_alloc(request, blocks, num_external_tokens=0)
+
+    send_req_info = scheduler._reqs_need_send_layerwise["req-0"]
+    assert send_req_info.local_transferred_tokens == 0
+    assert send_req_info.local_block_ids == [[1, 2], [3]]
+    assert request.kv_transfer_params["remote_cached_tokens"] == 0
+
+
 def test_producer_scheduler_rejects_missing_batch_metadata():
     scheduler = SFAPDRD2HProducerScheduler.__new__(SFAPDRD2HProducerScheduler)
     scheduler._reqs_need_send_layerwise = {}

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/scheduler.py
@@ -115,7 +115,12 @@ class SFAPDRD2HProducerScheduler:
             request.kv_transfer_params = params
 
         local_block_ids = self._normalize_block_ids(blocks.get_block_ids())
-        remote_cache_tokens = params["remote_cached_tokens"]
+        # The proxy only fills in remote_cached_tokens in the D-first flow
+        # (via the metaserver). Fall back to 0 so a P-first proxy that omits
+        # the key gets a full transfer instead of a KeyError. setdefault also
+        # keeps the .get() in build_connector_meta from handing None to the
+        # transfer metadata.
+        remote_cache_tokens = params.setdefault("remote_cached_tokens", 0)
         send_req_info = _SendReqInfo(
             local_block_ids=local_block_ids,
             local_transferred_tokens=remote_cache_tokens,


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up flagged in #14041: `SFAPDRD2HProducerScheduler.update_state_after_alloc` reads `params["remote_cached_tokens"]` with a bare dict access, the same pattern that crashed the Mooncake layerwise scheduler in #14000. The key is only guaranteed in the D-first flow, where D's `kv_transfer_params` reach the producer through the metaserver rendezvous; a P-first proxy or an external router sends `do_remote_decode` without it, and the first request kills the scheduler with `KeyError: 'remote_cached_tokens'`.

Same fix as #14041: `params.setdefault("remote_cached_tokens", 0)` — if the proxy didn't say how many tokens the remote side already holds, assume none and transfer everything. Using setdefault also keeps the bare `.get()` in `build_connector_meta` from writing None into the transfer metadata (the send thread would coerce it with `or 0`, but the metadata shouldn't carry None in the first place).

### Does this PR introduce _any_ user-facing change?

No. P-first setups that were crashing now start; the D-first flow behaves as before.

### How was this patch tested?

Added a regression test next to the existing producer-scheduler tests in `tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py`; it reproduces the KeyError without the fix and passes with it. `pytest -sv tests/ut/kv_offload/` passes locally on CPU (264 tests). I don't have Ascend hardware, so I'm relying on the NPU CI for e2e coverage.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
