### PR TITLE
[Bugfix] Account for ATB TilingBufferPool in memory profiling

### DIFF
--- a/tests/ut/worker/a2/test_worker_multi_instance.py
+++ b/tests/ut/worker/a2/test_worker_multi_instance.py
@@ -33,6 +33,17 @@ class TestDetermineAvailableMemoryMultiInstance(TestBase):
         mock_ascend_config.return_value.sparse_kv_offload_config.enabled = False
         self.addCleanup(self.ascend_config_patcher.stop)
 
+        self.device_type_patcher = patch("vllm_ascend.worker.worker.get_ascend_device_type")
+        mock_get_device_type = self.device_type_patcher.start()
+        from vllm_ascend.worker.worker import AscendDeviceType
+
+        mock_get_device_type.return_value = AscendDeviceType.A2
+        self.addCleanup(self.device_type_patcher.stop)
+
+        self.warm_up_atb_patcher = patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
+        self.warm_up_atb_patcher.start()
+        self.addCleanup(self.warm_up_atb_patcher.stop)
+
     # ------------------------------------------------------------------ #
     # Helpers
     # ------------------------------------------------------------------ #

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -748,8 +748,12 @@ class TestNPUWorker(TestBase):
     @patch("torch_npu.npu.memory_stats")
     @patch("torch_npu.npu.mem_get_info")
     @patch("vllm_ascend.worker.worker.logger")
+    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
+    @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
     def test_determine_available_memory_normal_case(
         self,
+        mock_warm_up_atb,
+        mock_get_ascend_device_type,
         mock_logger,
         mock_torch_mem_get_info,
         mock_torch_memory_stats,
@@ -759,7 +763,9 @@ class TestNPUWorker(TestBase):
         mock_get_ascend_config,
     ):
         """Test determine_available_memory normal case (no non-torch memory allocation)"""
-        from vllm_ascend.worker.worker import NPUWorker
+        from vllm_ascend.worker.worker import AscendDeviceType, NPUWorker
+
+        mock_get_ascend_device_type.return_value = AscendDeviceType.A2
 
         # Mock memory_profiling context manager
         mock_profile_result = MagicMock()
@@ -802,6 +808,7 @@ class TestNPUWorker(TestBase):
             result = worker.determine_available_memory()
 
             worker.model_runner.profile_run.assert_called_once()
+            mock_warm_up_atb.assert_called_once()
 
             # non_kv_cache_memory = non_torch_increase(1000) + torch_peak_increase(2000-0) + weights_memory(500) = 3500
             # result = requested_memory(8000) - non_kv_cache_memory(3500) = 4500
@@ -814,8 +821,12 @@ class TestNPUWorker(TestBase):
     @patch("torch.npu.empty_cache")
     @patch("torch_npu.npu.memory_stats")
     @patch("torch_npu.npu.mem_get_info")
+    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
+    @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
     def test_determine_available_memory_with_non_torch_allocations(
         self,
+        mock_warm_up_atb,
+        mock_get_ascend_device_type,
         mock_torch_mem_get_info,
         mock_torch_memory_stats,
         mock_torch_empty_cache,
@@ -824,7 +835,9 @@ class TestNPUWorker(TestBase):
         mock_get_ascend_config,
     ):
         """Test determine_available_memory with significant non-torch memory allocation"""
-        from vllm_ascend.worker.worker import NPUWorker
+        from vllm_ascend.worker.worker import AscendDeviceType, NPUWorker
+
+        mock_get_ascend_device_type.return_value = AscendDeviceType.A2
 
         # Mock memory_profiling context manager with large non-torch allocation
         mock_profile_result = MagicMock()
@@ -873,11 +886,21 @@ class TestNPUWorker(TestBase):
     @patch("torch.npu.mem_get_info")
     @patch("torch.npu.reset_peak_memory_stats")
     @patch("torch.npu.empty_cache")
