### PR TITLE
[Feature] adaptation for upstream fault tolerance framework on vllm-ascend

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -225,7 +225,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_w8a8_static.py: 40
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
-  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1200
+  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1800
 
 # === Runner Mapping ===
 # Maps test paths to logical partitions using regex patterns.

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -225,7 +225,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_w8a8_static.py: 40
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
-  tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py: 1200
+  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1200
 
 # === Runner Mapping ===
 # Maps test paths to logical partitions using regex patterns.
@@ -243,8 +243,6 @@ runner_mapping:
     310p: 310p-4
   tests/e2e/pull_request/eight_card:
     default: a3-8
-  tests/e2e/fault_tolerance:
-    default: a3-4
 
 # === Partition Configuration ===
 # Maps logical test buckets to exact labels from runner_label.json and controls

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -225,7 +225,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_w8a8_static.py: 40
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
-  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 1800
+  tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py: 900
 
 # === Runner Mapping ===
 # Maps test paths to logical partitions using regex patterns.

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -225,6 +225,7 @@ estimated_times:
   tests/e2e/pull_request/one_card/test_w8a8_static.py: 40
   tests/e2e/pull_request/one_card/test_gumbel_sampling.py: 110
   tests/e2e/pull_request/one_card/test_model_runner_v1_with_device.py: 70
+  tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py: 1200
 
 # === Runner Mapping ===
 # Maps test paths to logical partitions using regex patterns.
@@ -242,6 +243,8 @@ runner_mapping:
     310p: 310p-4
   tests/e2e/pull_request/eight_card:
     default: a3-8
+  tests/e2e/fault_tolerance:
+    default: a3-4
 
 # === Partition Configuration ===
 # Maps logical test buckets to exact labels from runner_label.json and controls

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -179,6 +179,7 @@ class FTServerManager:
                         server_host="localhost",
                         server_port=8000 + r,
                         auto_port=False,
+                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)}
                     )
                     self.servers.append((server, sargs))
                 except Exception:

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -179,7 +179,7 @@ class FTServerManager:
                         server_host="localhost",
                         server_port=8000 + r,
                         auto_port=False,
-                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)}
+                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)},
                     )
                     self.servers.append((server, sargs))
                 except Exception:

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -112,6 +112,7 @@ def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> Non
 # Server management
 # ---------------------------------------------------------------------------
 
+
 def _ft_server_args() -> list[str]:
     return [
         "--enforce-eager",
@@ -184,9 +185,7 @@ class FTServerManager:
                     print(f"Failed to start server rank {r}")
                     raise
 
-            thread = threading.Thread(
-                target=start_server, args=(rank, server_args)
-            )
+            thread = threading.Thread(target=start_server, args=(rank, server_args))
             thread.start()
             self.server_threads.append(thread)
 
@@ -194,9 +193,7 @@ class FTServerManager:
             thread.join()
 
         if len(self.servers) != self.dp_size:
-            raise RuntimeError(
-                f"Only {len(self.servers)}/{self.dp_size} servers started"
-            )
+            raise RuntimeError(f"Only {len(self.servers)}/{self.dp_size} servers started")
 
         return self.servers
 
@@ -216,9 +213,7 @@ def _ft_manager() -> FTServerManager:
     )
 
 
-def _server_for_rank(
-    servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: int
-) -> RemoteOpenAIServer:
+def _server_for_rank(servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: int) -> RemoteOpenAIServer:
     """Locate the server for a DP rank."""
     for server, sargs in servers:
         if "--data-parallel-rank" in sargs:
