### PR TITLE
[Feature][KV Transfer] Support KVConnectorStats for MooncakeLayerwiseConnector

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -51,6 +51,7 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector imp
     KVConnectorRole,
     LayerMetadata,
     MooncakeAgentMetadata,
+    MooncakeKVConnectorStats,
     MooncakeLayerwiseConnector,
     MooncakeLayerwiseConnectorMetadata,
     MooncakeLayerwiseConnectorScheduler,
@@ -1170,3 +1171,212 @@ class TestMooncakeLayerwiseConnectorWorker(unittest.TestCase):
         worker.register_kv_caches(mla_caches)
         self.assertTrue(worker.use_mla)
         self.assertEqual(len(worker.layer_metadata["encoder.layer.0"].block_len), 2)
+
+
+class TestMooncakeLayerwiseConnectorStats(unittest.TestCase):
+    def _make_send_thread(self, xfer_stats=None, total_layers=2):
+        thread = KVCacheSendingLayerThread(
+            engine=self.engine,
+            vllm_config=self.vllm_config,
+            kv_cache_config=_make_mock_kv_cache_config(),
+            kv_cache_specs=[MagicMock(block_size=16)],
+            attn_resharding_group_idx=set(),
+            total_layers=total_layers,
+            ready_event=self.ready_event,
+            tp_size=1,
+            tp_rank=0,
+            pd_head_ratio=2,
+            num_head_replica=1,
+            layer_metadata={
+                "layer0": _make_layer_metadata(
+                    tensor_group_idx=[0],
+                    kv_caches_base_addr=[1111, 2222],
+                    block_len=[64, 64],
+                    block_size_scale=[1, 1],
+                )
+            },
+            use_mla=False,
+            use_attn_mamba_hybrid=False,
+            k_buffer=MagicMock(),
+            v_buffer=MagicMock(),
+            enable_kv_quant=False,
+            enable_c8_quant=False,
+            resharding_stream=MagicMock(),
+            callback_func=MagicMock(),
+            xfer_stats=xfer_stats,
+        )
+        return thread
+
+    def _make_send_task(self):
+        req_meta = ReqMeta(
+            local_block_ids=[[5, 8]],
+            token_ids=[1, 2, 3],
+            remote_block_ids=[[10, 20]],
+            remote_block_size=[[16]],
+            remote_engine_id="remote_engine",
+            remote_host="127.0.0.1",
+            remote_port=7777,
+            remote_te_rpc_port=6000,
+            remote_layer_metadata={
+                "layer0": _make_layer_metadata(
+                    kv_caches_base_addr=[4000, 8000],
+                    block_len=[64, 64],
+                    block_size_scale=[1, 1],
+                ),
+            },
+            metaserver="http://dummy",
+            remote_tp_size=8,
+            remote_pcp_size=1,
+            remote_dcp_size=1,
+            chunk_finish=False,
+        )
+        return SendTask(
+            send_request={"req1": req_meta},
+            wait_event=MagicMock(),
+            k_cache=torch.zeros((1, 8), dtype=torch.float32),
+            v_cache=torch.zeros((1, 8), dtype=torch.float32),
+            layer_idx=0,
+            layer_name="layer0",
+            group_rearrange_block_ids=[[5, 8]],
+        )
+
+    def setUp(self):
+        self.engine = MagicMock()
+        self.engine.batch_transfer_sync_write.return_value = 1
+        self.ready_event = threading.Event()
+        self.vllm_config = MagicMock()
+        self.vllm_config.cache_config.mamba_cache_mode = None
+        self.vllm_config.speculative_config = None
+        self.recv_meta = MooncakeAgentMetadata(
+            te_rpc_port=6000,
+            layer_metadata={"layer0": _make_layer_metadata()},
+        )
+
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.npu_stream_switch",
+        side_effect=lambda *_args, **_kwargs: contextlib.nullcontext(),
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.Tensor.data_ptr",
+        autospec=True,
+        return_value=0x200000,
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.align_memory",
+        side_effect=lambda x, _align: x,
+    )
+    @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.npu.synchronize")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.group_concurrent_contiguous")
+    def test_transfer_success_records_stats(self, mock_group, _sync, _align, _dataptr, _stream):
+        mock_group.return_value = ([[10, 11], [20, 21]], [])
+        thread = self._make_send_thread()
+
+        thread._transfer_kv_cache(self._make_send_task())
+
+        _, src_list, _, length_list = self.engine.batch_transfer_sync_write.call_args[0]
+        stats_data = thread.xfer_stats.data
+        self.assertEqual(len(stats_data["transfer_duration"]), 1)
+        self.assertGreaterEqual(stats_data["transfer_duration"][0], 0)
+        self.assertEqual(stats_data["bytes_transferred"], [sum(length_list)])
+        self.assertEqual(stats_data["num_descriptors"], [len(src_list)])
+        self.assertEqual(stats_data["num_failed_transfers"], [])
+
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.npu_stream_switch",
+        side_effect=lambda *_args, **_kwargs: contextlib.nullcontext(),
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.Tensor.data_ptr",
+        autospec=True,
+        return_value=0x200000,
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.align_memory",
+        side_effect=lambda x, _align: x,
+    )
+    @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.npu.synchronize")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.group_concurrent_contiguous")
+    def test_transfer_engine_failure_records_failed_transfer(self, mock_group, _sync, _align, _dataptr, _stream):
+        mock_group.return_value = ([[10, 11], [20, 21]], [])
+        self.engine.batch_transfer_sync_write.return_value = -1
+        thread = self._make_send_thread()
+
+        thread._transfer_kv_cache(self._make_send_task())
+
+        stats_data = thread.xfer_stats.data
+        self.assertEqual(stats_data["num_failed_transfers"], [1])
+        self.assertEqual(stats_data["transfer_duration"], [])
+        self.assertIn("req1", thread.failed_reqs)
+
+    def test_handle_request_exception_records_failed_transfer(self):
+        thread = self._make_send_thread()
+        with patch.object(thread, "_transfer_kv_cache", side_effect=RuntimeError("boom")):
+            thread._handle_request(self._make_send_task())
+        self.assertEqual(thread.xfer_stats.data["num_failed_transfers"], [1])
+
+    def test_recv_thread_failed_task_records_failed_recv(self):
+        th = KVCacheRecvingLayerThread(
+            tp_rank=0,
+            side_channel_port=5555,
+            tp_size=2,
+            pd_head_ratio=1,
+            local_engine_id="engineA",
+            metadata=self.recv_meta,
+            ready_event=self.ready_event,
+        )
+        th.update_failed_task("reqX")
+        self.assertIn("reqX", th.failed_requests)
+        self.assertEqual(th.xfer_stats.data["num_failed_recvs"], [1])
+
+    def test_threads_share_worker_stats(self):
+        shared = MooncakeKVConnectorStats()
+        send_thread = self._make_send_thread(xfer_stats=shared)
+        recv_thread = KVCacheRecvingLayerThread(
+            tp_rank=0,
+            side_channel_port=5555,
+            tp_size=2,
+            pd_head_ratio=1,
+            local_engine_id="engineA",
+            metadata=self.recv_meta,
+            ready_event=self.ready_event,
+            xfer_stats=shared,
+        )
+        self.assertIs(send_thread.xfer_stats, shared)
+        self.assertIs(recv_thread.xfer_stats, shared)
+
+    def test_worker_get_kv_connector_stats_drains(self):
+        worker = object.__new__(MooncakeLayerwiseConnectorWorker)
+        worker.xfer_stats = MooncakeKVConnectorStats()
+
+        self.assertIsNone(worker.get_kv_connector_stats())
+
+        worker.xfer_stats.record_transfer(duration_s=0.25, total_bytes=2**20, num_descs=8)
+        worker.xfer_stats.record_failed_recv()
+        snapshot = worker.get_kv_connector_stats()
+
+        assert snapshot is not None
+        self.assertEqual(snapshot.data["transfer_duration"], [0.25])
+        self.assertEqual(snapshot.data["num_failed_recvs"], [1])
+        reduced = snapshot.reduce()
+        self.assertEqual(reduced["Num successful transfers"], 1)
+        self.assertEqual(reduced["Num failed recvs"], 1)
+        # A second call in the same interval has nothing new to report.
+        self.assertIsNone(worker.get_kv_connector_stats())
+
+    def test_connector_stats_methods(self):
+        connector = object.__new__(MooncakeLayerwiseConnector)
+        connector.connector_worker = None
+        self.assertIsNone(connector.get_kv_connector_stats())
+
+        worker = MagicMock()
+        sentinel = MooncakeKVConnectorStats()
+        worker.get_kv_connector_stats.return_value = sentinel
+        connector.connector_worker = worker
+        self.assertIs(connector.get_kv_connector_stats(), sentinel)
+
+        built = MooncakeLayerwiseConnector.build_kv_connector_stats()
+        self.assertIsInstance(built, MooncakeKVConnectorStats)
+        self.assertTrue(built.is_empty())
+        rebuilt = MooncakeLayerwiseConnector.build_kv_connector_stats({"transfer_duration": [0.1]})
+        assert rebuilt is not None
+        self.assertEqual(rebuilt.data["transfer_duration"], [0.1])

