### PR TITLE
[v0.25.1rc][BugFix][Frontend] Align DeepSeek V4 parser thinking default

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -2,6 +2,7 @@
 
 import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
 from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
 
@@ -10,6 +11,9 @@ class FakeTokenizer:
 
     def get_added_vocab(self):
         return {}
+
+    def get_vocab(self):
+        return {"<think>": 1, "</think>": 2}
 
     def encode(self, text, add_special_tokens=False, **kwargs):
         return text
@@ -170,6 +174,52 @@ def test_deepseek_v4_defaults_to_thinking_with_high_effort():
 
     assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum")
     assert prompt.endswith("<｜Assistant｜><think>")
+
+
+@pytest.mark.parametrize(
+    ("chat_template_kwargs", "expected_state"),
+    [
+        ({}, "REASONING"),
+        ({"thinking": True}, "REASONING"),
+        ({"enable_thinking": True}, "REASONING"),
+        ({"reasoning_effort": "high"}, "REASONING"),
+        ({"thinking": False}, "CONTENT"),
+        ({"enable_thinking": False}, "CONTENT"),
+        ({"enable_thinking": True, "reasoning_effort": "none"}, "CONTENT"),
+    ],
+)
+def test_parser_thinking_mode_matches_tokenizer_default(
+    chat_template_kwargs,
+    expected_state,
+):
+    parser = DeepSeekV4Parser(
+        FakeTokenizer(),
+        chat_template_kwargs=chat_template_kwargs,
+    )
+
+    assert parser.parser_engine_config.initial_state.name == expected_state
+
+
+@pytest.mark.parametrize("request_kwargs", [{}, {"reasoning_effort": "high"}])
+def test_parser_splits_implicit_start_reasoning(request_kwargs):
+    request = ChatCompletionRequest(
+        model="deepseek-v4",
+        messages=[{"role": "user", "content": "hi"}],
+        **request_kwargs,
+    )
+    params = request.build_chat_params(None, "auto")
+    parser = DeepSeekV4Parser(
+        FakeTokenizer(),
+        chat_template_kwargs=params.chat_template_kwargs,
+    )
+
+    reasoning, content = parser.extract_reasoning(
+        "reasoning text</think>answer text",
+        request,
+    )
+
+    assert reasoning == "reasoning text"
+    assert content == "answer text"
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -71,6 +71,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.tokenizers.deepseek_v4.get_deepseek_v4_tokenizer`
 #      `vllm.tokenizers.deepseek_v4_encoding.render_message`
+#      `vllm.parser.deepseek_v4.DeepSeekV4Parser.__init__`
 #    Why:
 #       DeepSeek-V4-Flash-0731 defines three reasoning effort levels: low has
 #       no prompt prefix, high uses the original "Absolute maximum" prefix,
@@ -80,11 +81,15 @@
 #       Monkey-patch tokenizer normalization so omitted options select
 #       thinking with high effort and compatibility aliases map to canonical
 #       low, high, or max. Wrap render_message to prepend the official 0731
-#       prompt before the first message in thinking mode.
+#       prompt before the first message in thinking mode. Align the parser's
+#       default state with the tokenizer so implicit thinking is extracted as
+#       reasoning instead of content.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/50580
+#       https://github.com/vllm-project/vllm/pull/51296
 #    Future Plan:
-#       Remove this patch once the supported vLLM version contains PR #50580.
+#       Remove this patch once the supported vLLM version contains PR #50580
+#       and PR #51296.
 #
 # ** 4. File: platform/patch_distributed.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from functools import wraps
 from typing import Any
 
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
 from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
 REASONING_EFFORT_PROMPTS = {
@@ -47,6 +49,7 @@ DEFAULT_REASONING_EFFORT = "low"
 
 _original_render_message = deepseek_v4_encoding.render_message
 _original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
+_original_deepseek_v4_parser_init = DeepSeekV4Parser.__init__
 
 
 def _patched_render_message(
@@ -139,7 +142,24 @@ def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
     return dsv4_tokenizer
 
 
+@wraps(_original_deepseek_v4_parser_init)
+def _patched_deepseek_v4_parser_init(
+    self: DeepSeekV4Parser,
+    tokenizer: Any,
+    tools: list[Any] | None = None,
+    **kwargs: Any,
+) -> None:
+    chat_kwargs = kwargs.get("chat_template_kwargs") or {}
+    if "thinking" not in chat_kwargs and "enable_thinking" not in chat_kwargs:
+        chat_kwargs = dict(chat_kwargs)
+        chat_kwargs["enable_thinking"] = True
+        kwargs["chat_template_kwargs"] = chat_kwargs
+
+    _original_deepseek_v4_parser_init(self, tokenizer, tools, **kwargs)
+
+
 if not hasattr(deepseek_v4_encoding, "REASONING_EFFORT_PROMPTS"):
     deepseek_v4_encoding.REASONING_EFFORT_PROMPTS = REASONING_EFFORT_PROMPTS
     deepseek_v4_encoding.render_message = _patched_render_message
     deepseek_v4.get_deepseek_v4_tokenizer = _patched_get_deepseek_v4_tokenizer
+    DeepSeekV4Parser.__init__ = _patched_deepseek_v4_parser_init

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -145,8 +145,7 @@ def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
 @wraps(_original_deepseek_v4_parser_init)
 def _patched_deepseek_v4_parser_init(
     self: DeepSeekV4Parser,
-    tokenizer: Any,
-    tools: list[Any] | None = None,
+    *args: Any,
     **kwargs: Any,
 ) -> None:
     chat_kwargs = kwargs.get("chat_template_kwargs") or {}
@@ -155,7 +154,7 @@ def _patched_deepseek_v4_parser_init(
         chat_kwargs["enable_thinking"] = True
         kwargs["chat_template_kwargs"] = chat_kwargs
 
-    _original_deepseek_v4_parser_init(self, tokenizer, tools, **kwargs)
+    _original_deepseek_v4_parser_init(self, *args, **kwargs)
 
 
 if not hasattr(deepseek_v4_encoding, "REASONING_EFFORT_PROMPTS"):


### PR DESCRIPTION
Backport vLLM-Ascend PR #14074 from releases/v0.26.0rc to releases/v0.25.1rc.

The DeepSeek V4 Flash 0731 tokenizer backport defaults omitted thinking controls to thinking mode with high reasoning effort, while the vLLM v0.25.1 parser still starts in CONTENT mode. Because the rendered prompt already ends with <think>, generated reasoning may not emit another opening tag and is consequently returned in content.

Enable the parser thinking state only when both thinking and enable_thinking are omitted. Preserve explicit thinking disablement and reasoning_effort=none semantics, and add parser state and implicit-start regression coverage.

Related upstream changes: vLLM PR #50580 and PR #51296.

Validation: python -m pytest -q tests/ut/patch/platform/test_deepseek_v4_thinking.py (35 passed); two-node real-weight DeepSeek-V4-Pro-0813 W4A8 regression requests passed for default and explicit high reasoning effort.

(cherry picked from commit 761066ead262db0a0427ca143a14f1035cb8908c)

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
