### PR TITLE
[Doc][Misc] Update LoRA MoE support status

### DIFF
--- a/docs/source/user_guide/feature_guide/lora.md
+++ b/docs/source/user_guide/feature_guide/lora.md
@@ -27,4 +27,12 @@ vllm serve meta-llama/Llama-2-7b \
 
 - We have implemented LoRA-related AscendC operators, such as bgmv_shrink, bgmv_expand, sgmv_shrink and sgmv_expand. You can find them under the `csrc/kernels` directory of [vllm-ascend repo](https://github.com/vllm-project/vllm-ascend/tree/main/csrc/kernels).
 
-- You can enable LoRA with dense or mixture-of-experts (MoE) models now ([PR #10977](https://github.com/vllm-project/vllm-ascend/pull/10977)). However, we haven't supported expert-parallel (EP) or quantization yet when you run MoE models with LoRA.
+LoRA is supported for both dense and mixture-of-experts (MoE) models. The current MoE support status is as follows:
+
+| MoE mode | Tensor parallel (AllGather) | Expert parallel (All-to-All) |
+| --- | --- | --- |
+| Non-quantized | Supported | Supported |
+| W8A8 dynamic quantization | Supported | Supported |
+
+Enable the EP All-to-All mode with `--enable-expert-parallel`. Other MoE quantization methods, Fused MC2, and dynamic
+EPLB are not supported with LoRA. Set `VLLM_ASCEND_ENABLE_FUSED_MC2=0` when using MoE LoRA.

--- a/docs/source/user_guide/feature_guide/lora.md
+++ b/docs/source/user_guide/feature_guide/lora.md
@@ -34,5 +34,5 @@ LoRA is supported for both dense and mixture-of-experts (MoE) models. The curren
 | Non-quantized | Supported | Supported |
 | W8A8 dynamic quantization | Supported | Supported |
 
-Enable the EP All-to-All mode with `--enable-expert-parallel`. Other MoE quantization methods, Fused MC2, and dynamic
-EPLB are not supported with LoRA. Set `VLLM_ASCEND_ENABLE_FUSED_MC2=0` when using MoE LoRA.
+Other MoE quantization methods, Fused MC2, and dynamic EPLB are not supported with LoRA. Set
+`VLLM_ASCEND_ENABLE_FUSED_MC2=0` when using MoE LoRA.

--- a/docs/source/user_guide/feature_guide/lora.md
+++ b/docs/source/user_guide/feature_guide/lora.md
@@ -34,5 +34,4 @@ LoRA is supported for both dense and mixture-of-experts (MoE) models. The curren
 | Non-quantized | Supported | Supported |
 | W8A8 dynamic quantization | Supported | Supported |
 
-Other MoE quantization methods, Fused MC2, and dynamic EPLB are not supported with LoRA. Set
-`VLLM_ASCEND_ENABLE_FUSED_MC2=0` when using MoE LoRA.
+Other MoE quantization methods, Fused MC2, and dynamic EPLB are not supported with LoRA.


### PR DESCRIPTION
### What this PR does / why we need it?

Updates the LoRA guide to reflect the current MoE support status. It documents support for EP All-to-All in non-quantized and W8A8 dynamic quantization modes, and clarifies the unsupported combinations.

### Does this PR introduce _any_ user-facing change?

Yes. This is a documentation-only update.

### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
