### PR TITLE
[CI] Temporarily skip DeepSeek V4 test due to PR conflicts

### DIFF
--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -25,6 +25,7 @@ from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
 
 
+@pytest.mark.skip("Temporarily skip this DeepSeek V4 test.")
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",


### PR DESCRIPTION
### What this PR does / why we need it?

Temporarily skip the DeepSeek V4 test due to conflicts between #13874 and #13995.
### Does this PR introduce _any_ user-facing change?

N/A
### How was this patch tested?
N/A

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
