### PR TITLE
[BugFix][310P][v0.23.0] Fix MTP overlay prefixcache precision on 310P

### DIFF
--- a/tests/ut/_310p/test_mamba_align_fallback_310p_source.py
+++ b/tests/ut/_310p/test_mamba_align_fallback_310p_source.py
@@ -31,6 +31,8 @@ def test_310p_postprocess_fallback_preserves_upstream_metadata_semantics() -> No
 
     assert "num_accepted_tokens_gpu" in src
     assert "num_accepted_tokens_cpu_tensor[:num_reqs].copy_(num_accepted_tokens_gpu[:num_reqs])" in src
+    assert "num_accepted_tokens = num_accepted_tokens_cpu_tensor" in src
+    assert "num_accepted_tokens = input_batch.num_accepted_tokens_cpu" not in src
     assert "num_tokens_running_state = num_computed_tokens[i] + num_scheduled_tokens[i] - num_draft_tokens[i]" in src
     assert "new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens[i] - 1" in src
     assert "aligned_new_computed_tokens = new_num_computed_tokens // block_size * block_size" in src

--- a/tests/ut/_310p/test_model_runner_310p.py
+++ b/tests/ut/_310p/test_model_runner_310p.py
@@ -49,6 +49,8 @@ def test_prepare_inputs_keeps_aclgraph_metadata_on_cpu() -> None:
     assert "self._positions_cpu_buf[:total_num_scheduled_tokens]" in source
     assert "self.seq_lens[:num_reqs].copy_(" in source
     assert "self.optimistic_seq_lens_cpu[:num_reqs]" in source
+    assert "self._sync_num_accepted_tokens(" in source
+    assert "self.input_batch.num_accepted_tokens_cpu[" not in source
 
 
 def test_model_forward_updates_mtp_full_graph_params_before_replay() -> None:

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -91,18 +91,18 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         """Pinned CPU per-request query lengths for ATB splitfuse (host qLensTensor)."""
         if self._query_lens_cpu_buffer is None:
             return (query_start_loc_cpu[1 : num_reqs + 1] - query_start_loc_cpu[:num_reqs]).contiguous()
-        if is_drafting:
-            # We are using the same buffer for multi step drafting,
-            # so we have to clone the buffer or the q lens of step 0
-            # will be overwritten by the following steps.
-            buffer = self._query_lens_cpu_buffer[:num_reqs].clone()
-        else:
-            buffer = self._query_lens_cpu_buffer[:num_reqs]
+        buffer = self._query_lens_cpu_buffer[:num_reqs]
         torch.sub(
             query_start_loc_cpu[1 : num_reqs + 1],
             query_start_loc_cpu[:num_reqs],
             out=buffer,
         )
+        if is_drafting:
+            # Draft steps reuse the work buffer. Keep a pinned snapshot so the
+            # next step cannot overwrite qLens while ATB consumes it.
+            snapshot = torch.empty_like(buffer, pin_memory=buffer.is_pinned())
+            snapshot.copy_(buffer)
+            return snapshot
         return buffer
 
     def build(

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -91,18 +91,18 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
         """Pinned CPU per-request query lengths for ATB splitfuse (host qLensTensor)."""
         if self._query_lens_cpu_buffer is None:
             return (query_start_loc_cpu[1 : num_reqs + 1] - query_start_loc_cpu[:num_reqs]).contiguous()
-        buffer = self._query_lens_cpu_buffer[:num_reqs]
+        if is_drafting:
+            # We are using the same buffer for multi step drafting,
+            # so we have to clone the buffer or the q lens of step 0
+            # will be overwritten by the following steps.
+            buffer = self._query_lens_cpu_buffer[:num_reqs].clone()
+        else:
+            buffer = self._query_lens_cpu_buffer[:num_reqs]
         torch.sub(
             query_start_loc_cpu[1 : num_reqs + 1],
             query_start_loc_cpu[:num_reqs],
             out=buffer,
         )
-        if is_drafting:
-            # Draft steps reuse the work buffer. Keep a pinned snapshot so the
-            # next step cannot overwrite qLens while ATB consumes it.
-            snapshot = torch.empty_like(buffer, pin_memory=buffer.is_pinned())
-            snapshot.copy_(buffer)
-            return snapshot
         return buffer
 
     def build(

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -283,16 +283,9 @@ class NPUModelRunner310(NPUModelRunner):
 
         if self.num_accepted_tokens_event is not None:
             self.num_accepted_tokens_event.synchronize()
-            if self.use_async_scheduling and prev_req_id_to_index:
-                prev_idx = self.prev_positions.np[:num_reqs]
-                new_mask = prev_idx < 0
-                self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[
-                    np.where(new_mask, 0, prev_idx)
-                ]
-                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = self.num_accepted_tokens.np[:num_reqs]
-            else:
-                self.num_accepted_tokens.np[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+            # Keep accepted-token ownership by request when async scheduling
+            # condenses/reorders the 310P input batch.
+            self._sync_num_accepted_tokens(num_reqs, has_prev_mapping=bool(prev_req_id_to_index))
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
         else:

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -138,7 +138,10 @@ def _postprocess_mamba_align_gpu_cpu_fallback(
     # block. Preserve that default so the next preprocess keeps the right
     # accept_token_bias when multiple draft tokens were accepted.
     num_accepted_tokens_cpu_tensor[:num_reqs].copy_(num_accepted_tokens_gpu[:num_reqs])
-    num_accepted_tokens = input_batch.num_accepted_tokens_cpu
+    # InputBatch rows may be condensed/reused by async scheduling before this
+    # fallback consumes the snapshot. Keep this step's accepted counts
+    # independent from those mutable request rows.
+    num_accepted_tokens = num_accepted_tokens_cpu_tensor
     for i in range(num_reqs):
         num_tokens_running_state = num_computed_tokens[i] + num_scheduled_tokens[i] - num_draft_tokens[i]
         new_num_computed_tokens = num_tokens_running_state + num_accepted_tokens[i] - 1


### PR DESCRIPTION
### What this PR does / why we need it?
MTP Overlay Precision: Refactored accepted token synchronization logic to ensure consistency when async scheduling condenses or reorders input batches on 310P hardware.
Decoupled Token Ownership: Updated the Mamba alignment fallback to use a local snapshot of accepted tokens, preventing interference from mutable request rows in the InputBatch.
Code Refactoring: Introduced a helper method _sync_num_accepted_tokens in the model runner to centralize and standardize the synchronization process.
### Does this PR introduce _any_ user-facing change?
None
### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
