### PR TITLE
[Model] Support text-only Qwen3.5 checkpoints

### DIFF
--- a/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
+++ b/docs/source/tutorials/models/Qwen3.5-397B-A17B.md
@@ -18,6 +18,13 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get feature
 The support matrix records the maximum verified capability for this model. The startup examples in this document use practical validation settings for online serving and performance testing. Adjust `--max-model-len`, `--max-num-seqs`, and `--max-num-batched-tokens` based on your service workload and available KV cache.
 :::
 
+Text-only checkpoints that use `Qwen3_5ForCausalLM` or
+`Qwen3_5MoeForCausalLM` are also supported. Unlike the multimodal
+`Qwen3_5ForConditionalGeneration` variants, these checkpoints do not need a
+`vision_config` or multimodal RoPE sections. W8A8 and MTP use the same command
+line options shown below when their corresponding checkpoint tensors are
+present.
+
 ## 3 Prerequisites
 
 ### 3.1 Model Weight

--- a/tests/ut/patch/platform/test_patch_pp_mtp.py
+++ b/tests/ut/patch/platform/test_patch_pp_mtp.py
@@ -3,7 +3,25 @@
 from types import SimpleNamespace
 
 import pytest
+from transformers import PretrainedConfig
 from vllm.config.model import ModelConfig
+
+from vllm_ascend.patch.platform.patch_speculative_config import hf_config_override
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected_architecture"),
+    [("qwen3_5_text", "Qwen3_5MTP"), ("qwen3_5_moe_text", "Qwen3_5MoeMTP")],
+)
+def test_qwen3_5_text_config_mtp_override(model_type, expected_architecture):
+    hf_config = PretrainedConfig()
+    hf_config.model_type = model_type
+    hf_config.architectures = ["Qwen3_5MoeForCausalLM" if "moe" in model_type else "Qwen3_5ForCausalLM"]
+    hf_config.mtp_num_hidden_layers = 1
+    result = hf_config_override(hf_config)
+    assert result.model_type == "qwen3_5_mtp"
+    assert result.n_predict == 1
+    assert result.architectures == [expected_architecture]
 
 
 def test_model_config_validates_local_mtp_drafter_as_single_pp_rank(monkeypatch):

--- a/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
+++ b/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
@@ -10,6 +10,22 @@ from vllm.sequence import IntermediateTensors
 from vllm_ascend.patch.worker import patch_qwen3_5
 
 
+def test_qwen3_5_text_attention_uses_standard_rope():
+    attention = SimpleNamespace(
+        config=SimpleNamespace(model_type="qwen3_5_moe_text"),
+        rotary_emb=SimpleNamespace(),
+    )
+    assert not patch_qwen3_5._uses_multimodal_rope(attention)
+
+
+def test_qwen3_5_multimodal_attention_uses_mrope():
+    attention = SimpleNamespace(
+        config=SimpleNamespace(model_type="qwen3_5_moe"),
+        rotary_emb=SimpleNamespace(mrope_section=[11, 11, 10]),
+    )
+    assert patch_qwen3_5._uses_multimodal_rope(attention)
+
+
 @pytest.mark.skipif(
     patch_qwen3_5.Qwen3_5MultiTokenPredictor is None,
     reason="Qwen3.5 MTP model is not available in this vLLM version.",

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -16,6 +16,7 @@ from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
     AscendModelSlimConfig,
+    get_packed_modules_mapping,
 )
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, vllm_version_is
 
@@ -305,6 +306,15 @@ class TestApplyVllmMapper(TestBase):
 
 
 class TestQuantPrefixMapper(TestBase):
+    def test_qwen3_5_text_backbones_use_packed_module_mappings(self):
+        dense_mapping = get_packed_modules_mapping("qwen3_5_text")
+        moe_mapping = get_packed_modules_mapping("qwen3_5_moe_text")
+        self.assertEqual(dense_mapping["qkv_proj"], ["q_proj", "k_proj", "v_proj"])
+        self.assertEqual(
+            moe_mapping["experts"],
+            ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+        )
+
     def test_lm_head_maps_to_language_model_lm_head_when_quant_key_exists(self):
         config = AscendModelSlimConfig({"language_model.lm_head.weight": "FLOAT"})
 

