### PR TITLE
[Feature][Disagg] Proxy /v1/models in load balance proxy server example

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -1197,6 +1197,42 @@ async def handle_chat_completions(request: Request):
     return await handle_completions_impl("/chat/completions", request)
 
 
+async def handle_models_impl():
+    runtime = get_runtime()
+    request_id = next_req_id()
+    await runtime.sync_clients()
+    snapshot = runtime.scheduler.get_snapshot()
+    candidates = [(ServerRole.PREFILL, s) for s in snapshot["prefill_instances"]] + [
+        (ServerRole.DECODE, s) for s in snapshot["decode_instances"]
+    ]
+    if not candidates:
+        return JSONResponse(status_code=503, content={"error": "No available backend instances"})
+    failures: list[str] = []
+    for role, server in candidates:
+        host, port = server["host"], server["port"]
+        key = server_key(host, port)
+        try:
+            client = await runtime.get_client(role, key)
+            response = await client.get("/models", headers=auth_headers(request_id), timeout=3.0)
+            response.raise_for_status()
+            return Response(content=response.content, media_type="application/json")
+        except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+            logger.warning("GET /models from %s:%s failed: %s", host, port, exc)
+            failures.append(f"{host}:{port}")
+    return JSONResponse(
+        status_code=503,
+        content={
+            "error": "All backend instances failed to serve /v1/models",
+            "failed": failures,
+        },
+    )
+
+
+@app.get("/v1/models")
+async def handle_models():
+    return await handle_models_impl()
+
+
 @app.post("/reset_prefix_cache")
 async def reset_prefix_cache(request: Request):
     params = dict(request.query_params)


### PR DESCRIPTION
### What this PR does / why we need it?

The load balance proxy only forwards /v1/completions and /v1/chat/completions, so OpenAI-compatible clients calling GET /v1/models get a 404. Add a GET /v1/models handler that:

1. Iterates prefiller instances first, then decoder instances, and returns the first successful backend response.
2. Falls through to the next backend on connection/HTTP errors, and returns 503 when no backend is available or all candidates fail.

It is a read-only metadata query and does not touch PD scheduling state.

Co-authored-by: taoqun110 taoqun@huawei.com

### Does this PR introduce *any* user-facing change?

None.

### How was this patch tested?

Manual: curl http://localhost:9000/v1/models with the proxy running, verified HTTP 200 with the backend model list, and 503 when all backends are unavailable.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
