### PR TITLE
[BugFix][Ops] Support dynamic W8A8 mm_reduce_scatter fusion

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -252,6 +252,7 @@ class TestRowParallelOpDispatch(unittest.TestCase):
 
 class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
     def test_dynamic_w8a8_uses_mm_reduce_scatter_fusion(self):
+        from vllm_ascend.device.hardware import AscendDeviceType
         from vllm_ascend.ops.linear_op import SequenceRowParallelOp
         from vllm_ascend.quantization.method_adapters import AscendLinearMethod
         from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
@@ -264,6 +265,7 @@ class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
         layer.weight_scale_fp32 = torch.randn(16, dtype=torch.float32)
         layer.tp_size = 2
         layer.tp_rank = 0
+        layer.prefix = "model.language_model.model.layers.0.self_attn.o_proj"
 
         op = SequenceRowParallelOp(layer)
         op.quant_method = layer.quant_method
@@ -280,6 +282,7 @@ class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
                 "vllm_ascend.ops.linear_op._EXTRA_CTX",
                 SimpleNamespace(flash_comm_v1_enabled=True, mmrs_fusion=True, pad_size=0),
             ),
+            patch("vllm_ascend.ops.linear_op.get_ascend_device_type", return_value=AscendDeviceType.A2),
             patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
             patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=tp_group),
             patch(
@@ -302,6 +305,127 @@ class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
         self.assertEqual(kwargs["x2_scale"].shape, (1, 16))
         self.assertTrue(torch.equal(kwargs["x2_scale"].squeeze(dim=0), layer.weight_scale_fp32))
         self.assertEqual(kwargs["output_dtype"], x.dtype)
+        self.assertEqual(kwargs["comm_mode"], "aiv")
+
+    def test_dynamic_w8a8_mmrs_fusion_disabled_on_a5(self):
+        from vllm_ascend.device.hardware import AscendDeviceType
+        from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+
+        layer = MagicMock()
+        layer.quant_method = MagicMock()
+        layer.quant_method.apply.return_value = torch.randn(4, 16, dtype=torch.bfloat16)
+        layer.weight = torch.randint(-8, 8, (8, 16), dtype=torch.int8)
+        layer.weight_scale = torch.randn(16, dtype=torch.bfloat16)
+        layer.tp_size = 2
+        layer.tp_rank = 0
+        layer.prefix = "model.language_model.model.layers.0.self_attn.o_proj"
+
+        op = SequenceRowParallelOp(layer)
+        op.quant_method = layer.quant_method
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        reduced_output = torch.randn(2, 16, dtype=torch.bfloat16)
+
+        tp_group = MagicMock()
+        tp_group.device_group._get_backend.return_value.get_hccl_comm_name.return_value = "hccl_comm"
+
+        with (
+            patch(
+                "vllm_ascend.ops.linear_op._EXTRA_CTX",
+                SimpleNamespace(flash_comm_v1_enabled=True, mmrs_fusion=True, pad_size=0),
+            ),
+            patch("vllm_ascend.ops.linear_op.get_ascend_device_type", return_value=AscendDeviceType.A5),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=tp_group),
+            patch("vllm_ascend.ops.linear_op.DeviceOperator.npu_mm_reduce_scatter_base") as mock_mmrs,
+            patch(
+                "vllm_ascend.ops.linear_op.tensor_model_parallel_reduce_scatter",
+                return_value=reduced_output,
+            ) as mock_reduce_scatter,
+        ):
+            output = op.matmul_and_reduce(x, bias_=None)
+
+        self.assertIs(output, reduced_output)
+        layer.quant_method.apply.assert_called_once_with(layer, x, bias=None)
+        mock_reduce_scatter.assert_called_once()
+        mock_mmrs.assert_not_called()
+
+    def test_unquantized_mmrs_fusion_allowed_on_a5(self):
+        from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+        from vllm_ascend.device.hardware import AscendDeviceType
+        from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+
+        layer = MagicMock()
+        layer.quant_method = UnquantizedLinearMethod()
+        layer.weight = torch.randn(16, 8, dtype=torch.bfloat16)
+        layer.tp_size = 2
+        layer.tp_rank = 0
+        layer.prefix = "model.language_model.model.layers.0.self_attn.o_proj"
+
+        op = SequenceRowParallelOp(layer)
+        op.quant_method = layer.quant_method
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        fused_output = torch.randn(2, 16, dtype=torch.bfloat16)
+
+        tp_group = MagicMock()
+        tp_group.device_group._get_backend.return_value.get_hccl_comm_name.return_value = "hccl_comm"
+
+        with (
+            patch(
+                "vllm_ascend.ops.linear_op._EXTRA_CTX",
+                SimpleNamespace(flash_comm_v1_enabled=True, mmrs_fusion=True, pad_size=0),
+            ),
+            patch("vllm_ascend.ops.linear_op.get_ascend_device_type", return_value=AscendDeviceType.A5),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=tp_group),
+            patch(
+                "vllm_ascend.ops.linear_op.DeviceOperator.npu_mm_reduce_scatter_base",
+                return_value=fused_output,
+            ) as mock_mmrs,
+        ):
+            output = op.matmul_and_reduce(x, bias_=None)
+
+        self.assertIs(output, fused_output)
+        mock_mmrs.assert_called_once()
+
+    def test_dynamic_w8a8_mmrs_fusion_only_for_self_attn_o_proj(self):
+        from vllm_ascend.device.hardware import AscendDeviceType
+        from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+
+        layer = MagicMock()
+        layer.quant_method.apply.return_value = torch.randn(4, 16, dtype=torch.bfloat16)
+        layer.tp_size = 2
+        layer.tp_rank = 0
+        layer.prefix = "model.language_model.model.layers.0.mlp.down_proj"
+
+        op = SequenceRowParallelOp(layer)
+        op.quant_method = layer.quant_method
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        reduced_output = torch.randn(2, 16, dtype=torch.bfloat16)
+
+        tp_group = MagicMock()
+        tp_group.device_group._get_backend.return_value.get_hccl_comm_name.return_value = "hccl_comm"
+
+        with (
+            patch(
+                "vllm_ascend.ops.linear_op._EXTRA_CTX",
+                SimpleNamespace(flash_comm_v1_enabled=True, mmrs_fusion=True, pad_size=0),
+            ),
+            patch("vllm_ascend.ops.linear_op.get_ascend_device_type", return_value=AscendDeviceType.A2),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=tp_group),
+            patch("vllm_ascend.ops.linear_op.DeviceOperator.npu_mm_reduce_scatter_base") as mock_mmrs,
+            patch(
+                "vllm_ascend.ops.linear_op.tensor_model_parallel_reduce_scatter",
+                return_value=reduced_output,
+            ) as mock_reduce_scatter,
+        ):
+            output = op.matmul_and_reduce(x, bias_=None)
+
+        self.assertIs(output, reduced_output)
+        layer.quant_method.apply.assert_called_once_with(layer, x, bias=None)
+        mock_reduce_scatter.assert_called_once()
+        mock_mmrs.assert_not_called()
 
 
 class TestGetParallelOpShareExpert(unittest.TestCase):

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -260,7 +260,8 @@ class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
         layer = MagicMock()
         layer.quant_method = AscendLinearMethod(quant_method)
         layer.weight = torch.randint(-8, 8, (8, 16), dtype=torch.int8)
