### PR TITLE
[Feat][Worker] Add MRV2 PP transfer DFX logs

### DIFF
--- a/tests/ut/worker/a2/test_worker_v2.py
+++ b/tests/ut/worker/a2/test_worker_v2.py
@@ -1,17 +1,30 @@
 from unittest.mock import MagicMock, patch
 
+import torch
 from vllm.sequence import IntermediateTensors
 
 from tests.ut.base import TestBase
+from vllm_ascend.worker.pp_dfx import (
+    PP_DFX_METADATA_KEY,
+    PPTransferDFX,
+    compute_tensor_fingerprints,
+    verify_tensor_fingerprints,
+)
 
 
 class TestNPUWorkerV2(TestBase):
+    @patch("vllm_ascend.worker.pp_dfx.logger.isEnabledFor", return_value=False)
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.enable_sp", return_value=False)
     @patch("vllm_ascend.worker.worker.get_pp_group")
     @patch("vllm_ascend.worker.worker.get_tp_group")
     def test_execute_model_middle_rank_pp(
-        self, mock_get_tp_group, mock_get_pp_group, mock_enable_sp, mock_get_ascend_config
+        self,
+        mock_get_tp_group,
+        mock_get_pp_group,
+        mock_enable_sp,
+        mock_get_ascend_config,
+        mock_debug_disabled,
     ):
         """MRV2 PP middle ranks send intermediate tensors and return None."""
         from vllm_ascend.worker.worker import NPUWorker
@@ -29,6 +42,7 @@ class TestNPUWorkerV2(TestBase):
             worker.use_v2_model_runner = True
             worker.profiler = None
             worker._pp_send_work = []
+            worker.pp_transfer_dfx = PPTransferDFX(worker.use_v2_model_runner)
 
             mock_pp_group = MagicMock()
             mock_pp_group.is_first_rank = False
@@ -52,3 +66,104 @@ class TestNPUWorkerV2(TestBase):
                 all_gather_group=mock_get_tp_group.return_value,
             )
             self.assertIsNone(result)
+
+    def test_pp_dfx_fingerprint_verification(self):
+        expected = compute_tensor_fingerprints(
+            {
+                "hidden_states": torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16),
+                "residual": torch.tensor([[3.0, 4.0]], dtype=torch.float32),
+            }
+        )
+
+        with patch("vllm_ascend.worker.pp_dfx.logger.debug") as mock_debug:
+            verify_tensor_fingerprints(
+                expected,
+                {
+                    "hidden_states": torch.tensor([[1.0, 2.0]], dtype=torch.bfloat16),
+                    "residual": torch.tensor([[3.0, 5.0]], dtype=torch.float32),
+                },
+                transfer_seq=3,
+                src_rank=0,
+                dst_rank=1,
+            )
+
+        mock_debug.assert_called_once_with(
+            "[pp-dfx] seq=%d link=%d->%d verify=failed tensor=%s",
+            3,
+            0,
+            1,
+            "residual",
+        )
+
+    @patch("vllm_ascend.worker.pp_dfx.time.perf_counter_ns", side_effect=[1_000_000, 2_500_000])
+    @patch("vllm_ascend.worker.pp_dfx.torch.npu.synchronize")
+    @patch("vllm_ascend.worker.pp_dfx.logger.isEnabledFor", return_value=True)
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    @patch("vllm_ascend.worker.worker.enable_sp", return_value=False)
+    @patch("vllm_ascend.worker.worker.get_pp_group")
+    @patch("vllm_ascend.worker.worker.get_tp_group")
+    def test_execute_model_middle_rank_pp_dfx(
+        self,
+        mock_get_tp_group,
+        mock_get_pp_group,
+        mock_enable_sp,
+        mock_get_ascend_config,
+        mock_debug_enabled,
+        mock_synchronize,
+        mock_perf_counter_ns,
+    ):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        mock_ascend_config = MagicMock()
+        mock_ascend_config.msmonitor_use_daemon = False
+        mock_get_ascend_config.return_value = mock_ascend_config
+
+        received_tensors = {"hidden_states": torch.tensor([[1.0, 2.0]])}
+        received_fingerprints = compute_tensor_fingerprints(received_tensors)
+        recv_tensor_dict = dict(received_tensors)
+        recv_tensor_dict[PP_DFX_METADATA_KEY] = {
+            "transfer_seq": 0,
+            "fingerprints": received_fingerprints,
+        }
+        send_handle = MagicMock()
+
+        with patch.object(NPUWorker, "__init__", lambda self, **kwargs: None):
+            worker = NPUWorker()
+            worker.model_runner = MagicMock()
+            worker.vllm_config = MagicMock()
+            worker.vllm_config.parallel_config = MagicMock()
+            worker.vllm_config.parallel_config.distributed_executor_backend = "ray"
+            worker.use_v2_model_runner = True
+            worker.profiler = None
+            worker.log_memory_stats = MagicMock()
+            worker._pp_send_work = []
+            worker.pp_transfer_dfx = PPTransferDFX(worker.use_v2_model_runner)
+
+            mock_pp_group = MagicMock()
+            mock_pp_group.is_first_rank = False
+            mock_pp_group.is_last_rank = False
+            mock_pp_group.rank_in_group = 1
+            mock_pp_group.world_size = 3
+            mock_pp_group.irecv_tensor_dict.return_value = (recv_tensor_dict, [], [])
+            mock_pp_group.isend_tensor_dict.return_value = [send_handle]
+            mock_get_pp_group.return_value = mock_pp_group
+
+            intermediate_output = IntermediateTensors({"hidden_states": torch.tensor([[3.0, 4.0]])})
+            worker.model_runner.execute_model.return_value = intermediate_output
+
+            scheduler_output = MagicMock()
+            scheduler_output.total_num_scheduled_tokens = 1
+
+            result = worker.execute_model(scheduler_output)
+            received = worker.model_runner.execute_model.call_args.args[1]
+            self.assertNotIn(PP_DFX_METADATA_KEY, received.tensors)
+            torch.testing.assert_close(
+                received.tensors["hidden_states"],
+                received_tensors["hidden_states"],
+            )
+
+        sent_tensors = mock_pp_group.isend_tensor_dict.call_args.args[0]
+        self.assertIn(PP_DFX_METADATA_KEY, sent_tensors)
+        send_handle.wait.assert_called_once_with()
+        self.assertEqual(mock_synchronize.call_count, 2)
+        self.assertIsNone(result)

