### PR TITLE
[BugFix][Model] Fix MiniMax-M3 shared vision tower pruning

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M3.md
+++ b/docs/source/tutorials/models/MiniMax-M3.md
@@ -131,7 +131,7 @@ Single-node deployment completes both Prefill and Decode within the same node. B
     --distributed_executor_backend "mp" \
     --gpu-memory-utilization 0.92 \
     --reasoning-parser minimax_m3 \
-    --limit-mm-per-prompt '{"image":1}' \
+    --limit-mm-per-prompt '{"image":1,"video":0}' \
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --additional-config '{
         "enable_cpu_binding": true,
@@ -167,7 +167,7 @@ Single-node deployment completes both Prefill and Decode within the same node. B
   --distributed_executor_backend "mp" \
   --gpu-memory-utilization 0.92 \
   --reasoning-parser minimax_m3 \
-  --limit-mm-per-prompt '{"image":1}' \
+  --limit-mm-per-prompt '{"image":1,"video":0}' \
   --speculative-config '{"model":"${EAGLE3_WEIGHT_PATH}", "method":"eagle3", "num_speculative_tokens":3}' \
   --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
   --additional-config '{
@@ -187,7 +187,7 @@ Single-node deployment completes both Prefill and Decode within the same node. B
 
 **Note**: In the script above, `max-num-seqs` is set to 16, which represents the maximum number of sequences the scheduler can process in a single iteration. Adjust the `max-num-seqs` parameter dynamically based on actual business.
 
-For text-only deployment, `--limit-mm-per-prompt` can be omitted. For multimodal deployment, configure this parameter according to the actual request shape. For example, use `--limit-mm-per-prompt '{"image":2}'` for two-image requests, and use `--limit-mm-per-prompt '{"video":1}'` for one-video requests.
+For text-only deployment, `--limit-mm-per-prompt` can be omitted. For multimodal deployment, configure this parameter according to the actual request shape. For example, use `--limit-mm-per-prompt '{"image":2,"video":0}'` for two-image requests, and use `--limit-mm-per-prompt '{"image":0,"video":1}'` for one-video requests.
 
 ### 5.2 Multi-Node Deployment
 
@@ -232,7 +232,7 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
     --distributed_executor_backend "mp" \
     --gpu-memory-utilization 0.94 \
     --reasoning-parser minimax_m3 \
-    --limit-mm-per-prompt '{"image":1}' \
+    --limit-mm-per-prompt '{"image":1,"video":0}' \
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --additional-config '{"enable_cpu_binding":true, "ascend_compilation_config":{"fuse_norm_quant":false}, "multistream_overlap_shared_expert": true, "weight_nz_mode": 2}' \
     --port 11223 > ${LOG_PATH} 2>&1 &
@@ -276,7 +276,7 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
     --distributed_executor_backend "mp" \
     --gpu-memory-utilization 0.94 \
     --reasoning-parser minimax_m3 \
-    --limit-mm-per-prompt '{"image":1}' \
+    --limit-mm-per-prompt '{"image":1,"video":0}' \
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --additional-config '{"enable_cpu_binding":true, "ascend_compilation_config":{"fuse_norm_quant":false}, "multistream_overlap_shared_expert": true, "weight_nz_mode": 2}' \
     --port 11223 > ${LOG_PATH} 2>&1 &
@@ -321,7 +321,7 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
     --distributed_executor_backend "mp" \
     --gpu-memory-utilization 0.92 \
     --reasoning-parser minimax_m3 \
-    --limit-mm-per-prompt '{"image":1}' \
+    --limit-mm-per-prompt '{"image":1,"video":0}' \
     --speculative-config '{"model":"${EAGLE3_WEIGHT_PATH}", "method":"eagle3", "num_speculative_tokens":3}' \
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --additional-config '{"enable_cpu_binding":true, "ascend_compilation_config":{"fuse_norm_quant":false}, "multistream_overlap_shared_expert": false, "weight_nz_mode": 2, "enable_flashcomm1": true}' \
@@ -366,7 +366,7 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
     --distributed_executor_backend "mp" \
     --gpu-memory-utilization 0.92 \
     --reasoning-parser minimax_m3 \
-    --limit-mm-per-prompt '{"image":1}' \
+    --limit-mm-per-prompt '{"image":1,"video":0}' \
     --speculative-config '{"model":"${EAGLE3_WEIGHT_PATH}", "method":"eagle3", "num_speculative_tokens":3}' \
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --additional-config '{"enable_cpu_binding":true, "ascend_compilation_config":{"fuse_norm_quant":false}, "multistream_overlap_shared_expert": false, "weight_nz_mode": 2, "enable_flashcomm1": true}' \
@@ -375,7 +375,9 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
 
 ### 5.3 Multimodal and ViT DP (Optional)
 
