### PR TITLE
[Feature][KV Transfer] Support KVConnectorStats for MooncakeHybridConnector

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_hybrid_connector.py
@@ -19,7 +19,11 @@ from vllm.v1.request import RequestStatus  # noqa: E402
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector import (  # noqa: E402
     MAX_REQUESTS_PER_PEER_HANDLER,
     KVCacheRecvingThread,
+    KVCacheTaskTracker,
+    MooncakeConnector,
     MooncakeConnectorScheduler,
+    MooncakeConnectorWorker,
+    MooncakeKVConnectorStats,
 )
 
 
@@ -294,3 +298,183 @@ class TestMooncakeHybridConnectorScheduler(unittest.TestCase):
         self.assertIsNotNone(params)
         self.assertEqual(params["remote_block_ids"], ([0], [100, 101]))
         self.assertEqual(params["num_prompt_blocks"], 2)
+
+
+class TestMooncakeHybridConnectorStats(unittest.TestCase):
+    def setUp(self):
+        self.engine = MagicMock()
+        self.engine.batch_transfer_sync_read.return_value = 0
+        self.req_meta = {
+            "request_id": "req1",
+            "remote_request_id": "req1",
+            "local_block_ids": [[1, 2]],
+            "remote_block_ids": [[3, 4]],
+            "remote_engine_id": "remote_engine",
+            "remote_host": "localhost",
+            "remote_handshake_port": 6666,
+            "remote_port_send_num": {},
+            "offset": 0,
+            "tp_num_need_pulls": 1,
+            "all_task_done": True,
+        }
+
+    def _make_recv_thread(self, use_hybrid=False, xfer_stats=None):
+        model_config = types.SimpleNamespace(
+            is_deepseek_mla=False,
+            hf_config=types.SimpleNamespace(compress_ratios=[1]),
+            hf_text_config=types.SimpleNamespace(num_hidden_layers=1),
+        )
+        vllm_config = types.SimpleNamespace(
+            model_config=model_config,
+            cache_config=types.SimpleNamespace(block_size=16),
+            speculative_config=None,
+        )
+        kv_cache = MagicMock(device=torch.device("npu:0"))
+        with (
+            patch("torch.npu.set_device"),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector.is_vl_model",
+                return_value=False,
+            ),
+        ):
+            thread = KVCacheRecvingThread(
+                tp_rank=0,
+                tp_size=1,
+                _prefill_pp_size=1,
+                engine=self.engine,
+                local_engine_id="local_engine",
+                local_handshake_port=5555,
+                side_channel_port=30000,
+                local_kv_caches_base_addr=[0x1000],
+                block_len_per_addr=[1024],
+                block_stride_per_addr=[1024],
+                addr_group_idx=[],
+                mamba_ssm_size=(0, 0),
+                use_hybrid=use_hybrid,
+                has_mamba=False,
+                hma_group_size=1,
+                ready_event=threading.Event(),
+                vllm_config=vllm_config,
+                kv_cache_config=types.SimpleNamespace(kv_cache_groups=[]),
+                kv_caches={"layer.0": (kv_cache,)},
+                xfer_stats=xfer_stats,
+            )
+        thread.kv_caches_base_addr["remote_engine"] = {6666: [0x3000]}
+        thread.remote_te_port["remote_engine"] = {6666: 7777}
+        thread.kv_cache_specs = [MagicMock()]
+        return thread
+
+    def test_transfer_success_records_stats(self):
+        thread = self._make_recv_thread()
+
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_hybrid_connector.get_ascend_config"
+        ) as mock_config:
+            mock_config.return_value.enable_kv_nz = False
+            thread._transfer_kv_cache(self.req_meta)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        stats_data = thread.xfer_stats.data
+        self.assertEqual(len(stats_data["transfer_duration"]), 1)
+        self.assertGreaterEqual(stats_data["transfer_duration"][0], 0)
+        self.assertEqual(stats_data["bytes_transferred"], [sum(call_args[3])])
+        self.assertEqual(stats_data["num_descriptors"], [len(call_args[1])])
+        self.assertEqual(stats_data["num_failed_transfers"], [])
+
+    def test_transfer_engine_failure_records_failed_transfer(self):
+        self.engine.batch_transfer_sync_read.return_value = -1
+        thread = self._make_recv_thread()
+
+        with self.assertRaises(RuntimeError):
+            thread._transfer_kv_cache(self.req_meta)
+
+        stats_data = thread.xfer_stats.data
+        self.assertEqual(stats_data["num_failed_transfers"], [1])
+        self.assertEqual(stats_data["transfer_duration"], [])
+
+    def test_hybrid_group_transfer_records_stats(self):
+        thread = self._make_recv_thread(use_hybrid=True)
+
+        thread._transfer_kv_cache_all_groups(self.req_meta)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        stats_data = thread.xfer_stats.data
+        self.assertEqual(stats_data["bytes_transferred"], [sum(call_args[3])])
+        self.assertEqual(stats_data["num_descriptors"], [len(call_args[1])])
+
+    @patch.object(KVCacheRecvingThread, "_send_done_signal_to_free_remote_port")
+    @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
+    @patch.object(KVCacheRecvingThread, "_transfer_kv_cache")
+    def test_handle_request_exception_records_failed_recv(self, mock_transfer, mock_send, mock_free):
+        mock_transfer.side_effect = RuntimeError("boom")
+        thread = self._make_recv_thread()
+        thread.request_queue = MagicMock()
+        thread.task_tracker = MagicMock()
+
+        thread._handle_request(self.req_meta)
+
+        self.assertEqual(thread.xfer_stats.data["num_failed_recvs"], [1])
+
+    def test_recv_thread_shares_worker_stats(self):
+        shared = MooncakeKVConnectorStats()
+        thread = self._make_recv_thread(xfer_stats=shared)
+        self.assertIs(thread.xfer_stats, shared)
+        self.assertIs(thread.task_tracker.xfer_stats, shared)
+
+    def test_tracker_records_expired_request(self):
+        from vllm import envs as vllm_envs
+
+        stats = MooncakeKVConnectorStats()
+        tracker = KVCacheTaskTracker(xfer_stats=stats)
+        tracker.add_req_to_process("req1")
+        tracker.add_delayed_request("req1", time.time() - vllm_envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT - 1)
+
+        result = tracker.get_and_clear_finished_requests()
+
+        self.assertEqual(result, {"req1"})
+        self.assertEqual(stats.data["num_kv_expired_reqs"], [1])
+
+    def test_tracker_without_stats_still_expires(self):
+        from vllm import envs as vllm_envs
+
+        tracker = KVCacheTaskTracker()
+        tracker.add_req_to_process("req1")
+        tracker.add_delayed_request("req1", time.time() - vllm_envs.VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT - 1)
+        self.assertEqual(tracker.get_and_clear_finished_requests(), {"req1"})
+
+    def test_worker_get_kv_connector_stats_drains(self):
+        worker = object.__new__(MooncakeConnectorWorker)
+        worker.xfer_stats = MooncakeKVConnectorStats()
+
+        self.assertIsNone(worker.get_kv_connector_stats())
+
+        worker.xfer_stats.record_transfer(duration_s=0.5, total_bytes=2**20, num_descs=4)
+        worker.xfer_stats.record_failed_recv()
+        snapshot = worker.get_kv_connector_stats()
+
+        assert snapshot is not None
+        self.assertEqual(snapshot.data["transfer_duration"], [0.5])
+        self.assertEqual(snapshot.data["num_failed_recvs"], [1])
+        reduced = snapshot.reduce()
+        self.assertEqual(reduced["Num successful transfers"], 1)
+        self.assertEqual(reduced["Num failed recvs"], 1)
+        # A second call in the same interval has nothing new to report.
+        self.assertIsNone(worker.get_kv_connector_stats())
+
+    def test_connector_stats_methods(self):
+        connector = object.__new__(MooncakeConnector)
+        connector.connector_worker = None
+        self.assertIsNone(connector.get_kv_connector_stats())
+
+        worker = MagicMock()
+        sentinel = MooncakeKVConnectorStats()
+        worker.get_kv_connector_stats.return_value = sentinel
+        connector.connector_worker = worker
+        self.assertIs(connector.get_kv_connector_stats(), sentinel)
+
+        built = MooncakeConnector.build_kv_connector_stats()
+        self.assertIsInstance(built, MooncakeKVConnectorStats)
+        self.assertTrue(built.is_empty())
+        rebuilt = MooncakeConnector.build_kv_connector_stats({"transfer_duration": [0.1]})
+        assert rebuilt is not None
+        self.assertEqual(rebuilt.data["transfer_duration"], [0.1])

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -31,6 +31,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import MooncakeKVConnectorStats
 from vllm.distributed.parallel_state import (
     get_pp_group,
     get_tensor_model_parallel_rank,
@@ -125,9 +127,10 @@ class SizedDict(OrderedDict):
 
 
 class KVCacheTaskTracker:
-    def __init__(self):
+    def __init__(self, xfer_stats: MooncakeKVConnectorStats | None = None):
         super().__init__()
 
+        self.xfer_stats = xfer_stats
         self.done_task_lock = threading.Lock()
         self.finished_requests: set[str] = set()
         # Only used in prefill node. Tracks requests whose kv blocks freeing is
@@ -191,6 +194,8 @@ class KVCacheTaskTracker:
                 self.delayed_free_requests.popitem(last=False)
                 self.reqs_to_process.discard(request_id)
                 expired_requests.add(request_id)
+                if self.xfer_stats is not None:
+                    self.xfer_stats.record_kv_expired_req()
                 logger.info(
                     "Force freed expired request: %s. "
                     "Reason: Request exceeded timeout threshold (%s seconds). "
@@ -215,6 +220,7 @@ class KVCacheSendingThread(threading.Thread):
         metadata: MooncakeAgentMetadata,
         ready_event: threading.Event,
         kv_caches: dict[str, Any],
+        xfer_stats: MooncakeKVConnectorStats | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheSendingThread")
         self.tp_rank = tp_rank
@@ -230,7 +236,7 @@ class KVCacheSendingThread(threading.Thread):
         self.kv_caches = kv_caches
         self.port_send_num: dict[str, int] = {}
 
-        self.task_tracker = KVCacheTaskTracker()
+        self.task_tracker = KVCacheTaskTracker(xfer_stats)
 
     def get_and_clear_finished_requests(self) -> set[str]:
         """
@@ -385,6 +391,7 @@ class KVCacheRecvingThread(threading.Thread):
         kv_cache_config: KVCacheConfig,
         kv_caches: dict[str, Any],
         prefill_pp_layer_partition: str | None = None,
+        xfer_stats: MooncakeKVConnectorStats | None = None,
     ):
         super().__init__(daemon=True, name="KVCacheRecvingThread")
         self.tp_rank = tp_rank
@@ -425,7 +432,8 @@ class KVCacheRecvingThread(threading.Thread):
         self.finished_request_markers: set[str] = set()
         self.request_task_counts_lock = threading.Lock()
 
-        self.task_tracker = KVCacheTaskTracker()
+        self.xfer_stats = xfer_stats if xfer_stats is not None else MooncakeKVConnectorStats()
+        self.task_tracker = KVCacheTaskTracker(self.xfer_stats)
 
         self.encoder = msgspec.msgpack.Encoder()
         self.decoder = msgspec.msgpack.Decoder(MooncakeAgentMetadata)
@@ -604,6 +612,9 @@ class KVCacheRecvingThread(threading.Thread):
                 self._transfer_kv_cache_all_groups(req_meta)
             logger.debug("Finished transferring KV cache for request %s.", remote_request_id)
         except Exception:
+            # Counted per failed receive task; an engine failure also counts
+            # once as a failed transfer op before raising here.
+            self.xfer_stats.record_failed_recv()
             logger.exception("Failed to transfer KV cache for request %s.", remote_request_id)
         finally:
             self._send_done_signal_to_free_remote_port(remote_request_id, remote_host, remote_port_send_num)
@@ -696,14 +707,22 @@ class KVCacheRecvingThread(threading.Thread):
                     dst_list.append(dst)
                     length_list.append(length)
 
+        xfer_start_time = time.perf_counter()
         ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
+        xfer_duration = time.perf_counter() - xfer_start_time
         if ret < 0:
+            self.xfer_stats.record_failed_transfer()
             logger.error(
                 "Mooncake transfer failed for request. remote_request_id=%s, ret=%d. ",
                 req_meta["remote_request_id"],
                 ret,
             )
             raise RuntimeError(f"Mooncake transfer failed, ret: {ret}")
+        self.xfer_stats.record_transfer(
+            duration_s=xfer_duration,
+            total_bytes=sum(length_list),
+            num_descs=len(src_list),
+        )
 
         req_end_time = time.perf_counter()
         req_transfer_elapsed = (req_end_time - req_start_time) * 1000
@@ -796,14 +815,22 @@ class KVCacheRecvingThread(threading.Thread):
                 dst_list.append(dst)
                 length_list.append(length)
 
+        xfer_start_time = time.perf_counter()
         ret = self.engine.batch_transfer_sync_read(session_id, src_list, dst_list, length_list)
+        xfer_duration = time.perf_counter() - xfer_start_time
         if ret < 0:
+            self.xfer_stats.record_failed_transfer()
             logger.error(
                 "Mooncake transfer failed for request. remote_request_id=%s, ret=%d. ",
                 req_meta["remote_request_id"],
                 ret,
             )
             raise RuntimeError(f"Mooncake transfer failed, ret: {ret}")
+        self.xfer_stats.record_transfer(
+            duration_s=xfer_duration,
+            total_bytes=sum(length_list),
+            num_descs=len(src_list),
+        )
 
         req_end_time = time.perf_counter()
         req_transfer_elapsed = (req_end_time - req_start_time) * 1000
@@ -1153,6 +1180,22 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def wait_for_save(self):
         """MooncakeConnector does not save explicitly."""
         pass
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return worker-local transfer stats since the last call.
+
+        Note the P/D asymmetry: this connector is D-pull (the decode worker
+        calls batch_transfer_sync_read), so D records successful transfer
+        latency, bytes and descriptor counts as well as failed pulls, while
+        P only records requests whose KV expired before being fetched.
+        """
+        if self.connector_worker is None:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+    @classmethod
+    def build_kv_connector_stats(cls, data: dict[str, Any] | None = None) -> KVConnectorStats | None:
+        return MooncakeKVConnectorStats(data=data or {})
 
     def get_handshake_metadata(self) -> KVConnectorHandshakeMetadata | None:
         """
@@ -1569,6 +1612,10 @@ class MooncakeConnectorWorker:
         self.kv_send_thread: KVCacheSendingThread | None = None
         self.kv_recv_thread: KVCacheRecvingThread | None = None
 
+        # Transfer stats shared with the sending/receiving thread; drained
+        # periodically via get_kv_connector_stats.
+        self.xfer_stats = MooncakeKVConnectorStats()
+
         # Handshake metadata of this worker
         self.xfer_handshake_metadata: MooncakeAgentMetadata | None = None
 
@@ -1714,6 +1761,7 @@ class MooncakeConnectorWorker:
                 metadata,
                 ready_event,
                 self.kv_caches,
+                xfer_stats=self.xfer_stats,
             )
             self.kv_send_thread.start()
         else:
@@ -1738,6 +1786,7 @@ class MooncakeConnectorWorker:
                 self.kv_cache_config,
                 self.kv_caches,
                 self._prefill_pp_layer_partition,
+                xfer_stats=self.xfer_stats,
             )
             self.kv_recv_thread.start()
 
@@ -1771,6 +1820,13 @@ class MooncakeConnectorWorker:
                 len(done_recving),
             )
         return done_sending, done_recving
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return transfer stats collected since the last call, or None
+        if nothing has been recorded in this interval."""
+        if self.xfer_stats.is_empty():
+            return None
+        return self.xfer_stats.clone_and_reset()
 
     def start_load_kv(self, metadata: MooncakeConnectorMetadata):
         """Start loading KV blocks from remote engine."""


### PR DESCRIPTION
### What this PR does / why we need it?

Third connector in the series after #14237 (plain Mooncake) and #14243 (layerwise): `MooncakeHybridConnector` had no KV transfer metrics either, so hybrid P/D deployments run blind — no transfer latency, no bytes, no failure counters.

Same approach as the other two: reuse the upstream `MooncakeKVConnectorStats` container and wire the Ascend record sites. Like the plain connector this one is D-pull, so the receiving thread records successful pulls (duration, bytes and descriptor count) and engine failures around both transfer paths — `_transfer_kv_cache_all_groups` for the hybrid layout and `_transfer_kv_cache` for the single-group one — `_handle_request` records failed receive tasks, and `KVCacheTaskTracker` records producer-side force-freed expired requests. The worker shares one stats object with its sending/receiving thread and drains it via `get_kv_connector_stats()`; everything downstream is inherited from vLLM.

### Does this PR introduce _any_ user-facing change?

KV transfer stats now show up in the standard vLLM connector stats logging when using `MooncakeHybridConnector`. No config or API change.

### How was this patch tested?

Added unit tests covering both transfer paths (success and engine failure), the failed receive task, the expired request, stats sharing between the worker and its thread, the drain semantics, and `build_kv_connector_stats`. `tests/ut/kv_offload/test_mooncake_hybrid_connector.py` (15 passed) plus the rest of `tests/ut/kv_offload` and `tests/ut/distributed/{kv_transfer,mooncake}` pass locally on CPU. I don't have Ascend hardware, so I'm relying on the NPU CI for hardware coverage.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
