### PR TITLE
[BugFix][Sample] Add phase-aware EOS policy for reasoning

### DIFF
--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -27,6 +27,7 @@ ucm_deployment
 Fine_grained_TP
 layer_sharding
 speculative_decoding
+reasoning_eos_policy
 context_parallel
 weight_prefetch
 sequence_parallelism

--- a/docs/source/user_guide/feature_guide/reasoning_eos_policy.md
+++ b/docs/source/user_guide/feature_guide/reasoning_eos_policy.md
@@ -1,0 +1,28 @@
+# Reasoning EOS Policy
+
+Some reasoning models can emit their model EOS token before closing the
+reasoning block. The optional phase-aware EOS policy masks model EOS tokens
+while the generated token stream is inside reasoning, then restores them after
+the parser's reasoning-end or tool-call transition.
+
+Enable the policy together with a reasoning parser:
+
+```bash
+vllm serve <model> \
+  --reasoning-parser <parser> \
+  --reasoning-config '{"premature_eos_policy":"mask_in_reasoning"}'
+```
+
+The default policy is `allow`, which preserves vLLM's existing behavior. With
+`mask_in_reasoning`, masking starts only after the complete reasoning-start
+marker has been generated. Multi-token start and exit markers are supported.
+Only EOS IDs supplied by the model generation configuration are masked; user
+`stop_token_ids` remain effective.
+
+The policy applies to the v1 Ascend model runner for normal sampling and
+speculative decoding, including the MTP target-token and bonus-token paths. If
+masking every model EOS candidate would leave a row without a finite token, the
+processor fails open and restores the original EOS logits.
+
+When requesting log probabilities, `raw_logits` and `raw_logprobs` report
+values before this processor, while processed modes include the EOS mask.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -266,6 +266,7 @@ nav:
         - user_guide/feature_guide/ucm_deployment.md
         - user_guide/feature_guide/Fine_grained_TP.md
         - user_guide/feature_guide/speculative_decoding.md
+        - user_guide/feature_guide/reasoning_eos_policy.md
         - user_guide/feature_guide/context_parallel.md
         - user_guide/feature_guide/sequence_parallelism.md
         - user_guide/feature_guide/batch_invariance.md

--- a/tests/ut/patch/platform/test_reasoning_eos.py
+++ b/tests/ut/patch/platform/test_reasoning_eos.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+
+import msgspec
+import pytest
+from vllm import SamplingParams
+
+from vllm_ascend.patch.platform.patch_reasoning_eos import (
+    _parse_reasoning_config,
+    update_reasoning_config_cli,
+)
+
+
+@pytest.mark.parametrize("ignore_eos", [False, True])
+def test_model_eos_ids_are_independent_from_user_stops(ignore_eos: bool):
+    params = SamplingParams(ignore_eos=ignore_eos, stop_token_ids=[7])
+    params.update_from_generation_config({"eos_token_id": [2, 3]}, 2)
+
+    assert params.model_eos_token_ids == {2, 3}
+    assert 7 not in params.model_eos_token_ids
+    assert params._eos_token_id == (None if ignore_eos else 2)
+    assert params.clone().model_eos_token_ids == {2, 3}
+    restored = msgspec.msgpack.decode(
+        msgspec.msgpack.encode(params), type=SamplingParams
+    )
+    assert restored.model_eos_token_ids == {2, 3}
+
+
+def test_reasoning_config_parser_accepts_phase_aware_policy():
+    config = _parse_reasoning_config('{"reasoning_parser":"deepseek_r1","premature_eos_policy":"mask_in_reasoning"}')
+
+    assert config is not None
+    assert config.reasoning_parser == "deepseek_r1"
+    assert config.premature_eos_policy == "mask_in_reasoning"
+
+
+def test_reasoning_config_parser_rejects_invalid_policy():
+    with pytest.raises(argparse.ArgumentTypeError):
+        _parse_reasoning_config('{"premature_eos_policy":"invalid"}')
+
+
+def test_reasoning_config_cli_action_is_replaced():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--reasoning-config", type=str)
+
+    update_reasoning_config_cli(parser)
+    args = parser.parse_args(
+        [
+            "--reasoning-config",
+            '{"premature_eos_policy":"mask_in_reasoning"}',
+        ]
+    )
+
+    assert args.reasoning_config.premature_eos_policy == "mask_in_reasoning"

--- a/tests/ut/sample/test_reasoning_config.py
+++ b/tests/ut/sample/test_reasoning_config.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+from vllm.parser.engine.parser_engine_config import ParserState
+
+import vllm_ascend.sample.reasoning_config as reasoning_config_module
+from vllm_ascend.sample.reasoning_config import (
+    AscendReasoningConfig,
+    _reasoning_exit_strs,
+)
+
+
+class FakeTokenizer:
+    token_ids = {"<think>": [90, 91], "</think>": [92, 93]}
+
+    def encode(self, text, add_special_tokens=False):
+        assert not add_special_tokens
+        return self.token_ids[text]
+
+
+def test_initialize_token_ids_from_explicit_reasoning_markers(monkeypatch):
+    monkeypatch.setattr(
+        reasoning_config_module,
+        "cached_tokenizer_from_config",
+        lambda model_config: FakeTokenizer(),
+    )
+    config = AscendReasoningConfig(
+        reasoning_start_str="<think>",
+        reasoning_end_str="</think>",
+        premature_eos_policy="mask_in_reasoning",
+    )
+
+    config.initialize_token_ids(SimpleNamespace())
+
+    assert config.enabled
+    assert config.reasoning_start_token_ids == [90, 91]
+    assert config.reasoning_exit_token_ids == [[92, 93]]
+
+
+def test_parser_engine_reasoning_exits_include_tool_transition():
+    parser_config = SimpleNamespace(
+        transitions={
+            (ParserState.REASONING, "end"): SimpleNamespace(next_state=ParserState.CONTENT),
+            (ParserState.REASONING, "tool"): SimpleNamespace(next_state=ParserState.TOOL_NAME),
+            (ParserState.REASONING, "stay"): SimpleNamespace(next_state=ParserState.REASONING),
+        },
+        terminals={
+            "end": "</think>",
+            "tool": "<tool>",
+            "stay": "continue",
+        },
+    )
+    parser = SimpleNamespace(_parser_engine=SimpleNamespace(parser_engine_config=parser_config))
+
+    assert _reasoning_exit_strs(parser) == ("</think>", "<tool>")

