### PR TITLE
[BugFix][PD] Validate SFA DCP consistency

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1473,11 +1473,13 @@ vllm serve <MODEL_PATH> \
       "use_ascend_direct": true,
       "prefill": {
         "dp_size": 4,
-        "tp_size": 8
+        "tp_size": 8,
+        "dcp_size": 8
       },
       "decode": {
         "dp_size": 4,
-        "tp_size": 8
+        "tp_size": 8,
+        "dcp_size": 8
       }
     }
   }'
@@ -1546,11 +1548,13 @@ vllm serve <MODEL_PATH> \
       "use_ascend_direct": true,
       "prefill": {
         "dp_size": 4,
-        "tp_size": 8
+        "tp_size": 8,
+        "dcp_size": 8
       },
       "decode": {
         "dp_size": 4,
-        "tp_size": 8
+        "tp_size": 8,
+        "dcp_size": 8
       }
     }
   }'
@@ -1576,7 +1580,7 @@ Key Parameter Descriptions (in addition to [Prefill-Decode Disaggregation](#5113
 **Prefill nodes (1M):**
 
 - `--additional-config '{"recompute_scheduler_enable": true, ...}'`: The recompute scheduler is enabled on both prefill and decode nodes in this scenario.
-- `--kv-transfer-config`: Mooncake connector as `kv_producer` with `prefill: dp4 tp8` / `decode: dp4 tp8` (matching the 1M P/D topology, in contrast to `dp32 tp1` decode in the sub-1M PD scenario).
+- `--kv-transfer-config`: Mooncake connector as `kv_producer` with `prefill: dp4 tp8 dcp8` / `decode: dp4 tp8 dcp8` (matching the 1M P/D topology, in contrast to `dp32 tp1` decode in the sub-1M PD scenario). For SFA models, set `dcp_size` to the actual DCP size in both sections; prefill and decode must either both enable DCP or both disable it.
 
 **Decode nodes (1M):**
 

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -15,6 +15,7 @@
 
 import math
 import os
+from types import SimpleNamespace
 from unittest import mock
 
 import pytest
@@ -23,6 +24,46 @@ import torch
 from tests.ut.base import TestBase
 from vllm_ascend import utils
 from vllm_ascend.utils import REGISTERED_ASCEND_OPS
+
+
+def _make_kv_extra_config(
+    *,
+    role: str,
+    local_dcp_size: int,
+    prefill_dcp_size: int | None,
+    decode_dcp_size: int | None,
+    use_sfa: bool = True,
+):
+    prefill_config = {"tp_size": 8, "dp_size": 1}
+    decode_config = {"tp_size": 8, "dp_size": 1}
+    if prefill_dcp_size is not None:
+        prefill_config["dcp_size"] = prefill_dcp_size
+    if decode_dcp_size is not None:
+        decode_config["dcp_size"] = decode_dcp_size
+
+    kv_transfer_config = mock.MagicMock(
+        kv_role=role,
+        is_kv_producer=role == "kv_producer",
+        is_kv_consumer=role == "kv_consumer",
+    )
+    kv_transfer_config.get_from_extra_config.side_effect = lambda key, default: {
+        "prefill": prefill_config,
+        "decode": decode_config,
+    }.get(key, default)
+
+    hf_text_config = SimpleNamespace(index_topk=2048) if use_sfa else SimpleNamespace()
+    return SimpleNamespace(
+        kv_transfer_config=kv_transfer_config,
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=8,
+            data_parallel_size=1,
+            decode_context_parallel_size=local_dcp_size,
+        ),
+        model_config=SimpleNamespace(
+            hf_text_config=hf_text_config,
+            hf_config=SimpleNamespace(),
+        ),
+    )
 
 
 class TestUtils(TestBase):
@@ -458,3 +499,88 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer_disabled():
     ascend_config.scheduler_config.recompute_scheduler_enable = False
     with mock.patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config):
         assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is False
