### PR TITLE
[v0.23.0][BugFix] fix rejection sampler when target_logits are NaN

### DIFF
--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -31,6 +31,7 @@ from vllm_ascend.ops.triton.reject_sample import (
 )
 from vllm_ascend.sample.penalties import apply_all_penalties
 from vllm_ascend.sample.sampler import apply_top_k_top_p
+from vllm_ascend.utils import is_310p
 
 
 class AscendRejectionSampler(RejectionSampler):
@@ -214,13 +215,14 @@ class AscendRejectionSampler(RejectionSampler):
         # torch.nan_to_num is a pure element-wise op that replaces
         # NaN/±inf in a single pass, avoiding the .any()/.item() sync
         # triggered by `if tensor.any()` branches. No-op when clean.
-        info = torch.finfo(target_logits.dtype)
-        target_logits = torch.nan_to_num(
-            target_logits,
-            nan=0.0,
-            posinf=info.max,
-            neginf=info.min,
-        )
+        if not is_310p():
+            info = torch.finfo(target_logits.dtype)
+            target_logits = torch.nan_to_num(
+                target_logits,
+                nan=0.0,
+                posinf=info.max,
+                neginf=info.min,
+            )
 
         target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
         # [num_tokens, vocab_size]

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -210,14 +210,17 @@ class AscendRejectionSampler(RejectionSampler):
             # apply_logits_processors modifies the tensor in-place.
             target_logits = target_logits.clone()
 
+        # Clean NaN/inf without introducing CPU sync.
+        # torch.nan_to_num is a pure element-wise op that replaces
+        # NaN/±inf in a single pass, avoiding the .any()/.item() sync
+        # triggered by `if tensor.any()` branches. No-op when clean.
         info = torch.finfo(target_logits.dtype)
-        if torch.isinf(target_logits).any():
-            target_logits[target_logits == torch.inf] = info.max
-            target_logits[target_logits == -torch.inf] = info.min
-        nan_mask = torch.isnan(target_logits)
-        if nan_mask.any():
-            target_logits[nan_mask] = 0
-            logger.warning_once("[sample/rejection_sampler] target_logits have NaN.")
+        target_logits = torch.nan_to_num(
+            target_logits,
+            nan=0.0,
+            posinf=info.max,
+            neginf=info.min,
+        )
 
         target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
         # [num_tokens, vocab_size]

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -209,6 +209,16 @@ class AscendRejectionSampler(RejectionSampler):
             # the original raw logits for logprobs computation, since
             # apply_logits_processors modifies the tensor in-place.
             target_logits = target_logits.clone()
+
+        info = torch.finfo(target_logits.dtype)
+        if torch.isinf(target_logits).any():
+            target_logits[target_logits == torch.inf] = info.max
+            target_logits[target_logits == -torch.inf] = info.min
+        nan_mask = torch.isnan(target_logits)
+        if nan_mask.any():
+            target_logits[nan_mask] = 0
+            logger.warning_once("[sample/rejection_sampler] target_logits have NaN.")
+
         target_logits = self.apply_logits_processors(target_logits, sampling_metadata, metadata)
         # [num_tokens, vocab_size]
         # NOTE(woosuk): `target_logits` can be updated in place inside the


### PR DESCRIPTION
### What this PR does / why we need it?
cherry pick #14098 
This PR cleans NaN/inf values from target logits in the rejection sampler using `torch.nan_to_num` to avoid CPU synchronization. However, replacing NaN with 0.0 can cause correctness issues as 0.0 represents a high probability in logit space. It is recommended to replace NaN with `info.min` to mask it out.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