--- a/tests/ut/sample/test_reasoning_eos.py
+++ b/tests/ut/sample/test_reasoning_eos.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+from vllm import SamplingParams
+from vllm.config import VllmConfig
+from vllm.v1.sample.logits_processor import BatchUpdate
+
+from vllm_ascend.sample.logits_processor import (
+    ReasoningEosLogitsProcessor,
+    build_ascend_logitsprocs,
+)
+from vllm_ascend.sample.reasoning_phase import (
+    ReasoningPhaseStateHolder,
+    ReasoningPhaseTracker,
+    ReasoningProtocolSpec,
+)
+
+
+class MockReasoningConfig:
+    premature_eos_policy = "mask_in_reasoning"
+    reasoning_start_token_ids = [90, 91]
+    reasoning_exit_token_ids = [[92, 93], [94]]
+
+
+class MockVllmConfig:
+    reasoning_config = MockReasoningConfig()
+
+
+def _params(*eos_token_ids: int) -> SamplingParams:
+    params = SamplingParams()
+    params.update_from_generation_config({"eos_token_id": list(eos_token_ids)}, eos_token_ids[0])
+    return params
+
+
+def _batch_update(*requests):
+    return BatchUpdate(batch_size=len(requests), removed=(), added=requests, moved=())
+
+
+def test_phase_tracker_handles_multitoken_markers_and_reentry():
+    tracker = ReasoningPhaseTracker(ReasoningProtocolSpec((90, 91), ((92, 93), (94,))))
+
+    tracker.extend([90])
+    assert not tracker.in_reasoning
+    tracker.consume(91)
+    assert tracker.in_reasoning
+    tracker.extend([92, 93])
+    assert not tracker.in_reasoning
+    tracker.extend([90, 91, 8, 94])
+    assert not tracker.in_reasoning
+
+
+def test_phase_holder_tracks_moves_swaps_and_async_placeholders():
+    holder = ReasoningPhaseStateHolder(ReasoningProtocolSpec((90, 91), ((92, 93),)))
+    async_output = [90, -1]
+    holder.add_request(0, [], async_output, [2])
+    holder.add_request(1, [], [], [3])
+    assert holder.normal_mask_entries() == []
+
+    async_output[-1] = 91
+    holder.move_request(0, 1, swap=True)
+
+    assert holder.normal_mask_entries() == [(1, (2,))]
+
+
+def test_phase_holder_only_seeds_from_prompt_suffix():
+    protocol = ReasoningProtocolSpec((90, 91), ((92, 93),))
+    holder = ReasoningPhaseStateHolder(protocol)
+    holder.add_request(0, [8, 90, 91], [], [2])
+    holder.add_request(1, [90, 91, 8], [], [3])
+
+    assert holder.normal_mask_entries() == [(0, (2,))]
+
+
+def test_processor_masks_only_model_eos_inside_reasoning():
+    processor = ReasoningEosLogitsProcessor(MockVllmConfig(), torch.device("cpu"), False)
+    output_ids = [[90, 91], [8]]
+    params = _params(2, 3)
+    params.stop_token_ids = [7]
+    processor.update_state(
+        _batch_update(
+            (0, params, [], output_ids[0]),
+            (1, _params(2), [], output_ids[1]),
+        )
+    )
+    logits = torch.zeros((2, 100))
+
+    processor.apply(logits)
+
+    assert torch.isneginf(logits[0, 2:4]).all()
+    assert logits[0, 7] == 0
+    assert logits[1, 2] == 0
+    output_ids[0].extend([92, 93])
+    logits.zero_()
+    processor.apply(logits)
+    assert logits[0, 2] == 0
+
+
+def test_processor_masks_spec_positions_and_bonus():
+    processor = ReasoningEosLogitsProcessor(MockVllmConfig(), torch.device("cpu"), False)
+    processor.update_state(
+        _batch_update(
+            (0, _params(2), [], [90, 91]),
+            (1, _params(3), [], []),
+        )
+    )
+    drafts = [[8, 92, 93, 9], [90, 91, 10]]
+    logits = torch.zeros((7, 100))
+
+    processor.apply_with_spec_decode(logits, drafts, [4, 3])
+
+    assert torch.isneginf(logits[:3, 2]).all()
+    assert logits[3, 2] == 0
+    assert logits[4, 3] == 0
+    assert logits[5, 3] == 0
+    assert torch.isneginf(logits[6, 3])
+
+    bonus_logits = torch.zeros((2, 100))
+    processor.apply_for_bonus(bonus_logits, drafts)
+    assert bonus_logits[0, 2] == 0
+    assert torch.isneginf(bonus_logits[1, 3])
+
+
+def test_processor_fails_open_if_all_logits_would_be_masked():
+    processor = ReasoningEosLogitsProcessor(MockVllmConfig(), torch.device("cpu"), False)
+    processor.update_state(_batch_update((0, _params(2), [], [90, 91])))
+    logits = torch.full((1, 100), -torch.inf)
+    logits[0, 2] = 5
+
+    processor.apply(logits)
+
+    assert logits[0, 2] == 5
+
+
+def test_builder_adds_plugin_processor_for_normal_and_spec_decode():
+    config = VllmConfig()
+    config.reasoning_config = MockReasoningConfig()
+
+    processors = build_ascend_logitsprocs(config, torch.device("cpu"), False, is_pooling_model=False)
+    assert sum(isinstance(processor, ReasoningEosLogitsProcessor) for processor in processors.all) == 1
+
+    config.speculative_config = SimpleNamespace()
+    processors = build_ascend_logitsprocs(config, torch.device("cpu"), False, is_pooling_model=False)
+    assert sum(isinstance(processor, ReasoningEosLogitsProcessor) for processor in processors.all) == 1
+
+
+def test_builder_preserves_default_allow_policy():
+    config = VllmConfig()
+    config.reasoning_config = SimpleNamespace(premature_eos_policy="allow")
+
+    processors = build_ascend_logitsprocs(config, torch.device("cpu"), False, is_pooling_model=False)
+
+    assert not any(isinstance(processor, ReasoningEosLogitsProcessor) for processor in processors.all)

