### PR TITLE
[CI] Record nodeid timings at their own key in update_estimated_times

### DIFF
--- a/.github/workflows/scripts/test_update_estimated_times.py
+++ b/.github/workflows/scripts/test_update_estimated_times.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import importlib
+import json
+import textwrap
+from pathlib import Path
+
+update_estimated_times = importlib.import_module("update_estimated_times")
+
+
+CONFIG_TEMPLATE = textwrap.dedent(
+    """\
+    modules:
+      - name: default_cpu_ut
+        optional: false
+
+    ---
+    # === Estimated Times ===
+    estimated_times:
+      tests/e2e/one_card/test_whole_file.py: 1110
+      tests/e2e/two_card/test_other.py: 300
+
+    partition:
+      a2_x1: 2
+    """
+)
+
+
+def _write_timings(tmp_path: Path, records: list[dict]) -> Path:
+    timing_dir = tmp_path / "timing"
+    timing_dir.mkdir()
+    (timing_dir / "timing.json").write_text(json.dumps({"tests": records}))
+    return timing_dir
+
+
+def _run(tmp_path: Path, records: list[dict]) -> dict[str, int]:
+    config = tmp_path / "test_config.yaml"
+    config.write_text(CONFIG_TEMPLATE)
+    timings = update_estimated_times.collect_timings(_write_timings(tmp_path, records))
+    update_estimated_times.update_config(config, timings)
+
+    import yaml
+
+    docs = list(yaml.safe_load_all(config.read_text()))
+    for doc in docs:
+        if isinstance(doc, dict) and "estimated_times" in doc:
+            return doc["estimated_times"]
+    raise AssertionError("estimated_times section missing after update")
+
+
+def test_nodeid_timing_does_not_clobber_file_level_estimate(tmp_path):
+    # A single method timed at 100s must not replace the 1110s whole-file
+    # estimate used when other modules run the file in full.
+    result = _run(
+        tmp_path,
+        [{"name": "tests/e2e/one_card/test_whole_file.py::test_small_case", "passed": True, "elapsed": 100}],
+    )
+
+    assert result["tests/e2e/one_card/test_whole_file.py"] == 1110
+    assert result["tests/e2e/one_card/test_whole_file.py::test_small_case"] == 110
+
+
+def test_sibling_nodeids_keep_independent_estimates(tmp_path):
+    result = _run(
+        tmp_path,
+        [
+            {"name": "tests/e2e/one_card/test_multi.py::test_fast", "passed": True, "elapsed": 30},
+            {"name": "tests/e2e/one_card/test_multi.py::test_slow", "passed": True, "elapsed": 600},
+        ],
+    )
+
+    assert result["tests/e2e/one_card/test_multi.py::test_fast"] == 30
+    assert result["tests/e2e/one_card/test_multi.py::test_slow"] == 660
+
+
+def test_file_level_timing_still_updates_file_key(tmp_path):
+    result = _run(
+        tmp_path,
+        [{"name": "tests/e2e/two_card/test_other.py", "passed": True, "elapsed": 500}],
+    )
+
+    assert result["tests/e2e/two_card/test_other.py"] == 550
+
+
+def test_non_test_entries_are_skipped(tmp_path):
+    result = _run(
+        tmp_path,
+        [{"name": "cpu-ut (115 targets)", "passed": True, "elapsed": 900}],
+    )
+
+    assert "cpu-ut (115 targets)" not in result

--- a/.github/workflows/scripts/update_estimated_times.py
+++ b/.github/workflows/scripts/update_estimated_times.py
@@ -90,11 +90,12 @@ def update_config(config_path: Path, timings: dict[str, list[int]]) -> int:
         new_val = int(round(median * 1.1 / 10.0) * 10.0)
         if new_val <= 0:
             new_val = 10
-        # Preserve existing ``::nodeid`` entries if configured, else fall back to file-level
-        if "::" in name and name in existing:
-            key = name
-        else:
-            key = name.split("::", 1)[0]
+        # Record the timing at the key it was measured under. A ``::nodeid``
+        # timing collapsed to its file path would overwrite the whole-file
+        # estimate with a single method's time (and sibling nodeids would
+        # overwrite each other), which skews partitioning; lookup already
+        # tries the exact key first and falls back to file-level.
+        key = name
         # Skip non-test entries (e.g. ``cpu-ut (115 targets)`` batch label)
         if not key.startswith("tests/"):
             continue


### PR DESCRIPTION
### What this PR does / why we need it?

`update_estimated_times.py` collapses a `::nodeid` timing record to its file-level key unless that exact nodeid is already listed in `estimated_times`. Two things go wrong when the every-3-days workflow runs:

- A single method's time overwrites the whole-file estimate. `test_config.yaml` today has `test_dense_model_310p.py: 1110` at file level while the same file also runs as a `::nodeid` entry in another module; one pass of the updater replaces 1110 with that one method's time, and the partitioner then schedules the full file 3-4x too light.
- Sibling nodeids from the same file (e.g. the three `test_flashcomm_distributed.py::` entries) all write the same file key, so whichever sorts last wins and the other methods inherit its time.

The config's own comment block says file-level and `::nodeid` entries coexist and `_lookup_estimated_time` tries the exact key first, then falls back to file level. This change makes the updater follow those semantics: each timing is recorded under the key it was measured as. Nodeid keys only appear for tests that are already listed as nodeids in `tests:` lists, so the section stays bounded.

### Does this PR introduce _any_ user-facing change?

No, CI-internal only.

### How was this patch tested?

Added `test_update_estimated_times.py` next to the script, following the `test_select_tests.py` convention (`PYTHONPATH=.github/workflows/scripts pytest -sv .github/workflows/scripts/test_update_estimated_times.py`). The two clobbering tests fail on the current code and pass with the change; file-level updates and the non-test-entry filter are covered as regression guards. `test_select_tests.py` still passes (12 tests), ruff clean.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
