### PR TITLE
[CI] nightly base image date defaults to latest, with manual input support

### DIFF
--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -44,6 +44,11 @@ on:
         type: string
         default: '2026.08.03'
         description: "CANN version for base image tag"
+      base_image_date:
+        required: false
+        type: string
+        default: 'auto'
+        description: "Base image date (YYYYMMDD). 'auto' to auto-detect latest available, or specify a custom date."
     secrets:
       HW_USERNAME:
         required: false
@@ -86,6 +91,7 @@ jobs:
       full_tag: ${{ steps.build.outputs.full_tag }}
       build_type: ${{ steps.build.outputs.build_type }}
       swr_logged_in: ${{ steps.build.outputs.swr_logged_in }}
+      date: ${{ steps.build.outputs.date }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -139,13 +145,34 @@ jobs:
           fi
 
           CANN_VERSION_LOWER=$(echo "${{ inputs.cann_version }}" | tr '[:upper:]' '[:lower:]')
-          DATE=$(date +'%Y%m%d')
           TAG_SUFFIX=""
           OS_MARK=""
           if [ "${{ matrix.os }}" = "openeuler" ]; then
             OS_MARK="-openeuler"
           fi
           if [ "${{ inputs.build_type }}" = "daily" ]; then
+            # Resolve the base image date: 'auto' backtracks day-by-day from today to find
+            # the latest date for which the quay base image exists; otherwise use the
+            # user-supplied date (YYYYMMDD).
+            if [ "${{ inputs.base_image_date }}" = "auto" ] || [ -z "${{ inputs.base_image_date }}" ]; then
+              DATE=""
+              for i in $(seq 0 30); do
+                CANDIDATE_DATE=$(date -d "$i days ago" +'%Y%m%d')
+                CANDIDATE_TAG="nightly-${BRANCH_TAG}${OS_MARK}-cann${CANN_VERSION_LOWER}-${CANDIDATE_DATE}"
+                if docker manifest inspect "quay.io/atlas_inference/vllm-ascend:${CANDIDATE_TAG}" > /dev/null 2>&1; then
+                  DATE="$CANDIDATE_DATE"
+                  echo "Found base image date: $DATE (tag: $CANDIDATE_TAG)"
+                  break
+                fi
+                echo "Tag $CANDIDATE_TAG not found, trying previous day..."
+              done
+              if [ -z "$DATE" ]; then
+                echo "ERROR: No base image found in the last 30 days"
+                exit 1
+              fi
+            else
+              DATE="${{ inputs.base_image_date }}"
+            fi
             TAG_SUFFIX="-cann${CANN_VERSION_LOWER}-${DATE}"
           fi
 
@@ -186,6 +213,7 @@ jobs:
           echo "tag_prefix=${TAG_PREFIX}"
           echo "full_tag=${FULL_TAG}"
           echo "build_type=${{ inputs.build_type }}"
+          echo "date=${DATE}"
           if [ "${{ inputs.build_type }}" = "daily" ]; then
             echo "push_registry=${SWR_TEMP_REGISTRY}"
           else
@@ -251,7 +279,7 @@ jobs:
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"
           CANN_VERSION_LOWER=$(echo "${{ inputs.cann_version }}" | tr '[:upper:]' '[:lower:]')
-          DATE=$(date +'%Y%m%d')
+          DATE="${{ needs.build.outputs.date }}"
           # Daily tag pattern: daily-<branch>-<target>[-openeuler]-cann<ver>-<date>
           # The OS_MARK ("-openeuler") goes between the target and the cann suffix, matching
           # how the build step composes FULL_TAG: daily-<branch>-<target>${OS_MARK}${TAG_SUFFIX}.

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -44,10 +44,10 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
 
 jobs:
@@ -58,7 +58,8 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -74,7 +75,8 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -90,7 +92,8 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}
@@ -105,7 +108,8 @@ jobs:
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_nightly_test_310p.yaml
+++ b/.github/workflows/schedule_nightly_test_310p.yaml
@@ -61,10 +61,10 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
 
 permissions:
@@ -185,7 +185,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -60,10 +60,11 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
@@ -191,7 +192,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -61,10 +61,11 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
@@ -190,7 +191,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -61,10 +61,11 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
@@ -191,7 +192,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_nightly_test_a5.yaml
+++ b/.github/workflows/schedule_nightly_test_a5.yaml
@@ -59,10 +59,10 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
 
 permissions:
@@ -181,7 +181,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_weekly_test_310p.yaml
+++ b/.github/workflows/schedule_weekly_test_310p.yaml
@@ -66,10 +66,11 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
@@ -192,7 +193,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -63,10 +63,12 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        type: string
+
 permissions:
   contents: read
   pull-requests: read
@@ -185,7 +187,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -64,10 +64,11 @@ on:
         options:
           - release
           - daily
-      cann_version:
-        description: 'CANN version for base image tag'
+      base_image_tag:
+        description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '2026.08.03'
+        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
@@ -192,7 +193,8 @@ jobs:
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
       quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
-      cann_version: ${{ inputs.cann_version }}
+      cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
+      base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
       HW_USERNAME: ${{ secrets.HW_USERNAME }}
       HW_TOKEN: ${{ secrets.HW_TOKEN }}


### PR DESCRIPTION
What this PR does / why we need it?
Adds a base_image_date option for nightly builds. Default auto backtracks day by day (up to 30 days) to pick the latest date that actually has a quay base image, so the build no longer fails when today's image isn't out yet. You can also set a specific date (YYYYMMDD) to pin it. Only affects the daily build.

Does this PR introduce any user-facing change?
No This is for internal nightly testing only

How was this patch tested?
1、**auto**:
 Inputs
    target: a2
    vllm_ascend_branch: main
    build_type: daily
    quay_daily_username: atlas_inference+robot
    cann_version: 2026.08.03
    base_image_date: auto
    base_image_tag: {"cann_version":"2026.08.03","base_image_date":"auto"}
Tag nightly-main-cann2026.08.03-20260813 not found, trying previous day...
Tag nightly-main-cann2026.08.03-20260812 not found, trying previous day...
Found base image date: 20260811 (tag: nightly-main-cann2026.08.03-20260811)
2、**specified date**:
 Inputs
    target: a2
    vllm_ascend_branch: main
    build_type: daily
    quay_daily_username: atlas_inference+robot
    cann_version: 2026.08.03
    base_image_date: 20260809
    base_image_tag: {"cann_version":"2026.08.03","base_image_date":"20260809"}
 load metadata for quay.io/atlas_inference/vllm-ascend:nightly-main-openeuler-cann2026.08.03-20260809
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
