### PR TITLE
[BugFix][Model] Restore Qwen2 decoder attention_type for DeepSeek-OCR2

### DIFF
--- a/tests/ut/ops/test_qwen2_decoder.py
+++ b/tests/ut/ops/test_qwen2_decoder.py
@@ -1,0 +1,19 @@
+import pytest
+from transformers import Qwen2Config
+
+from vllm_ascend.ops.qwen2_decoder import AscendQwen2DecoderLayer
+
+
+@pytest.mark.parametrize("layer_idx", [0, 1])
+def test_qwen2_decoder_layer_uses_configured_attention_type(layer_idx: int):
+    config = Qwen2Config(
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+    )
+
+    decoder_layer = AscendQwen2DecoderLayer(config, layer_idx)
+
+    assert decoder_layer.attention_type == config.layer_types[layer_idx]

--- a/vllm_ascend/ops/qwen2_decoder.py
+++ b/vllm_ascend/ops/qwen2_decoder.py
@@ -249,6 +249,11 @@ class AscendQwen2Model(Qwen2Model):
 class AscendQwen2DecoderLayer(Qwen2DecoderLayer):
     def __init__(self, config: Qwen2Config, layer_idx: int):
         super().__init__(config, layer_idx)
+        # transformers>=5.5 no longer exposes attention_type on decoder layers.
+        if hasattr(config, "layer_types"):
+            self.attention_type = config.layer_types[layer_idx]
+        else:
+            self.attention_type = "full_attention"
         self.self_attn = AscendQwen2Attention(config=config, layer_idx=layer_idx)
         self.input_layernorm = AscendQwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = AscendQwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #11926.

`transformers>=5.5` no longer exposes `attention_type` on Qwen2 decoder layers. Ascend's `AscendQwen2Model` still indexes `causal_mask_mapping` with `decoder_layer.attention_type`, which breaks DeepSeek-OCR2 when that attribute is missing.

This PR restores `attention_type` in `AscendQwen2DecoderLayer`:
- Use `config.layer_types[layer_idx]` when `layer_types` is present
- Fall back to full_attention` otherwise

Originally prepared against `releases/v0.22.1rc`; retargeted to `main` because `0.22.1` is no longer accepting merges.

### Does this PR introduce _any_ user-facing change?

No. Compatibility fix only; no new APIs or config options.

### How was this patch tested?

- Unit tests added in `tests/ut/ops/test_qwen2_decoder.py`
  - Asserts configured `layer_types` are reflected on decoder layers
  - Asserts default full_attention` when `layer_types` is absent

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
