### PR TITLE
[v0.26.0rc][BugFix][LoRA][MoE] Handle rank-wide packed expand slices (replaces #13493)

### DIFF
--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -1,2 +1,123 @@
-def test_lora_placeholder():
-    pass
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
+
+from vllm_ascend.lora.fused_moe import (
+    AscendFusedMoEWithLoRA,
+    _recover_moe_lora_routing_all2all,
+    _recover_moe_lora_routing_allgather,
+    has_lora,
+    moe_lora_apply_w2,
+    moe_lora_apply_w13,
+)
+from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
+
+
+def test_ascend_fused_moe_lora_initializes_skipped_upstream_fields() -> None:
+    parallel_config = SimpleNamespace(tp_size=8, tp_rank=3, ep_rank=0, use_ep=False)
+    shared_experts = torch.nn.Module()
+    base_layer = SimpleNamespace(
+        moe_config=SimpleNamespace(
+            hidden_dim=4096,
+            num_local_experts=256,
+            num_experts=256,
+            intermediate_size_per_partition=256,
+            experts_per_token=8,
+            moe_parallel_config=parallel_config,
+            is_act_and_mul=True,
+        ),
+        _shared_experts=shared_experts,
+    )
+
+    with (
+        patch("vllm_ascend.lora.fused_moe._assert_ascend_moe_lora_supported"),
+        patch("vllm_ascend.lora.fused_moe._get_lora_device", return_value=torch.device("cpu")),
+    ):
+        wrapper = AscendFusedMoEWithLoRA(base_layer)
+
+    assert wrapper._lora_stream is None
+    assert wrapper._events is None
+    assert wrapper.enable_moe_shared_loras is False
+    assert wrapper._shared_experts is shared_experts
+    assert wrapper.n_slices == 256 * 3
+
+
+def test_moe_lora_apply_uses_adapter_enabled() -> None:
+    punica_wrapper = Mock()
+    context = SimpleNamespace(
+        punica_wrapper=punica_wrapper,
+        w13_lora_a_stacked="w13_a",
+        w13_lora_b_stacked="w13_b",
+        w2_lora_a_stacked="w2_a",
+        w2_lora_b_stacked="w2_b",
+        adapter_enabled="all_enabled",
+    )
+    routing = (torch.tensor([0]), torch.tensor([0]))
+
+    moe_lora_apply_w13(
+        context,
+        gate_up_out="gate_up_out",
+        hidden_states="hidden_states",
+        lora_routing=routing,
+    )
+    moe_lora_apply_w2(
+        context,
+        down_out="down_out",
+        silu_out="silu_out",
+        lora_routing=routing,
+    )
+
+    calls = punica_wrapper.add_lora_fused_moe.call_args_list
+    assert calls[0].kwargs["adapter_enabled"] == "all_enabled"
+    assert calls[1].kwargs["adapter_enabled"] == "all_enabled"
+
+
+def test_allgather_routing_preserves_multi_adapter_and_base_mapping() -> None:
+    context = SimpleNamespace(
+        top_k=2,
+        punica_wrapper=SimpleNamespace(token_lora_indices=torch.tensor([0, -1, 1])),
+    )
+    topk_ids = torch.tensor([[1, 0], [0, 1], [1, 1]])
+    # Original flat rows [0..5] land at these expert-sorted positions.
+    expanded_row_idx = torch.tensor([2, 0, 1, 3, 4, 5])
+
+    expert_ids, lora_slots = _recover_moe_lora_routing_allgather(context, expanded_row_idx, topk_ids)
+
+    assert torch.equal(expert_ids, torch.tensor([0, 0, 1, 1, 1, 1]))
+    assert torch.equal(lora_slots, torch.tensor([0, -1, 0, -1, 1, 1]))
+
+
+def test_all2all_routing_uses_local_experts_and_exchanged_adapters() -> None:
+    context = SimpleNamespace(
+        local_num_experts=3,
+        exchanged_lora_indices=torch.tensor([1, -1, 0, 2]),
+    )
+
+    expert_ids, lora_slots = _recover_moe_lora_routing_all2all(
+        context,
+        group_list=torch.tensor([2, 0, 2]),
+    )
+
+    assert torch.equal(expert_ids, torch.tensor([0, 0, 2, 2]))
+    assert torch.equal(lora_slots, torch.tensor([1, -1, 0, 2]))
+
+
+def test_has_lora_follows_batch_metadata() -> None:
+    assert not has_lora(None)
+    assert not has_lora(SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=True)))
+    assert has_lora(SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=False)))
+
+
+@pytest.mark.parametrize(
+    ("index_mapping", "expected_no_lora"),
+    [((0, 0), True), ((0, 1), False), ((2, 0), False)],
+)
+def test_decode_metadata_refreshes_no_lora(index_mapping, expected_no_lora) -> None:
+    wrapper = object.__new__(PunicaWrapperNPU)
+    mapping = SimpleNamespace(index_mapping=index_mapping)
+    with patch.object(PunicaWrapperBase, "update_metadata"):
+        wrapper.update_metadata(mapping, [], 2, 100)
+    assert wrapper.no_lora is expected_no_lora

--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -1,4 +1,5 @@
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from vllm_ascend.lora.fused_moe import (
     moe_lora_apply_w2,
     moe_lora_apply_w13,
 )
+from vllm_ascend.lora.lora_ops import bmm_expand_slice
 from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
 
 
@@ -121,3 +123,101 @@ def test_decode_metadata_refreshes_no_lora(index_mapping, expected_no_lora) -> N
     with patch.object(PunicaWrapperBase, "update_metadata"):
         wrapper.update_metadata(mapping, [], 2, 100)
     assert wrapper.no_lora is expected_no_lora