--- a/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_layerwise_connector.py
@@ -1308,6 +1308,34 @@ class TestMooncakeLayerwiseConnectorStats(unittest.TestCase):
         self.assertEqual(stats_data["transfer_duration"], [])
         self.assertIn("req1", thread.failed_reqs)
 
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.npu_stream_switch",
+        side_effect=lambda *_args, **_kwargs: contextlib.nullcontext(),
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.Tensor.data_ptr",
+        autospec=True,
+        return_value=0x200000,
+    )
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.align_memory",
+        side_effect=lambda x, _align: x,
+    )
+    @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.torch.npu.synchronize")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_layerwise_connector.group_concurrent_contiguous")
+    def test_engine_failure_marks_all_requests_in_session_failed(self, mock_group, _sync, _align, _dataptr, _stream):
+        # Regression: a failed batched write must fail every request merged
+        # into that session's transfer, not just the last-iterated one.
+        mock_group.return_value = ([[10, 11], [20, 21]], [])
+        self.engine.batch_transfer_sync_write.return_value = -1
+        thread = self._make_send_thread()
+
+        task = self._make_send_task()
+        task.send_request["req2"] = task.send_request["req1"]
+        thread._transfer_kv_cache(task)
+
+        self.assertEqual(thread.failed_reqs, {"req1", "req2"})
+
     def test_handle_request_exception_records_failed_transfer(self):
         thread = self._make_send_thread()
         with patch.object(thread, "_transfer_kv_cache", side_effect=RuntimeError("boom")):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -32,6 +32,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import MooncakeKVConnectorStats
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tp_group,
@@ -224,6 +226,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         enable_c8_quant: bool,
         resharding_stream: torch.npu.Stream,
         callback_func: Callable[..., None] = lambda x: None,
