### PR TITLE
[Platform][BugFix] Patch shm_broadcast to prevent indefinite reader waits and unreleased slots

### DIFF
--- a/tests/ut/patch/platform/test_patch_shm_broadcast.py
+++ b/tests/ut/patch/platform/test_patch_shm_broadcast.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import threading
+from unittest import mock
+
+import pytest
+from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
+
+import vllm_ascend.patch.platform.patch_shm_broadcast as patch
+
+
+@pytest.mark.parametrize("should_warn", [False, True])
+def test_reader_timeout_caps_indefinite_waits(monkeypatch, should_warn):
+    monkeypatch.setattr(patch, "SHM_READER_RECHECK_INTERVAL_MS", 7)
+    timeout = MessageQueue.ReadTimeoutWithWarnings(timeout=None, should_warn=should_warn)
+    assert timeout.timeout_ms() == 7
+
+
+def test_reader_rechecks_shm_after_lost_notify(monkeypatch):
+    monkeypatch.setattr(patch, "SHM_READER_RECHECK_INTERVAL_MS", 50)
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024 * 1024,
+        max_chunks=1,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+    poll_started = threading.Event()
+    allow_timeout = threading.Event()
+    result = {}
+
+    def acquire_read():
+        try:
+            with reader.acquire_read(indefinite=True) as buf:
+                result["value"] = buf[0]
+        except Exception as exc:
+            result["exception"] = exc
+
+    def poll_timeout(*, timeout: int | None = None):
+        poll_started.set()
+        assert allow_timeout.wait(timeout=5)
+        return []
+
+    try:
+        writer.wait_until_ready()
+        reader.wait_until_ready()
+        reader._spin_condition.last_read = 0
+        reader._spin_condition.busy_loop_s = 0
+
+        with mock.patch.object(
+            reader._spin_condition.poller,
+            "poll",
+            side_effect=poll_timeout,
+        ) as poll:
+            read_thread = threading.Thread(target=acquire_read, daemon=True)
+            read_thread.start()
+            assert poll_started.wait(timeout=5)
+            with writer.acquire_write(timeout=0.1) as buf:
+                buf[0] = 123
+            allow_timeout.set()
+            read_thread.join(timeout=5)
+
+            assert not read_thread.is_alive()
+            poll.assert_called_once_with(timeout=50)
+
+        if exception := result.get("exception"):
+            raise exception
+        assert result["value"] == 123
+    finally:
+        writer.shutdown()
+        reader.shutdown()
+        for socket in (
+            writer.local_socket,
+            writer._spin_condition.local_notify_socket,
+            reader.local_socket,
+            reader._spin_condition.local_notify_socket,
+            reader._spin_condition.read_cancel_socket,
+            reader._spin_condition.write_cancel_socket,
+        ):
+            socket.close(linger=0)
+
+
+def test_acquire_read_releases_slot_when_reader_raises():
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024 * 1024,
+        max_chunks=1,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+    try:
+        writer.wait_until_ready()
+        reader.wait_until_ready()
+        writer.enqueue({"payload": "first"})
+
+        with (
+            pytest.raises(RuntimeError, match="reader failed"),
+            reader.acquire_read(timeout=0.1),
+        ):
+            raise RuntimeError("reader failed")
+
+        with writer.buffer.get_metadata(0) as metadata_buffer:
+            assert metadata_buffer[0] == 1
+            assert metadata_buffer[1] == 1
+
+        with writer.acquire_write(timeout=0.1) as buf:
+            buf[0] = 0
+    finally:
+        writer.shutdown()
+        reader.shutdown()

--- a/tests/ut/patch/platform/test_patch_shm_broadcast.py
+++ b/tests/ut/patch/platform/test_patch_shm_broadcast.py
@@ -90,9 +90,10 @@ def test_acquire_read_releases_slot_when_reader_raises():
     )
     reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
     try:
