### PR TITLE
[BugFix][Model] Enable Kimi K3 projector rotation

### DIFF
--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -168,7 +168,9 @@ def test_kimi_k3_projector_applies_rotation_only_after_weight_load():
     projector.post_norm = nn.Identity()
     image_features = torch.tensor([[1.0, 2.0]])
 
+    projector.rot_proj = ScaleLinear()
     del projector.rot_proj
+    assert not hasattr(projector, "rot_proj")
     torch.testing.assert_close(projector(image_features), image_features)
 
     projector.rot_proj = ScaleLinear()

--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -13,6 +13,7 @@ from vllm_ascend.models.kimi_k3 import (
     AscendKimiK3ForConditionalGeneration,
     KimiK3MLP,
     KimiK3MoE,
+    KimiK3MultiModalProjector,
     KimiK3TextModel,
     KimiK3VisionEncoderLayer,
     _move_module_to_device,
@@ -89,6 +90,89 @@ def test_kimi_k3_quantizes_latent_projections_only_for_modelslim(
 
 def test_kimi_k3_unquantized_model_keeps_latent_projections_unquantized():
     assert _routed_latent_quant_config(None) is None
+
+
+def test_kimi_k3_projector_registers_rotation_for_weight_loading(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class StubReplicatedLinear(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def forward(self, hidden_states):
+            return hidden_states, None
+
+    monkeypatch.setattr(kimi_k3, "ReplicatedLinear", StubReplicatedLinear)
+    monkeypatch.setattr(kimi_k3, "RMSNorm", lambda *args, **kwargs: nn.Identity())
+    monkeypatch.setattr(kimi_k3, "get_act_fn", lambda *args, **kwargs: nn.Identity())
+    config = KimiK3VisionConfig(
+        mm_hidden_size=2,
+        text_hidden_size=8,
+        merge_kernel_size=(2, 2),
+    )
+    projector = KimiK3MultiModalProjector(config)
+
+    assert projector.rot_proj is not None
+
+
+@pytest.mark.parametrize(
+    ("loaded_weights", "has_rot_proj"),
+    [
+        ({"mm_projector.rot_proj.weight"}, True),
+        ({"mm_projector.linear_1.weight"}, False),
+    ],
+)
+def test_kimi_k3_enables_projector_rotation_only_when_weight_is_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_weights: set[str],
+    has_rot_proj: bool,
+):
+    class StubLoader:
+        def __init__(self, model, *, skip_prefixes):
+            assert model is wrapper
+            assert skip_prefixes == []
+
+        def load_weights(self, weights, *, mapper):
+            assert list(weights) == []
+            assert mapper is wrapper.hf_to_vllm_mapper
+            return loaded_weights
+
+    monkeypatch.setattr(kimi_k3, "AutoWeightsLoader", StubLoader)
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(AscendKimiK3ForConditionalGeneration)
+    nn.Module.__init__(wrapper)
+    wrapper.mm_projector = nn.Module()
+    wrapper.mm_projector.rot_proj = nn.Linear(1, 1, bias=False)
+
+    actual = wrapper.load_weights(iter(()))
+
+    assert actual == loaded_weights
+    assert hasattr(wrapper.mm_projector, "rot_proj") is has_rot_proj
+    assert ("mm_projector.rot_proj.weight" in dict(wrapper.named_parameters())) is has_rot_proj
+
+
+def test_kimi_k3_projector_applies_rotation_only_after_weight_load():
+    class PassthroughLinear(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states, None
+
+    class ScaleLinear(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states * 2, None
+
+    projector = KimiK3MultiModalProjector.__new__(KimiK3MultiModalProjector)
+    nn.Module.__init__(projector)
+    projector.input_size = 2
+    projector.linear_1 = PassthroughLinear()
+    projector.linear_2 = PassthroughLinear()
+    projector.act = nn.Identity()
+    projector.post_norm = nn.Identity()
+    image_features = torch.tensor([[1.0, 2.0]])
+
+    del projector.rot_proj
+    torch.testing.assert_close(projector(image_features), image_features)
+
+    projector.rot_proj = ScaleLinear()
+    torch.testing.assert_close(projector(image_features), image_features * 2)
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -110,7 +110,7 @@ from vllm_ascend.ops.kimi_kda import uses_kimi_k3_global_inputs_embeds
 from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
 from vllm_ascend.transformers_utils.configs.kimi_k3 import KimiK3Config, KimiK3TextConfig, KimiK3VisionConfig
 from vllm_ascend.transformers_utils.processors.kimi_k3 import KimiK3Processor
-from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, vllm_version_is
+from vllm_ascend.utils import vllm_version_is
 
 apply_attn_res: (
     Callable[
@@ -603,12 +603,21 @@ class AscendKimiK3ForConditionalGeneration(
         return AscendKimiK3ForCausalLM.get_mamba_state_copy_func()
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        # The ModelSlim rotation is only needed for A3 FP4-to-INT4 conversion.
-        # Other SoCs retain the original projector graph and ignore the extra
-        # checkpoint tensor.
-        skip_prefixes = [] if self.mm_projector.rot_proj is not None else ["mm_projector.rot_proj."]
+        # ModelSlim checkpoints may include an explicit projector rotation.
+        # Build the optional layer before loading so streaming checkpoint
+        # iterators can populate it, then release it when the weight is absent.
+        rot_proj = getattr(self.mm_projector, "rot_proj", None)
+        skip_prefixes = [] if rot_proj is not None else ["mm_projector.rot_proj."]
         loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes)
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        rot_proj_weight_names = (
+            {name for name, _ in rot_proj.named_parameters(prefix="mm_projector.rot_proj")}
+            if rot_proj is not None
+            else set()
+        )
+        loaded_weights = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        if rot_proj is not None and rot_proj_weight_names.isdisjoint(loaded_weights):
+            del self.mm_projector.rot_proj
+        return loaded_weights
 
 
 class KimiK3MLP(nn.Module):
@@ -1674,15 +1683,13 @@ class KimiK3MultiModalProjector(nn.Module):
         # ModelSlim rotates K3's FP4 activations before INT4 inference. Text
         # embeddings fold this matrix into their input projection, but the
         # vision path ends in RMSNorm, so the rotation must remain explicit.
-        self.rot_proj: ReplicatedLinear | None = None
-        if get_ascend_device_type() == AscendDeviceType.A3:
-            self.rot_proj = ReplicatedLinear(
-                config.text_hidden_size,
-                config.text_hidden_size,
-                bias=False,
-                quant_config=None,
-                prefix=f"{prefix}.rot_proj",
-            )
+        self.rot_proj: ReplicatedLinear | None = ReplicatedLinear(
+            config.text_hidden_size,
+            config.text_hidden_size,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.rot_proj",
+        )
 
     def forward(self, image_features: torch.Tensor) -> torch.Tensor:
         hidden_states = image_features.reshape(-1, self.input_size)
@@ -1690,8 +1697,9 @@ class KimiK3MultiModalProjector(nn.Module):
         hidden_states = self.act(hidden_states)
         hidden_states = self.linear_2(hidden_states)[0]
         hidden_states = self.post_norm(hidden_states)
-        if self.rot_proj is not None:
-            hidden_states = self.rot_proj(hidden_states)[0]
+        rot_proj = getattr(self, "rot_proj", None)
+        if rot_proj is not None:
+            hidden_states = rot_proj(hidden_states)[0]
         return hidden_states
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3 ModelSlim checkpoints can carry an explicit `mm_projector.rot_proj` rotation matrix. The text path folds the rotation into its input projection, while multimodal vision embeddings require the projector rotation to be applied explicitly after `post_norm`.

The projector rotation is a checkpoint property, not a device-type property. This patch therefore always constructs `rot_proj` on A2, A3, and A5, then enables its forward path only when the checkpoint loader confirms that a `mm_projector.rot_proj.*` parameter was actually loaded. Checkpoints without the rotation tensor retain the original projector behavior.

This patch also adds regression coverage for unconditional layer construction, weight-gated activation, and the projector forward path.

### Does this PR introduce _any_ user-facing change?

Yes. Kimi K3 multimodal inference applies the ModelSlim projector rotation on A2, A3, and A5 whenever the checkpoint provides the corresponding weight.

### How was this patch tested?

- `ruff check vllm_ascend/models/kimi_k3.py tests/ut/models/test_kimi_k3.py`
- `ruff format --check vllm_ascend/models/kimi_k3.py tests/ut/models/test_kimi_k3.py`
- `python -m compileall -q vllm_ascend/models/kimi_k3.py tests/ut/models/test_kimi_k3.py`
- In an A5 development container, from an isolated worktree: `python -m pytest -q tests/ut/models/test_kimi_k3.py` (36 passed before the device-type restriction was removed; the updated regression no longer mocks a device type)


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
