### PR TITLE
[BugFix] allocate MTP hidden buffer only for speculative decoding

### DIFF
--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -813,6 +813,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         # Pre-hc_head residual stream buffer for the MTP draft. Only needed
         # when speculative decoding is enabled; allocating it unconditionally
         # would permanently cost max_num_batched_tokens * hc_dim per rank.
+        spec_config = vllm_config.speculative_config
         self._mtp_hidden_buffer = (
             torch.empty(
                 vllm_config.scheduler_config.max_num_batched_tokens,
@@ -820,7 +821,7 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 dtype=vllm_config.model_config.dtype,
                 device=self.device,
             )
-            if vllm_config.speculative_config is not None
+            if spec_config is not None and spec_config.method == "mtp"
             else None
         )
 

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -810,14 +810,18 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
         self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
         self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
 
-        # Pre-hc_head residual stream buffer for the MTP draft. Stable
-        # address (outside the cudagraph pool) so the copy_ in forward()
-        # refreshes it correctly across captured shapes.
-        self._mtp_hidden_buffer = torch.empty(
-            vllm_config.scheduler_config.max_num_batched_tokens,
-            hc_dim,
-            dtype=vllm_config.model_config.dtype,
-            device=self.device,
+        # Pre-hc_head residual stream buffer for the MTP draft. Only needed
+        # when speculative decoding is enabled; allocating it unconditionally
+        # would permanently cost max_num_batched_tokens * hc_dim per rank.
+        self._mtp_hidden_buffer = (
+            torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                hc_dim,
+                dtype=vllm_config.model_config.dtype,
+                device=self.device,
+            )
+            if vllm_config.speculative_config is not None
+            else None
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
@@ -879,22 +883,25 @@ class DeepseekV4Model(nn.Module, EagleModelMixin):
                 aux_hidden_states.append(hidden_states.mean(dim=1))
 
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
-        # When FlashComm1 (sequence parallelism) is enabled, tokens are
+        # Skipped entirely when speculative decoding is disabled: the buffer
+        # is None and the all_gather below would be pure overhead. When
+        # FlashComm1 (sequence parallelism) is enabled, tokens are
         # partitioned across TP ranks via reduce_scatter in each layer's
         # row-parallel output projection.  We must all_gather here so the
         # MTP layers receive the full token set — otherwise only rank 0's
         # partition is valid and the rest of the buffer holds stale data,
         # leading to NaN values and low acceptance rate.
-        if _EXTRA_CTX.flash_comm_v1_enabled:
-            h_states_flat = tensor_model_parallel_all_gather(hidden_states.flatten(1), dim=0)
-            pad_size = _EXTRA_CTX.pad_size
-            if pad_size > 0:
-                h_states_flat = h_states_flat[:-pad_size]
-            num_tokens = h_states_flat.shape[0]
-            self._mtp_hidden_buffer[:num_tokens].copy_(h_states_flat)
-        else:
-            num_tokens = hidden_states.shape[0]
-            self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
+        if self._mtp_hidden_buffer is not None:
+            if _EXTRA_CTX.flash_comm_v1_enabled:
+                h_states_flat = tensor_model_parallel_all_gather(hidden_states.flatten(1), dim=0)
+                pad_size = _EXTRA_CTX.pad_size
+                if pad_size > 0:
+                    h_states_flat = h_states_flat[:-pad_size]
+                num_tokens = h_states_flat.shape[0]
+                self._mtp_hidden_buffer[:num_tokens].copy_(h_states_flat)
+            else:
+                num_tokens = hidden_states.shape[0]
+                self._mtp_hidden_buffer[:num_tokens].copy_(hidden_states.flatten(1))
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors(


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek-V4 currently allocates `_mtp_hidden_buffer` for every deployment, even when speculative decoding is disabled. The buffer is only consumed by the MTP draft path, so in regular inference it permanently occupies NPU memory without being used.

This PR:

- Allocates `_mtp_hidden_buffer` only when `vllm_config.speculative_config` is configured.
- Skips the corresponding hidden-state copy and FlashComm1 all-gather when speculative decoding is disabled.
- Preserves the existing buffer allocation and update behavior when speculative decoding is enabled.

The avoided persistent allocation per rank is:

```
max_num_batched_tokens * hc_mult * hidden_size * dtype_size
```

### Does this PR introduce _any_ user-facing change?

No API or configuration changes.

For DeepSeek-V4 deployments without speculative decoding, this reduces persistent NPU memory usage and avoids an unnecessary hidden-state copy/all-gather. Speculative decoding behavior is unchanged.

### How was this patch tested?

- Ran Python compilation validation for `vllm_ascend/models/deepseek_v4.py`.
- Ran `git diff --check`.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