-        writer.wait_until_ready()
-        reader.wait_until_ready()
-        writer.enqueue({"payload": "first"})
+        # Prepare a written SHM slot directly. This test only verifies slot
+        # cleanup and does not need the ZMQ ready/notification path.
+        with writer.acquire_write(timeout=0.1) as buf:
+            buf[0] = 1
 
         with (
             pytest.raises(RuntimeError, match="reader failed"),
@@ -109,3 +110,12 @@ def test_acquire_read_releases_slot_when_reader_raises():
     finally:
         writer.shutdown()
         reader.shutdown()
+        for socket in (
+            writer.local_socket,
+            writer._spin_condition.local_notify_socket,
+            reader.local_socket,
+            reader._spin_condition.local_notify_socket,
+            reader._spin_condition.read_cancel_socket,
+            reader._spin_condition.write_cancel_socket,
+        ):
+            socket.close(linger=0)

--- a/tests/ut/patch/platform/test_patch_shm_broadcast.py
+++ b/tests/ut/patch/platform/test_patch_shm_broadcast.py
@@ -90,10 +90,9 @@ def test_acquire_read_releases_slot_when_reader_raises():
     )
     reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
     try:
-        # Prepare a written SHM slot directly. This test only verifies slot
-        # cleanup and does not need the ZMQ ready/notification path.
-        with writer.acquire_write(timeout=0.1) as buf:
-            buf[0] = 1
+        writer.wait_until_ready()
+        reader.wait_until_ready()
+        writer.enqueue({"payload": "first"})
 
         with (
             pytest.raises(RuntimeError, match="reader failed"),

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -67,6 +67,22 @@
 #    Future Plan:
 #       Remove this patch when vLLM fix the issue.
 #
+# ** 4. File: platform/patch_shm_broadcast.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.distributed.device_communicators.shm_broadcast.MessageQueue`
+#    Why:
+#       vLLM 0.23.0 local readers can wait indefinitely after a best-effort ZMQ
+#       notification is lost. A caller exception can also leave a read slot
+#       unreleased and block the writer.
+#    How:
+#       Replace timeout_ms and acquire_read with the implementations from the
+#       upstream fix. Idle waits are capped at five seconds, and read-slot cleanup
+#       runs in a finally block.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/45224
+#    Future Plan:
+#       Remove this patch when the supported vLLM release includes PR #45224.
+#
 # ** 5. File: platform/patch_balance_schedule.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -36,6 +36,7 @@ if vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa
+    import vllm_ascend.patch.platform.patch_shm_broadcast  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_tool_call_parser  # noqa
 import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa

--- a/vllm_ascend/patch/platform/patch_shm_broadcast.py
+++ b/vllm_ascend/patch/platform/patch_shm_broadcast.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import time
+from contextlib import contextmanager
+
+from vllm.distributed.device_communicators import shm_broadcast
+
+MessageQueue = shm_broadcast.MessageQueue
+
+# Cap on how long an idle reader parks before re-reading the authoritative SHM
+# written-flag. Bounds lost-notify recovery latency to ~5s while the periodic
+# wakeup stays negligible (one flag check per reader every 5s).
+SHM_READER_RECHECK_INTERVAL_MS = 5000
+
+
+def timeout_ms(self) -> int:
+    """Returns a timeout, capped at the recheck interval, that is:
+    - min(time to deadline, time to next warning) if we're logging warnings
+    - time to deadline, if we're not logging warnings
+    - recheck interval if the timeout is None and we're not logging warnings
+    - raise TimeoutError if we are past the deadline
+    """
+    wait_ms = SHM_READER_RECHECK_INTERVAL_MS
+    if self.warning_wait_time_ms is not None:
+        wait_ms = min(wait_ms, self.warning_wait_time_ms)
+    if self.timeout is None:
+        return wait_ms
+    time_left_ms = int((self.deadline - time.monotonic()) * 1000)
+    if time_left_ms <= 0:
+        raise TimeoutError
+    return min(wait_ms, time_left_ms)
+
+
+@contextmanager
+def acquire_read(
+    self,
+    timeout: float | None = None,
+    indefinite: bool = False,
+):
+    assert self._is_local_reader, "Only readers can acquire read"
+    read_timeout = self.ReadTimeoutWithWarnings(timeout=timeout, should_warn=not indefinite)
+    with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
+        while True:
+
+            def check():
+                shm_broadcast.memory_fence()
+                read_flag = metadata_buffer[self.local_reader_rank + 1]
+                written_flag = metadata_buffer[0]
+                return not (not written_flag or read_flag)
+
+            if shm_broadcast.SPINLOOP_EXT_ENABLED and not check():
+                shm_broadcast.spinloop(
+                    metadata_buffer[0 : self.local_reader_rank + 1],
+                    check,
+                    timeout=shm_broadcast.SPINLOOP_TIMEOUT_SECONDS,
+                )
+
+            if not check():
+                # this block is either
+                # (1) not written
+                # (2) already read by this reader
+
+                # for readers, `self.current_idx` is the next block to read
+                # if this block is not ready,
+                # we need to wait until it is written
+                self._spin_condition.wait(timeout_ms=read_timeout.timeout_ms())
+
+                if self.shutting_down:
+                    raise RuntimeError("cancelled")
+
+                # if we wait for a long time, log a message
+                if read_timeout.should_warn():
+                    shm_broadcast.logger.info(
+                        shm_broadcast.LONG_WAIT_TIME_LOG_MSG,
+                        shm_broadcast.VLLM_RINGBUFFER_WARNING_INTERVAL,
+                    )
+
+                continue
+
+            # found a block that is not read by this reader
+            # let caller read from the buffer
+            with self.buffer.get_data(self.current_idx) as buf:
+                try:
+                    yield buf
+                finally:
+                    # caller has read from the buffer; set the read flag.
+                    metadata_buffer[self.local_reader_rank + 1] = 1
+                    # Memory fence ensures the read flag is visible to the writer.
+                    # Without this, writer may not see our read completion and
+                    # could wait indefinitely for all readers to finish.
+                    shm_broadcast.memory_fence()
+                    next_idx = self.current_idx + 1
+                    self.current_idx = next_idx % self.buffer.max_chunks
+                    self._spin_condition.record_read()
+            break
+
+
+MessageQueue.ReadTimeoutWithWarnings.timeout_ms = timeout_ms
+MessageQueue.acquire_read = acquire_read


### PR DESCRIPTION
### What this PR does / why we need it?

This PR patches `vllm.distributed.device_communicators.shm_broadcast.MessageQueue` for vLLM 0.23.0 to address two failure modes in the local shared-memory broadcast path:

1. **Indefinite reader wait after a lost ZMQ notification**

   Local readers first check the shared-memory metadata and then wait for a ZMQ notification when entering the idle path. Since PUB/SUB notifications are not acknowledged and may be dropped, a reader can remain blocked in `poll(None)` even though the corresponding SHM slot has already been marked as written.

   This patch caps each idle ZMQ poll at 5 seconds. After the poll returns, the reader rechecks the SHM metadata. This is only a periodic wake-up mechanism; it does not impose a 5-second timeout on `dequeue()`.

2. **Ring-buffer slot not released when reading raises an exception**

   The read-slot cleanup previously ran only after the caller returned normally from the `acquire_read()` context. If deserialization or other processing inside the context raised an exception, the reader flag, ring-buffer index, and last-read timestamp could remain stale. The writer could then wait indefinitely for that slot to be released.

   This patch moves the cleanup into a `finally` block so that the reader slot is always released and its index is advanced, including exceptional paths.

Together, these changes prevent a single local worker from remaining indefinitely asleep or retaining a ring-buffer slot, which can otherwise cascade into TP/HCCL and DP/Gloo collective timeouts.

This is a temporary backport of [vLLM PR #45224](https://github.com/vllm-project/vllm/pull/45224) and can be removed once the supported vLLM release contains the upstream fix.

### Does this PR introduce *any* user-facing change?

No API or configuration changes are introduced.

The only behavioral change is internal fault recovery: if a ZMQ wake-up notification is missed, an idle reader rechecks shared memory within at most 5 seconds instead of waiting indefinitely.

### How was this patch tested?
1. Manually set up a fault injection scenario, using ptrace to freeze zmq's I/O thread so the worker doesn't receive the ping to wake up. The old logic causes the worker's corresponding rank to hang forever, while the new logic waits 5 seconds and then resends the ping.

2. Added unit tests in:

`tests/ut/patch/platform/test_patch_shm_broadcast.py`

The tests cover:

- recovery when the ZMQ wake-up notification is missed;
- periodic SHM metadata rechecking without timing out the overall dequeue;
- read-slot cleanup when an exception is raised inside the read context;
- advancement of the reader index and release of the corresponding ring-buffer slot on exceptional paths.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