+    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
+    @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
     def test_determine_available_memory_memory_profiling_error(
-        self, mock_torch_empty_cache, mock_torch_reset_peak_memory_stats, mock_torch_mem_get_info, mock_memory_profiling
+        self,
+        mock_warm_up_atb,
+        mock_get_ascend_device_type,
+        mock_torch_empty_cache,
+        mock_torch_reset_peak_memory_stats,
+        mock_torch_mem_get_info,
+        mock_memory_profiling,
     ):
         """Test determine_available_memory throws exception on memory profiling error"""
-        from vllm_ascend.worker.worker import NPUWorker
+        from vllm_ascend.worker.worker import AscendDeviceType, NPUWorker
+
+        mock_get_ascend_device_type.return_value = AscendDeviceType.A2
 
         # Mock memory_profiling where free memory after profile > init free memory (error case)
         mock_profile_result = MagicMock()
@@ -920,8 +943,12 @@ class TestNPUWorker(TestBase):
     @patch("torch.npu.empty_cache")
     @patch("torch_npu.npu.memory_stats")
     @patch("torch_npu.npu.mem_get_info")
+    @patch("vllm_ascend.worker.worker.get_ascend_device_type")
+    @patch("vllm_ascend.worker.worker.NPUWorker._warm_up_atb")
     def test_determine_available_memory_negative_result(
         self,
+        mock_warm_up_atb,
+        mock_get_ascend_device_type,
         mock_torch_mem_get_info,
         mock_torch_memory_stats,
         mock_torch_empty_cache,
@@ -930,7 +957,9 @@ class TestNPUWorker(TestBase):
         mock_get_ascend_config,
     ):
         """Test determine_available_memory returns 0 when result is negative"""
-        from vllm_ascend.worker.worker import NPUWorker
+        from vllm_ascend.worker.worker import AscendDeviceType, NPUWorker
+
+        mock_get_ascend_device_type.return_value = AscendDeviceType.A2
 
         # Mock memory_profiling where non_kv_cache_memory > requested_memory
         mock_profile_result = MagicMock()
@@ -1309,7 +1338,7 @@ class TestNPUWorker(TestBase):
             self.assertEqual(mock_logger.info.call_count, 4)
 
             # Verify atb warm up
-            mock_warm_up_atb.assert_called_once()
+            mock_warm_up_atb.assert_not_called()
             mock_kernel_warmup.assert_called_once_with(worker)
 
     @patch("vllm_ascend.worker.worker.set_random_seed")
@@ -1371,7 +1400,7 @@ class TestNPUWorker(TestBase):
             worker.model_runner.capture_model.assert_called_once()
 
             # Verify atb warm up
-            mock_warm_up_atb.assert_called_once()
+            mock_warm_up_atb.assert_not_called()
             mock_kernel_warmup.assert_called_once_with(worker)
 
     @patch("vllm_ascend.worker.worker.ensure_kv_transfer_initialized")

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -490,6 +490,8 @@ class NPUWorker(WorkerBase):
         # but skip the memory profiling calculation entirely.
         if kv_cache_memory_bytes := self.cache_config.kv_cache_memory_bytes:
             self.model_runner.profile_run()
+            if get_ascend_device_type() != AscendDeviceType.A5:
+                self._warm_up_atb()
             logger.info(
                 "Initial free memory %.2f GiB, reserved %.2f GiB for KV Cache "
                 "as specified by kv_cache_memory_bytes, skipping memory profiling. "
@@ -511,6 +513,11 @@ class NPUWorker(WorkerBase):
             weights_memory=int(self.model_runner.model_memory_usage),
         ) as profile_result:
             self.model_runner.profile_run()
+
+            # Call ATB matmul to warm up; otherwise, the first operation (ReshapeAndCache)
+            # may cause performance degradation at runtime.
+            if get_ascend_device_type() != AscendDeviceType.A5:
+                self._warm_up_atb()
 
             # Record torch peak INSIDE the context and BEFORE graph capture,
             # so that graph pool allocations don't inflate the activation peak.
@@ -791,10 +798,6 @@ class NPUWorker(WorkerBase):
             )
             logger.info(msg)
 