--- a/vllm_ascend/worker/pp_dfx.py
+++ b/vllm_ascend/worker/pp_dfx.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+"""Debug probes for Model Runner V2 pipeline-parallel transfers."""
+
+import hashlib
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+import torch
+from vllm.logger import logger
+
+PP_DFX_METADATA_KEY = "__vllm_ascend_pp_dfx__"
+
+
+class PPTransferDFX:
+    """Add DEBUG probes around pipeline-parallel tensor transfers."""
+
+    def __init__(self, use_v2_model_runner: bool) -> None:
+        self.use_v2_model_runner = use_v2_model_runner
+        self._send_seq = 0
+
+    @property
+    def enabled(self) -> bool:
+        return self.use_v2_model_runner and logger.isEnabledFor(logging.DEBUG)
+
+    def recv_tensor_dict(
+        self,
+        pp_group: Any,
+        all_gather_group: Any,
+    ) -> tuple[dict[str, torch.Tensor], list[Any], list[Callable[[], None]] | None]:
+        """Receive tensors and defer verification until communication completes."""
+        received_tensors, comm_handles, comm_postprocess = pp_group.irecv_tensor_dict(all_gather_group=all_gather_group)
+        assert received_tensors is not None
+        metadata = received_tensors.pop(PP_DFX_METADATA_KEY, None)
+        if not self.enabled or metadata is None:
+            return received_tensors, comm_handles, comm_postprocess
+
+        transfer_seq = metadata["transfer_seq"]
+        expected_fingerprints = metadata["fingerprints"]
+        src_rank = (pp_group.rank_in_group - 1) % pp_group.world_size
+        dst_rank = pp_group.rank_in_group
+
+        def verify_received_tensors() -> None:
+            verify_tensor_fingerprints(
+                expected_fingerprints,
+                received_tensors,
+                transfer_seq,
+                src_rank,
+                dst_rank,
+            )
+
+        postprocess = list(comm_postprocess or [])
+        # Verify the reconstructed payload after any TP all-gather.
+        postprocess.append(verify_received_tensors)
+        return received_tensors, comm_handles, postprocess
+
+    def send_tensor_dict(
+        self,
+        pp_group: Any,
+        tensors: dict[str, torch.Tensor],
+        all_gather_group: Any,
+    ) -> list[Any]:
+        """Send tensors, measuring completion time when DEBUG logging is enabled."""
+        if not self.enabled:
+            return pp_group.isend_tensor_dict(
+                tensors,
+                all_gather_group=all_gather_group,
+            )
+
+        transfer_seq = self._send_seq
+        self._send_seq += 1
+        src_rank = pp_group.rank_in_group
+        dst_rank = (src_rank + 1) % pp_group.world_size
+        send_tensors = dict(tensors)
+        send_tensors[PP_DFX_METADATA_KEY] = {
+            "transfer_seq": transfer_seq,
+            "fingerprints": compute_tensor_fingerprints(tensors),
+        }
+
+        # DEBUG DFX deliberately serializes the send so the wall-clock
+        # duration includes HCCL completion instead of only submission.
+        torch.npu.synchronize()
+        start_time_ns = time.perf_counter_ns()
+        send_work = pp_group.isend_tensor_dict(
+            send_tensors,
+            all_gather_group=all_gather_group,
+        )
+        for handle in send_work:
+            handle.wait()
+        torch.npu.synchronize()
+        comm_elapsed_ms = (time.perf_counter_ns() - start_time_ns) / 1e6
+        logger.debug(
+            "[pp-dfx] seq=%d link=%d->%d comm=%.3fms",
+            transfer_seq,
+            src_rank,
+            dst_rank,
+            comm_elapsed_ms,
+        )
+        return []
+
+
+def compute_tensor_fingerprints(tensors: dict[str, torch.Tensor]) -> dict[str, str]:
+    """Compute bitwise fingerprints for a pipeline payload."""
+    fingerprints: dict[str, str] = {}
+    for name, tensor in tensors.items():
+        digest = hashlib.sha256(usedforsecurity=False)
+        digest.update(str(tensor.dtype).encode())
+        digest.update(str(tuple(tensor.shape)).encode())
+        tensor_bytes = tensor.detach().contiguous().view(-1).cpu().view(torch.uint8)
+        digest.update(tensor_bytes.numpy().tobytes())
+        fingerprints[name] = digest.hexdigest()
+    return fingerprints
+
+
+def verify_tensor_fingerprints(
+    expected_fingerprints: dict[str, str],
+    tensors: dict[str, torch.Tensor],
+    transfer_seq: int,
+    src_rank: int,
+    dst_rank: int,
+) -> None:
+    """Compare a received payload with its sender-side fingerprints."""
+    received_fingerprints = compute_tensor_fingerprints(tensors)
+    mismatch = next(
+        (
+            name
+            for name in sorted(expected_fingerprints.keys() | received_fingerprints.keys())
+            if expected_fingerprints.get(name) != received_fingerprints.get(name)
+        ),
+        None,
+    )
+    if mismatch is None:
+        logger.debug(
+            "[pp-dfx] seq=%d link=%d->%d verify=pass",
+            transfer_seq,
+            src_rank,
+            dst_rank,
+        )
+    else:
+        logger.debug(
+            "[pp-dfx] seq=%d link=%d->%d verify=failed tensor=%s",
+            transfer_seq,
+            src_rank,
+            dst_rank,
+            mismatch,
+        )

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -82,6 +82,7 @@ from vllm_ascend.utils import (
     setup_ascend_local_comm_res,
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.pp_dfx import PPTransferDFX
 
 torch._dynamo.trace_rules.clear_lru_cache()  # noqa: E402
 from torch._dynamo.variables import TorchInGraphFunctionVariable  # noqa: E402
@@ -167,6 +168,7 @@ class NPUWorker(WorkerBase):
 
         self.use_v2_model_runner = self.vllm_config.use_v2_model_runner
         self._pp_send_work: list[Handle] = []
+        self.pp_transfer_dfx = PPTransferDFX(self.use_v2_model_runner)
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
         if ascend_compilation_config.enable_npugraph_ex and ascend_compilation_config.enable_static_kernel:
@@ -640,12 +642,11 @@ class NPUWorker(WorkerBase):
                 all_gather_group = None
             else:
                 all_gather_group = get_tp_group()
-            tensor_dict, comm_handles, comm_postprocess = get_pp_group().irecv_tensor_dict(
-                all_gather_group=all_gather_group
+            received_tensor_dict, comm_handles, comm_postprocess = self.pp_transfer_dfx.recv_tensor_dict(
+                get_pp_group(), all_gather_group
             )
-            assert tensor_dict is not None
             intermediate_tensors = AsyncIntermediateTensors(
-                tensor_dict,
+                received_tensor_dict,
                 comm_handles=comm_handles,
                 comm_postprocess=comm_postprocess,
             )
@@ -666,10 +667,7 @@ class NPUWorker(WorkerBase):
             all_gather_group = None
         else:
             all_gather_group = get_tp_group()
-        self._pp_send_work = get_pp_group().isend_tensor_dict(
-            output.tensors,
-            all_gather_group=all_gather_group,
-        )
+        self._pp_send_work = self.pp_transfer_dfx.send_tensor_dict(get_pp_group(), output.tensors, all_gather_group)
 
         # Align with upstream GPUWorker: Model Runner V2 has no
         # kv_connector_output to propagate from non-last PP ranks. Model Runner


### PR DESCRIPTION
### What this PR does / why we need it?

Adds DEBUG-only DFX probes for Model Runner V2 pipeline-parallel `IntermediateTensors` transfers.

- Computes per-tensor SHA256 fingerprints before sending and carries them through the existing tensor-dict metadata path.
- Verifies the reconstructed receive payload after communication post-processing, including TP all-gather when enabled.
- Measures sender-side communication completion time by waiting for all send handles and synchronizing the NPU before logging.
- Keeps the existing asynchronous PP path unchanged when DEBUG logging is disabled.

The DEBUG path deliberately serializes PP sends and copies tensors to CPU for exact bitwise fingerprints. It is intended for communication diagnosis, not performance benchmarking.

### Does this PR introduce _any_ user-facing change?

No change to the default serving path. With DEBUG logging enabled on Model Runner V2 PP workers, each transfer emits concise communication-time and verification-result logs.

### How was this patch tested?

- `pytest -sv tests/ut/worker/a2/test_worker_v2.py` in an Ascend test container: 3 passed.
- `ruff check vllm_ascend/worker/pp_dfx.py vllm_ascend/worker/worker.py tests/ut/worker/a2/test_worker_v2.py`
- `git diff --check`

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
