### PR TITLE
[CI] Enforce ready labels for selected PR tests

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -562,14 +562,11 @@ jobs:
           fi
 
           if [ "${HAS_TESTS_A5}" = "true" ]; then
-            if [ "${HAS_READY_A5_LABEL}" != "true" ]; then
-              echo "::error::Selected A5 tests are required; add the ready-a5 label"
-              exit 1
-            fi
-
             TESTS_A5_RESULT="${{ needs.run-selected-tests-a5.result }}"
             echo "run-selected-tests-a5: ${TESTS_A5_RESULT}"
-            if [ "${TESTS_A5_RESULT}" != "success" ]; then
+            if [ "${TESTS_A5_RESULT}" = "skipped" ] && [ "${HAS_READY_A5_LABEL}" != "true" ]; then
+              echo "::notice::run-selected-tests-a5 was skipped because ready-a5 is not set"
+            elif [ "${TESTS_A5_RESULT}" != "success" ]; then
               echo "::error::run-selected-tests-a5 did not succeed (result: ${TESTS_A5_RESULT})"
               exit 1
             fi

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -504,7 +504,7 @@ jobs:
   # in GitHub branch protection rules instead of tracking individual matrix job names.
   ci-gate:
     needs: [pre-commit, select-tests, run-selected-tests, run-selected-tests-a5]
-    if: ${{ !cancelled() && (contains(github.event.pull_request.labels.*.name, 'ready') || contains(github.event.pull_request.labels.*.name, 'ready-a5')) }}
+    if: ${{ !cancelled() }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Check all required jobs
@@ -525,47 +525,56 @@ jobs:
           echo "has_tests: ${HAS_TESTS}"
           echo "has_tests_a5: ${HAS_TESTS_A5}"
 
-          if [ "${PRE_COMMIT_RESULT}" != "success" ] && [ "${PRE_COMMIT_RESULT}" != "skipped" ]; then
+          if [ "${PRE_COMMIT_RESULT}" != "success" ]; then
             echo "::error::pre-commit did not succeed (result: ${PRE_COMMIT_RESULT})"
             exit 1
           fi
 
-          if [ "${SELECT_TESTS_RESULT}" != "success" ] && [ "${SELECT_TESTS_RESULT}" != "skipped" ]; then
+          if [ "${SELECT_TESTS_RESULT}" != "success" ]; then
             echo "::error::select-tests did not succeed (result: ${SELECT_TESTS_RESULT})"
             exit 1
           fi
 
+          # Even after successful test selection, only explicit true/false
+          # values are valid. A missing output must not mean no tests.
+          if [ "${HAS_TESTS}" != "true" ] && [ "${HAS_TESTS}" != "false" ]; then
+            echo "::error::Invalid or missing has_tests output: '${HAS_TESTS}'"
+            exit 1
+          fi
+
+          if [ "${HAS_TESTS_A5}" != "true" ] && [ "${HAS_TESTS_A5}" != "false" ]; then
+            echo "::error::Invalid or missing has_tests_a5 output: '${HAS_TESTS_A5}'"
+            exit 1
+          fi
+
           if [ "${HAS_TESTS}" = "true" ]; then
+            if [ "${HAS_READY_LABEL}" != "true" ]; then
+              echo "::error::Selected tests are required; add the ready label"
+              exit 1
+            fi
+
             TESTS_RESULT="${{ needs.run-selected-tests.result }}"
             echo "run-selected-tests: ${TESTS_RESULT}"
-            if [ "${HAS_READY_LABEL}" = "true" ]; then
-              if [ "${TESTS_RESULT}" != "success" ]; then
-                echo "::error::run-selected-tests did not succeed (result: ${TESTS_RESULT})"
-                exit 1
-              fi
-            else
-              if [ "${TESTS_RESULT}" != "success" ] && [ "${TESTS_RESULT}" != "skipped" ]; then
-                echo "::error::run-selected-tests did not succeed (result: ${TESTS_RESULT})"
-                exit 1
-              fi
+            if [ "${TESTS_RESULT}" != "success" ]; then
+              echo "::error::run-selected-tests did not succeed (result: ${TESTS_RESULT})"
+              exit 1
             fi
           fi
 
           if [ "${HAS_TESTS_A5}" = "true" ]; then
+            if [ "${HAS_READY_A5_LABEL}" != "true" ]; then
+              echo "::error::Selected A5 tests are required; add the ready-a5 label"
+              exit 1
+            fi
+
             TESTS_A5_RESULT="${{ needs.run-selected-tests-a5.result }}"
             echo "run-selected-tests-a5: ${TESTS_A5_RESULT}"
-            if [ "${HAS_READY_A5_LABEL}" = "true" ]; then
-              if [ "${TESTS_A5_RESULT}" != "success" ]; then
-                echo "::error::run-selected-tests-a5 did not succeed (result: ${TESTS_A5_RESULT})"
-                exit 1
-              fi
-            else
-              if [ "${TESTS_A5_RESULT}" != "success" ] && [ "${TESTS_A5_RESULT}" != "skipped" ]; then
-                echo "::error::run-selected-tests-a5 did not succeed (result: ${TESTS_A5_RESULT})"
-                exit 1
-              fi
+            if [ "${TESTS_A5_RESULT}" != "success" ]; then
+              echo "::error::run-selected-tests-a5 did not succeed (result: ${TESTS_A5_RESULT})"
+              exit 1
             fi
           fi
+
           echo "=== CI Gate: PASSED ==="
 
   # this job collects failure from uploaded logs


### PR DESCRIPTION
### What this PR does / why we need it?
This PR makes the PR CI gate fail closed when selected tests have not been triggered.

Previously, `ci-gate` only ran when the PR already had a `ready` or `ready-a5` label. As a result, a PR with selected tests but without the corresponding ready label could skip the gate and appear successful.

This patch:

- Runs `ci-gate` for every non-cancelled PR workflow run.
- Requires `pre-commit` and `select-tests` to complete successfully.
- Validates that `has_tests` and `has_tests_a5` are explicitly set to `true` or `false`.
  - Requires the `ready` label when `has_tests=true`.
  - Requires the `ready-a5` label when `has_tests_a5=true`.
- Requires the corresponding selected-test jobs to succeed.

An explicit `false` value means test selection completed successfully and confirmed that no tests are required. An empty value must not be treated as `false`, because it can indicate that the output was missing or the selection flow did not complete correctly. Rejecting empty or invalid values prevents the CI gate from passing unintentionally.

#### Notice
The a5 test case is not a necessary condition for PR merging criteria, so even when the selected test results in `HAS_TEST_A5 = true`, **skipping the a5 test case is still permitted**.

#### Comparison

- **Before fixed**:
<img width="392" height="242" alt="image" src="https://github.com/user-attachments/assets/b315f519-8b68-4ace-adc1-c3dc7886870f" />

- **After fixed**:
if `has_test == true` but not `ready` label:
  - https://github.com/vllm-project/vllm-ascend/actions/runs/31681591905?pr=14204

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
