### PR TITLE
[Attention][Misc] Optimize tiling registration vector in inplace_partial_rotary_mul

### DIFF
--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
@@ -80,10 +80,10 @@ ge::graphStatus Tiling4RotaryPositionEmbedding(gert::TilingContext *context)
     {
         std::vector<std::unique_ptr<RopeRegBaseTilingClass>> regBaseTilingCases;
         regBaseTilingCases.reserve(4);
-        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassAAndB(context));
-        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassAB(context));
-        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassABAAndBA(context));
-        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassBAB(context));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassAAndB>(context));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassAB>(context));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassABAAndBA>(context));
+        regBaseTilingCases.push_back(std::make_unique<RopeRegBaseTilingClassBAB>(context)); 
         OPS_LOG_I(context, "Using arch35 tiling for ASCEND950");
 
         for (const auto& ptr : regBaseTilingCases)

--- a/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
+++ b/csrc/attention/inplace_partial_rotary_mul/op_host/inplace_partial_rotary_mul_tiling.cpp
@@ -79,10 +79,11 @@ ge::graphStatus Tiling4RotaryPositionEmbedding(gert::TilingContext *context)
     if (socVersion == platform_ascendc::SocVersion::ASCEND950)
     {
         std::vector<std::unique_ptr<RopeRegBaseTilingClass>> regBaseTilingCases;
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassAAndB(context)));
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassAB(context)));
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassABAAndBA(context)));
-        regBaseTilingCases.push_back(std::unique_ptr<RopeRegBaseTilingClass>(new RopeRegBaseTilingClassBAB(context)));
+        regBaseTilingCases.reserve(4);
+        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassAAndB(context));
+        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassAB(context));
+        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassABAAndBA(context));
+        regBaseTilingCases.emplace_back(new RopeRegBaseTilingClassBAB(context));
         OPS_LOG_I(context, "Using arch35 tiling for ASCEND950");
 
         for (const auto& ptr : regBaseTilingCases)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR optimizes the initialization of the `regBaseTilingCases` vector in `Tiling4RotaryPositionEmbedding` by reserving capacity for 4 elements and using `make_unique_ptr ` to construct the elements.

Note:
- reserve(4): Pre‑allocate memory space for 4 elements to avoid repeated reallocations during push_back.
- use `make_unique_ptr` to avoid memory leak
### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No tests were provided in this PR.


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
