### PR TITLE
[v0.26.0rc][BugFix][Worker] Reserve MTP draft slot mapping capacity

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1087,6 +1087,16 @@ class TestEagleProposerPropose:
         set_current_vllm_config(None)
         clear_ascend_config()
 
+    def test_slot_mapping_group_reserves_mtp_draft_slots(self):
+        self.vllm_config.speculative_config.num_speculative_tokens = 5
+        self.vllm_config.speculative_config.speculative_token_tree = str([(i + 1) * (0,) for i in range(6)])
+
+        proposer = AscendEagleProposer(vllm_config=self.vllm_config, device=self.device, runner=self.runner)
+
+        expected_capacity = self.runner.max_num_tokens + 4 * self.runner.max_num_reqs
+        assert len(proposer.slot_mapping_group) == 5
+        assert all(slot_mapping.shape == torch.Size([expected_capacity]) for slot_mapping in proposer.slot_mapping_group)
+
     # config: prefill and decode, Qwen3-8B, tp1, enforce_eager, no_async_scheduling, eagle3, k=3, "disable_padded_drafter_batch": False
     @pytest.mark.parametrize(
         'flag_prefill_decode, query_start_loc, query_start_loc_cpu, seq_lens, num_reqs,' \

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -77,7 +77,7 @@ class TestBlockTableComputeSlotMapping(TestBase):
             return block_table
 
     def test_compute_slot_mapping_draft_reserves_mtp_slots(self):
-        """MTP5 draft slots can exceed the graph-padding-only capacity."""
+        """MTP5 draft slots can exceed the scheduler token capacity."""
         self.max_num_reqs = 12
         self.max_num_batched_tokens = 80
         block_table = self.create_block_table(
@@ -95,7 +95,7 @@ class TestBlockTableComputeSlotMapping(TestBase):
         positions = np.tile(np.arange(10, dtype=np.int64), num_active_reqs)
         block_table.compute_slot_mapping_draft(req_indices, positions)
 
-        self.assertEqual(block_table.slot_mapping.cpu.numel(), 152)
+        self.assertEqual(block_table.slot_mapping.cpu.numel(), 128)
         self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
 
     def setup_block_table_data(self, block_table, num_reqs=2):

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -44,7 +44,13 @@ class TestBlockTableComputeSlotMapping(TestBase):
         self.kernel_sizes = [128]
         self._skip_triton_kernel = True
 
-    def create_block_table(self, dcp_world_size, dcp_rank, cp_kv_cache_interleave_size):
+    def create_block_table(
+        self,
+        dcp_world_size,
+        dcp_rank,
+        cp_kv_cache_interleave_size,
+        num_speculative_tokens=0,
+    ):
         """Helper method to create BlockTable with mocked distributed groups"""
 
         with patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group:
@@ -65,10 +71,32 @@ class TestBlockTableComputeSlotMapping(TestBase):
                 device=self.device,
                 kernel_sizes=self.kernel_sizes,
                 cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
-                num_speculative_tokens=0,
+                num_speculative_tokens=num_speculative_tokens,
             )
 
             return block_table
+
+    def test_compute_slot_mapping_draft_reserves_mtp_slots(self):
+        """MTP5 draft slots can exceed the graph-padding-only capacity."""
+        self.max_num_reqs = 12
+        self.max_num_batched_tokens = 80
+        block_table = self.create_block_table(
+            dcp_world_size=4,
+            dcp_rank=0,
+            cp_kv_cache_interleave_size=1,
+            num_speculative_tokens=5,
+        )
+
+        num_active_reqs = 11
+        for req_idx in range(num_active_reqs):
+            block_table.add_row([req_idx], req_idx)
+
+        req_indices = np.repeat(np.arange(num_active_reqs, dtype=np.int32), 10)
+        positions = np.tile(np.arange(10, dtype=np.int64), num_active_reqs)
+        block_table.compute_slot_mapping_draft(req_indices, positions)
+
+        self.assertEqual(block_table.slot_mapping.cpu.numel(), 152)
+        self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
 
     def setup_block_table_data(self, block_table, num_reqs=2):
         """Helper method to populate block table with test data"""

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -209,9 +209,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample = torch.zeros(
             self.vllm_config.scheduler_config.max_num_batched_tokens, dtype=torch.int32, device=device
         )
-        # Graph capture appends two request-sized padding regions even when
-        # PCP is disabled in MRV1.
-        slot_mapping_lens = self.runner.max_num_tokens + 2 * self.runner.max_num_reqs
+        metadata_lens = self.runner.max_num_tokens + 2 * self.runner.max_num_reqs
+        num_mtp_draft_slots = max(self.num_speculative_tokens - 1, 0) * self.runner.max_num_reqs
+        slot_mapping_lens = self.runner.max_num_tokens + num_mtp_draft_slots
         self.slot_mapping_group = [
             torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
@@ -219,11 +219,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         # dsv32 needs seq_lens and query_start_loc persistent tensors for full graph mode
         self.seq_lens_group = [
-            torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
+            torch.zeros(metadata_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
         ]
         self.query_start_loc_group = [
-            torch.zeros(slot_mapping_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
+            torch.zeros(metadata_lens, dtype=torch.int32, device=device, pin_memory=self.runner.pin_memory)
             for _ in range(self.num_speculative_tokens)
         ]
 

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -94,10 +94,10 @@ class BlockTable:
         self.block_table = self._make_buffer(max_num_reqs * duplicate_size, logical_table_size, dtype=torch.int32)
         self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
         # MTP slot preparation appends up to num_speculative_tokens - 1
-        # draft positions for every request in addition to graph padding.
+        # draft positions for every request beyond the scheduler token limit.
         num_mtp_draft_slots = max(num_speculative_tokens - 1, 0) * self.max_num_reqs
         self.slot_mapping = self._make_buffer(
-            self.max_num_batched_tokens + 2 * self.max_num_reqs + num_mtp_draft_slots,
+            self.max_num_batched_tokens + num_mtp_draft_slots,
             dtype=torch.int32,
         )
 

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -93,7 +93,13 @@ class BlockTable:
             duplicate_size += num_speculative_tokens
         self.block_table = self._make_buffer(max_num_reqs * duplicate_size, logical_table_size, dtype=torch.int32)
         self.num_blocks_per_row = np.zeros(max_num_reqs, dtype=np.int32)
-        self.slot_mapping = self._make_buffer(self.max_num_batched_tokens + 2 * self.max_num_reqs, dtype=torch.int32)
+        # MTP slot preparation appends up to num_speculative_tokens - 1
+        # draft positions for every request in addition to graph padding.
+        num_mtp_draft_slots = max(num_speculative_tokens - 1, 0) * self.max_num_reqs
+        self.slot_mapping = self._make_buffer(
+            self.max_num_batched_tokens + 2 * self.max_num_reqs + num_mtp_draft_slots,
+            dtype=torch.int32,
+        )
 
         self.kernel_sizes = kernel_sizes
         self.cp_kv_cache_interleave_size = cp_kv_cache_interleave_size


### PR DESCRIPTION
> [!NOTE]
> This PR cherry-picks the merged main-branch fix from https://github.com/vllm-project/vllm-ascend/pull/14024 into `releases/v0.26.0rc`.
> The three commits were applied with `git cherry-pick -x`:
> - `6e83155b0a7b05dbc47df0fc9ba1d0efc7beda4b` → `8c233484af58c5d6fe377a612cbd0dcb4656c29f`
> - `df3d1e77786c92903b6e00e65299b6f074e6c063` → `e5d4687794c6454ee77c2c238a42730c91807660`
> - `23c59ea9c31c025cf096c7e543281537f4851a49` → `7946e98a5aa2ed9931849871605bfe66c5440aaf`

### What this PR does / why we need it?

This backport sizes both `BlockTable.slot_mapping` and the persistent proposer slot-mapping buffers from the scheduler token capacity plus the MTP draft capacity.

With DCP and MTP enabled, slot preparation appends up to `num_speculative_tokens - 1` positions per active request. The old buffers reserved `max_num_batched_tokens + 2 * max_num_reqs`; the `2 * max_num_reqs` term was a PCP padding reserve left behind after PCP was removed. For MTP5, the generated draft mapping can exceed that capacity and fail during CPU assignment or during the proposer full-graph warmup copy.

The slot-mapping capacity is changed to:

```text
max_num_batched_tokens
+ max(num_speculative_tokens - 1, 0) * max_num_reqs
```

The buffers remain statically allocated so graph-mode tensor addresses stay stable. Regression coverage includes the reported DCP4/MTP5 110-slot case and an MTP5 proposer construction test that distinguishes the MTP formula from the old two-request reserve.

### CI follow-up

The initial v0.26 CPU run failed in `tests/ut/ops/test_kimi_kda.py::test_repack_waits_until_all_source_weights_are_materialized`. The test fixture created q/k/v source weights with `torch.empty`, then materialized only v after exercising the meta-parameter guard. Allocator-dependent q/k contents could therefore contain NaNs, causing `assert_close` to fail even though the production guard behaved correctly.

Follow-up commit `7c4f94138` explicitly materializes deterministic q/k/v test inputs before replacing v with a meta parameter. Production Kimi KDA code is unchanged.

### Does this PR introduce _any_ user-facing change?

Yes. DCP serving with MTP no longer crashes when expanded draft slot mappings exceed the old capacity, and speculative decode graph warmup no longer copies an expanded BlockTable mapping into a shorter proposer buffer. There is no API or configuration change.

### How was this patch tested?

- Cherry-pick completed without conflicts; every commit retains its `-x` source record.
- `ruff 0.14.0 check vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `ruff 0.14.0 format --check vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `python3 -m py_compile vllm_ascend/worker/block_table.py vllm_ascend/spec_decode/llm_base_proposer.py tests/ut/worker/a2/test_block_table.py tests/ut/spec_decode/a2/test_eagle_proposer.py`
- `git diff --check upstream/releases/v0.26.0rc...HEAD`

Targeted NPU, single-rank, multi-rank, KV-cache, and prefix-cache validation is left to PR CI because the local host cannot execute the repository's `torch`/`torch_npu` tests.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
