### PR TITLE
[Ops][BugFix] Restore early routed-output reduce for AllGather + nonlinear routed_output_transform (fixes Kimi-K3 garbage output on A2)

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -575,6 +575,18 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         return False
 
     @property
+    def _allgather_requires_early_routed_reduce(self) -> bool:
+        # Back-ported from fused_moe_0_23_0 (v0.23 semantics). AllGather +
+        # a routed_output_transform (K3 latent MoE: RMSNorm + up_proj)
+        # requires summing the per-rank partials BEFORE the nonlinear
+        # transform: RMSNorm(allreduce(x)) != allreduce(RMSNorm(x)).
+        return (
+            _EXTRA_CTX.moe_comm_type == MoECommType.ALLGATHER
+            and not _EXTRA_CTX.flash_comm_v1_enabled
+            and getattr(self, "routed_output_transform", None) is not None
+        )
+
+    @property
     def _fused_output_is_reduced(self) -> bool:
         # For MC2/ALLTOALL/FUSED_MC2 comm types, finalize() already includes
         # TP all-reduce for the routed output, and _forward_shared_experts
@@ -582,11 +594,16 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # MoERunner.forward() so _maybe_reduce_final_output does not apply a
         # second TP all-reduce (which would double-count the contributions).
         moe_comm_type = _EXTRA_CTX.moe_comm_type
-        return moe_comm_type in {
-            MoECommType.ALLTOALL,
-            MoECommType.MC2,
-            MoECommType.FUSED_MC2,
-        } or (moe_comm_type == MoECommType.ALLGATHER and _EXTRA_CTX.flash_comm_v1_enabled)
+        return (
+            moe_comm_type
+            in {
+                MoECommType.ALLTOALL,
+                MoECommType.MC2,
+                MoECommType.FUSED_MC2,
+            }
+            or (moe_comm_type == MoECommType.ALLGATHER and _EXTRA_CTX.flash_comm_v1_enabled)
+            or (self._allgather_requires_early_routed_reduce)
+        )
 
     @property
     def local_num_experts(self) -> int:
@@ -621,7 +638,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         # _forward_shared_experts already handles shared expert TP all-reduce
         # for MC2/ALLTOALL/FUSED_MC2. For AllGather the reduction is done
         # via _maybe_reduce_final_output on the combined (shared + routed)
-        # output. Skip any additional reduction here.
+        # output. Skip any additional reduction here -- UNLESS the routed
+        # output goes through a nonlinear routed_output_transform (K3 latent
+        # MoE), in which case the early-reduce path reduces shared here to
+        # match the pre-transform routed reduce.
+        if shared_output is not None and self._allgather_requires_early_routed_reduce:
+            shared_output = tensor_model_parallel_all_reduce(shared_output)
         return shared_output
 
     def _maybe_reduce_final_output(
@@ -629,8 +651,19 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         states: torch.Tensor,
         trunc_size: int,
     ) -> torch.Tensor:
-        states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
+        if not self._allgather_requires_early_routed_reduce:
+            states = torch.ops.vllm.maybe_all_reduce_tensor_model_parallel(states)
         return states[..., :trunc_size]
+
+    def apply_routed_output_transform(
+        self,
+        fused_output: torch.Tensor,
+    ) -> torch.Tensor:
+        if self._allgather_requires_early_routed_reduce:
+            # K3 latent MoE: sum the per-rank routed partials BEFORE the
+            # nonlinear RMSNorm+up_proj (v0.23 early-reduce semantics).
+            fused_output = tensor_model_parallel_all_reduce(fused_output)
+        return super().apply_routed_output_transform(fused_output)
 
     @property
     def _flashcomm_uses_tp_shared_experts(self) -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?

**Problem**: the `AscendMoERunner` rewrite dropped the
`_allgather_requires_early_routed_reduce` guard that existed in v0.23
(`fused_moe_0_23_0.py`, whose comment literally warns that *"a nonlinear
transform (for example RMSNorm) cannot be applied to per-rank partials before
they are summed"*).

For latent-MoE models whose `routed_output_transform` contains a **nonlinear**
op (Kimi-K3: RMSNorm + up_proj back from the 3584-dim routed latent space),
running **AllGather** comm (forced on A2 when `num_experts > 512`) with
`TP > 1` and flashcomm disabled, the per-rank routed partials are passed through
RMSNorm + up_proj **before** the final TP all-reduce sums them:

```
v0.23 / MC2 / flashcomm (correct):  up_proj(RMSNorm(allreduce(x)))
v0.26 AllGather (broken):           allreduce(up_proj(RMSNorm(x_r)))
```

Since `RMSNorm(allreduce(x)) != allreduce(RMSNorm(x))` — each rank normalizes
its own 1/8 partial by a much smaller norm — every MoE layer emits
wrongly-scaled output and generation degrades to garbage from the first token.

A3 (MC2) is unaffected (finalize already reduces the routed output before the
transform) and v0.23 kept the guard, which is why this escaped A3-based
validation and only shows up as A2 (AllGather) × latent-MoE × TP>1.

**Fix** — restore the v0.23 early-reduce semantics in `AscendMoERunner`:

- add `_allgather_requires_early_routed_reduce` property
  (AllGather + flashcomm disabled + `routed_output_transform is not None`)
- include it in `_fused_output_is_reduced`
- reduce the shared-expert output early when the guard fires (to match)
- skip the final all-reduce when the guard fires
- override `apply_routed_output_transform` to all-reduce the routed partials
  **before** the nonlinear transform

All other comm paths (MC2 / ALLTOALL / FUSED_MC2 / flashcomm / models without
a `routed_output_transform`) keep their existing behavior unchanged.

### Does this PR introduce _any_ user-facing change?

Yes — it fixes wrong results. Any latent-MoE model with a nonlinear
`routed_output_transform` (e.g. Kimi-K3) running AllGather comm with `TP > 1`
and flashcomm disabled currently produces garbage from the first token; after
this patch the output is numerically correct. No API or config change.

### How was this patch tested?

No unit test added: the bug lives in cross-rank partial semantics, which
single-card CI cannot exercise. Manual reproduction:

1. Serve Kimi-K3-w4a8 (896 experts, latent MoE) on 8 nodes × Ascend 910B (A2),
   TP8 × DP8 × EP64, flashcomm disabled (comm selector picks AllGather because
   `num_experts > 512`); vllm v0.26.0, vllm-ascend releases/v0.26.0rc, CANN 9.1.0.
2. **Before**: greedy `"Calculate 12345 * 6789. Output only the final answer."`
   returns repetitive gibberish from the first token (accuracy evals are not
   even runnable).
3. **After**: returns exactly `83810205` with a coherent step-by-step reasoning
   trace; multi-prompt spot checks (code / long arithmetic / Chinese) correct.
4. **Accuracy after the patch**: ais_bench `GPQA_diamond` accuracy **92.42**

Metric | Value
--- | ---
Dataset | GPQA Diamond (198 items, thinking-high)
Completed requests | 198
Failed requests | 0
Accuracy | 92.42%


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
