### PR TITLE
[v0.26.0rc][Bugfix][LoRA][Qwen3.5] Backport dense LoRA runtime fixes from #11940

### DIFF
--- a/csrc/kernels/bgmv_shrink.cpp
+++ b/csrc/kernels/bgmv_shrink.cpp
@@ -188,7 +188,8 @@ private:
     __aicore__ inline void CopyOut(const int64_t idx)
     {
         AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.DeQue<Y_T>();
-        DataCopy(yOutGm_[maxLoRARank_ * idx], yOutLocal, maxLoRARank_);
+        uint16_t blockLen = static_cast<uint16_t>(maxLoRARank_ * sizeof(Y_T));
+        DataCopyPad(yOutGm_[maxLoRARank_ * idx], yOutLocal, {1, blockLen, 0, 0});
         outQueueY_.FreeTensor(yOutLocal);
     }
 

--- a/csrc/kernels/sgmv_shrink.cpp
+++ b/csrc/kernels/sgmv_shrink.cpp
@@ -200,7 +200,8 @@ private:
     __aicore__ inline void CopyOut(const int64_t idx)
     {
         AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.DeQue<Y_T>();
-        DataCopy(yOutGm_[maxLoRARank_ * idx], yOutLocal, maxLoRARank_);
+        uint16_t blockLen = static_cast<uint16_t>(maxLoRARank_ * sizeof(Y_T));
+        DataCopyPad(yOutGm_[maxLoRARank_ * idx], yOutLocal, {1, blockLen, 0, 0});
         outQueueY_.FreeTensor(yOutLocal);
     }
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -656,7 +656,10 @@ class AscendAttentionBackendImpl(AttentionImpl):
             else:
                 graph_params = get_graph_params()
                 attn_metadata = forward_context.attn_metadata
-                attn_keys = list(attn_metadata.keys())
+                # Only standard (FIA) attention layers have captured graph
+                # params here; linear/GDN layers (GDNAttentionMetadata) are
+                # updated separately by update_conv1d_graph_params. So we filter by `seq_lens_list`
+                attn_keys = [k for k in attn_metadata if hasattr(attn_metadata[k], "seq_lens_list")]
                 if not use_layer_aware_replay:
                     # In some speculative methods (such as DFlash), the order of
                     # attn_keys in the Target model will be disrupted instead of

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -1,82 +1,13 @@
 import vllm
-from torch import nn
-from transformers import PretrainedConfig
-from vllm.config import LoRAConfig
-from vllm.lora.layers import (
-    MergedQKVParallelLinearWithLoRA,
-    MergedQKVParallelLinearWithShardedLoRA,
-    QKVParallelLinearWithLoRA,
-    QKVParallelLinearWithShardedLoRA,
-)
-from vllm.lora.layers.utils import _fully_sharded_can_replace, _not_fully_sharded_can_replace
 
 from vllm_ascend.lora.fused_moe import (
     AscendFusedMoE3DWithLoRA,
     AscendFusedMoEWithLoRA,
 )
-from vllm_ascend.ops.linear import (
-    AscendQKVParallelLinear,
-)
-
-
-class AscendQKVParallelLinearWithLoRA(QKVParallelLinearWithLoRA):
-    @classmethod
-    @_not_fully_sharded_can_replace
-    def can_replace_layer(
-        cls,
-        source_layer: nn.Module,
-        lora_config: LoRAConfig,
-        packed_modules_list: list,
-        model_config: PretrainedConfig | None,
-    ) -> bool:
-        return type(source_layer) is AscendQKVParallelLinear and len(packed_modules_list) == 1
-
-
-class AscendMergedQKVParallelLinearWithLoRA(MergedQKVParallelLinearWithLoRA):
-    @classmethod
-    @_not_fully_sharded_can_replace
-    def can_replace_layer(
-        cls,
-        source_layer: nn.Module,
-        lora_config: LoRAConfig,
-        packed_modules_list: list,
-        model_config: PretrainedConfig | None,
-    ) -> bool:
-        return type(source_layer) is AscendQKVParallelLinear and len(packed_modules_list) == 3
-
-
-class AscendMergedQKVParallelLinearWithShardedLoRA(MergedQKVParallelLinearWithShardedLoRA):
-    @classmethod
-    @_fully_sharded_can_replace
-    def can_replace_layer(
-        cls,
-        source_layer: nn.Module,
-        lora_config: LoRAConfig,
-        packed_modules_list: list,
-        model_config: PretrainedConfig | None = None,
-    ) -> bool:
-        return type(source_layer) is AscendQKVParallelLinear and len(packed_modules_list) == 3
-
-
-class AscendQKVParallelLinearWithShardedLoRA(QKVParallelLinearWithShardedLoRA):
-    @classmethod
-    @_fully_sharded_can_replace
-    def can_replace_layer(
-        cls,
-        source_layer: nn.Module,
-        lora_config: LoRAConfig,
-        packed_modules_list: list,
-        model_config: PretrainedConfig | None = None,
-    ) -> bool:
-        return type(source_layer) is AscendQKVParallelLinear and len(packed_modules_list) == 1
 
 
 def refresh_all_lora_classes():
     ascend_classes = (
-        AscendQKVParallelLinearWithLoRA,
-        AscendMergedQKVParallelLinearWithLoRA,
-        AscendMergedQKVParallelLinearWithShardedLoRA,
-        AscendQKVParallelLinearWithShardedLoRA,
         AscendFusedMoEWithLoRA,
         AscendFusedMoE3DWithLoRA,
     )