-        layer.weight_scale = torch.randn(16, dtype=torch.float32)
+        layer.weight_scale = torch.randn(16, dtype=torch.bfloat16)
+        layer.weight_scale_fp32 = torch.randn(16, dtype=torch.float32)
         layer.tp_size = 2
         layer.tp_rank = 0
 
@@ -296,8 +297,10 @@ class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
         mock_dynamic_quant.assert_called_once_with(x, act_quant_type=quant_method.act_quant_type)
         mock_mmrs.assert_called_once()
         _, kwargs = mock_mmrs.call_args
-        self.assertIs(kwargs["x1_scale"], pertoken_scale)
-        self.assertIs(kwargs["x2_scale"], layer.weight_scale)
+        self.assertEqual(kwargs["x1_scale"].shape, (4, 1))
+        self.assertTrue(torch.equal(kwargs["x1_scale"].squeeze(dim=1), pertoken_scale))
+        self.assertEqual(kwargs["x2_scale"].shape, (1, 16))
+        self.assertTrue(torch.equal(kwargs["x2_scale"].squeeze(dim=0), layer.weight_scale_fp32))
         self.assertEqual(kwargs["output_dtype"], x.dtype)
 
 

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -210,6 +210,51 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
         self.assertIsNone(self._get_column_op("model.vision_model_proj.indexer_proj"))
         self.assertIsNone(self._get_column_op("model.vision_tower_encoder.qkv_proj"))
 
