### PR TITLE
 [v0.23.0][Doc][Misc] Document partial prefill limitation on PD P nodes

### DIFF
--- a/docs/source/developer_guide/Design_Documents/disaggregated_prefill.md
+++ b/docs/source/developer_guide/Design_Documents/disaggregated_prefill.md
@@ -102,4 +102,6 @@ Under non-symmetric PD scenarios, validate the P-to-D tp ratio against expected 
 
 - Heterogeneous P and D nodes are not supported, for example, running P nodes on A2 and D nodes on A3.
 
+- P nodes in PD-disaggregated deployments do not support non-default `max_num_partial_prefills` values. Keep it at the default value of `1`; other values are ignored and reset to `1`.
+
 - In non-symmetric TP configurations, only cases where the P nodes have a higher TP degree than the D nodes and the P TP count is an integer multiple of the D TP count are supported (i.e., P_tp > D_tp and P_tp % D_tp = 0).


### PR DESCRIPTION
### What this PR does / why we need it?

Documents that PD-disaggregated P nodes do not support non-default `max_num_partial_prefills` values.

The limitation is added to the common PD Disaggregation design guide rather than duplicated across connector-specific deployment examples. It also clarifies the current behavior: values other than the default `1` are ignored and reset to `1` on Ascend.

### Does this PR introduce _any_ user-facing change?

No. This PR only documents existing behavior.

### How was this patch tested?

- `markdownlint`: passed.
- `codespell`: passed.
- `typos`: passed.
- `bash format.sh ci`: all relevant hooks passed; the only failure was the pre-existing shellcheck `SC2328` in unchanged `csrc/build.sh`.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389