### PR TITLE
[BugFix][SpecDecode] Fix low MTP acceptance rate for SFA (MTP>1)

### DIFF
--- a/tests/ut/attention/a2/test_sfa_v1.py
+++ b/tests/ut/attention/a2/test_sfa_v1.py
@@ -640,6 +640,23 @@ class TestAscendSFAMetadataBuilder(TestBase):
         assert isinstance(metadata, AscendSFAMetadata)
         assert metadata.num_actual_tokens == common_attn_metadata.num_actual_tokens
         assert metadata.slot_mapping.shape == (100, 4, 1024)
+        # TODO: Revisit this logic after ModelRunner V1 is fully removed,
+        # and remove it if ModelRunner V2 no longer depends on these per-step buffers.
+        assert metadata.cum_query_lens.data_ptr() == builder.actual_seq_lengths_query.data_ptr()
+        assert metadata.seq_lens.data_ptr() == builder.actual_seq_lengths_key.data_ptr()
+
+        draft_metadata_0 = builder.build_for_drafting(common_attn_metadata, draft_index=0)
+        draft_0_cum_query_lens = draft_metadata_0.cum_query_lens.clone()
+        draft_0_seq_lens = draft_metadata_0.seq_lens.clone()
+
+        common_attn_metadata.query_start_loc = torch.arange(0, 111, 11, dtype=torch.int32)
+        common_attn_metadata.seq_lens = torch.full((10,), 11, dtype=torch.int32)
+        draft_metadata_1 = builder.build_for_drafting(common_attn_metadata, draft_index=1)
+
+        assert draft_metadata_0.cum_query_lens.data_ptr() != draft_metadata_1.cum_query_lens.data_ptr()
+        assert draft_metadata_0.seq_lens.data_ptr() != draft_metadata_1.seq_lens.data_ptr()
+        assert torch.equal(draft_metadata_0.cum_query_lens, draft_0_cum_query_lens)
+        assert torch.equal(draft_metadata_0.seq_lens, draft_0_seq_lens)
 
     @patch("vllm_ascend.attention.sfa_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.sfa_v1.get_cos_and_sin_mla")

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -349,14 +349,25 @@ class AscendSFAMetadataBuilder(MLACommonMetadataBuilder[AscendSFAMetadata]):
 
         block_size = self.kernel_block_size
 
+        # TODO: Revisit this logic after ModelRunner V1 is fully removed,
+        # and remove it if ModelRunner V2 no longer depends on these per-step buffers.
+        if draft_index is not None:
+            assert self.spec_actual_seq_lengths_query is not None
+            assert self.spec_actual_seq_lengths_key is not None
+            actual_seq_lengths_query = self.spec_actual_seq_lengths_query[draft_index - 1]
+            actual_seq_lengths_key = self.spec_actual_seq_lengths_key[draft_index - 1]
+        else:
+            actual_seq_lengths_query = self.actual_seq_lengths_query
+            actual_seq_lengths_key = self.actual_seq_lengths_key
+
         runtime_cum_query_lens = common_attn_metadata.query_start_loc[1 : num_reqs + 1]
-        self.actual_seq_lengths_query.zero_()
-        self.actual_seq_lengths_query[:num_reqs].copy_(runtime_cum_query_lens)
-        cum_query_lens = self.actual_seq_lengths_query[:num_reqs]
+        actual_seq_lengths_query.zero_()
+        actual_seq_lengths_query[:num_reqs].copy_(runtime_cum_query_lens)
+        cum_query_lens = actual_seq_lengths_query[:num_reqs]
         runtime_seq_lens = common_attn_metadata.seq_lens[:num_reqs]
-        self.actual_seq_lengths_key.zero_()
-        self.actual_seq_lengths_key[:num_reqs].copy_(runtime_seq_lens)
-        seq_lens = self.actual_seq_lengths_key[:num_reqs]
+        actual_seq_lengths_key.zero_()
+        actual_seq_lengths_key[:num_reqs].copy_(runtime_seq_lens)
+        seq_lens = actual_seq_lengths_key[:num_reqs]
 
         # Prefer _seq_lens_cpu (always available, updated during draft
         # iterations) over seq_lens_cpu (None in async spec decode mode).


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #14306

GLM-5.2 MTP with the SFA backend builds separate attention metadata for each draft step. The SFA builder already allocates graph-stable speculative sequence-length buffers, but the normal SFA path always wrote every step into actual_seq_lengths_query and actual_seq_lengths_key.

As a result, metadata produced for earlier draft steps referenced the same mutable tensors and was overwritten by later steps. Incorrect per-step sequence lengths lowered the MTP acceptance rate.

This PR selects spec_actual_seq_lengths_query and spec_actual_seq_lengths_key whenever draft_index is provided, using the same draft_index - 1 mapping as SFA-CP. Non-drafting calls continue to use the existing main graph-stable buffers. The change is shared by ModelRunner V1 and V2 and does not add runner-specific branches.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
