### PR TITLE
[BugFix][310P] Stop double-counting device-global HBM in KV cache sizing

### DIFF
--- a/tests/ut/_310p/test_worker_310p.py
+++ b/tests/ut/_310p/test_worker_310p.py
@@ -1,0 +1,146 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from vllm.utils.mem_constants import GiB_bytes
+
+from tests.ut.base import TestBase
+
+
+class TestDetermineAvailableMemory310P(TestBase):
+    @staticmethod
+    def _make_worker(
+        requested_memory: float,
+        init_free_memory: int,
+        model_memory_usage: int,
+    ):
+        from vllm_ascend._310p.worker_310p import NPUWorker310
+
+        with patch.object(NPUWorker310, "__init__", lambda worker: None):
+            worker = NPUWorker310()
+
+        worker.init_snapshot = SimpleNamespace(free_memory=init_free_memory)
+        worker.requested_memory = requested_memory
+        worker.model_runner = MagicMock()
+        worker.model_runner.model_memory_usage = model_memory_usage
+        return worker
+
+    @staticmethod
+    def _make_profile_result(
+        free_memory_after: int,
+        non_kv_cache_memory: int,
+        non_torch_increase: int,
+        torch_peak_increase: int,
+    ):
+        return SimpleNamespace(
+            after_profile=SimpleNamespace(free_memory=free_memory_after),
+            non_kv_cache_memory=non_kv_cache_memory,
+            non_torch_increase=non_torch_increase,
+            torch_peak_increase=torch_peak_increase,
+        )
+
+    @staticmethod
+    def _mock_memory_profiling(profile_result):
+        context = MagicMock()
+        context.__enter__.return_value = profile_result
+        context.__exit__.return_value = False
+        return MagicMock(return_value=context)
+
+    def test_ep_ignores_pre_existing_process_memory(self):
+        total_memory = int(43.24 * GiB_bytes)
+        init_free_memory = int(23.45 * GiB_bytes)
+        requested_memory = total_memory * 0.5
+        model_memory_usage = int(1.43 * GiB_bytes)
+        non_torch_increase = int(0.06 * GiB_bytes)
+        torch_peak_increase = int(0.07 * GiB_bytes)
+        non_kv_cache_memory = int(1.71 * GiB_bytes)
+
+        worker = self._make_worker(
+            requested_memory=requested_memory,
+            init_free_memory=init_free_memory,
+            model_memory_usage=model_memory_usage,
+        )
+        profile_result = self._make_profile_result(
+            free_memory_after=init_free_memory - non_kv_cache_memory,
+            non_kv_cache_memory=non_kv_cache_memory,
+            non_torch_increase=non_torch_increase,
+            torch_peak_increase=torch_peak_increase,
+        )
+        mock_memory_profiling = self._mock_memory_profiling(profile_result)
+
+        with (
+            patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=False),
+            patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
+            patch(
+                "torch.npu.mem_get_info",
+                return_value=(profile_result.after_profile.free_memory, total_memory),
+            ),
+            patch("torch.npu.memory_reserved", return_value=int(1.50 * GiB_bytes)),
+        ):
+            result = worker.determine_available_memory()
+
+        expected = int((requested_memory - non_kv_cache_memory) // 2)
+        self.assertEqual(result, expected)
+        self.assertAlmostEqual(result / GiB_bytes, 9.95, delta=0.1)
+        self.assertEqual(worker.non_torch_memory, non_torch_increase)
+        self.assertEqual(worker.peak_activation_memory, torch_peak_increase)
+        worker.model_runner.profile_run.assert_called_once_with()
+        mock_memory_profiling.assert_called_once_with(
+            worker.init_snapshot,
+            weights_memory=model_memory_usage,
+        )
+
+    def test_rc_keeps_shared_host_memory_calculation(self):
+        requested_memory = 32 * GiB_bytes
+        init_free_memory = 48 * GiB_bytes
+        model_memory_usage = int(1.43 * GiB_bytes)
+        non_kv_cache_memory = int(1.71 * GiB_bytes)
+
+        worker = self._make_worker(
+            requested_memory=requested_memory,
+            init_free_memory=init_free_memory,
+            model_memory_usage=model_memory_usage,
+        )
+        profile_result = self._make_profile_result(
+            free_memory_after=init_free_memory - non_kv_cache_memory,
+            non_kv_cache_memory=non_kv_cache_memory,
+            non_torch_increase=int(0.06 * GiB_bytes),
+            torch_peak_increase=int(0.07 * GiB_bytes),
+        )
+        mock_memory_profiling = self._mock_memory_profiling(profile_result)
+        host_memory = SimpleNamespace(
+            total=64 * GiB_bytes,
+            available=48 * GiB_bytes,
+        )
+
+        with (
+            patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=True),
+            patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
+            patch("vllm_ascend._310p.worker_310p.psutil.virtual_memory", return_value=host_memory),
+            patch(
+                "torch.npu.mem_get_info",
+                return_value=(profile_result.after_profile.free_memory, host_memory.total),
+            ),
+            patch("torch.npu.memory_reserved", return_value=0),
+        ):
+            result = worker.determine_available_memory()
+
+        expected = int((requested_memory - (host_memory.total - host_memory.available)) // 2)
+        self.assertEqual(result, expected)
+        self.assertEqual(result, 8 * GiB_bytes)

--- a/tests/ut/_310p/test_worker_310p.py
+++ b/tests/ut/_310p/test_worker_310p.py
@@ -64,6 +64,8 @@ class TestDetermineAvailableMemory310P(TestBase):
 
     def test_ep_ignores_pre_existing_process_memory(self):
         total_memory = int(43.24 * GiB_bytes)
+        # Pre-existing device occupancy is reflected by init_free_memory and
+        # must not be subtracted from the per-instance KV cache budget.
         init_free_memory = int(23.45 * GiB_bytes)
         requested_memory = total_memory * 0.5
         model_memory_usage = int(1.43 * GiB_bytes)
@@ -87,11 +89,6 @@ class TestDetermineAvailableMemory310P(TestBase):
         with (
             patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=False),
             patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
-            patch(
-                "torch.npu.mem_get_info",
-                return_value=(profile_result.after_profile.free_memory, total_memory),
-            ),
-            patch("torch.npu.memory_reserved", return_value=int(1.50 * GiB_bytes)),
         ):
             result = worker.determine_available_memory()
 
