### PR TITLE
[BugFix][Scheduler][v0.23.0] Disable preemption on PD prefill nodes

### DIFF
--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from vllm.v1.core.sched.interface import PauseState
+from vllm.v1.core.sched.request_queue import SchedulingPolicy
+
+from vllm_ascend.patch.platform.patch_balance_schedule import (
+    _ORIGINAL_SCHEDULER,
+    BalanceScheduler,
+    _disable_preemption_on_prefill_node,
+)
+
+
+@pytest.mark.parametrize(
+    ("kv_role", "expected"),
+    [
+        ("kv_producer", True),
+        ("kv_consumer", False),
+        ("kv_both", False),
+        (None, False),
+    ],
+)
+def test_disable_preemption_only_on_v023_prefill_nodes(kv_role, expected):
+    kv_transfer_config = None if kv_role is None else SimpleNamespace(kv_role=kv_role)
+    vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
+
+    with patch(
+        "vllm_ascend.patch.platform.patch_balance_schedule.vllm_version_is",
+        return_value=True,
+    ):
+        assert _disable_preemption_on_prefill_node(vllm_config) is expected
+
+
+def test_disable_preemption_is_limited_to_v023():
+    vllm_config = SimpleNamespace(kv_transfer_config=SimpleNamespace(kv_role="kv_producer"))
+
+    with patch(
+        "vllm_ascend.patch.platform.patch_balance_schedule.vllm_version_is",
+        return_value=False,
+    ):
+        assert not _disable_preemption_on_prefill_node(vllm_config)
+
+
+@pytest.mark.parametrize("scheduler_name", ["default", "profiling_chunk"])
+def test_prefill_node_keeps_running_request_when_allocation_fails(
+    scheduler_name,
+):
+    request = SimpleNamespace(
+        request_id="prefill-request",
+        num_output_placeholders=0,
+        num_tokens_with_spec=2,
+        num_computed_tokens=1,
+        num_prompt_tokens=2,
+        has_encoder_inputs=False,
+        spec_token_ids=[],
+    )
+    if scheduler_name == "default":
+        scheduler = BalanceScheduler.__new__(BalanceScheduler)
+        scheduler._balance_enabled = False
+    else:
+        from vllm_ascend.core.scheduler_profiling_chunk import (
+            ProfilingChunkScheduler,
+        )
+
+        scheduler = ProfilingChunkScheduler.__new__(ProfilingChunkScheduler)
+        scheduler.profiling_chunk_manager = SimpleNamespace(
+            predictor=SimpleNamespace(target_latency=None),
+            is_ready=False,
+        )
+        scheduler.needs_kv_cache_zeroing = False
+    scheduler._disable_preemption = True
+    scheduler._pause_state = PauseState.UNPAUSED
+    scheduler.running = [request]
+    scheduler.waiting = []
+    scheduler.skipped_waiting = []
+    scheduler.policy = SchedulingPolicy.FCFS
+    scheduler.max_num_scheduled_tokens = 1
+    scheduler.max_num_encoder_input_tokens = 0
+    scheduler.max_num_running_reqs = 1
+    scheduler.max_model_len = 16
+    scheduler.num_lookahead_tokens = 0
+    scheduler.need_mamba_block_aligned_split = False
+    scheduler.scheduler_config = SimpleNamespace(long_prefill_token_threshold=0)
+    scheduler.kv_cache_config = SimpleNamespace(kv_cache_groups=[object()])
+    scheduler.kv_cache_manager = MagicMock()
+    scheduler.kv_cache_manager.allocate_slots.return_value = None
+    scheduler.kv_cache_manager.get_num_common_prefix_blocks.return_value = [0]
+    scheduler.encoder_cache_manager = MagicMock()
+    scheduler.encoder_cache_manager.get_freed_mm_hashes.return_value = []
+    scheduler.connector = None
+    scheduler.ec_connector = None
+    scheduler.connector_prefix_cache_stats = None
+    scheduler.lora_config = None
+    scheduler.is_encoder_decoder = False
+    scheduler.log_stats = False
+    scheduler.use_eagle = False
+    scheduler.use_v2_model_runner = False
+    scheduler.finished_req_ids = set()
+    scheduler.prev_step_scheduled_req_ids = set()
+    scheduler._preempt_request = MagicMock()
+    scheduler._make_cached_request_data = MagicMock()
+    scheduler._update_after_schedule = MagicMock()
+
+    output = scheduler.schedule()
+
+    scheduler.kv_cache_manager.allocate_slots.assert_called_once_with(
+        request,
+        1,
+        num_lookahead_tokens=0,
+    )
+    scheduler._preempt_request.assert_not_called()
+    assert scheduler.running == [request]
+    assert output.total_num_scheduled_tokens == 0
+    assert output.preempted_req_ids == set()
+
+
+def test_non_prefill_node_uses_upstream_scheduler():
+    scheduler = BalanceScheduler.__new__(BalanceScheduler)
+    scheduler._balance_enabled = False
+    scheduler._disable_preemption = False
+    expected = object()
+
+    with (
+        patch(
+            "vllm_ascend.patch.platform.patch_balance_schedule.vllm_version_is",
+            return_value=True,
+        ),
+        patch.object(_ORIGINAL_SCHEDULER, "schedule", return_value=expected) as schedule,
+    ):
+        assert scheduler.schedule() is expected
+
+    schedule.assert_called_once_with()
+
+
+def test_async_scheduler_inherits_prefill_preemption_guard():
+    from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+
+    assert BalanceScheduler in AsyncScheduler.__mro__
+
+
+def test_profiling_chunk_scheduler_inherits_prefill_preemption_guard():
+    from vllm_ascend.core.scheduler_profiling_chunk import (
+        ProfilingChunkScheduler,
+    )
+
+    assert BalanceScheduler in ProfilingChunkScheduler.__mro__
+
+
+def test_prefill_node_rejects_forced_prefix_cache_reset_while_running():
+    scheduler = BalanceScheduler.__new__(BalanceScheduler)
+    scheduler._disable_preemption = True
+    scheduler.running = [object()]
+    scheduler._preempt_request = MagicMock()
+
+    with pytest.raises(RuntimeError, match="drain or abort"):
+        scheduler.reset_prefix_cache(reset_running_requests=True)
+
+    scheduler._preempt_request.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("disable_preemption", "running"),
+    [
+        (True, []),
+        (False, [object()]),
+    ],
+)
+def test_forced_prefix_cache_reset_delegates_when_safe(
+    disable_preemption,
+    running,
+):
+    scheduler = BalanceScheduler.__new__(BalanceScheduler)
+    scheduler._disable_preemption = disable_preemption
+    scheduler.running = running
+
+    with patch.object(
+        _ORIGINAL_SCHEDULER,
+        "reset_prefix_cache",
+        return_value=True,
+    ) as reset_prefix_cache:
+        assert scheduler.reset_prefix_cache(True, True)
+
+    reset_prefix_cache.assert_called_once_with(True, True)
+
+
+def test_non_forced_prefix_cache_reset_keeps_upstream_behavior():
+    scheduler = BalanceScheduler.__new__(BalanceScheduler)
+    scheduler._disable_preemption = True
+    scheduler.running = [object()]
+
+    with patch.object(
+        _ORIGINAL_SCHEDULER,
+        "reset_prefix_cache",
+        return_value=False,
+    ) as reset_prefix_cache:
+        assert not scheduler.reset_prefix_cache()
+
+    reset_prefix_cache.assert_called_once_with(False, False)

