### PR TITLE
[v0.26.0rc][Feature][LoRA] Isolate base and adapter ACL compile graphs

### DIFF
--- a/tests/ut/compilation/test_lora_graph_params.py
+++ b/tests/ut/compilation/test_lora_graph_params.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from vllm.config import CUDAGraphMode
+from vllm.forward_context import BatchDescriptor
+
+from vllm_ascend.compilation import acl_graph
+from vllm_ascend.compilation.acl_graph import (
+    get_draft_graph_params,
+    get_draft_graph_prefill_params,
+    get_graph_params,
+    set_draft_graph_params,
+    set_draft_graph_prefill_params,
+    set_graph_params,
+    update_graph_params_workspaces,
+)
+from vllm_ascend.device_allocator.sleep_mem_optimized import AclGraphSleepWakeupManager
+
+
+@pytest.fixture(autouse=True)
+def reset_graph_params():
+    names = ("_graph_params", "_draft_graph_params", "_draft_graph_prefill_params")
+    previous = {name: getattr(acl_graph, name) for name in names}
+    for name in names:
+        setattr(acl_graph, name, None)
+    yield
+    for name, value in previous.items():
+        setattr(acl_graph, name, value)
+
+
+def _forward_context(*, has_lora: bool, mode: CUDAGraphMode = CUDAGraphMode.FULL):
+    return SimpleNamespace(
+        cudagraph_runtime_mode=mode,
+        batch_descriptor=BatchDescriptor(num_tokens=4, has_lora=has_lora),
+    )
+
+
+def test_graph_params_isolate_base_and_lora_with_the_same_num_tokens() -> None:
+    set_graph_params([4])
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        return_value=_forward_context(has_lora=False),
+    ):
+        base_params = get_graph_params()
+        base_params.events[4].append("base")
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        return_value=_forward_context(has_lora=True),
+    ):
+        lora_params = get_graph_params()
+        lora_params.events[4].append("lora")
+
+    assert base_params is not lora_params
+    assert base_params.events[4] == ["base"]
+    assert lora_params.events[4] == ["lora"]
+
+
+def test_graph_params_use_base_storage_outside_full_graph() -> None:
+    set_graph_params([4])
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        return_value=_forward_context(has_lora=True, mode=CUDAGraphMode.PIECEWISE),
+    ):
+        piecewise_params = get_graph_params()
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        side_effect=AssertionError,
+    ):
+        no_context_params = get_graph_params()
+
+    assert piecewise_params is no_context_params
+
+
+def test_workspace_update_targets_the_active_route() -> None:
+    set_graph_params([4])
+    base_workspace = torch.empty(1)
+    lora_workspace = torch.empty(2)
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        return_value=_forward_context(has_lora=False),
+    ):
+        update_graph_params_workspaces(4, base_workspace)
+        base_params = get_graph_params()
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        return_value=_forward_context(has_lora=True),
+    ):
+        update_graph_params_workspaces(4, lora_workspace)
+        lora_params = get_graph_params()
+
+    assert base_params.workspaces[4] is base_workspace
+    assert lora_params.workspaces[4] is lora_workspace
+
+
+def test_draft_graph_params_are_isolated_by_route() -> None:
+    set_draft_graph_params([4])
+    set_draft_graph_prefill_params([4])
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        return_value=_forward_context(has_lora=False),
+    ):
+        base_draft = get_draft_graph_params()
+        base_prefill = get_draft_graph_prefill_params()
+
+    with patch(
+        "vllm_ascend.compilation.acl_graph.get_forward_context",
+        return_value=_forward_context(has_lora=True),
+    ):
+        lora_draft = get_draft_graph_params()
+        lora_prefill = get_draft_graph_prefill_params()
+
+    assert base_draft is not lora_draft
+    assert base_prefill is not lora_prefill
+
+
+def test_sleep_clears_both_base_and_lora_graph_params() -> None:
+    set_graph_params([4])
+    params = list(acl_graph.iter_graph_params())
+    assert len(params) == 2
+    for graph_params in params:
+        graph_params.workspaces[4] = torch.empty(1)
+        graph_params.events[4].append(object())
+
+    AclGraphSleepWakeupManager.clear_all_attention_workspaces()
+    AclGraphSleepWakeupManager.reset_all_graph_params()
+
+    for graph_params in params:
+        assert graph_params.workspaces[4] is None
+        assert graph_params.events[4] == []

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -221,12 +221,9 @@ class ACLGraphWrapper:
 
             # here we always use weak ref for the workspaces
             # to save memory
