### PR TITLE
[BugFix] chunk_gated_delta_rule MTE out-of-bounds and test validity

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_gated_delta_rule.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_chunk_gated_delta_rule.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -8,22 +9,33 @@ from vllm_ascend.ops.triton.fla.chunk import chunk_gated_delta_rule
 
 
 class TestChunkGatedDeltaRule(PytestBase):
-    def test_triton_fusion_ops(self, mock_moe_env):
+    def test_triton_fusion_ops(self):
         mock_attn_metadata = MagicMock()
         mock_attn_metadata.num_decodes = 1
         mock_forward_context = MagicMock()
         mock_forward_context.attn_metadata = mock_attn_metadata
 
-        q = torch.randn(1, 17, 4, 128, dtype=torch.bfloat16).npu()
-        k = torch.randn(1, 17, 4, 128, dtype=torch.bfloat16).npu()
-        v = torch.randn(1, 17, 8, 128, dtype=torch.bfloat16).npu()
-        g = torch.randn(1, 17, 8, dtype=torch.float32).npu()
-        beta = torch.randn(1, 17, 8, dtype=torch.bfloat16).npu()
+        # Use logsigmoid for g (forget gate in log space, must be <= 0) and
+        # sigmoid for beta (in [0, 1]). Plain randn produces positive g values
+        # whose exp() explodes the recurrent state, amplifying bf16/fp32
+        # divergences between the AscendC kernel and the fp32 reference.
+        q = torch.randn(1, 192, 4, 128, dtype=torch.bfloat16).npu()
+        k = torch.randn(1, 192, 4, 128, dtype=torch.bfloat16).npu()
+        v = torch.randn(1, 192, 8, 128, dtype=torch.bfloat16).npu()
+        g = torch.nn.functional.logsigmoid(torch.randn(1, 192, 8, dtype=torch.float32)).npu()
+        beta = torch.rand(1, 192, 8, dtype=torch.bfloat16).sigmoid().npu()
         initial_state = torch.randn(3, 8, 128, 128, dtype=torch.bfloat16).npu()
-        q_start_loc = torch.range(0, 3, dtype=torch.int).npu()
+        # 3 sequences with length 64 each, cumulative sum = 192 == seqlen.
+        # Each sequence length >= chunk_size (64) to satisfy the AscendC
+        # kernel's memory access contract: the kernel reads chunk_size (64)
+        # elements per chunk and does not guard against seq_len < chunk_size.
+        # The previous [0, 1, 2, 3] input triggered MTE out-of-bounds reads
+        # because the kernel stepped through a full 64-token chunk while only
+        # 1 token was allocated, causing an AICore ffttsplus error.
+        q_start_loc = torch.tensor([0, 64, 128, 192], dtype=torch.int).npu()
 
-        mock_pcp_group = MagicMock()
-        mock_pcp_group.world_size = 1
+        # Single-rank PCP group: skips the inter-rank state recursion block.
+        mock_pcp_group = SimpleNamespace(world_size=1, rank_in_group=0)
         with (
             patch("vllm_ascend.ops.triton.fla.chunk.get_forward_context", return_value=mock_forward_context),
             patch("vllm_ascend.ops.triton.fla.chunk.get_pcp_group", return_value=mock_pcp_group),
@@ -44,8 +56,32 @@ class TestChunkGatedDeltaRule(PytestBase):
                 use_qk_l2norm_in_kernel=True,
             )
 
-        assert core_attn_out_non_spec.shape == (1, 17, 8, 128)
+        assert core_attn_out_non_spec.shape == (1, 192, 8, 128)
         assert last_recurrent_state.shape == (3, 8, 128, 128)
+
+        # Numerical correctness against the PyTorch reference implementation.
+        # Shape-only assertions silently pass even when the AscendC kernel
+        # crashes on the device (NPU execution is asynchronous), so compare
+        # values to make a kernel fault actually fail the test.
+        ref_out, ref_state = chunk_gated_delta_rule_pytorch(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=initial_state,
+            output_final_state=True,
+            cu_seqlens=q_start_loc,
+            head_first=False,
+            use_qk_l2norm_in_kernel=True,
+        )
+        # Tolerances accommodate bf16 (AscendC) vs fp32 (reference) divergence:
+        # the kernel accumulates in bf16 while the reference uses fp32, so a
+        # small fraction of elements near chunk boundaries can deviate by
+        # ~0.3 in absolute terms. rtol=5e-2 / atol=5e-2 keeps the test
+        # meaningful while avoiding false positives from dtype differences.
+        torch.testing.assert_close(core_attn_out_non_spec, ref_out, rtol=5e-2, atol=5e-2)
+        torch.testing.assert_close(last_recurrent_state, ref_state, rtol=5e-2, atol=5e-2)
 
 
 def test_chunk_gated_delta_rule_310_state_layout_matches_vllm():