+    def test_sequence_column_op_calls_tensor_all_gather_matmul_in_eager(self):
+        from vllm_ascend.ops.linear_op import SequenceColumnParallelOp
+
+        layer = MagicMock()
+        layer.prefix = "model.layers.1.mlp.gate_up_proj"
+        layer.gather_output = False
+        layer.skip_bias_add = False
+        layer.return_bias = True
+        layer.quant_method = AscendUnquantizedLinearMethod()
+        layer.weight = torch.nn.Parameter(torch.empty(16, 8, dtype=torch.float16), requires_grad=False)
+        layer.bias = None
+        output = torch.empty(4, 16, dtype=torch.float16)
+
+        op = SequenceColumnParallelOp(layer)
+        op.update_attrs()
+        input_ = torch.empty(2, 8, dtype=torch.float16)
+        with (
+            patch("vllm_ascend.ops.linear_op.is_vl_model", return_value=False),
+            patch.object(
+                torch.ops.vllm, "all_gather_unquantized_matmul", return_value=output, create=True
+            ) as mock_fused,
+        ):
+            result, output_bias = op.apply_impl(input_)
+
+        self.assertIs(result, output)
+        self.assertIsNone(output_bias)
+        mock_fused.assert_called_once_with(input_, layer.weight, None)
+
+    def test_dynamic_all_gather_matmul_skips_a5(self):
+        from vllm_ascend.device.hardware import AscendDeviceType
+        from vllm_ascend.ops.linear_op import _apply_tensor_all_gather_matmul_if_supported
+        from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+        from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
+
+        layer = MagicMock()
+        layer.quant_method = AscendLinearMethod(AscendW8A8DynamicLinearMethod())
+        layer.weight = torch.empty(16, 8, dtype=torch.int8)
+        layer.weight_scale = torch.empty(16, dtype=torch.float32)
+        input_ = torch.empty(2, 8, dtype=torch.bfloat16)
+
+        with patch("vllm_ascend.ops.linear_op.get_ascend_device_type", return_value=AscendDeviceType.A5):
+            result = _apply_tensor_all_gather_matmul_if_supported(layer, input_, None, need_all_gather=True)
+
+        self.assertIsNone(result)
+
 
 class TestRowParallelOpDispatch(unittest.TestCase):
     """Tests for _get_row_parallel_op — mtp_block, share_expert."""

--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -247,6 +248,57 @@ class TestRowParallelOpDispatch(unittest.TestCase):
         self._patches[-1].start()
         self.assertIsNone(self._op("model.multi_modal_projector.down_proj"))
         self.assertIsNone(self._op("model.patch_merge_mlp.out_proj"))
+
+
+class TestSequenceRowParallelMatmulAndReduce(unittest.TestCase):
+    def test_dynamic_w8a8_uses_mm_reduce_scatter_fusion(self):
+        from vllm_ascend.ops.linear_op import SequenceRowParallelOp
+        from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+        from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
+
+        quant_method = AscendW8A8DynamicLinearMethod()
+        layer = MagicMock()
+        layer.quant_method = AscendLinearMethod(quant_method)
+        layer.weight = torch.randint(-8, 8, (8, 16), dtype=torch.int8)
+        layer.weight_scale = torch.randn(16, dtype=torch.float32)
+        layer.tp_size = 2
+        layer.tp_rank = 0
+
+        op = SequenceRowParallelOp(layer)
+        op.quant_method = layer.quant_method
+        x = torch.randn(4, 8, dtype=torch.bfloat16)
+        x_quant = torch.randint(-8, 8, (4, 8), dtype=torch.int8)
+        pertoken_scale = torch.randn(4, dtype=torch.float32)
+        fused_output = torch.randn(2, 16, dtype=torch.bfloat16)
+
+        tp_group = MagicMock()
+        tp_group.device_group._get_backend.return_value.get_hccl_comm_name.return_value = "hccl_comm"
+
+        with (
+            patch(
+                "vllm_ascend.ops.linear_op._EXTRA_CTX",
+                SimpleNamespace(flash_comm_v1_enabled=True, mmrs_fusion=True, pad_size=0),
+            ),
+            patch("vllm_ascend.ops.linear_op.enable_dsa_cp", return_value=False),
+            patch("vllm_ascend.ops.linear_op.get_tp_group", return_value=tp_group),
+            patch(
+                "vllm_ascend.ops.linear_op.DeviceOperator.npu_dynamic_quant",
+                return_value=(x_quant, pertoken_scale),
+            ) as mock_dynamic_quant,
+            patch(
+                "vllm_ascend.ops.linear_op.DeviceOperator.npu_mm_reduce_scatter_base",
+                return_value=fused_output,
+            ) as mock_mmrs,
+        ):
+            output = op.matmul_and_reduce(x, bias_=None)
+
+        self.assertIs(output, fused_output)
+        mock_dynamic_quant.assert_called_once_with(x, act_quant_type=quant_method.act_quant_type)
+        mock_mmrs.assert_called_once()
+        _, kwargs = mock_mmrs.call_args
+        self.assertIs(kwargs["x1_scale"], pertoken_scale)
+        self.assertIs(kwargs["x2_scale"], layer.weight_scale)
+        self.assertEqual(kwargs["output_dtype"], x.dtype)
 
 
 class TestGetParallelOpShareExpert(unittest.TestCase):

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -394,6 +394,7 @@ class TestNPUPlatform(TestBase):
             )
 
         self.assertFalse(kwargs["in_profile_run"])
