### PR TITLE
[MRV2] Support profiling chunk in model runner v2

### DIFF
--- a/tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py
+++ b/tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py
@@ -55,7 +55,12 @@ def test_profiling_chunk_ttft_performance() -> None:
         enforce_eager=True,
         async_scheduling=False,
         additional_config={
-            "profiling_chunk_config": {"enabled": True, "smooth_factor": 0.9},
+            "scheduler_config": {
+                "profiling_chunk_config": {
+                    "enabled": True,
+                    "smooth_factor": 0.9,
+                },
+            },
             "enable_cpu_binding": False,
         },
         hf_overrides={

--- a/tests/ut/worker/a2/test_worker_v2.py
+++ b/tests/ut/worker/a2/test_worker_v2.py
@@ -1,5 +1,7 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from vllm.config import CUDAGraphMode
 from vllm.sequence import IntermediateTensors
 
 from tests.ut.base import TestBase
@@ -52,3 +54,117 @@ class TestNPUWorkerV2(TestBase):
                 all_gather_group=mock_get_tp_group.return_value,
             )
             self.assertIsNone(result)
+
+    @patch("vllm_ascend.worker.worker.torch.npu.synchronize")
+    @patch("vllm_ascend.worker.worker.get_pp_group")
+    def test_profile_prefill_latency_v2_restores_runner_state(
+        self,
+        mock_get_pp_group,
+        mock_synchronize,
+    ):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda self, **kwargs: None):
+            worker = NPUWorker()
+            worker.use_v2_model_runner = True
+            worker.scheduler_config = SimpleNamespace(max_num_batched_tokens=1024)
+
+            model_runner = MagicMock()
+            model_runner.max_num_reqs = 8
+            worker.model_runner = model_runner
+
+            def check_temporary_state(**kwargs):
+                self.assertEqual(model_runner.max_num_reqs, 1)
+
+            model_runner._dummy_run.side_effect = check_temporary_state
+            mock_get_pp_group.return_value.is_first_rank = True
+
+            with patch("time.perf_counter", side_effect=[10.0, 10.25]):
+                latency_ms = worker.profile_prefill_latency(512)
+
+            self.assertEqual(latency_ms, 250.0)
+            self.assertEqual(model_runner.max_num_reqs, 8)
+            model_runner._dummy_run.assert_called_once_with(
+                num_tokens=512,
+                force_attention=True,
+                is_profile=False,
+                cudagraph_runtime_mode=CUDAGraphMode.NONE,
+            )
+            self.assertEqual(mock_synchronize.call_count, 2)
+
+    @patch("vllm_ascend.worker.worker.torch.npu.synchronize")
+    @patch("vllm_ascend.worker.worker.get_pp_group")
+    def test_profile_prefill_latency_v2_restores_state_on_error(
+        self,
+        mock_get_pp_group,
+        mock_synchronize,
+    ):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda self, **kwargs: None):
+            worker = NPUWorker()
+            worker.use_v2_model_runner = True
+            worker.scheduler_config = SimpleNamespace(max_num_batched_tokens=1024)
+
+            model_runner = MagicMock()
+            model_runner.max_num_reqs = 8
+            model_runner._dummy_run.side_effect = RuntimeError("dummy failure")
+            worker.model_runner = model_runner
+
+            mock_get_pp_group.return_value.is_first_rank = True
+
+            with self.assertRaisesRegex(RuntimeError, "dummy failure"):
+                worker.profile_prefill_latency(512)
+
+            self.assertEqual(model_runner.max_num_reqs, 8)
+            self.assertEqual(mock_synchronize.call_count, 1)
+
+    def test_sample_tokens_v2_attaches_execution_time(self):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda self, **kwargs: None):
+            worker = NPUWorker()
+            worker.use_v2_model_runner = True
+
+            profiling_config = SimpleNamespace(need_timing=True)
+            model_runner = MagicMock()
+            model_runner.ascend_config = SimpleNamespace(
+                scheduler_config=SimpleNamespace(
+                    profiling_chunk_config=profiling_config,
+                )
+            )
+            model_runner._cpp_execution_time_ms = 125.0
+            model_runner_output = SimpleNamespace()
+            output = SimpleNamespace(model_runner_output=model_runner_output)
+            model_runner.sample_tokens.return_value = output
+            worker.model_runner = model_runner
+
+            grammar_output = SimpleNamespace()
+            result = worker.sample_tokens(grammar_output)
+
+            self.assertIs(result, output)
+            self.assertEqual(model_runner_output.execution_time_ms, 125.0)
+            self.assertIsNone(model_runner._cpp_execution_time_ms)
+            model_runner.sample_tokens.assert_called_once_with(grammar_output)
+
+    @patch(
+        "vllm_ascend.worker.worker._attach_profiling_chunk_execution_time",
+    )
+    def test_sample_tokens_v1_keeps_original_path(self, mock_attach):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        with patch.object(NPUWorker, "__init__", lambda self, **kwargs: None):
+            worker = NPUWorker()
+            worker.use_v2_model_runner = False
+
+            model_runner = MagicMock()
+            output = SimpleNamespace()
+            model_runner.sample_tokens.return_value = output
+            worker.model_runner = model_runner
+
+            grammar_output = SimpleNamespace()
+            result = worker.sample_tokens(grammar_output)
+
+            self.assertIs(result, output)
+            mock_attach.assert_not_called()
+            model_runner.sample_tokens.assert_called_once_with(grammar_output)

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -18,7 +18,8 @@ def _make_runner(need_timing: bool = True):
     return runner
 
 
