### PR TITLE
[Bugfix]mask premature eos during in_reasoning for DeepSeek-V4

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -126,6 +126,7 @@ class TestAscendConfig(TestBase):
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertFalse(ascend_config.multistream_overlap_shared_expert)
         self.assertFalse(ascend_config.enable_kv_nz)
+        self.assertEqual(ascend_config.premature_eos_policy, "allow")
 
         ascend_compilation_config = ascend_config.ascend_compilation_config
         self.assertTrue(ascend_compilation_config.fuse_norm_quant)
@@ -148,10 +149,12 @@ class TestAscendConfig(TestBase):
             "eplb_config": {"num_redundant_experts": 2},
             "refresh": True,
             "enable_kv_nz": False,
+            "premature_eos_policy": "mask_in_reasoning",
         }
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertEqual(ascend_config.eplb_config.num_redundant_experts, 2)
         self.assertTrue(ascend_config.multistream_overlap_shared_expert)
+        self.assertEqual(ascend_config.premature_eos_policy, "mask_in_reasoning")
 
         ascend_compilation_config = ascend_config.ascend_compilation_config
         self.assertFalse(ascend_compilation_config.fuse_norm_quant)

--- a/tests/ut/worker/test_thinking_budget_state.py
+++ b/tests/ut/worker/test_thinking_budget_state.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.sample.logits_processor.interface import BatchUpdate
+
+from vllm_ascend.worker.thinking_budget_state import (
+    DSV4_EOS_TOKEN_ID,
+    DSV4_THINK_END_TOKEN_ID,
+    DSV4_THINK_START_TOKEN_ID,
+    PREMATURE_EOS_POLICY_ALLOW,
+    PREMATURE_EOS_POLICY_MASK_IN_REASONING,
+    AscendThinkingBudgetStateHolder,
+)
+
+VOCAB_SIZE = DSV4_THINK_END_TOKEN_ID + 8
+
+
+def _reasoning_config(start_token_ids=None, end_token_ids=None):
+    if start_token_ids is None:
+        start_token_ids = [DSV4_THINK_START_TOKEN_ID]
+    if end_token_ids is None:
+        end_token_ids = [DSV4_THINK_END_TOKEN_ID]
+    return SimpleNamespace(
+        reasoning_start_token_ids=start_token_ids,
+        reasoning_end_token_ids=end_token_ids,
+    )
+
+
+def _sampling_params(ignore_eos=False, eos_token_id=DSV4_EOS_TOKEN_ID, thinking_token_budget=None):
+    return SimpleNamespace(
+        ignore_eos=ignore_eos,
+        eos_token_id=eos_token_id,
+        thinking_token_budget=thinking_token_budget,
+    )
+
+
+def _holder(policy=PREMATURE_EOS_POLICY_MASK_IN_REASONING, num_spec_tokens=0, reasoning_config=None):
+    return AscendThinkingBudgetStateHolder(
+        reasoning_config or _reasoning_config(),
+        max_num_seqs=4,
+        num_spec_tokens=num_spec_tokens,
+        device=torch.device("cpu"),
+        is_pin_memory=False,
+        premature_eos_policy=policy,
+    )
+
+
+def _sync_request(holder, prompt_token_ids, output_token_ids, params=None):
+    holder.sync_batch(
+        BatchUpdate(
+            batch_size=1,
+            removed=[],
+            added=[(0, params or _sampling_params(), prompt_token_ids, output_token_ids)],
+            moved=[],
+        )
+    )
+
+
+def test_masks_eos_incrementally_until_think_end():
+    output_token_ids: list[int] = []
+    holder = _holder()
+    _sync_request(holder, [DSV4_THINK_START_TOKEN_ID], output_token_ids)
+
+    logits = torch.zeros((1, VOCAB_SIZE))
+    holder.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=None)
+    assert torch.isneginf(logits[0, DSV4_EOS_TOKEN_ID])
+
+    output_token_ids.extend([10, 11])
+    holder.update_state([output_token_ids], spec_token_ids=None)
+    assert holder._state[0]["in_reasoning"] is True
+    assert holder._state[0]["consumed_output_len"] == 2
+
+    output_token_ids.append(DSV4_THINK_END_TOKEN_ID)
+    logits = torch.zeros((1, VOCAB_SIZE))
+    holder.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=None)
+    assert logits[0, DSV4_EOS_TOKEN_ID] == 0
+
+
+def test_masks_spec_target_and_bonus_positions():
+    holder = _holder(num_spec_tokens=3)
+    _sync_request(holder, [DSV4_THINK_START_TOKEN_ID], [])
+
+    spec_token_ids = [[10, DSV4_THINK_END_TOKEN_ID, 11]]
+    logits = torch.zeros((3, VOCAB_SIZE))
+    holder.apply_to_logits(logits, predict_bonus_token=False, spec_token_ids=spec_token_ids)
+
+    assert torch.isneginf(logits[0, DSV4_EOS_TOKEN_ID])
+    assert torch.isneginf(logits[1, DSV4_EOS_TOKEN_ID])
+    assert logits[2, DSV4_EOS_TOKEN_ID] == 0
+
+    holder = _holder(num_spec_tokens=2)
+    _sync_request(holder, [DSV4_THINK_START_TOKEN_ID], [])
+
+    logits = torch.zeros((1, VOCAB_SIZE))
+    holder.apply_to_logits(
+        logits,
+        predict_bonus_token=True,
+        spec_token_ids=[[10, DSV4_THINK_END_TOKEN_ID]],
+    )
+    assert logits[0, DSV4_EOS_TOKEN_ID] == 0
+
+    holder = _holder(num_spec_tokens=2)
+    _sync_request(holder, [DSV4_THINK_START_TOKEN_ID], [])
+    logits = torch.zeros((1, VOCAB_SIZE))
+    holder.apply_to_logits(logits, predict_bonus_token=True, spec_token_ids=[[10, 11]])
+    assert torch.isneginf(logits[0, DSV4_EOS_TOKEN_ID])
+
+
+def test_eos_mask_requires_explicit_dsv4_policy_and_sampling_eos():
+    holder = _holder(policy=PREMATURE_EOS_POLICY_ALLOW)
+    _sync_request(holder, [DSV4_THINK_START_TOKEN_ID], [])
+    assert not holder.has_tracked_requests()
+
+    holder = _holder()
+    _sync_request(holder, [DSV4_THINK_START_TOKEN_ID], [], params=_sampling_params(ignore_eos=True))
+    assert not holder.has_tracked_requests()
+
+    holder = _holder()
+    _sync_request(holder, [DSV4_THINK_START_TOKEN_ID], [], params=_sampling_params(eos_token_id=2))
+    assert not holder.has_tracked_requests()
+
+    holder = _holder(reasoning_config=_reasoning_config(start_token_ids=[7], end_token_ids=[8]))
+    _sync_request(holder, [7], [])
+    assert not holder.has_tracked_requests()

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -34,6 +34,13 @@ class AscendConfig:
         additional_config = vllm_config.additional_config if vllm_config.additional_config is not None else {}
         self._check_mooncake_c8_kv_cache_quant(vllm_config)
 
