### PR TITLE
[Misc][Bugfix] Fix triton ops rope_forward_triton fails in CANN9.2 950PR

### DIFF
--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -272,7 +272,7 @@ def rope_forward_triton(
     n_kv_head = k.shape[1]
     # TODO: use a more robust method to get BLOCK_SIZE_HEAD
     if is_neox_style:
-        BLOCK_SIZE_HEAD = 64
+        BLOCK_SIZE_HEAD = 32
     else:
         BLOCK_SIZE_HEAD = 32
     # Large head_dim RoPE can overflow UB with the default tile on A2/A3.

--- a/vllm_ascend/ops/triton/rope.py
+++ b/vllm_ascend/ops/triton/rope.py
@@ -271,10 +271,7 @@ def rope_forward_triton(
     num_tokens, n_q_head, head_dim = q.shape
     n_kv_head = k.shape[1]
     # TODO: use a more robust method to get BLOCK_SIZE_HEAD
-    if is_neox_style:
-        BLOCK_SIZE_HEAD = 32
-    else:
-        BLOCK_SIZE_HEAD = 32
+    BLOCK_SIZE_HEAD = 32
     # Large head_dim RoPE can overflow UB with the default tile on A2/A3.
     # Keep the original tile for common head_dim models.
     large_head_dim_threshold, large_head_block_size = 256, 16


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes an error in CANN9.2.0 950PR ,which fails in previous tiling size.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
