### PR TITLE
[v0.22.1rc][Misc] Pin MemFabric and MemCache dependency versions

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -144,7 +144,7 @@ jobs:
         if: steps.filter.outputs.lint_tracker == 'true'
         env:
           UV_INDEX_URL: http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
-          UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi"
+          UV_EXTRA_INDEX_URL: "https://repo.huaweicloud.com/ascend/repos/pypi https://download.pytorch.org/whl/cpu"
           UV_INDEX_STRATEGY: unsafe-best-match
           UV_NO_CACHE: 1
           UV_SYSTEM_PYTHON: 1
@@ -152,7 +152,7 @@ jobs:
           pip install uv
           git config --global --add safe.directory /__w/vllm-ascend/vllm-ascend
           pip install uc-manager
-          uv pip install -r requirements-dev.txt --extra-index-url https://download.pytorch.org/whl/cpu
+          uv pip install -r requirements-dev.txt
 
       - name: Run pre-commit
         env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,8 @@ quart
 numba
 
 # Required for kvpool supports memcache backend
-memfabric_hybrid
-memcache_hybrid
+memfabric_hybrid==1.1.4
+memcache_hybrid==1.1.4
 
 arctic-inference==0.1.1
 transformers==5.5.4


### PR DESCRIPTION
## What this PR does

Pins the KV Pool dependencies to exact versions:

- `memfabric_hybrid==1.1.4`
- `memcache_hybrid==1.1.4`

## Changes

- Update only the root `requirements.txt`.

## Validation

- `git diff --check`
- Verified the commit changes only `requirements.txt`.

- vLLM version: v0.22.1
- vLLM main: https://github.com/vllm-project/vllm/commit/967c5c3bc38891f4465d3f4e99917ed837bb3833
