### PR TITLE
[Bugfix]Guard async SWA KV free queue handling

### DIFF
--- a/vllm_ascend/patch/platform/patch_async_swa_kv_lifetime.py
+++ b/vllm_ascend/patch/platform/patch_async_swa_kv_lifetime.py
@@ -6,6 +6,7 @@ from functools import wraps
 from typing import Any
 
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -16,7 +17,38 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.request import Request
 
+logger = init_logger(__name__)
+
 _prune_context: ContextVar[tuple[str, int] | None] = ContextVar("ascend_swa_prune_context", default=None)
+
+
+def _handle_negative_in_flight(
+    request_id: str,
+    num_in_flight_tokens: int,
+    where: str,
+    num_scheduled_tokens: int | None = None,
+) -> None:
+    msg = (
+        "SWA_BLOCK_DIAG negative_in_flight_tokens "
+        f"where={where} request_id={request_id} "
+        f"num_in_flight_tokens={num_in_flight_tokens}"
+    )
+    if num_scheduled_tokens is not None:
+        msg += f" num_scheduled_tokens={num_scheduled_tokens}"
+    logger.warning(msg)
+
+
+def _safe_in_flight_tokens(request: Request, where: str) -> int:
+    num_in_flight_tokens = getattr(request, "num_in_flight_tokens", 0)
+    if num_in_flight_tokens < 0:
+        _handle_negative_in_flight(
+            request.request_id,
+            num_in_flight_tokens,
+            where,
+        )
+        request.num_in_flight_tokens = 0
+        return 0
+    return num_in_flight_tokens
 
 
 def _max_in_flight_tokens(vllm_config: VllmConfig) -> int:
@@ -54,6 +86,14 @@ def _patched_update_from_output(
     for request_id, num_scheduled_tokens in scheduler_output.num_scheduled_tokens.items():
         if request := self.requests.get(request_id):
             request.num_in_flight_tokens -= num_scheduled_tokens
+            if request.num_in_flight_tokens < 0:
+                _handle_negative_in_flight(
+                    request_id,
+                    request.num_in_flight_tokens,
+                    "update_from_output",
+                    num_scheduled_tokens,
+                )
+                request.num_in_flight_tokens = 0
     return _original_update_from_output(self, scheduler_output, model_runner_output)
 
 
@@ -62,7 +102,7 @@ _original_allocate_slots = KVCacheManager.allocate_slots
 
 @wraps(_original_allocate_slots)
 def _patched_allocate_slots(self: KVCacheManager, request: Request, *args: Any, **kwargs: Any) -> Any:
-    token = _prune_context.set((request.request_id, request.num_in_flight_tokens))
+    token = _prune_context.set((request.request_id, _safe_in_flight_tokens(request, "allocate_slots")))
     try:
         return _original_allocate_slots(self, request, *args, **kwargs)
     finally:
@@ -74,7 +114,7 @@ _original_connector_finished = Scheduler._connector_finished
 
 @wraps(_original_connector_finished)
 def _patched_connector_finished(self: Scheduler, request: Request) -> tuple[bool, dict[str, Any] | None]:
-    token = _prune_context.set((request.request_id, request.num_in_flight_tokens))
+    token = _prune_context.set((request.request_id, _safe_in_flight_tokens(request, "connector_finished")))
     try:
         return _original_connector_finished(self, request)
     finally:
@@ -96,7 +136,15 @@ def _patched_remove_skipped_blocks(
         and context[0] == request_id
         and isinstance(self.kv_cache_spec, (ChunkedLocalAttentionSpec, SlidingWindowSpec))
     ):
-        total_computed_tokens = max(0, total_computed_tokens - context[1])
+        num_in_flight_tokens = context[1]
+        if num_in_flight_tokens < 0:
+            _handle_negative_in_flight(
+                request_id,
+                num_in_flight_tokens,
+                "remove_skipped_blocks",
+            )
+            num_in_flight_tokens = 0
+        total_computed_tokens = max(0, total_computed_tokens - num_in_flight_tokens)
     _original_remove_skipped_blocks(self, request_id, total_computed_tokens)
 
 

--- a/vllm_ascend/patch/platform/patch_async_swa_kv_lifetime.py
+++ b/vllm_ascend/patch/platform/patch_async_swa_kv_lifetime.py
@@ -6,7 +6,7 @@ from functools import wraps
 from typing import Any
 
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
+from vllm.logger import logger
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -16,8 +16,6 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
-
-logger = init_logger(__name__)
 
 _prune_context: ContextVar[tuple[str, int] | None] = ContextVar("ascend_swa_prune_context", default=None)
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 import vllm.v1.core.block_pool
 import vllm.v1.core.kv_cache_utils
 from vllm.config import VllmConfig
-from vllm.logger import init_logger
+from vllm.logger import logger
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
@@ -27,8 +27,6 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.utils import vllm_version_is
-
-logger = init_logger(__name__)
 
 
 def _queue_block_summary(block: KVCacheBlock) -> str:

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -2,11 +2,20 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
 import math
 from collections import defaultdict
+from collections.abc import Iterable
 
+import vllm.v1.core.block_pool
 import vllm.v1.core.kv_cache_utils
 from vllm.config import VllmConfig
+from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv, round_up
-from vllm.v1.core.kv_cache_utils import _approximate_gcd, may_override_num_blocks
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (
+    FreeKVCacheBlockQueue,
+    KVCacheBlock,
+    _approximate_gcd,
+    may_override_num_blocks,
+)
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
@@ -18,6 +27,86 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.utils import vllm_version_is
+
+logger = init_logger(__name__)
+
+
+def _queue_block_summary(block: KVCacheBlock) -> str:
+    prev_id = block.prev_free_block.block_id if block.prev_free_block is not None else None
+    next_id = block.next_free_block.block_id if block.next_free_block is not None else None
+    return (
+        f"block_id={block.block_id} ref_cnt={block.ref_cnt} "
+        f"is_null={block.is_null} prev_free_block={prev_id} next_free_block={next_id}"
+    )
+
+
+def _swa_block_diag(kind: str, block: KVCacheBlock, where: str) -> None:
+    msg = f"SWA_BLOCK_DIAG {kind} where={where} {_queue_block_summary(block)}"
+    logger.warning(msg)
+
+
+def _dedupe_free_blocks(blocks: Iterable[KVCacheBlock], where: str) -> list[KVCacheBlock]:
+    deduped_blocks: list[KVCacheBlock] = []
+    seen_block_ids: set[int] = set()
+    for block in blocks:
+        if not block.is_null and block.block_id in seen_block_ids:
+            _swa_block_diag("duplicate_free_batch", block, where)
+            continue
+        if not block.is_null:
+            seen_block_ids.add(block.block_id)
+        deduped_blocks.append(block)
+    return deduped_blocks
+
+
+def _filter_queue_insert_blocks(blocks: list[KVCacheBlock], where: str) -> list[KVCacheBlock]:
+    filtered_blocks: list[KVCacheBlock] = []
+    seen_block_ids: set[int] = set()
+    for block in blocks:
+        if block.is_null:
+            _swa_block_diag("null_free_queue_insert", block, where)
+            continue
+        if block.block_id in seen_block_ids:
+            _swa_block_diag("duplicate_free_queue_insert", block, where)
+            continue
+        if block.ref_cnt != 0:
+            _swa_block_diag("nonzero_ref_cnt_free_queue_insert", block, where)
+            continue
+        if block.prev_free_block is not None or block.next_free_block is not None:
+            _swa_block_diag("linked_free_queue_insert", block, where)
+            continue
+        seen_block_ids.add(block.block_id)
+        filtered_blocks.append(block)
+    return filtered_blocks
+
+
+_orig_block_pool_free_blocks = BlockPool.free_blocks
+
+
+def _ascend_free_blocks(
+    self: BlockPool,
+    ordered_blocks: Iterable[KVCacheBlock],
+    prepend: bool = False,
+) -> None:
+    filtered_blocks: list[KVCacheBlock] = []
+    for block in _dedupe_free_blocks(ordered_blocks, "BlockPool.free_blocks"):
+        if not block.is_null and block.ref_cnt <= 0:
+            _swa_block_diag("ref_cnt_underflow_free_blocks", block, "BlockPool.free_blocks")
+            continue
+        filtered_blocks.append(block)
+    _orig_block_pool_free_blocks(self, filtered_blocks, prepend)
+
+
+_orig_free_queue_prepend_n = FreeKVCacheBlockQueue.prepend_n
+_orig_free_queue_append_n = FreeKVCacheBlockQueue.append_n
+
+
+def _ascend_free_queue_prepend_n(self: FreeKVCacheBlockQueue, blocks: list[KVCacheBlock]) -> None:
+    _orig_free_queue_prepend_n(self, _filter_queue_insert_blocks(blocks, "FreeKVCacheBlockQueue.prepend_n"))
+
+
+def _ascend_free_queue_append_n(self: FreeKVCacheBlockQueue, blocks: list[KVCacheBlock]) -> None:
+    _orig_free_queue_append_n(self, _filter_queue_insert_blocks(blocks, "FreeKVCacheBlockQueue.append_n"))
+
 
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 
@@ -249,6 +338,12 @@ def _get_kv_cache_config_deepseek_v4(
     return num_blocks, kv_cache_tensors
 
 
+BlockPool.free_blocks = _ascend_free_blocks
+vllm.v1.core.block_pool.BlockPool.free_blocks = _ascend_free_blocks
+FreeKVCacheBlockQueue.prepend_n = _ascend_free_queue_prepend_n
+FreeKVCacheBlockQueue.append_n = _ascend_free_queue_append_n
+vllm.v1.core.kv_cache_utils.FreeKVCacheBlockQueue.prepend_n = _ascend_free_queue_prepend_n
+vllm.v1.core.kv_cache_utils.FreeKVCacheBlockQueue.append_n = _ascend_free_queue_append_n
 vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
 vllm.v1.core.kv_cache_utils.group_and_unify_kv_cache_specs = group_and_unify_kv_cache_specs
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_groups_uniform_groups


### PR DESCRIPTION
### What this PR does / why we need it?

Add safe guards for a rare "curr_block is no None" assertion error from vLLM:
1. set num_in_flight_tokens to 0 if it < 0.
2. dedup blocks to avoid breaking free block queue.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