-def test_execute_model_records_profiling_time():
+@pytest.mark.parametrize("is_vllm_0_27_1", [True, False], ids=["v0.27.1", "newer"])
+def test_execute_model_records_profiling_time(is_vllm_0_27_1):
     runner = _make_runner()
     scheduler_output = SimpleNamespace(disable_profiling_timing=False)
 
@@ -28,6 +29,10 @@ def test_execute_model_records_profiling_time():
             "execute_model",
             return_value=None,
         ) as mock_execute_model,
+        patch(
+            "vllm_ascend.worker.v2.model_runner.vllm_version_is",
+            return_value=is_vllm_0_27_1,
+        ),
         patch("vllm_ascend.core.profiling_chunk_predictor.torch.npu.synchronize") as mock_synchronize,
         patch(
             "vllm_ascend.core.profiling_chunk_predictor.time.perf_counter",
@@ -39,13 +44,15 @@ def test_execute_model_records_profiling_time():
     assert output is None
     assert runner._cpp_execution_time_ms == pytest.approx(125.0)
     assert mock_synchronize.call_count == 2
-    mock_execute_model.assert_called_once_with(
-        scheduler_output,
-        intermediate_tensors=None,
-        dummy_run=False,
-        skip_attn_for_dummy_run=False,
-        is_profile=False,
-    )
+    expected_kwargs = {
+        "intermediate_tensors": None,
+        "dummy_run": False,
+        "skip_attn_for_dummy_run": False,
+        "is_profile": False,
+    }
+    if not is_vllm_0_27_1:
+        expected_kwargs["context_len"] = 0
+    mock_execute_model.assert_called_once_with(scheduler_output, **expected_kwargs)
 
 
 def test_execute_model_disables_profiling_timer_and_clears_stale_time():

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -44,7 +44,7 @@ def test_execute_model_records_profiling_time(is_vllm_0_27_1):
     assert output is None
     assert runner._cpp_execution_time_ms == pytest.approx(125.0)
     assert mock_synchronize.call_count == 2
-    expected_kwargs = {
+    expected_kwargs: dict[str, object] = {
         "intermediate_tensors": None,
         "dummy_run": False,
         "skip_attn_for_dummy_run": False,

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -28,10 +28,6 @@ def test_execute_model_records_profiling_time():
             "execute_model",
             return_value=None,
         ) as mock_execute_model,
-        patch(
-            "vllm_ascend.worker.v2.model_runner.enable_sp",
-            return_value=False,
-        ),
         patch("vllm_ascend.core.profiling_chunk_predictor.torch.npu.synchronize") as mock_synchronize,
         patch(
             "vllm_ascend.core.profiling_chunk_predictor.time.perf_counter",
@@ -62,10 +58,6 @@ def test_execute_model_disables_profiling_timer_and_clears_stale_time():
             GPUModelRunner,
             "execute_model",
             return_value=None,
-        ),
-        patch(
-            "vllm_ascend.worker.v2.model_runner.enable_sp",
-            return_value=False,
         ),
         patch("vllm_ascend.core.profiling_chunk_predictor.torch.npu.synchronize") as mock_synchronize,
         patch("vllm_ascend.core.profiling_chunk_predictor.time.perf_counter") as mock_perf_counter,

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -77,7 +77,3 @@ def test_execute_model_disables_profiling_timer_and_clears_stale_time():
     assert runner._cpp_execution_time_ms is None
     mock_synchronize.assert_not_called()
     mock_perf_counter.assert_not_called()
-
-
-def test_sample_tokens_is_inherited_from_upstream():
-    assert NPUModelRunner.sample_tokens is GPUModelRunner.sample_tokens

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -1,0 +1,83 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner
+
+
+def _make_runner(need_timing: bool = True):
+    runner = NPUModelRunner.__new__(NPUModelRunner)
+    runner.ascend_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(profiling_chunk_config=SimpleNamespace(need_timing=need_timing))
+    )
+    runner.vllm_config = SimpleNamespace()
+    runner.execute_model_state = None
+    runner.is_last_pp_rank = False
+    return runner
+
+
+def test_execute_model_records_profiling_time():
+    runner = _make_runner()
+    scheduler_output = SimpleNamespace(disable_profiling_timing=False)
+
+    with (
+        patch.object(
+            GPUModelRunner,
+            "execute_model",
+            return_value=None,
+        ) as mock_execute_model,
+        patch(
+            "vllm_ascend.worker.v2.model_runner.enable_sp",
+            return_value=False,
+        ),
+        patch("vllm_ascend.core.profiling_chunk_predictor.torch.npu.synchronize") as mock_synchronize,
+        patch(
+            "vllm_ascend.core.profiling_chunk_predictor.time.perf_counter",
+            side_effect=[10.0, 10.125],
+        ),
+    ):
+        output = runner.execute_model(scheduler_output)
+
+    assert output is None
+    assert runner._cpp_execution_time_ms == pytest.approx(125.0)
+    assert mock_synchronize.call_count == 2
+    mock_execute_model.assert_called_once_with(
+        scheduler_output,
+        intermediate_tensors=None,
+        dummy_run=False,
+        skip_attn_for_dummy_run=False,
+        is_profile=False,
+    )
+
+
+def test_execute_model_disables_profiling_timer_and_clears_stale_time():
+    runner = _make_runner()
+    runner._cpp_execution_time_ms = 123.0
+    scheduler_output = SimpleNamespace(disable_profiling_timing=True)
+
+    with (
+        patch.object(
+            GPUModelRunner,
+            "execute_model",
+            return_value=None,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.model_runner.enable_sp",
+            return_value=False,
+        ),
+        patch("vllm_ascend.core.profiling_chunk_predictor.torch.npu.synchronize") as mock_synchronize,
+        patch("vllm_ascend.core.profiling_chunk_predictor.time.perf_counter") as mock_perf_counter,
+    ):
+        runner.execute_model(scheduler_output)
+
+    profiling_config = runner.ascend_config.scheduler_config.profiling_chunk_config
+    assert not profiling_config.need_timing
+    assert runner._cpp_execution_time_ms is None
+    mock_synchronize.assert_not_called()
+    mock_perf_counter.assert_not_called()
+
+
+def test_sample_tokens_is_inherited_from_upstream():
+    assert NPUModelRunner.sample_tokens is GPUModelRunner.sample_tokens

--- a/vllm_ascend/core/profiling_chunk_predictor.py
+++ b/vllm_ascend/core/profiling_chunk_predictor.py
@@ -28,9 +28,53 @@ The approach:
 """
 
 import math
+import time
 
 import numpy as np
+import torch
 from vllm.logger import logger
+
+
+def _start_profiling_chunk_timing(profiling_config, scheduler_output) -> float | None:
+    if not profiling_config.need_timing:
+        return None
+
+    if getattr(scheduler_output, "disable_profiling_timing", False):
+        profiling_config.need_timing = False
+        return None
+
+    torch.npu.synchronize()
+    return time.perf_counter()
+
+
+def _finish_profiling_chunk_timing(
+    profiling_config,
+    execution_start_time: float | None,
+) -> float | None:
+    if not profiling_config.need_timing or execution_start_time is None:
+        return None
+
+    torch.npu.synchronize()
+    return (time.perf_counter() - execution_start_time) * 1000.0
+
+
+def _attach_profiling_chunk_execution_time(
+    profiling_config,
+    model_runner,
+    output,
+) -> None:
+    execution_time_ms = getattr(model_runner, "_cpp_execution_time_ms", None)
+    model_runner._cpp_execution_time_ms = None
+
+    if not profiling_config.need_timing or execution_time_ms is None:
+        return
+
+    # MRV2 may return AsyncOutput on the last PP rank.
+    # Preserve the timing on its inner ModelRunnerOutput so it reaches
+    # the scheduler after get_output().
+    model_runner_output = getattr(output, "model_runner_output", output)
+    if model_runner_output is not None:
+        model_runner_output.execution_time_ms = execution_time_ms
 
 
 class ChunkSizePredictor:

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -50,6 +50,10 @@ from vllm_ascend.ascend_forward_context import (
     set_mc2_mask,
     set_mc2_tokens_capacity,
 )
+from vllm_ascend.core.profiling_chunk_predictor import (
+    _finish_profiling_chunk_timing,
+    _start_profiling_chunk_timing,
+)
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import set_potential_max_tokens, vllm_version_is
 
@@ -201,22 +205,36 @@ class NPUModelRunner(GPUModelRunner):
         is_profile: bool = False,
         context_len: int = 0,
     ):
+        self._cpp_execution_time_ms = None
+        profiling_config = self.ascend_config.scheduler_config.profiling_chunk_config
+        execution_start_time = _start_profiling_chunk_timing(
+            profiling_config,
+            scheduler_output,
+        )
+
         if vllm_version_is("0.27.1"):
-            return super().execute_model(
+            output = super().execute_model(
                 scheduler_output,
                 intermediate_tensors=intermediate_tensors,
                 dummy_run=dummy_run,
                 skip_attn_for_dummy_run=skip_attn_for_dummy_run,
                 is_profile=is_profile,
             )
-        return super().execute_model(
-            scheduler_output,
-            intermediate_tensors=intermediate_tensors,
-            dummy_run=dummy_run,
-            skip_attn_for_dummy_run=skip_attn_for_dummy_run,
-            is_profile=is_profile,
-            context_len=context_len,
+        else:
+            output = super().execute_model(
+                scheduler_output,
+                intermediate_tensors=intermediate_tensors,
+                dummy_run=dummy_run,
+                skip_attn_for_dummy_run=skip_attn_for_dummy_run,
+                is_profile=is_profile,
+                context_len=context_len,
+            )
+
+        self._cpp_execution_time_ms = _finish_profiling_chunk_timing(
+            profiling_config,
+            execution_start_time,
         )
+        return output
 
     @torch.inference_mode()
     def profile_run(self) -> None:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -19,6 +19,7 @@
 
 import copy
 import gc
+import inspect
 import logging
 from types import NoneType
 from typing import Any
@@ -58,6 +59,9 @@ from vllm.v1.worker.workspace import init_workspace_manager
 import vllm_ascend.envs as envs_ascend
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
+from vllm_ascend.core.profiling_chunk_predictor import (
+    _attach_profiling_chunk_execution_time,
+)
 from vllm_ascend.cpu_binding import bind_cpus
 from vllm_ascend.device_allocator.camem import CaMemAllocator
 from vllm_ascend.device_allocator.sleep_mem_optimized import SleepWakeupManager
@@ -692,7 +696,16 @@ class NPUWorker(WorkerBase):
 
     @torch.inference_mode()
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput | AsyncModelRunnerOutput:
-        return self.model_runner.sample_tokens(grammar_output)
+        if not self.use_v2_model_runner:
+            return self.model_runner.sample_tokens(grammar_output)
+
+        output = self.model_runner.sample_tokens(grammar_output)
+        _attach_profiling_chunk_execution_time(
+            self.model_runner.ascend_config.scheduler_config.profiling_chunk_config,
+            self.model_runner,
+            output,
+        )
+        return output
 
     def load_model(self) -> None:
         if self.vllm_config.model_config.enable_sleep_mode:
@@ -862,16 +875,25 @@ class NPUWorker(WorkerBase):
 
         start = time.perf_counter()
 
-        # Run real model forward with force_attention=True
-        # This ensures attention is actually executed, not skipped.
-        # Without force_attention, attn_metadata may be None and attention
-        # won't run, making profiling results inaccurate.
-        # _dummy_run handles PP internally (intermediate tensors, etc.)
-        self.model_runner._dummy_run(
-            num_tokens=num_tokens,
-            force_attention=True,  # Critical: ensure attention is executed
-            profile_cpp=True,
-        )
+        # Run a real model forward with attention enabled in eager mode.
+        # _dummy_run handles PP internally (intermediate tensors, etc.).
+        old_max_num_reqs = self.model_runner.max_num_reqs
+        try:
+            self.model_runner.max_num_reqs = 1
+
+            dummy_run_kwargs = {
+                "num_tokens": num_tokens,
+                "force_attention": True,
+                "is_profile": False,
+                "cudagraph_runtime_mode": CUDAGraphMode.NONE,
+            }
+
+            if "profile_cpp" in inspect.signature(self.model_runner._dummy_run).parameters:
+                dummy_run_kwargs["profile_cpp"] = True
+
+            self.model_runner._dummy_run(**dummy_run_kwargs)
+        finally:
+            self.model_runner.max_num_reqs = old_max_num_reqs
 
         # Synchronize after forward to ensure NPU operations complete
         torch.npu.synchronize()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adapts profiling-based chunk calculation for model runner v2.

The changes:

- Route CPP startup profiling through the model runner v2 dummy-run path.
- Propagate model execution timing through asynchronous model outputs.
- Force `CUDAGraphMode.NONE` during profiling dummy runs without mutating the captured graph state.
- Add a two-card profiling chunk performance test using PP=2 and TP=1.
- Keep coverage for the existing four-card PP=2 and TP=2 configuration.

Related to #5208.

### Does this PR introduce _any_ user-facing change?

This PR only adapts internal profiling and timing propagation for Model Runner V2. It does not change any user-facing API, configuration, CLI option, or default behavior.

### How was this patch tested?

CPP-related unit tests:

- 158 passed
- 1 skipped

Four-card E2E test:

```bash
pytest -sv tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py

Result:
- Passed on 4 Ascend NPUs
- Request time was approximately 4.3 seconds
- Performance baseline: 5.2 seconds

Two-card E2E test:
```bash
pytest -sv tests/e2e/pull_request/two_card/test_profiling_chunk_performance.py

Result:
- Passed on 2 Ascend NPUs
- TTFT measurements: 7.02s, 7.05s, 7.03s, 7.05s, 7.04s
- Median TTFT: 7.04 seconds
- Performance baseline: 8.0 seconds


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