@@ -133,11 +130,6 @@ class TestDetermineAvailableMemory310P(TestBase):
             patch("vllm_ascend._310p.worker_310p.is_rc_device", return_value=True),
             patch("vllm_ascend._310p.worker_310p.memory_profiling", mock_memory_profiling),
             patch("vllm_ascend._310p.worker_310p.psutil.virtual_memory", return_value=host_memory),
-            patch(
-                "torch.npu.mem_get_info",
-                return_value=(profile_result.after_profile.free_memory, host_memory.total),
-            ),
-            patch("torch.npu.memory_reserved", return_value=0),
         ):
             result = worker.determine_available_memory()
 

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -77,17 +77,9 @@ class NPUWorker310(NPUWorker):
             weights_memory=int(self.model_runner.model_memory_usage),
         ) as profile_result:
             self.model_runner.profile_run()
-            free_memory, total_memory = torch.npu.mem_get_info()
-            # The host memory or device memory for RC devices refers to the available portion of memory
-            # which cannot be obtained via torch.npu.mem_get_info()
-            if is_rc_device():
-                free_memory = psutil.virtual_memory().available
-            torch_memory = torch.npu.memory_reserved()
-            non_torch_memory_before_empty_cache = total_memory - free_memory - torch_memory
 
         self.non_torch_memory = profile_result.non_torch_increase
         self.peak_activation_memory = profile_result.torch_peak_increase
-        non_torch_memory_cleared_by_empty_cache = non_torch_memory_before_empty_cache - self.non_torch_memory
 
         free_gpu_memory = profile_result.after_profile.free_memory
         assert self.init_snapshot.free_memory > free_gpu_memory, (
@@ -110,9 +102,8 @@ class NPUWorker310(NPUWorker):
             vm = psutil.virtual_memory()
             self.available_kv_cache_memory_bytes = (self.requested_memory - (vm.total - vm.available)) // 2
         else:
-            self.available_kv_cache_memory_bytes = (
-                self.requested_memory - profile_result.non_kv_cache_memory - non_torch_memory_cleared_by_empty_cache
-            ) // 2
+            # Existing allocations from other processes are already covered by the startup free-memory check.
+            self.available_kv_cache_memory_bytes = (self.requested_memory - profile_result.non_kv_cache_memory) // 2
 
         logger.debug(profile_result)
         logger.info_once(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes KV cache sizing for the Ascend 310P EP/discrete-HBM path when the
device is shared with another service.

NPUWorker310 currently derives non-Torch memory from device-global HBM usage during
profiling and subtracts it from the current vLLM instance's requested memory. HBM
already held by another process is therefore charged twice: once by the startup
free-memory check and again by the KV cache calculation.

This PR:

- removes the redundant device-global memory calculation from the 310P profiling path;
- calculates EP KV cache memory from the current instance's requested budget and
  profiled non-KV memory only;
- keeps the existing 310P / 2 workspace reserve;
- keeps the startup free-memory check and profiling assertion unchanged;
- keeps the RC/shared-memory calculation unchanged;
- adds focused EP and RC regression tests.

Fixes #14274

### Does this PR introduce _any_ user-facing change?

Yes.

On 310P EP/discrete-HBM devices shared with another service, a vLLM instance that
passes the startup free-memory check will no longer lose KV cache capacity because
the other process's existing HBM was subtracted a second time.

### How was this patch tested?

#### Existing behavior reproduced on 310P3

Environment:

~~~text
Docker: quay.io/ascend/vllm-ascend:v0.22.1rc1-310p
vLLM: 0.22.1
vLLM Ascend: 0.22.1rc1
vLLM Ascend source commit: 5f6faa0cb8830f667266f3b8121cd1383606f2a
Hardware: Ascend 310P3
CANN: 9.1.0-beta.1
npu-smi: 25.5.1
Model: Qwen/Qwen3-0.6B
gpu_memory_utilization: 0.5
max_model_len: 4096
~~~

The captured device state showed 20,687 MB used out of 44,278 MB. The container
process table did not expose the owner of that usage.

The unmodified worker reported:

~~~text
Total non KV cache memory: 1.65GiB
Available KV cache memory: 0.09 GiB (halved for workspace)
~~~

Startup then failed because 0.44 GiB KV cache was required for max_model_len=4096,
while only 0.09 GiB was available; the estimated maximum model length was 768.

#### Tests and remaining validation

- Added tests/ut/_310p/test_worker_310p.py.
- The EP test uses the reproduced 310P values and verifies an expected result of
  approximately 9.95 GiB with a 1.71 GiB non-KV fixture.
- The RC test verifies that the existing shared host-memory calculation is unchanged.
- The post-fix 310P inference run has not yet been completed in this v0.22.1rc1
  image; the image is not the dependency environment for the current main branch.
- Current-main CI should run the unit tests, formatting checks, and 310P hardware
  validation before merge.

The proposed formula is:

~~~python
self.available_kv_cache_memory_bytes = (
    self.requested_memory - profile_result.non_kv_cache_memory
) // 2
~~~

vLLM version: v0.26.0

vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