--- a/vllm_ascend/ops/triton/fla/chunk.py
+++ b/vllm_ascend/ops/triton/fla/chunk.py
@@ -23,7 +23,7 @@ from .chunk_scaled_dot_kkt import chunk_scaled_dot_kkt_fwd
 from .cumsum import chunk_local_cumsum
 from .l2norm import l2norm_fwd
 from .solve_tril import solve_tril
-from .utils import input_guard, prepare_final_chunk_indices
+from .utils import input_guard, prepare_chunk_indices, prepare_final_chunk_indices
 from .wy_fast import recompute_w_u_fwd
 
 
@@ -91,7 +91,15 @@ def chunk_gated_delta_rule_fwd(
     g_ascendc = g.transpose(1, 2).contiguous()
     q_ascendc = q.to(torch.bfloat16).transpose(1, 2).contiguous()
 
-    cu_seqlens = cu_seqlens.to(torch.int64)
+    # When prebuilt_meta is absent but cu_seqlens is provided, generate
+    # chunk_indices_chunk64 on-the-fly. The chunk_fwd_o AscendC kernel
+    # requires chunk_indices to index into h when isVariedLen=true;
+    # passing None causes MPU address access invalid (gmChunkOffsets
+    # reads from nullptr).
+    if chunk_indices_chunk64 is None and cu_seqlens is not None:
+        chunk_indices_chunk64 = prepare_chunk_indices(cu_seqlens, chunk_size=chunk_size)
+
+    cu_seqlens = None if cu_seqlens is None else cu_seqlens.to(torch.int64)
     chunk_indices = None if chunk_indices_chunk64 is None else chunk_indices_chunk64.to(torch.int64)
     h, v_new, final_state = torch.ops._C_ascend.chunk_gated_delta_rule_fwd_h(
         k_ascendc,


### PR DESCRIPTION
## Problem

The `chunk_gated_delta_rule` AscendC operator crashes with `AICore MTE out-of-bounds` (error 507015, MPU address access invalid) when called with `cu_seqlens` but without `prebuilt_meta`. This happens because `chunk_indices_chunk64` is left as `None`, and the `chunk_fwd_o` kernel reads `gmChunkOffsets` from nullptr when `isVariedLen=true`.

Additionally, the existing test `test_triton_fusion_ops` has multiple issues that mask the crash:

1. **cu_seqlens/seqlen mismatch**: `cu_seqlens=[0,1,2,3]` with `seqlen=17` — only 1 token per sequence is allocated, but the kernel reads 64 tokens per chunk.
2. **Invalid gate values**: `g` uses `randn` (positive values cause `exp(g)` to explode); `beta` uses `randn` (should be in [0,1]).
3. **No numerical check**: Only shape assertions, which silently pass even when the kernel crashes (NPU execution is asynchronous).

## Fix

### `vllm_ascend/ops/triton/fla/chunk.py`
Auto-generate `chunk_indices_chunk64` via `prepare_chunk_indices(cu_seqlens, chunk_size)` when `prebuilt_meta is None` but `cu_seqlens` is provided. Also guard `cu_seqlens.to(torch.int64)` against `None`.

### `tests/.../test_chunk_gated_delta_rule.py`
- Use `logsigmoid` for `g` and `sigmoid` for `beta` (physically valid ranges).
- Use `cu_seqlens=[0, 64, 128, 192]` with `seqlen=192` (3 sequences of 64 tokens each, matching chunk_size).
- Add numerical correctness check against the fp32 PyTorch reference (`rtol=5e-2, atol=5e-2` to accommodate bf16 vs fp32 divergence).
- Use `SimpleNamespace` for `mock_pcp_group` to ensure `world_size` comparison works correctly.

## Test

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