+
+
+@pytest.mark.parametrize("role", ["kv_producer", "kv_consumer"])
+def test_check_kv_extra_config_accepts_sfa_pd_with_dcp_enabled_on_both_sides(role):
+    vllm_config = _make_kv_extra_config(
+        role=role,
+        local_dcp_size=8,
+        prefill_dcp_size=8,
+        decode_dcp_size=8,
+    )
+
+    utils.check_kv_extra_config(vllm_config)
+
+
+@pytest.mark.parametrize("role", ["kv_producer", "kv_consumer"])
+def test_check_kv_extra_config_accepts_sfa_pd_with_dcp_disabled_on_both_sides(role):
+    vllm_config = _make_kv_extra_config(
+        role=role,
+        local_dcp_size=1,
+        prefill_dcp_size=None,
+        decode_dcp_size=None,
+    )
+
+    utils.check_kv_extra_config(vllm_config)
+
+
+@pytest.mark.parametrize(
+    ("role", "local_dcp_size", "prefill_dcp_size", "decode_dcp_size"),
+    [
+        ("kv_producer", 8, 8, 1),
+        ("kv_consumer", 8, 1, 8),
+    ],
+)
+def test_check_kv_extra_config_rejects_sfa_pd_with_dcp_enabled_on_only_one_side(
+    role,
+    local_dcp_size,
+    prefill_dcp_size,
+    decode_dcp_size,
+):
+    vllm_config = _make_kv_extra_config(
+        role=role,
+        local_dcp_size=local_dcp_size,
+        prefill_dcp_size=prefill_dcp_size,
+        decode_dcp_size=decode_dcp_size,
+    )
+
+    with pytest.raises(ValueError, match="SFA models in PD disaggregation require DCP"):
+        utils.check_kv_extra_config(vllm_config)
+
+
+def test_check_kv_extra_config_rejects_sfa_pd_with_missing_local_dcp_size():
+    vllm_config = _make_kv_extra_config(
+        role="kv_producer",
+        local_dcp_size=8,
+        prefill_dcp_size=None,
+        decode_dcp_size=8,
+    )
+
+    with pytest.raises(ValueError, match="conflicting decode context parallel size"):
+        utils.check_kv_extra_config(vllm_config)
+
+
+def test_check_kv_extra_config_does_not_apply_sfa_dcp_rule_to_other_backends():
+    vllm_config = _make_kv_extra_config(
+        role="kv_producer",
+        local_dcp_size=8,
+        prefill_dcp_size=None,
+        decode_dcp_size=None,
+        use_sfa=False,
+    )
+
+    utils.check_kv_extra_config(vllm_config)
+
+
+def test_check_kv_extra_config_does_not_apply_sfa_dcp_rule_to_colocated_serving():
+    vllm_config = _make_kv_extra_config(
+        role="kv_both",
+        local_dcp_size=8,
+        prefill_dcp_size=None,
+        decode_dcp_size=None,
+    )
+    vllm_config.kv_transfer_config.is_kv_producer = True
+    vllm_config.kv_transfer_config.is_kv_consumer = True
+
+    utils.check_kv_extra_config(vllm_config)

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1238,6 +1238,12 @@ def dispose_layer(layer: Any):
 
 
 def check_kv_extra_config(vllm_config):
+    kv_transfer_config = vllm_config.kv_transfer_config
+    prefill_config = kv_transfer_config.get_from_extra_config("prefill", {})
+    decode_config = kv_transfer_config.get_from_extra_config("decode", {})
+    is_pd_disaggregated = bool(kv_transfer_config.is_kv_producer) != bool(kv_transfer_config.is_kv_consumer)
+    validate_sfa_dcp = is_pd_disaggregated and model_uses_sfa_sparse(vllm_config.model_config)
+
     def _check(name: str, config: dict):
         tp_key = "tp_size"
         dp_key = "dp_size"
@@ -1258,10 +1264,29 @@ def check_kv_extra_config(vllm_config):
                     f"Expected {vllm_dp}, but got {config_dp}."
                 )
 
-    if vllm_config.kv_transfer_config.is_kv_producer:
-        _check("prefill", vllm_config.kv_transfer_config.get_from_extra_config("prefill", {}))
-    if vllm_config.kv_transfer_config.is_kv_consumer:
-        _check("decode", vllm_config.kv_transfer_config.get_from_extra_config("decode", {}))
+        if validate_sfa_dcp:
+            config_dcp = config.get("dcp_size", 1)
+            vllm_dcp = vllm_config.parallel_config.decode_context_parallel_size
+            if config_dcp != vllm_dcp:
+                raise ValueError(
+                    f"KV transfer '{name}' config has a conflicting decode context parallel size. "
+                    f"Expected {vllm_dcp}, but got {config_dcp}."
+                )
+
+    if kv_transfer_config.is_kv_producer:
+        _check("prefill", prefill_config)
+    if kv_transfer_config.is_kv_consumer:
+        _check("decode", decode_config)
+
+    if validate_sfa_dcp:
+        prefill_dcp = prefill_config.get("dcp_size", 1)
+        decode_dcp = decode_config.get("dcp_size", 1)
+        if (prefill_dcp > 1) != (decode_dcp > 1):
+            raise ValueError(
+                "SFA models in PD disaggregation require DCP to be enabled on both prefill and decode nodes "
+                "or disabled on both. "
+                f"Got prefill dcp_size={prefill_dcp} and decode dcp_size={decode_dcp}."
+            )
 
 
 def is_gqa_backend(vllm_config: VllmConfig) -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?

SFA PD disaggregation requires compatible DCP layouts on the prefill and decode sides. A mixed deployment—DCP enabled on only one side—can produce incompatible KV/indexer layouts.

This change extends the existing KV connector extra-config validation to:

- reuse `model_uses_sfa_sparse` for SFA model detection;
- treat an omitted `dcp_size` as DCP disabled (`1`);
- validate the local PD role's declared `dcp_size` against the actual parallel configuration;
- reject configurations where only one PD side enables DCP, while allowing both sides enabled or both disabled;
- document both-side `dcp_size` configuration in the GLM-5.2 DCP8 PD example.

### Does this PR introduce _any_ user-facing change?

Yes. For SFA models in PD disaggregation, `prefill` and `decode` in `kv_connector_extra_config` must enable DCP together or disable it together.

### How was this patch tested?

- `uvx ruff==0.14.0 check vllm_ascend/utils.py tests/ut/test_utils.py`
- `git diff --check`
- Added targeted unit cases for both-enabled, both-disabled, both mismatch directions, local runtime/config mismatch, non-SFA models, and colocated SFA serving.
- Attempted a four-NPU, single-layer synthetic DeepSeek-V3.2 PD service validation. It was blocked before source synchronization and service launch by invalid ownership/permissions on the local OpenSSH system configuration file `/etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf` (workspace knowledge match: `machine-management-openssh-system-config-ownership`). The temporary container and NPU lease were cleaned up.
- Target pytest and service smoke were not executed because of that infrastructure blocker.

https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