@@ -231,6 +226,7 @@ def _server_for_rank(
 # ---------------------------------------------------------------------------
 # Test primitives
 # ---------------------------------------------------------------------------
+
 
 def _complete(client) -> Any:
     """Issue one completion request; used to drive the serving loop."""
@@ -255,9 +251,7 @@ def _get_ft_status(server: RemoteOpenAIServer) -> dict:
     return resp.json()
 
 
-def _apply_ft(
-    server: RemoteOpenAIServer, instruction: str, params: dict | None = None
-) -> dict:
+def _apply_ft(server: RemoteOpenAIServer, instruction: str, params: dict | None = None) -> dict:
     """POST an FT instruction; assert it is accepted (202) and return body."""
     resp = requests.post(
         server.url_for("fault_tolerance/apply"),
@@ -272,20 +266,14 @@ def _assert_serving_and_healthy(
     servers: tuple[RemoteOpenAIServer, ...],
 ) -> None:
     """Wait until every engine is healthy, then serve one request per server."""
-    healthy = _wait_for_engines(
-        list(servers), match_key="status", match_values={"healthy"}
-    )
+    healthy = _wait_for_engines(list(servers), match_key="status", match_values={"healthy"})
     assert all(healthy), healthy
     _in_parallel(lambda s: _complete(s.get_client()), servers)
 
 
 def _kill_worker_process(server: RemoteOpenAIServer) -> None:
     """SIGKILL only the worker proc, leaving EngineCore and API server alive."""
-    workers = [
-        p
-        for p in psutil.Process(server.proc.pid).children(recursive=True)
-        if "Worker" in " ".join(p.cmdline())
-    ]
+    workers = [p for p in psutil.Process(server.proc.pid).children(recursive=True) if "Worker" in " ".join(p.cmdline())]
     assert len(workers) == 1, f"expected 1 worker proc, found: {workers}"
     workers[0].kill()
 
@@ -334,10 +322,7 @@ def _driving(*servers: RemoteOpenAIServer):
                 _complete(client)
             time.sleep(0.2)
 
-    threads = [
-        threading.Thread(target=_drive, args=(s,), daemon=True)
-        for s in servers
-    ]
+    threads = [threading.Thread(target=_drive, args=(s,), daemon=True) for s in servers]
     for t in threads:
         t.start()
     try:
@@ -348,9 +333,7 @@ def _driving(*servers: RemoteOpenAIServer):
             t.join(timeout=2)
 
 
-def _wait_for_ft_apply_outcome(
-    server: RemoteOpenAIServer, request_id: str, deadline_s: int
-) -> str | None:
+def _wait_for_ft_apply_outcome(server: RemoteOpenAIServer, request_id: str, deadline_s: int) -> str | None:
     """Wait until ``/fault_tolerance/status`` records the FT apply outcome."""
     engine_status = _wait_for_engines(
         [server],
@@ -365,6 +348,7 @@ def _wait_for_ft_apply_outcome(
 # Feature guard
 # ---------------------------------------------------------------------------
 
+
 def has_npu_ft_capability() -> bool:
     """Require at least 4 visible NPUs for DP=4 fault-tolerance tests."""
     if not torch.npu.is_available():
@@ -378,6 +362,7 @@ def has_npu_ft_capability() -> bool:
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.skipif(
     not has_npu_ft_capability(),
@@ -401,9 +386,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
 
     with _ft_manager() as servers:
         assert len(servers) == DP_SIZE
-        all_ranks = tuple(
-            _server_for_rank(servers, r) for r in range(DP_SIZE)
-        )
+        all_ranks = tuple(_server_for_rank(servers, r) for r in range(DP_SIZE))
 
         # 1. All engines healthy and serving.
         _assert_serving_and_healthy(all_ranks)
@@ -419,8 +402,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
 
         for rank, engine_status in enumerate(faulted):
             assert engine_status is not None, (
-                f"rank {rank} did not report UNHEALTHY within "
-                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+                f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
             )
 
         # The rank that raised carries the fault info from its own exception.
@@ -481,16 +463,14 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
         # Survivors must report the peer fault as UNHEALTHY.
         for label, result in [("rank 0", s0), ("rank 1", s1), ("rank 2", s2)]:
             assert result is not None, (
-                f"{label} did not report the peer fault within "
-                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+                f"{label} did not report the peer fault within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
             )
             assert result["status"] == "unhealthy", result
             assert result.get("fault_info"), result
 
         # Victim must report DEAD (its own worker is gone).
         assert victim_faulted is not None, (
-            "victim (rank 3) did not report its worker's death within "
-            f"{FAULT_DETECTION_DEADLINE_S}s"
+            f"victim (rank 3) did not report its worker's death within {FAULT_DETECTION_DEADLINE_S}s"
         )
         assert victim_faulted["status"] == "dead", victim_faulted
 
@@ -498,10 +478,6 @@ def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
         request_id = _apply_ft(victim, "retry")["request_id"]
 
         # 5. ...but the DEAD engine must reject it: recovery requires UNHEALTHY.
-        ft_error = _wait_for_ft_apply_outcome(
-            victim, request_id, FAULT_DETECTION_DEADLINE_S
-        )
-        assert ft_error is not None, (
-            "rejection was never recorded in /fault_tolerance/status"
-        )
+        ft_error = _wait_for_ft_apply_outcome(victim, request_id, FAULT_DETECTION_DEADLINE_S)
+        assert ft_error is not None, "rejection was never recorded in /fault_tolerance/status"
         assert "status is DEAD" in ft_error, ft_error

--- a/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py
@@ -1,0 +1,507 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end tests for the fault-tolerance framework on Ascend NPU.
+
+Requires 4 NPUs (DP=4); gated behind ``has_npu_ft_capability()``.
+"""
+
+import contextlib
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import psutil
+import pytest
+import requests
+import torch
+
+from tests.e2e.conftest import RemoteOpenAIServer
+
+MODEL_NAME = os.getenv("MODEL_NAME", "Qwen/Qwen3-30B-A3B")
+DP_SIZE = 4
+
+# Fault-detection timeout budget:
+# - CPU: Gloo DP allreduce timeout (30s) detects the dead peer.
+# - NPU: HCSP operator timeout detects the dead peer.
+# - Deadline (45s): slowest fallback (30s) + margin.
+CPU_DISTRIBUTED_TIMEOUT_S = 30
+FAULT_DETECTION_DEADLINE_S = 45
+
+
+# ---------------------------------------------------------------------------
+# Fault-injection via sitecustomize.py
+# ---------------------------------------------------------------------------
+# Patches ``NPUModelRunner._sync_metadata_across_dp`` to raise on ``rank`` at
+# a chosen step. Gated on VLLM_FT_TEST_INJECT_FAULT.
+#
+# The import hook waits for ``vllm_ascend.worker.model_runner_v1`` to land
+# in sys.modules and for ``NPUModelRunner._sync_metadata_across_dp`` to be
+# defined, then wraps the method with a step-counting wrapper.
+_FAULT_INJECT_SITECUSTOMIZE = """\
+import builtins
+import os
+import sys
+
+_SPEC = os.environ.get("VLLM_FT_TEST_INJECT_FAULT")
+_MODULE = "vllm_ascend.worker.model_runner_v1"
+_CLASS = "NPUModelRunner"
+_METHOD = "_sync_metadata_across_dp"
+
+if _SPEC:
+    _f = dict(kv.split("=", 1) for kv in _SPEC.split(","))
+    _RANK, _STEP = int(_f["rank"]), int(_f["step"])
+    _steps = [0]
+
+    def _patch(m):
+        cls = getattr(m, _CLASS)
+        _orig = getattr(cls, _METHOD)
+
+        def _wrapped(self, *args, **kwargs):
+            result = _orig(self, *args, **kwargs)
+            if self.dp_rank == _RANK:
+                _steps[0] += 1
+                if _steps[0] == _STEP:
+                    raise RuntimeError(
+                        "FT test fault injection (rank=%d step=%d)"
+                        % (_RANK, _STEP)
+                    )
+            return result
+
+        setattr(cls, _METHOD, _wrapped)
+
+    _real_import = builtins.__import__
+
+    def _hook(name, *a, **k):
+        module = _real_import(name, *a, **k)
+        m = sys.modules.get(_MODULE)
+        if (
+            m is not None
+            and hasattr(m, _CLASS)
+            and not getattr(m, "_ft_patched", False)
+        ):
+            cls = getattr(m, _CLASS)
+            if hasattr(cls, _METHOD):
+                m._ft_patched = True
+                _patch(m)
+        return module
+
+    builtins.__import__ = _hook
+"""
+
+
+def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> None:
+    """Arrange for the DP-sync method to raise on ``rank`` at serving ``step``.
+
+    Writes a ``sitecustomize.py`` and prepends its dir to PYTHONPATH so every
+    vLLM subprocess picks it up; the fault spec is read from the environment.
+    """
+    site_dir = tmp_path / "ft_inject"
+    site_dir.mkdir()
+    (site_dir / "sitecustomize.py").write_text(_FAULT_INJECT_SITECUSTOMIZE)
+    existing = os.environ.get("PYTHONPATH", "")
+    monkeypatch.setenv(
+        "PYTHONPATH",
+        str(site_dir) + (os.pathsep + existing if existing else ""),
+    )
+    monkeypatch.setenv("VLLM_FT_TEST_INJECT_FAULT", f"rank={rank},step={step}")
+
+
+# ---------------------------------------------------------------------------
+# Server management
+# ---------------------------------------------------------------------------
+
+def _ft_server_args() -> list[str]:
+    return [
+        "--enforce-eager",
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "2048",
+        "--max-num-seqs",
+        "128",
+        "--enable-expert-parallel",
+        "--enable-fault-tolerance",
+        "--cpu-distributed-timeout-seconds",
+        str(CPU_DISTRIBUTED_TIMEOUT_S),
+        "--fault-tolerance-config",
+        '{"engine_recovery_timeout_sec": 120}',
+    ]
+
+
+class FTServerManager:
+    """Manages DP=4 vLLM server instances for fault-tolerance testing.
+
+    Starts one process per DP rank with fixed ports (8000 + rank).
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        dp_size: int,
+        base_server_args: list[str],
+        tp_size: int = 1,
+    ):
+        self.model_name = model_name
+        self.dp_size = dp_size
+        self.tp_size = tp_size
+        self.base_server_args = base_server_args
+        self.servers: list[tuple[RemoteOpenAIServer, list[str]]] = []
+        self.server_threads: list[threading.Thread] = []
+
+    def __enter__(self) -> list[tuple[RemoteOpenAIServer, list[str]]]:
+        for rank in range(self.dp_size):
+            server_args = self.base_server_args.copy()
+            server_args.extend(
+                [
+                    "--data-parallel-size",
+                    str(self.dp_size),
+                    "--data-parallel-rank",
+                    str(rank),
+                    "--data-parallel-size-local",
+                    "1",
+                    "--tensor-parallel-size",
+                    str(self.tp_size),
+                    "--port",
+                    str(8000 + rank),
+                    "--api-server-count",
+                    "1",
+                ]
+            )
+
+            def start_server(r: int, sargs: list[str]) -> None:
+                try:
+                    server = RemoteOpenAIServer(
+                        self.model_name,
+                        sargs,
+                        server_host="localhost",
+                        server_port=8000 + r,
+                        auto_port=False,
+                    )
+                    self.servers.append((server, sargs))
+                except Exception:
+                    print(f"Failed to start server rank {r}")
+                    raise
+
+            thread = threading.Thread(
+                target=start_server, args=(rank, server_args)
+            )
+            thread.start()
+            self.server_threads.append(thread)
+
+        for thread in self.server_threads:
+            thread.join()
+
+        if len(self.servers) != self.dp_size:
+            raise RuntimeError(
+                f"Only {len(self.servers)}/{self.dp_size} servers started"
+            )
+
+        return self.servers
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        for server, _ in reversed(self.servers):
+            with contextlib.suppress(Exception):
+                server.__exit__(None, None, None)
+        self.servers.clear()
+
+
+def _ft_manager() -> FTServerManager:
+    return FTServerManager(
+        MODEL_NAME,
+        DP_SIZE,
+        base_server_args=_ft_server_args(),
+        tp_size=1,
+    )
+
+
+def _server_for_rank(
+    servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: int
+) -> RemoteOpenAIServer:
+    """Locate the server for a DP rank."""
+    for server, sargs in servers:
+        if "--data-parallel-rank" in sargs:
+            idx = sargs.index("--data-parallel-rank")
+            if int(sargs[idx + 1]) == rank:
+                return server
+    raise AssertionError(f"no server found for DP rank {rank}")
+
+
+# ---------------------------------------------------------------------------
+# Test primitives
+# ---------------------------------------------------------------------------
+
+def _complete(client) -> Any:
+    """Issue one completion request; used to drive the serving loop."""
+    return client.completions.create(
+        model=MODEL_NAME,
+        prompt="Hello, my name is",
+        max_tokens=5,
+        temperature=0.0,
+        timeout=10.0,
+    )
+
+
+def _in_parallel(fn, servers) -> list[Any]:
+    """Run ``fn(server)`` for all servers concurrently; return in order."""
+    with ThreadPoolExecutor(max_workers=len(servers)) as ex:
+        return list(ex.map(fn, servers))
+
+
+def _get_ft_status(server: RemoteOpenAIServer) -> dict:
+    resp = requests.get(server.url_for("fault_tolerance/status"), timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _apply_ft(
+    server: RemoteOpenAIServer, instruction: str, params: dict | None = None
+) -> dict:
+    """POST an FT instruction; assert it is accepted (202) and return body."""
+    resp = requests.post(
+        server.url_for("fault_tolerance/apply"),
+        json={"instruction": instruction, "params": params or {}},
+        timeout=10,
+    )
+    assert resp.status_code == 202, resp.text
+    return resp.json()
+
+
+def _assert_serving_and_healthy(
+    servers: tuple[RemoteOpenAIServer, ...],
+) -> None:
+    """Wait until every engine is healthy, then serve one request per server."""
+    healthy = _wait_for_engines(
+        list(servers), match_key="status", match_values={"healthy"}
+    )
+    assert all(healthy), healthy
+    _in_parallel(lambda s: _complete(s.get_client()), servers)
+
+
+def _kill_worker_process(server: RemoteOpenAIServer) -> None:
+    """SIGKILL only the worker proc, leaving EngineCore and API server alive."""
+    workers = [
+        p
+        for p in psutil.Process(server.proc.pid).children(recursive=True)
+        if "Worker" in " ".join(p.cmdline())
+    ]
+    assert len(workers) == 1, f"expected 1 worker proc, found: {workers}"
+    workers[0].kill()
+
+
+def _wait_for_engines(
+    servers: list[RemoteOpenAIServer],
+    match_key: str,
+    match_values: set[str],
+    deadline_s: int = FAULT_DETECTION_DEADLINE_S,
+) -> list[dict[str, Any] | None]:
+    """Poll ``/fault_tolerance/status`` until each server's engine status matches.
+
+    A server matches when its engine-status dict has ``match_key`` equal to
+    one of ``match_values``. Returns one engine-status dict per server.
+    Servers still unmatched after ``deadline_s`` get None.
+    """
+    results: dict[int, dict[str, Any]] = {}
+    pending = dict(enumerate(servers))
+    start = time.time()
+    while pending and time.time() - start < deadline_s:
+        for i, server in list(pending.items()):
+            with contextlib.suppress(Exception):
+                for engine_status in _get_ft_status(server)["engines"]:
+                    if engine_status.get(match_key) in match_values:
+                        results[i] = engine_status
+                        del pending[i]
+                        break
+        if pending:
+            time.sleep(1.0)
+    return [results.get(i) for i in range(len(servers))]
+
+
+@contextlib.contextmanager
+def _driving(*servers: RemoteOpenAIServer):
+    """Pump completions at each server in the background for the block's duration.
+
+    Keeps every engine stepping into its failed component so a fault surfaces.
+    Errors are expected once faulted and are ignored.
+    """
+    stop = threading.Event()
+
+    def _drive(server):
+        client = server.get_client()
+        while not stop.is_set():
+            with contextlib.suppress(Exception):
+                _complete(client)
+            time.sleep(0.2)
+
+    threads = [
+        threading.Thread(target=_drive, args=(s,), daemon=True)
+        for s in servers
+    ]
+    for t in threads:
+        t.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        for t in threads:
+            t.join(timeout=2)
+
+
+def _wait_for_ft_apply_outcome(
+    server: RemoteOpenAIServer, request_id: str, deadline_s: int
+) -> str | None:
+    """Wait until ``/fault_tolerance/status`` records the FT apply outcome."""
+    engine_status = _wait_for_engines(
+        [server],
+        match_key="last_ft_request_id",
+        match_values={request_id},
+        deadline_s=deadline_s,
+    )[0]
+    return engine_status.get("ft_error") if engine_status else None
+
+
+# ---------------------------------------------------------------------------
+# Feature guard
+# ---------------------------------------------------------------------------
+
+def has_npu_ft_capability() -> bool:
+    """Require at least 4 visible NPUs for DP=4 fault-tolerance tests."""
+    if not torch.npu.is_available():
+        return False
+    try:
+        return torch.npu.device_count() >= DP_SIZE
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not has_npu_ft_capability(),
+    reason="Requires at least 4 NPUs for DP=4 fault-tolerance testing",
+)
+def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
+    """An exception injected into _sync_metadata_across_dp drives full
+    retry recovery on all 4 DP ranks.
+
+    Inject a fault at a chosen step on rank 3:
+
+    - Rank 3 raises after allreduce and goes UNHEALTHY.
+    - Ranks 0, 1, 2 detect the now-absent peer via the Gloo DP allreduce
+      timeout and also go UNHEALTHY.
+
+    All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
+    is patched via a generated ``sitecustomize.py``.
+    """
+    fault_step = int(os.getenv("FT_FAULT_STEP", "50"))
+    _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
+
+    with _ft_manager() as servers:
+        assert len(servers) == DP_SIZE
+        all_ranks = tuple(
+            _server_for_rank(servers, r) for r in range(DP_SIZE)
+        )
+
+        # 1. All engines healthy and serving.
+        _assert_serving_and_healthy(all_ranks)
+
+        # 2. Drive all ranks so rank 3 accumulates steps and trips the
+        #    injected fault; ranks 0,1,2 then time out on DP allreduce.
+        with _driving(*all_ranks):
+            faulted = _wait_for_engines(
+                list(all_ranks),
+                match_key="status",
+                match_values={"unhealthy"},
+            )
+
+        for rank, engine_status in enumerate(faulted):
+            assert engine_status is not None, (
+                f"rank {rank} did not report UNHEALTHY within "
+                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+            )
+
+        # The rank that raised carries the fault info from its own exception.
+        assert faulted[3] is not None
+        assert faulted[3].get("fault_info"), faulted[3]
+
+        # 3. retry all engines.
+        for server in all_ranks:
+            _apply_ft(server, "retry")
+
+        # 4. Recovery completes: all engines return to healthy and serve again.
+        _assert_serving_and_healthy(all_ranks)
+
+
+@pytest.mark.skipif(
+    not has_npu_ft_capability(),
+    reason="Requires at least 4 NPUs for DP=4 fault-tolerance testing",
+)
+def test_worker_kill_survivor_unhealthy_and_dead_rejects_retry():
+    """SIGKILL one Worker; survivors go UNHEALTHY, victim goes DEAD.
+
+    Killing only rank 3's worker leaves all EngineCores alive, so the same
+    fault is seen two ways:
+
+    - Survivors (ranks 0, 1, 2): detect the dead peer via Gloo DP allreduce
+      / HCSP timeout. Their own executor is fine, so ``on_fault`` marks them
+      UNHEALTHY with a ``fault_info``.
+    - Victim (rank 3): detects its own executor failure and marks itself DEAD.
+
+    Recovery is gated on UNHEALTHY: the DEAD engine accepts ``retry`` at the
+    HTTP layer (202 = background dispatch) but rejects it in the engine,
+    recording the reason as ``ft_error``.
+    """
+    with _ft_manager() as servers:
+        assert len(servers) == DP_SIZE
+        survivor0 = _server_for_rank(servers, 0)
+        survivor1 = _server_for_rank(servers, 1)
+        survivor2 = _server_for_rank(servers, 2)
+        victim = _server_for_rank(servers, 3)
+        all_ranks = (survivor0, survivor1, survivor2, victim)
+
+        # 1. Confirm all engines are healthy and serving.
+        _assert_serving_and_healthy(all_ranks)
+
+        # 2. Kill only the victim's worker; all EngineCores stay alive.
+        _kill_worker_process(victim)
+
+        # 3. Drive all engines so each keeps stepping into the failed component.
+        with _driving(*all_ranks):
+            faulted_results = _wait_for_engines(
+                list(all_ranks),
+                match_key="status",
+                match_values={"dead", "unhealthy"},
+            )
+
+        s0, s1, s2, victim_faulted = faulted_results
+
+        # Survivors must report the peer fault as UNHEALTHY.
+        for label, result in [("rank 0", s0), ("rank 1", s1), ("rank 2", s2)]:
+            assert result is not None, (
+                f"{label} did not report the peer fault within "
+                f"{FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+            )
+            assert result["status"] == "unhealthy", result
+            assert result.get("fault_info"), result
+
+        # Victim must report DEAD (its own worker is gone).
+        assert victim_faulted is not None, (
+            "victim (rank 3) did not report its worker's death within "
+            f"{FAULT_DETECTION_DEADLINE_S}s"
+        )
+        assert victim_faulted["status"] == "dead", victim_faulted
+
+        # 4. retry is accepted at the HTTP layer (202 = background dispatch)...
+        request_id = _apply_ft(victim, "retry")["request_id"]
+
+        # 5. ...but the DEAD engine must reject it: recovery requires UNHEALTHY.
+        ft_error = _wait_for_ft_apply_outcome(
+            victim, request_id, FAULT_DETECTION_DEADLINE_S
+        )
+        assert ft_error is not None, (
+            "rejection was never recorded in /fault_tolerance/status"
+        )
+        assert "status is DEAD" in ft_error, ft_error

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -34,21 +34,21 @@ FAULT_DETECTION_DEADLINE_S = 45
 # ---------------------------------------------------------------------------
 # Fault-injection via sitecustomize.py
 # ---------------------------------------------------------------------------
-# Patches ``NPUModelRunner._sync_metadata_across_dp`` to raise on ``rank`` at
-# a chosen step. Gated on VLLM_FT_TEST_INJECT_FAULT.
+# Patches ``dp_utils.sync_cudagraph_and_dp_padding`` to raise on ``rank`` after
+# the DP all_reduce at a chosen step. Gated on VLLM_FT_TEST_INJECT_FAULT.
 #
-# The import hook waits for ``vllm_ascend.worker.model_runner_v1`` to land
-# in sys.modules and for ``NPUModelRunner._sync_metadata_across_dp`` to be
-# defined, then wraps the method with a step-counting wrapper.
+# The import hook waits for ``vllm.v1.worker.gpu.dp_utils`` to land in
+# sys.modules and for ``sync_cudagraph_and_dp_padding`` to be defined, then
+# wraps the function with a step-counting wrapper. The wrapper calls the
+# original (so the all_reduce completes) and raises after it returns.
 _FAULT_INJECT_SITECUSTOMIZE = """\
 import builtins
 import os
 import sys
 
 _SPEC = os.environ.get("VLLM_FT_TEST_INJECT_FAULT")
-_MODULE = "vllm_ascend.worker.model_runner_v1"
-_CLASS = "NPUModelRunner"
-_METHOD = "_sync_metadata_across_dp"
+_MODULE = "vllm.v1.worker.gpu.dp_utils"
+_FUNC = "sync_cudagraph_and_dp_padding"
 
 if _SPEC:
     _f = dict(kv.split("=", 1) for kv in _SPEC.split(","))
@@ -56,12 +56,17 @@ if _SPEC:
     _steps = [0]
 
     def _patch(m):
-        cls = getattr(m, _CLASS)
-        _orig = getattr(cls, _METHOD)
+        import inspect
 
-        def _wrapped(self, *args, **kwargs):
-            result = _orig(self, *args, **kwargs)
-            if self.dp_rank == _RANK:
+        _orig = getattr(m, _FUNC)
+        _sig = inspect.signature(_orig)
+
+        def _wrapped(*args, **kwargs):
+            result = _orig(*args, **kwargs)
+            bound = _sig.bind(*args, **kwargs)
+            bound.apply_defaults()
+            dp_rank = bound.arguments.get("dp_rank")
+            if dp_rank == _RANK:
                 _steps[0] += 1
                 if _steps[0] == _STEP:
                     raise RuntimeError(
@@ -70,7 +75,7 @@ if _SPEC:
                     )
             return result
 
-        setattr(cls, _METHOD, _wrapped)
+        setattr(m, _FUNC, _wrapped)
 
     _real_import = builtins.__import__
 
@@ -79,13 +84,11 @@ if _SPEC:
         m = sys.modules.get(_MODULE)
         if (
             m is not None
-            and hasattr(m, _CLASS)
+            and hasattr(m, _FUNC)
             and not getattr(m, "_ft_patched", False)
         ):
-            cls = getattr(m, _CLASS)
-            if hasattr(cls, _METHOD):
-                m._ft_patched = True
-                _patch(m)
+            m._ft_patched = True
+            _patch(m)
         return module
 
     builtins.__import__ = _hook
@@ -93,7 +96,7 @@ if _SPEC:
 
 
 def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> None:
-    """Arrange for the DP-sync method to raise on ``rank`` at serving ``step``.
+    """Arrange for the DP all_reduce sync to raise on ``rank`` at serving ``step``.
 
     Writes a ``sitecustomize.py`` and prepends its dir to PYTHONPATH so every
     vLLM subprocess picks it up; the fault spec is read from the environment.
@@ -181,7 +184,10 @@ class FTServerManager:
                         server_host="localhost",
                         server_port=8000 + r,
                         auto_port=False,
-                        env_dict={"ASCEND_RT_VISIBLE_DEVICES": str(r)},
+                        env_dict={
+                            "ASCEND_RT_VISIBLE_DEVICES": str(r),
+                            "VLLM_USE_V2_MODEL_RUNNER": "1",
+                        },
                     )
                     self.servers.append((server, sargs))
                 except Exception:
@@ -372,7 +378,7 @@ def has_npu_ft_capability() -> bool:
     reason="Requires at least 4 NPUs for DP=4 fault-tolerance testing",
 )
 def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
-    """An exception injected into _sync_metadata_across_dp drives full
+    """An exception injected after the DP allreduce drives full
     retry recovery on all 4 DP ranks.
 
     Inject a fault at a chosen step on rank 3:

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -47,8 +47,10 @@ _GOLDEN_PROMPTS = [
 ]
 _GOLDEN_OUTPUTS = [
     " Sarah, and I am 14 years old. I have a question about the equation $x^2 + y^2 = 1$. I know",
-    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. The capital of Spain is Madrid. The capital of Italy is Rome.",
-    " Is it possible to find a single, universal answer to this question, and how do different perspectives approach it?\n\nThe question of the meaning of life is one of",
+    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. "
+    "The capital of Spain is Madrid. The capital of Italy is Rome.",
+    " Is it possible to find a single, universal answer to this question, and how do "
+    "different perspectives approach it?\n\nThe question of the meaning of life is one of",
 ]
 _GOLDEN_MAX_TOKENS = 32
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -27,6 +27,7 @@ DP_SIZE = 4
 # - NPU: HCSP operator timeout detects the dead peer.
 # - Deadline (45s): slowest fallback (30s) + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 30
+FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS = 15
 FAULT_DETECTION_DEADLINE_S = 45
 
 
@@ -115,7 +116,6 @@ def _install_fault_injection(monkeypatch, tmp_path, rank: int, step: int) -> Non
 
 def _ft_server_args() -> list[str]:
     return [
-        "--enforce-eager",
         "--dtype",
         "bfloat16",
         "--max-model-len",
@@ -128,6 +128,8 @@ def _ft_server_args() -> list[str]:
         str(CPU_DISTRIBUTED_TIMEOUT_S),
         "--fault-tolerance-config",
         '{"engine_recovery_timeout_sec": 120}',
+        "--additional-config",
+        f'{{"ft_communication_ops_abort_timeout_ms": {FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS}}}',
     ]
 
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -6,12 +6,9 @@ Requires 4 NPUs (DP=4); gated behind ``has_npu_ft_capability()``.
 """
 
 import contextlib
-import http.server
 import os
 import threading
 import time
-import urllib.error
-import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -33,17 +30,27 @@ CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
 
-BENCHMARK_HOME = "./benchmark"
-_GSM8K_CASE = {
-    "case_type": "accuracy",
-    "dataset_path": "vllm-ascend/gsm8k-lite",
-    "request_conf": "vllm_api_general_chat",
-    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_chat_prompt",
-    "max_out_len": 32768,
-    "batch_size": 32,
-    "baseline": 95,
-    "threshold": 5,
-}
+# Golden-output accuracy check, mirroring the pattern in
+# tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: greedy
+# completions for fixed prompts must be reproduced exactly after retry recovery.
+#
+# The golden outputs are hardcoded (NOT captured during the test): the fault
+# injection is step-triggered while serving, so it could fire mid-request and
+# corrupt a self-captured reference. Generate them by starting a healthy
+# Qwen/Qwen3-30B-A3B server once and issuing the prompts below with
+# temperature=0, max_tokens=_GOLDEN_MAX_TOKENS, then paste the returned texts
+# into _GOLDEN_OUTPUTS.
+_GOLDEN_PROMPTS = [
+    "Hello, my name is",
+    "The capital of France is",
+    "What is the meaning of life?",
+]
+_GOLDEN_OUTPUTS = [
+    " Sarah, and I am 14 years old. I have a question about the equation $x^2 + y^2 = 1$. I know",
+    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. The capital of Spain is Madrid. The capital of Italy is Rome.",
+    " Is it possible to find a single, universal answer to this question, and how do different perspectives approach it?\n\nThe question of the meaning of life is one of",
+]
+_GOLDEN_MAX_TOKENS = 32
 
 
 # ---------------------------------------------------------------------------
@@ -248,107 +255,6 @@ def _server_for_rank(servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: 
 
 
 # ---------------------------------------------------------------------------
-# Round-robin proxy
-# ---------------------------------------------------------------------------
-
-
-class RoundRobinProxy:
-    """Tiny standard-library HTTP proxy that round-robins requests across
-    the DP rank server ports.
-
-    Listens on ``listen_port`` and forwards every request (method, path,
-    headers, body) verbatim to one of ``backend_ports``, chosen by a
-    thread-safe round-robin counter, so requests are spread evenly across
-    the ranks. Responses are passed back unchanged.
-
-    Usage::
-
-        with _ft_manager() as servers:
-            backend_ports = [server.port for server, _ in servers]
-            with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
-                resp = requests.post(f"{proxy.url}/v1/completions", json={...})
-    """
-
-    def __init__(
-        self,
-        backend_ports: list[int],
-        listen_port: int,
-        host: str = "127.0.0.1",
-    ):
-        self._backend_ports = list(backend_ports)
-        self._host = host
-        self._listen_port = listen_port
-        self._next = 0
-        self._lock = threading.Lock()
-        self._httpd: http.server.ThreadingHTTPServer | None = None
-        self._thread: threading.Thread | None = None
-
-    def __enter__(self) -> "RoundRobinProxy":
-        self._httpd = http.server.ThreadingHTTPServer((self._host, self._listen_port), self._make_handler())
-        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
-        self._thread.start()
-        return self
-
-    def __exit__(self, *exc) -> None:
-        if self._httpd is not None:
-            self._httpd.shutdown()
-            self._httpd.server_close()
-            self._httpd = None
-        if self._thread is not None:
-            self._thread.join(timeout=2)
-            self._thread = None
-
-    @property
-    def url(self) -> str:
-        return f"http://{self._host}:{self._listen_port}"
-
-    @property
-    def port(self) -> int:
-        """Proxy listen port; makes ``RoundRobinProxy`` interchangeable with a
-        ``RemoteOpenAIServer`` for helpers that only need ``.port``."""
-        return self._listen_port
-
-    def _pick_backend(self) -> int:
-        with self._lock:
-            port = self._backend_ports[self._next % len(self._backend_ports)]
-            self._next += 1
-            return port
-
-    def _make_handler(self):
-        proxy = self
-
-        class Handler(http.server.BaseHTTPRequestHandler):
-            def _forward(self) -> None:
-                length = int(self.headers.get("Content-Length", 0) or 0)
-                body = self.rfile.read(length) if length else b""
-                port = proxy._pick_backend()
-                url = f"http://127.0.0.1:{port}{self.path}"
-                req = urllib.request.Request(url, data=body, method=self.command)
-                for key, value in self.headers.items():
-                    if key.lower() not in ("host", "content-length", "accept-encoding"):
-                        req.add_header(key, value)
-                try:
-                    with urllib.request.urlopen(req, timeout=300) as resp:
-                        status, resp_headers, resp_body = resp.status, dict(resp.headers), resp.read()
-                except urllib.error.HTTPError as exc:
-                    status, resp_headers, resp_body = exc.code, dict(exc.headers), exc.read()
-                self.send_response(status)
-                for key, value in resp_headers.items():
-                    if key.lower() not in ("transfer-encoding", "connection", "content-length"):
-                        self.send_header(key, value)
-                self.send_header("Content-Length", str(len(resp_body)))
-                self.end_headers()
-                self.wfile.write(resp_body)
-
-            do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = _forward
-
-            def log_message(self, *args):  # silence request logging
-                pass
-
-        return Handler
-
-
-# ---------------------------------------------------------------------------
 # Test primitives
 # ---------------------------------------------------------------------------
 
@@ -395,27 +301,32 @@ def _assert_serving_and_healthy(
     _in_parallel(lambda s: _complete(s.get_client()), servers)
 
 
-def _run_gsm8k_eval(server: Any, stage: str) -> float:
-    """Run GSM8K accuracy evaluation using aisbench.
+def _assert_golden_outputs(servers: tuple[RemoteOpenAIServer, ...]) -> None:
+    """Send the golden prompts to every DP rank directly and assert each rank
+    reproduces the expected output exactly.
 
-    ``server`` is any object exposing ``.port`` — either a
-    ``RemoteOpenAIServer`` or a ``RoundRobinProxy``.
-
-    Returns the measured accuracy percentage.
+    Must only be called after retry recovery has fully completed (see
+    ``_assert_serving_and_healthy``), so the golden requests are not sent into
+    a still-faulting cluster.
     """
-
-    os.environ.setdefault("BENCHMARK_HOME", BENCHMARK_HOME)
-    from tools.aisbench import AisbenchRunner
-
-    with AisbenchRunner(
-        model=MODEL_NAME,
-        port=server.port,
-        aisbench_config=_GSM8K_CASE,
-        verify=True,
-    ) as aisbench:
-        accuracy = aisbench.result
-        print(f"[{stage}] GSM8K accuracy: {accuracy:.2f}")
-        return accuracy
+    for server in servers:
+        client = server.get_client()
+        for prompt, golden in zip(_GOLDEN_PROMPTS, _GOLDEN_OUTPUTS):
+            resp = client.completions.create(
+                model=MODEL_NAME,
+                prompt=prompt,
+                max_tokens=_GOLDEN_MAX_TOKENS,
+                temperature=0.0,
+            )
+            text = resp.choices[0].text
+            print(f"[golden] rank {server.port} prompt {prompt!r}:")
+            print(f"  golden: {golden!r}")
+            print(f"  actual: {text!r}")
+            assert text.strip() == golden.strip(), (
+                f"[post-retry] rank {server.port} output for prompt {prompt!r} diverged from golden:\n"
+                f"  golden: {golden}\n"
+                f"  actual: {text}"
+            )
 
 
 def _kill_worker_process(server: RemoteOpenAIServer) -> None:
@@ -528,9 +439,10 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
 
-    After recovery, the serving cluster must still meet the GSM8K accuracy
-    standard used by tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
-    (baseline=95, threshold=5, i.e. accuracy >= 90%).
+    After retry recovery completes, the serving cluster must reproduce the
+    hardcoded golden outputs exactly (greedy decoding is deterministic, so an
+    exact match verifies correctness without needing an ais_bench benchmark
+    tree).
     """
     fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
@@ -538,46 +450,39 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     with _ft_manager() as servers:
         assert len(servers) == DP_SIZE
         all_ranks = tuple(_server_for_rank(servers, r) for r in range(DP_SIZE))
-        backend_ports = [server.port for server, _ in servers]
 
-        # Requests through the round-robin proxy are spread evenly across
-        # the DP rank ports; the proxy stays alive for the whole test so the
-        # GSM8K accuracy evaluation is also driven through it.
-        with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
-            # 1. All engines healthy and serving.
-            _assert_serving_and_healthy(all_ranks)
+        # 1. All engines healthy and serving.
+        _assert_serving_and_healthy(all_ranks)
 
-            # 2. Drive all ranks so rank 3 accumulates steps and trips the
-            #    injected fault; ranks 0,1,2 then time out on DP allreduce.
-            with _driving(*all_ranks):
-                faulted = _wait_for_engines(
-                    list(all_ranks),
-                    match_key="status",
-                    match_values={"unhealthy"},
-                )
+        # 2. Drive all ranks so rank 3 accumulates steps and trips the
+        #    injected fault; ranks 0,1,2 then time out on DP allreduce.
+        with _driving(*all_ranks):
+            faulted = _wait_for_engines(
+                list(all_ranks),
+                match_key="status",
+                match_values={"unhealthy"},
+            )
 
-            for rank, engine_status in enumerate(faulted):
-                assert engine_status is not None, (
-                    f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
-                )
+        for rank, engine_status in enumerate(faulted):
+            assert engine_status is not None, (
+                f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+            )
 
-            # The rank that raised carries the fault info from its own exception.
-            assert faulted[3] is not None
-            assert faulted[3].get("fault_info"), faulted[3]
+        # The rank that raised carries the fault info from its own exception.
+        assert faulted[3] is not None
+        assert faulted[3].get("fault_info"), faulted[3]
 
-            # 3. retry all engines.
-            for server in all_ranks:
-                _apply_ft(server, "retry")
+        # 3. retry all engines.
+        for server in all_ranks:
+            _apply_ft(server, "retry")
 
-            # 4. Recovery completes: all engines return to healthy and serve again.
-            _assert_serving_and_healthy(all_ranks)
+        # 4. Recovery completes: all engines return to healthy and serve again.
+        _assert_serving_and_healthy(all_ranks)
 
-            # 5. The recovered cluster must still meet the GSM8K accuracy
-            #    standard (>= 90%); AisbenchRunner raises otherwise. The injected
-            #    fault is a one-shot step guard, so this dataset run does not
-            #    re-trigger it. The evaluation runs through the proxy, which
-            #    spreads the requests across all DP ranks.
-            _run_gsm8k_eval(proxy, "post-retry")
+        # 5. Only now (after retry fully completed) send the golden prompts to
+        #    every DP rank directly. The injected fault is a one-shot step
+        #    guard, so these requests do not re-trigger it.
+        _assert_golden_outputs(all_ranks)
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -6,9 +6,12 @@ Requires 4 NPUs (DP=4); gated behind ``has_npu_ft_capability()``.
 """
 
 import contextlib
+import http.server
 import os
 import threading
 import time
+import urllib.error
+import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
@@ -23,12 +26,24 @@ MODEL_NAME = os.getenv("MODEL_NAME", "Qwen/Qwen3-30B-A3B")
 DP_SIZE = 4
 
 # Fault-detection timeout budget:
-# - CPU: Gloo DP allreduce timeout  detects the dead peer.
+# - CPU: Gloo DP allreduce timeout detects the dead peer.
 # - NPU: HCSP operator timeout detects the dead peer.
-# - Deadline : slowest fallback + margin.
+# - Deadline: slowest fallback + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
+
+BENCHMARK_HOME = "./benchmark"
+_GSM8K_CASE = {
+    "case_type": "accuracy",
+    "dataset_path": "vllm-ascend/gsm8k-lite",
+    "request_conf": "vllm_api_general_chat",
+    "dataset_conf": "gsm8k/gsm8k_gen_0_shot_cot_chat_prompt",
+    "max_out_len": 32768,
+    "batch_size": 32,
+    "baseline": 95,
+    "threshold": 5,
+}
 
 
 # ---------------------------------------------------------------------------
@@ -122,7 +137,7 @@ def _ft_server_args() -> list[str]:
         "--dtype",
         "bfloat16",
         "--max-model-len",
-        "2048",
+        "37364",
         "--max-num-seqs",
         "128",
         "--enable-expert-parallel",
@@ -233,6 +248,107 @@ def _server_for_rank(servers: list[tuple[RemoteOpenAIServer, list[str]]], rank: 
 
 
 # ---------------------------------------------------------------------------
+# Round-robin proxy
+# ---------------------------------------------------------------------------
+
+
+class RoundRobinProxy:
+    """Tiny standard-library HTTP proxy that round-robins requests across
+    the DP rank server ports.
+
+    Listens on ``listen_port`` and forwards every request (method, path,
+    headers, body) verbatim to one of ``backend_ports``, chosen by a
+    thread-safe round-robin counter, so requests are spread evenly across
+    the ranks. Responses are passed back unchanged.
+
+    Usage::
+
+        with _ft_manager() as servers:
+            backend_ports = [server.port for server, _ in servers]
+            with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
+                resp = requests.post(f"{proxy.url}/v1/completions", json={...})
+    """
+
+    def __init__(
+        self,
+        backend_ports: list[int],
+        listen_port: int,
+        host: str = "127.0.0.1",
+    ):
+        self._backend_ports = list(backend_ports)
+        self._host = host
+        self._listen_port = listen_port
+        self._next = 0
+        self._lock = threading.Lock()
+        self._httpd: http.server.ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> "RoundRobinProxy":
+        self._httpd = http.server.ThreadingHTTPServer((self._host, self._listen_port), self._make_handler())
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._httpd is not None:
+            self._httpd.shutdown()
+            self._httpd.server_close()
+            self._httpd = None
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+    @property
+    def url(self) -> str:
+        return f"http://{self._host}:{self._listen_port}"
+
+    @property
+    def port(self) -> int:
+        """Proxy listen port; makes ``RoundRobinProxy`` interchangeable with a
+        ``RemoteOpenAIServer`` for helpers that only need ``.port``."""
+        return self._listen_port
+
+    def _pick_backend(self) -> int:
+        with self._lock:
+            port = self._backend_ports[self._next % len(self._backend_ports)]
+            self._next += 1
+            return port
+
+    def _make_handler(self):
+        proxy = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def _forward(self) -> None:
+                length = int(self.headers.get("Content-Length", 0) or 0)
+                body = self.rfile.read(length) if length else b""
+                port = proxy._pick_backend()
+                url = f"http://127.0.0.1:{port}{self.path}"
+                req = urllib.request.Request(url, data=body, method=self.command)
+                for key, value in self.headers.items():
+                    if key.lower() not in ("host", "content-length", "accept-encoding"):
+                        req.add_header(key, value)
+                try:
+                    with urllib.request.urlopen(req, timeout=300) as resp:
+                        status, resp_headers, resp_body = resp.status, dict(resp.headers), resp.read()
+                except urllib.error.HTTPError as exc:
+                    status, resp_headers, resp_body = exc.code, dict(exc.headers), exc.read()
+                self.send_response(status)
+                for key, value in resp_headers.items():
+                    if key.lower() not in ("transfer-encoding", "connection", "content-length"):
+                        self.send_header(key, value)
+                self.send_header("Content-Length", str(len(resp_body)))
+                self.end_headers()
+                self.wfile.write(resp_body)
+
+            do_GET = do_POST = do_PUT = do_DELETE = do_PATCH = _forward
+
+            def log_message(self, *args):  # silence request logging
+                pass
+
+        return Handler
+
+
+# ---------------------------------------------------------------------------
 # Test primitives
 # ---------------------------------------------------------------------------
 
@@ -278,6 +394,29 @@ def _assert_serving_and_healthy(
     healthy = _wait_for_engines(list(servers), match_key="status", match_values={"healthy"})
     assert all(healthy), healthy
     _in_parallel(lambda s: _complete(s.get_client()), servers)
+
+
+def _run_gsm8k_eval(server: Any, stage: str) -> float:
+    """Run GSM8K accuracy evaluation using aisbench.
+
+    ``server`` is any object exposing ``.port`` — either a
+    ``RemoteOpenAIServer`` or a ``RoundRobinProxy``.
+
+    Returns the measured accuracy percentage.
+    """
+
+    os.environ.setdefault("BENCHMARK_HOME", BENCHMARK_HOME)
+    from tools.aisbench import AisbenchRunner
+
+    with AisbenchRunner(
+        model=MODEL_NAME,
+        port=server.port,
+        aisbench_config=_GSM8K_CASE,
+        verify=True,
+    ) as aisbench:
+        accuracy = aisbench.result
+        print(f"[{stage}] GSM8K accuracy: {accuracy:.2f}")
+        return accuracy
 
 
 def _kill_worker_process(server: RemoteOpenAIServer) -> None:
@@ -389,6 +528,10 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
 
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
+
+    After recovery, the serving cluster must still meet the GSM8K accuracy
+    standard used by tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
+    (baseline=95, threshold=5, i.e. accuracy >= 90%).
     """
     fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
@@ -396,34 +539,50 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     with _ft_manager() as servers:
         assert len(servers) == DP_SIZE
         all_ranks = tuple(_server_for_rank(servers, r) for r in range(DP_SIZE))
+        backend_ports = [server.port for server, _ in servers]
 
-        # 1. All engines healthy and serving.
-        _assert_serving_and_healthy(all_ranks)
+        # Requests through the round-robin proxy are spread evenly across
+        # the DP rank ports; the proxy stays alive for the whole test so the
+        # GSM8K accuracy evaluation is also driven through it.
+        with RoundRobinProxy(backend_ports=backend_ports, listen_port=8100) as proxy:
+            # 1. All engines healthy and serving.
+            _assert_serving_and_healthy(all_ranks)
 
-        # 2. Drive all ranks so rank 3 accumulates steps and trips the
-        #    injected fault; ranks 0,1,2 then time out on DP allreduce.
-        with _driving(*all_ranks):
-            faulted = _wait_for_engines(
-                list(all_ranks),
-                match_key="status",
-                match_values={"unhealthy"},
+            # 2. Drive all ranks so rank 3 accumulates steps and trips the
+            #    injected fault; ranks 0,1,2 then time out on DP allreduce.
+            with _driving(*all_ranks):
+                faulted = _wait_for_engines(
+                    list(all_ranks),
+                    match_key="status",
+                    match_values={"unhealthy"},
+                )
+
+            for rank, engine_status in enumerate(faulted):
+                assert engine_status is not None, (
+                    f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
+                )
+
+            # The rank that raised carries the fault info from its own exception.
+            assert faulted[3] is not None
+            assert faulted[3].get("fault_info"), faulted[3]
+
+            # 3. retry all engines.
+            for server in all_ranks:
+                _apply_ft(server, "retry")
+
+            # 4. Recovery completes: all engines return to healthy and serve again.
+            _assert_serving_and_healthy(all_ranks)
+
+            # 5. The recovered cluster must still meet the GSM8K accuracy
+            #    standard (>= 90%); AisbenchRunner raises otherwise. The injected
+            #    fault is a one-shot step guard, so this dataset run does not
+            #    re-trigger it. The evaluation runs through the proxy, which
+            #    spreads the requests across all DP ranks.
+            recovered_acc = _run_gsm8k_eval(proxy, "post-retry")
+            print(
+                f"[GSM8K acc] recovered={recovered_acc:.2f}% "
+                f"(standard: >= {_GSM8K_CASE['baseline'] - _GSM8K_CASE['threshold']}%)"
             )
-
-        for rank, engine_status in enumerate(faulted):
-            assert engine_status is not None, (
-                f"rank {rank} did not report UNHEALTHY within {FAULT_DETECTION_DEADLINE_S}s -- it likely hung"
-            )
-
-        # The rank that raised carries the fault info from its own exception.
-        assert faulted[3] is not None
-        assert faulted[3].get("fault_info"), faulted[3]
-
-        # 3. retry all engines.
-        for server in all_ranks:
-            _apply_ft(server, "retry")
-
-        # 4. Recovery completes: all engines return to healthy and serve again.
-        _assert_serving_and_healthy(all_ranks)
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -23,9 +23,9 @@ MODEL_NAME = os.getenv("MODEL_NAME", "Qwen/Qwen3-30B-A3B")
 DP_SIZE = 4
 
 # Fault-detection timeout budget:
-# - CPU: Gloo DP allreduce timeout (30s) detects the dead peer.
+# - CPU: Gloo DP allreduce timeout  detects the dead peer.
 # - NPU: HCSP operator timeout detects the dead peer.
-# - Deadline (45s): slowest fallback (30s) + margin.
+# - Deadline : slowest fallback + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -578,11 +578,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
             #    fault is a one-shot step guard, so this dataset run does not
             #    re-trigger it. The evaluation runs through the proxy, which
             #    spreads the requests across all DP ranks.
-            recovered_acc = _run_gsm8k_eval(proxy, "post-retry")
-            print(
-                f"[GSM8K acc] recovered={recovered_acc:.2f}% "
-                f"(standard: >= {_GSM8K_CASE['baseline'] - _GSM8K_CASE['threshold']}%)"
-            )
+            _run_gsm8k_eval(proxy, "post-retry")
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -360,7 +360,6 @@ def _complete(client) -> Any:
         prompt="Hello, my name is",
         max_tokens=5,
         temperature=0.0,
-        timeout=10.0,
     )
 
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import psutil
 import pytest
+import regex as re
 import requests
 import torch
 
@@ -30,29 +31,16 @@ CPU_DISTRIBUTED_TIMEOUT_S = 15
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
 
-# Golden-output accuracy check, mirroring the pattern in
-# tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py: greedy
-# completions for fixed prompts must be reproduced exactly after retry recovery.
-#
-# The golden outputs are hardcoded (NOT captured during the test): the fault
-# injection is step-triggered while serving, so it could fire mid-request and
-# corrupt a self-captured reference. Generate them by starting a healthy
-# Qwen/Qwen3-30B-A3B server once and issuing the prompts below with
-# temperature=0, max_tokens=_GOLDEN_MAX_TOKENS, then paste the returned texts
-# into _GOLDEN_OUTPUTS.
-_GOLDEN_PROMPTS = [
-    "Hello, my name is",
-    "The capital of France is",
-    "What is the meaning of life?",
+# Post-recovery accuracy check: after retry recovery, every DP rank must
+# answer these factual prompts correctly. Each expected answer is a single
+# word, matched case-insensitively on word boundaries anywhere in the
+# completion, so harmless phrasing variations do not fail the check.
+_ANSWER_CASES = [
+    ("The capital of France is", ("Paris",)),
+    ("The largest planet in our solar system is", ("Jupiter",)),
+    ("The first month of the year is", ("January",)),
 ]
-_GOLDEN_OUTPUTS = [
-    " Sarah, and I am 14 years old. I have a question about the equation $x^2 + y^2 = 1$. I know",
-    " Paris. The capital of the United Kingdom is London. The capital of Germany is Berlin. "
-    "The capital of Spain is Madrid. The capital of Italy is Rome.",
-    " Is it possible to find a single, universal answer to this question, and how do "
-    "different perspectives approach it?\n\nThe question of the meaning of life is one of",
-]
-_GOLDEN_MAX_TOKENS = 32
+_ANSWER_MAX_TOKENS = 16
 
 
 # ---------------------------------------------------------------------------
@@ -303,31 +291,28 @@ def _assert_serving_and_healthy(
     _in_parallel(lambda s: _complete(s.get_client()), servers)
 
 
-def _assert_golden_outputs(servers: tuple[RemoteOpenAIServer, ...]) -> None:
-    """Send the golden prompts to every DP rank directly and assert each rank
-    reproduces the expected output exactly.
+def _assert_correct_answers(servers: tuple[RemoteOpenAIServer, ...]) -> None:
+    """Send factual prompts to every DP rank and assert the answer appears.
 
     Must only be called after retry recovery has fully completed (see
-    ``_assert_serving_and_healthy``), so the golden requests are not sent into
-    a still-faulting cluster.
+    ``_assert_serving_and_healthy``), so the requests are not sent into a
+    still-faulting cluster.
     """
     for server in servers:
         client = server.get_client()
-        for prompt, golden in zip(_GOLDEN_PROMPTS, _GOLDEN_OUTPUTS):
+        for prompt, answers in _ANSWER_CASES:
             resp = client.completions.create(
                 model=MODEL_NAME,
                 prompt=prompt,
-                max_tokens=_GOLDEN_MAX_TOKENS,
+                max_tokens=_ANSWER_MAX_TOKENS,
                 temperature=0.0,
             )
-            text = resp.choices[0].text
-            print(f"[golden] rank {server.port} prompt {prompt!r}:")
-            print(f"  golden: {golden!r}")
-            print(f"  actual: {text!r}")
-            assert text.strip() == golden.strip(), (
-                f"[post-retry] rank {server.port} output for prompt {prompt!r} diverged from golden:\n"
-                f"  golden: {golden}\n"
-                f"  actual: {text}"
+            completion = resp.choices[0].text
+            matched = any(re.search(rf"\b{re.escape(answer)}\b", completion, re.IGNORECASE) for answer in answers)
+            print(f"[accuracy] rank {server.port} prompt {prompt!r}: {completion!r}")
+            assert matched, (
+                f"[post-retry] rank {server.port} answered {prompt!r} incorrectly: "
+                f"expected one of {answers!r}, got {completion!r}"
             )
 
 
@@ -441,10 +426,9 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
 
-    After retry recovery completes, the serving cluster must reproduce the
-    hardcoded golden outputs exactly (greedy decoding is deterministic, so an
-    exact match verifies correctness without needing an ais_bench benchmark
-    tree).
+    After retry recovery completes, every rank must answer factual prompts
+    correctly (greedy decoding; case-insensitive whole-word match, not an
+    exact-match golden, so the check is independent of environment numerics).
     """
     fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
@@ -481,10 +465,10 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
         # 4. Recovery completes: all engines return to healthy and serve again.
         _assert_serving_and_healthy(all_ranks)
 
-        # 5. Only now (after retry fully completed) send the golden prompts to
-        #    every DP rank directly. The injected fault is a one-shot step
+        # 5. Only now (after retry fully completed) send the accuracy prompts
+        #    to every DP rank directly. The injected fault is a one-shot step
         #    guard, so these requests do not re-trigger it.
-        _assert_golden_outputs(all_ranks)
+        _assert_correct_answers(all_ranks)
 
 
 @pytest.mark.skipif(

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -26,8 +26,8 @@ DP_SIZE = 4
 # - CPU: Gloo DP allreduce timeout (30s) detects the dead peer.
 # - NPU: HCSP operator timeout detects the dead peer.
 # - Deadline (45s): slowest fallback (30s) + margin.
-CPU_DISTRIBUTED_TIMEOUT_S = 30
-FT_COMMUNICATION_ABORT_TIMEOUT_S = 15
+CPU_DISTRIBUTED_TIMEOUT_S = 15
+FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
 FAULT_DETECTION_DEADLINE_S = 45
 
 
@@ -384,7 +384,7 @@ def test_injected_fault_retry_recovers_all_ranks(monkeypatch, tmp_path):
     All 4 being UNHEALTHY is the precondition for ``retry``.  The fault
     is patched via a generated ``sitecustomize.py``.
     """
-    fault_step = int(os.getenv("FT_FAULT_STEP", "50"))
+    fault_step = int(os.getenv("FT_FAULT_STEP", "100"))
     _install_fault_injection(monkeypatch, tmp_path, rank=3, step=fault_step)
 
     with _ft_manager() as servers:

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -27,7 +27,7 @@ DP_SIZE = 4
 # - NPU: HCSP operator timeout detects the dead peer.
 # - Deadline (45s): slowest fallback (30s) + margin.
 CPU_DISTRIBUTED_TIMEOUT_S = 30
-FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS = 15
+FT_COMMUNICATION_ABORT_TIMEOUT_S = 15
 FAULT_DETECTION_DEADLINE_S = 45
 
 
@@ -129,7 +129,7 @@ def _ft_server_args() -> list[str]:
         "--fault-tolerance-config",
         '{"engine_recovery_timeout_sec": 120}',
         "--additional-config",
-        f'{{"ft_communication_ops_abort_timeout_ms": {FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS}}}',
+        f'{{"ft_communication_abort_timeout": {FT_COMMUNICATION_ABORT_TIMEOUT_S}}}',
     ]
 
 

--- a/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
+++ b/tests/e2e/pull_request/four_card/fault_tolerance/test_fault_tolerance_e2e.py
@@ -27,9 +27,9 @@ DP_SIZE = 4
 # - CPU: Gloo DP allreduce timeout detects the dead peer.
 # - NPU: HCSP operator timeout detects the dead peer.
 # - Deadline: slowest fallback + margin.
-CPU_DISTRIBUTED_TIMEOUT_S = 15
+CPU_DISTRIBUTED_TIMEOUT_S = 30
 FT_COMMUNICATION_ABORT_TIMEOUT_S = 10
-FAULT_DETECTION_DEADLINE_S = 45
+FAULT_DETECTION_DEADLINE_S = 60
 
 # Post-recovery accuracy check: after retry recovery, every DP rank must
 # answer these factual prompts correctly. Each expected answer is a single

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -530,6 +530,8 @@ class TestNPUWorker(TestBase):
             worker.parallel_config.data_parallel_size = 1
             worker.parallel_config.assigned_physical_gpu_ids = None
             worker.parallel_config.distributed_executor_backend = "ray"
+            worker.parallel_config.enable_fault_tolerance = False
+            worker.use_v2_model_runner = False
             worker.vllm_config = MagicMock()
             worker.vllm_config.kv_transfer_config = None
             worker.cache_config = MagicMock()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -423,10 +423,9 @@ class AscendConfig:
     msmonitor_use_daemon: bool = False
     enable_transpose_kv_cache_by_block: bool = True
     weight_nz_mode: int = 1
-    # Fault-tolerance comm op abort timeout (seconds); 0 = disable. When fault
-    # tolerance is enabled and > 0, a hung NPU comm op is aborted after this
-    # many seconds. Drives HCCL_EVENT_TIMEOUT / HCCL_EXEC_TIMEOUT (= timeout - 1)
-    # and set_op_timeout_ms(timeout * 1000). Validated to be 0 or >= 2.
+    # ---- fault-tolerance: comm op abort timeout (s); 0 = disable ----
+    # Drives HCCL_EVENT_TIMEOUT / HCCL_EXEC_TIMEOUT (= timeout - 1) and
+    # set_op_timeout_ms(timeout * 1000). Validated to be 0 or >= 2.
     ft_communication_abort_timeout: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
@@ -584,9 +583,6 @@ class AscendConfig:
             logger.warning_once(
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."
             )
-        # ft_communication_abort_timeout is a declared AscendConfig field; it is
-        # populated from additional_config via the factory kwargs
-        # (see init_ascend_config) and validated by _validate_user_input_ranges.
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only
@@ -690,6 +686,17 @@ class AscendConfig:
 
         # sparse KV offload vs sparse SFA C8 main cache mutex
         self._validate_sparse_c8_kv_offload_compatibility()
+
+        # ft_communication_abort_timeout only takes effect when fault tolerance
+        # is enabled, so validate it only then: a stray value in additional_config
+        # must not fail startup for non-FT runs.
+        if vc.parallel_config.enable_fault_tolerance and (
+            self.ft_communication_abort_timeout != 0 and self.ft_communication_abort_timeout < 2
+        ):
+            raise ValueError(
+                f"ft_communication_abort_timeout must be 0 (disabled) or an integer of at least "
+                f"2 seconds, got {self.ft_communication_abort_timeout}"
+            )
         return self
 
     def _validate_mc2_comm_alg(self, vllm_config: VllmConfig) -> None:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -423,6 +423,8 @@ class AscendConfig:
     msmonitor_use_daemon: bool = False
     enable_transpose_kv_cache_by_block: bool = True
     weight_nz_mode: int = 1
+    # NPU operator timeout (ms) used by fault tolerance retry; 0 = disable.
+    operator_timeout_ms: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
     ascend_compilation_config: AscendCompilationConfig = dataclasses.field(default_factory=AscendCompilationConfig)
@@ -579,6 +581,8 @@ class AscendConfig:
             logger.warning_once(
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."
             )
+        # operator_timeout_ms is a declared AscendConfig field; it is populated
+        # from additional_config via the factory kwargs (see init_ascend_config).
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -425,6 +425,9 @@ class AscendConfig:
     weight_nz_mode: int = 1
     # NPU operator timeout (ms) used by fault tolerance retry; 0 = disable.
     operator_timeout_ms: int = 0
+    # Fault-tolerance comm op abort timeout (ms); 0 = disable. Injected via
+    # additional_config["ft_communication_ops_abort_timeout_ms"].
+    ft_communication_ops_abort_timeout_ms: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
     ascend_compilation_config: AscendCompilationConfig = dataclasses.field(default_factory=AscendCompilationConfig)
@@ -583,6 +586,8 @@ class AscendConfig:
             )
         # operator_timeout_ms is a declared AscendConfig field; it is populated
         # from additional_config via the factory kwargs (see init_ascend_config).
+        # ft_communication_ops_abort_timeout_ms is likewise a declared field
+        # (retry-based fault tolerance comm op abort timeout).
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -423,11 +423,11 @@ class AscendConfig:
     msmonitor_use_daemon: bool = False
     enable_transpose_kv_cache_by_block: bool = True
     weight_nz_mode: int = 1
-    # NPU operator timeout (ms) used by fault tolerance retry; 0 = disable.
-    operator_timeout_ms: int = 0
-    # Fault-tolerance comm op abort timeout (ms); 0 = disable. Injected via
-    # additional_config["ft_communication_ops_abort_timeout_ms"].
-    ft_communication_ops_abort_timeout_ms: int = 0
+    # Fault-tolerance comm op abort timeout (seconds); 0 = disable. When fault
+    # tolerance is enabled and > 0, a hung NPU comm op is aborted after this
+    # many seconds. Drives HCCL_EVENT_TIMEOUT / HCCL_EXEC_TIMEOUT (= timeout - 1)
+    # and set_op_timeout_ms(timeout * 1000). Validated to be 0 or >= 2.
+    ft_communication_abort_timeout: int = 0
 
     # ---- sub-configs (no vllm_config dep): pydantic dict→dataclass coercion ----
     ascend_compilation_config: AscendCompilationConfig = dataclasses.field(default_factory=AscendCompilationConfig)
@@ -584,10 +584,9 @@ class AscendConfig:
             logger.warning_once(
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."
             )
-        # operator_timeout_ms is a declared AscendConfig field; it is populated
-        # from additional_config via the factory kwargs (see init_ascend_config).
-        # ft_communication_ops_abort_timeout_ms is likewise a declared field
-        # (retry-based fault tolerance comm op abort timeout).
+        # ft_communication_abort_timeout is a declared AscendConfig field; it is
+        # populated from additional_config via the factory kwargs
+        # (see init_ascend_config) and validated by _validate_user_input_ranges.
 
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only

--- a/vllm_ascend/distributed/device_communicators/npu_communicator.py
+++ b/vllm_ascend/distributed/device_communicators/npu_communicator.py
@@ -36,6 +36,9 @@ class _NpuAll2AllManager:
     def query_active_mask(self) -> torch.Tensor:
         return torch.zeros(1, dtype=torch.bool, device="cpu")
 
+    def clean_buffers(self) -> None:
+        """No-op: NPU registers no RDMA buffers or all2all mask state."""
+
 
 class NPUCommunicator(DeviceCommunicatorBase):
     def __init__(

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,14 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Fault-tolerance timeout (in milliseconds) after which a hung NPU operator
+    # (e.g. a communication op) is aborted with a timeout exception, so fault
+    # tolerance can detect it and trigger recovery. 0 (default) disables the
+    # timeout. Applied via torch_npu.npu.set_op_timeout_ms when fault tolerance
+    # is enabled.
+    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(
+        os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -76,9 +76,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # tolerance can detect it and trigger recovery. 0 (default) disables the
     # timeout. Applied via torch_npu.npu.set_op_timeout_ms when fault tolerance
     # is enabled.
-    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(
-        os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")
-    ),
+    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,12 +71,6 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
-    # Fault-tolerance timeout (in milliseconds) after which a hung NPU operator
-    # (e.g. a communication op) is aborted with a timeout exception, so fault
-    # tolerance can detect it and trigger recovery. 0 (default) disables the
-    # timeout. Applied via torch_npu.npu.set_op_timeout_ms when fault tolerance
-    # is enabled.
-    "FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS": lambda: int(os.getenv("FT_COMMUNICATION_OPS_ABORT_TIMEOUT_MS", "0")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -22,7 +22,9 @@ from typing import Any, cast
 import torch
 import vllm
 from torch.distributed import Backend
+from torch.distributed.distributed_c10d import _set_pg_timeout
 from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
+from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
 from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
 from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgKey, HcclPgRegistry, make_hccl_pg_key
@@ -154,9 +156,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
             raise
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
-        from torch.distributed.distributed_c10d import _set_pg_timeout
-        from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
-
         timeout = get_cpu_distributed_timeout_or_none()
         reuse_domain = _resolve_reuse_domain(self.group_name)
         self_device_group = None

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -22,7 +22,6 @@ from typing import Any, cast
 import torch
 import vllm
 from torch.distributed import Backend
-from torch.distributed.distributed_c10d import _set_pg_timeout
 from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
 from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
@@ -180,7 +179,7 @@ class GroupCoordinatorPatch(GroupCoordinator):
                     self.rank_in_group = ranks.index(self.rank)
                     self.cpu_group = cpu_group
                     if timeout is not None:
-                        _set_pg_timeout(timeout=timeout, group=cpu_group)
+                        cpu_group.set_timeout(timeout)
                 self_device_group = device_group
 
         if self_device_group is not None:

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -155,7 +155,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
         from torch.distributed.distributed_c10d import _set_pg_timeout
-
         from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
         timeout = get_cpu_distributed_timeout_or_none()

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -154,6 +154,11 @@ class GroupCoordinatorPatch(GroupCoordinator):
             raise
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
+        from torch.distributed.distributed_c10d import _set_pg_timeout
+
+        from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
+
+        timeout = get_cpu_distributed_timeout_or_none()
         reuse_domain = _resolve_reuse_domain(self.group_name)
         self_device_group = None
         for ranks in self.group_ranks:
@@ -176,6 +181,8 @@ class GroupCoordinatorPatch(GroupCoordinator):
                     self.world_size = len(ranks)
                     self.rank_in_group = ranks.index(self.rank)
                     self.cpu_group = cpu_group
+                    if timeout is not None:
+                        _set_pg_timeout(timeout=timeout, group=cpu_group)
                 self_device_group = device_group
 
         if self_device_group is not None:

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -23,7 +23,6 @@ import torch
 import vllm
 from torch.distributed import Backend
 from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
-from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 
 from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
 from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgKey, HcclPgRegistry, make_hccl_pg_key
@@ -155,7 +154,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
             raise
 
     def _init_device_groups(self, create_cpu_group: bool) -> None:
-        timeout = get_cpu_distributed_timeout_or_none()
         reuse_domain = _resolve_reuse_domain(self.group_name)
         self_device_group = None
         for ranks in self.group_ranks:
@@ -178,8 +176,6 @@ class GroupCoordinatorPatch(GroupCoordinator):
                     self.world_size = len(ranks)
                     self.rank_in_group = ranks.index(self.rank)
                     self.cpu_group = cpu_group
-                    if timeout is not None:
-                        cpu_group.set_timeout(timeout)
                 self_device_group = device_group
 
         if self_device_group is not None:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2041,6 +2041,25 @@ class NPUModelRunner(GPUModelRunner):
         )
         return cut_tokens
 
+    @contextmanager
+    def synchronize_input_prep(self):
+        """Override to skip prepare_input_event synchronize/record after
+        a fault has been detected."""
+
+        if self.prepare_inputs_event is None:
+            yield
+            return
+
+        self.prepare_inputs_event.synchronize()
+        try:
+            yield
+        except:
+            raise RuntimeError(
+                "prepare_inputs_event record skipped due to fault."
+            )
+        else:
+            self.prepare_inputs_event.record()
+
     @torch.inference_mode()
     def execute_model(
         self,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2053,10 +2053,10 @@ class NPUModelRunner(GPUModelRunner):
         self.prepare_inputs_event.synchronize()
         try:
             yield
-        except:
+        except Exception as e:
             raise RuntimeError(
                 "prepare_inputs_event record skipped due to fault."
-            )
+            ) from e
         else:
             self.prepare_inputs_event.record()
 

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -6,7 +6,6 @@ import torch
 from vllm.distributed import (
     get_ep_group,
 )
-from vllm.logger import init_logger
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
@@ -14,8 +13,6 @@ from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
-
-logger = init_logger(__name__)
 
 
 class WorkerSentinel(GPUWorkerSentinel):

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+import torch
+from torch.distributed.distributed_c10d import _set_pg_timeout
+from vllm.config import set_current_vllm_config
+from vllm.distributed import (
+    get_dp_group,
+    get_ep_group,
+    stateless_destroy_torch_distributed_process_group,
+    stateless_init_torch_distributed_process_group,
+)
+from vllm.logger import init_logger
+from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
+from vllm.v1.serial_utils import run_method
+
+if TYPE_CHECKING:
+    from vllm.v1.worker.gpu_worker import Worker
+
+logger = init_logger(__name__)
+
+
+class WorkerSentinel:
+    """Per-worker sentinel for fault tolerance.
+
+    Handles commands dispatched from EngineCoreSentinel via collective_rpc,
+    including device restart and DP group re-initialization on retry.
+    """
+
+    def __init__(self, worker: "Worker", device: torch.device):
+        self.worker = worker
+        self.device = device
+        self.dp_rank = worker.parallel_config.data_parallel_rank
+        self.dp_size = worker.parallel_config.data_parallel_size
+        self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
+        self.set_dp_gloo_timeout()
+
+    def set_dp_gloo_timeout(self) -> None:
+        timeout = timedelta(seconds=self.worker.vllm_config.parallel_config.cpu_distributed_timeout_seconds)
+        dp_cpu_group = get_dp_group()
+        _set_pg_timeout(timeout=timeout, group=dp_cpu_group.cpu_group)
+
+    def handle_command(self, ft_request: FaultToleranceRequest):
+        """Dispatch an FT command by instruction name."""
+        with set_current_vllm_config(self.worker.vllm_config):
+            return run_method(self, ft_request.instruction, (ft_request,), {})
+
+    def query_mask(self, ft_request: FaultToleranceRequest) -> dict:
+        """Query mask for fault tolerance.
+
+        Ascend's all2all operator does not currently support querying mask.
+        Returns all-zero mask for now; will be updated once the operator
+        supports it.
+        """
+        return {"mask": get_ep_group().world_size * [0]}
+
+    def retry(self, ft_request: FaultToleranceRequest):
+        self._clean_worker_state()
+        torch.accelerator.synchronize()
+        params = ft_request.params
+        if self.dp_size > 1:
+            old_cpu_group = get_dp_group().cpu_group
+            stateless_destroy_torch_distributed_process_group(old_cpu_group)
+            world_size = self.worker.parallel_config.world_size
+            port = params["new_stateless_dp_group_ports"][self.worker.rank % world_size]
+            get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
+                self.data_parallel_master_ip,
+                port,
+                self.dp_rank,
+                self.dp_size,
+                backend="gloo",
+            )
+
+    def _clean_worker_state(self):
+        import torch_npu
+
+        from vllm_ascend.platform import NPUPlatform
+
+        NPUPlatform.set_device(self.device)
+        torch_npu.npu.stop_device(self.device.index)
+        torch_npu.npu.restart_device(self.device.index)
+        torch_npu.distributed.reinit_process_group(None, False)
+        torch.npu.synchronize()
+        model_runner = self.worker.model_runner
+        model_runner.execute_model_state = None
+        if self.worker.use_v2_model_runner:
+            for req_id in list(model_runner.req_states.req_id_to_index):
+                model_runner._remove_request(req_id)
+        else:
+            model_runner.kv_connector_output = None
+            input_batch = model_runner.input_batch
+            cached_req_ids = list(input_batch.req_id_to_index)
+            for req_id in cached_req_ids:
+                model_runner.requests.pop(req_id, None)
+                model_runner.num_prompt_logprobs.pop(req_id, None)
+                input_batch.remove_request(req_id)
+            input_batch.condense()
+            input_batch.refresh_metadata()
+            input_batch.req_prompt_embeds.clear()
+            model_runner.async_output_copy_stream = torch.cuda.Stream()
+            model_runner.prepare_inputs_event = torch.Event()

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -1,20 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import torch
-from torch.distributed.distributed_c10d import _set_pg_timeout
-from vllm.config import set_current_vllm_config
 from vllm.distributed import (
-    get_dp_group,
     get_ep_group,
-    stateless_destroy_torch_distributed_process_group,
-    stateless_init_torch_distributed_process_group,
 )
 from vllm.logger import init_logger
 from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
-from vllm.v1.serial_utils import run_method
+from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
+    WorkerSentinel as GPUWorkerSentinel,
+)
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -22,8 +18,8 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-class WorkerSentinel:
-    """Per-worker sentinel for fault tolerance.
+class WorkerSentinel(GPUWorkerSentinel):
+    """Per-worker sentinel for fault tolerance on Ascend NPU.
 
     Handles commands dispatched from EngineCoreSentinel via collective_rpc,
     including device restart and DP group re-initialization on retry.
@@ -35,17 +31,6 @@ class WorkerSentinel:
         self.dp_rank = worker.parallel_config.data_parallel_rank
         self.dp_size = worker.parallel_config.data_parallel_size
         self.data_parallel_master_ip = worker.parallel_config.data_parallel_master_ip
-        self.set_dp_gloo_timeout()
-
-    def set_dp_gloo_timeout(self) -> None:
-        timeout = timedelta(seconds=self.worker.vllm_config.parallel_config.cpu_distributed_timeout_seconds)
-        dp_cpu_group = get_dp_group()
-        _set_pg_timeout(timeout=timeout, group=dp_cpu_group.cpu_group)
-
-    def handle_command(self, ft_request: FaultToleranceRequest):
-        """Dispatch an FT command by instruction name."""
-        with set_current_vllm_config(self.worker.vllm_config):
-            return run_method(self, ft_request.instruction, (ft_request,), {})
 
     def query_mask(self, ft_request: FaultToleranceRequest) -> dict:
         """Query mask for fault tolerance.
@@ -56,24 +41,7 @@ class WorkerSentinel:
         """
         return {"mask": get_ep_group().world_size * [0]}
 
-    def retry(self, ft_request: FaultToleranceRequest):
-        self._clean_worker_state()
-        torch.accelerator.synchronize()
-        params = ft_request.params
-        if self.dp_size > 1:
-            old_cpu_group = get_dp_group().cpu_group
-            stateless_destroy_torch_distributed_process_group(old_cpu_group)
-            world_size = self.worker.parallel_config.world_size
-            port = params["new_stateless_dp_group_ports"][self.worker.rank % world_size]
-            get_dp_group().cpu_group = stateless_init_torch_distributed_process_group(
-                self.data_parallel_master_ip,
-                port,
-                self.dp_rank,
-                self.dp_size,
-                backend="gloo",
-            )
-
-    def _clean_worker_state(self):
+    def reset_device(self) -> None:
         import torch_npu
 
         from vllm_ascend.platform import NPUPlatform
@@ -83,21 +51,11 @@ class WorkerSentinel:
         torch_npu.npu.restart_device(self.device.index)
         torch_npu.distributed.reinit_process_group(None, False)
         torch.npu.synchronize()
-        model_runner = self.worker.model_runner
-        model_runner.execute_model_state = None
-        if self.worker.use_v2_model_runner:
-            for req_id in list(model_runner.req_states.req_id_to_index):
-                model_runner._remove_request(req_id)
-        else:
-            model_runner.kv_connector_output = None
-            input_batch = model_runner.input_batch
-            cached_req_ids = list(input_batch.req_id_to_index)
-            for req_id in cached_req_ids:
-                model_runner.requests.pop(req_id, None)
-                model_runner.num_prompt_logprobs.pop(req_id, None)
-                input_batch.remove_request(req_id)
-            input_batch.condense()
-            input_batch.refresh_metadata()
-            input_batch.req_prompt_embeds.clear()
-            model_runner.async_output_copy_stream = torch.cuda.Stream()
-            model_runner.prepare_inputs_event = torch.Event()
+
+    def retry(self, ft_request: FaultToleranceRequest):
+        # reset the device first so any hung device-side collectives are
+        # aborted, then run the base class flow (synchronize, clean worker
+        # state, re-initialize the DP group).
+        self.reset_device()
+        super().retry(ft_request)
+

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -58,4 +58,3 @@ class WorkerSentinel(GPUWorkerSentinel):
         # state, re-initialize the DP group).
         self.reset_device()
         super().retry(ft_request)
-

--- a/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
+++ b/vllm_ascend/worker/sentinel/npu_worker_sentinel.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 import torch
+import torch_npu
 from vllm.distributed import (
     get_ep_group,
 )
@@ -10,6 +11,8 @@ from vllm.v1.fault_tolerance.utils import FaultToleranceRequest
 from vllm.v1.worker.sentinel.gpu_worker_sentinel import (
     WorkerSentinel as GPUWorkerSentinel,
 )
+
+from vllm_ascend.platform import NPUPlatform
 
 if TYPE_CHECKING:
     from vllm.v1.worker.gpu_worker import Worker
@@ -39,10 +42,6 @@ class WorkerSentinel(GPUWorkerSentinel):
         return {"mask": get_ep_group().world_size * [0]}
 
     def reset_device(self) -> None:
-        import torch_npu
-
-        from vllm_ascend.platform import NPUPlatform
-
         NPUPlatform.set_device(self.device)
         torch_npu.npu.stop_device(self.device.index)
         torch_npu.npu.restart_device(self.device.index)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -391,7 +391,8 @@ class NPUWorker(WorkerBase):
         if self.parallel_config.enable_fault_tolerance:
             import torch_npu
 
-            torch_npu.npu.set_op_timeout_ms(get_ascend_config().operator_timeout_ms)
+            torch_npu.npu.set_op_timeout_ms(
+                get_ascend_config().ft_communication_ops_abort_timeout_ms)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -390,6 +390,14 @@ class NPUWorker(WorkerBase):
         # that each DP group binds to a distinct set of NPUs.
         parallel_config = self.parallel_config
         if self.parallel_config.enable_fault_tolerance:
+            if self.use_v2_model_runner:
+                # Model Runner V2 + fault tolerance task queue
+                # (TASK_QUEUE_ENABLE) hangs abnormally; force it off.
+                os.environ["TASK_QUEUE_ENABLE"] = "0"
+                logger.warning(
+                    "Fault tolerance with Model Runner V2 does not support the "
+                    "task queue (TASK_QUEUE_ENABLE); forcing TASK_QUEUE_ENABLE=0."
+                )
             import torch_npu
 
             abort_timeout = get_ascend_config().ft_communication_abort_timeout

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -21,6 +21,7 @@ import copy
 import gc
 import inspect
 import logging
+import os
 from types import NoneType
 from typing import Any
 
@@ -391,7 +392,21 @@ class NPUWorker(WorkerBase):
         if self.parallel_config.enable_fault_tolerance:
             import torch_npu
 
-            torch_npu.npu.set_op_timeout_ms(get_ascend_config().ft_communication_ops_abort_timeout_ms)
+            abort_timeout = get_ascend_config().ft_communication_abort_timeout
+            if abort_timeout > 0:
+                # User-provided HCCL timeouts win; otherwise derive them
+                # from the config value. HCCL_EVENT_TIMEOUT must be
+                # greater than HCCL_EXEC_TIMEOUT, hence EXEC defaults to
+                # abort_timeout - 1.
+                os.environ.setdefault("HCCL_EVENT_TIMEOUT", str(abort_timeout))
+                os.environ.setdefault("HCCL_EXEC_TIMEOUT", str(abort_timeout - 1))
+                if int(os.environ["HCCL_EVENT_TIMEOUT"]) <= int(os.environ["HCCL_EXEC_TIMEOUT"]):
+                    raise ValueError(
+                        f"HCCL_EVENT_TIMEOUT ({os.environ['HCCL_EVENT_TIMEOUT']}) "
+                        "must be greater than HCCL_EXEC_TIMEOUT "
+                        f"({os.environ['HCCL_EXEC_TIMEOUT']})"
+                    )
+                torch_npu.npu.set_op_timeout_ms(abort_timeout * 1000)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -89,6 +89,7 @@ from vllm_ascend.utils import (
     setup_ascend_local_comm_res,
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.sentinel.npu_worker_sentinel import WorkerSentinel
 
 torch._dynamo.trace_rules.clear_lru_cache()  # noqa: E402
 from torch._dynamo.variables import TorchInGraphFunctionVariable  # noqa: E402
@@ -181,6 +182,8 @@ class NPUWorker(WorkerBase):
         if "UnquantizedLinearMethod" in WEIGHT_LOADER_V2_SUPPORTED:
             WEIGHT_LOADER_V2_SUPPORTED.remove("UnquantizedLinearMethod")
 
+        self.worker_sentinel: WorkerSentinel | None = None
+
         self.use_v2_model_runner = self.vllm_config.use_v2_model_runner
         self._pp_send_work: list[Handle] = []
 
@@ -201,6 +204,10 @@ class NPUWorker(WorkerBase):
 
             signal.signal(signal.SIGTERM, signal_handler)
             signal.signal(signal.SIGINT, signal_handler)
+
+    def handle_ft_command(self, ft_request):
+        assert self.worker_sentinel is not None
+        return self.worker_sentinel.handle_command(ft_request)
 
     def uninstall_static_kernel(self):
         import fcntl
@@ -381,6 +388,10 @@ class NPUWorker(WorkerBase):
         # shift self.local_rank by dp_local_rank * tp_pp_world_size so
         # that each DP group binds to a distinct set of NPUs.
         parallel_config = self.parallel_config
+        if self.parallel_config.enable_fault_tolerance:
+            import torch_npu
+
+            torch_npu.npu.set_op_timeout_ms(get_ascend_config().operator_timeout_ms)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"
@@ -472,6 +483,8 @@ class NPUWorker(WorkerBase):
 
         # Initialize the distributed environment.
         self._init_worker_distributed_environment()
+        if self.parallel_config.enable_fault_tolerance:
+            self.worker_sentinel = WorkerSentinel(worker=self, device=device)
         # Set random seed.
         set_random_seed(self.model_config.seed)
         # Initialize device properties used by triton kernels.

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -398,7 +398,12 @@ class NPUWorker(WorkerBase):
                     "Fault tolerance with Model Runner V2 does not support the "
                     "task queue (TASK_QUEUE_ENABLE); forcing TASK_QUEUE_ENABLE=0."
                 )
-            import torch_npu
+
+            if parallel_config.tensor_parallel_size > 1:
+                # TP>1 relies on collective HCCL comms; disable HCCL's async
+                # error handling so it cannot abort the process out-of-band
+                # during fault-tolerance recovery.
+                os.environ["HCCL_ASYNC_ERROR_HANDLING"] = "0"
 
             abort_timeout = get_ascend_config().ft_communication_abort_timeout
             if abort_timeout > 0:
@@ -414,7 +419,7 @@ class NPUWorker(WorkerBase):
                         "must be greater than HCCL_EXEC_TIMEOUT "
                         f"({os.environ['HCCL_EXEC_TIMEOUT']})"
                     )
-                torch_npu.npu.set_op_timeout_ms(abort_timeout * 1000)
+                torch.npu.set_op_timeout_ms(abort_timeout * 1000)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -40,7 +40,8 @@ from vllm.distributed.kv_transfer import (
     has_kv_transfer_group,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorHandshakeMetadata
-from vllm.distributed.parallel_state import Handle, get_pp_group, get_tp_group
+from vllm.distributed.parallel_state import Handle, _groups, get_pp_group, get_tp_group
+from vllm.distributed.utils import get_cpu_distributed_timeout_or_none
 from vllm.logger import logger
 from vllm.lora.request import LoRARequest
 from vllm.platforms import current_platform
@@ -1155,6 +1156,20 @@ class NPUWorker(WorkerBase):
         )
         init_ascend_model_parallel(self.parallel_config)
         ensure_ec_transfer_initialized(self.vllm_config)
+        self._apply_cpu_distributed_timeout()
+
+    def _apply_cpu_distributed_timeout(self) -> None:
+        # Apply the user-configured CPU (gloo) distributed timeout only after
+        # all process groups exist: passing it at group creation would make the
+        # group-creation barrier itself abort on slow multi-rank startup.
+        timeout = get_cpu_distributed_timeout_or_none()
+        if timeout is None:
+            return
+        for group_ref in _groups.values():
+            group = group_ref()
+            cpu_group = getattr(group, "cpu_group", None) if group is not None else None
+            if cpu_group is not None:
+                cpu_group.set_timeout(timeout)
 
     def get_supported_pooling_tasks(self):
         return self.model_runner.get_supported_pooling_tasks()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -391,8 +391,7 @@ class NPUWorker(WorkerBase):
         if self.parallel_config.enable_fault_tolerance:
             import torch_npu
 
-            torch_npu.npu.set_op_timeout_ms(
-                get_ascend_config().ft_communication_ops_abort_timeout_ms)
+            torch_npu.npu.set_op_timeout_ms(get_ascend_config().ft_communication_ops_abort_timeout_ms)
         if (
             parallel_config.distributed_executor_backend not in ("ray", "external_launcher")
             and parallel_config.data_parallel_backend != "ray"


### PR DESCRIPTION
### What this PR does / why we need it?
In DP+EP (Data Parallelism + Expert Parallelism) MoE deployments, when one DP rank dies, the EP all2all operation on surviving ranks blocks indefinitely, causing a full cluster hang. The upstream fault tolerance framework introduced in vllm-project/vllm#44428 (https://github.com/vllm-project/vllm/pull/44428) detects the fault, aborts in-flight requests, and lets an external orchestrator trigger coordinated recovery via a REST API, but it needs an Ascend NPU backend to work on NPU hardware.
This PR provides that NPU backend: it implements retry-based fault tolerance for Ascend NPU by reusing the upstream GPUWorkerSentinel flow (clean worker state + DP-group re-initialization on retry) and adding the NPU-specific pieces the upstream design cannot cover:
- NPU fault detection: upstream relies on an FT-capable all2all backend (deepep_low_latency/nixl_ep) for timeout + rank masking, which Ascend does not use (MoE communication goes through mc2/all_gather). This PR instead aborts hung NPU communication ops via torch_npu.npu.set_op_timeout_ms (new `ft_communication_abort_timeout` ascend config) and applies the CPU distributed timeout to DP-sync process groups in patch_distributed.py, so peer failures surface as exceptions instead of hanging.
- NPU-specific recovery: on retry, the device is physically reset (stop_device/restart_device + process-group re-init) before the upstream clean-state flow runs, to abort any hung device-side collectives. query_mask returns an all-zero mask since Ascend's all2all does not support querying the mask yet.

### Does this PR introduce _any_ user-facing change?
Yes, when --enable-fault-tolerance is used on Ascend NPU:
- A new ascend config  ft_communication_abort_timeout controls how long a hung NPU operator (e.g. a communication op) is allowed to run before being aborted with a timeout exception (default 0, disabled).
- The --fault-tolerance-config engine_recovery_timeout_sec knob is respected for recovery timeout.
- No API/CLI interface changes beyond the upstream FT flags.

Examples for the start up command:
```bash
# Rank 0
vllm serve /Qwen/Qwen3-30B-A3B-W8A8/ \
  --dtype bfloat16 \
  --max-model-len 2048 \
  --max-num-seqs 128 \
  --enable-expert-parallel \
  --data-parallel-size 4 \
  --data-parallel-rank 0 \
  --data-parallel-size-local 1 \
  --tensor-parallel-size 1 \
  --port 8111 \
  --api-server-count 1\
  --enable-fault-tolerance \
  --cpu-distributed-timeout-seconds 15 \
  --fault-tolerance-config '{"engine_recovery_timeout_sec": 120}' \
  --additional-config '{"ft_communication_abort_timeout": 15}' 

# Rank 1/2/3 use the same configuration with:
# --data-parallel-rank {1,2,3}
# --port {8112,8113,8114}
```

### How was this patch tested?
1. Added DP=4 end-to-end coverage in tests/e2e/fault_tolerance/test_fault_tolerance_e2e.py:
- test_injected_fault_retry_recovers_all_ranks — injected fault on rank 3 drives all 4 engines UNHEALTHY; retry restores all ranks to HEALTHY and serving resumes.
- test_worker_kill_survivor_unhealthy_and_dead_rejects_retry — SIGKILL of one worker marks survivors UNHEALTHY and the victim DEAD; retry on a DEAD engine is correctly rejected with "status is DEAD"


- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
