### PR TITLE
[BugFix][v0.25.1][Model] Propagate DeepSeek V4 routed SwiGLU limit

### DIFF
--- a/tests/ut/model_executor/test_deepseek_v4.py
+++ b/tests/ut/model_executor/test_deepseek_v4.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from torch import nn
+
+from vllm_ascend.models import deepseek_v4
+
+
+class StubModule(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+
+def test_routed_moe_receives_configured_swiglu_limit(monkeypatch):
+    fused_moe_kwargs = {}
+
+    class StubFusedMoE(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            fused_moe_kwargs.update(kwargs)
+
+    monkeypatch.setattr(deepseek_v4, "FusedMoE", StubFusedMoE)
+    monkeypatch.setattr(deepseek_v4, "ReplicatedLinear", StubModule)
+    monkeypatch.setattr(deepseek_v4, "DeepseekV2MLP", StubModule)
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        deepseek_v4,
+        "get_ep_group",
+        lambda: SimpleNamespace(device_group=SimpleNamespace(size=lambda: 1), rank_in_group=0),
+    )
+    monkeypatch.setattr(deepseek_v4, "get_ascend_config", lambda: SimpleNamespace(mix_placement=False))
+    monkeypatch.setattr(deepseek_v4.rocm_aiter_ops, "is_fused_moe_enabled", lambda: False)
+    monkeypatch.setattr(deepseek_v4.rocm_aiter_ops, "is_fusion_moe_shared_experts_enabled", lambda: False)
+
+    config = SimpleNamespace(
+        hidden_act="silu",
+        hidden_size=16,
+        moe_intermediate_size=8,
+        n_group=1,
+        n_routed_experts=8,
+        n_shared_experts=1,
+        norm_topk_prob=True,
+        num_experts_per_tok=2,
+        num_hash_layers=0,
+        routed_scaling_factor=2.5,
+        scoring_func="sigmoid",
+        swiglu_limit=10.0,
+        topk_group=1,
+    )
+    parallel_config = SimpleNamespace(
+        enable_eplb=False,
+        eplb_config=SimpleNamespace(num_redundant_experts=0),
+        use_sequence_parallel_moe=False,
+    )
+
+    deepseek_v4.DeepseekV4MoE(config, parallel_config, prefix="model.layers.1.mlp")
+
+    assert fused_moe_kwargs["swiglu_limit"] == config.swiglu_limit

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -450,6 +450,7 @@ class DeepseekV4MoE(nn.Module):
             # DeepSeek V4: normalize top-k weights, then scale routed output.
             # AITER applies routed_scaling_factor internally.
             routed_scaling_factor=self.routed_scaling_factor,
+            swiglu_limit=self.swiglu_limit,
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek V4 reads `config.swiglu_limit` and already passes it to the shared expert, but the Ascend model adapter does not pass it to the routed `FusedMoE`. As a result, checkpoints with `swiglu_limit=10.0` execute routed experts without the required gate/up clamp and can produce severe next-token logits cliffs.

This PR:

- passes `self.swiglu_limit` to the routed `FusedMoE` constructor;
- adds a focused unit test that pins the model-adapter contract.

This is distinct from #9589, which concerns finite-clamp implementation after the value reaches fused quantization paths. The current bug prevents the routed path from receiving the value at all, and affects BF16 as well as quantized models.

Fixes #14363

### Does this PR introduce _any_ user-facing change?

Yes. It restores the released DeepSeek V4 routed-expert activation contract and prevents abnormal next-token distributions caused by missing SwiGLU clamping.

### How was this patch tested?

Unit and static checks on `releases/v0.25.1rc@40714c724`:

```bash
pytest -q tests/ut/model_executor/test_deepseek_v4.py
# 1 passed

ruff check vllm_ascend/models/deepseek_v4.py tests/ut/model_executor/test_deepseek_v4.py
# All checks passed!

python -m py_compile vllm_ascend/models/deepseek_v4.py tests/ut/model_executor/test_deepseek_v4.py
git diff --check origin/releases/v0.25.1rc...HEAD
```

Real-weight causal validation used DeepSeek-V4-Flash-0731 BF16 and W8A8 checkpoints with exact prompt-token parity:

| Model/scope | Missing clamp | Clamp propagated |
| --- | ---: | ---: |
| BF16 q0081 cliff top-1 match versus official | `0/2` | `2/2` |
| BF16 q0081 mean top-20 overlap | `0/20` | `18.5/20` |
| W8A8 historical 47 top-1 match versus official | `12/47` | `44/47` |
| W8A8 historical 47 mean top-20 overlap | `3.57/20` | `18.55/20` |
| W8A8 abnormal target in top-20 | `6/47` | `0/47` |

The fixed W8A8 result was reproduced across independent cold starts. A patched W8A8 + DSpark online trace also matched the official top-1 at `59/60` first/out128/out1024 positions; the remaining strict mismatch was a local maximum-probability tie, giving tie-aware `60/60`.

The official API exposes normalized top-20 logprobs rather than full raw logits, so these results validate ranking recovery and relative margins rather than bitwise raw-logit identity.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