-MiniMax-M3 supports image and video inputs on Ascend. The deployment examples above keep `--limit-mm-per-prompt '{"image":1}'` as the default multimodal capacity assumption because the other serving parameters are tuned for the single-image path.
+MiniMax-M3 supports image and video inputs on Ascend. The deployment examples above keep `--limit-mm-per-prompt '{"image":1,"video":0}'` as the default multimodal capacity assumption because the other serving parameters are tuned for the single-image path.
+
+MiniMax-M3 image and video inputs share the same Vision Tower. If a service only needs one modality, explicitly set the unused modality to `0`; for example, use `{"image":1,"video":0}` for image-only serving and `{"image":0,"video":1}` for video-only serving. As long as either image or video remains enabled, the shared Vision Tower is retained. Setting an unused modality to `0` is clearer than omitting it, because omitted modalities may still participate in multimodal capacity and profiling planning.
 
 For the ViT / multimodal encoder part, data parallel execution is supported and can be enabled with:
 
@@ -389,10 +391,10 @@ For video or mixed image-video requests, adjust the multimodal limit according t
 
 ```bash
 # one video
---limit-mm-per-prompt '{"video":1}'
+--limit-mm-per-prompt '{"image":0,"video":1}'
 
 # one image and one video
---limit-mm-per-prompt '{"image":1, "video":1}'
+--limit-mm-per-prompt '{"image":1,"video":1}'
 ```
 
 When using local media paths in requests, such as `file:///path/to/video.mp4`, add an explicit allowlist path:
@@ -594,7 +596,7 @@ curl http://{ip}:{port}/v1/chat/completions \
 
 ### 7.2 Single Image
 