+
+
+@pytest.mark.parametrize(
+    ("rank", "slice_size", "expect_fallback"),
+    [(4, 8, False), (16, 8, True)],
+)
+def test_expand_slice_selects_fallback_from_tensor_shape(
+    rank: int,
+    slice_size: int,
+    expect_fallback: bool,
+) -> None:
+    wrapper: Any = SimpleNamespace(
+        no_lora=False,
+        _bmm_expand_slice=Mock(),
+        sgmv_expand_slice=Mock(),
+        prefill_metadata=("batches", "tokens", "indices"),
+    )
+    wrapper._requires_bmm_expand_slice = MethodType(PunicaWrapperNPU._requires_bmm_expand_slice, wrapper)
+    x = SimpleNamespace(shape=(2, rank))
+
+    PunicaWrapperNPU._expand_slice_prefill(
+        wrapper,
+        "y",
+        x,
+        "weights",
+        4,
+        slice_size,
+        True,
+    )
+
+    if expect_fallback:
+        wrapper._bmm_expand_slice.assert_called_once_with("y", x, "weights", 4, slice_size, True)
+        wrapper.sgmv_expand_slice.assert_not_called()
+    else:
+        wrapper._bmm_expand_slice.assert_not_called()
+        wrapper.sgmv_expand_slice.assert_called_once_with(
+            x,
+            "weights",
+            "y",
+            "batches",
+            "tokens",
+            "indices",
+            4,
+            slice_size,
+            True,
+        )
+
+
+@pytest.mark.parametrize("add_inputs", [False, True])
+def test_lora_bmm_expand_slice_fallback_matches_reference(add_inputs: bool) -> None:
+    x = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    weights = torch.tensor(
+        [
+            [[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]],
+            [[[2.0, 0.0], [0.0, 2.0], [1.0, -1.0]]],
+        ]
+    )
+    indices = torch.tensor([0, 1, -1], dtype=torch.long)
+    y = torch.ones((3, 5))
+
+    bmm_expand_slice(x, weights, y, indices, 1, 3, add_inputs)
+
+    delta = torch.stack(
+        [
+            x[0] @ weights[0, 0].T,
+            x[1] @ weights[1, 0].T,
+            torch.zeros(3),
+        ]
+    )
+    expected = torch.ones((3, 5))
+    expected[:, 1:4] = expected[:, 1:4] + delta if add_inputs else delta
+    torch.testing.assert_close(y, expected)
+
+
+@pytest.mark.parametrize(
+    ("x_shape", "weight_shape", "indices_shape", "y_shape", "slice_size", "message"),
+    [
+        ((3, 4), (2, 1, 5, 2), (3,), (3, 8), 5, "shrink rank"),
+        ((3, 2), (2, 1, 5, 2), (2,), (3, 8), 5, "same row count"),
+        ((3, 2), (2, 1, 5, 2), (3,), (2, 8), 5, "same row count"),
+        ((3, 2), (2, 1, 4, 2), (3,), (3, 8), 5, "destination slice"),
+    ],
+)
+def test_lora_bmm_expand_slice_rejects_incompatible_shapes(
+    x_shape,
+    weight_shape,
+    indices_shape,
+    y_shape,
+    slice_size,
+    message,
+) -> None:
+    x = torch.zeros(x_shape)
+    weights = torch.zeros(weight_shape)
+    indices = torch.zeros(indices_shape, dtype=torch.long)
+    y = torch.zeros(y_shape)
+
+    with pytest.raises(ValueError, match=message):
+        bmm_expand_slice(x, weights, y, indices, 1, slice_size, True)

--- a/tests/ut/lora/test_quant_moe.py
+++ b/tests/ut/lora/test_quant_moe.py
@@ -1,0 +1,189 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+import torch_npu  # noqa: F401 -- registers torch.npu
+
+from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.lora.quant_moe import (
+    _apply_moe_activation,
+    quant_apply_mlp_with_moe_lora,
+    validate_quant_moe_lora_activation_input,
+)
+from vllm_ascend.ops.activation import SituActivationConfig
+from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput, MoEQuantParams, MoEWeights
+from vllm_ascend.quantization.quant_type import QuantType
+
+QUANT_MOE = "vllm_ascend.lora.quant_moe"
+
+
+def _make_input(**overrides) -> MoEMlpComputeInput:
+    values = dict(
+        hidden_states=torch.randn(2, 4, dtype=torch.bfloat16),
+        group_list=torch.tensor([1, 1], dtype=torch.int64),
+        group_list_type=1,
+        dynamic_scale=None,
+        topk_scales=None,
+        weights=MoEWeights(
+            w1=[torch.ones(1, 4, 6, dtype=torch.int8)],
+            w2=[torch.ones(1, 3, 4, dtype=torch.int8)],
+            w1_scale=[torch.ones(1, 6)],
+            w2_scale=[torch.ones(1, 4, dtype=torch.bfloat16)],
+        ),
+        quant=MoEQuantParams(quant_type=QuantType.W8A8),
+        fusion=True,
+        activation="silu",
+        expanded_row_idx=torch.tensor([0, 1], dtype=torch.int32),
+        topk_ids=torch.tensor([[0], [1]], dtype=torch.int32),
+        lora_context=SimpleNamespace(use_ep=False),
+    )
+    values.update(overrides)
+    return MoEMlpComputeInput(**values)
+
+
+@pytest.mark.parametrize(
+    ("comm_type", "mlp_input"),
+    [
+        (MoECommType.ALLGATHER, _make_input()),
+        (
+            MoECommType.ALLTOALL,
+            _make_input(
+                expanded_row_idx=None,
+                topk_ids=None,
+                lora_context=SimpleNamespace(use_ep=True),
+            ),
+        ),
+    ],
+)
+def test_dynamic_int8_lora_injects_at_float_boundaries(comm_type, mlp_input) -> None:
+    quantized_input = torch.ones(2, 4, dtype=torch.int8)
+    input_scale = torch.ones(2)
+    gate_up_out = torch.randn(2, 6, dtype=torch.bfloat16)
+    activated = torch.randn(2, 3, dtype=torch.bfloat16)
+    quantized_activated = torch.ones(2, 3, dtype=torch.int8)
+    activated_scale = torch.ones(2)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    routing = (torch.tensor([0, 1]), torch.tensor([0, 1]))
+    event = object()
+    stream = Mock(record_event=Mock(return_value=event))
+
+    with (
+        patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx,
+        patch(
+            f"{QUANT_MOE}.DeviceOperator.npu_dynamic_quant",
+            side_effect=[(quantized_input, input_scale), (quantized_activated, activated_scale)],
+        ) as dynamic_quant,
+        patch(
+            f"{QUANT_MOE}.torch_npu.npu_grouped_matmul",
+            return_value=[gate_up_out],
+            create=True,
+        ) as gmm1,
+        patch(f"{QUANT_MOE}._apply_moe_activation", return_value=activated),
+        patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=down_out) as gmm2,
+        patch(f"{QUANT_MOE}._recover_moe_lora_routing_allgather", return_value=routing) as recover_allgather,
+        patch(f"{QUANT_MOE}._recover_moe_lora_routing_all2all", return_value=routing) as recover_all2all,
+        patch(f"{QUANT_MOE}.moe_lora_apply_w13") as apply_w13,
+        patch(f"{QUANT_MOE}.moe_lora_apply_w2") as apply_w2,
+        patch("torch.npu.current_stream", return_value=stream),
+    ):
+        extra_ctx.moe_comm_type = comm_type
+        output, output_event = quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_input)
+
+    assert output is down_out
+    assert output_event is event
+    assert dynamic_quant.call_count == 2
+    assert dynamic_quant.call_args_list[0].kwargs["hidden_states"] is mlp_input.hidden_states
+    assert dynamic_quant.call_args_list[1].kwargs["hidden_states"] is activated
+    assert gmm1.call_args.kwargs["x"][0] is quantized_input
+    assert gmm2.call_args.kwargs["hidden_states"] is quantized_activated
+    if comm_type == MoECommType.ALLGATHER:
+        recover_allgather.assert_called_once_with(
+            mlp_input.lora_context,
+            mlp_input.expanded_row_idx,
+            mlp_input.topk_ids,
+        )
+        recover_all2all.assert_not_called()
+    else:
+        recover_all2all.assert_called_once_with(
+            mlp_input.lora_context,
+            group_list=mlp_input.group_list,
+        )
+        recover_allgather.assert_not_called()
+    apply_w13.assert_called_once_with(
+        mlp_input.lora_context,
+        gate_up_out=gate_up_out,
+        hidden_states=mlp_input.hidden_states,
+        lora_routing=routing,
+    )
+    apply_w2.assert_called_once_with(
+        mlp_input.lora_context,
+        down_out=down_out,
+        silu_out=activated,
+        lora_routing=routing,
+    )
+
+
+@pytest.mark.parametrize(
+    ("comm_type", "mlp_input", "message"),
+    [
+        (MoECommType.FUSED_MC2, _make_input(), "AllGather TP"),
+        (MoECommType.ALLGATHER, _make_input(dynamic_eplb=True), "dynamic EPLB"),
+    ],
+)
+def test_dynamic_int8_lora_rejects_unsupported_modes(comm_type, mlp_input, message) -> None:
+    with patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx:
+        extra_ctx.moe_comm_type = comm_type
+        with pytest.raises(NotImplementedError, match=message):
+            quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_input)
+
+
+def test_dynamic_int8_all2all_lora_handles_empty_ep_rank() -> None:
+    mlp_input = _make_input(
+        hidden_states=torch.empty(0, 4, dtype=torch.bfloat16),
+        group_list=torch.zeros(2, dtype=torch.int64),
+        expanded_row_idx=None,
+        topk_ids=None,
+        lora_context=SimpleNamespace(use_ep=True),
+    )
+
+    with (
+        patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx,
+        patch(f"{QUANT_MOE}.DeviceOperator.npu_dynamic_quant") as dynamic_quant,
+    ):
+        extra_ctx.moe_comm_type = MoECommType.ALLTOALL
+        output, output_event = quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_input)
+
+    assert output is mlp_input.hidden_states
+    assert output_event is None
+    dynamic_quant.assert_not_called()
+
+
+def test_registered_backend_requires_float_input() -> None:
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    validate_quant_moe_lora_activation_input(
+        quant_type=QuantType.W8A8,
+        hidden_states=hidden_states,
+        dynamic_scale=None,
+    )
+    with pytest.raises(NotImplementedError, match="unquantized activations"):
+        validate_quant_moe_lora_activation_input(
+            quant_type=QuantType.W8A8,
+            hidden_states=hidden_states.to(torch.int8),
+            dynamic_scale=torch.ones(2),
+        )
+
+
+def test_quantized_moe_lora_rejects_situ_activation() -> None:
+    with pytest.raises(NotImplementedError, match="SiTU"):
+        _apply_moe_activation(torch.empty(1, 2), SituActivationConfig(), 0.0, 1.0, 0.0)
+
+
+def test_unregistered_quantized_moe_lora_fails_fast() -> None:
+    with pytest.raises(NotImplementedError, match="no implementation registered"):
+        validate_quant_moe_lora_activation_input(
+            quant_type=QuantType.W4A8,
+            hidden_states=torch.randn(2, 4),
+            dynamic_scale=None,
+        )