+        self.premature_eos_policy = additional_config.get("premature_eos_policy", "allow")
+        if self.premature_eos_policy not in ("allow", "mask_in_reasoning"):
+            raise ValueError(
+                "additional_config.premature_eos_policy must be one of "
+                f"['allow', 'mask_in_reasoning'], got {self.premature_eos_policy!r}."
+            )
+
         xlite_graph_config = additional_config.get("xlite_graph_config", {})
         self.xlite_graph_config = XliteGraphConfig(xlite_graph_config, vllm_config)
 

--- a/vllm_ascend/worker/npu_input_batch.py
+++ b/vllm_ascend/worker/npu_input_batch.py
@@ -27,12 +27,14 @@ from vllm.v1.kv_cache_interface import KVCacheGroupSpec
 from vllm.v1.outputs import LogprobsTensors
 from vllm.v1.pool.metadata import PoolingStates
 from vllm.v1.sample.logits_processor import BatchUpdateBuilder, LogitsProcessors
-from vllm.v1.sample.thinking_budget_state import (
-    maybe_create_thinking_budget_state_holder,
-)
 from vllm.v1.worker.gpu_input_batch import InputBatch
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.worker.block_table import MultiGroupBlockTable
+from vllm_ascend.worker.thinking_budget_state import (
+    PREMATURE_EOS_POLICY_ALLOW,
+    maybe_create_ascend_thinking_budget_state_holder,
+)
 
 
 class NPUInputBatch(InputBatch):
@@ -68,12 +70,16 @@ class NPUInputBatch(InputBatch):
 
         self.is_pooling_model = is_pooling_model
         self.is_spec_decode = is_spec_decode