-            global _graph_params
-            global _draft_graph_params
-            global _draft_graph_prefill_params
-            weak_ref_workspaces(_graph_params)
-            weak_ref_workspaces(_draft_graph_params)
-            weak_ref_workspaces(_draft_graph_prefill_params)
+            weak_ref_workspaces(get_graph_params())
+            weak_ref_workspaces(get_draft_graph_params())
+            weak_ref_workspaces(get_draft_graph_prefill_params())
 
             # here we always use weak ref for the output
             # to save memory
@@ -299,81 +296,100 @@ def update_full_graph_params(
 @dataclass
 class GraphParams:
     events: dict[int, list[torch.npu.ExternalEvent]]
-    workspaces: dict[int, torch.Tensor]
+    workspaces: dict[int, torch.Tensor | None]
     handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]
     attn_params: dict[int, list[tuple]]
 
 
-_graph_params: GraphParams | None = None
+GraphParamsByLoRA = dict[bool, GraphParams]
+
+
+def _new_graph_params(aclgraph_capture_sizes: list[int]) -> GraphParams:
+    return GraphParams(
+        {size: [] for size in aclgraph_capture_sizes},
+        {size: None for size in aclgraph_capture_sizes},
+        {size: [] for size in aclgraph_capture_sizes},
+        {size: [] for size in aclgraph_capture_sizes},
+    )
+
+
+def _select_graph_params(params: GraphParams | GraphParamsByLoRA | None) -> GraphParams | None:
+    if params is None or not isinstance(params, dict):
+        return params
+    try:
+        forward_context = get_forward_context()
+    except (AssertionError, LookupError, RuntimeError):
+        return params[False]
+    descriptor = forward_context.batch_descriptor
+    has_lora = (
+        forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and descriptor is not None and descriptor.has_lora
+    )
+    return params[has_lora]
+
+
+def iter_graph_params():
+    for params in (_graph_params, _draft_graph_params, _draft_graph_prefill_params):
+        if isinstance(params, dict):
+            yield from params.values()
+        elif params is not None:
+            yield params
+
+
+_graph_params: GraphParamsByLoRA | None = None
 
 
 def set_graph_params(aclgraph_capture_sizes: list[int]):
     global _graph_params
     if _graph_params is not None:
         raise ValueError("Graph parameters have already been set!")
-    _graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-    )
+    _graph_params = {has_lora: _new_graph_params(aclgraph_capture_sizes) for has_lora in (False, True)}
 
 
 def update_graph_params_workspaces(num_tokens: int, workspace: torch.Tensor):
-    global _graph_params
-    if _graph_params is not None:
-        _graph_params.workspaces[num_tokens] = workspace
+    graph_params = get_graph_params()
+    if graph_params is not None:
+        graph_params.workspaces[num_tokens] = workspace
 
 
 def get_graph_params():
-    return _graph_params
+    return _select_graph_params(_graph_params)
 
 
-_draft_graph_params: GraphParams | None = None
+_draft_graph_params: GraphParamsByLoRA | None = None
 
 
 def set_draft_graph_params(aclgraph_capture_sizes: list[int]):
     global _draft_graph_params
     if _draft_graph_params is not None:
         raise ValueError("DraftGraph parameters have already been set!")
-    _draft_graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-    )
+    _draft_graph_params = {has_lora: _new_graph_params(aclgraph_capture_sizes) for has_lora in (False, True)}
 
 
 def update_draft_graph_params_workspaces(num_tokens: int, workspace: Any):
-    global _draft_graph_params
-    if _draft_graph_params is not None:
-        _draft_graph_params.workspaces[num_tokens] = workspace
+    graph_params = get_draft_graph_params()
+    if graph_params is not None:
+        graph_params.workspaces[num_tokens] = workspace
 
 
 def get_draft_graph_params():
