### PR TITLE
[BugFix][MoE] Keep DP token counts uniform for MegaMoe

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1126,7 +1126,8 @@ def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = Fa
     - Decode requires MC2 and ascend_config.scheduler_config.recompute_scheduler_enable is True.
 
     Skipping means each rank may have a different number of tokens, so MC2 needs
-    a non-zero global_bs and must NOT receive mc2_mask.
+    a non-zero global_bs and must NOT receive mc2_mask. CANN MegaMoe requires
+    uniform token counts across ranks, so its FUSED_MC2 path cannot skip.
 
     Returns False when hierarchy comm is enabled because hierarchy requires
     global_bs=0 (uniform tokens), which is incompatible with skipping allreduce.
@@ -1149,21 +1150,23 @@ def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = Fa
     if not is_kv_consumer:
         return False
 
-    from vllm_ascend.ascend_forward_context import select_moe_comm_method
+    from vllm_ascend.ascend_forward_context import _MEGA_MOE_SUPPORTED, select_moe_comm_method
     from vllm_ascend.ops.fused_moe.moe_comm_method import MoECommType
-
-    def needs_mc2(n: int) -> bool:
-        return select_moe_comm_method(n, vllm_config) in {MoECommType.MC2, MoECommType.FUSED_MC2}
 
     scheduler_config = vllm_config.scheduler_config
     # potential_max_tokens is read from the set/get global (computed once in init).
-    decode_must_use_mc2 = needs_mc2(get_potential_max_tokens())
+    decode_comm_method = select_moe_comm_method(get_potential_max_tokens(), vllm_config)
     # For prefill, use the scheduler's max_num_batched_tokens for a single batch.
-    prefill_must_use_mc2 = needs_mc2(scheduler_config.max_num_batched_tokens)
+    prefill_comm_method = select_moe_comm_method(scheduler_config.max_num_batched_tokens, vllm_config)
+
+    if _MEGA_MOE_SUPPORTED and MoECommType.FUSED_MC2 in {decode_comm_method, prefill_comm_method}:
+        return False
+
+    mc2_comm_methods = {MoECommType.MC2, MoECommType.FUSED_MC2}
     # Skip all-reduce if decode requires MC2 and either prefill also
     # requires MC2 or recompute-based scheduler is enabled.
-    return decode_must_use_mc2 and (
-        prefill_must_use_mc2 or get_ascend_config().scheduler_config.recompute_scheduler_enable
+    return decode_comm_method in mc2_comm_methods and (
+        prefill_comm_method in mc2_comm_methods or get_ascend_config().scheduler_config.recompute_scheduler_enable
     )
 
 


### PR DESCRIPTION
Fixes #14273

### What this PR does / why we need it?

CANN MegaMoe requires every rank in its communication domain to use the same number of input tokens. In a Prefill/Decode-disaggregated deployment, KV consumer workers could skip the DP metadata all-reduce when the selected communication method was `FUSED_MC2`. That allowed ranks to enter MegaMoe with different token counts and produced incorrect MoE outputs.

This change checks the resolved decode and prefill communication methods. When MegaMoe is available and either path selects `FUSED_MC2`, DP metadata synchronization is retained so all ranks are padded to a uniform token count. The existing skip optimization remains unchanged for MC2 and legacy fused MC2 implementations that support non-uniform token counts.

This fixes the output-corruption part of #14273.

### Does this PR introduce _any_ user-facing change?

Yes. Prefill/Decode-disaggregated MoE deployments using CANN MegaMoe no longer produce incorrect output because of non-uniform token counts across DP ranks.

### How was this patch tested?

- `python3 -m py_compile vllm_ascend/utils.py`
- `ruff check vllm_ascend/utils.py`
- `ruff format --check vllm_ascend/utils.py`
- `git diff --check`
- End-to-end validation with a multi-rank PD Decode consumer using CANN 9.1.0, expert parallelism, `FUSED_MC2`/MegaMoe, and graph-mode Decode:
  - Before the change, deterministic requests returned corrupted output.
  - After the change, repeated direct and proxied requests returned valid, consistent output.

No unit test was added because the failure requires runtime MegaMoe availability together with distributed communication-method selection and multi-rank PD execution.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