--- a/tests/ut/test_qwen3_5_text_model.py
+++ b/tests/ut/test_qwen3_5_text_model.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.model_executor.models.config import (
+    MODELS_CONFIG_MAP,
+    Qwen3_5ForConditionalGenerationConfig,
+)
+from vllm.model_executor.models.interfaces import is_hybrid
+
+from vllm_ascend.models import register_model
+from vllm_ascend.models.qwen3_5_text import (
+    AscendQwen3_5ForCausalLM,
+    AscendQwen3_5MoeForCausalLM,
+)
+
+
+def test_qwen3_5_text_models_are_hybrid():
+    assert is_hybrid(AscendQwen3_5ForCausalLM)
+    assert is_hybrid(AscendQwen3_5MoeForCausalLM)
+
+
+def test_qwen3_5_text_models_use_qwen_config_updater():
+    register_model()
+    assert MODELS_CONFIG_MAP["Qwen3_5ForCausalLM"] is Qwen3_5ForConditionalGenerationConfig
+    assert MODELS_CONFIG_MAP["Qwen3_5MoeForCausalLM"] is Qwen3_5ForConditionalGenerationConfig

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -2,6 +2,30 @@ from vllm import ModelRegistry
 
 
 def register_model():
+    # Qwen3.5 text-only checkpoints use the *ForCausalLM architecture names.
+    # Register them explicitly so they are not resolved through the multimodal
+    # conditional-generation wrappers, which require a vision_config.
+    ModelRegistry.register_model(
+        "Qwen3_5ForCausalLM",
+        "vllm_ascend.models.qwen3_5_text:AscendQwen3_5ForCausalLM",
+    )
+    ModelRegistry.register_model(
+        "Qwen3_5MoeForCausalLM",
+        "vllm_ascend.models.qwen3_5_text:AscendQwen3_5MoeForCausalLM",
+    )
+
+    from vllm.model_executor.models.config import (
+        MODELS_CONFIG_MAP,
+        Qwen3_5ForConditionalGenerationConfig,
+    )
+
+    MODELS_CONFIG_MAP.update(
+        {
+            "Qwen3_5ForCausalLM": Qwen3_5ForConditionalGenerationConfig,
+            "Qwen3_5MoeForCausalLM": Qwen3_5ForConditionalGenerationConfig,
+        }
+    )
+
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
 
     ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")