--- a/tests/ut/sample/test_rejection_sampler.py
+++ b/tests/ut/sample/test_rejection_sampler.py
@@ -1,9 +1,14 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import BatchUpdate, LogitsProcessors
 
 from tests.ut.base import TestBase
+from vllm_ascend.sample.logits_processor import ReasoningEosLogitsProcessor
 from vllm_ascend.sample.rejection_sampler import (
+    AscendRejectionSampler,
     expand_batch_to_tokens,
     expand_pytorch,
     rejection_greedy_sample_pytorch,
@@ -29,6 +34,45 @@ def mock_pin_memory(original_func):
 
 
 class TestAscendRejectionSampler(TestBase):
+    def test_apply_logits_processors_dispatches_reasoning_eos_per_position(self):
+        from vllm_ascend.sample.reasoning_phase import (
+            ReasoningPhaseStateHolder,
+            ReasoningProtocolSpec,
+        )
+
+        processor = object.__new__(ReasoningEosLogitsProcessor)
+        processor.phase_state = ReasoningPhaseStateHolder(ReasoningProtocolSpec((90,), ((91,),)))
+        params = SamplingParams()
+        params.update_from_generation_config({"eos_token_id": 2}, 2)
+        processor.update_state(
+            BatchUpdate(
+                batch_size=1,
+                removed=(),
+                added=((0, params, [], [90]),),
+                moved=(),
+            )
+        )
+        sampling_metadata = SimpleNamespace(
+            no_penalties=True,
+            bad_words_token_ids=None,
+            output_token_ids=[[90]],
+            allowed_token_ids_mask=None,
+            logitsprocs=LogitsProcessors([processor]),
+            thinking_budget_state_holder=None,
+            spec_token_ids=[[8, 91, 9]],
+        )
+        spec_metadata = SimpleNamespace(num_draft_tokens=[3])
+
+        result = AscendRejectionSampler.apply_logits_processors(
+            None,
+            torch.zeros((3, 100)),
+            sampling_metadata,
+            spec_metadata,
+        )
+
+        assert torch.isneginf(result[:2, 2]).all()
+        assert result[2, 2] == 0
+
     @patch("torch.arange", new=mock_pin_memory(torch.arange))
     @patch("torch.ones", new=mock_pin_memory(torch.ones))
     @patch("torch.full", new=mock_pin_memory(torch.full))

--- a/tests/ut/sample/test_sampler.py
+++ b/tests/ut/sample/test_sampler.py
@@ -1,4 +1,15 @@
+from types import SimpleNamespace
+
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.sample.logits_processor import BatchUpdate, LogitsProcessors
+
 from tests.ut.base import TestBase
+from vllm_ascend.sample.logits_processor import ReasoningEosLogitsProcessor
+from vllm_ascend.sample.reasoning_phase import (
+    ReasoningPhaseStateHolder,
+    ReasoningProtocolSpec,
+)
 from vllm_ascend.sample.sampler import AscendSampler, AscendTopKTopPSampler
 
 
@@ -8,3 +19,30 @@ class TestAscendSampler(TestBase):
         self.assertEqual(sampler.logprobs_mode, "raw_logprobs")
         self.assertTrue(hasattr(sampler, "topk_topp_sampler"))
         self.assertIsInstance(sampler.topk_topp_sampler, AscendTopKTopPSampler)
+
+    def test_dispatches_reasoning_eos_processor_for_bonus(self):
+        processor = object.__new__(ReasoningEosLogitsProcessor)
+        processor.phase_state = ReasoningPhaseStateHolder(ReasoningProtocolSpec((90,), ((91,),)))
+        params = SamplingParams()
+        params.update_from_generation_config({"eos_token_id": 2}, 2)
+        processor.update_state(
+            BatchUpdate(
+                batch_size=1,
+                removed=(),
+                added=((0, params, [], []),),
+                moved=(),
+            )
+        )
+        metadata = SimpleNamespace(
+            no_penalties=True,
+            bad_words_token_ids=None,
+            output_token_ids=[[]],
+            allowed_token_ids_mask=None,
+            logitsprocs=LogitsProcessors([processor]),
+            thinking_budget_state_holder=None,
+            spec_token_ids=[[90]],
+        )
+
+        logits = AscendSampler().apply_logits_processors(torch.zeros((1, 100)), metadata, predict_bonus_token=True)
+
+        assert torch.isneginf(logits[0, 2])

--- a/tests/ut/worker/test_reasoning_eos_source.py
+++ b/tests/ut/worker/test_reasoning_eos_source.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import ast
+from pathlib import Path
+
+MODEL_RUNNER_PATH = Path(__file__).parents[3] / "vllm_ascend" / "worker" / "model_runner_v1.py"
+
+
+def _npu_input_batch_calls() -> list[ast.Call]:
+    tree = ast.parse(MODEL_RUNNER_PATH.read_text())
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "NPUInputBatch"
+    ]
+
+
+def test_npu_input_batches_keep_reasoning_phase_output_ids():
+    calls = _npu_input_batch_calls()
+
+    assert len(calls) == 2
+    for call in calls:
+        keywords = {keyword.arg: keyword.value for keyword in call.keywords}
+        assert "logitsprocs_need_output_token_ids" in keywords
+
+    initial_value = ast.unparse(
+        {keyword.arg: keyword.value for keyword in calls[0].keywords}["logitsprocs_need_output_token_ids"]
+    )
+    assert "reasoning_eos_policy_enabled" in initial_value
+
+    reinitialized_value = ast.unparse(
+        {keyword.arg: keyword.value for keyword in calls[1].keywords}["logitsprocs_need_output_token_ids"]
+    )
+    assert reinitialized_value == ("self.input_batch.logitsprocs_need_output_token_ids")

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -454,7 +454,29 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
-# ** 18. File: platform/patch_speculative_config.py**
+# ** 18. File: platform/patch_reasoning_eos.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.sampling_params.SamplingParams.update_from_generation_config`
+#   2. The `--reasoning-config` CLI argument parser
+#    Why:
+#       The supported vLLM release does not expose the phase-aware premature
+#       EOS policy or retain model EOS token IDs independently from user stop
+#       token IDs. The latter distinction is required so user stops remain
+#       effective while only model EOS tokens are masked during reasoning.
+#    How:
+#       Extend the reasoning config accepted by the CLI with
+#       `premature_eos_policy`, and patch generation-config handling to retain
+#       model EOS IDs as internal SamplingParams metadata. The implementation
+#       is compatibility-gated and leaves newer vLLM versions with native
+#       support unchanged.
+#    Related PR (if no, explain why):
+#       https://github.com/Zhaocen/vllm/pull/1
+#       https://github.com/vllm-project/vllm-ascend/issues/14031
+#    Future Plan:
+#       Remove this compatibility patch after the minimum supported vLLM
+#       version contains the upstream phase-aware reasoning EOS policy.
+#
+# ** 19. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`
 #    Why:
@@ -477,7 +499,7 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
-# ** 19. File: platform/patch_structured_output.py**
+# ** 20. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
@@ -499,7 +521,7 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
-# ** 20. File: platform/patch_torch_accelerator.py**
+# ** 21. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,
 #      `torch.accelerator.reset_peak_memory_stats`, `torch.accelerator.get_memory_info`,
@@ -519,7 +541,7 @@
 #       Remove this patch once `torch.accelerator` correctly routes to the NPU
 #       backend for these memory APIs.
 #
-# ** 21. File: platform/patch_tool_choice_none_content.py**
+# ** 22. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
 #      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
@@ -535,7 +557,7 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #44105.
 #
-# ** 22. File: platform/patch_use_v2_model_runner.py**
+# ** 23. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
 #    Why:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -40,6 +40,7 @@ import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 import vllm_ascend.patch.platform.patch_dyntra_lb_core  # noqa
 
 import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
+import vllm_ascend.patch.platform.patch_reasoning_eos  # noqa
 import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 
 import vllm_ascend.patch.platform.patch_eplb  # noqa

--- a/vllm_ascend/patch/platform/patch_reasoning_eos.py
+++ b/vllm_ascend/patch/platform/patch_reasoning_eos.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+import argparse
+import json
+from typing import Any
+
+from pydantic import TypeAdapter, ValidationError
+from vllm.sampling_params import SamplingParams
+
+from vllm_ascend.sample.reasoning_config import AscendReasoningConfig
+
+_ORIGINAL_UPDATE_ATTR = "_ascend_original_update_from_generation_config"
+_MODEL_EOS_KEY = "vllm_ascend_model_eos_token_ids"
+
+
+def _patch_sampling_params_model_eos() -> None:
+    if hasattr(SamplingParams, "model_eos_token_ids"):
+        return
+    if hasattr(SamplingParams, _ORIGINAL_UPDATE_ATTR):
+        return
+
+    original_update = SamplingParams.update_from_generation_config
+    setattr(SamplingParams, _ORIGINAL_UPDATE_ATTR, original_update)
+
+    def update_from_generation_config(
+        self: SamplingParams,
+        generation_config: dict[str, Any],
+        eos_token_id: int | None = None,
+    ) -> None:
+        if self.extra_args is None:
+            self.extra_args = {}
+        model_eos_token_ids = set(self.extra_args.get(_MODEL_EOS_KEY, ()))
+        if eos_token_id is not None:
+            model_eos_token_ids.add(eos_token_id)
+        if (eos_ids := generation_config.get("eos_token_id")) is not None:
+            if isinstance(eos_ids, int):
+                model_eos_token_ids.add(eos_ids)
+            else:
+                model_eos_token_ids.update(eos_ids)
+
+        original_update(self, generation_config, eos_token_id)
+        self.extra_args[_MODEL_EOS_KEY] = tuple(sorted(model_eos_token_ids))
+
+    def model_eos_token_ids(self: SamplingParams) -> set[int]:
+        if self.extra_args is None:
+            return set()
+        return set(self.extra_args.get(_MODEL_EOS_KEY, ()))
+
+    SamplingParams.update_from_generation_config = update_from_generation_config
+    SamplingParams.model_eos_token_ids = property(model_eos_token_ids)  # type: ignore[attr-defined]
+
+
+def update_reasoning_config_cli(parser: object) -> None:
+    actions = getattr(parser, "_option_string_actions", {})
+    action = actions.get("--reasoning-config")
+    if action is not None:
+        action.type = _parse_reasoning_config
+
+
+def _parse_reasoning_config(value: str) -> AscendReasoningConfig | None:
+    if value.lower() == "none":
+        return None
+    try:
+        return TypeAdapter(AscendReasoningConfig).validate_json(value)
+    except (ValidationError, json.JSONDecodeError) as error:
+        raise argparse.ArgumentTypeError(repr(error)) from error
+
+
+_patch_sampling_params_model_eos()

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -264,6 +264,13 @@ class NPUPlatform(Platform):
 
         adapt_patch(is_global_patch=True)
 
+        if parser is not None:
+            from vllm_ascend.patch.platform.patch_reasoning_eos import (
+                update_reasoning_config_cli,
+            )
+
+            update_reasoning_config_cli(parser)
+
         # For online serving, "ascend" quantization method is not a choice natively,
         # so we need to add "ascend" quantization method to quantization methods list
         # and the user can enable quantization using "vllm serve --quantization ascend".

