### PR TITLE
[Feature][KV Transfer] Support KVConnectorStats for SfaRemoteD2HConnector

### DIFF
--- a/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
+++ b/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
@@ -37,6 +37,7 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h.protocol import (  #
 from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h.read_thread import (  # noqa: E402
     ConsumerReadState,
     MembPullReadThread,
+    MooncakeKVConnectorStats,
 )
 from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h.scheduler import (  # noqa: E402
     SFAPDRD2HProducerScheduler,
@@ -168,6 +169,7 @@ def _make_read_thread() -> MembPullReadThread:
         dest_blocks_by_req={"req-0": ([3, 4], [8])},
         get_offload_layer_id=lambda _: 0,
     )
+    thread.xfer_stats = MooncakeKVConnectorStats()
     return thread
 
 
@@ -1337,3 +1339,104 @@ def test_discard_requests_clears_partial_contributor_state():
     thread.discard_requests({"req-0"})
     assert "req-0" not in thread._done_contributors
     assert "req-0" not in thread._expected_ratio
+
+
+def test_read_batch_records_transfer_stats():
+    thread = _make_read_thread()
+    thread.engine = MagicMock()
+    thread.engine.batch_transfer_sync_read.return_value = 0
+    layer = _make_layer(k_cpu_ptr=3000, v_cpu_ptr=4000, has_indexer=False)
+    thread._resolve_read_layer = MagicMock(return_value=layer)  # type: ignore[method-assign]
+
+    thread._do_read_batch(
+        layer["layer_name"],
+        [("req-0", [1, 2], [], 0, 0)],
+        p_session="p-session",
+        p_layer_meta={},
+    )
+
+    _, local_ptrs, _, lengths = thread.engine.batch_transfer_sync_read.call_args[0]
+    stats_data = thread.xfer_stats.data
+    assert len(stats_data["transfer_duration"]) == 1
+    assert stats_data["transfer_duration"][0] >= 0
+    assert stats_data["bytes_transferred"] == [sum(lengths)]
+    assert stats_data["num_descriptors"] == [len(local_ptrs)]
+    assert stats_data["num_failed_transfers"] == []
+
+
+def test_read_batch_failure_records_failed_transfer():
+    thread = _make_read_thread()
+    thread.engine = MagicMock()
+    thread.engine.batch_transfer_sync_read.return_value = -1
+    layer = _make_layer(k_cpu_ptr=3000, v_cpu_ptr=4000, has_indexer=False)
+    thread._resolve_read_layer = MagicMock(return_value=layer)  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        thread._do_read_batch(
+            layer["layer_name"],
+            [("req-0", [1, 2], [], 0, 0)],
+            p_session="p-session",
+            p_layer_meta={},
+        )
+
+    assert thread.xfer_stats.data["num_failed_transfers"] == [1]
+    assert thread.xfer_stats.data["transfer_duration"] == []
+
+
+def test_read_thread_uses_the_stats_object_it_is_given():
+    shared = MooncakeKVConnectorStats()
+    thread = MembPullReadThread(
+        tp_rank=0,
+        side_channel_port=5555,
+        engine=MagicMock(),
+        state=_make_read_thread()._state,
+        xfer_stats=shared,
+    )
+    assert thread.xfer_stats is shared
+
+
+def test_consumer_worker_drains_stats():
+    worker = object.__new__(SFAPDRD2HConsumerWorker)
+    worker.xfer_stats = MooncakeKVConnectorStats()
+
+    assert worker.get_kv_connector_stats() is None
+
+    worker.xfer_stats.record_transfer(duration_s=0.25, total_bytes=2**20, num_descs=6)
+    worker.xfer_stats.record_failed_recv()
+    snapshot = worker.get_kv_connector_stats()
+
+    assert snapshot is not None
+    assert snapshot.data["transfer_duration"] == [0.25]
+    assert snapshot.data["num_failed_recvs"] == [1]
+    reduced = snapshot.reduce()
+    assert reduced["Num successful transfers"] == 1
+    assert reduced["Num failed recvs"] == 1
+    # A second call in the same interval has nothing new to report.
+    assert worker.get_kv_connector_stats() is None
+
+
+def test_connector_stats_only_reported_by_the_consumer_side():
+    connector = object.__new__(SfaRemoteD2HConnector)
+    connector.is_consumer = True
+    connector.connector_worker = None
+    assert connector.get_kv_connector_stats() is None
+
+    sentinel = MooncakeKVConnectorStats()
+    worker = MagicMock()
+    worker.get_kv_connector_stats.return_value = sentinel
+    connector.connector_worker = worker
+    assert connector.get_kv_connector_stats() is sentinel
+
+    # P holds no transfer stats: its send thread only notifies readiness.
+    connector.is_consumer = False
+    assert connector.get_kv_connector_stats() is None
+
+
+def test_connector_builds_stats_from_wire_data():
+    built = SfaRemoteD2HConnector.build_kv_connector_stats()
+    assert isinstance(built, MooncakeKVConnectorStats)
+    assert built.is_empty()
+
+    rebuilt = SfaRemoteD2HConnector.build_kv_connector_stats({"transfer_duration": [0.1]})
+    assert rebuilt is not None
+    assert rebuilt.data["transfer_duration"] == [0.1]

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/connector.py
@@ -20,6 +20,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import MooncakeKVConnectorStats
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -158,6 +160,20 @@ class SfaRemoteD2HConnector(KVConnectorBase_V1, SupportsHMA):
     def get_block_ids_with_load_errors(self) -> set[int]:
         assert self.connector_worker is not None
         return self.connector_worker.get_block_ids_with_load_errors()
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return worker-local transfer stats since the last call.
+
+        Only D records transfers: the memfabric path is a D-side pull, and the
+        P-side send thread just notifies readiness without moving KV itself.
+        """
+        if self.connector_worker is None or not self.is_consumer:
+            return None
+        return self.connector_worker.get_kv_connector_stats()
+
+    @classmethod
+    def build_kv_connector_stats(cls, data: dict[str, Any] | None = None) -> KVConnectorStats | None:
+        return MooncakeKVConnectorStats(data=data or {})
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/read_thread.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/read_thread.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import math
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -13,6 +14,7 @@ from typing import Any
 import msgspec
 import numpy as np
 import zmq
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import MooncakeKVConnectorStats
 from vllm.logger import logger
 from vllm.utils.network_utils import get_ip
 
@@ -88,12 +90,14 @@ class MembPullReadThread(threading.Thread):
         side_channel_port: int,
         engine: Any,
         state: ConsumerReadState,
+        xfer_stats: MooncakeKVConnectorStats | None = None,
     ):
         super().__init__(daemon=True, name=f"MembPullReadThread-TP{tp_rank}")
         self.tp_rank = tp_rank
         self.side_channel_port = side_channel_port
         self.engine = engine
         self._state = state
+        self.xfer_stats = xfer_stats if xfer_stats is not None else MooncakeKVConnectorStats()
         self.ready_event = threading.Event()
         self._p_session: str | None = None
         self._p_layer_meta: dict[str, Any] = {}
@@ -280,6 +284,9 @@ class MembPullReadThread(threading.Thread):
                             failed_ids.update(done_ext_ids)
                             with self._lock:
                                 self._failed_requests.update(failed_ids)
+                            # Counted per failed batch; an engine error also
+                            # counts once as a failed transfer before raising.
+                            self.xfer_stats.record_failed_recv()
                         if succeeded and done_ext_ids:
                             self._record_chunk_done(done_ext_ids, group_member_idx, ratio)
 
@@ -747,8 +754,16 @@ class MembPullReadThread(threading.Thread):
                 len(all_local_ptrs),
                 atomic_total,
             )
+        read_start_time = time.perf_counter()
         ret = self.engine.batch_transfer_sync_read(p_session, all_local_ptrs, all_peer_ptrs, all_lengths)
+        read_duration = time.perf_counter() - read_start_time
         if ret != 0:
+            self.xfer_stats.record_failed_transfer()
             raise RuntimeError(f"memfabric batch read failed for layer {layer_name}, ret={ret}")
+        self.xfer_stats.record_transfer(
+            duration_s=read_duration,
+            total_bytes=sum(all_lengths),
+            num_descs=len(all_local_ptrs),
+        )
         for read_info in read_infos:
             self._log_read_result(read_info)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/worker.py
@@ -25,6 +25,8 @@ import torch
 from vllm.config import VllmConfig
 from vllm.distributed import get_tensor_model_parallel_rank, get_tp_group
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.mooncake.stats import MooncakeKVConnectorStats
 from vllm.logger import logger
 from vllm.utils.network_utils import get_ip
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -144,6 +146,10 @@ class SFAPDRD2HConsumerWorker:
         # rank has finished the same request. This is scheduler readiness state,
         # not a per-layer barrier.
         self._terminal_ext_ids: set[str] = set()
+        # Transfer stats shared with the read thread, drained periodically via
+        # get_kv_connector_stats. The container is upstream's Mooncake one: the
+        # transport here is memfabric, but the recorded series are identical.
+        self.xfer_stats = MooncakeKVConnectorStats()
 
     # ------------------------------------------------------------------
     # Common
@@ -292,6 +298,13 @@ class SFAPDRD2HConsumerWorker:
         self._invalid_block_ids = set()
         return result
 
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return transfer stats collected since the last call, or None
+        if nothing has been recorded in this interval."""
+        if self.xfer_stats.is_empty():
+            return None
+        return self.xfer_stats.clone_and_reset()
+
     def get_num_cpu_blocks(self, req_ids: list[str]) -> dict[str, int] | None:
         """Per-req actual main-MLA CPU-block count for the solution-1 threshold."""
         if self.offload_manager is None:
@@ -403,6 +416,7 @@ class SFAPDRD2HConsumerWorker:
             side_channel_port=self.side_channel_port,
             engine=self.engine,
             state=read_state,
+            xfer_stats=self.xfer_stats,
         )
         self._mf_read_thread.start()
         if not self._mf_read_thread.ready_event.wait(timeout=CONNECTOR_THREAD_STARTUP_TIMEOUT_SECONDS):


