### PR TITLE
[BugFix][KV Offload] Normalize aligned Mamba state block transfer

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -977,8 +977,11 @@ class TestCoreFunctionality(unittest.TestCase):
         # Pure metadata/address arithmetic: no NPU tensor or torch.npu call.
         self._configure_mock_mamba_transfer()
         self.thread.mamba_cache_mode = "align"
+        self.thread.num_speculative_tokens = 7
         req = dict(self.test_req)
-        req["local_block_ids"] = [[2]]
+        # The aligned allocator returns the running-state destination first,
+        # followed by speculative blocks. The transfer must target block 2.
+        req["local_block_ids"] = [[2, 20, 21, 22, 23, 24, 25, 26]]
         req["remote_block_ids"] = [[3]]
         req["group_pulls"] = [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)]
 

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -976,6 +976,7 @@ class TestCoreFunctionality(unittest.TestCase):
     def test_transfer_mamba_uses_normalized_prompt_state_block(self, mock_get_meta):
         # Pure metadata/address arithmetic: no NPU tensor or torch.npu call.
         self._configure_mock_mamba_transfer()
+        self.thread.mamba_cache_mode = "align"
         req = dict(self.test_req)
         req["local_block_ids"] = [[2]]
         req["remote_block_ids"] = [[3]]
@@ -994,6 +995,7 @@ class TestCoreFunctionality(unittest.TestCase):
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
     def test_transfer_mamba_rejects_unnormalized_remote_blocks(self, mock_get_meta):
         self._configure_mock_mamba_transfer()
+        self.thread.mamba_cache_mode = "align"
         req = dict(self.test_req)
         req["local_block_ids"] = [[2]]
         # The old token-count based selector crashed for one to three blocks
@@ -1006,6 +1008,27 @@ class TestCoreFunctionality(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "exactly one normalized remote state block"):
             self.thread._transfer_kv_cache_all_groups(req)
         self.engine.batch_transfer_sync_read.assert_not_called()
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_mamba_non_aligned_selects_prompt_state_before_draft_blocks(self, mock_get_meta):
+        # Pure metadata/address arithmetic: no NPU tensor or torch.npu call.
+        self._configure_mock_mamba_transfer()
+        self.thread.mamba_cache_mode = "none"
+        self.thread.num_speculative_tokens = 7
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[2, 20, 21, 22, 23, 24, 25, 26]]
+        req["remote_block_ids"] = [[3, 30, 31, 32, 33, 34, 35, 36]]
+        req["group_pulls"] = [
+            GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)
+        ]
+
+        self.thread._transfer_kv_cache_all_groups(req)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[1], [0x1000 + 2 * 128, 0x2000 + 2 * 256])
+        self.assertEqual(call_args[2], [0x3000 + 3 * 160, 0x4000 + 3 * 512])
+        self.assertEqual(call_args[3], [100, 200])
         mock_get_meta.assert_not_called()
 
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -933,6 +933,15 @@ class TestCoreFunctionality(unittest.TestCase):
         self.thread.remote_te_port = {"remote_engine": {6666: 7777}}
         self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[1024]]
 
+    def _configure_mock_mamba_transfer(self):
+        self.thread.kv_group2layeridx = {0: ({"kv_cache_spec_type": "MambaSpec"}, [0])}
+        self.thread.kv_caches_base_addr["local_engine"][5555] = [[0x1000, 0x2000]]
+        self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000, 0x4000]]}
+        self.thread.block_len_per_addr = [[100, 200]]
+        self.thread.block_stride_per_addr = [[128, 256]]
+        self.thread.remote_block_size_scale["remote_engine"] = {6666: [[1, 1]]}
+        self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[160, 512]]
+
     @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
     @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
     def test_handle_request(self, mock_send, mock_transfer):
