### PR TITLE
[v0.23.0][Doc] Add PD DCP consistency warning for SFA models

### DIFF
--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
@@ -6,6 +6,10 @@ vLLM-Ascend now supports prefill-decode (PD) disaggregation with EP (Expert Para
 
 Take the DeepSeek-r1-w8a8 model as an example, use 4 Atlas 800T A3 servers to deploy the "2P1D" architecture. Assume the IP of the prefiller server is 192.0.0.1 (prefill 1) and 192.0.0.2 (prefill 2), and the decoder servers are 192.0.0.3 (decoder 1) and 192.0.0.4 (decoder 2). On each server, use 8 NPUs and 16 chips to deploy one service instance.
 
+```{warning}
+When using Decode Context Parallelism (DCP) in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
+```
+
 ## Verify Multi-Node Communication Environment
 
 ### Physical Layer Requirements

--- a/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
+++ b/docs/source/tutorials/features/pd_disaggregation_mooncake_multi_node.md
@@ -7,7 +7,7 @@ vLLM-Ascend now supports prefill-decode (PD) disaggregation with EP (Expert Para
 Take the DeepSeek-r1-w8a8 model as an example, use 4 Atlas 800T A3 servers to deploy the "2P1D" architecture. Assume the IP of the prefiller server is 192.0.0.1 (prefill 1) and 192.0.0.2 (prefill 2), and the decoder servers are 192.0.0.3 (decoder 1) and 192.0.0.4 (decoder 2). On each server, use 8 NPUs and 16 chips to deploy one service instance.
 
 ```{warning}
-When using Decode Context Parallelism (DCP) in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
+This limitation applies to models with a DeepSeek-V3.2-style architecture that use the Sparse Flash Attention (SFA) backend, such as DeepSeek-V3.2, GLM-5.1, and GLM-5.2. When using Decode Context Parallelism (DCP) with these models, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
 ```
 
 ## Verify Multi-Node Communication Environment

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -393,6 +393,10 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V3.2-W8A8 \
 
 We recommend using Mooncake for deployment: [Mooncake](../features/pd_disaggregation_mooncake_multi_node.md).
 
+```{warning}
+When using Decode Context Parallelism (DCP) in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
+```
+
 In the standard single-node deployment mode, Prefill (prompt processing) and Decode (token generation) tasks run on the same set of NPUs. PD (Prefill-Decode) separation addresses this by running Prefill and Decode on dedicated node groups, each configured independently:
 
 - **Prefill nodes** focus on high-throughput prompt processing, optimized for compute and communication.

--- a/docs/source/tutorials/models/DeepSeek-V3.2.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.2.md
@@ -394,7 +394,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/DeepSeek-V3.2-W8A8 \
 We recommend using Mooncake for deployment: [Mooncake](../features/pd_disaggregation_mooncake_multi_node.md).
 
 ```{warning}
-When using Decode Context Parallelism (DCP) in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
+For DeepSeek-V3.2's Sparse Flash Attention (SFA) backend, when using Decode Context Parallelism (DCP) in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
 ```
 
 In the standard single-node deployment mode, Prefill (prompt processing) and Decode (token generation) tasks run on the same set of NPUs. PD (Prefill-Decode) separation addresses this by running Prefill and Decode on dedicated node groups, each configured independently:

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1271,6 +1271,8 @@ Recommended configurations for serving `GLM-5.2` with a 1M context window on Atl
 The 1M context scenarios are validated on Atlas 800 A3 only; the A2 series is not validated for 1M context.
 
 ::::{warning}
+For GLM-5.2's Sparse Flash Attention (SFA) backend, when using DCP in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
+
 DCP and Sparse Flash Attention C8 (`enable_sparse_sfa_c8`, also referred to as `sfa_c8`) are experimental features in v0.23.0. Enabling them together has known issues in this release, including performance degradation, and is not recommended. The following 1M deployment examples enable DCP and leave `enable_sparse_sfa_c8` disabled.
 ::::
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -809,6 +809,10 @@ In addition to all single-node parameters described in [Single-Node Online Deplo
 
 We'd like to show the deployment guide of `GLM-5` on multi-node environment with 1P1D for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
 
+```{warning}
+For GLM-5.1's Sparse Flash Attention (SFA) backend, when using Decode Context Parallelism (DCP) in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
+```
+
 Before you start, please
 
 1. prepare the script `launch_online_dp.py` on each node:
@@ -1383,6 +1387,10 @@ Once the preparation is done, you can start the server with the following comman
 ### 5.4 Prefill-Decode Disaggregation (Ascend950DT series)
 
 We'd like to show the deployment guide of `GLM-5` on multi-node environment with 2P1D for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
+
+```{warning}
+For GLM-5.1's Sparse Flash Attention (SFA) backend, when using Decode Context Parallelism (DCP) in PD disaggregation, enable it on both the prefiller and decoder nodes, or disable it on both. Enabling DCP on only one side can cause known accuracy issues.
+```
 
 Before you start, please
 


### PR DESCRIPTION
## What changed

- scope the PD DCP consistency limitation to DeepSeek-V3.2-style models that use the Sparse Flash Attention (SFA) backend
- list DeepSeek-V3.2, GLM-5.1, and GLM-5.2 as representative affected models in the multi-node PD disaggregation guide
- add model-specific warnings to the DeepSeek-V3.2 and GLM-5/GLM-5.1 PD deployment sections
- add the GLM-5.2 warning to the 1M Context Deployment section alongside its existing DCP/SFA known-issue guidance

## Why

For affected SFA models, enabling DCP on only one side of a PD deployment can cause known accuracy issues. DCP must be enabled on both prefiller and decoder nodes, or disabled on both.

## User impact

Users can identify which model architecture and attention backend the limitation applies to and keep DCP configuration consistent across both sides of a PD deployment.

## Validation

- `git diff --check`
- verified that only the four intended Markdown files changed

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
