### PR TITLE
[v0.26.0rc][Performance][LoRA] Add A3 single-adapter masked GEMM fast path

### DIFF
--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -7,9 +7,12 @@ import torch
 import vllm
 from torch import nn
 from vllm.lora.layers import MergedColumnParallelLinearWithLoRA, MergedQKVParallelLinearWithLoRA
+from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
 from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
 from vllm_ascend.lora.utils import (
+    AscendFusedMoE3DWithLoRA,
+    AscendFusedMoEWithLoRA,
     AscendMergedColumnParallelLinearWithLoRA,
     AscendMergedQKVParallelLinearWithLoRA,
     _PackedLoRAAWeightsMixin,
@@ -208,12 +211,21 @@ def test_packed_lora_wrappers_extend_only_non_sharded_merged_layers() -> None:
 
 def test_refresh_lora_classes_prioritizes_packed_wrappers() -> None:
     original_classes = vllm.lora.utils._all_lora_classes
+    ascend_classes = (
+        AscendMergedColumnParallelLinearWithLoRA,
+        AscendMergedQKVParallelLinearWithLoRA,
+        AscendFusedMoEWithLoRA,
+        AscendFusedMoE3DWithLoRA,
+    )
+    expected_count = len(ascend_classes) + sum(cls not in ascend_classes for cls in original_classes)
     with patch.object(vllm.lora.utils, "_all_lora_classes", original_classes):
+        refresh_all_lora_classes()
         refresh_all_lora_classes()
         assert vllm.lora.utils._all_lora_classes[:2] == (
             AscendMergedColumnParallelLinearWithLoRA,
             AscendMergedQKVParallelLinearWithLoRA,
         )
+        assert len(vllm.lora.utils._all_lora_classes) == expected_count
 
 
 def test_packed_lora_a_weights_follow_set_and_reset_lifecycle() -> None:

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -10,9 +10,10 @@ from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
 @pytest.mark.parametrize("add_inputs", [True, False])
 def test_single_lora_linear_masks_base_rows(add_inputs: bool) -> None:
     token_indices = torch.tensor([0, -1, 0, -1, 0])
+    adapter_mask = token_indices.eq(0).unsqueeze(1).to(torch.bfloat16)
     wrapper = SimpleNamespace(
         _single_lora_slot=True,
-        _get_token_lora_indices=Mock(return_value=token_indices),
+        _get_single_lora_mask=Mock(return_value=adapter_mask),
     )
     x = torch.randn(5, 6, dtype=torch.bfloat16)
     y = torch.randn(5, 7, dtype=torch.bfloat16)
@@ -37,6 +38,120 @@ def test_single_lora_linear_masks_base_rows(add_inputs: bool) -> None:
         lora_b[0][0, 0].transpose(0, 1),
     )
     delta.mul_(token_indices.eq(0).unsqueeze(1))