--- a/vllm_ascend/sample/logits_processor.py
+++ b/vllm_ascend/sample/logits_processor.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import torch
+from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.v1.sample.logits_processor import (
+    BatchUpdate,
+    LogitsProcessor,
+    LogitsProcessors,
+    MoveDirectionality,
+    build_logitsprocs,
+)
+
+from vllm_ascend.sample.reasoning_phase import (
+    ReasoningPhaseStateHolder,
+    ReasoningProtocolSpec,
+)
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+
+class ReasoningEosLogitsProcessor(LogitsProcessor):
+    """Mask model EOS tokens while requests are inside reasoning."""
+
+    def __init__(self, vllm_config: "VllmConfig", device: torch.device, is_pin_memory: bool) -> None:
+        _ = is_pin_memory
+        config = vllm_config.reasoning_config
+        if config is None:
+            raise ValueError("Reasoning EOS policy requires reasoning config")
+        start_ids = config.reasoning_start_token_ids
+        exit_ids = config.reasoning_exit_token_ids
+        if not start_ids or not exit_ids:
+            raise ValueError("Reasoning EOS policy requires tokenized phase markers")
+        protocol = ReasoningProtocolSpec(
+            start_token_ids=tuple(start_ids),
+            exit_token_ids=tuple(tuple(ids) for ids in exit_ids),
+        )
+        self.phase_state = ReasoningPhaseStateHolder(protocol)
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    def update_state(self, batch_update: BatchUpdate | None) -> None:
+        if batch_update is None:
+            return
+        for index in batch_update.removed:
+            self.phase_state.remove_request(index)
+        for index, params, prompt_ids, output_ids in batch_update.added:
+            self.phase_state.add_request(
+                index,
+                prompt_ids,
+                output_ids,
+                params.model_eos_token_ids,
+            )
+        for source, destination, direction in batch_update.moved:
+            self.phase_state.move_request(
+                source,
+                destination,
+                swap=direction == MoveDirectionality.SWAP,
+            )
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        return self._apply_entries(logits, self.phase_state.normal_mask_entries())
+
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        draft_token_ids: Sequence[Sequence[int]],
+        num_draft_tokens: Sequence[int],
+    ) -> torch.Tensor:
+        entries = self.phase_state.speculative_mask_entries(draft_token_ids, num_draft_tokens)
+        return self._apply_entries(logits, entries)
+
+    def apply_for_bonus(
+        self,
+        logits: torch.Tensor,
+        draft_token_ids: Sequence[Sequence[int]],
+    ) -> torch.Tensor:
+        entries = self.phase_state.bonus_mask_entries(draft_token_ids)
+        return self._apply_entries(logits, entries)
+
+    @staticmethod
+    def _apply_entries(
+        logits: torch.Tensor,
+        entries: Sequence[tuple[int, tuple[int, ...]]],
+    ) -> torch.Tensor:
+        if not entries:
+            return logits
+
+        entry_rows = [row for row, _ in entries]
+        rows = async_tensor_h2d(
+            [row for row, eos_ids in entries for _ in eos_ids],
+            device=logits.device,
+        )
+        token_ids = async_tensor_h2d(
+            [token_id for _, eos_ids in entries for token_id in eos_ids],
+            device=logits.device,
+        )
+        entry_indices = async_tensor_h2d(
+            [index for index, (_, eos_ids) in enumerate(entries) for _ in eos_ids],
+            device=logits.device,
+        )
+        previous = logits[rows, token_ids].clone()
+        logits[rows, token_ids] = -torch.inf
+        affected_rows = async_tensor_h2d(entry_rows, device=logits.device)
+        restore_entries = torch.isneginf(logits[affected_rows]).all(dim=1)
+        logits[rows, token_ids] = torch.where(restore_entries[entry_indices], previous, -torch.inf)
+        return logits
+
+
+def reasoning_eos_policy_enabled(reasoning_config: object | None) -> bool:
+    return (
+        reasoning_config is not None
+        and getattr(reasoning_config, "premature_eos_policy", "allow") == "mask_in_reasoning"
+    )
+
+
+def build_ascend_logitsprocs(
+    vllm_config: "VllmConfig",
+    device: torch.device,
+    is_pin_memory: bool,
+    is_pooling_model: bool,
+    custom_logitsprocs: Sequence[str | type[LogitsProcessor]] = (),
+) -> LogitsProcessors:
+    processors = list(
+        build_logitsprocs(
+            vllm_config,
+            device,
+            is_pin_memory,
+            is_pooling_model,
+            custom_logitsprocs,
+        ).all
+    )
+    if is_pooling_model or not reasoning_eos_policy_enabled(vllm_config.reasoning_config):
+        return LogitsProcessors(processors)
+
+    processors = [
+        processor
+        for processor in processors
+        if not (
+            type(processor).__name__ == "ReasoningEosLogitsProcessor"
+            and type(processor).__module__.startswith("vllm.v1.sample.logits_processor")
+        )
+    ]
+    processors.append(ReasoningEosLogitsProcessor(vllm_config, device, is_pin_memory))
+    return LogitsProcessors(processors)

