### PR TITLE
[v0.26.0rc][Bugfix][MoE] Fix SiTU activation raising NotImplementedError in unquantized MoE MLP path

### DIFF
--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -31,6 +31,7 @@ from vllm_ascend.ops.activation import (
     AscendSwigluOAIAndMul,
     AscendSwigluStepAndMul,
     SituActivationConfig,
+    situ_and_mul,
 )
 from vllm_ascend.ops.fused_moe.moe_runtime_args import MoEMlpComputeInput
 from vllm_ascend.quantization.quant_type import QuantType
@@ -708,7 +709,11 @@ def unquant_apply_mlp(
 
     act_name = getattr(activation, "value", activation)
     if isinstance(activation, SituActivationConfig):
-        raise NotImplementedError("SiTU requires a fused quantization path.")
+        gate_up_out = situ_and_mul(
+            gate_up_out,
+            beta=activation.beta,
+            linear_beta=activation.linear_beta,
+        )
     elif activation == MoEActivation.SWIGLUOAI:
         w1_tensor = _require_single_tensor_for_swiglu_quant(w1, name="w1")
         num_experts, _, hidden_size = w1_tensor.shape


### PR DESCRIPTION
### What this PR does / why we need it?

- Kimi K3 support (#12950) added the SiTU gated activation for MoE. On the
  quantized W4A8 path (`quant_apply_mlp` -> `_w4a8_situ_apply_mlp`), SiTU must
  be fused with the quantization kernel (`situ_mx_quant` / `dequant_situ_quant`)
  because the GMM2 input has to be quantized; that fusion is a performance
  requirement of the quant path only.

- However, the same change also made the unquantized path (`unquant_apply_mlp`)
  raise `NotImplementedError("SiTU requires a fused quantization path.")`. This
  restriction is wrong there: the unquantized path has no quantization after the
  activation, so no fusion is needed. As a result, any MoE configuration that
  routes SiTU through the unquantized MLP path (e.g. unquantized shared experts
  per `moe_comm_method.py`) crashes at runtime.

- This PR fixes it by applying the existing `situ_and_mul` reference
  implementation (already used by dense/shared-expert MLPs via
  `AscendSituAndMul`) in `unquant_apply_mlp`. It is numerically identical to the
  SiTU math inside the fused kernel: `beta * tanh(gate/beta) * sigmoid(gate)`
  with optional `linear_beta * tanh(up/linear_beta)`, computed in FP32 and cast
  back to the input dtype.

### Does this PR introduce _any_ user-facing change?

- Yes. Models using the SiTU activation (e.g. Kimi K3 family) on an unquantized
  MoE MLP path now run correctly instead of crashing with `NotImplementedError`.
  No behavior change for the quantized path or other activations.

### How was this patch tested?

- Manually tested on NPU with vLLM version v0.26.0.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