+    expected = original_y.add(delta, alpha=scale) if add_inputs else delta.mul(scale)
+    assert applied
+    torch.testing.assert_close(y, expected)
+
+
+def test_single_lora_mask_is_refreshed_with_metadata() -> None:
+    wrapper = object.__new__(PunicaWrapperNPU)
+    wrapper._token_lora_indices = torch.tensor([0, -1, 0, -1])
+    wrapper._single_lora_mask = torch.empty(4, 1, dtype=torch.bfloat16)
+    wrapper.indices_len = [4, 0, 0, 0]
+
+    with patch.object(PunicaWrapperBase, "_update_base_metadata"):
+        PunicaWrapperNPU._update_base_metadata(wrapper, Mock(), [], 1, 100)
+
+    torch.testing.assert_close(
+        wrapper._single_lora_mask,
+        torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16),
+    )
+
+
+def test_single_lora_mask_matches_input_rows() -> None:
+    wrapper = SimpleNamespace(
+        _single_lora_mask=torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16),
+    )
+    x = torch.empty(3, 5)
+
+    mask = PunicaWrapperNPU._get_single_lora_mask(wrapper, x)
+
+    torch.testing.assert_close(mask, wrapper._single_lora_mask[:3])
+
+
+@pytest.mark.parametrize("add_inputs", [True, False])
+@pytest.mark.parametrize("scale", [0.5, 1.0])
+def test_single_lora_linear_packed_slices(add_inputs: bool, scale: float) -> None:
+    token_indices = torch.tensor([0, -1, 0, -1])
+    adapter_mask = token_indices.eq(0).unsqueeze(1).to(torch.bfloat16)
+    wrapper = SimpleNamespace(
+        _single_lora_slot=True,
+        _get_single_lora_mask=Mock(return_value=adapter_mask),
+    )
+    x = torch.randn(4, 6, dtype=torch.bfloat16)
+    y = torch.randn(4, 7, dtype=torch.bfloat16)
+    original_y = y.clone()
+    lora_a = (
+        torch.randn(1, 1, 3, 6, dtype=torch.bfloat16),
+        torch.randn(1, 1, 3, 6, dtype=torch.bfloat16),
+    )
+    lora_b = (
+        torch.randn(1, 1, 4, 3, dtype=torch.bfloat16),
+        torch.randn(1, 1, 3, 3, dtype=torch.bfloat16),
+    )
+    applied = PunicaWrapperNPU._apply_single_lora_linear(
+        wrapper,
+        y,
+        x,
+        lora_a,
+        lora_b,
+        scale,
+        (4, 3),
+        add_inputs=add_inputs,
+    )
+
+    deltas = []
+    for a_weight, b_weight in zip(lora_a, lora_b, strict=True):
+        shrink = torch.matmul(x, a_weight[0, 0].transpose(0, 1))
+        shrink.mul_(adapter_mask)
+        deltas.append(torch.matmul(shrink, b_weight[0, 0].transpose(0, 1)))
+    delta = torch.cat(deltas, dim=1)
+    expected = original_y.add(delta, alpha=scale) if add_inputs else delta.mul(scale)
+    assert applied
+    torch.testing.assert_close(y, expected)
+
+
+@pytest.mark.parametrize("add_inputs", [True, False])
+@pytest.mark.parametrize("scale", [0.5, 1.0])
+def test_single_lora_linear_uses_prepacked_a(add_inputs: bool, scale: float) -> None:
+    adapter_mask = torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16)
+    wrapper = SimpleNamespace(
+        _single_lora_slot=True,
+        _get_single_lora_mask=Mock(return_value=adapter_mask),
+    )
+    x = torch.randn(4, 6, dtype=torch.bfloat16)
+    y = torch.randn(4, 7, dtype=torch.bfloat16)
+    original_y = y.clone()
+    lora_a = (
+        torch.randn(1, 1, 3, 6, dtype=torch.bfloat16),
+        torch.randn(1, 1, 3, 6, dtype=torch.bfloat16),
+    )
+    packed_lora_a = torch.cat(lora_a, dim=2)
+    lora_b = (
+        torch.randn(1, 1, 4, 3, dtype=torch.bfloat16),
+        torch.randn(1, 1, 3, 3, dtype=torch.bfloat16),
+    )
+    applied = PunicaWrapperNPU._apply_single_lora_linear(
+        wrapper,
+        y,
+        x,
+        lora_a,
+        lora_b,
+        scale,
+        (4, 3),
+        packed_lora_a=packed_lora_a,
+        add_inputs=add_inputs,
+    )
+
+    shrink = torch.matmul(x, packed_lora_a[0, 0].transpose(0, 1))
+    shrink.mul_(adapter_mask)
+    delta = torch.cat(
+        (
+            torch.matmul(shrink[:, :3], lora_b[0][0, 0].transpose(0, 1)),
+            torch.matmul(shrink[:, 3:], lora_b[1][0, 0].transpose(0, 1)),
+        ),
+        dim=1,
+    )
     expected = original_y.add(delta, alpha=scale) if add_inputs else delta.mul(scale)
     assert applied
     torch.testing.assert_close(y, expected)

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -1,4 +1,5 @@
 from types import MethodType, SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -11,7 +12,7 @@ from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
 def test_single_lora_linear_masks_base_rows(add_inputs: bool) -> None:
     token_indices = torch.tensor([0, -1, 0, -1, 0])
     adapter_mask = token_indices.eq(0).unsqueeze(1).to(torch.bfloat16)
