### PR TITLE
[BugFix][Test] Fix disaggregated encoder test after send_image_request API change

### DIFF
--- a/tests/e2e/pull_request/two_card/test_disaggregated_encoder.py
+++ b/tests/e2e/pull_request/two_card/test_disaggregated_encoder.py
@@ -19,6 +19,7 @@ import pytest
 from vllm.utils.network_utils import get_open_port
 
 from tests.e2e.conftest import DisaggEpdProxy, RemoteEPDServer
+from tests.e2e.nightly.single_node.models.scripts.single_node_config import SingleNodeConfig
 from tools.send_mm_request import send_image_request
 
 MODELS = [
@@ -94,4 +95,27 @@ async def test_models(model: str, tp_size: int) -> None:
     ]
 
     with RemoteEPDServer(vllm_serve_args=vllm_server_args) as _, DisaggEpdProxy(proxy_args=proxy_args) as proxy:
-        send_image_request(model, proxy)
+        config = SingleNodeConfig(
+            name=model,
+            model=model,
+            mm_request={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "text", "text": "What is the content of this image?"},
+                            {"type": "image_url", "image_url": {"url": "{IMAGE_0}"}},
+                        ],
+                    }
+                ],
+                "api_args": {
+                    "eos_token_id": [1, 106],
+                    "pad_token_id": 0,
+                    "top_k": 64,
+                    "top_p": 0.95,
+                    "max_tokens": 8192,
+                    "stream": False,
+                },
+            },
+        )
+        send_image_request(config, proxy)


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream #13751 changed `send_image_request`'s signature from `(model, server)` to `(config: SingleNodeConfig, server)` but left `test_disaggregated_encoder.py` passing a bare model string, breaking `test_disaggregated_encoder` with `AttributeError: 'str' object has no attribute 'mm_request'`.

Build a `SingleNodeConfig` carrying the same image chat-completion payload the old hardcoded request sent and pass it to `send_image_request`.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?

CI verification only
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