--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import numpy as np
@@ -486,6 +487,72 @@ def test_allgather_token_dispatch_mxfp4_keeps_prequantized_scale():
     assert output.dynamic_scale is returned_scale
 
 
+@pytest.mark.parametrize(
+    ("no_lora", "expected_quant_mode", "expect_dynamic_scale"),
+    [(False, -1, False), (True, 1, True)],
+)
+def test_allgather_w8a8_lora_controls_dispatch_quantization(
+    no_lora,
+    expected_quant_mode,
+    expect_dynamic_scale,
+):
+    dispatcher = TokenDispatcherWithAllGather(top_k=1, num_experts=2)
+    dispatcher.set_lora_context(MagicMock(punica_wrapper=MagicMock(no_lora=no_lora)))
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    returned_scale = torch.randn(2)
+    token_dispatch_input = build_token_dispatch_input_fixture(
+        hidden_states=hidden_states,
+        topk_weights=torch.ones(2, 1),
+        topk_ids=torch.tensor([[0], [1]], dtype=torch.int32),
+        quant_type=QuantType.W8A8,
+    )
+    init_routing_output = (
+        hidden_states,
+        torch.tensor([0, 1], dtype=torch.int32),
+        torch.tensor([1, 1], dtype=torch.int32),
+        returned_scale,
+    )
+
+    with patch(
+        "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
+        return_value=init_routing_output,
+    ) as mock_init_routing:
+        output = dispatcher.token_dispatch(token_dispatch_input)
+
+    assert mock_init_routing.call_args.kwargs["quant_mode"] == expected_quant_mode
+    assert (output.dynamic_scale is not None) == expect_dynamic_scale
+
+
+def test_allgather_bf16_lora_skips_quant_backend_validation():
+    dispatcher = TokenDispatcherWithAllGather(top_k=1, num_experts=2)
+    dispatcher.set_lora_context(MagicMock(punica_wrapper=MagicMock(no_lora=False)))
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    token_dispatch_input = build_token_dispatch_input_fixture(
+        hidden_states=hidden_states,
+        topk_weights=torch.ones(2, 1),
+        topk_ids=torch.tensor([[0], [1]], dtype=torch.int32),
+        quant_type=QuantType.NONE,
+    )
+    init_routing_output = (
+        hidden_states,
+        torch.tensor([0, 1], dtype=torch.int32),
+        torch.tensor([1, 1], dtype=torch.int32),
+        None,
+    )
+
+    with (
+        patch("vllm_ascend.ops.fused_moe.token_dispatcher.validate_quant_moe_lora_activation_input") as mock_validate,
+        patch(
+            "vllm_ascend.ops.fused_moe.token_dispatcher.DeviceOperator.npu_moe_init_routing",
+            return_value=init_routing_output,
+        ),
+    ):
+        output = dispatcher.token_dispatch(token_dispatch_input)
+
+    mock_validate.assert_not_called()
+    assert output.dynamic_scale is None
+
+
 class TestTokenDispatcherWithAllGather(TestBase):
     def setUp(self):
         # Mock dependencies
@@ -666,6 +733,14 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
         self.mock_ep_rank_prop = patcher2.start()
         self.mock_ep_size_prop = patcher3.start()
 
+        # TokenDispatcherWithAll2AllV obtains the local rank while building
+        # the HCCL group name.  A MagicMock group alone is not sufficient on
+        # vLLM v0.26.0: torch.distributed.get_rank still attempts to resolve
+        # the uninitialized default process group first.
+        patcher_rank = patch("torch.distributed.get_rank", return_value=0)
+        self.mock_get_rank = patcher_rank.start()
+        self.addCleanup(patcher_rank.stop)
+
         # Mock torch_npu.npu_moe_token_permute
         patcher4 = patch("torch_npu.npu_moe_token_permute")
         self.mock_npu_moe_token_permute = patcher4.start()
@@ -679,7 +754,7 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
         self.mock_npu_moe_token_unpermute.return_value = torch.randn(8, 16)
 
         # Mock async_all_to_all
-        patcher6 = patch("vllm_ascend.ops.fused_moe.comm_utils.async_all_to_all")
+        patcher6 = patch("vllm_ascend.ops.fused_moe.token_dispatcher.async_all_to_all")
         self.mock_async_all_to_all = patcher6.start()
         self.addCleanup(patcher6.stop)
         self.mock_async_all_to_all.return_value = (None, torch.randn(16, 16), MagicMock())
@@ -705,7 +780,7 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
         self.mock_current_device.return_value = "cpu"
 
         # Mock torch_npu.npu_dynamic_quant
-        patcher10 = patch("torch_npu.npu_dynamic_quant")
+        patcher10 = patch("torch_npu.npu_dynamic_quant", create=True)
         self.mock_npu_dynamic_quant = patcher10.start()
         self.addCleanup(patcher10.stop)
         self.mock_npu_dynamic_quant.return_value = (torch.randn(16, 16), torch.randn(16))
@@ -751,6 +826,36 @@ class TestTokenDispatcherWithAll2AllV(TestBase):
         self.assertIsNotNone(result.group_list)
         self.assertEqual(result.group_list_type, 1)
         self.assertIsInstance(result.combine_metadata, MoEAllToAllCombineMetadata)
