### PR TITLE
[BugFix][v0.26] Backport SWA DSpark fixes

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -382,7 +382,7 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
         ("hf_config", "expected_sample_from_anchor", "expected_num_query_per_req"),
         [
             pytest.param(SimpleNamespace(), True, _NUM_SPECULATIVE_TOKENS),
-            pytest.param(SimpleNamespace(dspark_bonus_anchor=True), False, 1 + _NUM_SPECULATIVE_TOKENS),
+            pytest.param(SimpleNamespace(sample_from_anchor=False), False, 1 + _NUM_SPECULATIVE_TOKENS),
         ],
     )
     def test_configures_anchor_sampling(
@@ -391,7 +391,7 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
         expected_sample_from_anchor: bool,
         expected_num_query_per_req: int,
     ) -> None:
-        """Verify the bonus-anchor flag selects the expected query layout."""
+        """Verify the anchor-sampling setting selects the expected query layout."""
         proposer = self._make_proposer(
             max_num_tokens=_MAX_NUM_TOKENS,
             num_reqs=_MAX_BATCH_SIZE,

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -252,6 +252,21 @@
 #       Remove this patch once upstream vLLM supports hybrid KV cache + CP for
 #       non-CUDA backends, or exposes a platform hook for this behavior.
 #
+#   2. vllm.v1.core.kv_cache_utils.get_kv_cache_groups
+#    Why:
+#       The v0.26 branch cannot unify the different page sizes used by a sparse
+#       MLA target (GLM-5.2) and its regular sliding-window DSpark draft, so
+#       service startup fails while building KV cache groups.
+#    How:
+#       If page-size unification fails for this supported combination, promote
+#       the draft's allocation spec to full attention with the target block
+#       size. Its sliding-window attention compute remains unchanged.
+#    Related PR:
+#       https://github.com/vllm-project/vllm/pull/48776
+#    Future Plan:
+#       Remove this part of the patch when the supported vLLM release includes
+#       PR #48776.
+#
 # ** 11. File: platform/patch_mamba_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.model_executor.models.config.HybridAttentionMambaModelConfig.verify_and_update_config`
@@ -554,6 +569,22 @@
 #       Remove this patch once upstream vLLM supports loading these MTP draft
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
+#
+#   2. `vllm.transformers_utils.configs.speculators.algos.update_dspark`
+#    Why:
+#       vLLM v0.26 discards a Speculators DSpark checkpoint's
+#       `sample_from_anchor` setting and omits `dflash_config.target_layer_ids`.
+#       This selects the wrong anchor layout and sizes the GLM-5.2 draft FC from
+#       three draft layers instead of five target auxiliary layers.
+#    How:
+#       Preserve `sample_from_anchor` while translating the checkpoint config
+#       and populate `dflash_config` with the mask token and zero-based target
+#       layer IDs consumed by v0.26's DFlash model constructor.
+#    Related PRs:
+#       https://github.com/vllm-project/vllm/pull/48524
+#       https://github.com/vllm-project/vllm/pull/48639
+#    Future Plan:
+#       Remove this patch when the supported vLLM release includes both fixes.
 #
 # ** 21. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -8,16 +8,21 @@ from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.v1.core.kv_cache_utils import _approximate_gcd, may_override_num_blocks
 from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    HiddenStateCacheSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
+
+_orig_get_kv_cache_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_groups
 
 
 def _ascend_resolve_kv_cache_block_sizes(
@@ -54,6 +59,75 @@ def _ascend_resolve_kv_cache_block_sizes(
         return scheduler_block_size, hash_block_size
 
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+
+
+def _try_get_full_allocation_fallback_groups(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec] | None:
+    if any(isinstance(spec, HiddenStateCacheSpec) for spec in kv_cache_spec.values()):
+        return None
+    if any(isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()):
+        return None
+
+    has_mla = any(isinstance(spec, MLAAttentionSpec) for spec in kv_cache_spec.values())
+    has_regular_swa = any(isinstance(spec, SlidingWindowSpec) for spec in kv_cache_spec.values())
+    if not (has_mla and has_regular_swa):
+        return None
+
+    full_block_sizes = {spec.block_size for spec in kv_cache_spec.values() if isinstance(spec, FullAttentionSpec)}
+    full_attention_block_size = next(iter(full_block_sizes)) if len(full_block_sizes) == 1 else None
+    promoted_specs = kv_cache_spec.copy()
+    for layer_name, spec in kv_cache_spec.items():
+        if not isinstance(spec, SlidingWindowSpec):
+            continue
+        page_size_padded = None
+        block_size = full_attention_block_size or spec.block_size
+        if spec.page_size_padded is not None:
+            unpadded_page_size = spec.unpadded_page_size_bytes * block_size // spec.block_size
+            page_size_padded = max(spec.page_size_padded, unpadded_page_size)
+        promoted_specs[layer_name] = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=spec.num_kv_heads,
+            head_size=spec.head_size,
+            head_size_v=spec.head_size_v,
+            dtype=spec.dtype,
+            kv_quant_mode=spec.kv_quant_mode,
+            page_size_padded=page_size_padded,
+            indexes_kv_by_block_stride=spec.indexes_kv_by_block_stride,
+            sliding_window=spec.sliding_window,
+        )
+
+    uniform_spec = UniformTypeKVCacheSpecs.from_specs(promoted_specs)
+    if uniform_spec is None:
+        return None
+    vllm.v1.core.kv_cache_utils.logger.warning(
+        "KV cache page sizes cannot be unified; treating sliding-window "
+        "layers as full attention for cache allocation. Sliding-window "
+        "attention compute is unchanged."
+    )
+    return vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_type(uniform_spec)
+
+
+def get_kv_cache_groups(vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCacheSpec]) -> list[KVCacheGroupSpec]:
+    try:
+        return _orig_get_kv_cache_groups(vllm_config, kv_cache_spec)
+    except NotImplementedError as exc:
+        fallback_groups = _try_get_full_allocation_fallback_groups(kv_cache_spec)
+        if fallback_groups is None:
+            spec_summary = sorted(
+                {
+                    (type(spec).__name__, spec.block_size, spec.page_size_bytes, spec.page_size_padded)
+                    for spec in kv_cache_spec.values()
+                }
+            )
+            raise NotImplementedError(
+                "KV cache page-size unification failed and the vllm-ascend "
+                "full-allocation fallback could not build a uniform KV cache "
+                "group. Detected specs are listed as "
+                "(type, block_size, page_size_bytes, page_size_padded): "
+                f"{spec_summary}."
+            ) from exc
+        return fallback_groups
 
 
 def group_and_unify_kv_cache_specs(
@@ -246,6 +320,7 @@ def _get_kv_cache_config_deepseek_v4(
 
 
 vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
+vllm.v1.core.kv_cache_utils.get_kv_cache_groups = get_kv_cache_groups
 vllm.v1.core.kv_cache_utils.group_and_unify_kv_cache_specs = group_and_unify_kv_cache_specs
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_groups_uniform_groups
 # vLLM v0.24.0 renamed _get_kv_cache_config_deepseek_v4 to _get_kv_cache_config_packed and

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from vllm.config.speculative import SpeculativeConfig
+from vllm.transformers_utils.configs.speculators import algos as speculator_algos
 from vllm.utils.import_utils import LazyLoader
 
 from vllm_ascend.transformers_utils.configs.kimi_k3 import (
@@ -23,6 +24,25 @@ else:
 # the lightweight config here as well so ModelConfig can parse the draft before
 # speculative post-init normalizes its architecture.
 register_k3_dspark_config()
+
+
+# Backport vLLM #48639. v0.26 unconditionally rewrites Speculators DSpark
+# checkpoints to the legacy bonus-anchor layout and drops the checkpoint's
+# sample_from_anchor field before hf_config_override() runs.
+_orig_update_dspark = speculator_algos.SUPPORTED_SPECULATORS_TYPES["dspark"]
+
+
+def _update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
+    _orig_update_dspark(config_dict, pre_trained_config)
+    aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
+    pre_trained_config["dflash_config"] = {
+        "mask_token_id": config_dict["mask_token_id"],
+        "target_layer_ids": [i - 1 for i in aux_layer_ids],
+    }
+    pre_trained_config["sample_from_anchor"] = config_dict.get("sample_from_anchor", False)
+
+
+speculator_algos.SUPPORTED_SPECULATORS_TYPES["dspark"] = _update_dspark
 
 
 def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -58,7 +58,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "model runner; use greedy (the default) instead."
             )
         super().__init__(vllm_config, device, runner=runner)
-        self.sample_from_anchor = not getattr(self.draft_model_config.hf_config, "dspark_bonus_anchor", False)
+        self.sample_from_anchor = getattr(self.draft_model_config.hf_config, "sample_from_anchor", True)
         if self.sample_from_anchor:
             self.num_query_per_req = self.num_speculative_tokens
         else:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -264,6 +264,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         """Align the draft hidden-state projection with a QuaRot target."""
         if self.method not in ("dflash", "dspark"):
             return
+        # Qwen3 DSpark aligns fc.* in its model-specific weight loader and owns
+        # separate embedding/lm_head weights, so no generic alignment is needed.
+        if isinstance(self.model, Qwen3DSparkForCausalLM):
+            return
         target_model_path = self.vllm_config.model_config.model
         rotation = self._load_quarot_rotation(target_model_path)
         if rotation is None:


### PR DESCRIPTION
### What this PR does / why we need it?
The following PRs are not cherry-picked to vllm v0.26.0 branch, so patches should be added on vllm-ascend releases/v0.26.0rc branch, if we want to use some kinds of DSpark (e.g. https://huggingface.co/RedHatAI/GLM-5.2-speculator.dspark).
- https://github.com/vllm-project/vllm/pull/48524: solving fc shape error when num_target_layers != num_hidden_layers
- https://github.com/vllm-project/vllm/pull/48776: solving KV Cache planning when target model is sparse-MLA and draft model is SWA
- https://github.com/vllm-project/vllm/pull/48639: solving `sample_from_anchor` wrongly loaded

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
- GLM-5.2 W4A8 + DSpark acceptance rate
```
INFO 08-14 15:40:22 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 2.82, Accepted throughput: 73.39 tokens/s, Drafted throughput: 282.88 tokens/s, Accepted: 790 tokens, Drafted: 3045 tokens, Per-position acceptance rate: 0.729, 0.457, 0.278, 0.161, 0.083, 0.064, 0.044, Avg Draft acceptance rate: 25.9%
INFO 08-14 15:40:32 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 4.38, Accepted throughput: 146.65 tokens/s, Drafted throughput: 303.29 tokens/s, Accepted: 1469 tokens, Drafted: 3038 tokens, Per-position acceptance rate: 0.836, 0.652, 0.537, 0.408, 0.353, 0.318, 0.281, Avg Draft acceptance rate: 48.4%
INFO 08-14 15:40:42 [metrics.py:120] SpecDecoding metrics: Mean acceptance length: 3.48, Accepted throughput: 59.89 tokens/s, Drafted throughput: 169.09 tokens/s, Accepted: 600 tokens, Drafted: 1694 tokens, Per-position acceptance rate: 0.719, 0.537, 0.372, 0.273, 0.219, 0.186, 0.174, Avg Draft acceptance rate: 35.4%

```


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
