### PR TITLE
[v0.25.1rc][Misc] Pin MemFabric and MemCache dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,8 @@ quart
 numba
 
 # Required for kvpool supports memcache backend
-memfabric_hybrid
-memcache_hybrid
+memfabric_hybrid==1.2.0
+memcache_hybrid==1.2.0
 
 arctic-inference==0.1.1
 transformers==5.14.1


### PR DESCRIPTION
## What this PR does

Pins the KV Pool dependencies to exact versions:

- `memfabric_hybrid==1.2.0`
- `memcache_hybrid==1.2.0`

## Changes

- Update only the root `requirements.txt`.

## Validation

- `git diff --check`
- Verified the commit changes only `requirements.txt`.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