-        # Call ATB matmul to warm up; otherwise, the first operation (ReshapeAndCache)
-        # may cause performance degradation at runtime.
-        if get_ascend_device_type() != AscendDeviceType.A5:
-            self._warm_up_atb()
         # Bind after warmup so hot allocations are already materialized on the
         # worker process before migratepages/taskset run.
         if get_ascend_config().enable_cpu_binding:


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #14300.

`NPUWorker._warm_up_atb()` triggers a fixed **96 MiB** device allocation from the
NNAL/ATB `TilingBufferPool`. It was called after `memory_profiling` had closed
and after `capture_model()` had reported graph memory, so the allocation was
counted in neither. Because it goes through ACL directly rather than the PyTorch
allocator, `torch.npu.memory_allocated()` / `memory_reserved()` do not see it
either.

The pool is allocated **per rank**, so the unaccounted amount scales with tensor
parallelism — ~98 MiB at TP=1, ~196 MiB at TP=2, which already exceeds the
existing 150 MiB `redundancy_buffer`.

This PR moves the warm-up call to right after `profile_run()`, inside the
`memory_profiling` context and before `profile_torch_peak` is recorded, so the
pool is included in `non_torch_increase` and correctly deducted from the KV cache
budget.

The explicit `--kv-cache-memory` fast path bypasses `memory_profiling` entirely,
so it gets its own warm-up call after `profile_run()`.

**This is a user-visible change**: KV cache shrinks by ~98 MiB per rank. That is
correct accounting rather than a regression — the previous value was an
overestimate.

### Does this PR introduce any user-facing change?

Yes. Available KV cache is reduced by approximately 98 MiB per rank, reflecting
memory that was already being consumed but not accounted for.

### How was this patch tested?

Measured on Ascend A3 (`Ascend910_9362`), CANN 9.1.0, NNAL/ATB 9.1.0.B150.

**KV cache before / after**

| Config | State | KV cache | Tokens |
|---|---|---|---|
| Qwen3-8B BF16, TP=1, PIECEWISE | before | 27.46 GiB | 199,936 |
| Qwen3-8B BF16, TP=1, PIECEWISE | after | 27.37 GiB | 199,296 |
| Qwen3.6-35B-A3B-W8A8, TP=2, PIECEWISE | before | 22.69 GiB/rank | — |
| Qwen3.6-35B-A3B-W8A8, TP=2, PIECEWISE | after | 22.59 GiB/rank | — |

For TP=2 the per-worker process memory confirms the per-rank reduction:
```
before:  42,502 MB / 42,502 MB
after:   42,402 MB / 42,402 MB     (-100 MB per rank)
```
**The delayed post-capture step is gone**

With 50 ms DCMI sampling:

| Config | before | after |
|---|---|---|
| TP=1 | +96 MB / +98 MB after capture | no positive step (−3 MB jitter) |
| TP=2 | +98 MB on both dies | chip0 +1 MB, chip1 0 MB |

This confirms the allocation is now inside the profiling window rather than
disappearing.

**Functional checks**

- Both models start, serve one request, and exit cleanly before and after
- Generated text is byte-identical before and after
- No startup regression: engine init 21.20 s before, 21.33 / 21.65 s after
- No residual NPU processes; HBM returns to idle baseline

### Notes and limitations

- **Validation was performed on v0.18.0**, since that is the version running on
  the available hardware. The patch here targets `main`; the change is
  equivalent, but the line numbers differ.
- **v0.18.0 has no `--kv-cache-memory` fast path**, so the warm-up call added on
  that path in this PR is not covered by the measurements above. It follows the
  same reasoning: that path skips `memory_profiling`, so it needs its own
  warm-up.
- The `310P` no-op override and the `A5` exclusion are unchanged.
- Unit tests updated: `determine_available_memory_normal_case` now asserts
  `_warm_up_atb()` is called once; the two `compile_or_warm_up_model` cases
  assert it is no longer called there. **The full test suite was not run on
  `main`** — the available environment is v0.18.0 with torch-npu 2.9, while
  `main` requires torch-npu 2.10.0.post4.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
