### PR TITLE
[BugFix][P/D] Recompute preempted prefill output on P

### DIFF
--- a/tests/ut/patch/platform/test_patch_async_prefill_recompute.py
+++ b/tests/ut/patch/platform/test_patch_async_prefill_recompute.py
@@ -1,0 +1,80 @@
+from unittest.mock import MagicMock
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.request import Request, RequestStatus
+
+import vllm_ascend.patch.platform.patch_async_prefill_recompute  # noqa: F401
+
+
+def _make_request(*, do_remote_decode: bool, status: RequestStatus) -> Request:
+    request = Request(
+        request_id="request-id",
+        prompt_token_ids=[1, 2, 3, 4],
+        sampling_params=SamplingParams(
+            max_tokens=1,
+            extra_args={
+                "kv_transfer_params": {
+                    "do_remote_decode": do_remote_decode,
+                    "do_remote_prefill": not do_remote_decode,
+                }
+            },
+        ),
+        pooling_params=None,
+    )
+    request.status = status
+    request.num_output_placeholders = 1
+    return request
+
+
+def test_prefiller_drops_terminal_output_after_async_preemption():
+    scheduler = AsyncScheduler.__new__(AsyncScheduler)
+    request = _make_request(
+        do_remote_decode=True,
+        status=RequestStatus.PREEMPTED,
+    )
+    request.num_computed_tokens = 0
+
+    new_token_ids, stopped = scheduler._update_request_with_output(request, [42])
+
+    assert new_token_ids == []
+    assert not stopped
+    assert request.status == RequestStatus.PREEMPTED
+    assert request.num_computed_tokens == 0
+    assert list(request.output_token_ids) == []
+    assert request.num_output_placeholders == 0
+
+
+def test_prefiller_keeps_terminal_output_without_preemption():
+    scheduler = AsyncScheduler.__new__(AsyncScheduler)
+    scheduler.max_model_len = 16
+    scheduler.kv_cache_manager = MagicMock()
+    request = _make_request(
+        do_remote_decode=True,
+        status=RequestStatus.RUNNING,
+    )
+
+    new_token_ids, stopped = scheduler._update_request_with_output(request, [42])
+
+    assert new_token_ids == [42]
+    assert stopped
+    assert list(request.output_token_ids) == [42]
+    assert request.num_output_placeholders == 0
+    scheduler.kv_cache_manager.cache_blocks.assert_called_once()
+
+
+def test_decoder_keeps_terminal_output_after_async_preemption():
+    scheduler = AsyncScheduler.__new__(AsyncScheduler)
+    scheduler.max_model_len = 16
+    scheduler.kv_cache_manager = MagicMock()
+    request = _make_request(
+        do_remote_decode=False,
+        status=RequestStatus.PREEMPTED,
+    )
+
+    new_token_ids, stopped = scheduler._update_request_with_output(request, [42])
+
+    assert new_token_ids == [42]
+    assert stopped
+    assert list(request.output_token_ids) == [42]
+    assert request.num_output_placeholders == 0

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -48,6 +48,24 @@
 #    Future Plan:
 #       Remove this patch when vLLM merge the PR.
 #
+# ** 2. File: platform/patch_async_prefill_recompute.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.v1.core.sched.async_scheduler.AsyncScheduler._update_request_with_output`
+#    Why:
+#       A P-side request can be preempted while an async output is in flight.
+#       Preemption frees its block table, but the stale output can still make
+#       the one-token prefill request finish and emit empty transfer metadata.
+#    How:
+#       Drop only terminal in-flight outputs for preempted remote-decode
+#       requests. The request remains in the P-side waiting queue and is
+#       recomputed there before valid transfer metadata is emitted.
+#    Related PR (if no, explain why):
+#       No, this is a vLLM-Ascend P/D stopgap while block-table snapshot
+#       ownership across async preemption is being designed.
+#    Future Plan:
+#       Remove this patch after the scheduler and KV connector share a stable
+#       block-table snapshot or ownership contract for in-flight outputs.
+#
 # ** 3. File: platform/patch_distributed.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.distributed.all_reduce`, `torch.distributed.broadcast`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -16,6 +16,7 @@
 
 import os
 
+import vllm_ascend.patch.platform.patch_async_prefill_recompute  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa

--- a/vllm_ascend/patch/platform/patch_async_prefill_recompute.py
+++ b/vllm_ascend/patch/platform/patch_async_prefill_recompute.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+from functools import wraps
+
+from vllm.logger import logger
+from vllm.v1.request import Request, RequestStatus
+
+
+def _should_recompute_on_prefiller(request: Request, new_token_ids: list[int]) -> bool:
+    params = request.kv_transfer_params
+    return bool(
+        request.status == RequestStatus.PREEMPTED
+        and request.num_computed_tokens == 0
+        and new_token_ids
+        and params is not None
+        and params.get("do_remote_decode")
+        and request.num_output_tokens + len(new_token_ids) >= request.max_tokens
+    )
+
+
+def _patch_async_scheduler() -> None:
+    from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+
+    original_update_request_with_output = AsyncScheduler._update_request_with_output
+    if getattr(original_update_request_with_output, "_vllm_ascend_prefill_recompute_patched", False):
+        return
+
+    @wraps(original_update_request_with_output)
+    def _patched_update_request_with_output(
+        self,
+        request: Request,
+        new_token_ids: list[int],
+    ) -> tuple[list[int], bool]:
+        if _should_recompute_on_prefiller(request, new_token_ids):
+            # Preemption has already freed the P-side block table and put the
+            # request back in the waiting queue with num_computed_tokens=0.
+            # Accepting this terminal in-flight output would finish the request
+            # with no KV blocks to transfer. Consume its placeholders without
+            # accepting its tokens so the prefiller recomputes the request.
+            request.num_output_placeholders -= len(new_token_ids)
+            assert request.num_output_placeholders >= 0
+            logger.warning(
+                "Dropping terminal in-flight output for preempted remote-decode "
+                "request %s so the prefiller recomputes it.",
+                request.request_id,
+            )
+            return [], False
+
+        return original_update_request_with_output(self, request, new_token_ids)
+
+    _patched_update_request_with_output._vllm_ascend_prefill_recompute_patched = True  # type: ignore[attr-defined]
+    AsyncScheduler._update_request_with_output = _patched_update_request_with_output
+
+
+_patch_async_scheduler()


### PR DESCRIPTION
## What this PR does / why we need it

With async scheduling, a P-side remote-decode request can be preempted while its model output is still in flight. Preemption frees the request block table and resets `num_computed_tokens` to zero, but the stale output may subsequently supply the one terminal token and finish the P request. Mooncake then emits remote-prefill metadata whose block groups are all empty, which can make a hybrid Mamba decoder index an empty remote block list.

This stopgap patches `AsyncScheduler._update_request_with_output` on Ascend. It drops the terminal in-flight frame only when all of these hold:

- the request is `PREEMPTED`;
- `num_computed_tokens == 0`, confirming preemption reset its P-side cache state;
- the request has `do_remote_decode`, identifying the P-side PD request;
- accepting the frame would reach `max_tokens`.

The frame placeholders are consumed, but its tokens are not accepted and the request is not finished. Because preemption already returned the request to the P-side waiting queue, it is recomputed on P from `num_computed_tokens=0`; metadata is emitted only after that recomputation completes. This does not fall back to recomputation on D.

Normal non-preempted P outputs and D-side outputs retain the existing behavior.

## How was this patch tested?

E2E tested and all ut passed.

Against the vLLM main commit pinned by `.github/vllm-main-verified.commit` (`58d3918e3ea0a544ffedadad2ba84559e9c51d8f`):

```bash
PYTHONPATH=/tmp/vllm-ascend-prefill-recompute.WOAGtP/vllm uv run pytest -q tests/ut/patch/platform/test_patch_async_prefill_recompute.py tests/ut/core/test_recompute_scheduler.py
```

Result: `7 passed`.

```bash
PYTHONPATH=/tmp/vllm-ascend-prefill-recompute.WOAGtP/vllm SKIP=gitleaks-offline-scan uv run pre-commit run --files vllm_ascend/patch/__init__.py vllm_ascend/patch/platform/__init__.py vllm_ascend/patch/platform/patch_async_prefill_recompute.py tests/ut/patch/platform/test_patch_async_prefill_recompute.py
```

Result: all executed hooks passed. The local gitleaks hook was skipped because its downloader requires `wget`, which is unavailable in this environment.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