-  Start the service with image input enabled, for example `--limit-mm-per-prompt '{"image":1}'`. Replace `${IMAGE_PATH}` with a local image path on the client side.
+  Start the service with image input enabled, for example `--limit-mm-per-prompt '{"image":1,"video":0}'`. Replace `${IMAGE_PATH}` with a local image path on the client side.
 
   ```bash
   IMAGE_PATH=/path/to/image.jpg
@@ -622,7 +624,7 @@ curl http://{ip}:{port}/v1/chat/completions \
 
 ### 7.3 Single Video
 
-  Start the service with video input enabled, for example `--limit-mm-per-prompt '{"video":1}'`. If the request uses `file://` local video paths, also add `--allowed-local-media-path /` or a narrower allowed directory. If `media_io_kwargs.video.num_frames` is not specified, vLLM samples 32 frames by default.
+  Start the service with video input enabled, for example `--limit-mm-per-prompt '{"image":0,"video":1}'`. If the request uses `file://` local video paths, also add `--allowed-local-media-path /` or a narrower allowed directory. If `media_io_kwargs.video.num_frames` is not specified, vLLM samples 32 frames by default.
 
   ```bash
   curl http://{ip}:{port}/v1/chat/completions \
@@ -704,7 +706,7 @@ The Video-MME results below are measured on chunk1 and chunk2, not the full data
 
 For Video-MME evaluation, run the vLLM OpenAI-compatible service with video input enabled and use AISBench to send the Video-MME requests. The official AISBench guide may not list Video-MME as a built-in example, so the key MiniMax-M3 settings used here are:
 
-- serve with `--limit-mm-per-prompt '{"video":1}'`;
+- serve with `--limit-mm-per-prompt '{"image":0,"video":1}'`;
 - do not set `media_io_kwargs.video.num_frames`, so vLLM uses the default 32 sampled frames;
 - use `max-model-len=90112` and `max_out_len=8192`;
 - evaluate Video-MME chunk1 and chunk2, not the full dataset.
@@ -724,10 +726,10 @@ ais_bench \
 
 | Dataset | Modality | Tool | Hardware | ViT DP | max-model-len | max_out_len | Input Config | generation_kwargs | Score |
 |---------|----------|------|----------|--------|---------------|-------------|--------------|-------------------|-------|
-| TextVQA | Image | AISBench | GPU | disabled | 65536 | 512 | `--limit-mm-per-prompt '{"image":1}'` | temperature=1.0, top_p=0.95 | 70.82 |
-| TextVQA | Image | AISBench | NPU | disabled | 65536 | 512 | `--limit-mm-per-prompt '{"image":1}'` | temperature=1.0, top_p=0.95 | 72.75 |
-| Video-MME chunk1+chunk2 | Video | AISBench | GPU | - | 90112 | 8192 | `--limit-mm-per-prompt '{"video":1}'`, default 32 frames | temperature=1.0, top_p=0.95 | 73.41 |
-| Video-MME chunk1+chunk2 | Video | AISBench | NPU | - | 90112 | 8192 | `--limit-mm-per-prompt '{"video":1}'`, default 32 frames | temperature=1.0, top_p=0.95 | 74.21 |
+| TextVQA | Image | AISBench | GPU | disabled | 65536 | 512 | `--limit-mm-per-prompt '{"image":1,"video":0}'` | temperature=1.0, top_p=0.95 | 70.82 |
+| TextVQA | Image | AISBench | NPU | disabled | 65536 | 512 | `--limit-mm-per-prompt '{"image":1,"video":0}'` | temperature=1.0, top_p=0.95 | 72.75 |
+| Video-MME chunk1+chunk2 | Video | AISBench | GPU | - | 90112 | 8192 | `--limit-mm-per-prompt '{"image":0,"video":1}'`, default 32 frames | temperature=1.0, top_p=0.95 | 73.41 |
+| Video-MME chunk1+chunk2 | Video | AISBench | NPU | - | 90112 | 8192 | `--limit-mm-per-prompt '{"image":0,"video":1}'`, default 32 frames | temperature=1.0, top_p=0.95 | 74.21 |
 
 ## 9 Performance Tuning
 

--- a/tests/ut/models/minimax_m3/test_minimax_m3_vit.py
+++ b/tests/ut/models/minimax_m3/test_minimax_m3_vit.py
@@ -7,15 +7,46 @@ import importlib.util
 import inspect
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import vllm
+from torch import nn
+from vllm.model_executor.models.utils import StageMissingLayer
 
+from vllm_ascend.models.minimax_m3 import minimax_m3_vl as m3_vl
 from vllm_ascend.models.minimax_m3.minimax_m3_vl import (
+    MiniMaxM3SparseForConditionalGeneration,
     MiniMaxM3VLDummyInputsBuilder,
     MiniMaxM3VLMultiModalProcessor,
     MiniMaxM3VLProcessingInfo,
     MiniMaxVLVisionModel,
 )
+
+
+class _DummyMiniMaxM3MultimodalConfig:
+    mm_encoder_only = False
+    mm_encoder_tp_mode = "weights"
+
+    def __init__(self, limit_mm_per_prompt: dict[str, int]) -> None:
+        self.limit_mm_per_prompt = limit_mm_per_prompt
+
+    def get_limit_per_prompt(self, modality: str) -> int:
+        return self.limit_mm_per_prompt.get(modality, 999)
+
+
+class _DummyVisionTower(nn.Module):
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+
+
+class _DummyLanguageModel(nn.Module):
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self.lm_head = nn.Identity()
+
+    def make_empty_intermediate_tensors(self, *args, **kwargs):
+        return None
 
 
 class TestMiniMaxM3VitProcessor(unittest.TestCase):
@@ -39,3 +70,32 @@ class TestMiniMaxM3VitProcessor(unittest.TestCase):
             inspect.getsourcefile(MiniMaxM3VLProcessingInfo),
             inspect.getsourcefile(MiniMaxM3VLMultiModalProcessor),
         )
+
+    def test_shared_vision_tower_pruning_follows_image_video_limits(self) -> None:
+        def make_vllm_config(limit_mm_per_prompt: dict[str, int]):
+            return SimpleNamespace(
+                model_config=SimpleNamespace(
+                    hf_config=SimpleNamespace(vision_config=SimpleNamespace()),
+                    hf_text_config=SimpleNamespace(hidden_size=1),
+                    multimodal_config=_DummyMiniMaxM3MultimodalConfig(limit_mm_per_prompt),
+                ),
+                quant_config=None,
+            )
+
+        test_cases = [
+            ({"image": 1, "video": 1}, _DummyVisionTower),
+            ({"image": 1, "video": 0}, _DummyVisionTower),
+            ({"image": 0, "video": 1}, _DummyVisionTower),
+            ({"image": 0, "video": 0}, StageMissingLayer),
+        ]
+
+        with (
+            patch.object(m3_vl, "MiniMaxVLVisionModel", _DummyVisionTower),
+            patch.object(m3_vl, "MiniMaxM3SparseForCausalLM", _DummyLanguageModel),
+        ):
+            for limit_mm_per_prompt, expected_tower_type in test_cases:
+                with self.subTest(limit_mm_per_prompt=limit_mm_per_prompt):
+                    model = MiniMaxM3SparseForConditionalGeneration(vllm_config=make_vllm_config(limit_mm_per_prompt))
+
+                    self.assertIsInstance(model.model.vision_tower, expected_tower_type)
+                    self.assertIsInstance(model.language_model, _DummyLanguageModel)

--- a/vllm_ascend/models/minimax_m3/minimax_m3_vl.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3_vl.py
@@ -189,10 +189,16 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module, SupportsMultiModal, Sup
             self.multimodal_config is not None and self.multimodal_config.mm_encoder_tp_mode == "data"
         )
 
-        with self._mark_composite_model(
-            vllm_config,
-            language_targets=MiniMaxM3SparseForCausalLM,
-            tower_targets={"image": MiniMaxVLVisionModel, "video": MiniMaxVLVisionModel},
+        with (
+            self._mark_language_model(
+                vllm_config,
+                targets=MiniMaxM3SparseForCausalLM,
+            ),
+            self._mark_tower_model(
+                vllm_config,
+                {"image", "video"},
+                targets=MiniMaxVLVisionModel,
+            ),
         ):
             self.model = MiniMaxM3VLModel(
                 vllm_config=vllm_config,


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes incorrect Vision Tower pruning for MiniMax-M3 when only one multimodal input type is enabled.

MiniMax-M3 image and video inputs share the same `MiniMaxVLVisionModel`. However, the current implementation registers image and video as two independent tower targets:

```python
tower_targets={
    "image": MiniMaxVLVisionModel,
    "video": MiniMaxVLVisionModel,
}
```

Since both modalities point to the same shared Vision Tower, disabling either modality can incorrectly mark the shared tower as missing even when the other modality is still enabled. For example:

```bash
--limit-mm-per-prompt '{"image":1,"video":0}'
```

should retain the Vision Tower because image input is still enabled, but the previous model marking could prune the shared `MiniMaxVLVisionModel`, which then causes Vision Tower weight loading to fail.

This PR represents the MiniMax-M3 model topology explicitly by marking the language model and the shared multimodal tower separately:

```python
with (
    self._mark_language_model(
        vllm_config,
        targets=MiniMaxM3SparseForCausalLM,
    ),
    self._mark_tower_model(
        vllm_config,
        {"image", "video"},
        targets=MiniMaxVLVisionModel,
    ),
):
```

With this change, the shared Vision Tower follows the expected behavior:

| Image | Video | Vision Tower |
| --- | --- | --- |
| enabled | enabled | retained |
| enabled | disabled | retained |
| disabled | enabled | retained |
| disabled | disabled | pruned |

The MiniMax-M3 documentation is also updated to explicitly disable unused modalities, for example:

```bash
# Image-only
--limit-mm-per-prompt '{"image":1,"video":0}'