### PR DESCRIPTION
### What this PR does / why we need it?

Last of the four `kv_p2p` connectors, after #14237, #14243 and #14252. With this one the whole family reports KV transfer metrics through the standard vLLM pipeline instead of nothing.

Two things differ from the Mooncake connectors. The transport is memfabric rather than the Mooncake engine, but the recorded series are identical (durations, bytes, descriptor counts, failure counters), so I reused upstream's `MooncakeKVConnectorStats` instead of duplicating a container — there is a comment saying so where the object is created. And the traffic is one-sided: only D moves KV, through `batch_transfer_sync_read` in the read thread, while P's send thread just notifies readiness. So the read thread records duration, bytes and descriptor count per batched read plus engine failures, the batch error path records the failed read, and `get_kv_connector_stats()` returns None on the producer side rather than pretending P has transfer stats.

### Does this PR introduce _any_ user-facing change?

KV transfer stats now show up in the standard vLLM connector stats logging when using `SfaRemoteD2HConnector`. No config or API change.

### How was this patch tested?

Added unit tests for the batched read (success and engine failure), the stats object being shared with the read thread, the consumer worker drain semantics, `build_kv_connector_stats`, and the producer side returning no stats. `tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py` (78 passed) plus the rest of `tests/ut/kv_offload` and `tests/ut/distributed/{kv_transfer,mooncake}` pass locally on CPU. I don't have Ascend hardware, so I'm relying on the NPU CI for hardware coverage.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
