### PR TITLE
[MRV2][BugFix][Kernel]Support apply_thinking_budget on Ascend

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -881,6 +881,7 @@ estimated_times:
   tests/ut/quantization/methods/a2/test_w8a8_dynamic.py: 40
   tests/ut/quantization/methods/a2/test_w8a8_static.py: 40
   tests/ut/sample/a2/test_gumbel_sampling.py: 80
+  tests/ut/sample/a2/test_thinking_budget.py: 80
   tests/ut/spec_decode/a2/test_eagle_proposer.py: 50
   tests/ut/worker/a2/test_block_table.py: 30
   tests/ut/worker/a2/test_model_runner_v1.py: 30

--- a/tests/ut/sample/a2/test_thinking_budget.py
+++ b/tests/ut/sample/a2/test_thinking_budget.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+"""Ascend coverage for the upstream Model Runner V2 thinking-budget tests."""
+
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample.thinking_budget import ThinkingBudgetState
+from vllm.v1.worker.gpu.states import RequestState
+
+DEVICE = torch.device("npu")
+START = 90
+END = 91
+END_A = 92
+END_B = 93
+VOCAB_SIZE = 128
+
+
+class MockReasoningConfig:
+    reasoning_start_token_ids = [START]
+    reasoning_end_token_ids = [END]
+    natural_reasoning_end_token_ids = [END]
+
+
+class MockMultiTokenEndReasoningConfig:
+    reasoning_start_token_ids = [START]
+    reasoning_end_token_ids = [END_A, END_B]
+    natural_reasoning_end_token_ids = [END_A, END_B]
+
+
+class MockDistinctEndReasoningConfig:
+    reasoning_start_token_ids = [START]
+    reasoning_end_token_ids = [END_A, END_B]
+    natural_reasoning_end_token_ids = [END]
+
+
+def _make_req_states(tokens: list[int], prompt_len: int = 1) -> RequestState:
+    req_states = RequestState(
+        max_num_reqs=4,
+        max_model_len=max(64, len(tokens) + 1),
+        max_num_batched_tokens=16,
+        num_speculative_steps=4,
+        vocab_size=VOCAB_SIZE,
+        device=DEVICE,
+    )
+    req_states.add_request(
+        req_id="req",
+        prompt_len=prompt_len,
+        all_token_ids=tokens,
+        num_computed_tokens=len(tokens),
+        max_tokens=32,
+    )
+    req_states.apply_staged_writes()
+    return req_states
+
+
+def _apply(
+    state: ThinkingBudgetState,
+    logits: torch.Tensor,
+    input_ids: list[int],
+    local_pos: list[int],
+) -> torch.Tensor:
+    idx_mapping = torch.tensor([3], dtype=torch.int32, device=DEVICE)
+    expanded_idx_mapping = torch.tensor([3] * len(input_ids), dtype=torch.int32, device=DEVICE)
+    state.apply(
+        logits,
+        expanded_idx_mapping,
+        idx_mapping,
+        idx_mapping.cpu().numpy(),
+        torch.tensor(input_ids, dtype=torch.int32, device=DEVICE),
+        torch.tensor(local_pos, dtype=torch.int32, device=DEVICE),
+    )
+    return logits.cpu()
+
+
+def test_v2_thinking_budget_forces_end_after_budget_reached():
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.arange(VOCAB_SIZE, dtype=torch.float32, device=DEVICE).view(1, -1)
+    expected = logits.cpu()
+    out = _apply(state, logits, input_ids=[12], local_pos=[0])
+
+    expected[0, END] = 1.0e9
+    torch.testing.assert_close(out, expected)
+
+
+def test_v2_thinking_budget_restores_masked_end_token():
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    logits[0, END] = -float("inf")
+    out = _apply(state, logits, input_ids=[12], local_pos=[0])
+
+    assert out[0, END] == pytest.approx(1.0e9)
+
+
+def test_v2_thinking_budget_allows_tokens_before_budget():
+    req_states = _make_req_states([1, START, 10, 11], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[11], local_pos=[0])
+
+    assert torch.all(out == 0)
+
+
+def test_v2_thinking_budget_continues_multi_token_end_marker():
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockMultiTokenEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((2, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[12, END_A], local_pos=[0, 1])
+
+    assert out[0, END_A] == pytest.approx(1.0e9)
+    assert out[1, END_B] == pytest.approx(1.0e9)
+
+
+def test_v2_thinking_budget_uses_distinct_forced_end_marker():
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockDistinctEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((2, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[12, END_A], local_pos=[0, 1])
+
+    assert out[0, END_A] == pytest.approx(1.0e9)
+    assert out[1, END_B] == pytest.approx(1.0e9)
+
+
+def test_v2_thinking_budget_stops_after_natural_end_marker():
+    req_states = _make_req_states([1, START, 10, END, 20, 21, 22], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockDistinctEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[22], local_pos=[0])
+
+    assert torch.all(out == 0)
+
+
+def test_v2_thinking_budget_ignores_plain_request():
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams())
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[12], local_pos=[0])
+
+    assert torch.all(out == 0)
+
+
+def test_v2_thinking_budget_latest_prefill_end_disables_forcing():
+    req_states = _make_req_states([1, START, 10, 11, 12, END, 13], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[13], local_pos=[0])
+
+    assert torch.all(out == 0)
+
+
+def test_v2_thinking_budget_uses_latest_prefill_start_boundary():
+    req_states = _make_req_states([1, START, 10, 11, 12, END, 13, START, 14, 15, 16], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[16], local_pos=[0])
+
+    assert out[0, END] == pytest.approx(1.0e9)
+
+
+def test_v2_thinking_budget_incrementally_scans_long_generation():
+    tokens = [1, START, *([10] * 16382)]
+    req_states = _make_req_states(tokens)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=32768))
+    state.apply_staged_writes()
+
+    _apply(state, torch.zeros((1, VOCAB_SIZE), device=DEVICE), [10], [0])
+    assert state.cached_scan_pos[3].item() == len(tokens)
+
+    req_states.all_token_ids.stage_write(3, len(tokens), [10])
+    req_states.total_len.stage_write_elem(3, len(tokens) + 1)
+    req_states.apply_staged_writes()
+    _apply(state, torch.zeros((1, VOCAB_SIZE), device=DEVICE), [10], [0])
+
+    assert state.cached_scan_pos[3].item() == len(tokens) + 1
+
+
+def test_v2_thinking_budget_clamps_oversized_budget():
+    req_states = _make_req_states([1, START, 10, 11, 12], prompt_len=1)
+    state = ThinkingBudgetState(req_states, MockReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=2**40))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[12], local_pos=[0])
+
+    assert torch.all(out == 0)
+
+
+def test_v2_thinking_budget_continues_end_prefix_from_prompt():
+    req_states = _make_req_states([1, START, 10, 11, END_A], prompt_len=5)
+    state = ThinkingBudgetState(req_states, MockMultiTokenEndReasoningConfig())
+    state.add_request(3, SamplingParams(thinking_token_budget=3))
+    state.apply_staged_writes()
+
+    logits = torch.zeros((1, VOCAB_SIZE), device=DEVICE)
+    out = _apply(state, logits, input_ids=[END_A], local_pos=[0])
+
+    assert out[0, END_B] == pytest.approx(1.0e9)
+    assert out[0, END_A] == 0

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1132,6 +1132,41 @@
 #       Remove this patch once vLLM selects the Triton libdevice through a
 #       backend-dispatch mechanism.
 #
