### PR TITLE
[BugFix] Isolate Base and LoRA ACL graph params on V2 runner

### DIFF
--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -5,6 +5,7 @@ import dataclasses
 import weakref
 from collections.abc import Callable
 from contextlib import ExitStack
+from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import patch
@@ -32,6 +33,13 @@ _STREAM_RESOURCE_ERROR_MARKERS = (
 )
 _OLD_HDK_CAPTURE_ERROR_MARKERS = ("alloc sq cq fail",)
 
+# Capture-time override so FULL-graph capture (which often sets
+# batch_descriptor=None) can still isolate Base vs LoRA graph params.
+# True/False while capturing a LoRA/Base graph; None means "do not specialize".
+_GRAPH_PARAM_HAS_LORA: ContextVar[bool | None] = ContextVar("_GRAPH_PARAM_HAS_LORA", default=None)
+
+GraphParamKey = int | tuple[int, bool]
+
 
 def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
     message = str(exc)
@@ -44,6 +52,65 @@ def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
 def _is_old_hdk_capture_error(exc: RuntimeError) -> bool:
     message = str(exc).lower()
     return any(marker in message for marker in _OLD_HDK_CAPTURE_ERROR_MARKERS)
+
+
+def set_graph_param_has_lora(has_lora: bool | None):
+    """Pin Base/LoRA isolation for the current capture or replay."""
+    return _GRAPH_PARAM_HAS_LORA.set(has_lora)
+
+
+def reset_graph_param_has_lora(token) -> None:
+    _GRAPH_PARAM_HAS_LORA.reset(token)
+
+
+def _lora_graph_param_key(num_tokens: int) -> GraphParamKey:
+    """Map a token-count lookup onto (num_tokens, has_lora) when possible."""
+    batch_descriptor = None
+    try:
+        forward_context = get_forward_context()
+        batch_descriptor = getattr(forward_context, "batch_descriptor", None)
+    except (AssertionError, LookupError, RuntimeError):
+        batch_descriptor = None
+
+    if (
+        batch_descriptor is not None
+        and getattr(batch_descriptor, "num_tokens", None) == num_tokens
+    ):
+        return (num_tokens, bool(batch_descriptor.has_lora))
+
+    has_lora = _GRAPH_PARAM_HAS_LORA.get()
+    if has_lora is not None:
+        return (num_tokens, bool(has_lora))
+    return num_tokens
+
+
+class _GraphParamStore(dict):
+    """Isolate graph resources by (num_tokens, has_lora) while keeping int keys."""
+
+    def __init__(self, capture_sizes: list[int], default_factory: Callable[[], Any]):
+        super().__init__((size, default_factory()) for size in capture_sizes)
+        self.default_factory = default_factory
+
+    def _resolve_key(self, key):
+        if isinstance(key, int):
+            return _lora_graph_param_key(key)
+        return key
+
+    def __contains__(self, key):
+        return dict.__contains__(self, self._resolve_key(key))
+
+    def __getitem__(self, key):
+        resolved_key = self._resolve_key(key)
+        if not dict.__contains__(self, resolved_key):
+            dict.__setitem__(self, resolved_key, self.default_factory())
+        return dict.__getitem__(self, resolved_key)
+
+    def __setitem__(self, key, value):
+        dict.__setitem__(self, self._resolve_key(key), value)
+
+    def get(self, key, default=None):
+        resolved_key = self._resolve_key(key)
+        return dict.get(self, resolved_key, default)
 
 
 @dataclasses.dataclass
@@ -270,10 +337,10 @@ class ACLGraphWrapper:
 def weak_ref_workspaces(params):
     if params is None:
         return
-    for num_tokens in params.workspaces:
-        if params.workspaces[num_tokens] is None:
+    for graph_key, workspace in list(dict.items(params.workspaces)):
+        if workspace is None:
             continue
