### PR TITLE
[feature][Kimi-K3] Support Kimi-K3 DCP decode context parallelism on Ascend

### DIFF
--- a/tests/ut/attention/a2/test_kimi_k3_dcp2_empty_shard.py
+++ b/tests/ut/attention/a2/test_kimi_k3_dcp2_empty_shard.py
@@ -1,0 +1,142 @@
+import torch
+
+from vllm_ascend.attention.context_parallel.common_cp import (
+    _mask_empty_kv_shards,
+    _update_out_and_lse,
+)
+from vllm_ascend.attention.context_parallel.fia_mla_heads import (
+    pad_fia_mla_query_heads,
+    trim_fia_mla_query_heads,
+)
+
+
+def test_mask_empty_dcp_kv_shard() -> None:
+    attn_output = torch.tensor([[[7.0, 9.0]], [[2.0, 3.0]]])
+    softmax_lse = torch.tensor([[[5.0]], [[4.0]]])
+
+    output, lse = _mask_empty_kv_shards(attn_output, softmax_lse, [0, 8])
+
+    torch.testing.assert_close(output[0], torch.zeros_like(output[0]))
+    assert torch.isneginf(lse[0]).all()
+    torch.testing.assert_close(output[1], attn_output[1])
+    torch.testing.assert_close(lse[1], softmax_lse[1])
+
+
+def test_dcp_lse_combine_ignores_empty_shard() -> None:
+    empty_output = torch.zeros(1, 1, 2)
+    valid_output = torch.tensor([[[2.0, 3.0]]])
+    outputs = torch.stack([empty_output, valid_output])
+    lses = torch.tensor([[[[float("-inf")]]], [[[4.0]]]])
+
+    output, lse = _update_out_and_lse(outputs, lses)
+
+    torch.testing.assert_close(output, valid_output)
+    torch.testing.assert_close(lse, torch.tensor([[[4.0]]]))
+
+
+def test_dcp_lse_combine_all_empty_graph_padding_row() -> None:
+    outputs = torch.randn(2, 1, 1, 2)
+    lses = torch.full((2, 1, 1, 1), float("-inf"))
+
+    output, lse = _update_out_and_lse(outputs, lses)
+
+    torch.testing.assert_close(output, torch.zeros_like(output))
+    assert torch.isneginf(lse).all()
+
+
+def test_empty_shard_mask_graph_replay_is_dynamic() -> None:
+    compiled = torch.compile(_mask_empty_kv_shards, backend="eager", fullgraph=True)
+    attn_output = torch.tensor([[[7.0, 9.0]], [[2.0, 3.0]]])
+    softmax_lse = torch.tensor([[[5.0]], [[4.0]]])
+
+    first_output, first_lse = compiled(attn_output, softmax_lse, torch.tensor([0, 8]))
+    second_output, second_lse = compiled(attn_output, softmax_lse, torch.tensor([8, 0]))
+
+    torch.testing.assert_close(first_output[0], torch.zeros_like(first_output[0]))
+    torch.testing.assert_close(first_output[1], attn_output[1])
+    assert torch.isneginf(first_lse[0]).all()
+    torch.testing.assert_close(second_output[0], attn_output[0])
+    torch.testing.assert_close(second_output[1], torch.zeros_like(second_output[1]))
+    assert torch.isneginf(second_lse[1]).all()
+
+
+def test_graph_padding_rows_missing_from_cp_lengths_are_empty() -> None:
+    attn_output = torch.arange(12, dtype=torch.float32).view(4, 1, 3)
+    softmax_lse = torch.arange(4, dtype=torch.float32).view(4, 1, 1)
+
+    output, lse = _mask_empty_kv_shards(attn_output, softmax_lse, [129, 65])
+
+    torch.testing.assert_close(output[:2], attn_output[:2])
+    torch.testing.assert_close(lse[:2], softmax_lse[:2])
+    torch.testing.assert_close(output[2:], torch.zeros_like(output[2:]))
+    assert torch.isneginf(lse[2:]).all()
+
+
+def test_empty_shard_preserves_greedy_token_and_logprobs() -> None:
+    valid_output = torch.tensor([[[0.5, -0.25, 1.0]]])
+    outputs = torch.stack([torch.zeros_like(valid_output), valid_output])
+    lses = torch.tensor([[[[float("-inf")]]], [[[3.0]]]])
+    projection = torch.tensor(
+        [
+            [0.1, 0.2, -0.3, 0.4],
+            [0.2, -0.1, 0.5, 0.3],
+            [-0.4, 0.6, 0.2, -0.2],
+        ]
+    )
+
+    combined, _ = _update_out_and_lse(outputs, lses)
+    reference_logits = valid_output @ projection
+    combined_logits = combined @ projection
+
+    assert combined_logits.argmax(dim=-1).item() == reference_logits.argmax(dim=-1).item()
+    torch.testing.assert_close(
+        combined_logits.log_softmax(dim=-1),
+        reference_logits.log_softmax(dim=-1),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_fia_mla_query_heads_pad_and_trim_bnsd() -> None:
+    q_nope = torch.arange(2 * 12 * 512, dtype=torch.float32).view(2, 12, 1, 512)
+    q_pe = torch.arange(2 * 12 * 64, dtype=torch.float32).view(2, 12, 1, 64)
+    padded_nope, padded_pe, padded_heads = pad_fia_mla_query_heads(q_nope, q_pe, "BNSD", 12)
+
+    assert padded_heads == 16
+    torch.testing.assert_close(padded_nope[:, :12], q_nope)
+    torch.testing.assert_close(padded_pe[:, :12], q_pe)
+    torch.testing.assert_close(padded_nope[:, 12:], torch.zeros_like(padded_nope[:, 12:]))
+    torch.testing.assert_close(padded_pe[:, 12:], torch.zeros_like(padded_pe[:, 12:]))
+
+    lse = torch.arange(2 * 16, dtype=torch.float32).view(2, 16, 1, 1)
+    output, trimmed_lse = trim_fia_mla_query_heads(padded_nope, lse, "BNSD", 12)
+    torch.testing.assert_close(output, q_nope)
+    torch.testing.assert_close(trimmed_lse, lse[:, :12])
+
+
+def test_fia_mla_query_heads_pad_and_trim_bsnd() -> None:
+    q_nope = torch.randn(2, 1, 12, 512)
+    q_pe = torch.randn(2, 1, 12, 64)
+    padded_nope, padded_pe, padded_heads = pad_fia_mla_query_heads(q_nope, q_pe, "BSND", 12)
+    lse = torch.randn(2, 16, 1, 1)
+    output, trimmed_lse = trim_fia_mla_query_heads(padded_nope, lse, "BSND", 12)
+
+    assert padded_heads == 16
+    torch.testing.assert_close(output, q_nope)
+    torch.testing.assert_close(trimmed_lse, lse[:, :12])
+    torch.testing.assert_close(padded_pe[:, :, 12:], torch.zeros_like(padded_pe[:, :, 12:]))
+
+
+def test_fia_mla_query_head_padding_graph_replay() -> None:
+    compiled = torch.compile(pad_fia_mla_query_heads, backend="eager", fullgraph=True)
+    first = torch.ones(1, 12, 1, 512)
+    second = torch.full((1, 12, 1, 512), 2.0)
+    rope = torch.ones(1, 12, 1, 64)
+
+    first_padded, _, first_heads = compiled(first, rope, "BNSD", 12)
+    second_padded, _, second_heads = compiled(second, rope, "BNSD", 12)
+
+    assert first_heads == second_heads == 16
+    torch.testing.assert_close(first_padded[:, :12], first)
+    torch.testing.assert_close(second_padded[:, :12], second)
+    torch.testing.assert_close(second_padded[:, 12:], torch.zeros_like(second_padded[:, 12:]))

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -108,6 +108,36 @@ class AscendMetadataForDecode:
     dcp_mtp_attn_mask: torch.Tensor = None
 
 
+def _mask_empty_kv_shards(
+    attn_output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    local_kv_seq_lens: list[int] | torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Turn an empty local KV shard into the online-softmax identity."""
+    if isinstance(local_kv_seq_lens, torch.Tensor):
+        seq_lens = local_kv_seq_lens.to(device=attn_output.device)
+    else:
+        seq_lens = torch.as_tensor(local_kv_seq_lens, device=attn_output.device)
+    num_rows = attn_output.shape[0]
+    if seq_lens.numel() > num_rows:
+        raise ValueError(
+            "local KV sequence lengths cannot exceed attention rows: "
+            f"{seq_lens.numel()} > {num_rows}"
+        )
+    if seq_lens.numel() < num_rows:
+        seq_lens = torch.cat(
+            [
+                seq_lens,
+                torch.zeros(num_rows - seq_lens.numel(), dtype=seq_lens.dtype, device=seq_lens.device),
+            ]
+        )
+    valid = seq_lens.reshape(-1, 1, 1) > 0
+    return (
+        torch.where(valid, attn_output, torch.zeros_like(attn_output)),
+        torch.where(valid, softmax_lse, torch.full_like(softmax_lse, float("-inf"))),
+    )
+
+
 def _process_attn_out_lse(attn_output: torch.Tensor, softmax_lse: torch.Tensor) -> torch.Tensor:
     pcp_size = get_pcp_group().world_size
     dcp_size = get_decode_context_model_parallel_world_size()
@@ -193,5 +223,9 @@ def _update_out_and_lse(out_list: torch.Tensor, lse_list: torch.Tensor) -> torch
         lse_final: shape = [batch_size, num_heads, 1]
     """
     lse_final = torch.logsumexp(lse_list, dim=0, keepdim=False)
-    out_final = torch.sum(torch.exp(lse_list - lse_final) * out_list, dim=0)
+    all_empty = torch.isneginf(lse_final)
+    safe_lse_final = torch.where(all_empty, torch.zeros_like(lse_final), lse_final)
+    weights = torch.exp(lse_list - safe_lse_final)
+    weights = torch.where(all_empty, torch.zeros_like(weights), weights)
+    out_final = torch.sum(weights * out_list, dim=0)
     return out_final, lse_final

--- a/vllm_ascend/attention/context_parallel/fia_mla_heads.py
+++ b/vllm_ascend/attention/context_parallel/fia_mla_heads.py
@@ -1,0 +1,43 @@
+import torch
+
+_SUPPORTED_NUM_HEADS = (1, 2, 4, 8, 16, 32, 64, 128)
+
+
+def pad_fia_mla_query_heads(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    input_layout: str,
+    num_heads: int,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Pad MLA query heads to a shape accepted by FIA with D=512 and RoPE."""
+    if num_heads in _SUPPORTED_NUM_HEADS:
+        return q_nope, q_pe, num_heads
+
+    head_axis = {"BNSD": 1, "BSND": 2}.get(input_layout)
+    if head_axis is None:
+        raise ValueError(f"Cannot pad FIA MLA query heads for input layout {input_layout}")
+    padded_num_heads = next((value for value in _SUPPORTED_NUM_HEADS if value > num_heads), None)
+    if padded_num_heads is None:
+        raise ValueError(f"FIA MLA query head count {num_heads} exceeds the supported range")
+
+    pad_shape = list(q_nope.shape)
+    pad_shape[head_axis] = padded_num_heads - num_heads
+    q_nope = torch.cat((q_nope, q_nope.new_zeros(pad_shape)), dim=head_axis)
+    pad_shape[-1] = q_pe.shape[-1]
+    q_pe = torch.cat((q_pe, q_pe.new_zeros(pad_shape)), dim=head_axis)
+    return q_nope, q_pe, padded_num_heads
+
+
+def trim_fia_mla_query_heads(
+    attn_output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    input_layout: str,
+    num_heads: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output_head_axis = {"BNSD": 1, "BSND": 2}.get(input_layout)
+    if output_head_axis is None:
+        raise ValueError(f"Cannot trim FIA MLA query heads for input layout {input_layout}")
+    return (
+        attn_output.narrow(output_head_axis, 0, num_heads),
+        softmax_lse.narrow(1, 0, num_heads),
+    )

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -37,8 +37,13 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.context_parallel.common_cp import (
     AscendPCPMetadata,
     CPChunkedContextMetadata,
+    _mask_empty_kv_shards,
     _npu_attention_update,
     _process_attn_out_lse,
+)
+from vllm_ascend.attention.context_parallel.fia_mla_heads import (
+    pad_fia_mla_query_heads,
+    trim_fia_mla_query_heads,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, notify_kv_cache_written
 from vllm_ascend.compilation.acl_graph import (
@@ -52,7 +57,6 @@ from vllm_ascend.utils import weak_ref_tensors
 MAX_O_PROJ_PREFETCH_SIZE = 16 * 1024 * 1024
 
 M = TypeVar("M", bound=AscendMLAMetadata)
-
 
 class AscendMlaCPMetadataBuilder(AscendMLAMetadataBuilder):
     """
@@ -79,6 +83,14 @@ class AscendMlaCPMetadataBuilder(AscendMLAMetadataBuilder):
         self.cp_virtual_block_size = self.cp_local_block_size * self.dcp_size * self.pcp_size
         self.block_size = (self.block_size * self.cp_virtual_block_size) // np.gcd(
             self.block_size, self.cp_virtual_block_size
+        )
+        # Keep a stable device address for ACL graph replay. The FIA API still
+        # consumes Python sequence lengths, while the empty-shard mask must use
+        # a device tensor without creating an H2D copy inside graph capture.
+        self.cp_seq_len_tensor = torch.zeros(
+            vllm_config.scheduler_config.max_num_seqs,
+            dtype=torch.int32,
+            device=device,
         )
 
     def build(
@@ -250,6 +262,11 @@ class AscendMlaCPMetadataBuilder(AscendMLAMetadataBuilder):
         cp_seq_len = num_computed_tokens_of_cp_dcp_array[:, self.pcp_rank, self.dcp_rank]
         cp_seq_len = torch.tensor(cp_seq_len, dtype=torch.int32)
         decode_metadata.cp_seq_len = cp_seq_len.tolist()
+        mask_num_rows = max(self.num_decodes, self.graph_pad_size)
+        cp_seq_len_tensor = self.cp_seq_len_tensor[:mask_num_rows]
+        cp_seq_len_tensor.zero_()
+        cp_seq_len_tensor[: self.num_decodes].copy_(cp_seq_len, non_blocking=True)
+        decode_metadata.cp_seq_len_tensor = cp_seq_len_tensor
 
         actual_seq_lengths_q = torch.arange(self.num_decodes) + 1
         decode_metadata.actual_seq_lengths_q = actual_seq_lengths_q
@@ -659,6 +676,9 @@ class AscendMlaCPImpl(AscendMLAImpl):
             sparse_mode = 0
             spec_attn_mask = None
 
+        original_num_heads = num_heads
+        q_nope, q_pe, num_heads = pad_fia_mla_query_heads(q_nope, q_pe, input_layout, num_heads)
+
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
@@ -743,6 +763,14 @@ class AscendMlaCPImpl(AscendMLAImpl):
                 k_nope,
                 **common_kwargs,
             )
+        if num_heads != original_num_heads:
+            attn_output, softmax_lse = trim_fia_mla_query_heads(
+                attn_output,
+                softmax_lse,
+                input_layout,
+                original_num_heads,
+            )
+
         if input_layout == "BSND":
             attn_output = attn_output.view(-1, attn_output.shape[2], attn_output.shape[3])
             softmax_lse = softmax_lse.transpose(1, 2).reshape(-1, softmax_lse.shape[1], 1)
@@ -753,6 +781,12 @@ class AscendMlaCPImpl(AscendMLAImpl):
 
             attn_output = attn_output.permute(0, 2, 1, 3).reshape(B_attn * S, N_attn, D)
             softmax_lse = softmax_lse.permute(0, 2, 1, 3).reshape(B_lse * Q_S, N_lse, 1)
+
+        attn_output, softmax_lse = _mask_empty_kv_shards(
+            attn_output,
+            softmax_lse,
+            decode_meta.cp_seq_len_tensor,
+        )
 
         # Update out&lse
         attn_out_lse = _process_attn_out_lse(attn_output, softmax_lse)

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -172,6 +172,7 @@ class AscendMLADecodeMetadata:
     sin: torch.Tensor = None
     cos: torch.Tensor = None
     cp_seq_len: torch.Tensor = None
+    cp_seq_len_tensor: torch.Tensor = None
     dcp_mtp_attn_mask: torch.Tensor = None
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream vLLM https://github.com/vllm-project/vllm/pull/50484 already provides the decode-context-parallel configuration and scheduler metadata used by the Kimi-K3 path. vLLM Ascend also contains the MLA context-parallel backend, but the Kimi-K3 A3 decode path is not currently runnable with DCP because three backend correctness gaps remain:

1. Kimi-K3 has 96 attention heads. With TP16 and DCP2, each FIA call receives `96 / 16 * 2 = 12` query heads. The current A3 FIA operator accepts only specific head counts, so 12 heads fail with `aclnnFusedInferAttentionScoreV3` error `561002`.
2. A DCP rank can own an empty local KV shard. Its local attention result must be the online-softmax identity: zero output and negative-infinity LSE. Combining all-empty graph-padding rows must not produce NaNs.
3. Creating the local sequence-length tensor from a Python list during ACL graph capture triggers a host-to-device copy and fails with `Not allow to synchronize captured-stream`.

This PR:

- pads MLA CP query heads to the next FIA-supported count and trims attention output/LSE back to the original head count;
- maps empty local KV shards to the online-softmax identity and handles all-empty combine rows;
- keeps a persistent device-side `cp_seq_len_tensor` in the metadata builder, preserving a stable address for ACL graph capture and replay;
- adds focused CPU tests for BNSD/BSND padding, graph replay, empty shards, graph-padding rows, combine behavior, and greedy-token/logprob preservation.

For Kimi-K3 TP16/DCP2, the effective query-head transformation is `12 -> 16 -> 12` around FIA.

### Does this PR introduce _any_ user-facing change?

Yes. It enables the Kimi-K3 MLA decode path to initialize and serve requests with decode context parallelism on Ascend A3 instead of failing during FIA execution or ACL graph capture.

The change does not add a new CLI flag. It makes the existing vLLM `--decode-context-parallel-size` path usable by this backend/model combination.

### How was this patch tested?

#### Focused tests on the clean upstream port

Base: `vllm-project/vllm-ascend@19695928`, branch `releases/v0.23.0`.

```text
git diff --check: PASS
python -m py_compile: PASS
pytest -q tests/ut/attention/a2/test_kimi_k3_dcp2_empty_shard.py
9 passed, 14 warnings in 0.93s
```

#### A3 runtime validation

Runtime source:

```text
image: quay.io/ascend/vllm-ascend:kimi-k3-a3-openeuler
vllm-ascend commit: 8f192c9fef507ea5e51d40e46c3cf9d442a6c5ab
topology: two ARM A3 nodes, DP2/TP16/EP32
context: 131072
DCP backend: ag_rs
```

Operational results:

| DCP | Max context | KV budget/rank | Logical KV capacity | Full-context concurrency | Graph capture | First request TTFT / TPOT | Prefix-reuse TTFT / TPOT |
| ---: | ---: | ---: | ---: | ---: | --- | --- | --- |
| 1 | 48,000 | 3.18 GiB | 114,320 tokens (measured) | 2.38x at 48K | graph memory about 0.61 GiB | 120K not supported; 30K TTFT 0.689 s / TPOT 0.10437 s | not measured |
| 2 | 131,072 | 3.19 GiB | 231,042 tokens (measured) | 1.76x at 131K | 56 s / 1.04 GiB | 45.28 s / 0.11339 s | 0.916 s / 0.11329 s |
| 8 | 131,072 | 3.18 GiB | about 914,560 tokens (linear estimate) | about 6.98x at 131K (estimate) | 59 s / 1.05 GiB | 40.64 s / 0.11548 s | 1.032 s / 0.11541 s |
| 16 | 131,072 | 3.18 GiB | 1,460,516 tokens (measured) | 11.14x at 131K | 63 s / 1.05 GiB | 41.09 s / 0.12029 s | 11.45 s / 0.12037 s |

`KV budget/rank` is the physical byte budget left after weights, profiled activations, non-framework allocations, and graph memory. It stays near 3.18 GiB because those allocations are almost unchanged. DCP increases logical capacity instead: each rank stores approximately `ceil(max_model_len / DCP)` local sequence tokens, so the same physical KV budget represents more global sequence tokens. The DCP8 logical-capacity line is explicitly an estimate because its capacity log was rotated before collection; no engine was restarted only to recreate that line.

The DCP1 row is the proven TP-only 48K baseline and is not a matched 120K run. Its 131K attempt did not reach API readiness, so no DCP1 120K latency result exists.

All 32 NPUs remained healthy. The candidate Service remained drained throughout validation.

The original `561002` unsupported-head failure and captured-stream H2D failure did not recur.

#### Known limitation: strict logprob parity

Greedy tokens and reasoning are identical to the DCP1 reference, and all candidate logprobs are finite. Strict `atol=0.01` parity remains unresolved:

| DCP | Maximum DCP1 logprob delta |
| ---: | ---: |
| 2 | 0.16367 |
| 8 | 0.21742 |
| 16 | 0.21667 |

This is why the PR should remain Draft. DCP2 is the current mixed-serving recommendation; DCP8 is useful only for a dedicated cold long-prefill workload, and DCP16 is not recommended for the measured workload.

## Intended changed files

- `vllm_ascend/attention/mla_v1.py`
- `vllm_ascend/attention/context_parallel/common_cp.py`
- `vllm_ascend/attention/context_parallel/mla_cp.py`
- `vllm_ascend/attention/context_parallel/fia_mla_heads.py`
- `tests/ut/attention/a2/test_kimi_k3_dcp2_empty_shard.py`

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
#### DCP16 1M runtime validation

DCP16 was additionally validated with a real near-1M-token request on the same two-node A3 topology. The candidate Service remained drained.

| Metric | Result |
| --- | ---: |
| `max_model_len` | 1,048,576 |
| Logical KV capacity | 1,848,337 tokens |
| 1M concurrency | 1.76x |
| KV budget/rank | 3.18 GiB |
| Graph capture | 64 s / 1.05 GiB |
| Actual prompt | 1,040,147 tokens |
| Completion | 99 tokens |
| TTFT | 673.20 s |
| TPOT | 0.12075 s/token |
| Total elapsed | 685.04 s |
| Result | PASS, normal stop |
| Post-run health | 32/32 chips OK |

This proves that DCP16 can serve a real near-1M context on two A3 nodes. Its approximately 11.2-minute TTFT makes it suitable only for a dedicated 1M long-context service, not as the mixed-serving default. The DCP16/1M engine remained running after validation and the candidate Service remained drained.