+        xfer_stats: MooncakeKVConnectorStats | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheSendingLayerThread")
         self.engine = engine
@@ -262,6 +265,7 @@ class KVCacheSendingLayerThread(threading.Thread):
         self.enable_c8_quant = enable_c8_quant
         self.ready_event = ready_event
         self.callback_func = callback_func
+        self.xfer_stats = xfer_stats if xfer_stats is not None else MooncakeKVConnectorStats()
 
     def run(self):
         local_rank = get_world_group().local_rank
@@ -276,6 +280,9 @@ class KVCacheSendingLayerThread(threading.Thread):
         try:
             self._transfer_kv_cache(send_task)
         except Exception as e:
+            # Counted per failed layer task; engine failures inside
+            # _transfer_kv_cache do not raise, so there is no double count.
+            self.xfer_stats.record_failed_transfer()
             logger.error(
                 "Failed to transfer KV cache. layer_idx=%s, error=%s. Check transfer engine and memory state.",
                 send_task.layer_idx,
@@ -498,6 +505,7 @@ class KVCacheSendingLayerThread(threading.Thread):
                     session_id, transfer_meta.src, transfer_meta.dst, transfer_meta.length
                 )
                 if ret < 0:
+                    self.xfer_stats.record_failed_transfer()
                     logger.error(
                         "Mooncake transfer failed for send requests. req_ids=%s, destination=%s, ret=%d. ",
                         transfer_meta.req_ids,
@@ -507,6 +515,11 @@ class KVCacheSendingLayerThread(threading.Thread):
                     self.failed_reqs.add(req_id)
                 else:
                     req_end_time = time.perf_counter()
+                    self.xfer_stats.record_transfer(
+                        duration_s=req_end_time - req_start_time,
+                        total_bytes=sum(transfer_meta.length),
+                        num_descs=len(transfer_meta.src),
+                    )
                     total_transfer_size = sum(transfer_meta.length) / 1024
                     req_transfer_elapsed = (req_end_time - req_start_time) * 1000
                     logger.debug(
@@ -537,6 +550,7 @@ class KVCacheRecvingLayerThread(threading.Thread):
         local_engine_id: str,
         metadata: MooncakeAgentMetadata,
         ready_event: threading.Event,
+        xfer_stats: MooncakeKVConnectorStats | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheRecvingLayerThread")
         self.tp_rank = tp_rank
@@ -551,6 +565,7 @@ class KVCacheRecvingLayerThread(threading.Thread):
         self.task_tracker = dict[str, int]()
         self.ready_event = ready_event
         self.metadata = metadata
+        self.xfer_stats = xfer_stats if xfer_stats is not None else MooncakeKVConnectorStats()
 
     def get_and_clear_done_requests(self) -> set[str]:
         """
@@ -585,6 +600,7 @@ class KVCacheRecvingLayerThread(threading.Thread):
                 self.task_tracker[req_id] = set()
             self.task_tracker.pop(req_id, None)
             self.failed_requests.add(req_id)
+        self.xfer_stats.record_failed_recv()
 
     def update_done_task(self, req_id, trans_count, side_channel_path):
         """
@@ -787,6 +803,22 @@ class MooncakeLayerwiseConnector(KVConnectorBase_V1, SupportsHMA):
     def wait_for_save(self):
         """MooncakeLayerwiseConnector does not save explicitly."""
         pass
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return worker-local transfer stats since the last call.
+
+        This connector is P-push (the prefill worker calls
+        batch_transfer_sync_write per layer), so P records transfer
+        latency, bytes, descriptor counts and failed sends, while D only
+        records requests whose KV failed to arrive (FAILED_SENDING_MSG).
+        """
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+    @classmethod
+    def build_kv_connector_stats(cls, data: dict[str, Any] | None = None) -> KVConnectorStats | None:
+        return MooncakeKVConnectorStats(data=data or {})
 
 
 class MooncakeLayerwiseConnectorScheduler:
@@ -1178,6 +1210,10 @@ class MooncakeLayerwiseConnectorWorker:
         self.kv_recv_layer_thread: KVCacheRecvingLayerThread | None = None
         self.kv_send_layer_thread: KVCacheSendingLayerThread | None = None
 
+        # Transfer stats shared with the sending/receiving thread; drained
+        # periodically via get_kv_connector_stats.
+        self.xfer_stats = MooncakeKVConnectorStats()
+
         self.block_size: list[int] = [spec.block_size for spec in self.kv_cache_specs]
         self.kernel_block_size_scale: list[int] = [1 for _ in range(self.num_kv_cache_groups)]
         self.layer_metadata: dict[str, LayerMetadata] = {}
@@ -1382,6 +1418,7 @@ class MooncakeLayerwiseConnectorWorker:
                 enable_c8_quant=self.enable_c8_quant,
                 resharding_stream=self.resharding_stream,
                 callback_func=self.send_done_send_signal,
+                xfer_stats=self.xfer_stats,
             )
             self.kv_send_layer_thread.start()
             ready_event.wait()
@@ -1396,6 +1433,7 @@ class MooncakeLayerwiseConnectorWorker:
                 self.engine_id,
                 metadata,
                 ready_event,
+                xfer_stats=self.xfer_stats,
             )
             self.kv_recv_layer_thread.start()
             ready_event.wait()
@@ -1439,6 +1477,13 @@ class MooncakeLayerwiseConnectorWorker:
         result = self._invalid_block_ids
         self._invalid_block_ids = set()
         return result
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return transfer stats collected since the last call, or None
+        if nothing has been recorded in this interval."""
+        if self.xfer_stats.is_empty():
+            return None
+        return self.xfer_stats.clone_and_reset()
 
     # {(ip, port)]: {local_block_ids: [], remote_block_ids: {}}}
     def _get_kv_split_metadata(self, req_meta: ReqMeta, req_idx: int, req_id: str, group_idx: int):

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -512,7 +512,10 @@ class KVCacheSendingLayerThread(threading.Thread):
                         session_id,
                         ret,
                     )
-                    self.failed_reqs.add(req_id)
+                    # The whole batched write failed, so every request merged
+                    # into this session's transfer failed, not just the last
+                    # one iterated above.
+                    self.failed_reqs.update(transfer_meta.req_ids)
                 else:
                     req_end_time = time.perf_counter()
                     self.xfer_stats.record_transfer(


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up to #14237, which wired the upstream KV connector stats pipeline into the Ascend `MooncakeConnector`. This PR does the same for `MooncakeLayerwiseConnector`, so layerwise P/D deployments also get KV transfer metrics (latency, bytes, failure counters) instead of none.

Unlike the plain connector, the layerwise connector is P-push: the prefill worker pushes each layer via `batch_transfer_sync_write`. So the sending thread records successful layer transfers (duration, bytes and descriptor count) and failed ones — both engine errors and layer-task exceptions — while the consumer side records requests whose KV failed to arrive (`FAILED_SENDING_MSG`). The worker shares one `MooncakeKVConnectorStats` object with both threads and drains it via `get_kv_connector_stats()`; the rest of the pipeline is inherited from vLLM. `num_kv_expired_reqs` stays unused here because this connector has no expiry path.

### Does this PR introduce _any_ user-facing change?

KV transfer stats now show up in the standard vLLM connector stats logging when using `MooncakeLayerwiseConnector`. No config or API change.

### How was this patch tested?

Added unit tests covering each record site (successful layer transfer, engine failure, layer-task exception, failed arrival on the consumer side), stats sharing between the worker and its threads, the drain semantics, and `build_kv_connector_stats`. `tests/ut/kv_offload/test_mooncake_layerwise_connector.py` (48 passed) plus the rest of `tests/ut/kv_offload` and `tests/ut/distributed/{kv_transfer,mooncake}` pass locally on CPU. I don't have Ascend hardware, so I'm relying on the NPU CI for hardware coverage.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