+        self.assertTrue(kwargs["mmrs_fusion"])
         self.assertEqual(kwargs["padded_num_tokens"], 8)
         self.assertIs(kwargs["moe_comm_method"], dummy_comm_method)
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -164,7 +164,6 @@ def set_ascend_forward_context(
         is_context_moe_model = is_drafter_moe_model(vllm_config) if is_draft_model else is_moe_model(vllm_config)
         if is_context_moe_model:
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None
-            mmrs_fusion = False
         elif is_draft_model:
             # TODO: for dense drafter, `sp` is redundant and is not compatible with `dp` and `graph`.
             # Disable it to avoid more problems.

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -190,6 +190,37 @@ class BaseDeviceAdaptor:
         )
 
     @staticmethod
+    def npu_all_gather_base_mm(
+        x1: torch.Tensor,
+        x2: torch.Tensor,
+        hcom: str,
+        world_size: int,
+        *,
+        bias: torch.Tensor | None = None,
+        x1_scale: torch.Tensor | None = None,
+        x2_scale: torch.Tensor | None = None,
+        gather_index: int = 0,
+        gather_output: bool = False,
+        comm_turn: int = 0,
+        output_dtype: torch.dtype | None = None,
+        comm_mode: str = "aiv",
+    ):
+        return torch_npu.npu_all_gather_base_mm(
+            x1,
+            x2,
+            hcom,
+            world_size,
+            bias=bias,
+            x1_scale=x1_scale,
+            x2_scale=x2_scale,
+            gather_index=gather_index,
+            gather_output=gather_output,
+            comm_turn=comm_turn,
+            output_dtype=output_dtype,
+            comm_mode=comm_mode,
+        )
+
+    @staticmethod
     def npu_dynamic_quant(
         hidden_states: torch.Tensor,
         dynamic_scale: torch.Tensor | None = None,

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -364,7 +364,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
         from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 
         from vllm_ascend.quantization.method_adapters import AscendLinearMethod
-        from vllm_ascend.quantization.methods import AscendW8A8LinearMethod
+        from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod, AscendW8A8LinearMethod
 
         # For unquant
         if mmrs_fusion and isinstance(self.layer.quant_method, UnquantizedLinearMethod):
@@ -408,6 +408,36 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 output_dtype=output_dtype,
             )
             output = torch.add(output, torch.mul(quant_bias, deq_scale).to(self.layer.params_dtype))
