### PR TITLE
[Doc][Model] Add Dots3 Note title to nav_titles hook

### DIFF
--- a/docs/hooks/nav_titles.py
+++ b/docs/hooks/nav_titles.py
@@ -112,6 +112,7 @@ TITLES = {
     "tutorials/models/DeepSeek-V4-Flash.md": {"en": "DeepSeek-V4-Flash", "zh": "DeepSeek-V4-Flash"},
     "tutorials/models/DeepSeek-V4-Pro.md": {"en": "DeepSeek-V4-Pro", "zh": "DeepSeek-V4-Pro"},
     "tutorials/models/DeepSeekOCR2.md": {"en": "DeepSeekOCR2", "zh": "DeepSeekOCR2"},
+    "tutorials/models/Dots3-Note.md": {"en": "Dots3 Note", "zh": "Dots3 Note"},
     "tutorials/models/GLM4.x.md": {"en": "GLM-4.x", "zh": "GLM-4.x"},
     "tutorials/models/GLM5.2.md": {"en": "GLM-5.2", "zh": "GLM-5.2"},
     "tutorials/models/GLM5.md": {"en": "GLM-5", "zh": "GLM-5"},


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds the Dots3 Note tutorial page title to the MkDocs 
av_titles hook.

- Registers 	utorials/models/Dots3-Note.md in docs/hooks/nav_titles.py with English and Chinese titles, following the Dots3 Note deployment tutorial added in #14279.

### Does this PR introduce _any_ user-facing change?

No. It only sets the page title shown in the MkDocs navigation for the already-published Dots3 Note tutorial.

### How was this patch tested?

- python -m py_compile docs/hooks/nav_titles.py passes.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
