### PR TITLE
[v0.26.0rc][BugFix][MoE] Fix MegaMoe prefill buffer sizing

### DIFF
--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -280,6 +280,8 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
             )
         return layer
 
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config", new=lambda: None)
+    @patch("vllm_ascend.quantization.methods.w4a8.use_cann_megamoe", new=lambda _: False)
     @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
@@ -350,6 +352,8 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         self.assertEqual(result["w13_weight_scale"].dtype, torch.bfloat16)
         self.assertEqual(result["w2_weight_scale"].dtype, torch.bfloat16)
 
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config", new=lambda: None)
+    @patch("vllm_ascend.quantization.methods.w4a8.use_cann_megamoe", new=lambda _: False)
     @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -413,6 +413,7 @@ class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
         expected_output = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
         mock_comm.fused_experts.return_value = expected_output
         mock_ctx.moe_comm_method = mock_comm
+        mock_ctx.use_mega_moe = False
 
         output = self.quant_method.apply(
             layer=layer,

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -31,7 +31,10 @@ def _make_vllm_config(
     max_num_batched_tokens: int = 0,
     hidden_size: int = 2048,
 ):
-    hf_text_config_attrs: dict[str, object] = {"top_k_experts": top_k_experts}
+    hf_text_config_attrs: dict[str, object] = {
+        "top_k_experts": top_k_experts,
+        "moe_intermediate_size": 2048,
+    }
     if quant_type is not None:
         hf_text_config_attrs["quantize"] = quant_type
     if num_experts_per_tok is not None:

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -93,6 +93,20 @@ def _cann_megamoe_supported_by_config(vllm_config: VllmConfig) -> bool:
     return quant_name in _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES
 
 
+def use_cann_megamoe(vllm_config: VllmConfig) -> bool:
+    # TODO: drop the EP-size guard when MegaMoe supports larger EP sizes.
+    return (
+        _MEGA_MOE_SUPPORTED
+        and get_ascend_device_type() == AscendDeviceType.A3
+        and get_ascend_config().enable_fused_mc2 == 1
+        and is_moe_model(vllm_config)
+        and vllm_config.parallel_config.enable_expert_parallel
+        and 1 < get_ep_group().world_size <= 64
+        and getattr(vllm_config, "lora_config", None) is None
+        and _cann_megamoe_supported_by_config(vllm_config)
+    )
+
+
 @contextmanager
 def set_ascend_forward_context(
     attn_metadata: Any,
@@ -141,6 +155,7 @@ def set_ascend_forward_context(
 
         forward_context.moe_comm_type = moe_comm_type
         forward_context.moe_comm_method = get_moe_comm_method(moe_comm_type)
+        forward_context.use_mega_moe = use_cann_megamoe(vllm_config)
 
         tp_world_size = get_tensor_model_parallel_world_size()
 
@@ -243,7 +258,11 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
     global _mc2_tokens_capacity
     if _mc2_tokens_capacity is not None:
         return
-    if get_ascend_config().enable_prefill_mc2:
+
+    ascend_config = get_ascend_config()
+    use_mega_moe = use_cann_megamoe(vllm_config)
+
+    if ascend_config.enable_prefill_mc2 or use_mega_moe:
         max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
     elif vllm_config.compilation_config.cudagraph_capture_sizes:
         max_num_tokens = vllm_config.compilation_config.max_cudagraph_capture_size
@@ -254,8 +273,8 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
     # Use integer arithmetic for ceiling division.
     num_tokens_per_tp_rank = (max_num_tokens + tp_size - 1) // tp_size
     # keep the num_tokens_per_tp_rank less than fused_mc2 (mega_moe) tokens per rank limit
-    if get_ascend_config().enable_fused_mc2:
-        if _MEGA_MOE_SUPPORTED:
+    if ascend_config.enable_fused_mc2:
+        if use_mega_moe:
             num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _MEGA_MOE_TOKENS_PER_RANK_LIMIT)
         else:
             num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT)
@@ -308,12 +327,10 @@ def _select_a3_moe_comm_method(
     mc2_tokens_capacity: int,
     vllm_config: VllmConfig,
 ) -> MoECommType:
-    if get_ascend_config().enable_fused_mc2 == 1:
-        # TODO: drop the EP-size guard when mega_moe supports larger EP sizes
-        mega_moe_enable = get_ep_group().world_size <= 64 and _cann_megamoe_supported_by_config(vllm_config)
-        dispatch_ffn_combine_enable = get_ep_group().world_size <= 32
-        if (_MEGA_MOE_SUPPORTED and mega_moe_enable) or dispatch_ffn_combine_enable:
-            return MoECommType.FUSED_MC2
+    if use_cann_megamoe(vllm_config):
+        return MoECommType.FUSED_MC2
+    if get_ascend_config().enable_fused_mc2 == 1 and get_ep_group().world_size <= 32:
+        return MoECommType.FUSED_MC2
 
     if num_tokens <= mc2_tokens_capacity:
         return MoECommType.MC2
@@ -412,6 +429,7 @@ class _ExtraForwardContextProxy:
         "capturing",
         "moe_comm_type",
         "moe_comm_method",
+        "use_mega_moe",
         "mmrs_fusion",
         "num_tokens",
         "flash_comm_v1_enabled",

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -82,6 +82,16 @@ def _cann_megamoe_supported_by_config(vllm_config: VllmConfig) -> bool:
     if hidden_size < 1024 or hidden_size > 8192 or hidden_size % 512 != 0:
         return False
 
+    # Intermediate-size bounds come from the CANN MegaMoe kernel constraints:
+    # For CANN 9.1.0 MegaMoe tiling requires intermediate_size in the closed
+    # range [1024, 3072] and a multiple of 512. This constraint may be removed
+    # in CANN 9.2.0
+    moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
+    if moe_intermediate_size is None:
+        return False
+    if moe_intermediate_size < 1024 or moe_intermediate_size > 3072 or moe_intermediate_size % 512 != 0:
+        return False
+
     quant_type = getattr(
         vllm_config.model_config.hf_text_config,
         "moe_quantize",

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -367,6 +367,14 @@ class FusedMC2CommImpl(MoECommMethod):
         # TokenDispatcherWithMC2 carries global_bs (used below for the mc2_mask
         # branch); assert the subtype so mypy resolves it off the base class.
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
+        num_tokens = fused_experts_input.hidden_states.shape[0]
+        num_max_tokens = self.token_dispatcher.max_num_tokens_per_rank
+        if num_tokens > num_max_tokens:
+            raise ValueError(
+                f"MegaMoe received {num_tokens} tokens per rank, but its symmetric buffer "
+                f"was allocated for at most {num_max_tokens}. Increase max_num_batched_tokens "
+                "or disable fused MC2."
+            )
 
         def to_list(x):
             return x if isinstance(x, list) else [x]
@@ -456,7 +464,7 @@ class FusedMC2CommImpl(MoECommMethod):
 
         expert_tokens = None
         if get_ascend_config().enable_fused_mc2 == 1:
-            if _MEGA_MOE_SUPPORTED:
+            if _EXTRA_CTX.use_mega_moe:
                 out, expert_tokens = self._apply_cann_mega_moe(fused_experts_input, topk_ids)
             else:
                 assert not (

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -26,7 +26,7 @@ from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, use_cann_megamoe
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
@@ -568,11 +568,7 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             w2_scale = layer.w2_weight_scale_list
             w1_scale_bias = layer.w13_scale_bias_list
             w2_scale_bias = layer.w2_scale_bias_list
-        elif (
-            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2
-            and get_ascend_config().enable_fused_mc2 == 1
-            and _MEGA_MOE_SUPPORTED
-        ):
+        elif _EXTRA_CTX.use_mega_moe:
             w1 = layer.cann_mega_moe_w13_weight_list
             w1_scale = layer.cann_mega_moe_w13_weight_scale_list
             w2 = layer.cann_mega_moe_w2_weight_list
@@ -748,7 +744,7 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
         # FIX(mega W4A8 all-route): with MegaMoe on, keep ND int8 (skip trans_nz + pack_to_int32);
         # _maybe_build_cann_mega_moe_lists casts each expert slice to FRACTAL_NZ individually. See
         # the modelslim path below for the full rationale. Non-mega keeps the standard NZ-int32 form.
-        if get_ascend_config().enable_fused_mc2 == 1 and not self.dynamic_eplb and _MEGA_MOE_SUPPORTED:
+        if not self.dynamic_eplb and use_cann_megamoe(get_current_vllm_config()):
             self._maybe_build_cann_mega_moe_lists(layer)
         else:
             layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
@@ -828,7 +824,7 @@ class AscendW4A8DynamicFusedMoEMethod(AscendMoEScheme):
             del layer.w13_scale_bias
             del layer.w2_scale_bias
         # keep weights as ND int8 when MegaMoe is on (skip trans_nz).
-        elif get_ascend_config().enable_fused_mc2 == 1 and _MEGA_MOE_SUPPORTED:
+        elif use_cann_megamoe(get_current_vllm_config()):
             self._maybe_build_cann_mega_moe_lists(layer)
 
         else:

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -24,7 +24,7 @@ from vllm.config import CompilationMode, get_current_vllm_config
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType, use_cann_megamoe
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.experts_selector import select_experts, zero_experts_compute
 from vllm_ascend.ops.fused_moe.moe_runtime_args import build_fused_experts_input
@@ -309,7 +309,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
             w1_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
             w2_scale_bias = [torch.tensor([], dtype=torch.float32)] if fused_scale_flag else None
 
-        elif fused_scale_flag and _MEGA_MOE_SUPPORTED:
+        elif fused_scale_flag and _EXTRA_CTX.use_mega_moe:
             w1 = layer.cann_mega_moe_w13_weight_list
             w1_scale = layer.cann_mega_moe_fused_w1_scale_list
             w2 = layer.cann_mega_moe_w2_weight_list
@@ -398,7 +398,7 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
                 del layer.fused_w2_scale
             torch.npu.empty_cache()
 
-        elif get_ascend_config().enable_fused_mc2 == 1 and _MEGA_MOE_SUPPORTED:
+        elif use_cann_megamoe(get_current_vllm_config()):
             layer.cann_mega_moe_w13_weight_list = list(layer.w13_weight.data.unbind(dim=0))
             layer.cann_mega_moe_w2_weight_list = list(layer.w2_weight.data.unbind(dim=0))
             layer.cann_mega_moe_fused_w1_scale_list = list(

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1179,7 +1179,8 @@ def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_mode
     - Decode requires MC2 and ascend_config.scheduler_config.recompute_scheduler_enable is True.
 
     Skipping means each rank may have a different number of tokens, so MC2 needs
-    a non-zero global_bs and must NOT receive mc2_mask.
+    a non-zero global_bs and must NOT receive mc2_mask. CANN MegaMoe requires
+    uniform token counts across ranks, so its FUSED_MC2 path cannot skip.
 
     Returns False when hierarchy comm is enabled because hierarchy requires
     global_bs=0 (uniform tokens), which is incompatible with skipping allreduce.
@@ -1202,20 +1203,27 @@ def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_mode
     if not is_kv_consumer:
         return False
 
-    from vllm_ascend.ascend_forward_context import select_moe_comm_method
+    from vllm_ascend.ascend_forward_context import (
+        select_moe_comm_method,
+        use_cann_megamoe,
+    )
     from vllm_ascend.ops.fused_moe.moe_comm_method import MoECommType
-
-    def needs_mc2(n: int) -> bool:
-        return select_moe_comm_method(n, vllm_config) in {MoECommType.MC2, MoECommType.FUSED_MC2}
 
     scheduler_config = vllm_config.scheduler_config
     # potential_max_tokens is read from the set/get global (computed once in init).
-    # if mc2 is used in decode max potential tokens case, we can skip allreduce in decode only case.
-    decode_can_skip = needs_mc2(get_potential_max_tokens())
+    decode_comm_method = select_moe_comm_method(get_potential_max_tokens(), vllm_config)
     # For prefill, use the scheduler's max_num_batched_tokens for a single batch.
+    prefill_comm_method = select_moe_comm_method(scheduler_config.max_num_batched_tokens, vllm_config)
+
+    if use_cann_megamoe(vllm_config):
+        return False
+
+    mc2_comm_methods = {MoECommType.MC2, MoECommType.FUSED_MC2}
+    # if mc2 is used in decode max potential tokens case, we can skip allreduce in decode only case.
+    decode_can_skip = decode_comm_method in mc2_comm_methods
     # if mc2 is used in prefill max potential tokens case and prefill and decode have the same cudagraph mode,
     # we can skip allreduce in chunked prefill case.
-    prefill_must_use_mc2 = needs_mc2(scheduler_config.max_num_batched_tokens)
+    prefill_must_use_mc2 = prefill_comm_method in mc2_comm_methods
 
     uniform_cudagraph_mode = not vllm_config.compilation_config.cudagraph_mode.separate_routine()
 


### PR DESCRIPTION
### What this PR does / why we need it?

CANN MegaMoe allocates its symmetric communication buffer once from the MC2 token capacity. When `enable_prefill_mc2` is disabled, that capacity was derived from the decode graph capture size even though eager prefill could still select MegaMoe through fused MC2. A larger prefill batch could therefore exceed the allocated capacity and produce invalid outputs.

This PR:

- Sizes the MegaMoe buffer from `max_num_batched_tokens` when MegaMoe is actually eligible.
- Centralizes MegaMoe eligibility in `use_cann_megamoe` so communication selection, buffer sizing, DP token handling, and W4A8/W8A8 weight preparation use the same decision, while preserving the `dispatch_ffn_combine` fallback.
- Rejects intermediate sizes outside the CANN 9.1.0 MegaMoe range of 1024 to 3072 or not aligned to 512.
- Keeps DP token counts uniform for MegaMoe, without disabling the uneven-token optimization for `dispatch_ffn_combine`.
- Raises an explicit error if a MegaMoe input exceeds the allocated per-rank capacity.

### Does this PR introduce _any_ user-facing change?

Yes. MegaMoe now allocates enough symmetric-buffer capacity for eager prefill batches when prefill MC2 is disabled. Unsupported model configurations continue to use `dispatch_ffn_combine`, and an invalid capacity is reported explicitly instead of producing incorrect output.

### How was this patch tested?

- `python3 -m py_compile vllm_ascend/ascend_forward_context.py vllm_ascend/ops/fused_moe/moe_comm_method.py vllm_ascend/quantization/methods/w4a8.py vllm_ascend/quantization/methods/w8a8_dynamic.py vllm_ascend/utils.py`
- `ruff check vllm_ascend/ascend_forward_context.py vllm_ascend/ops/fused_moe/moe_comm_method.py vllm_ascend/quantization/methods/w4a8.py vllm_ascend/quantization/methods/w8a8_dynamic.py vllm_ascend/utils.py`
- `python3 -m pytest tests/ut/test_ascend_forward_context.py -q` (`26 passed`)
- End-to-end DeepSeek V4 W8A8 inference on Ascend A3 with TP8/DP2, eager prefill, fused MC2 enabled, and prefill MC2 disabled. A prefill batch larger than the decode graph capture capacity completed without non-finite output and produced the expected response. This validated the buffer fix before the eligibility helper was centralized; the final helper refactor and rebase were verified with the static checks above.

No new test case was added because the buffer failure depends on CANN MegaMoe symmetric-buffer allocation and collective execution across an NPU communication group. The existing config fixture was updated to cover the new intermediate-size eligibility requirement.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