+        # For dynamic w8a8 quant
+        elif mmrs_fusion and (
+            isinstance(self.layer.quant_method, AscendLinearMethod)
+            and isinstance(self.layer.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
+            and hasattr(self.layer, "weight")
+            and hasattr(self.layer, "weight_scale")
+        ):
+            quant_method = self.layer.quant_method.quant_method
+            x_quant, pertoken_scale = DeviceOperator.npu_dynamic_quant(x, act_quant_type=quant_method.act_quant_type)
+            need_unsqueeze = False
+            if pertoken_scale.dim() == 2:
+                need_unsqueeze = True
+                x_quant = x_quant.squeeze(dim=1)
+                pertoken_scale = pertoken_scale.squeeze(dim=1)
+            output = DeviceOperator.npu_mm_reduce_scatter_base(
+                x_quant,
+                self.layer.weight,
+                hcom_name,
+                world_size,
+                reduce_op="sum",
+                bias=bias_ if quant_method.act_quant_type == torch.int8 else None,
+                comm_turn=0,
+                x1_scale=pertoken_scale,
+                x2_scale=self.layer.weight_scale,
+                output_dtype=x.dtype,
+            )
+            if need_unsqueeze:
+                output = output.unsqueeze(dim=1)
+            if bias_ is not None and quant_method.act_quant_type != torch.int8:
+                output = (output + bias_).to(x.dtype)
         else:
             output_parallel = self.layer.quant_method.apply(self.layer, x, bias=bias_)
             output = tensor_model_parallel_reduce_scatter(output_parallel, 0)

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -55,7 +55,9 @@ from vllm.logger import logger
 from vllm.model_executor.models.utils import extract_layer_index
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.device.device_config import get_ascend_device_type
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.distributed.parallel_state import (
     get_mlp_tp_group,
     get_otp_group,
@@ -68,6 +70,8 @@ from vllm_ascend.utils import (
     oproj_tp_enable,
     shared_expert_dp_enabled,
 )
+
+DYNAMIC_W8A8_MMRS_COMM_MODE = "aiv"
 
 
 class CustomLinearOp:
@@ -366,8 +370,13 @@ class SequenceRowParallelOp(CustomRowParallelOp):
         from vllm_ascend.quantization.method_adapters import AscendLinearMethod
         from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod, AscendW8A8LinearMethod
 
+        layer_prefix = getattr(self.layer, "prefix", "<unknown>")
+        mmrs_op_enabled = mmrs_fusion and "self_attn.o_proj" in layer_prefix
+        quantized_mmrs_op_enabled = mmrs_op_enabled and get_ascend_device_type() != AscendDeviceType.A5
+        dynamic_w8a8_mmrs_enabled = quantized_mmrs_op_enabled
+
         # For unquant
-        if mmrs_fusion and isinstance(self.layer.quant_method, UnquantizedLinearMethod):
+        if mmrs_op_enabled and isinstance(self.layer.quant_method, UnquantizedLinearMethod):
             output = DeviceOperator.npu_mm_reduce_scatter_base(
                 x,
                 self.layer.weight.t(),
@@ -380,7 +389,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
             if bias_ is not None:
                 output.add_(bias_)
         # For w8a8 quant
-        elif mmrs_fusion and (
+        elif quantized_mmrs_op_enabled and (
             isinstance(self.layer.quant_method, AscendLinearMethod)
             and isinstance(self.layer.quant_method.quant_method, AscendW8A8LinearMethod)
         ):
@@ -409,7 +418,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
             )
             output = torch.add(output, torch.mul(quant_bias, deq_scale).to(self.layer.params_dtype))
         # For dynamic w8a8 quant
-        elif mmrs_fusion and (
+        elif dynamic_w8a8_mmrs_enabled and (
             isinstance(self.layer.quant_method, AscendLinearMethod)
             and isinstance(self.layer.quant_method.quant_method, AscendW8A8DynamicLinearMethod)
             and hasattr(self.layer, "weight")
@@ -436,6 +445,7 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 x1_scale=x1_scale,
                 x2_scale=x2_scale,
                 output_dtype=x.dtype,
+                comm_mode=DYNAMIC_W8A8_MMRS_COMM_MODE,
             )
             if need_unsqueeze:
                 output = output.unsqueeze(dim=1)

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -422,6 +422,9 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 need_unsqueeze = True
                 x_quant = x_quant.squeeze(dim=1)
                 pertoken_scale = pertoken_scale.squeeze(dim=1)
+            x1_scale = pertoken_scale.reshape(-1, 1).contiguous()
+            weight_scale = getattr(self.layer, "weight_scale_fp32", self.layer.weight_scale)
+            x2_scale = weight_scale.reshape(1, -1).contiguous()
             output = DeviceOperator.npu_mm_reduce_scatter_base(
                 x_quant,
                 self.layer.weight,
@@ -430,8 +433,8 @@ class SequenceRowParallelOp(CustomRowParallelOp):
                 reduce_op="sum",
                 bias=bias_ if quant_method.act_quant_type == torch.int8 else None,
                 comm_turn=0,
-                x1_scale=pertoken_scale,
-                x2_scale=self.layer.weight_scale,
+                x1_scale=x1_scale,
+                x2_scale=x2_scale,
                 output_dtype=x.dtype,
             )
             if need_unsqueeze:

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -302,8 +302,10 @@ class SequenceColumnParallelOp(CustomColumnParallelOp):
         # Matrix multiply.
         assert self.quant_method is not None
         need_all_gather = not (extract_layer_index(self.layer.prefix) == 0 and is_vl_model() and "attn" in self.prefix)
-        input_ = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(input_, label=need_all_gather)
-        output_parallel = self.quant_method.apply(self.layer, input_, bias)
+        output_parallel = _apply_tensor_all_gather_matmul_if_supported(self.layer, input_, bias, need_all_gather)
+        if output_parallel is None:
+            input_ = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(input_, label=need_all_gather)
+            output_parallel = self.quant_method.apply(self.layer, input_, bias)
 
         if self.gather_output:
             # All-gather across the partitions.
@@ -493,6 +495,55 @@ _MULTIMODAL_ENCODER_PREFIX_PARTS = (
 
 def _should_skip_sp_for_multimodal_encoder(prefix: str) -> bool:
     return any(part in prefix for part in _MULTIMODAL_ENCODER_PREFIX_PARTS)
+
+
+_TENSOR_ALL_GATHER_MATMUL_DTYPES = {torch.float16, torch.bfloat16}
+
+
+def _get_weight_dtype(layer) -> torch.dtype | None:
+    weight = getattr(layer, "weight", None)
+    if weight is None:
+        return None
+    return getattr(weight, "dtype", getattr(getattr(weight, "data", None), "dtype", None))
+
+
+def _apply_tensor_all_gather_matmul_if_supported(
+    layer,
+    input_: torch.Tensor,
+    bias: torch.Tensor | None,
+    need_all_gather: bool,
+) -> torch.Tensor | None:
+    if not need_all_gather:
+        return None
+
+    from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+
+    from vllm_ascend.quantization.method_adapters import AscendLinearMethod
+    from vllm_ascend.quantization.methods import AscendW8A8DynamicLinearMethod
+
+    quant_method = getattr(layer, "quant_method", None)
+    if (
+        isinstance(quant_method, UnquantizedLinearMethod)
+        and _get_weight_dtype(layer) in _TENSOR_ALL_GATHER_MATMUL_DTYPES
+    ):
+        return torch.ops.vllm.all_gather_unquantized_matmul(input_, layer.weight, bias)
+
+    chunk_size = getattr(layer, "_chunk_size", 0)
+    has_dynamic_weight_chunks = isinstance(chunk_size, int) and chunk_size > 0
+    if (
+        bias is None
+        and get_ascend_device_type() != AscendDeviceType.A5
+        and isinstance(quant_method, AscendLinearMethod)
+        and isinstance(quant_method.quant_method, AscendW8A8DynamicLinearMethod)
+        and quant_method.quant_method.act_quant_type == torch.int8
+        and hasattr(layer, "weight")
+        and hasattr(layer, "weight_scale")
+        and not has_dynamic_weight_chunks
+    ):
+        weight_scale = getattr(layer, "weight_scale_fp32", layer.weight_scale)
+        return torch.ops.vllm.all_gather_dynamic_quant_matmul(input_, layer.weight, weight_scale)
+
+    return None
 
 
 def _get_column_parallel_op(

--- a/vllm_ascend/ops/register_custom_ops.py
+++ b/vllm_ascend/ops/register_custom_ops.py
@@ -10,10 +10,14 @@ from vllm.distributed import (
     tensor_model_parallel_all_reduce,
     tensor_model_parallel_reduce_scatter,
 )
+from vllm.distributed.parallel_state import get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.utils.torch_utils import direct_register_custom_op
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.device.device_config import get_ascend_device_type
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.ops.rotary_embedding import rope_forward_oot
 from vllm_ascend.ops.triton.muls_add import muls_add_triton
 from vllm_ascend.utils import enable_sp_by_pass, is_vl_model
@@ -172,6 +176,210 @@ def _quantize_impl_fake(
     return torch_npu.npu_quantize(in_tensor, input_scale_reciprocal, input_offset, torch.qint8, -1, False)
 
 
+def _dynamic_quant_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(input_, dst_type=torch.int8)
+    need_unsqueeze = False
+    if pertoken_scale.dim() == 2:
+        need_unsqueeze = True
+        quantized_x = quantized_x.squeeze(dim=1)
+        pertoken_scale = pertoken_scale.squeeze(dim=1)
+
+    output = torch_npu.npu_quant_matmul(
+        quantized_x,
+        weight,
+        weight_scale,
+        pertoken_scale=pertoken_scale,
+        bias=None,
+        output_dtype=input_.dtype,
+    )
+    if need_unsqueeze:
+        output = output.unsqueeze(dim=1)
+    return output
+
+
+def _all_gather_then_dynamic_quant_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    gathered = tensor_model_parallel_all_gather(input_, 0)
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        gathered = gathered[:-pad_size]
+    return _dynamic_quant_matmul(gathered, weight, weight_scale)
+
+
+def _all_gather_then_unquantized_matmul(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    gathered = tensor_model_parallel_all_gather(input_, 0)
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        gathered = gathered[:-pad_size]
+    return torch.ops.vllm.unquantized_gemm(gathered, weight, bias)
+
+
+def _is_tp_all_gather_enabled() -> bool:
+    try:
+        forward_context = get_forward_context()
+    except AssertionError:
+        return False
+
+    return bool(getattr(forward_context, "flash_comm_v1_enabled", False))
+
+
+def _all_gather_matmul_comm_mode() -> str:
+    device_type = get_ascend_device_type()
+    if device_type == AscendDeviceType.A5:
+        return "ccu"
+    return "aiv"
+
+
+def _get_tp_hcom_name() -> tuple[str, int]:
+    tp_group = get_tp_group()
+    hcom_name = tp_group.device_group._get_backend(torch.device("npu")).get_hccl_comm_name(
+        tp_group.rank_in_group,
+    )
+    return hcom_name, tp_group.world_size
+
+
+def _all_gather_dynamic_quant_matmul_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    if not _is_tp_all_gather_enabled():
+        return _dynamic_quant_matmul(input_, weight, weight_scale)
+
+    if input_.dim() != 2:
+        return _all_gather_then_dynamic_quant_matmul(input_, weight, weight_scale)
+
+    if get_ascend_device_type() == AscendDeviceType.A5:
+        return _all_gather_then_dynamic_quant_matmul(input_, weight, weight_scale)
+
+    hcom_name, world_size = _get_tp_hcom_name()
+    if world_size == 1:
+        return _dynamic_quant_matmul(input_, weight, weight_scale)
+
+    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(input_, dst_type=torch.int8)
+    x1_scale = pertoken_scale.reshape(-1, 1).contiguous()
+    x2_scale = weight_scale.reshape(1, -1).to(torch.float32).contiguous()
+
+    output, _ = DeviceOperator.npu_all_gather_base_mm(
+        quantized_x,
+        weight,
+        hcom_name,
+        world_size,
+        bias=None,
+        x1_scale=x1_scale,
+        x2_scale=x2_scale,
+        gather_index=0,
+        gather_output=True,
+        comm_turn=0,
+        output_dtype=input_.dtype,
+        comm_mode=_all_gather_matmul_comm_mode(),
+    )
+
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        output = output[:-pad_size]
+    return output
+
+
+def _all_gather_unquantized_matmul_impl(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    if not _is_tp_all_gather_enabled():
+        return torch.ops.vllm.unquantized_gemm(input_, weight, bias)
+
+    if input_.dim() != 2:
+        return _all_gather_then_unquantized_matmul(input_, weight, bias)
+
+    hcom_name, world_size = _get_tp_hcom_name()
+    if world_size == 1:
+        return torch.ops.vllm.unquantized_gemm(input_, weight, bias)
+
+    output, _ = DeviceOperator.npu_all_gather_base_mm(
+        input_,
+        weight.t(),
+        hcom_name,
+        world_size,
+        bias=bias,
+        x1_scale=None,
+        x2_scale=None,
+        gather_index=0,
+        gather_output=True,
+        comm_turn=0,
+        output_dtype=input_.dtype,
+        comm_mode=_all_gather_matmul_comm_mode(),
+    )
+
+    pad_size = _EXTRA_CTX.pad_size
+    if pad_size > 0:
+        output = output[:-pad_size]
+    return output
+
+
+def _all_gather_dynamic_quant_matmul_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+) -> torch.Tensor:
+    try:
+        world_size = get_tensor_model_parallel_world_size()
+        pad_size = _EXTRA_CTX.pad_size
+    except Exception:
+        world_size = 1
+        pad_size = 0
+
+    if not _is_tp_all_gather_enabled():
+        world_size = 1
+        pad_size = 0
+
+    output_tokens = input_.shape[0] * world_size
+    if pad_size > 0:
+        output_tokens -= pad_size
+    return torch.empty(
+        (output_tokens, *input_.shape[1:-1], weight.shape[-1]),
+        device=input_.device,
+        dtype=input_.dtype,
+    )
+
+
+def _all_gather_unquantized_matmul_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    try:
+        world_size = get_tensor_model_parallel_world_size()
+        pad_size = _EXTRA_CTX.pad_size
+    except Exception:
+        world_size = 1
+        pad_size = 0
+
+    if not _is_tp_all_gather_enabled():
+        world_size = 1
+        pad_size = 0
+
+    output_tokens = input_.shape[0] * world_size
+    if pad_size > 0:
+        output_tokens -= pad_size
+    return torch.empty(
+        (output_tokens, *input_.shape[1:-1], weight.shape[0]),
+        device=input_.device,
+        dtype=input_.dtype,
+    )
+
+
 def _rope_forward_oot_impl_fake(
     positions: torch.Tensor,
     query: torch.Tensor,
@@ -236,6 +444,22 @@ direct_register_custom_op(
     op_name="quantize",
     op_func=_quantize_impl,
     fake_impl=_quantize_impl_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="all_gather_dynamic_quant_matmul",
+    op_func=_all_gather_dynamic_quant_matmul_impl,
+    fake_impl=_all_gather_dynamic_quant_matmul_fake,
+    mutates_args=[],
+    dispatch_key="PrivateUse1",
+)
+
+direct_register_custom_op(
+    op_name="all_gather_unquantized_matmul",
+    op_func=_all_gather_unquantized_matmul_impl,
+    fake_impl=_all_gather_unquantized_matmul_fake,
     mutates_args=[],
     dispatch_key="PrivateUse1",
 )

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -471,10 +471,11 @@ class NPUPlatform(Platform):
         # if the concurrency is below the threshold,
         # the performance may degrade due to the switching of
         # communication methods.
-        mmrs_fusion = True
+        # TODO: remove the TP-size guard when torch_npu.npu_mm_reduce_scatter_base
+        # supports tp_size >= 16.
+        mmrs_fusion = tp_world_size <= 8
         if is_moe_model(vllm_config):
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None
-            mmrs_fusion = False
         else:
             flash_comm_v1_enabled = enable_sp(vllm_config) and num_tokens is not None and num_tokens > 1000
         pad_size = 0


### PR DESCRIPTION
### What this PR does / why we need it?

  This PR adds and fixes dynamic W8A8 support for `mm_reduce_scatter` fusion in row-parallel linear ops.

  Main changes:

  - Route dynamic W8A8 row-parallel linear through `npu_dynamic_quant` and `npu_mm_reduce_scatter_base` when fusion is enabled.
  - Reshape dynamic W8A8 scales to the layout required by `npu_mm_reduce_scatter_base`:
    - `x1_scale` to `(M, 1)` for per-token quantization.
    - `x2_scale` to `(1, N)`, preferring precomputed `weight_scale_fp32`.
  - Restrict dynamic W8A8 mmrs fusion to `self_attn.o_proj` in the `SequenceRowParallelOp` path.
  - Use `comm_mode="aiv"` for the dynamic W8A8 mmrs path, which is the supported communication mode on A3.
  - Keep other row-parallel layers, such as `down_proj`, on the existing matmul + reduce_scatter path when flashcomm is enabled.

  ### Does this PR introduce _any_ user-facing change?

  No API or configuration changes.

  This changes internal execution behavior for dynamic W8A8 row-parallel linear layers when `mm_reduce_scatter` fusion is enabled.

  ### How was this patch tested?

  Added and updated unit coverage for:

  - Dynamic W8A8 fused reduce-scatter path.
  - `MatmulReduceScatterV2` scale layout.
  - Ensuring dynamic W8A8 mmrs fusion is only enabled for supported `self_attn.o_proj` usage.

  Test files:

  - `tests/ut/ops/test_linear.py`
  - `tests/ut/test_platform.py`

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
