### PR TITLE
[Performance] Optimize stream handling and residual copy in deepseekv4

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1296,8 +1296,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         e_q_quant_done = main_stream.record_event()
 
-        with npu_stream_switch(aux_stream, enabled=True):
-            torch.npu.current_stream().wait_event(e_q_quant_done)
+        with torch.npu.stream(aux_stream):
+            aux_stream.wait_event(e_q_quant_done)
             kv_quant, kv_pertoken_scale = self.cv_wkv.quantize(hidden_states)
 
         wq_a_result = self.cv_wq_a.matmul(q_quant, q_pertoken_scale)
@@ -1306,8 +1306,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         # Part2: q_norm[V] + q_b_quant[V]  ||  kv_matmul[C]
         e_part2_start = main_stream.record_event()
 
-        with npu_stream_switch(aux_stream, enabled=True):
-            torch.npu.current_stream().wait_event(e_part2_start)
+        with torch.npu.stream(aux_stream):
+            aux_stream.wait_event(e_part2_start)
             kv = self.cv_wkv.matmul(kv_quant, kv_pertoken_scale)
 
         if is_prefill:
@@ -1329,8 +1329,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         # Part3: q_b_matmul[C]  ||  kv_norm[V] + rope[V] + scatter[AIV]
         e_part3_start = main_stream.record_event()
 
-        with npu_stream_switch(aux_stream, enabled=True):
-            torch.npu.current_stream().wait_event(e_part3_start)
+        with torch.npu.stream(aux_stream):
+            aux_stream.wait_event(e_part3_start)
             kv = self.kv_norm(kv)
             assert self.rope_head_dim is not None
             kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -1001,13 +1001,13 @@ class DeepseekV2DecoderLayer(nn.Module):
         llama_4_scaling: torch.Tensor | None = None,
         input_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        residual = hidden_states.clone()
+        residual = hidden_states
         hidden_states, post, comb = self.hc_pre(hidden_states, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base)
         hidden_states = self.input_layernorm(hidden_states)
         attn_kwargs = {"positions": positions, "hidden_states": hidden_states, "llama_4_scaling": llama_4_scaling}
         hidden_states = self.self_attn(**attn_kwargs)
         hidden_states = self.hc_post(hidden_states, residual, post, comb)
-        residual = hidden_states.clone()
+        residual = hidden_states
         hidden_states, post, comb = self.hc_pre(hidden_states, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base)
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states, input_ids)

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -114,10 +114,10 @@ class MoECommMethod(ABC):
         hidden_states = self.prepare_finalize.finalize(hidden_states, reduce_results, padded_hidden_states_shape)
         return hidden_states
 
