### PR TITLE
[bugfix] fix bug when D node with mix_cudagraph_mode and without recompute_scheduler

### DIFF
--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1162,7 +1162,7 @@ def get_potential_max_tokens() -> int:
     return _potential_max_tokens
 
 
-def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = False) -> bool:
+def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_model: bool = False) -> bool:
     """Decide whether to skip the all-reduce across the DP group.
 
     Skipping is applicable for all dense models and for moe models only on ranks
@@ -1202,13 +1202,16 @@ def should_skip_allreduce_across_dp_group(vllm_config, is_draft_model: bool = Fa
 
     scheduler_config = vllm_config.scheduler_config
     # potential_max_tokens is read from the set/get global (computed once in init).
-    decode_must_use_mc2 = needs_mc2(get_potential_max_tokens())
+    # if mc2 is used in decode max potential tokens case, we can skip allreduce in decode only case.
+    decode_can_skip = needs_mc2(get_potential_max_tokens())
     # For prefill, use the scheduler's max_num_batched_tokens for a single batch.
+    # if mc2 is used in prefill max potential tokens case and prefill and decode have the same cudagraph mode,
+    # we can skip allreduce in chunked prefill case.
     prefill_must_use_mc2 = needs_mc2(scheduler_config.max_num_batched_tokens)
-    # Skip all-reduce if decode requires MC2 and either prefill also
-    # requires MC2 or recompute-based scheduler is enabled.
-    return decode_must_use_mc2 and (
-        prefill_must_use_mc2 or get_ascend_config().scheduler_config.recompute_scheduler_enable
+    uniform_cudagraph_mode = not vllm_config.compilation_config.cudagraph_mode.separate_routine()
+    chunked_prefill_can_skip = prefill_must_use_mc2 and uniform_cudagraph_mode
+    return decode_can_skip and (
+        chunked_prefill_can_skip or get_ascend_config().scheduler_config.recompute_scheduler_enable
     )
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

When D node with mix_cudagraph_mode and without recompute_scheduler, We overlooked the verification of the cudagraph mode earlier, which may cause different DP running on different cudagraph mode.

### Does this PR introduce _any_ user-facing change?

None.

### How was this patch tested?


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
