### PR TITLE
[Feature][KV Transfer] Support KVConnectorStats for MooncakeConnector

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -77,6 +77,7 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import (  # n
     MooncakeConnectorMetadata,
     MooncakeConnectorScheduler,
     MooncakeConnectorWorker,
+    MooncakeKVConnectorStats,
     ReqMeta,
     ensure_zmq_recv,
     ensure_zmq_send,
@@ -3291,6 +3292,174 @@ class TestMooncakeConnectorWorker(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             worker._get_sfa_replicate_k_block_ids(cast(ReqMeta, meta))
+
+
+class TestMooncakeConnectorStats(unittest.TestCase):
+    def setUp(self):
+        self.engine = MagicMock()
+        self.ready_event = threading.Event()
+        self.vllm_config = MockVllmConfig()
+        self.kv_caches = make_mock_kv_caches()
+        self.thread = KVCacheRecvingThread(
+            tp_rank=0,
+            tp_size=4,
+            _prefill_pp_size=1,
+            engine=self.engine,
+            local_engine_id="local_engine",
+            local_handshake_port=5555,
+            side_channel_port=30000,
+            local_kv_caches_base_addr=[[0x1000], [0x2000]],
+            block_len_per_addr=[[1024], [2048]],
+            block_stride_per_addr=[[1024], [2048]],
+            ready_event=self.ready_event,
+            vllm_config=self.vllm_config,
+            kv_caches=self.kv_caches,
+            prefill_pp_layer_partition=None,
+        )
+        self.test_req = {
+            "request_id": "req1",
+            "remote_request_id": "req1",
+            "local_block_ids": [[1, 2]],
+            "remote_block_ids": [[3, 4]],
+            "group_pulls": [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)],
+            "remote_engine_id": "remote_engine",
+            "remote_host": "localhost",
+            "remote_handshake_port": 6666,
+            "remote_port_send_num": {6666: 1},
+            "all_task_done": True,
+            "remote_block_size": 16,
+        }
+        self.thread.kv_group2layeridx = {0: ({"kv_cache_spec_type": "FullAttentionSpec"}, [0])}
+        self.thread.group_compress_ratios = {0: 1}
+        self.thread.block_size_scale = [[1]]
+        self.thread.task_tracker = MagicMock()
+        self.thread.remote_te_port = {"remote_engine": {6666: 7777}}
+        self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[1024]]
+        self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000]]}
+        self.thread.remote_block_size_scale["remote_engine"] = {6666: [[1]]}
+
+    def _transfer(self):
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.get_ascend_config") as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            self.thread._transfer_kv_cache_all_groups(self.test_req)
+
+    def test_transfer_success_records_stats(self):
+        self.engine.batch_transfer_sync_read.return_value = 0
+        self._transfer()
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        stats_data = self.thread.xfer_stats.data
+        self.assertEqual(len(stats_data["transfer_duration"]), 1)
+        self.assertGreaterEqual(stats_data["transfer_duration"][0], 0)
+        self.assertEqual(stats_data["bytes_transferred"], [sum(call_args[3])])
+        self.assertEqual(stats_data["num_descriptors"], [len(call_args[1])])
+        self.assertEqual(stats_data["num_failed_transfers"], [])
+
+    def test_transfer_engine_failure_records_failed_transfer(self):
+        self.engine.batch_transfer_sync_read.return_value = -1
+        with self.assertRaises(RuntimeError):
+            self._transfer()
+
+        stats_data = self.thread.xfer_stats.data
+        self.assertEqual(stats_data["num_failed_transfers"], [1])
+        self.assertEqual(stats_data["transfer_duration"], [])
+
+    @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
+    @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
+    @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
+    def test_handle_request_exception_records_failed_recv(self, mock_transfer, mock_send, mock_free):
+        mock_transfer.side_effect = RuntimeError("boom")
+        self.thread.request_queue = MagicMock()
+
+        self.thread._handle_request(self.test_req)
+
+        self.assertEqual(self.thread.xfer_stats.data["num_failed_recvs"], [1])
+        # The failed-request mark is cleared once the last task finishes, but
+        # the failed blocks stay recorded for the scheduler to invalidate.
+        self.assertEqual(self.thread.invalid_block_ids, {1, 2})
+
+    def test_recv_thread_shares_worker_stats(self):
+        shared = MooncakeKVConnectorStats()
+        thread = KVCacheRecvingThread(
+            tp_rank=0,
+            tp_size=4,
+            _prefill_pp_size=1,
+            engine=self.engine,
+            local_engine_id="local_engine",
+            local_handshake_port=5555,
+            side_channel_port=30000,
+            local_kv_caches_base_addr=[[0x1000]],
+            block_len_per_addr=[[1024]],
+            block_stride_per_addr=[[1024]],
+            ready_event=self.ready_event,
+            vllm_config=self.vllm_config,
+            kv_caches=self.kv_caches,
+            prefill_pp_layer_partition=None,
+            xfer_stats=shared,
+        )
+        self.assertIs(thread.xfer_stats, shared)
+        self.assertIs(thread.task_tracker.xfer_stats, shared)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.logger")
+    def test_tracker_records_expired_request(self, mock_logger):
+        from vllm import envs as vllm_envs
+
+        stats = MooncakeKVConnectorStats()
+        tracker = KVCacheTaskTracker(xfer_stats=stats)
+        tracker.add_req_to_process("req1")
+        tracker.add_delayed_request("req1", time.time() - vllm_envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT - 1)
+
+        result = tracker.get_and_clear_finished_requests()
+
+        self.assertEqual(result, {"req1"})
+        self.assertEqual(stats.data["num_kv_expired_reqs"], [1])
+
+    def test_tracker_without_stats_still_expires(self):
+        tracker = KVCacheTaskTracker()
+        tracker.add_req_to_process("req1")
+        with patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector.logger"):
+            from vllm import envs as vllm_envs
+
+            tracker.add_delayed_request("req1", time.time() - vllm_envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT - 1)
+            result = tracker.get_and_clear_finished_requests()
+        self.assertEqual(result, {"req1"})
+
+    def test_worker_get_kv_connector_stats_drains(self):
+        worker = object.__new__(MooncakeConnectorWorker)
+        worker.xfer_stats = MooncakeKVConnectorStats()
+
+        self.assertIsNone(worker.get_kv_connector_stats())
+
+        worker.xfer_stats.record_transfer(duration_s=0.5, total_bytes=2**20, num_descs=4)
+        worker.xfer_stats.record_failed_recv()
+        snapshot = worker.get_kv_connector_stats()
+
+        assert snapshot is not None
+        self.assertEqual(snapshot.data["transfer_duration"], [0.5])
+        self.assertEqual(snapshot.data["num_failed_recvs"], [1])
+        reduced = snapshot.reduce()
+        self.assertEqual(reduced["Num successful transfers"], 1)
+        self.assertEqual(reduced["Num failed recvs"], 1)
+        # A second call in the same interval has nothing new to report.
+        self.assertIsNone(worker.get_kv_connector_stats())
+
+    def test_connector_stats_methods(self):
+        connector = object.__new__(MooncakeConnector)
+        connector.connector_worker = None
+        self.assertIsNone(connector.get_kv_connector_stats())
+
+        worker = MagicMock()
+        sentinel = MooncakeKVConnectorStats()
+        worker.get_kv_connector_stats.return_value = sentinel
+        connector.connector_worker = worker
+        self.assertIs(connector.get_kv_connector_stats(), sentinel)
+
+        built = MooncakeConnector.build_kv_connector_stats()
+        self.assertIsInstance(built, MooncakeKVConnectorStats)
+        self.assertTrue(built.is_empty())
+        rebuilt = MooncakeConnector.build_kv_connector_stats({"transfer_duration": [0.1]})
+        assert rebuilt is not None
+        self.assertEqual(rebuilt.data["transfer_duration"], [0.1])
 
 
 if __name__ == "__main__":

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -34,6 +34,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import MooncakeKVConnectorStats
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tensor_model_parallel_rank,
@@ -166,9 +168,10 @@ class SizedDict(OrderedDict):
 
 
 class KVCacheTaskTracker:
-    def __init__(self):
+    def __init__(self, xfer_stats: MooncakeKVConnectorStats | None = None):
         super().__init__()
 
+        self.xfer_stats = xfer_stats
         self.done_task_lock = threading.Lock()
         self.finished_requests: set[str] = set()
         # Only used in prefill node. Tracks requests whose kv blocks freeing is
@@ -232,6 +235,8 @@ class KVCacheTaskTracker:
                 self.delayed_free_requests.popitem(last=False)
                 self.reqs_to_process.discard(request_id)
                 expired_requests.add(request_id)
+                if self.xfer_stats is not None:
+                    self.xfer_stats.record_kv_expired_req()
                 logger.error(
                     "Force freed expired request: %s. "
                     "Reason: Request exceeded timeout threshold (%s seconds). "
@@ -257,6 +262,7 @@ class KVCacheSendingThread(threading.Thread):
         ready_event: threading.Event,
         kv_caches: dict[str, Any],
         pcp_rank: int,
+        xfer_stats: MooncakeKVConnectorStats | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheSendingThread")
         self.tp_rank = tp_rank
@@ -274,7 +280,7 @@ class KVCacheSendingThread(threading.Thread):
         self.pcp_rank = pcp_rank
         self.port_send_num: dict[str, int] = {}
 
-        self.task_tracker = KVCacheTaskTracker()
+        self.task_tracker = KVCacheTaskTracker(xfer_stats)
 
     def get_and_clear_finished_requests(self) -> set[str]:
         """
@@ -428,6 +434,7 @@ class KVCacheRecvingThread(threading.Thread):
         prefill_pp_layer_partition: str | None = None,
         kv_group2layeridx: dict[int, tuple[dict[str, Any], list[int]]] | None = None,
         block_size_scale: list[list[int]] | None = None,
+        xfer_stats: MooncakeKVConnectorStats | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheRecvingThread")
         self.tp_rank = tp_rank
@@ -485,7 +492,8 @@ class KVCacheRecvingThread(threading.Thread):
         self.finished_request_markers: set[str] = set()
         self.request_task_counts_lock = threading.Lock()
 
-        self.task_tracker = KVCacheTaskTracker()
+        self.xfer_stats = xfer_stats if xfer_stats is not None else MooncakeKVConnectorStats()
+        self.task_tracker = KVCacheTaskTracker(self.xfer_stats)
 
         self.encoder = msgspec.msgpack.Encoder()
         self.decoder = msgspec.msgpack.Decoder(MooncakeAgentMetadata)
@@ -715,6 +723,9 @@ class KVCacheRecvingThread(threading.Thread):
                     logger.debug("Finished transferring KV cache for request %s.", remote_request_id)
                 except Exception as e:
                     transfer_failed = True
+                    # Counted per failed receive task; an engine failure also
+                    # counts once as a failed transfer op before raising here.
+                    self.xfer_stats.record_failed_recv()
                     self._mark_failed_recv_request(request_id, req_meta["local_block_ids"])
                     logger.exception("Failed to transfer KV cache for request %s: %s", remote_request_id, e)
         finally:
@@ -982,14 +993,22 @@ class KVCacheRecvingThread(threading.Thread):
             dst_list,
             length_list,
         )
+        xfer_start_time = time.perf_counter()
         ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
+        xfer_duration = time.perf_counter() - xfer_start_time
         if ret < 0:
+            self.xfer_stats.record_failed_transfer()
             logger.error(
                 "Mooncake transfer failed for request. remote_request_id=%s, ret=%d. ",
                 req_meta["remote_request_id"],
                 ret,
             )
             raise RuntimeError(f"Mooncake transfer failed, ret: {ret}")
+        self.xfer_stats.record_transfer(
+            duration_s=xfer_duration,
+            total_bytes=sum(length_list),
+            num_descs=len(src_list),
+        )
 
         req_end_time = time.perf_counter()
         req_transfer_elapsed = (req_end_time - req_start_time) * 1000
@@ -1596,6 +1615,22 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         """MooncakeConnector does not save explicitly."""
         pass
 
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return worker-local transfer stats since the last call.
+
+        Note the P/D asymmetry: this connector is D-pull (the decode worker
+        calls batch_transfer_sync_read), so D records successful transfer
+        latency, bytes and descriptor counts as well as failed pulls, while
+        P only records requests whose KV expired before being fetched.
+        """
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+    @classmethod
+    def build_kv_connector_stats(cls, data: dict[str, Any] | None = None) -> KVConnectorStats | None:
+        return MooncakeKVConnectorStats(data=data or {})
+
     def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
         """
         Get the KVConnector handshake metadata for this connector.
@@ -2056,6 +2091,10 @@ class MooncakeConnectorWorker:
         self.kv_send_thread: KVCacheSendingThread | None = None
         self.kv_recv_thread: KVCacheRecvingThread | None = None
 
+        # Transfer stats shared with the sending/receiving thread; drained
+        # periodically via get_kv_connector_stats.
+        self.xfer_stats = MooncakeKVConnectorStats()
+
         # Handshake metadata of this worker
         self.xfer_handshake_metadata: MooncakeAgentMetadata | None = None
 
@@ -2477,6 +2516,7 @@ class MooncakeConnectorWorker:
                 ready_event,
                 self.kv_caches,
                 self.pcp_rank,
+                xfer_stats=self.xfer_stats,
             )
             self.kv_send_thread.start()
         else:
@@ -2498,6 +2538,7 @@ class MooncakeConnectorWorker:
                 self._prefill_pp_layer_partition,
                 self.kv_group2layeridx,
                 self.block_size_scale,
+                xfer_stats=self.xfer_stats,
             )
             self.kv_recv_thread.start()
         start_wait_time = time.time()
@@ -2536,6 +2577,13 @@ class MooncakeConnectorWorker:
         if self.kv_role == "kv_consumer" and self.kv_recv_thread is not None:
             return self.kv_recv_thread.get_and_clear_invalid_block_ids()
         return set()
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return transfer stats collected since the last call, or None
+        if nothing has been recorded in this interval."""
+        if self.xfer_stats.is_empty():
+            return None
+        return self.xfer_stats.clone_and_reset()
 
     @staticmethod
     def _expand_block_ids(block_ids, scale):


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream vLLM has a KV connector stats pipeline (worker connector -> `KVConnectorOutput` -> scheduler -> `KVConnectorLogging`), and upstream's own Mooncake connector implements it, but the Ascend `MooncakeConnector` never did — so P/D deployments on Ascend get no KV transfer metrics at all: no transfer latency, no bytes, no failure counters.

This PR reuses the upstream `MooncakeKVConnectorStats` container and wires the Ascend record sites: the receiving thread records successful pulls (duration, bytes and descriptor count around `batch_transfer_sync_read`) and engine failures, `_handle_request` records failed receive tasks, and `KVCacheTaskTracker` records producer-side force-freed expired requests. The worker shares one stats object with its sending/receiving thread and drains it via `get_kv_connector_stats()`; everything downstream (model-runner mixin, cross-worker aggregation, logging) is inherited from vLLM.

One asymmetry worth noting: upstream's Mooncake connector is P-push, this one is D-pull, so here the decode worker records transfer metrics while the prefill side only records expired requests. This is documented in the connector docstring.

### Does this PR introduce _any_ user-facing change?

KV transfer stats now show up in the standard vLLM connector stats logging when using `MooncakeConnector`. No config or API change.

### How was this patch tested?

Added unit tests covering each record site (successful pull, engine failure, failed receive task, expired request), the worker drain semantics, and `build_kv_connector_stats`. `tests/ut/kv_offload/test_mooncake_connector.py` plus `tests/ut/distributed/kv_transfer` and `tests/ut/distributed/mooncake` pass locally on CPU (146 passed). I don't have Ascend hardware, so I'm relying on the NPU CI for hardware coverage.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