-    def fused_experts(
-        self,
-        fused_experts_input: MoEFusedExpertsInput,
-    ):
+    def fused_experts(self, fused_experts_input: MoEFusedExpertsInput):
+        return self.fused_experts_with_stream(fused_experts_input=fused_experts_input)
+
+    def fused_experts_with_stream(self, fused_experts_input: MoEFusedExpertsInput, maybe_current_stream=None):
         # Check constraints
         assert fused_experts_input.hidden_states.dtype in [
             torch.float32,
@@ -131,7 +131,10 @@ class MoECommMethod(ABC):
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         assert moe_comm_method is not None, "Missing communication context"
 
-        before_dispatch_evt = torch.npu.current_stream().record_event()
+        current_stream = maybe_current_stream
+        if current_stream is None:
+            current_stream = torch.npu.current_stream()
+        before_dispatch_evt = current_stream.record_event()
 
         token_dispatch_input = build_token_dispatch_input(
             fused_experts_input=fused_experts_input,
@@ -144,9 +147,11 @@ class MoECommMethod(ABC):
             moe_config=self.moe_config,
         )
 
+        if hasattr(self, "_apply_mlp_with_stream"):
+            mlp_output, before_gmm2_evt = self._apply_mlp_with_stream(mlp_compute_input, maybe_current_stream)  # type: ignore
         mlp_output, before_gmm2_evt = self._apply_mlp(mlp_compute_input)
 
-        before_combine_evt = torch.npu.current_stream().record_event()
+        before_combine_evt = current_stream.record_event()
         routed_out = self.token_dispatcher.token_combine(
             hidden_states=mlp_output,
             combine_metadata=token_dispatch_output.combine_metadata,
@@ -163,6 +168,9 @@ class MoECommMethod(ABC):
 
     def _apply_mlp(self, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         return unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+    def _apply_mlp_with_stream(self, mlp_compute_input: MoEMlpComputeInput, maybe_current_stream=None) -> torch.Tensor:
+        return unified_apply_mlp(mlp_compute_input=mlp_compute_input, s=maybe_current_stream)
 
     @abstractmethod
     def _get_token_dispatcher(self) -> MoETokenDispatcher:

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -146,6 +146,7 @@ def quant_apply_mlp(
     swiglu_alpha: float = 1.0,
     swiglu_beta: float = 0.0,
     use_w4a8_per_channel_gmm_swiglu: bool = False,
+    s=None,
 ) -> torch.Tensor:
     input_hidden_dtype = hidden_states.dtype
     act_name = getattr(activation, "value", activation)
@@ -463,7 +464,9 @@ def quant_apply_mlp(
             else:
                 hidden_states = torch_npu.npu_swiglu(hidden_states)
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
-        before_gmm2_evt = torch.npu.current_stream().record_event()
+        if s is None:
+            s = torch.npu.current_stream()
+        before_gmm2_evt = s.record_event()
         # gmm2: down_proj
         hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
             hidden_states=hidden_states,
@@ -608,7 +611,7 @@ def unquant_apply_mlp(
     return hidden_states, None
 
 
-def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
+def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput, s=None) -> torch.Tensor:
     """
     Unified MoE MLP entry.
     Quant path is dispatched by DeviceOperator with explicit typed kernel flags.
@@ -712,4 +715,5 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,
         use_w4a8_per_channel_gmm_swiglu=mlp_compute_input.quant.use_w4a8_per_channel_gmm_swiglu,
+        s=s,
     )

--- a/vllm_ascend/quantization/method_adapters.py
+++ b/vllm_ascend/quantization/method_adapters.py
@@ -252,7 +252,18 @@ class AscendFusedMoEMethod(FusedMoEMethodBase):
         topk_ids: torch.Tensor,
         shared_experts=None,
         shared_experts_input: torch.Tensor | None = None,
+        maybe_current_stream=None,
     ) -> torch.Tensor:
+        if hasattr(self.quant_method, "apply_with_stream"):
+            return self.quant_method.apply_with_stream(  # type: ignore
+                layer=layer,
+                x=x,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                shared_experts=shared_experts,
+                shared_experts_input=shared_experts_input,
+                maybe_current_stream=maybe_current_stream,
+            )
         return self.quant_method.apply(
             layer=layer,
             x=x,

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -203,6 +203,26 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         shared_experts: Any | None,
         shared_experts_input: torch.Tensor | None,
     ) -> torch.Tensor:
+        return self.apply_with_stream(
+            layer=layer,
+            x=x,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            shared_experts=shared_experts,
+            shared_experts_input=shared_experts_input,
+            maybe_current_stream=None,
+        )
+
+    def apply_with_stream(
+        self,
+        layer: "AscendRoutedExperts",
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts: Any | None,
+        shared_experts_input: torch.Tensor | None,
+        maybe_current_stream=None,
+    ) -> torch.Tensor:
         topk_weights = topk_weights.to(x.dtype)
 
         if self.use_expert_weight_list:
@@ -257,7 +277,8 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
                 w1_scale_bias=w1_scale_bias,
                 w2_scale_bias=w2_scale_bias,
                 is_per_channel_weight=True,
-            )
+            ),
+            maybe_current_stream=maybe_current_stream,
         )
 
     @staticmethod


### PR DESCRIPTION
### What this PR does / why we need it?
The execution of torch.npu.current_stream introduces overhead. Profiling shows it causes NPU bubbles. Reusing the stream object removes these bubbles

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Re-run deepseek-v4 with dspark speculator.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