-        params.workspaces[num_tokens] = weak_ref_tensors(params.workspaces[num_tokens])
+        dict.__setitem__(params.workspaces, graph_key, weak_ref_tensors(workspace))
 
 
 def update_full_graph_params(
@@ -298,10 +365,20 @@ def update_full_graph_params(
 
 @dataclass
 class GraphParams:
-    events: dict[int, list[torch.npu.ExternalEvent]]
-    workspaces: dict[int, torch.Tensor]
-    handles: dict[int, list[torch_npu._C._NPUTaskGroupHandle]]
-    attn_params: dict[int, list[tuple]]
+    events: dict[Any, list[torch.npu.ExternalEvent]]
+    workspaces: dict[Any, torch.Tensor | None]
+    handles: dict[Any, list[torch_npu._C._NPUTaskGroupHandle]]
+    attn_params: dict[Any, list[tuple]]
+
+
+def _make_graph_params(aclgraph_capture_sizes: list[int]) -> GraphParams:
+    capture_sizes = list(aclgraph_capture_sizes)
+    return GraphParams(
+        _GraphParamStore(capture_sizes, list),
+        _GraphParamStore(capture_sizes, lambda: None),
+        _GraphParamStore(capture_sizes, list),
+        _GraphParamStore(capture_sizes, list),
+    )
 
 
 _graph_params: GraphParams | None = None
@@ -311,12 +388,7 @@ def set_graph_params(aclgraph_capture_sizes: list[int]):
     global _graph_params
     if _graph_params is not None:
         raise ValueError("Graph parameters have already been set!")
-    _graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-    )
+    _graph_params = _make_graph_params(aclgraph_capture_sizes)
 
 
 def update_graph_params_workspaces(num_tokens: int, workspace: torch.Tensor):
@@ -336,12 +408,7 @@ def set_draft_graph_params(aclgraph_capture_sizes: list[int]):
     global _draft_graph_params
     if _draft_graph_params is not None:
         raise ValueError("DraftGraph parameters have already been set!")
-    _draft_graph_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-    )
+    _draft_graph_params = _make_graph_params(aclgraph_capture_sizes)
 
 
 def update_draft_graph_params_workspaces(num_tokens: int, workspace: Any):
@@ -361,12 +428,7 @@ def set_draft_graph_prefill_params(aclgraph_capture_sizes: list[int]):
     global _draft_graph_prefill_params
     if _draft_graph_prefill_params is not None:
         raise ValueError("DraftGraph preill parameters have already been set!")
-    _draft_graph_prefill_params = GraphParams(
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: None for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-        {size: [] for size in aclgraph_capture_sizes},
-    )
+    _draft_graph_prefill_params = _make_graph_params(aclgraph_capture_sizes)
 
 
 def update_draft_graph_prefill_params_workspaces(num_tokens: int, workspace: Any):

--- a/vllm_ascend/device_allocator/sleep_mem_optimized.py
+++ b/vllm_ascend/device_allocator/sleep_mem_optimized.py
@@ -73,8 +73,8 @@ class AclGraphSleepWakeupManager:
     def clear_attention_workspaces(params) -> None:
         if params is None:
             return