@@ -961,6 +970,42 @@ class TestCoreFunctionality(unittest.TestCase):
         self.assertIsInstance(call_args[3], list)
         self.assertEqual(len(call_args[1]), len(call_args[2]))
         self.assertEqual(len(call_args[1]), len(call_args[3]))
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_mamba_uses_normalized_prompt_state_block(self, mock_get_meta):
+        # Pure metadata/address arithmetic: no NPU tensor or torch.npu call.
+        self._configure_mock_mamba_transfer()
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[2]]
+        req["remote_block_ids"] = [[3]]
+        req["group_pulls"] = [
+            GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)
+        ]
+
+        self.thread._transfer_kv_cache_all_groups(req)
+
+        call_args, _ = self.engine.batch_transfer_sync_read.call_args
+        self.assertEqual(call_args[1], [0x1000 + 2 * 128, 0x2000 + 2 * 256])
+        self.assertEqual(call_args[2], [0x3000 + 3 * 160, 0x4000 + 3 * 512])
+        self.assertEqual(call_args[3], [100, 200])
+        mock_get_meta.assert_not_called()
+
+    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
+    def test_transfer_mamba_rejects_unnormalized_remote_blocks(self, mock_get_meta):
+        self._configure_mock_mamba_transfer()
+        req = dict(self.test_req)
+        req["local_block_ids"] = [[2]]
+        # The old token-count based selector crashed for one to three blocks
+        # and silently wrapped for four to seven blocks. Reject both forms.
+        req["remote_block_ids"] = [[3, 4, 5]]
+        req["group_pulls"] = [
+            GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "exactly one normalized remote state block"):
+            self.thread._transfer_kv_cache_all_groups(req)
+        self.engine.batch_transfer_sync_read.assert_not_called()
         mock_get_meta.assert_not_called()
 
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
@@ -1908,7 +1953,22 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
 
         self.assertEqual(block_ids, ([10, 11, 12],))
 
-    def test_get_transfer_block_ids_keeps_state_group(self):
+    def test_get_transfer_block_ids_selects_aligned_prompt_state_block(self):
+        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "align"
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(  # type: ignore[list-item]
+                tokens_per_block=16,
+                blocks_per_window=0,
+                is_state_group=True,
+            )
+        ]
+
+        block_ids = self.scheduler._get_transfer_block_ids(([20, 21, 22, 23, 24],), prompt_len=33)
+
+        self.assertEqual(block_ids, ([22],))
+
+    def test_get_transfer_block_ids_keeps_non_aligned_state_group(self):
+        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "none"
         self.scheduler.group_transfer_info = [
             types.SimpleNamespace(  # type: ignore[list-item]
                 tokens_per_block=16,
@@ -1920,6 +1980,19 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         block_ids = self.scheduler._get_transfer_block_ids(([20, 21, 22, 23],), prompt_len=16)
 
         self.assertEqual(block_ids, ([20, 21, 22, 23],))
+
+    def test_get_transfer_block_ids_rejects_short_aligned_state_metadata(self):
+        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "align"
+        self.scheduler.group_transfer_info = [
+            types.SimpleNamespace(  # type: ignore[list-item]
+                tokens_per_block=16,
+                blocks_per_window=0,
+                is_state_group=True,
+            )
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "Invalid aligned Mamba state block metadata"):
+            self.scheduler._get_transfer_block_ids(([20, 21],), prompt_len=48)
 
     def test_get_transfer_block_ids_uses_compressed_prompt_len(self):
         self.scheduler.group_transfer_info = [
@@ -2082,6 +2155,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertIn("req_mtp_swa", self.scheduler._reqs_need_send)
 
     def test_request_finished_handles_mtp_swa_and_state_groups_together(self):
+        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "align"
         self.scheduler.group_transfer_info = [
             types.SimpleNamespace(
                 tokens_per_block=16,
@@ -2118,7 +2192,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
             (
                 [100, 101, 102, 103],
                 [200, 201, 202],
-                [300, 301, 302, 303, 304],
+                [303],
             ),
         )
         self.assertEqual(params["num_prompt_blocks"], 4)

--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -980,9 +980,7 @@ class TestCoreFunctionality(unittest.TestCase):
         req = dict(self.test_req)
         req["local_block_ids"] = [[2]]
         req["remote_block_ids"] = [[3]]
-        req["group_pulls"] = [
-            GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)
-        ]
+        req["group_pulls"] = [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)]
 
         self.thread._transfer_kv_cache_all_groups(req)
 
@@ -1001,9 +999,7 @@ class TestCoreFunctionality(unittest.TestCase):
         # The old token-count based selector crashed for one to three blocks
         # and silently wrapped for four to seven blocks. Reject both forms.
         req["remote_block_ids"] = [[3, 4, 5]]
-        req["group_pulls"] = [
-            GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)
-        ]
+        req["group_pulls"] = [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)]
 
         with self.assertRaisesRegex(RuntimeError, "exactly one normalized remote state block"):
             self.thread._transfer_kv_cache_all_groups(req)