--- a/vllm_ascend/sample/reasoning_config.py
+++ b/vllm_ascend/sample/reasoning_config.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from dataclasses import field
+from typing import Literal
+
+from vllm.config.model import ModelConfig
+from vllm.config.reasoning import ReasoningConfig
+from vllm.config.utils import config
+from vllm.parser.engine.parser_engine_config import ParserState
+from vllm.reasoning import ReasoningParserManager
+from vllm.tokenizers import cached_tokenizer_from_config
+
+
+@config
+class AscendReasoningConfig(ReasoningConfig):
+    """Ascend reasoning configuration with phase-aware EOS policy metadata."""
+
+    premature_eos_policy: Literal["allow", "mask_in_reasoning"] = "allow"
+    """Whether to mask model EOS tokens inside an open reasoning phase."""
+
+    _natural_reasoning_end_token_ids: list[int] | None = field(default=None, init=False, repr=False)
+    _reasoning_exit_token_ids: list[list[int]] | None = field(default=None, init=False, repr=False)
+
+    @property
+    def natural_reasoning_end_token_ids(self) -> list[int] | None:
+        return self._natural_reasoning_end_token_ids
+
+    @property
+    def reasoning_exit_token_ids(self) -> list[list[int]] | None:
+        return self._reasoning_exit_token_ids
+
+    def initialize_token_ids(self, model_config: ModelConfig) -> None:
+        if (
+            self._reasoning_start_token_ids is not None
+            and self._reasoning_end_token_ids is not None
+            and self._natural_reasoning_end_token_ids is not None
+            and self._reasoning_exit_token_ids is not None
+        ):
+            self._enabled = True
+            return
+
+        tokenizer = cached_tokenizer_from_config(model_config=model_config)
+        reasoning_start_str = self.reasoning_start_str
+        reasoning_end_str = self.reasoning_end_str
+        natural_reasoning_end_str = ""
+        reasoning_exit_strs: tuple[str, ...] = ()
+        if self.reasoning_parser:
+            parser_cls = ReasoningParserManager.get_reasoning_parser(self.reasoning_parser)
+            reasoning_parser = parser_cls(tokenizer)
+            start_token = reasoning_parser.reasoning_start_str
+            if start_token and not reasoning_start_str:
+                reasoning_start_str = start_token
+
+            end_token = reasoning_parser.reasoning_end_str
+            if end_token and not reasoning_end_str:
+                reasoning_end_str = end_token
+            natural_reasoning_end_str = end_token or ""
+            reasoning_exit_strs = _reasoning_exit_strs(reasoning_parser)
+
+        if not natural_reasoning_end_str:
+            natural_reasoning_end_str = reasoning_end_str
+        if not reasoning_start_str or not reasoning_end_str:
+            return
+
+        self._reasoning_start_token_ids = tokenizer.encode(reasoning_start_str, add_special_tokens=False)
+        self._reasoning_end_token_ids = tokenizer.encode(reasoning_end_str, add_special_tokens=False)
+        self._natural_reasoning_end_token_ids = tokenizer.encode(natural_reasoning_end_str, add_special_tokens=False)
+        if not reasoning_exit_strs:
+            reasoning_exit_strs = (natural_reasoning_end_str,)
+        self._reasoning_exit_token_ids = []
+        for exit_str in reasoning_exit_strs:
+            token_ids = tokenizer.encode(exit_str, add_special_tokens=False)
+            if token_ids and token_ids not in self._reasoning_exit_token_ids:
+                self._reasoning_exit_token_ids.append(token_ids)
+
+        if (
+            not self._reasoning_start_token_ids
+            or not self._reasoning_end_token_ids
+            or not self._natural_reasoning_end_token_ids
+            or not self._reasoning_exit_token_ids
+        ):
+            raise ValueError(
+                "ReasoningConfig: failed to tokenize reasoning strings: "
+                f"reasoning_start_str='{self.reasoning_start_str}', "
+                f"reasoning_end_str='{self.reasoning_end_str}'. "
+                "Ensure the strings are valid tokens in the model's vocabulary."
+            )
+        self._enabled = True
+
+
+def _reasoning_exit_strs(reasoning_parser: object) -> tuple[str, ...]:
+    exit_strs = getattr(reasoning_parser, "reasoning_exit_strs", ())
+    if exit_strs:
+        return tuple(exit_strs)
+
+    parser_engine = getattr(reasoning_parser, "_parser_engine", None)
+    parser_config = getattr(parser_engine, "parser_engine_config", None)
+    if parser_config is not None:
+        exit_strs: list[str] = []
+        for (state, terminal), transition in parser_config.transitions.items():
+            if (
+                state == ParserState.REASONING
+                and transition.next_state != ParserState.REASONING
+                and terminal in parser_config.terminals
+            ):
+                exit_strs.append(parser_config.terminals[terminal])
+        return tuple(dict.fromkeys(exit_strs))
+
+    end_str = getattr(reasoning_parser, "reasoning_end_str", None)
+    return (end_str,) if end_str else ()