--- a/vllm_ascend/models/qwen3_5_text.py
+++ b/vllm_ascend/models/qwen3_5_text.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ascend hybrid-cache adapters for text-only Qwen3.5 checkpoints."""
+
+import torch
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForCausalLM,
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForCausalLM,
+)
+
+
+class _Qwen3_5TextHybridMixin:
+    """Expose the hybrid GDN state contract implemented by the VL wrapper."""
+
+    is_hybrid = True
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return Qwen3_5ForConditionalGeneration.get_mamba_state_dtype_from_config(
+            vllm_config
+        )
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return Qwen3_5ForConditionalGeneration.get_mamba_state_shape_from_config(
+            vllm_config
+        )
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return Qwen3_5ForConditionalGeneration.get_mamba_state_copy_func()
+
+
+class AscendQwen3_5ForCausalLM(_Qwen3_5TextHybridMixin, Qwen3_5ForCausalLM):
+    """Text-only Qwen3.5 model with hybrid attention/GDN cache setup."""
+
+
+class AscendQwen3_5MoeForCausalLM(
+    _Qwen3_5TextHybridMixin,
+    Qwen3_5MoeForCausalLM,
+):
+    """MoE text-only Qwen3.5 model with hybrid attention/GDN cache setup."""

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -101,8 +101,13 @@ def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
         n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
         hf_config.update({"n_predict": n_predict, "architectures": ["ExaoneMoeMTP"]})
 
-    if hf_config.model_type in ("qwen3_5", "qwen3_5_moe"):
-        is_moe = hf_config.model_type == "qwen3_5_moe"
+    if hf_config.model_type in (
+        "qwen3_5",
+        "qwen3_5_text",
+        "qwen3_5_moe",
+        "qwen3_5_moe_text",
+    ):
+        is_moe = hf_config.model_type in ("qwen3_5_moe", "qwen3_5_moe_text")
         hf_config.model_type = "qwen3_5_mtp"
         n_predict = getattr(hf_config, "mtp_num_hidden_layers", None)
         hf_config.update(

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -38,10 +38,15 @@ from vllm_ascend.utils import is_310p
 _GDN_PATCH_TARGET = _GDNBaseCls
 
 
+def _uses_multimodal_rope(attention: Qwen3NextAttention) -> bool:
+    """Return whether a Qwen3.5 attention layer exposes multimodal RoPE."""
+    return "qwen3_5" in attention.config.model_type and hasattr(attention.rotary_emb, "mrope_section")
+
+
 class AscendQwen3NextAttention(Qwen3NextAttention):
     def forward(self, positions: torch.Tensor, output: torch.Tensor, hidden_states: torch.Tensor):
         qkv, _ = self.qkv_proj(hidden_states)
-        if "qwen3_5" in self.config.model_type:
+        if _uses_multimodal_rope(self):
             cos_sin = self.rotary_emb.cos_sin_cache[positions]
             if cos_sin.device != qkv.device:
                 cos_sin = cos_sin.to(qkv.device)

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -87,7 +87,20 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
         "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     },
+    "qwen3_5_text": {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+    },
     "qwen3_5_moe": {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    },
+    "qwen3_5_moe_text": {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
         "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds vLLM Ascend support for text-only Qwen3.5-family checkpoints whose Hugging Face architecture is `Qwen3_5ForCausalLM` or `Qwen3_5MoeForCausalLM` and whose model type is `qwen3_5_text` or `qwen3_5_moe_text`.

Before this change, these checkpoints can be rejected or routed through the multimodal conditional-generation path, which expects `vision_config` and multimodal RoPE fields. Hybrid GDN cache initialization, ModelSlim packed-module mapping, and Qwen3.5 MTP config conversion also only covered the multimodal model types.

The change:

- registers Ascend text-only dense and MoE wrappers;
- reuses the existing Qwen3.5 hybrid GDN state contract and config updater;
- uses standard RoPE when no multimodal RoPE section exists;
- adds ModelSlim packed mappings for the text-only model types;
- permits `qwen3_5_mtp` speculative decoding for text-only checkpoints;
- documents the supported text-only architecture names.

Related upstream report: https://github.com/vllm-project/vllm/issues/48060

### Does this PR introduce _any_ user-facing change?

Yes. Text-only Qwen3.5-family causal-LM checkpoints can be loaded directly without a synthetic `vision_config` or an `hf_overrides` architecture remap. W8A8 ModelSlim checkpoints and checkpoints containing Qwen3.5 MTP tensors are supported by the existing `--quantization ascend` and `qwen3_5_mtp` options.

### How was this patch tested?

- Added unit coverage for model registration, hybrid-cache interfaces, standard-vs-multimodal RoPE selection, ModelSlim packed-module mappings, and MTP config conversion.
- Targeted tests in the vLLM Ascend 0.23.0 A3 development image: `7 passed, 14 warnings in 12.62s`.
- `git diff --check` passed.
- Loaded a real `qwen3_5_moe_text` W8A8 checkpoint (2.33 TiB) on four Atlas 800I A3 nodes with DP4, TP16, and EP enabled; all 64 workers completed weight loading and an OpenAI-compatible chat completion returned HTTP 200.
- Verified `VLLM_ASCEND_ENABLE_FUSED_MC2=1` and `additional_config.enable_fused_mc2=1` in every data-parallel engine.
- Repeated the real-checkpoint service test with one Qwen3.5 MTP speculative token. The draft architecture resolved to `Qwen3_5MoeMTP`, real `mtp.*` tensors were loaded, and draft tokens were accepted during inference.
- Verified Ascend `FULL_DECODE_ONLY`: compilation mode `VLLM_COMPILE`, capture sizes `[1, 2, 4, 8, 16]`, target and MTP draft full-graph wrappers, 0.52 GiB graph memory per NPU, and two successful graph replays with the correct deterministic result.

The four-file test selection contains 45 tests. A full local run passed its first 26 tests and then hung in an existing later test before pytest produced a summary, so this PR only claims the seven directly changed tests above. Ruff could not be installed from the environment's package mirror; no Ruff result is claimed.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