+
+    def test_w8a8_lora_dispatch_preserves_float_activations(self):
+        hidden_states = torch.randn(8, 16, dtype=torch.bfloat16)
+        topk_weights = torch.rand(8, 4)
+        topk_ids = torch.randint(0, 4, (8, 2)).long()
+        expert_map = torch.tensor([0, 1, 2, 3])
+
+        self.dispatcher.expert_ids_per_ep_rank = torch.tensor([0, 1], dtype=torch.int32)
+        self.dispatcher.local_expert_indices = [0, 1]
+        self.dispatcher.set_lora_context(
+            SimpleNamespace(
+                punica_wrapper=SimpleNamespace(no_lora=False),
+                split_lora_indices=None,
+            )
+        )
+        token_dispatch_input = build_token_dispatch_input_fixture(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            expert_map=expert_map,
+            quant_type=QuantType.W8A8,
+        )
+
+        # This test covers dispatch-side activation quantization, not the
+        # separately tested LoRA index exchange collective.
+        with patch("vllm_ascend.ops.fused_moe.token_dispatcher.all2all_lora_indices"):
+            result = self.dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+
+        self.mock_npu_dynamic_quant.assert_not_called()
+        self.assertIsNone(result.dynamic_scale)
 
     @pytest.mark.skip("Skip as register_kernels has NPU SocName checking in CANN 8.5.0.")
     def test_token_combine(self):

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -392,6 +392,67 @@ def test_shared_experts_part2_applies_optional_gate(with_gate):
     torch.testing.assert_close(output, expected)
 
 