--- a/vllm_ascend/sample/reasoning_phase.py
+++ b/vllm_ascend/sample/reasoning_phase.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReasoningProtocolSpec:
+    """Token sequences that enter and leave a reasoning phase."""
+
+    start_token_ids: tuple[int, ...]
+    exit_token_ids: tuple[tuple[int, ...], ...]
+
+    def __post_init__(self) -> None:
+        if not self.start_token_ids or not self.exit_token_ids:
+            raise ValueError("Reasoning phase markers must not be empty")
+        if any(not token_ids for token_ids in self.exit_token_ids):
+            raise ValueError("Reasoning exit markers must not be empty")
+
+    @property
+    def max_marker_len(self) -> int:
+        return max(
+            len(self.start_token_ids),
+            *(len(token_ids) for token_ids in self.exit_token_ids),
+        )
+
+
+class ReasoningPhaseTracker:
+    """Incrementally track whether a token stream is inside reasoning."""
+
+    def __init__(
+        self,
+        protocol: ReasoningProtocolSpec,
+        token_ids: Sequence[int] = (),
+    ) -> None:
+        self.protocol = protocol
+        self.in_reasoning = False
+        self._suffix: list[int] = []
+        self.extend(token_ids)
+
+    def clone(self) -> "ReasoningPhaseTracker":
+        tracker = ReasoningPhaseTracker(self.protocol)
+        tracker.in_reasoning = self.in_reasoning
+        tracker._suffix = self._suffix.copy()
+        return tracker
+
+    def extend(self, token_ids: Iterable[int]) -> None:
+        for token_id in token_ids:
+            self.consume(token_id)
+
+    def consume(self, token_id: int) -> None:
+        self._suffix.append(token_id)
+        max_marker_len = self.protocol.max_marker_len
+        if len(self._suffix) > max_marker_len:
+            del self._suffix[:-max_marker_len]
+
+        if self.in_reasoning:
+            if any(self._endswith(ids) for ids in self.protocol.exit_token_ids):
+                self.in_reasoning = False
+        elif self._endswith(self.protocol.start_token_ids):
+            self.in_reasoning = True
+
+    def _endswith(self, token_ids: tuple[int, ...]) -> bool:
+        marker_len = len(token_ids)
+        return self._suffix[-marker_len:] == list(token_ids)
+
+
+@dataclass
+class _RequestPhaseState:
+    tracker: ReasoningPhaseTracker
+    prompt_token_ids: tuple[int, ...]
+    output_token_ids: Sequence[int]
+    num_consumed_output_tokens: int
+    model_eos_token_ids: tuple[int, ...]
+
+
+class ReasoningPhaseStateHolder:
+    """Maintain committed reasoning phases for a persistent request batch."""
+
+    def __init__(self, protocol: ReasoningProtocolSpec) -> None:
+        self.protocol = protocol
+        self._states: dict[int, _RequestPhaseState] = {}
+
+    def add_request(
+        self,
+        index: int,
+        prompt_token_ids: Sequence[int] | None,
+        output_token_ids: Sequence[int],
+        model_eos_token_ids: Iterable[int],
+    ) -> None:
+        eos_ids = tuple(sorted(model_eos_token_ids))
+        if not eos_ids:
+            self.remove_request(index)
+            return
+        prompt = tuple(prompt_token_ids or ())
+        tracker = self._tracker_from_prompt(prompt)
+        confirmed_output_len = self._confirmed_output_len(output_token_ids)
+        tracker.extend(output_token_ids[:confirmed_output_len])
+        self._states[index] = _RequestPhaseState(
+            tracker=tracker,
+            prompt_token_ids=prompt,
+            output_token_ids=output_token_ids,
+            num_consumed_output_tokens=confirmed_output_len,
+            model_eos_token_ids=eos_ids,
+        )
+
+    def remove_request(self, index: int) -> None:
+        self._states.pop(index, None)
+
+    def move_request(self, source: int, destination: int, swap: bool) -> None:
+        source_state = self._states.pop(source, None)
+        destination_state = self._states.pop(destination, None)
+        if source_state is not None:
+            self._states[destination] = source_state
+        if swap and destination_state is not None:
+            self._states[source] = destination_state
+
+    def sync_committed_outputs(self) -> None:
+        for state in self._states.values():
+            output_len = self._confirmed_output_len(state.output_token_ids)
+            if output_len < state.num_consumed_output_tokens:
+                state.tracker = self._tracker_from_prompt(state.prompt_token_ids)
+                state.tracker.extend(state.output_token_ids[:output_len])
+            else:
+                state.tracker.extend(state.output_token_ids[state.num_consumed_output_tokens : output_len])
+            state.num_consumed_output_tokens = output_len
+
+    def normal_mask_entries(self) -> list[tuple[int, tuple[int, ...]]]:
+        self.sync_committed_outputs()
+        return [
+            (index, state.model_eos_token_ids) for index, state in self._states.items() if state.tracker.in_reasoning
+        ]
+
+    def speculative_mask_entries(
+        self,
+        draft_token_ids: Sequence[Sequence[int]],
+        num_draft_tokens: Sequence[int],
+    ) -> list[tuple[int, tuple[int, ...]]]:
+        self.sync_committed_outputs()
+        entries: list[tuple[int, tuple[int, ...]]] = []
+        row = 0
+        for index, num_tokens in enumerate(num_draft_tokens):
+            state = self._states.get(index)
+            if state is None:
+                row += num_tokens
+                continue
+            tracker = state.tracker.clone()
+            drafts = draft_token_ids[index]
+            for position in range(num_tokens):
+                if tracker.in_reasoning:
+                    entries.append((row + position, state.model_eos_token_ids))
+                tracker.consume(drafts[position])
+            row += num_tokens
+        return entries
+
+    def bonus_mask_entries(
+        self,
+        draft_token_ids: Sequence[Sequence[int]],
+    ) -> list[tuple[int, tuple[int, ...]]]:
+        self.sync_committed_outputs()
+        entries: list[tuple[int, tuple[int, ...]]] = []
+        for index, state in self._states.items():
+            tracker = state.tracker.clone()
+            if index < len(draft_token_ids):
+                tracker.extend(draft_token_ids[index])
+            if tracker.in_reasoning:
+                entries.append((index, state.model_eos_token_ids))
+        return entries
+
+    def _tracker_from_prompt(self, prompt_token_ids: Sequence[int]) -> ReasoningPhaseTracker:
+        prompt_suffix = prompt_token_ids[-self.protocol.max_marker_len :]
+        return ReasoningPhaseTracker(self.protocol, prompt_suffix)
+
+    @staticmethod
+    def _confirmed_output_len(output_token_ids: Sequence[int]) -> int:
+        try:
+            return output_token_ids.index(-1)  # type: ignore[attr-defined]
+        except (AttributeError, ValueError):
+            for index, token_id in enumerate(output_token_ids):
+                if token_id == -1:
+                    return index
+            return len(output_token_ids)

--- a/vllm_ascend/sample/rejection_sampler.py
+++ b/vllm_ascend/sample/rejection_sampler.py
@@ -30,6 +30,7 @@ from vllm_ascend.ops.triton.reject_sample import (
     rejection_random_sample_kernel,
     sample_recovered_tokens_kernel,
 )
+from vllm_ascend.sample.logits_processor import ReasoningEosLogitsProcessor
 from vllm_ascend.sample.penalties import apply_all_penalties
 from vllm_ascend.sample.sampler import apply_top_k_top_p
 
@@ -144,6 +145,12 @@ class AscendRejectionSampler(RejectionSampler):
         for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
             if isinstance(processor, MinTokensLogitsProcessor):
                 logits = processor.apply_with_spec_decode(logits, metadata.num_draft_tokens)