--- a/vllm_ascend/core/scheduler_profiling_chunk.py
+++ b/vllm_ascend/core/scheduler_profiling_chunk.py
@@ -360,6 +360,9 @@ class ProfilingChunkScheduler(Scheduler):
                     if new_blocks is not None:
                         break
 
+                    if self._disable_preemption:
+                        break
+
                     if self.policy == SchedulingPolicy.PRIORITY:
                         preempted_req = max(
                             self.running,

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -83,6 +83,23 @@
 #    Future Plan:
 #       Remove this patch when vLLM merge the PR.
 #
+#   2. Disable automatic scheduler preemption on vLLM 0.23.0 PD-disaggregated
+#      prefill nodes.
+#    Why:
+#       Async scheduling can finish the one-token prefill request while memory
+#       pressure preempts it, releasing delayed KV blocks before their block IDs
+#       are sent to the decode node.
+#    How:
+#       When a pure KV producer cannot allocate slots, the default, async, and
+#       profiling-chunk schedulers stop the current step without preempting a
+#       running request; forced prefix-cache reset is rejected until requests
+#       drain.
+#    Related PR (if no, explain why):
+#       No, this is a temporary vLLM 0.23.0 compatibility fix.
+#    Future Plan:
+#       Remove this patch after the upstream scheduler and KV connector handle
+#       async prefill completion and delayed block release atomically.
+#
 # ** 6. File: platform/patch_minimax_m2_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.ModelConfig._verify_quantization`

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -46,6 +46,13 @@ def _balance_scheduling_enabled(vllm_config) -> bool:
     return bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0")))
 
 
+def _disable_preemption_on_prefill_node(vllm_config) -> bool:
+    if not vllm_version_is("0.23.0"):
+        return False
+    kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+    return getattr(kv_transfer_config, "kv_role", None) == "kv_producer"
+
+
 class BalanceScheduler(Scheduler):
     def __init__(
         self,
@@ -69,6 +76,9 @@ class BalanceScheduler(Scheduler):
             log_stats,
         )
         self._balance_enabled = _balance_scheduling_enabled(vllm_config)
+        self._disable_preemption = _disable_preemption_on_prefill_node(vllm_config)
+        if self._disable_preemption:
+            logger.warning("Automatic scheduler preemption is disabled on this PD-disaggregated prefill node.")
         if self._balance_enabled:
             self.balance_queue = [
                 torch.tensor([0], dtype=torch.int, device="cpu")
@@ -81,8 +91,21 @@ class BalanceScheduler(Scheduler):
         running_tensor = torch.tensor([len(self.running)], dtype=torch.int, device="cpu")
         dist.all_gather(self.balance_queue, running_tensor, group=dp_group)
 
+    def reset_prefix_cache(
+        self,
+        reset_running_requests: bool = False,
+        reset_connector: bool = False,
+    ) -> bool:
+        if self._disable_preemption and reset_running_requests and self.running:
+            raise RuntimeError(
+                "Cannot reset the prefix cache with running requests on a "
+                "PD-disaggregated prefill node because scheduler preemption "
+                "is disabled; drain or abort the requests first."
+            )
+        return super().reset_prefix_cache(reset_running_requests, reset_connector)
+
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
-        if not self._balance_enabled:
+        if not self._balance_enabled and not self._disable_preemption:
             if vllm_version_is("0.23.0"):
                 return super().schedule()
             return super().schedule(throttle_prefills)
@@ -204,6 +227,9 @@ class BalanceScheduler(Scheduler):
                         # The request can be scheduled.
                         break
 
+                    if self._disable_preemption:
+                        break
+
                     # The request cannot be scheduled.
                     # Preempt the lowest-priority request.
                     if self.policy == SchedulingPolicy.PRIORITY:
@@ -294,9 +320,10 @@ class BalanceScheduler(Scheduler):
                 if len(self.running) == self.max_num_running_reqs:
                     break
 
-                balance_flag = max(t.item() for t in self.balance_queue) == self.max_num_running_reqs
-                if balance_flag:
-                    break
+                if self._balance_enabled:
+                    balance_flag = max(t.item() for t in self.balance_queue) == self.max_num_running_reqs
+                    if balance_flag:
+                        break
 
                 request_queue = self._select_waiting_queue_for_scheduling()
                 if request_queue is None:


### PR DESCRIPTION
### What this PR does / why we need it?

On vLLM 0.23.0 PD-disaggregated prefill nodes, async scheduling can accept the one-token terminal output while memory-pressure preemption releases the request's delayed KV blocks. The prefill result may then carry empty block IDs to the decode node.

This release-only mitigation disables automatic scheduler preemption when `kv_role='kv_producer'`. It covers the default scheduler, `AsyncScheduler` (through the patched base class), and the profiling-based dynamic-chunk scheduler. A forced prefix-cache reset with running P-node requests now raises instead of preempting and freeing their blocks; callers can retry after draining or aborting those requests.

Other vLLM versions, D nodes, and PD-mixed nodes keep the existing behavior.

This does not duplicate #14180: that main-branch PR recomputes a P request after preemption, while this PR applies the smaller conservative mitigation specifically to the v0.23.0 release branch.

### Does this PR introduce _any_ user-facing change?

Yes. On a vLLM 0.23.0 pure P node, memory pressure waits instead of automatically preempting a running request. `reset_prefix_cache(reset_running_requests=True)` raises while P-node requests are running.

### How was this patch tested?

```bash
VLLM_VERSION=0.23.0 python -m pytest -q -p no:cacheprovider \
  --confcutdir=tests/ut/patch/platform \
  tests/ut/patch/platform/test_patch_balance_schedule.py
```

Result in a real Ascend NPU environment: `14 passed`.

Additional checks:

- Ruff check and format: passed for all changed Python files.
- Changed-file mypy for Python 3.10, 3.11, and 3.12: passed.
- Full `tools/mypy.sh 1` was compared with a clean `releases/v0.23.0` worktree and produced the same pre-existing errors; no changed file was reported.
- `bash format.sh ci`: all relevant hooks passed; the only failure was the pre-existing shellcheck `SC2328` in unchanged `csrc/build.sh`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