-        self.thinking_budget_state_holder = maybe_create_thinking_budget_state_holder(
+        premature_eos_policy = PREMATURE_EOS_POLICY_ALLOW
+        if reasoning_config is not None:
+            premature_eos_policy = get_ascend_config().premature_eos_policy
+        self.thinking_budget_state_holder = maybe_create_ascend_thinking_budget_state_holder(
             reasoning_config,
             max_num_reqs,
             num_speculative_tokens,
             device,
             pin_memory,
+            premature_eos_policy=premature_eos_policy,
         )
         self.thinking_token_budget_reqs: set[str] = set()
         self.max_num_reqs = max_num_reqs

--- a/vllm_ascend/worker/thinking_budget_state.py
+++ b/vllm_ascend/worker/thinking_budget_state.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Ascend-local thinking budget state extensions."""
+
+from typing import TYPE_CHECKING, Any
+
+import torch
+from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.v1.sample.logits_processor.interface import BatchUpdate
+from vllm.v1.sample.thinking_budget_state import ThinkingBudgetStateHolder
+
+if TYPE_CHECKING:
+    from vllm.config.reasoning import ReasoningConfig
+    from vllm.sampling_params import SamplingParams
+
+
+PREMATURE_EOS_POLICY_ALLOW = "allow"
+PREMATURE_EOS_POLICY_MASK_IN_REASONING = "mask_in_reasoning"
+PREMATURE_EOS_POLICIES = {
+    PREMATURE_EOS_POLICY_ALLOW,
+    PREMATURE_EOS_POLICY_MASK_IN_REASONING,
+}
+
+DSV4_EOS_TOKEN_ID = 1
+DSV4_THINK_START_TOKEN_ID = 128821
+DSV4_THINK_END_TOKEN_ID = 128822
+
+
+def maybe_create_ascend_thinking_budget_state_holder(
+    reasoning_config: "ReasoningConfig | None",
+    max_num_seqs: int,
+    num_spec_tokens: int,
+    device: torch.device,
+    is_pin_memory: bool,
+    premature_eos_policy: str = PREMATURE_EOS_POLICY_ALLOW,
+) -> "AscendThinkingBudgetStateHolder | None":
+    if reasoning_config is None:
+        return None
+    return AscendThinkingBudgetStateHolder(
+        reasoning_config,
+        max_num_seqs,
+        num_spec_tokens,
+        device,
+        is_pin_memory,
+        premature_eos_policy=premature_eos_policy,
+    )
+
+
+class AscendThinkingBudgetStateHolder(ThinkingBudgetStateHolder):
+    """Adds DeepSeek V4 premature-EOS masking on top of vLLM thinking budget."""
+
+    def __init__(
+        self,
+        reasoning_config: "ReasoningConfig | None",
+        max_num_seqs: int,
+        num_spec_tokens: int,
+        device: torch.device,
+        is_pin_memory: bool,
+        premature_eos_policy: str = PREMATURE_EOS_POLICY_ALLOW,
+    ):
+        if premature_eos_policy not in PREMATURE_EOS_POLICIES:
+            raise ValueError(
+                f"premature_eos_policy must be one of {sorted(PREMATURE_EOS_POLICIES)}, got {premature_eos_policy!r}."
+            )
+
+        super().__init__(reasoning_config, max_num_seqs, num_spec_tokens, device, is_pin_memory)
+        self._mask_premature_eos = (
+            premature_eos_policy == PREMATURE_EOS_POLICY_MASK_IN_REASONING
+            and self.think_start_token_ids == [DSV4_THINK_START_TOKEN_ID]
+            and self.think_end_token_ids == [DSV4_THINK_END_TOKEN_ID]
+        )
+
+    def sync_batch(self, batch_update: BatchUpdate | None) -> None:
+        """Add EOS-only tracked rows after upstream thinking-budget sync."""
+        super().sync_batch(batch_update)
+        if not self.is_enabled or not batch_update:
+            return
+
+        for index, params, prompt_tok_ids, output_tok_ids in batch_update.added:
+            eos_token_id = self._get_eos_token_id(params)
+            if not self._mask_premature_eos or eos_token_id is None:
+                if index in self._state:
+                    self._state[index]["eos_token_id"] = None
+                continue
+            if index not in self._state:
+                self._state[index] = self._init_state_entry(prompt_tok_ids, -1)
+            self._state[index]["eos_token_id"] = eos_token_id
+            self._state[index]["output_tok_ids"] = output_tok_ids
+            self._state[index]["spec_token_ids"] = []
+            self._init_eos_mask_state(self._state[index])
+
+    def update_state(
+        self,
+        output_token_ids: list[list[int]],
+        spec_token_ids: list[list[int]] | None,
+        repeat_indices: torch.Tensor | None = None,
+    ) -> None:
+        super().update_state(output_token_ids, spec_token_ids, repeat_indices)
+        if not self.is_enabled or not self._state:
+            return
+        for state in self._state.values():
+            self._update_eos_mask_state(state)
+
+    def apply_to_logits(
+        self,
+        logits: torch.Tensor,
+        predict_bonus_token: bool,
+        spec_token_ids: list[list[int]] | None,
+    ) -> torch.Tensor:
+        logits = super().apply_to_logits(logits, predict_bonus_token, spec_token_ids)
+        if not self.is_enabled or not self._state or not self._mask_premature_eos:
+            return logits
+
+        spec_lists = spec_token_ids or []
+        eos_mask_indices_cpu: list[int] = []
+        eos_tokens_cpu: list[int] = []
+        for seq_idx in sorted(self._state.keys()):
+            if seq_idx not in self.cu_num_tokens:
+                continue
+            state = self._state[seq_idx]
+            self._update_eos_mask_state(state)
+            spec_tokens = spec_lists[seq_idx] if seq_idx < len(spec_lists) else []
+            self._append_eos_mask_entries(
+                eos_mask_indices_cpu,
+                eos_tokens_cpu,
+                seq_idx,
+                state,
+                spec_tokens,
+                predict_bonus_token,
+                logits.shape[0],
+            )
+
+        self._set_logits_values(logits, eos_mask_indices_cpu, eos_tokens_cpu, -float("inf"))
+        return logits
+
+    @staticmethod
+    def _get_eos_token_id(params: "SamplingParams") -> int | None:
+        if params.ignore_eos or params.eos_token_id != DSV4_EOS_TOKEN_ID:
+            return None
+        return params.eos_token_id
+
+    @staticmethod
+    def _consume_reasoning_token(in_reasoning: bool, token_id: int) -> bool:
+        if token_id == DSV4_THINK_START_TOKEN_ID:
+            return True
+        if token_id == DSV4_THINK_END_TOKEN_ID:
+            return False
+        return in_reasoning
+
+    def _advance_reasoning_state(self, in_reasoning: bool, token_ids: list[int]) -> bool:
+        for token_id in token_ids:
+            in_reasoning = self._consume_reasoning_token(in_reasoning, token_id)
+        return in_reasoning
+
+    def _init_eos_mask_state(self, state: dict[str, Any]) -> None:
+        prompt_tok_ids = state.get("prompt_tok_ids") or []
+        output_tok_ids = state.get("output_tok_ids") or []
+        in_reasoning = self._advance_reasoning_state(False, prompt_tok_ids)
+        state["in_reasoning"] = self._advance_reasoning_state(in_reasoning, output_tok_ids)
+        state["consumed_output_len"] = len(output_tok_ids)
+
+    def _update_eos_mask_state(self, state: dict[str, Any]) -> None:
+        if not self._mask_premature_eos or state.get("eos_token_id") is None:
+            state["in_reasoning"] = False
+            state["consumed_output_len"] = len(state.get("output_tok_ids") or [])
+            return
+        output_tok_ids = state.get("output_tok_ids") or []
+        consumed_output_len = state.get("consumed_output_len", 0)
+        if consumed_output_len > len(output_tok_ids):
+            self._init_eos_mask_state(state)
+            return
+        state["in_reasoning"] = self._advance_reasoning_state(
+            state.get("in_reasoning", False),
+            output_tok_ids[consumed_output_len:],
+        )
+        state["consumed_output_len"] = len(output_tok_ids)
+
+    def _append_eos_mask_entries(
+        self,
+        rows: list[int],
+        tokens: list[int],
+        seq_idx: int,
+        state: dict[str, Any],
+        spec_tokens: list[int],
+        predict_bonus_token: bool,
+        num_logits_rows: int,
+    ) -> None:
+        base_row = self.cu_num_tokens[seq_idx]
+        eos_token_id = state.get("eos_token_id")
+        if eos_token_id is None:
+            return
+
+        def append_row(row: int) -> None:
+            if row >= num_logits_rows:
+                return
+            rows.append(row)
+            tokens.append(eos_token_id)
+
+        if not self.in_spec_mode:
+            if state.get("in_reasoning", False):
+                append_row(base_row)
+            return
+
+        in_reasoning = state.get("in_reasoning", False)
+        if predict_bonus_token:
+            if self._advance_reasoning_state(in_reasoning, spec_tokens):
+                append_row(base_row)
+            return
+
+        for draft_idx, token_id in enumerate(spec_tokens):
+            if in_reasoning:
+                append_row(base_row + draft_idx)
+            in_reasoning = self._consume_reasoning_token(in_reasoning, token_id)
+
+    def _set_logits_values(
+        self,
+        logits: torch.Tensor,
+        rows_cpu: list[int],
+        tokens_cpu: list[int],
+        value: float,
+    ) -> None:
+        if not rows_cpu:
+            return
+        device = logits.device
+        tensor_h2d = torch.tensor if device.type == "cpu" else async_tensor_h2d
+        rows = tensor_h2d(rows_cpu, dtype=torch.long, device=device)
+        tokens = tensor_h2d(tokens_cpu, dtype=torch.long, device=device)
+        fill = logits.new_full((len(rows_cpu),), value)
+        logits.index_put_((rows, tokens), fill)


### PR DESCRIPTION
Fixes #14031 

### What this PR does / why we need it?

  This PR fixes the DeepSeek-V4 premature EOS issue on Ascend NPU during reasoning. When reasoning has started with `<think>` but has not reached `</think>`, EOS
  token id `1` can be sampled unexpectedly and terminate generation early.

  The fix is implemented in vLLM-Ascend only and is gated by an explicit Ascend config:

  {"premature_eos_policy": "mask_in_reasoning"}

  Scope is intentionally limited to the MVP requested:

  - DeepSeek-V4 only
  - EOS token id: 1
  - <think> token id: 128821
  - </think> token id: 128822
  - Uses SamplingParams.eos_token_id
  - Disabled when ignore_eos=True
  - Default behavior remains allow

  ### Does this PR introduce any user-facing change?

  Yes, but only when explicitly enabled.

  A new Ascend additional config option is added:

  {"premature_eos_policy": "mask_in_reasoning"}

  By default, premature_eos_policy is allow, so existing behavior is unchanged.

  ### How was this patch tested?

  Related unit tests:

  pytest -q tests/ut/worker/test_thinking_budget_state.py tests/ut/test_ascend_config.py

  Result:

  46 passed, 3 warnings, 10 subtests passed in 0.98s

  An Ascend NPU tensor-level smoke test was also run. This is not a full model inference test. It directly verifies that
  AscendThinkingBudgetStateHolder.apply_to_logits() masks EOS token id 1 on real NPU logits tensors while the request is inside <think>, and restores EOS after </think>.

  Environment:

  - Hardware: Ascend A3
  - CANN: 8.5.1
  - torch-npu: 2.10.0.post4
  - vLLM-Ascend source: current PR branch

  Command:

  ```bash
  PYTHONPATH=/tmp/codex_test_shims:/tmp/codex_vllm_58d:/mnt/share_space/codex_dir/vllm-ascend:$PYTHONPATH \
  ASCEND_VISIBLE_DEVICES=2 \
  OMP_PROC_BIND=false \
  OMP_NUM_THREADS=1 \
  PYTORCH_NPU_ALLOC_CONF=expandable_segments:True \
  python /tmp/test_ascend_eos_mask.py
  <details>
  <summary>Temporary test script: /tmp/test_ascend_eos_mask.py</summary>

  from types import SimpleNamespace

  import torch
  import torch_npu
  from vllm.v1.sample.logits_processor.interface import BatchUpdate

  from vllm_ascend.worker.thinking_budget_state import (
      DSV4_EOS_TOKEN_ID,
      DSV4_THINK_END_TOKEN_ID,
      DSV4_THINK_START_TOKEN_ID,
      PREMATURE_EOS_POLICY_MASK_IN_REASONING,
      AscendThinkingBudgetStateHolder,
  )

  VOCAB_SIZE = DSV4_THINK_END_TOKEN_ID + 8

  torch.npu.set_device(0)
  device = torch.device("npu:0")

  reasoning_config = SimpleNamespace(
      reasoning_start_token_ids=[DSV4_THINK_START_TOKEN_ID],
      reasoning_end_token_ids=[DSV4_THINK_END_TOKEN_ID],
  )

  sampling_params = SimpleNamespace(
      ignore_eos=False,
      eos_token_id=DSV4_EOS_TOKEN_ID,
      thinking_token_budget=None,
  )

  def make_holder(num_spec_tokens):
      return AscendThinkingBudgetStateHolder(
          reasoning_config,
          max_num_seqs=4,
          num_spec_tokens=num_spec_tokens,
          device=device,
          is_pin_memory=False,
          premature_eos_policy=PREMATURE_EOS_POLICY_MASK_IN_REASONING,
      )

  def sync(holder, output_token_ids):
      holder.sync_batch(
          BatchUpdate(
              batch_size=1,
              removed=[],
              added=[
                  (
                      0,
                      sampling_params,
                      [DSV4_THINK_START_TOKEN_ID],
                      output_token_ids,
                  )
              ],
              moved=[],
          )
      )

  normal_output = []
  normal_holder = make_holder(num_spec_tokens=0)
  sync(normal_holder, normal_output)

  normal_logits = torch.zeros((1, VOCAB_SIZE), device=device)
  normal_holder.apply_to_logits(
      normal_logits,
      predict_bonus_token=False,
      spec_token_ids=None,
  )
  torch.npu.synchronize()
  normal_eos = normal_logits[0, DSV4_EOS_TOKEN_ID].cpu()
  print("NPU_NORMAL_EOS", normal_eos.item())
  assert torch.isneginf(normal_eos)

  normal_output.append(DSV4_THINK_END_TOKEN_ID)
  normal_holder.update_state([normal_output], spec_token_ids=None)

  after_logits = torch.zeros((1, VOCAB_SIZE), device=device)
  normal_holder.apply_to_logits(
      after_logits,
      predict_bonus_token=False,
      spec_token_ids=None,
  )
  torch.npu.synchronize()
  after_eos = after_logits[0, DSV4_EOS_TOKEN_ID].cpu().item()
  print("NPU_AFTER_END_EOS", after_eos)
  assert after_eos == 0.0

  spec_holder = make_holder(num_spec_tokens=2)
  sync(spec_holder, [])

  spec_logits = torch.zeros((2, VOCAB_SIZE), device=device)
  spec_holder.apply_to_logits(
      spec_logits,
      predict_bonus_token=False,
      spec_token_ids=[[10, DSV4_THINK_END_TOKEN_ID]],
  )
  torch.npu.synchronize()
  spec_values = [spec_logits[i, DSV4_EOS_TOKEN_ID].cpu() for i in range(2)]
  print("NPU_SPEC_EOS", [v.item() for v in spec_values])
  assert torch.isneginf(spec_values[0])
  assert torch.isneginf(spec_values[1])

  bonus_holder = make_holder(num_spec_tokens=2)
  sync(bonus_holder, [])

  bonus_logits = torch.zeros((1, VOCAB_SIZE), device=device)
  bonus_holder.apply_to_logits(
      bonus_logits,
      predict_bonus_token=True,
      spec_token_ids=[[10, DSV4_THINK_END_TOKEN_ID]],
  )
  torch.npu.synchronize()
  bonus_eos = bonus_logits[0, DSV4_EOS_TOKEN_ID].cpu().item()
  print("NPU_BONUS_AFTER_DRAFT_END_EOS", bonus_eos)
  assert bonus_eos == 0.0

  print("NPU_MASK_SMOKE_DONE")
  </details>
  ```

  Result:

  NPU_NORMAL_EOS -inf
  NPU_AFTER_END_EOS 0.0
  NPU_SPEC_EOS [-inf, -inf]
  NPU_BONUS_AFTER_DRAFT_END_EOS 0.0
  NPU_MASK_SMOKE_DONE

  Result interpretation:

  - NPU_NORMAL_EOS -inf: EOS token id 1 was masked while still inside <think>.
  - NPU_AFTER_END_EOS 0.0: EOS token id 1 was restored after </think>.
  - NPU_SPEC_EOS [-inf, -inf]: EOS was masked for speculative target logits while still inside reasoning.
  - NPU_BONUS_AFTER_DRAFT_END_EOS 0.0: EOS was restored for the bonus token when draft tokens already included </think>.
  - NPU_MASK_SMOKE_DONE: All assertions passed.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