@@ -1019,9 +1015,7 @@ class TestCoreFunctionality(unittest.TestCase):
         req = dict(self.test_req)
         req["local_block_ids"] = [[2, 20, 21, 22, 23, 24, 25, 26]]
         req["remote_block_ids"] = [[3, 30, 31, 32, 33, 34, 35, 36]]
-        req["group_pulls"] = [
-            GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)
-        ]
+        req["group_pulls"] = [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)]
 
         self.thread._transfer_kv_cache_all_groups(req)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -500,6 +500,12 @@ class KVCacheRecvingThread(threading.Thread):
         assert vllm_config is not None
         self.vllm_config: VllmConfig = vllm_config
         self.model_config = self.vllm_config.model_config
+        self.mamba_cache_mode = getattr(self.vllm_config.cache_config, "mamba_cache_mode", None)
+        self.num_speculative_tokens = (
+            self.vllm_config.speculative_config.num_speculative_tokens
+            if self.vllm_config.speculative_config is not None
+            else 0
+        )
         self.use_mla = self.model_config.is_deepseek_mla
         self.enable_sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(self.vllm_config)
         self.is_hma_required = is_hma_required
@@ -831,14 +837,26 @@ class KVCacheRecvingThread(threading.Thread):
                         )
                     )
             else:
-                if len(remote_group_block_ids) != 1:
-                    raise RuntimeError(
-                        "Mooncake Mamba transfer requires exactly one normalized remote state block; "
-                        f"request_id={remote_request_id}, group_idx={group_idx}, "
-                        f"remote_block_count={len(remote_group_block_ids)}, "
-                        f"local_block_count={len(local_group_block_ids)}."
-                    )
-                grouped_remote_block_ids = [[remote_group_block_ids[0]]]
+                if self.mamba_cache_mode == "align":
+                    if len(remote_group_block_ids) != 1:
+                        raise RuntimeError(
+                            "Mooncake Mamba transfer requires exactly one normalized remote state block; "
+                            f"request_id={remote_request_id}, group_idx={group_idx}, "
+                            f"remote_block_count={len(remote_group_block_ids)}, "
+                            f"local_block_count={len(local_group_block_ids)}."
+                        )
+                    remote_state_block_id = remote_group_block_ids[0]
+                else:
+                    transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
+                    if transfer_block_idx < 0:
+                        raise RuntimeError(
+                            "Invalid non-aligned Mamba state block metadata: "
+                            f"request_id={remote_request_id}, group_idx={group_idx}, "
+                            f"remote_block_count={len(remote_group_block_ids)}, "
+                            f"num_speculative_tokens={self.num_speculative_tokens}."
+                        )
+                    remote_state_block_id = remote_group_block_ids[transfer_block_idx]
+                grouped_remote_block_ids = [[remote_state_block_id]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
 
             if is_mamba_group:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -500,11 +500,6 @@ class KVCacheRecvingThread(threading.Thread):
         assert vllm_config is not None
         self.vllm_config: VllmConfig = vllm_config
         self.model_config = self.vllm_config.model_config
-        self.num_speculative_tokens = (
-            self.vllm_config.speculative_config.num_speculative_tokens
-            if self.vllm_config.speculative_config is not None
-            else 0
-        )
         self.use_mla = self.model_config.is_deepseek_mla
         self.enable_sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(self.vllm_config)
         self.is_hma_required = is_hma_required
@@ -836,10 +831,14 @@ class KVCacheRecvingThread(threading.Thread):
                         )
                     )
             else:
-                # When Prefix Caching is enabled on both P and D nodes, num_block should not be forced to match,
-                # as the D-node requires dynamic allocation based on its specific cache hit rate.
-                transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
-                grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
+                if len(remote_group_block_ids) != 1:
+                    raise RuntimeError(
+                        "Mooncake Mamba transfer requires exactly one normalized remote state block; "
+                        f"request_id={remote_request_id}, group_idx={group_idx}, "
+                        f"remote_block_count={len(remote_group_block_ids)}, "
+                        f"local_block_count={len(local_group_block_ids)}."
+                    )
+                grouped_remote_block_ids = [[remote_group_block_ids[0]]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
 
             if is_mamba_group:
@@ -1658,9 +1657,11 @@ class MooncakeConnectorScheduler:
     def _get_transfer_block_ids(self, block_ids: BlockIds, prompt_len: int) -> BlockIds:
         """Return blocks that contain prompt KV, dropping MTP extra blocks.
 
-        State groups such as Mamba are not context-block aligned with attention
-        KV, so keep them unchanged and only clip attention-like groups here.
-        SWA tail clipping is handled as a separate step after this.
+        In aligned Mamba mode, normalize each state group to the single block
+        containing the final prompt state. This prevents the receiver from
+        inferring a block index from a speculative *token* count. Non-aligned
+        state groups keep their existing behavior. SWA tail clipping is handled
+        as a separate step after this.
         """
         if len(block_ids) == 0:
             return block_ids
@@ -1670,8 +1671,23 @@ class MooncakeConnectorScheduler:
         transfer_block_ids = []
         cp_size = max(1, self.pcp_size * self.dcp_size)
         for blocks, group_info in zip(block_ids, self.group_transfer_info):
-            if group_info.is_state_group:
+            is_aligned_state_group = group_info.is_state_group and (
+                getattr(self.vllm_config.cache_config, "mamba_cache_mode", None) == "align"
+            )
+            if group_info.is_state_group and not is_aligned_state_group:
                 transfer_block_ids.append(blocks)
+            elif is_aligned_state_group:
+                # Mamba state is not CP-sharded like attention KV. Its aligned
+                # block index is derived from the actual (already truncated)
+                # prompt length, without multiplying by the CP size.
+                num_prompt_state_blocks = cdiv(prompt_len, group_info.tokens_per_block)
+                if num_prompt_state_blocks <= 0 or num_prompt_state_blocks > len(blocks):
+                    raise RuntimeError(
+                        "Invalid aligned Mamba state block metadata: "
+                        f"prompt_len={prompt_len}, tokens_per_block={group_info.tokens_per_block}, "
+                        f"required_block_count={num_prompt_state_blocks}, available_block_count={len(blocks)}."
+                    )
+                transfer_block_ids.append(blocks[num_prompt_state_blocks - 1 : num_prompt_state_blocks])
             else:
                 # In context parallelism, each scheduler-visible block id is a
                 # CP-grouped/virtual block shared by all CP ranks. It therefore

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -837,6 +837,8 @@ class KVCacheRecvingThread(threading.Thread):
                         )
                     )
             else:
+                # Ascend Hybrid Mamba supports "align" (prefix caching) and
+                # "none" (no prefix caching), but not "all".
                 if self.mamba_cache_mode == "align":
                     if len(remote_group_block_ids) != 1:
                         raise RuntimeError(


### PR DESCRIPTION
## Problem

For aligned Mamba state groups, the Mooncake receiver selected a remote block with:

```python
len(remote_group_block_ids) - num_speculative_tokens - 1
```

This mixes two different units: a block count and a speculative-token count. With DSpark enabled, short metadata lists can either raise `IndexError` or silently select the wrong block through Python negative-index wrapping. Higher concurrency increases exposure to these request lengths and retry overlap, but the selection is incorrect even for a single request.

## Fix

- Normalize aligned Mamba metadata on the producer to the one block containing the final prompt state.
- Require exactly one normalized remote state block on the receiver and consume it directly.
- Keep non-aligned state groups and attention/SWA behavior unchanged.
- Add CPU-only unit coverage for producer selection, receiver address arithmetic, invalid legacy metadata, and mixed attention/SWA/Mamba groups.

The resulting transfer metadata is deterministic per request and no longer depends on DSpark's speculative-token count or concurrent completion order.

On the decode side, `KVCacheBlocks.get_unhashed_block_ids_all_groups()` preserves the aligned Mamba allocator order: the first unhashed block is the running-state destination, followed by speculative blocks. The existing `local_group_block_ids[0]` destination is therefore retained; only the invalid remote-block inference is removed.

## Deployment note

This changes the aligned-Mamba Mooncake metadata contract, so prefill and decode nodes must be upgraded together. A rolling mixed-version deployment is not supported by this patch.

## Tests

- `git diff --check`
- Both modified Python files pass `py_compile`.
- A stdlib-only extraction of the producer selector passes seven assertions covering aligned/non-aligned state groups, attention CP clipping, invalid short metadata, and the one-block receiver contract.
- Added targeted CPU-only Mooncake connector unit tests (no NPU tensors or `torch.npu` calls); full pytest execution is left to CI because the local Python environment does not provide pytest/torch/vLLM.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