# Video-only
--limit-mm-per-prompt '{"image":0,"video":1}'

# Image + video
--limit-mm-per-prompt '{"image":1,"video":1}'
```

This is preferable to omitting an unused modality because omitted modalities keep their default per-prompt limit and may still participate in multimodal capacity and profiling planning.

### Does this PR introduce _any_ user-facing change?

Yes.

There is no API change, but this PR fixes MiniMax-M3 multimodal serving behavior when image or video is explicitly disabled through `--limit-mm-per-prompt`.

Users can now independently configure:

```bash
--limit-mm-per-prompt '{"image":1,"video":0}'
```

or:

```bash
--limit-mm-per-prompt '{"image":0,"video":1}'
```

without incorrectly pruning the shared Vision Tower while the other modality remains enabled.

The MiniMax-M3 deployment and evaluation examples are updated accordingly.

### How was this patch tested?

Added the unit test:

```text
tests/ut/models/minimax_m3/test_minimax_m3_vit.py::TestMiniMaxM3VitProcessor::test_shared_vision_tower_pruning_follows_image_video_limits
```

The regression test covers all four image/video configurations:

```text
image=1, video=1 -> Vision Tower retained
image=1, video=0 -> Vision Tower retained
image=0, video=1 -> Vision Tower retained
image=0, video=0 -> Vision Tower pruned
```

The test uses lightweight mocked Vision Tower and language model modules, so it validates the model-marking and pruning behavior without loading the full MiniMax-M3 checkpoint.

The image-only configuration was also validated on Ascend with:

```bash
--limit-mm-per-prompt '{"image":1,"video":0}'
```

and the shared Vision Tower was retained and its weights were loaded correctly.

Documentation builds for both English and Chinese documentation also pass.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