-        for num_tokens in params.workspaces:
-            params.workspaces[num_tokens] = None
+        for graph_key in list(dict.keys(params.workspaces)):
+            dict.__setitem__(params.workspaces, graph_key, None)
 
     @classmethod
     def clear_all_attention_workspaces(cls) -> None:

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -24,7 +24,7 @@ import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.config.compilation import CUDAGraphMode
-from vllm.forward_context import get_forward_context, set_forward_context
+from vllm.forward_context import BatchDescriptor, get_forward_context, set_forward_context
 from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -35,7 +35,12 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.compilation.acl_graph import (
+    reset_graph_param_has_lora,
+    set_graph_param_has_lora,
+    set_graph_params,
+    update_full_graph_params,
+)
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -51,6 +56,18 @@ def collect_sorted_captured_token_sizes(capture_descs: dict) -> list[int]:
     capture descriptors, not the raw config sizes.
     """
     return sorted({desc.num_tokens for descs in capture_descs.values() for desc in descs})
+
+
+def batch_descriptor_from_exec_desc(desc: BatchExecutionDescriptor) -> BatchDescriptor:
+    """Build a LoRA-aware BatchDescriptor for ACL graph param lookup."""
+    num_active_loras = int(getattr(desc, "num_active_loras", 0) or 0)
+    return BatchDescriptor(
+        num_tokens=desc.num_tokens,
+        num_reqs=desc.num_reqs,
+        uniform=desc.uniform_token_count is not None,
+        has_lora=num_active_loras > 0,
+        num_active_loras=num_active_loras,
+    )
 
 
 class ModelAclGraphManager(ModelCudaGraphManager):
@@ -99,25 +116,30 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         # refer to vllm.v1.worker.gpu.dp_utils.sync_cudagraph_and_dp_padding to
         # calculate num_tokens_across_dp.
         num_tokens_across_dp = torch.full([self.model_runner.dp_size], num_tokens)
-        with set_forward_context(
-            self.model_runner.model_state.attn_metadata,
-            self.vllm_config,
-            num_tokens=num_tokens,
-            cudagraph_runtime_mode=desc.cg_mode,
-            num_tokens_across_dp=num_tokens_across_dp,
-            batch_descriptor=None,  # Full graph model don't need batch_descriptor
-            slot_mapping=None,
-        ):
-            forward_context = get_forward_context()
-            update_full_graph_params(
-                # FIXME(Ronald1995): support hybrid attn backend
-                self.model_runner.attn_groups[0][0].backend,
-                self.update_stream,
-                forward_context,
-                num_tokens,
+        batch_descriptor = batch_descriptor_from_exec_desc(desc)
+        lora_token = set_graph_param_has_lora(batch_descriptor.has_lora)
+        try:
+            with set_forward_context(
+                self.model_runner.model_state.attn_metadata,
                 self.vllm_config,
-                self.model_runner.speculative_config,
-            )
+                num_tokens=num_tokens,
+                cudagraph_runtime_mode=desc.cg_mode,
+                num_tokens_across_dp=num_tokens_across_dp,
+                batch_descriptor=batch_descriptor,
+                slot_mapping=None,
+            ):
+                forward_context = get_forward_context()
+                update_full_graph_params(
+                    # FIXME(Ronald1995): support hybrid attn backend
+                    self.model_runner.attn_groups[0][0].backend,
+                    self.update_stream,
+                    forward_context,
+                    num_tokens,
+                    self.vllm_config,
+                    self.model_runner.speculative_config,
+                )
+        finally:
+            reset_graph_param_has_lora(lora_token)
         return ret
 
     def capture(
@@ -136,20 +158,31 @@ class ModelAclGraphManager(ModelCudaGraphManager):
     ) -> None:
         """Capture CUDA graphs for model forward pass."""
         model = ModelWithContext(model)
-        with communicator_switch():
-            return super().capture(
-                model,
-                model_state,
-                input_buffers,
-                intermediate_tensors,
-                block_tables,
-                attn_groups,
-                kv_cache_config,
-                has_lora=has_lora,
-                use_aux_hidden_state_outputs=use_aux_hidden_state_outputs,
-                lora_capture_hook=lora_capture_hook,
-                progress_bar_desc=progress_bar_desc,
-            )
+        orig_hook = lora_capture_hook
+
+        def _lora_graph_param_hook(num_active_loras: int, num_reqs: int, num_tokens: int) -> None:
+            # FULL capture uses cg_mode=NONE and batch_descriptor=None.
+            set_graph_param_has_lora(num_active_loras > 0)
+            if orig_hook is not None:
+                orig_hook(num_active_loras, num_reqs, num_tokens)
+
+        try:
+            with communicator_switch():
+                return super().capture(
+                    model,
+                    model_state,
+                    input_buffers,
+                    intermediate_tensors,
+                    block_tables,
+                    attn_groups,
+                    kv_cache_config,
+                    has_lora=has_lora,
+                    use_aux_hidden_state_outputs=use_aux_hidden_state_outputs,
+                    lora_capture_hook=_lora_graph_param_hook,
+                    progress_bar_desc=progress_bar_desc,
+                )
+        finally:
+            set_graph_param_has_lora(None)
 
 
 class ModelWithContext(nn.Module):


### PR DESCRIPTION
### What this PR does / why we need it?
On Ascend Model Runner V2 with FULL decode ACL graphs, Base and LoRA requests that share the same `num_tokens` reuse the same GraphParams slots (`workspaces` / `events` / `handles` / `attn_params`). After a Base request warms the decode graph, a LoRA request can hang during graph replay (HTTP 200 is already sent for streaming, but no tokens are produced).

This PR isolates Base vs LoRA graph resources by `(num_tokens, has_lora)`:

- Add `_GraphParamStore` so integer lookups like `workspaces[num_tokens]` resolve to a LoRA-aware key when `batch_descriptor.has_lora` or a capture-time override is set.
- V2 `run_fullgraph` now passes a `BatchDescriptor` (instead of `None`) so replay updates the correct slot.
- V2 `capture` pins `has_lora` from `num_active_loras` because FULL capture still uses `cg_mode=NONE` and `batch_descriptor=None`.

Draft graphs (Eagle/DFlash) are left keyed by token count only.

### Does this PR introduce _any_ user-facing change?
No. Bugfix for graph-mode LoRA serving; no API or flag changes.

### How was this patch tested?
- Code change reviewed locally on `vllm-ascend` main (vLLM 0.27.0).
- On-device: start with `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY", ...}'` and `--enable-lora` (no `--enforce-eager`).
  1. `curl` the base served model name: first request may be slow, later requests should be fine.
  2. `curl` the LoRA adapter name (`model: mix-lora`): should stream tokens instead of hanging after HTTP 200.
  3. Restart, reverse the order (LoRA first, then base): base should not hang.
- Unit tests were not added in this patch; the behavior depends on ACL graph capture/replay on NPU. Follow-up UT for `_GraphParamStore` can be added if needed.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