-    return _draft_graph_params
+    return _select_graph_params(_draft_graph_params)
 
 
-_draft_graph_prefill_params: GraphParams | None = None
+_draft_graph_prefill_params: GraphParamsByLoRA | None = None
 
 
 def set_draft_graph_prefill_params(aclgraph_capture_sizes: list[int]):
     global _draft_graph_prefill_params
     if _draft_graph_prefill_params is not None:
         raise ValueError("DraftGraph preill parameters have already been set!")
-    _draft_graph_prefill_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-    )
+    _draft_graph_prefill_params = {has_lora: _new_graph_params(aclgraph_capture_sizes) for has_lora in (False, True)}
 
 
 def update_draft_graph_prefill_params_workspaces(num_tokens: int, workspace: Any):
-    global _draft_graph_prefill_params
-    if _draft_graph_prefill_params is not None:
-        _draft_graph_prefill_params.workspaces[num_tokens] = workspace
+    graph_params = get_draft_graph_prefill_params()
+    if graph_params is not None:
+        graph_params.workspaces[num_tokens] = workspace
 
 
 def get_draft_graph_prefill_params():
-    return _draft_graph_prefill_params
+    return _select_graph_params(_draft_graph_prefill_params)

--- a/vllm_ascend/device_allocator/sleep_mem_optimized.py
+++ b/vllm_ascend/device_allocator/sleep_mem_optimized.py
@@ -78,9 +78,8 @@ class AclGraphSleepWakeupManager:
 
     @classmethod
     def clear_all_attention_workspaces(cls) -> None:
-        cls.clear_attention_workspaces(acl_graph._graph_params)
-        cls.clear_attention_workspaces(acl_graph._draft_graph_params)
-        cls.clear_attention_workspaces(acl_graph._draft_graph_prefill_params)
+        for params in acl_graph.iter_graph_params():
+            cls.clear_attention_workspaces(params)
 
     @staticmethod
     def reset_graph_params(params) -> None:
@@ -96,9 +95,8 @@ class AclGraphSleepWakeupManager:
 
     @classmethod
     def reset_all_graph_params(cls) -> None:
-        cls.reset_graph_params(acl_graph._graph_params)
-        cls.reset_graph_params(acl_graph._draft_graph_params)
-        cls.reset_graph_params(acl_graph._draft_graph_prefill_params)
+        for params in acl_graph.iter_graph_params():
+            cls.reset_graph_params(params)
         for wrapper in list(acl_graph._acl_graph_wrappers):
             wrapper.concrete_aclgraph_entries.clear()
             wrapper.first_run_finished = False


### PR DESCRIPTION
> **v0.26.0rc backport** of main PR #13490.
> Targets `releases/v0.26.0rc`. Companion main PR: #13490.

### What this PR does / why we need it?

Establishes independent ACL compile graphs for Base (multi-token), Base single-token, and LoRA requests, isolating graph events, workspace, attention parameters, and `BatchDescriptor` so that LoRA requests do not pollute the Base graph or force Base to fall back to eager.

- LoRA requests use a `/backbone` callable and an independent LoRA ACL Graph.
- Base multi-token requests use a `/base` callable; Base single-token uses `/base_one`.
- Base/LoRA use independent code objects, backends, and compile caches.
- Keeps speculative draft models out of dual-graph specialization.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. On `releases/v0.26.0rc`, LoRA requests no longer pollute the Base ACL compile graph or force Base to fall back to eager; the Base and LoRA paths now use independent compile graphs. Existing deployments without LoRA are unaffected.

### How was this patch tested?

```
Ruff check/format: Pass
mypy Python 3.10/3.11/3.12: Pass
Focused pytest: 13 passed
git diff --check: Pass
```

Latest-head on-device matrix: pending.

### Scope

Based on `releases/v0.26.0rc`. Backport of main PR #13490. Does not include the A3 single-adapter performance path (PR 3) or A2 enablement (PR 4).

### Related

- Stacked: PR 3 (A3 perf) → PR 4 (A2) depend on this PR.

Co-Authored-By: yupeng <14888724+paulyu12@users.noreply.github.com>
Co-Authored-By: wangzhao-11a <73340653+wangzhao-11a@users.noreply.github.com>

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