+#   3. `vllm.v1.worker.gpu.sample.thinking_budget._update_committed_marker_cache_kernel`,
+#      `vllm.v1.worker.gpu.sample.thinking_budget._load_effective_token`
+#    Why:
+#       These kernels expose two independent Triton-Ascend compiler issues.
+#
+#       On Triton-Ascend versions earlier than 3.6, the marker-cache kernel
+#       cannot compile chained runtime boolean expressions such as
+#       `A and B and C`. Triton-Ascend 3.6 supports this syntax, so this part of
+#       the compatibility patch is unnecessary when 3.6 or later is the
+#       minimum supported version.
+#
+#       The thinking-budget kernel calls `_load_effective_token`, which returns
+#       a value from inside a runtime `if` branch and otherwise returns a value
+#       loaded through a different pointer. During TTIR-to-Linalg conversion,
+#       Triton-Ascend can emit a zero-operand `func.return` for this one-result
+#       helper and leave an unresolved `memref<?xi32>` to `!tt.ptr<i32>`
+#       materialization. Compilation then fails in
+#       `ConvertTritonIRToLinalgIR` before the kernel runs.
+#    How:
+#       For pre-3.6 compatibility, express the marker-cache chained conditions
+#       as nested two-operand conditions without changing the scan algorithm.
+#
+#       Replace only `_load_effective_token` with an Ascend helper that performs
+#       complementary masked loads from committed and in-flight token buffers,
+#       then selects the loaded scalar with `tl.where`. This gives the helper
+#       one explicit value-return path and avoids the unsupported control-flow
+#       and pointer conversion while retaining the upstream thinking-budget
+#       kernel unchanged.
+#    Related PR (if no, explain why):
+#       No. These are Triton-Ascend compiler compatibility issues.
+#    Future Plan:
+#       Remove the marker-cache replacement once Triton-Ascend 3.6 is the
+#       minimum supported version. Remove the thinking-budget replacement once
+#       Triton-Ascend can lower the upstream runtime branch return correctly.
+#
 # ** 29. File: worker/patch_v2/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`

