### PR TITLE
[v0.26.0rc][Feature][LoRA] Enable single-adapter graph path on A2

### DIFF
--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -18,6 +18,27 @@ from vllm_ascend.lora.utils import (
     _PackedLoRAAWeightsMixin,
     refresh_all_lora_classes,
 )
+from vllm_ascend.utils import AscendDeviceType
+
+
+@pytest.mark.parametrize("device_type", [AscendDeviceType.A2, AscendDeviceType.A3])
+def test_single_lora_slot_enabled_on_a2_and_a3(device_type: AscendDeviceType) -> None:
+    lora_config = SimpleNamespace(
+        max_lora_rank=8,
+        max_loras=1,
+        fully_sharded_loras=False,
+        lora_dtype=torch.bfloat16,
+    )
+
+    with (
+        patch.object(PunicaWrapperBase, "__init__", return_value=None),
+        patch("vllm_ascend.lora.punica_npu.refresh_all_lora_classes"),
+        patch("vllm_ascend.lora.punica_npu.get_ascend_device_type", return_value=device_type),
+    ):
+        wrapper = PunicaWrapperNPU(16, 4, "cpu", lora_config=lora_config)
+
+    assert wrapper._single_lora_slot
+    assert wrapper._single_lora_mask.shape == (16, 1)
 
 
 @pytest.mark.parametrize("add_inputs", [True, False])

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -38,6 +38,7 @@ def test_single_lora_slot_enabled_on_a2_and_a3(device_type: AscendDeviceType) ->
         wrapper = PunicaWrapperNPU(16, 4, "cpu", lora_config=lora_config)
 
     assert wrapper._single_lora_slot
+    assert wrapper._single_lora_mask is not None
     assert wrapper._single_lora_mask.shape == (16, 1)
 
 

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -50,7 +50,7 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.sgmv_expand_slice = sgmv_expand_slice
         self.sgmv_shrink = sgmv_shrink
         self._single_lora_slot = (
-            ascend_device_type == AscendDeviceType.A3
+            ascend_device_type in {AscendDeviceType.A2, AscendDeviceType.A3}
             and self.lora_config is not None
             and self.lora_config.max_loras == 1
             and not self.lora_config.fully_sharded_loras


### PR DESCRIPTION
> **v0.26.0rc backport** of main PR #13492.
> Targets `releases/v0.26.0rc`. Companion main PR: #13492.

## What this PR does

Extends the single-adapter fast path from A3-only to A2/A3. Production change is minimal:

```python
ascend_device_type in {AscendDeviceType.A2, AscendDeviceType.A3}
```

Other eligibility conditions unchanged: `max_loras=1`, `fully_sharded_loras=false`. This PR only extends eligibility; it adds no A2-specific kernel.

## A2 performance

A2 on-device A/B: `split/lora-single-adapter-a3-perf` (fast path disabled on A2, fallback) vs this branch (fast path enabled on A2). Random input 1,024, fixed output 128, TP4, temperature 0, ignore-eos.

| Concurrency | LoRA uplift | Base Δ |
|---:|---:|---:|
| C1 | **+15.87%** | ±0.1% |
| C4 | **+22.06%** | ±0.1% |
| C8 | **+26.65%** | ±0.1% |
| C16 | **+31.31%** | ±0.1% |

232 production requests completed successfully (Base/LoRA, 8 groups). This PR only extends hardware eligibility; it does not change the PR 3 algorithm.

## Scope

Builds on PR 3 (`split/lora-single-adapter-a3-perf`).

## Validation

```
Ruff check/format: Pass
mypy Python 3.10/3.11/3.12: Pass
Focused pytest: 31 passed
git diff --check: Pass
```

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