+            elif isinstance(processor, ReasoningEosLogitsProcessor):
+                logits = processor.apply_with_spec_decode(
+                    logits,
+                    sampling_metadata.spec_token_ids or (),
+                    metadata.num_draft_tokens,
+                )
         holder = sampling_metadata.thinking_budget_state_holder
         if holder is not None and holder.has_tracked_requests():
             logits = holder.apply_to_logits(

--- a/vllm_ascend/sample/sampler.py
+++ b/vllm_ascend/sample/sampler.py
@@ -5,10 +5,12 @@ from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import logger
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.sample.metadata import SamplingMetadata
+from vllm.v1.sample.ops.bad_words import apply_bad_words
 from vllm.v1.sample.ops.topk_topp_sampler import TopKTopPSampler
 from vllm.v1.sample.sampler import Sampler
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.sample.logits_processor import ReasoningEosLogitsProcessor
 from vllm_ascend.sample.penalties import apply_all_penalties
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type, global_stream, npu_stream_switch
 
@@ -83,6 +85,48 @@ class AscendSampler(Sampler):
 
     def prepare_sampling(self, top_k):
         self.topk_topp_sampler.prepare_sampling(top_k)
+
+    def apply_logits_processors(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata,
+        predict_bonus_token: bool,
+    ) -> torch.Tensor:
+        bad_words_token_ids = sampling_metadata.bad_words_token_ids
+        any_penalties_or_bad_words = bool(bad_words_token_ids) or not sampling_metadata.no_penalties
+        output_token_ids = sampling_metadata.output_token_ids
+        if predict_bonus_token and any_penalties_or_bad_words:
+            output_token_ids = self._combine_outputs_with_spec_tokens(
+                output_token_ids,
+                sampling_metadata.spec_token_ids,
+            )
+
+        if sampling_metadata.allowed_token_ids_mask is not None:
+            logits.masked_fill_(sampling_metadata.allowed_token_ids_mask, float("-inf"))
+
+        if bad_words_token_ids:
+            apply_bad_words(logits, bad_words_token_ids, output_token_ids)
+
+        for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
+            if predict_bonus_token and isinstance(processor, ReasoningEosLogitsProcessor):
+                logits = processor.apply_for_bonus(logits, sampling_metadata.spec_token_ids or ())
+            else:
+                logits = processor.apply(logits)
+
+        logits = self.apply_penalties(logits, sampling_metadata, output_token_ids)
+        holder = sampling_metadata.thinking_budget_state_holder
+        if holder is not None and holder.has_tracked_requests():
+            holder.update_state(
+                sampling_metadata.output_token_ids,
+                sampling_metadata.spec_token_ids,
+                repeat_indices=None,
+            )
+            logits = holder.apply_to_logits(
+                logits,
+                predict_bonus_token,
+                sampling_metadata.spec_token_ids,
+            )
+        return logits
 
     @staticmethod
     def greedy_sample(logits: torch.Tensor) -> torch.Tensor:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -96,7 +96,6 @@ from vllm.v1.outputs import (
     SamplerOutput,
     make_empty_encoder_model_runner_output,
 )
-from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID, RejectionSampler
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
@@ -151,6 +150,10 @@ from vllm_ascend.model_executor.offloader import create_offloader
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.ops.triton.spec_decode.ngram import triton_ngram_spec_decode
 from vllm_ascend.quantization.utils import enable_fa_quant
+from vllm_ascend.sample.logits_processor import (
+    build_ascend_logitsprocs,
+    reasoning_eos_policy_enabled,
+)
 from vllm_ascend.sample.sampler import AscendSampler
 from vllm_ascend.spec_decode import get_spec_decode_method
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
@@ -521,7 +524,7 @@ class NPUModelRunner(GPUModelRunner):
             block_sizes=[self.block_size],
             kernel_block_sizes=[[self.cache_config.block_size]],
             is_spec_decode=bool(self.vllm_config.speculative_config),
-            logitsprocs=build_logitsprocs(
+            logitsprocs=build_ascend_logitsprocs(
                 self.vllm_config,
                 self.device,
                 self.pin_memory,
@@ -530,7 +533,8 @@ class NPUModelRunner(GPUModelRunner):
             ),
             logitsprocs_need_output_token_ids=bool(
                 self.vllm_config.model_config.logits_processors
-            ),
+            )
+            or reasoning_eos_policy_enabled(self.vllm_config.reasoning_config),
             is_pooling_model=self.is_pooling_model,
             num_speculative_tokens=(
                 self.vllm_config.speculative_config.num_speculative_tokens if self.vllm_config.speculative_config else 0
@@ -4565,6 +4569,9 @@ class NPUModelRunner(GPUModelRunner):
                 block_sizes=block_sizes,
                 is_spec_decode=bool(self.vllm_config.speculative_config),
                 logitsprocs=self.input_batch.logitsprocs,
+                logitsprocs_need_output_token_ids=(
+                    self.input_batch.logitsprocs_need_output_token_ids
+                ),
                 is_pooling_model=self.is_pooling_model,
                 num_speculative_tokens=(
                     self.vllm_config.speculative_config.num_speculative_tokens


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds an opt-in, phase-aware EOS policy for reasoning and tool-call generation on Ascend.

- Add premature_eos_policy=allow|mask_in_reasoning to the Ascend reasoning configuration. The default remains allow.
- Track reasoning phases from actual prompt and generated token sequences, including multi-token markers, request moves/swaps, and async output placeholders.
- Mask only model EOS token IDs while an established reasoning phase is open. User stop_token_ids remain effective.
- Restore EOS after the natural reasoning end marker or parser-engine transitions such as tool start.
- Apply the policy to V1 normal sampling, speculative target verification, and MTP/speculative bonus-token prediction.
- Add a compatibility layer for vLLM versions that do not yet retain model EOS IDs independently, while avoiding duplicate processors on newer versions with native support.
- Add unit tests and a user guide.

Fixes #14031


### Does this PR introduce _any_ user-facing change?

Yes. Users can opt in when starting the server:

    --reasoning-parser <parser> \
    --reasoning-config {"premature_eos_policy":"mask_in_reasoning"}

The default policy is allow, so existing behavior is unchanged unless explicitly enabled.

### How was this patch tested?

- Added focused unit coverage for phase tracking, multi-token markers, parser/tool transitions, mixed batch state, user-stop isolation, fail-open behavior, SamplingParams clone/msgpack persistence, CLI parsing, normal sampling, speculative verification, and bonus-token prediction.
- Targeted unit suite on the supported vLLM 0.27.1 source: 38 passed.
- Ruff check: passed.
- Repository hooks passed for Ruff, formatting, codespell, typos, clang-format, markdownlint, actionlint, and project-specific checks. The local machine did not have gitleaks/wget or shellcheck installed; this PR does not modify shell files.
- Compatibility smoke check against the upstream prototype source passed and confirmed that the Ascend builder removes the upstream duplicate before installing the plugin processor.

Real Ascend NPU end-to-end serving was not available in the current macOS development environment; NPU CI validation is still required.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