--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -1,7 +1,16 @@
 from vllm.triton_utils import triton
 from vllm.v1.worker.gpu import structured_outputs
 from vllm.v1.worker.gpu.metrics import logits as metrics_logits
-from vllm.v1.worker.gpu.sample import bad_words, gumbel, logprob, penalties, prompt_logprob, sampler, states
+from vllm.v1.worker.gpu.sample import (
+    bad_words,
+    gumbel,
+    logprob,
+    penalties,
+    prompt_logprob,
+    sampler,
+    states,
+    thinking_budget,
+)
 from vllm.v1.worker.gpu.spec_decode import rejection_sampler, rejection_sampler_utils
 from vllm.v1.worker.gpu.spec_decode.dflash import speculator as dflash_speculator
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator
@@ -11,6 +20,10 @@ from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
 from vllm_ascend.worker.v2.sample.logprob import compute_token_logprobs, compute_topk_logprobs
 from vllm_ascend.worker.v2.sample.min_p import apply_min_p
 from vllm_ascend.worker.v2.sample.penalties import apply_penalties, bincount
+from vllm_ascend.worker.v2.sample.thinking_budget import (
+    _load_effective_token_ascend,
+    _update_committed_marker_cache_kernel_ascend,
+)
 from vllm_ascend.worker.v2.spec_decode.dflash.speculator import _prepare_dflash_inputs_kernel_ascend
 from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import (
     rejection_sample as npu_rejection_sample,
@@ -35,3 +48,6 @@ rejection_sampler_utils.rejection_sample = npu_rejection_sample
 rejection_sampler.rejection_sample = npu_rejection_sample
 dflash_speculator._prepare_dflash_inputs_kernel = _prepare_dflash_inputs_kernel_ascend
 metrics_logits.libdevice = triton.language.extra.cann.libdevice
+thinking_budget._load_effective_token = _load_effective_token_ascend
+# remove _update_committed_marker_cache_kernel patch when TA upgrade to 3.6
+thinking_budget._update_committed_marker_cache_kernel = _update_committed_marker_cache_kernel_ascend

--- a/vllm_ascend/worker/v2/sample/thinking_budget.py
+++ b/vllm_ascend/worker/v2/sample/thinking_budget.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+"""Ascend-compatible kernels for Model Runner V2 thinking budgets."""
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _load_effective_token_ascend(
+    all_token_ids_ptr,
+    all_token_ids_stride,
+    input_ids_ptr,
+    cur_req_first_pos,
+    req_state_idx,
+    total_len,
+    pos,
+):
+    """Load one committed or in-flight token without branch-local returns."""
+    is_committed = pos < total_len
+    committed = tl.load(
+        all_token_ids_ptr + req_state_idx * all_token_ids_stride + pos,
+        mask=is_committed,
+        other=0,
+    )
+    input_pos = cur_req_first_pos + pos - total_len + 1
+    in_flight = tl.load(
+        input_ids_ptr + input_pos,
+        mask=~is_committed,
+        other=0,
+    )
+    return tl.where(is_committed, committed, in_flight)
+
+
+@triton.jit
+def _update_committed_marker_cache_kernel_ascend(
+    req_ids_ptr,
+    thinking_token_budget_ptr,
+    all_token_ids_ptr,
+    all_token_ids_stride,
+    total_len_ptr,
+    cached_last_start_ptr,
+    cached_last_end_ptr,
+    cached_scan_pos_ptr,
+    reasoning_start_token_ids_ptr,
+    natural_reasoning_end_token_ids_ptr,
+    START_LEN: tl.constexpr,
+    NATURAL_END_LEN: tl.constexpr,
+    MAX_LEN: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    req_state_idx = tl.load(req_ids_ptr + tl.program_id(0))
+    budget = tl.load(thinking_token_budget_ptr + req_state_idx)
+    if budget < 0:
+        return
+
+    total_len = tl.load(total_len_ptr + req_state_idx)
+    scan_pos = tl.load(cached_scan_pos_ptr + req_state_idx)
+    last_start = tl.load(cached_last_start_ptr + req_state_idx)
+    last_end = tl.load(cached_last_end_ptr + req_state_idx)
+
+    if scan_pos > total_len:
+        scan_pos = 0
+        last_start = -1
+        last_end = -1
+
+    if (scan_pos == 0 and last_start < 0) and last_end < 0:
+        # Cold scan: walk backward in vectorized blocks, stopping at the first
+        # block with a marker; only the relative order of the two positions
+        # found matters below.
+        block_hi = total_len
+        while (block_hi > 0 and last_start < 0) and last_end < 0:
+            block_lo = block_hi - BLOCK
+            if block_lo < 0:
+                block_lo = 0
+            offs = block_lo + tl.arange(0, BLOCK)
+
+            start_match = (offs < block_hi) & (offs + START_LEN <= total_len)
+            for j in tl.static_range(0, START_LEN):
+                expected = tl.load(reasoning_start_token_ids_ptr + j)
+                actual = tl.load(
+                    all_token_ids_ptr + req_state_idx * all_token_ids_stride + offs + j,
+                    mask=offs + j < total_len,
+                    other=-1,
+                )
+                start_match = start_match & (actual == expected)
+
+            end_match = (offs < block_hi) & (offs + NATURAL_END_LEN <= total_len)
+            for j in tl.static_range(0, NATURAL_END_LEN):
+                expected = tl.load(natural_reasoning_end_token_ids_ptr + j)
+                actual = tl.load(
+                    all_token_ids_ptr + req_state_idx * all_token_ids_stride + offs + j,
+                    mask=offs + j < total_len,
+                    other=-1,
+                )
+                end_match = end_match & (actual == expected)
+
+            last_start = tl.max(tl.where(start_match, offs, -1), axis=0)
+            last_end = tl.max(tl.where(end_match, offs, -1), axis=0)
+            block_hi = block_lo
+    else:
+        for i in tl.range(scan_pos, total_len):
+            if i + START_LEN <= total_len:
+                start_match = True
+                for j in tl.static_range(0, START_LEN):
+                    expected = tl.load(reasoning_start_token_ids_ptr + j)
+                    actual = tl.load(all_token_ids_ptr + req_state_idx * all_token_ids_stride + i + j)
+                    start_match = start_match & (actual == expected)
+                if start_match:
+                    last_start = i
+
+            if i + NATURAL_END_LEN <= total_len:
+                end_match = True
+                for j in tl.static_range(0, NATURAL_END_LEN):
+                    expected = tl.load(natural_reasoning_end_token_ids_ptr + j)
+                    actual = tl.load(all_token_ids_ptr + req_state_idx * all_token_ids_stride + i + j)
+                    end_match = end_match & (actual == expected)
+                if end_match:
+                    last_end = i
+
+    tl.store(cached_last_start_ptr + req_state_idx, last_start)
+    tl.store(cached_last_end_ptr + req_state_idx, last_end)
+    new_scan_pos = total_len - (MAX_LEN - 1)
+    if new_scan_pos < 0:
+        new_scan_pos = 0
+    tl.store(cached_scan_pos_ptr + req_state_idx, new_scan_pos)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR adds Ascend support for the Model Runner V2 thinking-token-budget kernels.

The upstream implementation exposes two independent Triton-Ascend compatibility issues:

1. `_update_committed_marker_cache_kernel`

   Triton-Ascend versions earlier than 3.6 cannot compile chained runtime boolean expressions such as `A and B and C`. The Ascend implementation expresses these conditions as nested two-operand conditions without changing the scanning algorithm.

   Triton-Ascend 3.6 already supports the upstream syntax. This compatibility implementation can be removed once 3.6 becomes the minimum supported version.

2. `_thinking_budget_kernel`

   Its `_load_effective_token` helper returns values from different runtime branches and pointer sources. During TTIR-to-Linalg conversion, this can produce an invalid zero-operand `func.return` and leave an unresolved `memref<?xi32>` to `!tt.ptr<i32>` materialization.

   The Ascend helper replaces the runtime branch returns with complementary masked loads followed by `tl.where`. The three effective-token loading call sites are the only functional changes to the thinking-budget kernel itself.

This PR also:

- Patches the two upstream kernel bindings to use their Ascend-compatible implementations.
- Keeps the upstream `apply_thinking_budget` wrapper unchanged.
- Ports all 12 upstream Model Runner V2 thinking-budget tests to the A2 NPU test suite.
- Documents the compiler issues, adaptations, and removal conditions in `vllm_ascend/patch/__init__.py`.

### Does this PR introduce _any_ user-facing change?
No 

### How was this patch tested?
```bash
pytest -q tests/ut/sample/a2/test_thinking_budget.py

result : 12 passed
```


- vLLM version: v0.27.2rc0
- vLLM main: https://github.com/vllm-project/vllm/commit/7f7a32cfec0f1bc5b73c37200b86631523a1ea8f