+def test_set_lora_context_updates_routed_experts():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    runner.routed_experts = SimpleNamespace()
+    lora_context = object()
+
+    runner.set_lora_context(lora_context)
+
+    assert runner.routed_experts._ascend_moe_lora_context is lora_context
+
+
+def test_active_shared_expert_lora_uses_wrapped_projections(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up_proj = MagicMock(weight_scale=torch.ones(1))
+    down_proj = MagicMock(weight_scale=torch.ones(1))
+    runner._shared_experts = SimpleNamespace(
+        gate_up_proj=gate_up_proj,
+        down_proj=down_proj,
+        act_fn=nn.Identity(),
+    )
+    runner._shared_experts_part1 = MagicMock(return_value=gate_up)
+    runner._shared_experts_part2 = MagicMock(return_value=down_out)
+    runner.routed_experts = SimpleNamespace(
+        _ascend_moe_lora_context=SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=False))
+    )
+    runner.quant_type = QuantType.W8A8
+    runner.multistream_overlap_shared_expert = False
+    events = fused_moe_module.FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    dynamic_quant = MagicMock()
+
+    monkeypatch.setattr(fused_moe_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(fused_moe_module, "shared_expert_dp_enabled", lambda: True)
+    monkeypatch.setattr(fused_moe_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(fused_moe_module.torch.npu, "current_stream", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_dynamic_quant", dynamic_quant, raising=False)
+    monkeypatch.setattr(
+        fused_moe_module,
+        "_EXTRA_CTX",
+        SimpleNamespace(
+            flash_comm_v1_enabled=False,
+            moe_comm_type=MoECommType.ALLGATHER,
+        ),
+    )
+
+    output = runner._forward_shared_experts(hidden_states, events)
+
+    assert output is down_out
+    dynamic_quant.assert_not_called()
+    runner._shared_experts_part1.assert_called_once_with(hidden_states)
+    runner._shared_experts_part2.assert_called_once_with(hidden_states, gate_up)
+
+
 def test_unquantized_shared_situ_uses_split_bf16_path(monkeypatch):
     runner = AscendMoERunner.__new__(AscendMoERunner)
     nn.Module.__init__(runner)

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -358,6 +358,69 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                 self.assertFalse(quant_kwargs["use_bf16"])
                 mock_unquant.assert_not_called()
 
+    def test_active_quantized_lora_uses_registered_backend(self):
+        expected = (torch.randn(2, 8), None)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=torch.randn(2, 8, dtype=torch.bfloat16),
+            group_list=torch.tensor([2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=[torch.ones(1, 8, 16, dtype=torch.int8)],
+                w2=[torch.ones(1, 8, 8, dtype=torch.int8)],
+                w1_scale=[torch.ones(1, 16)],
+                w2_scale=[torch.ones(1, 8)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            fusion=True,
+            expanded_row_idx=torch.tensor([0, 1], dtype=torch.int32),
+            topk_ids=torch.tensor([[0], [0]], dtype=torch.int32),
+            lora_context=SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=False)),
+        )
+
+        with (
+            patch(
+                "vllm_ascend.lora.quant_moe.quant_apply_mlp_with_moe_lora",
+                return_value=expected,
+            ) as mock_lora,
+            patch(f"{MOE_MLP}.quant_apply_mlp") as mock_quant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertIs(output, expected)
+        mock_lora.assert_called_once_with(mlp_compute_input=mlp_compute_input)
+        mock_quant.assert_not_called()
+
+    def test_base_only_quantized_lora_context_keeps_existing_path(self):
+        expected = (torch.randn(2, 8), None)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=torch.ones(2, 8, dtype=torch.int8),
+            group_list=torch.tensor([2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=torch.ones(2),
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=[torch.ones(1, 8, 16, dtype=torch.int8)],
+                w2=[torch.ones(1, 8, 8, dtype=torch.int8)],
+                w1_scale=[torch.ones(1, 16)],
+                w2_scale=[torch.ones(1, 8)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            fusion=True,
+            lora_context=SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=True)),
+        )
+
+        with (
+            patch(f"{MOE_MLP}.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch("vllm_ascend.lora.quant_moe.quant_apply_mlp_with_moe_lora") as mock_lora,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertIs(output, expected)
+        mock_quant.assert_called_once()
+        mock_lora.assert_not_called()
+
     def test_request_quant_path_passes_w4a8_per_channel_flag(self):
         hidden_states = torch.randn(2, 8)
         expected = torch.randn(2, 8)

--- a/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import torch
@@ -150,6 +151,8 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         layer.w13_weight_scale_fp32 = torch.ones(self.num_experts, 2 * self.intermediate_size, dtype=torch.float32)
         layer.w2_weight_scale = torch.ones(self.num_experts, hidden_size, dtype=torch.float32)
         layer.swiglu_limit = 1000000
+        lora_context = SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=False))
+        layer._ascend_moe_lora_context = lora_context
 
         x = torch.randn(tokens, hidden_size, dtype=torch.float32)
         router_logits = torch.randn(tokens, self.num_experts, dtype=torch.float32)
@@ -185,6 +188,7 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertIs(fused_experts_input.routing.pertoken_scale, pertoken_scale)
         self.assertIs(fused_experts_input.topk_weights, topk_weights)
         self.assertIs(fused_experts_input.topk_ids, topk_ids)
+        self.assertIs(fused_experts_input.lora_context, lora_context)
 
     @patch("torch_npu.npu_format_cast")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")

--- a/vllm_ascend/lora/fused_moe.py
+++ b/vllm_ascend/lora/fused_moe.py
@@ -13,29 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Ascend MoE-LoRA wrapper (v1).
+"""Ascend MoE LoRA wrapper and routed-token mapping helpers.
 
-Design (see plan in conversation history):
+The wrapper reuses upstream weight allocation, loading, and TP/EP slicing but
+publishes the resulting LoRA context through Ascend's MoERunner pipeline rather
+than the GPU modular kernel. Unquantized LoRA keeps the existing AllGather and
+AlltoAll implementations. Quantized backends inject deltas at their floating
+point GMM boundaries; the first implementation supports W8A8_DYNAMIC with
+AllGather TP and AlltoAll EP execution.
 
-  - Inherits weight allocation / set_lora / slice helpers from upstream
-    FusedMoEWithLoRA. Only the injection mechanism differs: upstream wraps
-    Triton modular kernel internals (`TritonExperts.activation` / `moe_sum`),
-    which do not exist on Ascend. We instead wrap the per-layer
-    `quant_method.apply` and, inside it, temporarily swap the active
-    `MoECommMethod._apply_mlp` so the LoRA delta is added on permuted
-    activations between the grouped GMMs.
-
-  - Per-layer ownership is critical: `_MoECommMethods` is a module-level
-    singleton shared by all 48 MoE layers. If we wrapped `_apply_mlp` at
-    init time, layer N+1 would compose on top of layer N's wrapper and
-    every forward would stack all layers' LoRA deltas. We bracket the swap
-    inside `apply_wrapper` so only the active layer is in effect.
-
-  - v1 deliberately limits scope to: unquant + AllGather + TP-only +
-    no shared experts + no FusedMC2 + no dynamic EPLB. These are the exact
-    conditions under which `Qwen3-30B-A3B-Thinking-2507` runs cleanly with
-    TP=4 EP=1 on 4×64GB. Other paths assert early so users get a clear
-    error rather than silently wrong outputs.
+Shared experts remain ordinary dense LoRA layers. This module preserves their
+module hierarchy and selects a compatible NPU dense expand implementation when
+the MoE wrapper is mapped.
 """
 
 from __future__ import annotations
@@ -43,6 +32,7 @@ from __future__ import annotations
 import torch
 from torch import nn
 from vllm import envs
+from vllm.logger import logger
 from vllm.lora.layers.base import BaseLayerWithLoRA
 from vllm.lora.layers.fused_moe import FusedMoE3DWithLoRA, FusedMoEWithLoRA
 from vllm.lora.layers.utils import _get_lora_device
@@ -56,6 +46,11 @@ _MOE_LORA_INDEX_FIELDS = (
     "permuted_lora_indices",
     "exchanged_lora_indices",
 )
+
+
+def has_lora(lora_context) -> bool:
+    """Return whether the current batch contains at least one LoRA token."""
+    return lora_context is not None and not lora_context.punica_wrapper.no_lora
 
 
 def reset_lora_indices(lora_context) -> None:
@@ -185,11 +180,10 @@ def _assert_ascend_moe_lora_supported(base_layer: nn.Module) -> None:
             "Set VLLM_ASCEND_ENABLE_FUSED_MC2=0."
         )
     if getattr(base_layer, "_shared_experts", None) is not None:
-        raise AssertionError(
-            "Ascend MoE LoRA does not wrap the shared_experts path "
-            "(it runs outside quant_method.apply). The target model "
-            "Qwen3-30B-A3B-Thinking-2507 has no shared experts; models "
-            "like DeepSeek-V3 are not yet supported."
+        logger.warning_once(
+            "Ascend MoE LoRA: shared_experts detected. Routed-expert LoRA "
+            "uses the MoE path; shared-expert LoRA uses dense wrappers with "
+            "the compatible NPU expand-slice implementation."
         )
 
 
@@ -338,11 +332,26 @@ class AscendFusedMoEWithLoRA(FusedMoEWithLoRA):
         self.tp_rank = moe_parallel_config.tp_rank
         self.device = _get_lora_device(base_layer)
         self._enable_aux_cuda_stream = envs.VLLM_LORA_ENABLE_DUAL_STREAM
+        # _build_lora_context is inherited from vLLM, whose GPU constructor
+        # normally initializes these fields. Ascend deliberately skips it.
+        self._lora_stream = None
+        self._events = None
+        self.enable_moe_shared_loras = False
         self._w13_slices = 2 if base_layer.moe_config.is_act_and_mul else 1
         # Mirrors per-(lora_id) layout of `self.lora_a_stacked` (built in
         # `create_lora_weights`) so `create_dummy_lora`'s n_slices fallback
         # matches `lora_a_stacked` length under EP.
         self.n_slices = self.local_num_experts * (self._w13_slices + 1)
+        # Preserve the model-manager-visible module path used to discover and
+        # wrap shared_experts.{gate_up,down}_proj as ordinary dense LoRA.
+        shared_experts = getattr(base_layer, "_shared_experts", None)
+        if shared_experts is not None:
+            self._shared_experts = shared_experts
+
+    def _build_lora_context(self):
+        lora_context = super()._build_lora_context()
+        lora_context.use_ep = self.use_ep
+        return lora_context
 
     # ------------------------------------------------------------------
     # Mapping

--- a/vllm_ascend/lora/lora_ops.py
+++ b/vllm_ascend/lora/lora_ops.py
@@ -16,6 +16,99 @@
 import torch
 
 
+@torch.library.custom_op("vllm_ascend::lora_bmm_expand_slice", mutates_args={"output_tensor"})
+def _bmm_expand_slice_op(
+    output_tensor: torch.Tensor,
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool,
+) -> None:
+    if inputs.ndim != 2:
+        raise ValueError(f"Expected 2D LoRA shrink input, got shape {tuple(inputs.shape)}")
+    if output_tensor.ndim != 2:
+        raise ValueError(f"Expected 2D LoRA output, got shape {tuple(output_tensor.shape)}")
+    if lora_b_weights.ndim != 4 or lora_b_weights.shape[1] != 1:
+        raise ValueError(f"Expected LoRA-B shape [slots, 1, output_size, rank], got {tuple(lora_b_weights.shape)}")
+    if lora_indices_tensor.ndim != 1 or lora_indices_tensor.shape[0] != inputs.shape[0]:
+        raise ValueError(
+            "LoRA indices and shrink input must have the same row count, "
+            f"got indices={tuple(lora_indices_tensor.shape)} and inputs={tuple(inputs.shape)}"
+        )
+    if output_tensor.shape[0] != inputs.shape[0]:
+        raise ValueError(
+            "LoRA output and shrink input must have the same row count, "
+            f"got output={tuple(output_tensor.shape)} and inputs={tuple(inputs.shape)}"
+        )
+    if inputs.shape[-1] != lora_b_weights.shape[-1]:
+        raise ValueError(
+            "LoRA shrink rank must match LoRA-B input rank, "
+            f"got input rank={inputs.shape[-1]} and LoRA-B rank={lora_b_weights.shape[-1]}"
+        )
+    if lora_b_weights.shape[-2] != slice_size:
+        raise ValueError(
+            "LoRA-B output size must match the destination slice, "
+            f"got LoRA-B output={lora_b_weights.shape[-2]} and slice={slice_size}"
+        )
+    if slice_offset < 0 or slice_offset + slice_size > output_tensor.shape[-1]:
+        raise ValueError(
+            "LoRA destination slice is outside the output tensor, "
+            f"got offset={slice_offset}, size={slice_size}, output={output_tensor.shape[-1]}"
+        )
+
+    safe_indices = lora_indices_tensor.clamp(min=0).to(torch.long)
+    gathered_weights = lora_b_weights[safe_indices, 0].to(output_tensor.dtype)
+    if inputs.shape[0] == 0 or gathered_weights.shape[1] == 0:
+        return
+
+    delta = torch.bmm(gathered_weights, inputs.to(output_tensor.dtype).unsqueeze(-1)).squeeze(-1)
+    delta = torch.where(
+        (lora_indices_tensor >= 0).unsqueeze(-1),
+        delta,
+        torch.zeros_like(delta),
+    )
+    output_slice = output_tensor.narrow(1, slice_offset, slice_size)
+    if add_inputs:
+        output_slice.add_(delta)
+    else:
+        output_slice.copy_(delta)
+
+
+@_bmm_expand_slice_op.register_fake
+def _bmm_expand_slice_fake(
+    output_tensor: torch.Tensor,
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool,
+) -> None:
+    return None
+
+
+def bmm_expand_slice(
+    inputs: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    slice_offset: int,
+    slice_size: int,
+    add_inputs: bool = True,
+) -> None:
+    _bmm_expand_slice_op(
+        output_tensor,
+        inputs,
+        lora_b_weights,
+        lora_indices_tensor,
+        slice_offset,
+        slice_size,
+        add_inputs,
+    )
+
+
 def bgmv_shrink(
     inputs: torch.Tensor,
     lora_a_weights: torch.Tensor,

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -49,6 +49,25 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.sgmv_expand_slice = sgmv_expand_slice
         self.sgmv_shrink = sgmv_shrink
 
+    def update_metadata(
+        self,
+        mapping,
+        lora_index_to_id,
+        max_loras,
+        vocab_size,
+        **kwargs,
+    ) -> None:
+        super().update_metadata(
+            mapping,
+            lora_index_to_id,
+            max_loras,
+            vocab_size,
+            **kwargs,
+        )
+        # PunicaWrapperBase computes this only for prefill. Decode must also
+        # choose between the active-LoRA and base-only quantized MoE paths.
+        self.no_lora = not any(lora_id > 0 for lora_id in mapping.index_mapping)
+
     def _shrink_prefill(
         self,
         y: torch.Tensor,

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 import torch
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
+from vllm_ascend.lora.lora_ops import bmm_expand_slice
 from vllm_ascend.lora.utils import refresh_all_lora_classes
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -67,6 +68,9 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         # PunicaWrapperBase computes this only for prefill. Decode must also
         # choose between the active-LoRA and base-only quantized MoE paths.
         self.no_lora = not any(lora_id > 0 for lora_id in mapping.index_mapping)
+
+    def _requires_bmm_expand_slice(self, x: torch.Tensor, y_slice_size: int) -> bool:
+        return x.shape[-1] > y_slice_size
 
     def _shrink_prefill(
         self,
@@ -134,6 +138,9 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         # No LoRA request, so return directly
         if self.no_lora:
             return
+        if self._requires_bmm_expand_slice(x, y_slice_size):
+            self._bmm_expand_slice(y, x, w_t_all, y_offset, y_slice_size, add_inputs)
+            return
         self.sgmv_expand_slice(
             x,
             w_t_all,
@@ -153,7 +160,29 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         y_slice_size: int,
         add_inputs: bool,
     ):
+        if self._requires_bmm_expand_slice(x, y_slice_size):
+            self._bmm_expand_slice(y, x, w_t_all, y_offset, y_slice_size, add_inputs)
+            return
         self.bgmv_expand_slice(
+            x,
+            w_t_all,
+            y,
+            self._get_token_lora_indices(x),
+            y_offset,
+            y_slice_size,
+            add_inputs,
+        )
+
+    def _bmm_expand_slice(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        w_t_all: torch.Tensor,
+        y_offset: int,
+        y_slice_size: int,
+        add_inputs: bool,
+    ):
+        bmm_expand_slice(
             x,
             w_t_all,
             y,

--- a/vllm_ascend/lora/quant_moe.py
+++ b/vllm_ascend/lora/quant_moe.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Extensible quantized MoE LoRA execution for Ascend.
+
+Each quantization scheme registers the dispatch policy and MLP implementation
+needed to preserve floating-point LoRA boundaries around quantized base expert
+matmuls. The token dispatcher and the common MoE MLP entry therefore do not
+need scheme-specific dtype checks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+import torch_npu
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.lora.fused_moe import (
+    _recover_moe_lora_routing_all2all,
+    _recover_moe_lora_routing_allgather,
+    moe_lora_apply_w2,
+    moe_lora_apply_w13,
+)
+from vllm_ascend.ops.activation import AscendSwigluOAIAndMul, AscendSwigluStepAndMul, SituActivationConfig
+from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
+from vllm_ascend.quantization.quant_type import QuantType
+
+QuantMoELoRAApply = Callable[[MoEMlpComputeInput], tuple[torch.Tensor, torch.npu.Event | None]]
+QuantMoELoRAActivationValidator = Callable[[torch.Tensor, torch.Tensor | None], None]
+
+
+@dataclass(frozen=True)
+class QuantMoELoRAImpl:
+    apply: QuantMoELoRAApply
+    validate_activation_input: QuantMoELoRAActivationValidator | None
+
+
+_QUANT_MOE_LORA_IMPLS: dict[QuantType, QuantMoELoRAImpl] = {}
+
+
+def register_quant_moe_lora_impl(
+    quant_type: QuantType,
+    *,
+    validate_activation_input: QuantMoELoRAActivationValidator | None = None,
+):
+    """Register one quantized MoE LoRA implementation."""
+
+    def decorator(apply: QuantMoELoRAApply) -> QuantMoELoRAApply:
+        if quant_type in _QUANT_MOE_LORA_IMPLS:
+            raise ValueError(f"Quantized MoE LoRA implementation already registered for {quant_type}.")
+        _QUANT_MOE_LORA_IMPLS[quant_type] = QuantMoELoRAImpl(
+            apply=apply,
+            validate_activation_input=validate_activation_input,
+        )
+        return apply
+
+    return decorator
+
+
+def _get_quant_moe_lora_impl(quant_type: QuantType) -> QuantMoELoRAImpl:
+    impl = _QUANT_MOE_LORA_IMPLS.get(quant_type)
+    if impl is None:
+        supported = ", ".join(item.name for item in _QUANT_MOE_LORA_IMPLS)
+        raise NotImplementedError(
+            "Ascend quantized MoE LoRA has no implementation registered for "
+            f"{quant_type.name}. Registered quant types: {supported or 'none'}."
+        )
+    return impl
+
+
+def quant_apply_mlp_with_moe_lora(
+    *,
+    mlp_compute_input: MoEMlpComputeInput,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Dispatch an active quantized MoE LoRA batch to its backend."""
+    return _get_quant_moe_lora_impl(mlp_compute_input.quant.quant_type).apply(mlp_compute_input)
+
+
+def validate_quant_moe_lora_activation_input(
+    *,
+    quant_type: QuantType,
+    hidden_states: torch.Tensor,
+    dynamic_scale: torch.Tensor | None,
+) -> None:
+    """Validate activations before quantized MoE LoRA prepare/dispatch."""
+    impl = _get_quant_moe_lora_impl(quant_type)
+    if impl.validate_activation_input is not None:
+        impl.validate_activation_input(hidden_states, dynamic_scale)
+
+
+def _apply_moe_activation(
+    gate_up_out: torch.Tensor,
+    activation: str | MoEActivation | SituActivationConfig | None,
+    swiglu_limit: float,
+    swiglu_alpha: float,
+    swiglu_beta: float,
+) -> torch.Tensor:
+    """Match the activation semantics of the common unquantized MoE path."""
+    if isinstance(activation, SituActivationConfig):
+        raise NotImplementedError("Quantized MoE LoRA does not support SiTU activation.")
+    act_name = getattr(activation, "value", activation)
+    if activation == MoEActivation.SWIGLUOAI:
+        return AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out)
+    if act_name == "swigluoai_uninterleave":
+        return torch_npu.npu_clipped_swiglu(
+            gate_up_out,
+            interleaved=False,
+            alpha=swiglu_alpha,
+            limit=swiglu_limit,
+            bias=swiglu_beta,
+        )
+    if activation == MoEActivation.SWIGLUSTEP:
+        return AscendSwigluStepAndMul.swiglustep_forward(gate_up_out, limit=swiglu_limit or 7.0)
+    if activation in (MoEActivation.GELU, MoEActivation.GELU_TANH):
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
+        return torch.nn.functional.gelu(gate, approximate=approximate) * up
+    if swiglu_limit > 0:
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        gate = gate.clamp(max=swiglu_limit)
+        up = up.clamp(min=-swiglu_limit, max=swiglu_limit)
+        gate_up_out = torch.cat((gate, up), dim=-1)
+    return torch_npu.npu_swiglu(gate_up_out)
+
+
+def _validate_dynamic_int8_activations(
+    hidden_states: torch.Tensor,
+    dynamic_scale: torch.Tensor | None,
+) -> None:
+    if dynamic_scale is not None or hidden_states.dtype == torch.int8:
+        raise NotImplementedError("Dynamic INT8 MoE LoRA requires unquantized activations before expert routing.")
+
+
+@register_quant_moe_lora_impl(
+    QuantType.W8A8,
+    validate_activation_input=_validate_dynamic_int8_activations,
+)
+def _apply_dynamic_int8_moe_lora(
+    mlp_compute_input: MoEMlpComputeInput,
+) -> tuple[torch.Tensor, torch.npu.Event | None]:
+    """Run INT8 base experts and inject LoRA at BF16/FP16 boundaries."""
+    comm_type = _EXTRA_CTX.moe_comm_type
+    if comm_type not in {MoECommType.ALLGATHER, MoECommType.ALLTOALL}:
+        raise NotImplementedError(
+            "Ascend quantized MoE LoRA currently supports the AllGather TP and AlltoAll EP paths; "
+            "MC2 and FusedMC2 are unsupported."
+        )
+    lora_context = mlp_compute_input.lora_context
+    if mlp_compute_input.dynamic_eplb:
+        raise NotImplementedError("Ascend quantized MoE LoRA does not support dynamic EPLB.")
+
+    hidden_states = mlp_compute_input.hidden_states
+    if mlp_compute_input.dynamic_scale is not None or hidden_states.dtype == torch.int8:
+        raise AssertionError(
+            "Quantized MoE LoRA requires BF16/FP16 routed activations. "
+            "Dispatch-side quantization must be disabled for LoRA batches."
+        )
+    if comm_type == MoECommType.ALLGATHER and (
+        mlp_compute_input.expanded_row_idx is None or mlp_compute_input.topk_ids is None
+    ):
+        raise AssertionError("Quantized MoE LoRA requires AllGather routing metadata (expanded_row_idx and topk_ids).")
+    if hidden_states.shape[0] == 0:
+        # An EP rank may receive no routed tokens. Keep participating in the
+        # surrounding AlltoAll collectives, but avoid empty-tensor NPU kernels.
+        return hidden_states, None
+
+    weights = mlp_compute_input.weights
+    if weights.w1_scale_bias is not None or weights.w2_scale_bias is not None:
+        raise NotImplementedError("Quantized MoE LoRA does not support fused scale-bias.")
+    if weights.w1_offset is not None or weights.w2_offset is not None:
+        raise NotImplementedError("Quantized MoE LoRA does not support antiquant offsets.")
+    if weights.w1_scale is None or weights.w2_scale is None:
+        raise AssertionError("Quantized MoE LoRA requires w1 and w2 weight scales.")
+
+    w1 = weights.w1 if isinstance(weights.w1, list) else [weights.w1]
+    w2 = weights.w2 if isinstance(weights.w2, list) else [weights.w2]
+    w1_scale = weights.w1_scale if isinstance(weights.w1_scale, list) else [weights.w1_scale]
+    w2_scale = weights.w2_scale if isinstance(weights.w2_scale, list) else [weights.w2_scale]
+    if not all(len(values) == 1 for values in (w1, w2, w1_scale, w2_scale)):
+        raise NotImplementedError("Quantized MoE LoRA does not support per-expert tensor lists used by dynamic EPLB.")
+
+    input_dtype = hidden_states.dtype
+    quantized_input, input_scale = DeviceOperator.npu_dynamic_quant(
+        hidden_states=hidden_states,
+        dynamic_scale=None,
+        act_quant_type=torch.int8,
+        use_mxfp_quant=False,
+    )
+    gate_up_out = torch_npu.npu_grouped_matmul(
+        x=[quantized_input],
+        weight=w1,
+        scale=[w1_scale[0].to(w2_scale[0].dtype)],
+        per_token_scale=[input_scale],
+        split_item=2,
+        group_type=0,
+        group_list=mlp_compute_input.group_list,
+        group_list_type=mlp_compute_input.group_list_type,
+        output_dtype=input_dtype,
+    )[0]
+
+    if comm_type == MoECommType.ALLGATHER:
+        lora_routing = _recover_moe_lora_routing_allgather(
+            lora_context,
+            mlp_compute_input.expanded_row_idx,
+            mlp_compute_input.topk_ids,
+        )
+    else:
+        lora_routing = _recover_moe_lora_routing_all2all(
+            lora_context,
+            group_list=mlp_compute_input.group_list,
+        )
+    moe_lora_apply_w13(
+        lora_context,
+        gate_up_out=gate_up_out,
+        hidden_states=hidden_states,
+        lora_routing=lora_routing,
+    )
+
+    activated = _apply_moe_activation(
+        gate_up_out,
+        mlp_compute_input.activation,
+        mlp_compute_input.swiglu_limit,
+        mlp_compute_input.swiglu_alpha,
+        mlp_compute_input.swiglu_beta,
+    )
+    if mlp_compute_input.topk_scales is not None:
+        activated *= mlp_compute_input.topk_scales
+
+    quantized_activated, activated_scale = DeviceOperator.npu_dynamic_quant(
+        hidden_states=activated,
+        dynamic_scale=None,
+        act_quant_type=torch.int8,
+        use_mxfp_quant=False,
+    )
+    before_gmm2_evt = torch.npu.current_stream().record_event()
+    down_out = DeviceOperator.npu_grouped_matmul_gmm2(
+        hidden_states=quantized_activated,
+        weight=w2,
+        weight_scale=w2_scale,
+        per_token_scale=activated_scale,
+        group_list=mlp_compute_input.group_list,
+        group_list_type=mlp_compute_input.group_list_type,
+        input_dtype=input_dtype,
+        act_quant_type=torch.int8,
+        weight_quant_type=None,
+        scale_type=None,
+        per_token_scale_type=None,
+        use_bf16=input_dtype == torch.bfloat16,
+        use_mxfp_quant=False,
+        bias=None,
+        fallback_output_dtype=w2_scale[0].dtype,
+        mxfp_quant_dtype=None,
+    )
+    moe_lora_apply_w2(
+        lora_context,
+        down_out=down_out,
+        silu_out=activated,
+        lora_routing=lora_routing,
+    )
+    return down_out, before_gmm2_evt
+
+
+__all__ = [
+    "quant_apply_mlp_with_moe_lora",
+    "register_quant_moe_lora_impl",
+    "validate_quant_moe_lora_activation_input",
+]

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -40,7 +40,7 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_utils import init_eplb_config
-from vllm_ascend.lora.fused_moe import sync_lora_context
+from vllm_ascend.lora.fused_moe import has_lora, sync_lora_context
 from vllm_ascend.ops.activation import AscendSituAndMul, SituActivationConfig
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl, FusedExpertsResult, setup_moe_comm_method
@@ -777,11 +777,15 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             hidden_states = self._prepare_shared_expert_input(hidden_states)
 
             # Only used for int quantization
-            has_quantized_shared = hasattr(self._shared_experts.gate_up_proj, "weight_scale") and hasattr(
-                self._shared_experts.down_proj, "weight_scale"
+            routed_experts = getattr(self, "routed_experts", None)
+            lora_context = getattr(routed_experts, "_ascend_moe_lora_context", None)
+            has_quantized_shared_without_lora = (
+                not has_lora(lora_context)
+                and hasattr(self._shared_experts.gate_up_proj, "weight_scale")
+                and hasattr(self._shared_experts.down_proj, "weight_scale")
             )
             shared_uses_situ = isinstance(self._shared_experts.act_fn, AscendSituAndMul)
-            if has_quantized_shared and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+            if has_quantized_shared_without_lora and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
@@ -840,7 +844,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     bias=None,
                     output_dtype=original_dtype,
                 )
-            elif has_quantized_shared and self.quant_type in (QuantType.W8A8MXFP, QuantType.W4A8MXFP):
+            elif has_quantized_shared_without_lora and self.quant_type in (QuantType.W8A8MXFP, QuantType.W4A8MXFP):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 quantized_x, pertoken_scale = torch_npu.npu_dynamic_mx_quant(

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -809,6 +809,13 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
             topk_ids=mlp_compute_input.topk_ids,
         )
 
+    from vllm_ascend.lora.fused_moe import has_lora
+
+    if has_lora(mlp_compute_input.lora_context):
+        from vllm_ascend.lora.quant_moe import quant_apply_mlp_with_moe_lora
+
+        return quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_compute_input)
+
     assert w1_scale is not None and w2_scale is not None
     act_quant_type = torch.int8 if mlp_compute_input.quant.is_int_quant else torch.float8_e4m3fn
     weight_quant_type = torch.float8_e4m3fn

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -34,9 +34,11 @@ from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.lora.fused_moe import (
     all2all_lora_indices,
+    has_lora,
     postprocess_lora_indices,
     preprocess_lora_indices,
 )
+from vllm_ascend.lora.quant_moe import validate_quant_moe_lora_activation_input
 from vllm_ascend.ops.fused_moe.comm_utils import async_all_to_all, gather_from_sequence_parallel_region
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEAllGatherCombineMetadata,
@@ -373,6 +375,13 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         # is quantized again inside the MLP path.
         with_quant = token_dispatch_input.quant.dispatch_with_quant and quant_type != QuantType.W8A8FP
         with_quant = with_quant and not unquantized_mxfp4_dispatch
+        if has_lora(self.lora_context) and token_dispatch_input.quant.is_quant:
+            validate_quant_moe_lora_activation_input(
+                quant_type=quant_type,
+                hidden_states=token_dispatch_input.hidden_states,
+                dynamic_scale=dynamic_scale,
+            )
+            with_quant = False
         is_mxfp = token_dispatch_input.quant.is_mxfp
         hidden_states = token_dispatch_input.hidden_states
         topk_weights = token_dispatch_input.topk_weights
@@ -491,6 +500,13 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
     ):
         use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.dispatch_with_quant
+        if has_lora(self.lora_context) and token_dispatch_input.quant.is_quant:
+            validate_quant_moe_lora_activation_input(
+                quant_type=token_dispatch_input.quant.quant_type,
+                hidden_states=token_dispatch_input.hidden_states,
+                dynamic_scale=token_dispatch_input.routing.pertoken_scale,
+            )
+            with_quant = False
         dst_type = token_dispatch_input.quant.get_dst_type
         scale_type = token_dispatch_input.quant.get_scale_type
         hidden_states = token_dispatch_input.hidden_states

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -234,6 +234,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         mc2_mask: torch.Tensor | None = None,
         tid2eid: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        lora_context = getattr(layer, "_ascend_moe_lora_context", None)
         zero_expert_num = getattr(layer, "zero_expert_num", 0)
         zero_expert_type = getattr(layer, "zero_expert_type", None)
         n_shared_experts = getattr(layer, "n_shared_experts", 0)
@@ -348,6 +349,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 swiglu_limit=layer.swiglu_limit,
                 swiglu_alpha=getattr(layer, "swiglu_alpha", 1.0),
                 swiglu_beta=getattr(layer, "swiglu_beta", 0.0),
+                lora_context=lora_context,
             )
         )
         if zero_expert_num > 0 and zero_expert_type is not None:


### PR DESCRIPTION
> **v0.26.0rc backport** of main PR #14033.
> Targets `releases/v0.26.0rc`. Companion main PR: #14033.

## What this PR fixes

This PR fixes a remaining packed LoRA expand-slice case after #13365. The general shared-expert LoRA implementation is already provided by #13365 and is not duplicated here.

Some Qwen3.5 packed projections have a LoRA shrink rank larger than one destination output slice. For example, the valid matrix contract can be:

- shrink input: `[tokens, 16]`;
- LoRA-B: `[slots, 1, 8, 16]`;
- destination slice size: `8`.

The existing Ascend fused expand-slice kernel requires `rank <= slice_size`, so it cannot represent this valid `16 > 8` layout.

## Implementation

- Select an exact graph-safe BMM fallback only when `rank > slice_size`.
- Validate input rows, output rows, shrink rank, LoRA-B shape, adapter-index rows, and destination bounds before execution.
- Preserve base-token semantics for adapter index `-1`.
- Raise `ValueError` for incompatible dimensions.
- Never pad, truncate, clip, or silently reshape tensors.

The fallback computes the exact LoRA delta with `torch.bmm(gathered_weights, inputs.unsqueeze(-1)).squeeze(-1)` and writes only to the requested output slice.

## Scope

- Based on current main including #13365.
- No duplicate shared-expert wrapper or routing implementation.
- No vLLM source modification.
- No zero-LoRA-B projection skipping; that remains in #13494.

## Validation

- Ruff check and format: passed.
- mypy on Python 3.10/3.11/3.12: passed.
- Focused unit tests: 16 passed.
- Combined Dense + MoE integration tests: 50 passed.
- Direct A3 BMM/reference check for `[4, 16]` and `[2, 1, 8, 16]`: passed.
- Qwen3.5-35B-A3B BF16 TP4 FULL_DECODE_ONLY: 8/8 graphs captured.
- Mixed Base/LoRA C8: 80/80 successful requests.
- C1/C4/C8 performance traffic: 96/96 successful requests.
- LoRA throughput: 47.16/138.01/214.78 tok/s, within -0.34%/-0.71%/-0.55% of the previous validated stack.
- Runtime fatal errors: 0.

Replaces #13493 (closed due to #13365 overlap; the force-pushed head could not be reopened). The bugfix content is unchanged: 3 files, +225/-1, rebased onto main including #13365.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