-    wrapper = SimpleNamespace(
+    wrapper: Any = SimpleNamespace(
         _single_lora_slot=True,
         _get_single_lora_mask=Mock(return_value=adapter_mask),
     )
@@ -59,7 +60,7 @@ def test_single_lora_mask_is_refreshed_with_metadata() -> None:
 
 
 def test_single_lora_mask_matches_input_rows() -> None:
-    wrapper = SimpleNamespace(
+    wrapper: Any = SimpleNamespace(
         _single_lora_mask=torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16),
     )
     x = torch.empty(3, 5)
@@ -74,7 +75,7 @@ def test_single_lora_mask_matches_input_rows() -> None:
 def test_single_lora_linear_packed_slices(add_inputs: bool, scale: float) -> None:
     token_indices = torch.tensor([0, -1, 0, -1])
     adapter_mask = token_indices.eq(0).unsqueeze(1).to(torch.bfloat16)
-    wrapper = SimpleNamespace(
+    wrapper: Any = SimpleNamespace(
         _single_lora_slot=True,
         _get_single_lora_mask=Mock(return_value=adapter_mask),
     )
@@ -115,7 +116,7 @@ def test_single_lora_linear_packed_slices(add_inputs: bool, scale: float) -> Non
 @pytest.mark.parametrize("scale", [0.5, 1.0])
 def test_single_lora_linear_uses_prepacked_a(add_inputs: bool, scale: float) -> None:
     adapter_mask = torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16)
-    wrapper = SimpleNamespace(
+    wrapper: Any = SimpleNamespace(
         _single_lora_slot=True,
         _get_single_lora_mask=Mock(return_value=adapter_mask),
     )
@@ -158,7 +159,7 @@ def test_single_lora_linear_uses_prepacked_a(add_inputs: bool, scale: float) -> 
 
 
 def test_non_homogeneous_prefill_linear_falls_back() -> None:
-    wrapper = SimpleNamespace(
+    wrapper: Any = SimpleNamespace(
         no_lora=False,
         _single_lora_slot=False,
         add_shrink=Mock(),

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -1,11 +1,20 @@
 from types import MethodType, SimpleNamespace
 from typing import Any
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
+import vllm
+from torch import nn
+from vllm.lora.layers import MergedColumnParallelLinearWithLoRA, MergedQKVParallelLinearWithLoRA
 
 from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
+from vllm_ascend.lora.utils import (
+    AscendMergedColumnParallelLinearWithLoRA,
+    AscendMergedQKVParallelLinearWithLoRA,
+    _PackedLoRAAWeightsMixin,
+    refresh_all_lora_classes,
+)
 
 
 @pytest.mark.parametrize("add_inputs", [True, False])
@@ -185,3 +194,49 @@ def test_non_homogeneous_prefill_linear_falls_back() -> None:
 
     wrapper.add_shrink.assert_called_once_with(buffer, x, lora_a, 1.0)
     wrapper.add_expand.assert_called_once_with(y, buffer, lora_b, (6,), add_inputs=True)
+
+
+def test_packed_lora_wrappers_extend_only_non_sharded_merged_layers() -> None:
+    assert AscendMergedColumnParallelLinearWithLoRA.__mro__[:3] == (
+        AscendMergedColumnParallelLinearWithLoRA,
+        _PackedLoRAAWeightsMixin,
+        MergedColumnParallelLinearWithLoRA,
+    )
+    assert MergedQKVParallelLinearWithLoRA in AscendMergedQKVParallelLinearWithLoRA.__mro__
+    assert all("Sharded" not in base.__name__ for base in AscendMergedQKVParallelLinearWithLoRA.__mro__)
+
+
+def test_refresh_lora_classes_prioritizes_packed_wrappers() -> None:
+    original_classes = vllm.lora.utils._all_lora_classes
+    with patch.object(vllm.lora.utils, "_all_lora_classes", original_classes):
+        refresh_all_lora_classes()
+        assert vllm.lora.utils._all_lora_classes[:2] == (
+            AscendMergedColumnParallelLinearWithLoRA,
+            AscendMergedQKVParallelLinearWithLoRA,
+        )
+
+
+def test_packed_lora_a_weights_follow_set_and_reset_lifecycle() -> None:
+    layer: Any = object.__new__(AscendMergedColumnParallelLinearWithLoRA)
+    nn.Module.__init__(layer)
+    layer.n_slices = 2
+    layer.input_size = 4
+    layer.device = torch.device("cpu")
+    layer.lora_a_stacked = (
+        torch.ones(1, 1, 2, 4),
+        torch.full((1, 1, 2, 4), 2.0),
+    )
+    lora_config: Any = SimpleNamespace(lora_dtype=torch.float32)
+
+    with patch.object(MergedColumnParallelLinearWithLoRA, "create_lora_weights"):
+        layer.create_lora_weights(1, lora_config)
+
+    assert layer.lora_a_packed.shape == (1, 1, 4, 4)
+    with patch.object(MergedColumnParallelLinearWithLoRA, "set_lora"):
+        layer.set_lora(0, [], [])
+    torch.testing.assert_close(layer.lora_a_packed[0, 0, :2], layer.lora_a_stacked[0][0, 0])
+    torch.testing.assert_close(layer.lora_a_packed[0, 0, 2:], layer.lora_a_stacked[1][0, 0])
+
+    with patch.object(MergedColumnParallelLinearWithLoRA, "reset_lora"):
+        layer.reset_lora(0)
+    assert not torch.count_nonzero(layer.lora_a_packed)

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -1,2 +1,71 @@
-def test_lora_placeholder():
-    pass
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
+
+
+@pytest.mark.parametrize("add_inputs", [True, False])
+def test_single_lora_linear_masks_base_rows(add_inputs: bool) -> None:
+    token_indices = torch.tensor([0, -1, 0, -1, 0])
+    wrapper = SimpleNamespace(
+        _single_lora_slot=True,
+        _get_token_lora_indices=Mock(return_value=token_indices),
+    )
+    x = torch.randn(5, 6, dtype=torch.bfloat16)
+    y = torch.randn(5, 7, dtype=torch.bfloat16)
+    original_y = y.clone()
+    lora_a = (torch.randn(1, 1, 3, 6, dtype=torch.bfloat16),)
+    lora_b = (torch.randn(1, 1, 7, 3, dtype=torch.bfloat16),)
+    scale = 0.5
+
+    applied = PunicaWrapperNPU._apply_single_lora_linear(
+        wrapper,
+        y,
+        x,
+        lora_a,
+        lora_b,
+        scale,
+        (7,),
+        add_inputs=add_inputs,
+    )
+
+    delta = torch.matmul(
+        torch.matmul(x, lora_a[0][0, 0].transpose(0, 1)),
+        lora_b[0][0, 0].transpose(0, 1),
+    )
+    delta.mul_(token_indices.eq(0).unsqueeze(1))
+    expected = original_y.add(delta, alpha=scale) if add_inputs else delta.mul(scale)
+    assert applied
+    torch.testing.assert_close(y, expected)
+
+
+def test_non_homogeneous_prefill_linear_falls_back() -> None:
+    wrapper = SimpleNamespace(
+        no_lora=False,
+        _single_lora_slot=False,
+        add_shrink=Mock(),
+        add_expand=Mock(),
+    )
+    wrapper._apply_single_lora_linear = MethodType(PunicaWrapperNPU._apply_single_lora_linear, wrapper)
+    x = torch.randn(2, 4)
+    y = torch.randn(2, 6)
+    lora_a = (torch.randn(1, 1, 2, 4),)
+    lora_b = (torch.randn(1, 1, 6, 2),)
+    buffer = (torch.empty(2, 2),)
+
+    PunicaWrapperNPU.add_lora_linear(
+        wrapper,
+        y,
+        x,
+        lora_a,
+        lora_b,
+        1.0,
+        (6,),
+        buffer=buffer,
+    )
+
+    wrapper.add_shrink.assert_called_once_with(buffer, x, lora_a, 1.0)
+    wrapper.add_expand.assert_called_once_with(y, buffer, lora_b, (6,), add_inputs=True)

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -26,7 +26,7 @@ def test_single_lora_linear_masks_base_rows(add_inputs: bool) -> None:
     adapter_mask = token_indices.eq(0).unsqueeze(1).to(torch.bfloat16)
     wrapper: Any = SimpleNamespace(
         _single_lora_slot=True,
-        _get_single_lora_mask=Mock(return_value=adapter_mask),
+        _single_lora_mask=adapter_mask,
     )
     x = torch.randn(5, 6, dtype=torch.bfloat16)
     y = torch.randn(5, 7, dtype=torch.bfloat16)
@@ -71,17 +71,6 @@ def test_single_lora_mask_is_refreshed_with_metadata() -> None:
     )
 
 
-def test_single_lora_mask_matches_input_rows() -> None:
-    wrapper: Any = SimpleNamespace(
-        _single_lora_mask=torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16),
-    )
-    x = torch.empty(3, 5)
-
-    mask = PunicaWrapperNPU._get_single_lora_mask(wrapper, x)
-
-    torch.testing.assert_close(mask, wrapper._single_lora_mask[:3])
-
-
 @pytest.mark.parametrize("add_inputs", [True, False])
 @pytest.mark.parametrize("scale", [0.5, 1.0])
 def test_single_lora_linear_packed_slices(add_inputs: bool, scale: float) -> None:
@@ -89,7 +78,7 @@ def test_single_lora_linear_packed_slices(add_inputs: bool, scale: float) -> Non
     adapter_mask = token_indices.eq(0).unsqueeze(1).to(torch.bfloat16)
     wrapper: Any = SimpleNamespace(
         _single_lora_slot=True,
-        _get_single_lora_mask=Mock(return_value=adapter_mask),
+        _single_lora_mask=adapter_mask,
     )
     x = torch.randn(4, 6, dtype=torch.bfloat16)
     y = torch.randn(4, 7, dtype=torch.bfloat16)
@@ -130,7 +119,7 @@ def test_single_lora_linear_uses_prepacked_a(add_inputs: bool, scale: float) -> 
     adapter_mask = torch.tensor([[1], [0], [1], [0]], dtype=torch.bfloat16)
     wrapper: Any = SimpleNamespace(
         _single_lora_slot=True,
-        _get_single_lora_mask=Mock(return_value=adapter_mask),
+        _single_lora_mask=adapter_mask,
     )
     x = torch.randn(4, 6, dtype=torch.bfloat16)
     y = torch.randn(4, 7, dtype=torch.bfloat16)
@@ -207,6 +196,40 @@ def test_packed_lora_wrappers_extend_only_non_sharded_merged_layers() -> None:
     )
     assert MergedQKVParallelLinearWithLoRA in AscendMergedQKVParallelLinearWithLoRA.__mro__
     assert all("Sharded" not in base.__name__ for base in AscendMergedQKVParallelLinearWithLoRA.__mro__)
+
+
+@pytest.mark.parametrize(("max_loras", "expected"), [(1, True), (2, False)])
+def test_merged_column_packed_wrapper_requires_single_adapter_slot(max_loras: int, expected: bool) -> None:
+    lora_config: Any = SimpleNamespace(max_loras=max_loras, fully_sharded_loras=False)
+
+    with patch("vllm_ascend.lora.utils.maybe_get_oot_by_class", return_value=nn.Linear):
+        can_replace = AscendMergedColumnParallelLinearWithLoRA.can_replace_layer(
+            source_layer=nn.Linear(2, 2),
+            lora_config=lora_config,
+            packed_modules_list=["gate", "up"],
+            model_config=None,
+        )
+
+    assert can_replace is expected
+
+
+@pytest.mark.parametrize(("max_loras", "expected"), [(1, True), (2, False)])
+def test_qkv_packed_wrapper_requires_single_adapter_slot(max_loras: int, expected: bool) -> None:
+    class FakeAscendQKVParallelLinear(nn.Module):
+        pass
+
+    lora_config: Any = SimpleNamespace(max_loras=max_loras, fully_sharded_loras=False)
+    source_layer = FakeAscendQKVParallelLinear()
+
+    with patch("vllm_ascend.lora.utils.AscendQKVParallelLinear", FakeAscendQKVParallelLinear):
+        can_replace = AscendMergedQKVParallelLinearWithLoRA.can_replace_layer(
+            source_layer=source_layer,
+            lora_config=lora_config,
+            packed_modules_list=["q", "k", "v"],
+            model_config=None,
+        )
+
+    assert can_replace is expected
 
 
 def test_refresh_lora_classes_prioritizes_packed_wrappers() -> None:

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -80,9 +80,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
         token_count = self.indices_len[0]
         assert token_count is not None
-        token_indices = torch.narrow(self._token_lora_indices, 0, 0, token_count)
-        mask = torch.narrow(self._single_lora_mask, 0, 0, token_count)
-        mask.copy_(token_indices.eq(0).unsqueeze(1))
+        self._single_lora_mask[:token_count].copy_(self._token_lora_indices[:token_count].eq(0).unsqueeze(1))
 
     def _shrink_prefill(
         self,
@@ -181,10 +179,6 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
     def _get_token_lora_indices(self, x: torch.Tensor) -> torch.Tensor:
         return torch.narrow(self._token_lora_indices, 0, 0, x.size(0))
-
-    def _get_single_lora_mask(self, x: torch.Tensor) -> torch.Tensor:
-        assert self._single_lora_mask is not None
-        return torch.narrow(self._single_lora_mask, 0, 0, x.size(0))
 
     def _apply_expand(
         self,
@@ -389,7 +383,8 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
         x = x.view(-1, x.shape[-1])
         y = y.view(-1, y.shape[-1])
-        adapter_mask = self._get_single_lora_mask(x)
+        assert self._single_lora_mask is not None
+        adapter_mask = self._single_lora_mask[: x.size(0)]
         deltas = []
         if packed_lora_a is not None and len(lora_a_stacked) > 1:
             rank = lora_b_stacked[0].size(-1)

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -49,8 +49,6 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.sgmv_expand = sgmv_expand
         self.sgmv_expand_slice = sgmv_expand_slice
         self.sgmv_shrink = sgmv_shrink
-        # This flag is graph-static. Per-token indices below preserve base rows
-        # when the single adapter shares a compiled batch with base requests.
         self._single_lora_slot = (
             ascend_device_type == AscendDeviceType.A3
             and self.lora_config is not None
@@ -386,7 +384,6 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         packed_lora_a: torch.Tensor | None = None,
         add_inputs: bool,
     ) -> bool:
-        """Use masked GEMM when the service has one runtime LoRA slot."""
         if not self._single_lora_slot:
             return False
 

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -57,6 +57,34 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             and self.lora_config.max_loras == 1
             and not self.lora_config.fully_sharded_loras
         )
+        self._single_lora_mask = None
+        if self._single_lora_slot:
+            assert self.lora_config is not None
+            lora_dtype = self.lora_config.lora_dtype
+            if not isinstance(lora_dtype, torch.dtype):
+                raise ValueError(f"LoRA dtype must be resolved before creating the Punica wrapper, got {lora_dtype!r}")
+            self._single_lora_mask = torch.empty(
+                (max_num_batched_tokens, 1),
+                dtype=lora_dtype,
+                device=device,
+            )
+
+    def _update_base_metadata(
+        self,
+        mapping,
+        lora_index_to_id: list[int | None],
+        max_loras: int,
+        vocab_size: int,
+    ) -> None:
+        super()._update_base_metadata(mapping, lora_index_to_id, max_loras, vocab_size)
+        if self._single_lora_mask is None:
+            return
+
+        token_count = self.indices_len[0]
+        assert token_count is not None
+        token_indices = torch.narrow(self._token_lora_indices, 0, 0, token_count)
+        mask = torch.narrow(self._single_lora_mask, 0, 0, token_count)
+        mask.copy_(token_indices.eq(0).unsqueeze(1))
 
     def _shrink_prefill(
         self,
@@ -155,6 +183,10 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
     def _get_token_lora_indices(self, x: torch.Tensor) -> torch.Tensor:
         return torch.narrow(self._token_lora_indices, 0, 0, x.size(0))
+
+    def _get_single_lora_mask(self, x: torch.Tensor) -> torch.Tensor:
+        assert self._single_lora_mask is not None
+        return torch.narrow(self._single_lora_mask, 0, 0, x.size(0))
 
     def _apply_expand(
         self,
@@ -327,6 +359,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             lora_b_stacked,
             scale,
             output_slices,
+            packed_lora_a=kwargs.get("packed_lora_a"),
             add_inputs=kwargs.get("add_inputs", True),
         ):
             return
@@ -350,6 +383,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         scale: float,
         output_slices: tuple[int, ...],
         *,
+        packed_lora_a: torch.Tensor | None = None,
         add_inputs: bool,
     ) -> bool:
         """Use masked GEMM when the service has one runtime LoRA slot."""
@@ -358,21 +392,52 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
         x = x.view(-1, x.shape[-1])
         y = y.view(-1, y.shape[-1])
-        adapter_mask = self._get_token_lora_indices(x).eq(0).unsqueeze(1)
-        offset = 0
-        for lora_a, lora_b, output_size in zip(lora_a_stacked, lora_b_stacked, output_slices, strict=True):
-            a_weight = lora_a[0, 0]
+        adapter_mask = self._get_single_lora_mask(x)
+        deltas = []
+        if packed_lora_a is not None and len(lora_a_stacked) > 1:
+            rank = lora_b_stacked[0].size(-1)
+            shrink = torch.matmul(x, packed_lora_a[0, 0].transpose(0, 1))
+            shrink.mul_(adapter_mask)
+            shrink_slices = tuple(
+                shrink.narrow(1, slice_index * rank, rank) for slice_index in range(len(lora_a_stacked))
+            )
+        else:
+            shrink_slices = tuple(
+                torch.matmul(x, lora_a[0, 0].transpose(0, 1)).mul_(adapter_mask) for lora_a in lora_a_stacked
+            )
+
+        for shrink, lora_b, output_size in zip(shrink_slices, lora_b_stacked, output_slices, strict=True):
             b_weight = lora_b[0, 0, :output_size]
-            shrink = torch.matmul(x, a_weight.transpose(0, 1))
-            delta = torch.matmul(shrink, b_weight.transpose(0, 1))
-            delta.mul_(adapter_mask)
+            deltas.append(torch.matmul(shrink, b_weight.transpose(0, 1)))
+
+        if len(deltas) > 1 and sum(output_slices) == y.shape[1]:
+            delta = torch.cat(deltas, dim=1)
+            PunicaWrapperNPU._update_single_lora_output(y, delta, scale, add_inputs)
+            return True
+
+        offset = 0
+        for delta, output_size in zip(deltas, output_slices, strict=True):
             y_slice = y.narrow(1, offset, output_size)
-            if add_inputs:
-                y_slice.add_(delta, alpha=scale)
-            else:
-                torch.mul(delta, scale, out=y_slice)
+            PunicaWrapperNPU._update_single_lora_output(y_slice, delta, scale, add_inputs)
             offset += output_size
         return True
+
+    @staticmethod
+    def _update_single_lora_output(
+        y: torch.Tensor,
+        delta: torch.Tensor,
+        scale: float,
+        add_inputs: bool,
+    ) -> None:
+        if add_inputs:
+            if scale == 1.0:
+                y.add_(delta)
+            else:
+                y.add_(delta, alpha=scale)
+        elif scale == 1.0:
+            y.copy_(delta)
+        else:
+            torch.mul(delta, scale, out=y)
 
     def add_lora_fused_moe(
         self,

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -22,7 +22,8 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         PunicaWrapperBase.__init__(self, max_num_batched_tokens, max_batches, device)
         refresh_all_lora_classes()
         self.lora_config = kwargs.get("lora_config")
-        if get_ascend_device_type() == AscendDeviceType._310P or (
+        ascend_device_type = get_ascend_device_type()
+        if ascend_device_type == AscendDeviceType._310P or (
             self.lora_config is not None and self.lora_config.max_lora_rank >= 128
         ):
             from vllm.lora.ops.torch_ops import (
@@ -48,6 +49,14 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.sgmv_expand = sgmv_expand
         self.sgmv_expand_slice = sgmv_expand_slice
         self.sgmv_shrink = sgmv_shrink
+        # This flag is graph-static. Per-token indices below preserve base rows
+        # when the single adapter shares a compiled batch with base requests.
+        self._single_lora_slot = (
+            ascend_device_type == AscendDeviceType.A3
+            and self.lora_config is not None
+            and self.lora_config.max_loras == 1
+            and not self.lora_config.fully_sharded_loras
+        )
 
     def _shrink_prefill(
         self,
@@ -311,6 +320,17 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
         assert len(lora_a_stacked) == len(lora_b_stacked) == len(output_slices)
 
+        if self._apply_single_lora_linear(
+            y,
+            x,
+            lora_a_stacked,
+            lora_b_stacked,
+            scale,
+            output_slices,
+            add_inputs=kwargs.get("add_inputs", True),
+        ):
+            return
+
         if buffer is None:
             r = lora_b_stacked[0].size(-1)
             # We set the buffer to be float32 by default, consistent with the
@@ -320,6 +340,39 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             )
         self.add_shrink(buffer, x, lora_a_stacked, scale, **kwargs)
         self.add_expand(y, buffer, lora_b_stacked, output_slices, add_inputs=True, **kwargs)
+
+    def _apply_single_lora_linear(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+        scale: float,
+        output_slices: tuple[int, ...],
+        *,
+        add_inputs: bool,
+    ) -> bool:
+        """Use masked GEMM when the service has one runtime LoRA slot."""
+        if not self._single_lora_slot:
+            return False
+
+        x = x.view(-1, x.shape[-1])
+        y = y.view(-1, y.shape[-1])
+        adapter_mask = self._get_token_lora_indices(x).eq(0).unsqueeze(1)
+        offset = 0
+        for lora_a, lora_b, output_size in zip(lora_a_stacked, lora_b_stacked, output_slices, strict=True):
+            a_weight = lora_a[0, 0]
+            b_weight = lora_b[0, 0, :output_size]
+            shrink = torch.matmul(x, a_weight.transpose(0, 1))
+            delta = torch.matmul(shrink, b_weight.transpose(0, 1))
+            delta.mul_(adapter_mask)
+            y_slice = y.narrow(1, offset, output_size)
+            if add_inputs:
+                y_slice.add_(delta, alpha=scale)
+            else:
+                torch.mul(delta, scale, out=y_slice)
+            offset += output_size
+        return True
 
     def add_lora_fused_moe(
         self,

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -85,7 +85,9 @@ class AscendMergedColumnParallelLinearWithLoRA(_PackedLoRAAWeightsMixin):
         model_config: PretrainedConfig | None,
     ) -> bool:
         return (
-            type(source_layer) is maybe_get_oot_by_class(MergedColumnParallelLinear) and len(packed_modules_list) == 2
+            lora_config.max_loras == 1
+            and type(source_layer) is maybe_get_oot_by_class(MergedColumnParallelLinear)
+            and len(packed_modules_list) == 2
         )
 
 
@@ -99,7 +101,11 @@ class AscendMergedQKVParallelLinearWithLoRA(_PackedLoRAAWeightsMixin, MergedQKVP
         packed_modules_list: list,
         model_config: PretrainedConfig | None,
     ) -> bool:
-        return type(source_layer) is AscendQKVParallelLinear and len(packed_modules_list) == 3
+        return (
+            lora_config.max_loras == 1
+            and type(source_layer) is AscendQKVParallelLinear
+            and len(packed_modules_list) == 3
+        )
 
 
 def refresh_all_lora_classes():

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -17,8 +17,6 @@ from vllm_ascend.ops.linear import AscendQKVParallelLinear
 
 
 class _PackedLoRAAWeightsMixin(MergedColumnParallelLinearWithLoRA):
-    """Keep packed LoRA-A weights in sync for the single-adapter GEMM path."""
-
     def create_lora_weights(
         self,
         max_loras: int,

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -1,13 +1,113 @@
+import torch
 import vllm
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.config import LoRAConfig
+from vllm.lora.layers import MergedColumnParallelLinearWithLoRA, MergedQKVParallelLinearWithLoRA
+from vllm.lora.layers.utils import _not_fully_sharded_can_replace
+from vllm.model_executor.custom_op import maybe_get_oot_by_class
+from vllm.model_executor.layers.linear import MergedColumnParallelLinear
+from vllm.platforms import current_platform
 
 from vllm_ascend.lora.fused_moe import (
     AscendFusedMoE3DWithLoRA,
     AscendFusedMoEWithLoRA,
 )
+from vllm_ascend.ops.linear import AscendQKVParallelLinear
+
+
+class _PackedLoRAAWeightsMixin(MergedColumnParallelLinearWithLoRA):
+    """Keep packed LoRA-A weights in sync for the single-adapter GEMM path."""
+
+    def create_lora_weights(
+        self,
+        max_loras: int,
+        lora_config: LoRAConfig,
+        model_config: PretrainedConfig | None = None,
+    ) -> None:
+        super().create_lora_weights(max_loras, lora_config, model_config)
+        rank = self.lora_a_stacked[0].size(2)
+        self.lora_a_packed = torch.zeros(
+            max_loras,
+            1,
+            self.n_slices * rank,
+            self.input_size,
+            dtype=lora_config.lora_dtype,
+            device=self.device,
+        )
+
+    def reset_lora(self, index: int) -> None:
+        super().reset_lora(index)
+        if hasattr(self, "lora_a_packed"):
+            self.lora_a_packed[index].zero_()
+
+    def set_lora(
+        self,
+        index: int,
+        lora_a: torch.Tensor | list[torch.Tensor],
+        lora_b: torch.Tensor | list[torch.Tensor],
+    ) -> None:
+        super().set_lora(index, lora_a, lora_b)
+        rank = self.lora_a_stacked[0].size(2)
+        for slice_index, slice_weight in enumerate(self.lora_a_stacked):
+            packed_slice = self.lora_a_packed[index, 0].narrow(0, slice_index * rank, rank)
+            packed_slice.copy_(slice_weight[index, 0], non_blocking=True)
+
+    def _apply_lora_to_output(self, x: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+        original_shape = output.shape if output.ndim == 3 else None
+        if x.ndim == 3 and output.ndim == 3:
+            output = output.flatten(0, 1)
+            x = x.flatten(0, 1)
+
+        lora_output: torch.Tensor | None = self.punica_wrapper.add_lora_linear(
+            output,
+            x,
+            self.lora_a_stacked,
+            self.lora_b_stacked,
+            1.0,
+            self.output_slices,
+            packed_lora_a=self.lora_a_packed,
+        )
+        if not current_platform.can_update_inplace():
+            output = lora_output
+
+        if original_shape is not None:
+            output = output.reshape(original_shape)
+        return output
+
+
+class AscendMergedColumnParallelLinearWithLoRA(_PackedLoRAAWeightsMixin):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return (
+            type(source_layer) is maybe_get_oot_by_class(MergedColumnParallelLinear) and len(packed_modules_list) == 2
+        )
+
+
+class AscendMergedQKVParallelLinearWithLoRA(_PackedLoRAAWeightsMixin, MergedQKVParallelLinearWithLoRA):
+    @classmethod
+    @_not_fully_sharded_can_replace
+    def can_replace_layer(
+        cls,
+        source_layer: nn.Module,
+        lora_config: LoRAConfig,
+        packed_modules_list: list,
+        model_config: PretrainedConfig | None,
+    ) -> bool:
+        return type(source_layer) is AscendQKVParallelLinear and len(packed_modules_list) == 3
 
 
 def refresh_all_lora_classes():
     ascend_classes = (
+        AscendMergedColumnParallelLinearWithLoRA,
+        AscendMergedQKVParallelLinearWithLoRA,
         AscendFusedMoEWithLoRA,
         AscendFusedMoE3DWithLoRA,
     )

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -109,9 +109,8 @@ def refresh_all_lora_classes():
         AscendFusedMoEWithLoRA,
         AscendFusedMoE3DWithLoRA,
     )
-    # vLLM #35077 changed _all_lora_classes from set to ordered tuple.
-    # Append the Ascend classes in a deterministic order.
+    existing_classes = tuple(cls for cls in vllm.lora.utils._all_lora_classes if cls not in ascend_classes)
     vllm.lora.utils._all_lora_classes = (
         *ascend_classes,
-        *vllm.lora.utils._all_lora_classes,
+        *existing_classes,
     )


### PR DESCRIPTION
> **v0.26.0rc backport** of main PR #13496.
> Targets `releases/v0.26.0rc`. Companion main PR: #13496.

## What this PR does

A3 single-adapter performance optimization. Adds the masked GEMM fast path for `max_loras=1`, non-fully-sharded LoRA on A3:

- Metadata stage precomputes BF16/FP16 adapter mask; graph reuses a fixed-address mask buffer.
- Mask hoisted from the wide output delta to the rank=8 shrink.
- Packed QKV / Gate-Up projection with one contiguous writeback.
- Adapter create/set/reset maintains packed LoRA-A; multiple LoRA-A merged into one shrink GEMM.
- `scale == 1.0` fast path: direct `add_`/`copy_`, drops the no-op scalar multiply.
- Multi-adapter, fully-sharded, and non-qualifying requests keep the original fallback.

## Eligibility

```
device = A3
max_loras = 1
fully_sharded_loras = false
```

## Performance (historical A3)

| Concurrency | Original PR #12295 | Optimized | Δ |
|---:|---:|---:|---:|
| C1 | 29.33 tok/s | 33.27 tok/s | **+13.4%** |
| C4 | 82.15 tok/s | 107.45 tok/s | **+30.8%** |
| C8 | 134.36 tok/s | 173.09 tok/s | **+28.8%** |
| C16 | 199.29 tok/s | 252.66 tok/s | **+26.8%** |

Two A3 environments reproduce within 0.2%-0.3%.

## Scope

Builds on PR 2 (`split/lora-dual-acl-graph`). Does not include A2 enablement (PR 4).

## Validation

```
Ruff check/format: Pass
mypy Python 3.10/3.11/3.12: Pass
Focused pytest: 29 passed
git diff --check: Pass
```

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485

Co-Authored-By: wangzhao-11a <73340653+wangzhao-11a@users.noreply.github.com>