### PR DESCRIPTION
> **v0.26.0rc backport** of main PR #11940.
> Targets `releases/v0.26.0rc`. Companion main PR: #11940 (merged 2026-07-30).

### What this PR does / why we need it?

Backports the Qwen3.5 dense LoRA runtime fixes from main PR #11940 so that
Qwen3.5 dense models work correctly with TP, `fully_sharded_loras`, and
ACLGraph on `releases/v0.26.0rc`.

- **LoRA shrink kernels** (`csrc/kernels/bgmv_shrink.cpp`, `sgmv_shrink.cpp`):
  `CopyOut` used `DataCopy`, which requires block-aligned lengths. For LoRA
  ranks/dtypes whose `maxLoRARank_ * sizeof(Y_T)` is not block-aligned, this
  produced incorrect/corrupted output. Switched to `DataCopyPad` with an
  explicit byte length so arbitrary rank sizes copy out correctly.
- **Attention cudagraph replay** (`vllm_ascend/attention/attention_v1.py`):
  when LoRA specialization (`cudagraph_specialize_lora`) is combined with TP,
  the previous zip-based key/param pairing could drop GDN/linear-attn
  metadata into the FIA loop or leave extra captured ops unmatched. Now
  filters `attn_keys` to only standard FIA layers (via `seq_lens_list`);
  GDN/linear layers remain updated separately by `update_conv1d_graph_params`.
- **LoRA utils cleanup** (`vllm_ascend/lora/utils.py`): removes the redundant
  Ascend `QKVParallelLinearWithLoRA` / `Merged...` / `...ShardedLoRA` classes
  that are no longer needed now that upstream vLLM provides them.

This PR ports only the runtime fixes. It does not change CI test scheduling
metadata or the release E2E layout.

### Does this PR introduce _any_ user-facing change?

Yes. On `releases/v0.26.0rc`, Qwen3.5 dense models with LoRA no longer
produce corrupted shrink-kernel output for non-block-aligned LoRA ranks, and
ACLGraph replay no longer mis-pairs GDN/linear attention layers under
`cudagraph_specialize_lora` + TP. Deployments not using LoRA, or not using
`fully_sharded_loras` / `cudagraph_specialize_lora`, are unaffected.

### How was this patch tested?

- Source validation on `main` (PR #11940): focused pytest + on-device
  Qwen3.5 dense LoRA run with TP, `fully_sharded_loras`, and ACLGraph.
- Backport verification on `releases/v0.26.0rc`: pending (latest-head
  on-device matrix).
- `python -m py_compile` and `git diff --check`: pass.

### Scope

Based on `releases/v0.26.0rc`. Backport of main PR #11940. Runtime fixes
only; no CI/E2E scheduling metadata change.

### Related

- Original main PR: #11940 (author: @paulyu12).
- Stacked with the v0.26.0rc LoRA ACL-graph series (#14169 and companions).

Co-Authored-By: yupeng <14888724+paulyu12@users.noreply.github.com>
Co-Authored-By: wangzhao-11a <73340653+wangzhao-11a@users.noreply.github.com>

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
