### PR TITLE
[v0.26.0rc][Feature][Spec Decode] Support probabilistic DSpark sampling on V1

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -41,6 +41,7 @@ _NUM_SPECULATIVE_TOKENS = 3
 _MAX_BATCH_SIZE = 2
 _MAX_NUM_TOKENS = 8
 _HIDDEN_SIZE = 16
+_VOCAB_SIZE = 7
 
 
 class _DSparkProposerTestBase:
@@ -51,7 +52,8 @@ class _DSparkProposerTestBase:
         """Build the minimal config consumed by the DSpark initializer."""
         draft_model_config = SimpleNamespace(hf_config=hf_config, get_hidden_size=lambda: _HIDDEN_SIZE)
         return SimpleNamespace(
-            speculative_config=SimpleNamespace(draft_sample_method="greedy", draft_model_config=draft_model_config)
+            speculative_config=SimpleNamespace(draft_sample_method="greedy", draft_model_config=draft_model_config),
+            model_config=SimpleNamespace(get_vocab_size=lambda: _VOCAB_SIZE),
         )
 
     @classmethod
@@ -83,6 +85,10 @@ class _DSparkProposerTestBase:
             proposer.hidden_size = _HIDDEN_SIZE
             proposer.hidden_states = torch.empty(0)
             proposer._dflash_hidden_states = torch.empty(0)
+            proposer._enable_probabilistic_draft_probs = (
+                vllm_config.speculative_config.draft_sample_method == "probabilistic"
+            )
+            proposer._last_draft_probs = None
             proposer.model = (
                 SimpleNamespace(get_draft_attn_causal=lambda: [draft_attn_causal])
                 if draft_attn_causal is not None
@@ -332,6 +338,27 @@ class TestPadDraftBuffersBeforeBuild(_DSparkProposerTestBase):
 class TestDSparkInitialization(_DSparkProposerTestBase):
     """Tests for DSpark initialization configuration."""
 
+    def test_rejects_reduced_vocab_before_parent_initialization(self) -> None:
+        vllm_config = self._make_vllm_config(
+            SimpleNamespace(
+                vocab_size=_VOCAB_SIZE,
+                draft_vocab_size=_VOCAB_SIZE - 1,
+            )
+        )
+        parent_init = MagicMock()
+
+        with (
+            pytest.raises(ValueError, match="does not support reduced-vocabulary"),
+            patch.object(
+                AscendDSparkProposer.__base__,
+                "__init__",
+                parent_init,
+            ),
+        ):
+            AscendDSparkProposer(vllm_config, torch.device("cpu"))
+
+        parent_init.assert_not_called()
+
     @pytest.mark.parametrize(
         ("additional_config", "draft_sample_method", "message"),
         [
@@ -346,12 +373,6 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
                 "greedy",
                 "does not support fine-grained LM-head",
                 id="finegrained-lmhead-tp",
-            ),
-            pytest.param(
-                {},
-                "probabilistic",
-                "probabilistic draft sampling is not supported",
-                id="probabilistic-draft-sampling",
             ),
         ],
     )
@@ -443,10 +464,7 @@ class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
 
 
 class TestDSparkInitValidation:
-    """``AscendDSparkProposer.__init__`` rejects probabilistic draft sampling
-    (unsupported on the v1 model runner) and, for the greedy path, allocates
-    the DSpark-specific draft/seed buffers and overrides the DFlash
-    query-token / cudagraph defaults."""
+    """Tests DSpark-specific buffers and eager/query-layout overrides."""
 
     @staticmethod
     def _make_vllm_config(
@@ -465,7 +483,10 @@ class TestDSparkInitValidation:
                 get_hidden_size=lambda: hidden_size
             ),
         )
-        return SimpleNamespace(speculative_config=speculative_config)
+        return SimpleNamespace(
+            speculative_config=speculative_config,
+            model_config=SimpleNamespace(get_vocab_size=lambda: _VOCAB_SIZE),
+        )
 
     @staticmethod
     def _stub_dflash_init(
@@ -491,27 +512,40 @@ class TestDSparkInitValidation:
             self.hidden_size = 0
             self.hidden_states = None
             self._dflash_hidden_states = None
+            self._enable_probabilistic_draft_probs = (
+                vllm_config.speculative_config.draft_sample_method
+                == "probabilistic"
+            )
+            self._last_draft_probs = None
 
         monkeypatch.setattr(AscendDflashProposer, "__init__", _stub)
 
-    def test_probabilistic_rejected(self, monkeypatch):
+    def test_probabilistic_allocates_draft_probs_buffer(self, monkeypatch):
         device = torch.device("cpu")
+        num_spec, max_batch = 5, 16
         self._stub_dflash_init(
             monkeypatch,
-            num_speculative_tokens=5,
-            max_batch_size=16,
+            num_speculative_tokens=num_spec,
+            max_batch_size=max_batch,
             max_num_tokens=256,
             dtype=torch.float32,
             device=device,
         )
         vllm_config = self._make_vllm_config(
-            num_speculative_tokens=5,
-            max_batch_size=16,
+            num_speculative_tokens=num_spec,
+            max_batch_size=max_batch,
             max_num_tokens=256,
             draft_sample_method="probabilistic",
         )
-        with pytest.raises(ValueError, match="probabilistic"):
-            AscendDSparkProposer(vllm_config, device)
+        proposer = AscendDSparkProposer(vllm_config, device)
+
+        assert proposer._dspark_draft_probs is not None
+        assert proposer._dspark_draft_probs.shape == (
+            max_batch,
+            num_spec,
+            _VOCAB_SIZE,
+        )
+        assert proposer._dspark_draft_probs.dtype == torch.float32
 
     def test_greedy_allocates_dspark_buffers(self, monkeypatch):
         device = torch.device("cpu")
@@ -540,6 +574,7 @@ class TestDSparkInitValidation:
         assert proposer._dspark_draft_buffer.dtype == torch.int64
         assert proposer._dspark_seed_buffer.shape == (max_batch,)
         assert proposer._dspark_seed_buffer.dtype == torch.int64
+        assert proposer._dspark_draft_probs is None
         # hidden_size / hidden states come from the draft model config.
         assert proposer.hidden_size == hidden
         assert proposer.hidden_states.shape == (max_num_tokens, hidden)
@@ -556,6 +591,111 @@ class TestDSparkInitValidation:
         assert proposer._per_group_block_tables == {}
         assert proposer._per_group_slot_mappings == {}
         assert proposer._context_slot_mapping_buffers is None
+
+
+class TestDSparkSampling(_DSparkProposerTestBase):
+    """Tests sequential Markov sampling and draft-probability retention."""
+
+    def _make_sampling_proposer(self) -> AscendDSparkProposer:
+        proposer = self._make_proposer(
+            max_num_tokens=8,
+            num_reqs=2,
+            block_size=2,
+        )
+        proposer._enable_probabilistic_draft_probs = True
+        proposer._last_draft_probs = None
+        proposer._dspark_draft_probs = torch.empty(
+            (2, 2, 3),
+            dtype=torch.float32,
+        )
+        proposer._dspark_seed_buffer[:2] = torch.tensor([2, 1])
+        proposer.runner = SimpleNamespace(
+            input_batch=SimpleNamespace(
+                sampling_metadata=SimpleNamespace(all_greedy=False),
+            ),
+        )
+        proposer.model = SimpleNamespace(
+            markov_embed=MagicMock(side_effect=lambda token_ids: token_ids.clone()),
+            markov_bias=MagicMock(
+                side_effect=lambda token_ids: torch.stack(
+                    [
+                        token_ids.float(),
+                        token_ids.float() + 1,
+                        token_ids.float() + 2,
+                    ],
+                    dim=-1,
+                )
+            ),
+        )
+        return proposer
+
+    def test_probabilistic_sampling_keeps_conditional_probs(self) -> None:
+        proposer = self._make_sampling_proposer()
+        step0_probs = torch.tensor(
+            [[0.1, 0.7, 0.2], [0.6, 0.3, 0.1]],
+            dtype=torch.float32,
+        )
+        step1_probs = torch.tensor(
+            [[0.2, 0.3, 0.5], [0.1, 0.8, 0.1]],
+            dtype=torch.float32,
+        )
+        proposer._sample_from_logits = MagicMock(
+            side_effect=[
+                (torch.tensor([1, 2]), step0_probs),
+                (torch.tensor([2, 0]), step1_probs),
+            ]
+        )
+
+        draft_token_ids = proposer._sample_dspark_tokens(
+            torch.zeros((4, 3), dtype=torch.float32),
+        )
+
+        assert torch.equal(
+            draft_token_ids,
+            torch.tensor([[2, 1, 2], [1, 2, 0]]),
+        )
+        assert proposer._last_draft_probs is not None
+        assert torch.equal(proposer._last_draft_probs[:, 0], step0_probs)
+        assert torch.equal(proposer._last_draft_probs[:, 1], step1_probs)
+        sampled_logits = [
+            call.args[0] for call in proposer._sample_from_logits.call_args_list
+        ]
+        assert torch.equal(
+            sampled_logits[0],
+            torch.tensor([[2.0, 3.0, 4.0], [1.0, 2.0, 3.0]]),
+        )
+        assert torch.equal(
+            sampled_logits[1],
+            torch.tensor([[1.0, 2.0, 3.0], [2.0, 3.0, 4.0]]),
+        )
+        markov_inputs = [call.args[0] for call in proposer.model.markov_embed.call_args_list]
+        assert torch.equal(markov_inputs[0], torch.tensor([2, 1]))
+        assert torch.equal(markov_inputs[1], torch.tensor([1, 2]))
+
+    def test_all_greedy_clears_cached_probs(self) -> None:
+        proposer = self._make_sampling_proposer()
+        proposer._last_draft_probs = torch.ones((2, 2, 3))
+        proposer._sample_from_logits = MagicMock()
+        proposer.runner.input_batch.sampling_metadata = SimpleNamespace(
+            all_greedy=True,
+        )
+        raw_logits = torch.tensor(
+            [
+                [0.0, 2.0, 1.0],
+                [3.0, 1.0, 0.0],
+                [2.0, 0.0, 1.0],
+                [0.0, 1.0, 4.0],
+            ]
+        )
+
+        draft_token_ids = proposer._sample_dspark_tokens(raw_logits)
+
+        assert torch.equal(
+            draft_token_ids,
+            torch.tensor([[2, 1, 0], [1, 2, 2]]),
+        )
+        assert proposer._last_draft_probs is None
+        proposer._sample_from_logits.assert_not_called()
 
 
 class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -14,6 +14,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheTensor,
     UniformTypeKVCacheSpecs,
 )
+from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
@@ -65,6 +66,97 @@ class TestDSparkAuxCaptureMode(unittest.TestCase):
         )
 
         self.assertFalse(runner._draft_uses_qwen3_gqa_dspark())
+
+
+class TestProbabilisticDraftProbHandoff(unittest.TestCase):
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.lmhead_tp_enable",
+        return_value=False,
+    )
+    @patch("vllm_ascend.worker.model_runner_v1.get_pp_group")
+    def test_pp1_caches_and_forwards_reordered_draft_probs(
+        self,
+        mock_get_pp_group,
+        _mock_lmhead_tp_enable,
+    ):
+        mock_get_pp_group.return_value = SimpleNamespace(world_size=1)
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        spec_config = SimpleNamespace(
+            disable_padded_drafter_batch=False,
+            method="dspark",
+            use_eagle=MagicMock(return_value=True),
+            uses_draft_model=MagicMock(return_value=False),
+            uses_extract_hidden_states=MagicMock(return_value=False),
+        )
+        runner.speculative_config = spec_config
+        runner.vllm_config = SimpleNamespace(speculative_config=spec_config)
+        runner.input_batch = SimpleNamespace(
+            req_ids=["req_c", "req_a", "req_b"],
+            sampling_metadata=SimpleNamespace(top_k=None),
+            update_async_output_token_ids=MagicMock(),
+        )
+        runner.input_ids = SimpleNamespace(gpu=torch.arange(3, dtype=torch.int64))
+        runner.requests = {}
+        runner.discard_request_indices = SimpleNamespace(gpu=torch.zeros(3, dtype=torch.int64))
+        runner.num_discarded_requests = 0
+        runner.use_aux_hidden_state_outputs = False
+        runner.dcp_size = 1
+        runner._log_propose_draft_token_ids_entry = MagicMock()
+        runner._copy_valid_sampled_token_count = MagicMock()
+        runner._get_positions = MagicMock(return_value=torch.arange(3, dtype=torch.int64))
+        runner.get_model = MagicMock(return_value=SimpleNamespace(get_mtp_target_hidden_states=lambda: None))
+
+        draft_probs = torch.arange(3 * 3 * 4, dtype=torch.float32).reshape(3, 3, 4)
+        runner.drafter = MagicMock()
+        runner.drafter.prepare_next_token_ids_padded.return_value = (
+            torch.tensor([10, 11, 12]),
+            torch.ones(3, dtype=torch.int32),
+        )
+        runner.drafter._propose.return_value = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        runner.drafter.take_last_draft_probs.return_value = draft_probs
+        scheduler_output = SimpleNamespace(
+            num_spec_tokens_to_schedule=3,
+            num_scheduled_tokens={"req_c": 1, "req_a": 1, "req_b": 1},
+        )
+
+        NPUModelRunner.propose_draft_token_ids(
+            runner,
+            valid_sampled_token_ids=torch.tensor([[1], [2], [3]]),
+            sampling_metadata=runner.input_batch.sampling_metadata,
+            scheduler_output=scheduler_output,
+            spec_decode_metadata=None,
+            spec_decode_common_attn_metadata=MagicMock(),
+            positions=torch.arange(3),
+            num_scheduled_tokens=3,
+            hidden_states=torch.zeros((3, 4)),
+        )
+
+        self.assertIs(runner._draft_probs, draft_probs)
+        self.assertEqual(runner._draft_prob_req_ids, ["req_c", "req_a", "req_b"])
+
+        runner.input_batch.req_ids = ["req_a", "req_b", "req_c"]
+        runner.rejection_sampler = MagicMock(return_value="sampler_output")
+        runner.sampler = MagicMock()
+        spec_decode_metadata = SpecDecodeMetadata.make_dummy(
+            [[1, 2], [], [3]],
+            device=torch.device("cpu"),
+        )
+        output = NPUModelRunner._sample(
+            runner,
+            torch.randn(6, 4),
+            spec_decode_metadata,
+        )
+
+        self.assertEqual(output, "sampler_output")
+        passed_draft_probs = runner.rejection_sampler.call_args.args[1]
+        expected_draft_probs = torch.cat(
+            [
+                draft_probs[1, :2],
+                draft_probs[0, :1],
+            ],
+            dim=0,
+        )
+        self.assertTrue(torch.equal(passed_draft_probs, expected_draft_probs))
 
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -189,7 +189,7 @@ class TestProbabilisticDraftProbHandoff(unittest.TestCase):
             runner,
             torch.randn(6, 4),
             spec_decode_metadata,
-            {"req_padding": 2},
+            {"req_padding"},
         )
 
         self.assertEqual(output, "sampler_output")
@@ -231,7 +231,7 @@ class TestProbabilisticDraftProbHandoff(unittest.TestCase):
             runner,
             torch.randn(6, 4),
             spec_decode_metadata,
-            {"req_padding": 1},
+            {"req_padding"},
         )
 
         self.assertEqual(output, "sampler_output")

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -158,6 +158,86 @@ class TestProbabilisticDraftProbHandoff(unittest.TestCase):
         )
         self.assertTrue(torch.equal(passed_draft_probs, expected_draft_probs))
 
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.logger.warning",
+    )
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.lmhead_tp_enable",
+        return_value=False,
+    )
+    def test_mixed_batch_fills_missing_padding_probs(
+        self,
+        _mock_lmhead_tp_enable,
+        mock_warning,
+    ):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.input_batch = SimpleNamespace(
+            req_ids=["req_cached", "req_padding"],
+            sampling_metadata=SimpleNamespace(top_k=None),
+            update_async_output_token_ids=MagicMock(),
+        )
+        cached_probs = torch.arange(3 * 4, dtype=torch.float32).reshape(1, 3, 4)
+        runner._draft_probs = cached_probs
+        runner._draft_prob_req_ids = ["req_cached"]
+        runner.rejection_sampler = MagicMock(return_value="sampler_output")
+        spec_decode_metadata = SpecDecodeMetadata.make_dummy(
+            [[1, 2], [-1, -1]],
+            device=torch.device("cpu"),
+        )
+
+        output = NPUModelRunner._sample(
+            runner,
+            torch.randn(6, 4),
+            spec_decode_metadata,
+            {"req_padding": 2},
+        )
+
+        self.assertEqual(output, "sampler_output")
+        passed_draft_probs = runner.rejection_sampler.call_args.args[1]
+        expected_draft_probs = torch.cat(
+            [cached_probs[0, :2], torch.zeros((2, 4))],
+            dim=0,
+        )
+        self.assertTrue(torch.equal(passed_draft_probs, expected_draft_probs))
+        mock_warning.assert_not_called()
+
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.logger.warning",
+    )
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.lmhead_tp_enable",
+        return_value=False,
+    )
+    def test_mixed_batch_warns_for_missing_real_draft_probs(
+        self,
+        _mock_lmhead_tp_enable,
+        mock_warning,
+    ):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.input_batch = SimpleNamespace(
+            req_ids=["req_cached", "req_padding", "req_missing"],
+            sampling_metadata=SimpleNamespace(top_k=None),
+            update_async_output_token_ids=MagicMock(),
+        )
+        runner._draft_probs = torch.ones((1, 3, 4))
+        runner._draft_prob_req_ids = ["req_cached"]
+        runner.rejection_sampler = MagicMock(return_value="sampler_output")
+        spec_decode_metadata = SpecDecodeMetadata.make_dummy(
+            [[1], [-1], [2]],
+            device=torch.device("cpu"),
+        )
+
+        output = NPUModelRunner._sample(
+            runner,
+            torch.randn(6, 4),
+            spec_decode_metadata,
+            {"req_padding": 1},
+        )
+
+        self.assertEqual(output, "sampler_output")
+        self.assertIsNone(runner.rejection_sampler.call_args.args[1])
+        mock_warning.assert_called_once()
+
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):
     def _build_runner(self):

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -161,81 +161,60 @@ class TestProbabilisticDraftProbHandoff(unittest.TestCase):
     @patch(
         "vllm_ascend.worker.model_runner_v1.logger.warning",
     )
-    @patch(
-        "vllm_ascend.worker.model_runner_v1.lmhead_tp_enable",
-        return_value=False,
-    )
     def test_mixed_batch_fills_missing_padding_probs(
         self,
-        _mock_lmhead_tp_enable,
         mock_warning,
     ):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.input_batch = SimpleNamespace(
             req_ids=["req_cached", "req_padding"],
-            sampling_metadata=SimpleNamespace(top_k=None),
-            update_async_output_token_ids=MagicMock(),
         )
         cached_probs = torch.arange(3 * 4, dtype=torch.float32).reshape(1, 3, 4)
         runner._draft_probs = cached_probs
         runner._draft_prob_req_ids = ["req_cached"]
-        runner.rejection_sampler = MagicMock(return_value="sampler_output")
         spec_decode_metadata = SpecDecodeMetadata.make_dummy(
             [[1, 2], [-1, -1]],
             device=torch.device("cpu"),
         )
 
-        output = NPUModelRunner._sample(
+        draft_probs = NPUModelRunner._get_spec_decode_draft_probs(
             runner,
-            torch.randn(6, 4),
             spec_decode_metadata,
             {"req_padding"},
         )
 
-        self.assertEqual(output, "sampler_output")
-        passed_draft_probs = runner.rejection_sampler.call_args.args[1]
         expected_draft_probs = torch.cat(
             [cached_probs[0, :2], torch.zeros((2, 4))],
             dim=0,
         )
-        self.assertTrue(torch.equal(passed_draft_probs, expected_draft_probs))
+        self.assertTrue(torch.equal(draft_probs, expected_draft_probs))
         mock_warning.assert_not_called()
 
     @patch(
         "vllm_ascend.worker.model_runner_v1.logger.warning",
     )
-    @patch(
-        "vllm_ascend.worker.model_runner_v1.lmhead_tp_enable",
-        return_value=False,
-    )
     def test_mixed_batch_warns_for_missing_real_draft_probs(
         self,
-        _mock_lmhead_tp_enable,
         mock_warning,
     ):
         runner = NPUModelRunner.__new__(NPUModelRunner)
         runner.input_batch = SimpleNamespace(
             req_ids=["req_cached", "req_padding", "req_missing"],
-            sampling_metadata=SimpleNamespace(top_k=None),
-            update_async_output_token_ids=MagicMock(),
         )
         runner._draft_probs = torch.ones((1, 3, 4))
         runner._draft_prob_req_ids = ["req_cached"]
-        runner.rejection_sampler = MagicMock(return_value="sampler_output")
         spec_decode_metadata = SpecDecodeMetadata.make_dummy(
             [[1], [-1], [2]],
             device=torch.device("cpu"),
         )
 
-        output = NPUModelRunner._sample(
+        draft_probs = NPUModelRunner._get_spec_decode_draft_probs(
             runner,
-            torch.randn(6, 4),
             spec_decode_metadata,
             {"req_padding"},
         )
 
-        self.assertEqual(output, "sampler_output")
-        self.assertIsNone(runner.rejection_sampler.call_args.args[1])
+        self.assertIsNone(draft_probs)
         mock_warning.assert_called_once()
 
 

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -52,10 +52,16 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "additional_config.finegrained_tp_config."
                 "lmhead_tensor_parallel_size=0."
             )
-        if vllm_config.speculative_config.draft_sample_method == "probabilistic":
+        draft_hf_config = vllm_config.speculative_config.draft_model_config.hf_config
+        target_vocab_size = vllm_config.model_config.get_vocab_size()
+        draft_vocab_size = getattr(draft_hf_config, "draft_vocab_size", None) or getattr(
+            draft_hf_config, "vocab_size", target_vocab_size
+        )
+        if draft_vocab_size != target_vocab_size:
             raise ValueError(
-                "DSpark probabilistic draft sampling is not supported on the v1 "
-                "model runner; use greedy (the default) instead."
+                "DSpark on the v1 model runner does not support reduced-vocabulary "
+                f"drafts: draft_vocab_size={draft_vocab_size}, "
+                f"target_vocab_size={target_vocab_size}."
             )
         super().__init__(vllm_config, device, runner=runner)
         self.sample_from_anchor = not getattr(self.draft_model_config.hf_config, "dspark_bonus_anchor", False)
@@ -67,6 +73,17 @@ class AscendDSparkProposer(AscendDflashProposer):
         blk = 1 + self.num_speculative_tokens
         self._dspark_draft_buffer = torch.zeros((self.max_batch_size, blk), dtype=torch.int64, device=device)
         self._dspark_seed_buffer = torch.zeros(self.max_batch_size, dtype=torch.int64, device=device)
+        self._dspark_draft_probs: torch.Tensor | None = None
+        if self._enable_probabilistic_draft_probs:
+            self._dspark_draft_probs = torch.empty(
+                (
+                    self.max_batch_size,
+                    self.num_speculative_tokens,
+                    vllm_config.model_config.get_vocab_size(),
+                ),
+                dtype=torch.float32,
+                device=device,
+            )
         # DSpark is not supported in vllm v1, so related property needs to be reset here.
         del self.hidden_size, self.hidden_states, self._dflash_hidden_states  # type: ignore[has-type]
         self.hidden_size = vllm_config.speculative_config.draft_model_config.get_hidden_size()
@@ -256,6 +273,53 @@ class AscendDSparkProposer(AscendDflashProposer):
     ) -> None:
         self._per_group_block_tables[gid] = block_table
         self._per_group_slot_mappings[gid] = slot_mapping
+
+    def _sample_dspark_tokens(
+        self,
+        raw_logits: torch.Tensor,
+    ) -> torch.Tensor:
+        """Apply the Markov correction and sample one DSpark block."""
+        sampling_metadata = self.runner.input_batch.sampling_metadata
+        logits = raw_logits.view(
+            -1,
+            self.num_speculative_tokens,
+            raw_logits.shape[-1],
+        )
+        num_reqs = logits.shape[0]
+        draft_token_ids = self._dspark_draft_buffer[:num_reqs]
+        draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_reqs])
+
+        self._last_draft_probs = None
+        use_probabilistic = (
+            self._dspark_draft_probs is not None and sampling_metadata is not None and not sampling_metadata.all_greedy
+        )
+        draft_probs = None
+        if use_probabilistic:
+            assert self._dspark_draft_probs is not None
+            if logits.shape[-1] != self._dspark_draft_probs.shape[-1]:
+                raise RuntimeError(
+                    "DSpark draft/target vocabulary mismatch for probabilistic "
+                    f"sampling: draft={logits.shape[-1]}, "
+                    f"target={self._dspark_draft_probs.shape[-1]}"
+                )
+            draft_probs = self._dspark_draft_probs[:num_reqs]
+
+        for idx in range(self.num_speculative_tokens):
+            markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
+            logits[:, idx].add_(self.model.markov_bias(markov_emb))
+            if draft_probs is None:
+                next_token_ids = logits[:, idx].argmax(dim=-1)
+            else:
+                next_token_ids, probs = self._sample_from_logits(
+                    logits[:, idx],
+                    sampling_metadata,
+                )
+                assert probs is not None
+                draft_probs[:, idx].copy_(probs)
+            draft_token_ids[:, idx + 1].copy_(next_token_ids)
+
+        self._last_draft_probs = draft_probs
+        return draft_token_ids
 
     def set_inputs_first_pass(
         self,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1409,15 +1409,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # We changed `flash_comm_v1_enabled` to avoid `markov_emb` from being split.
                 with _disable_flash_comm_v1_context():
                     raw_logits = self.model.compute_logits(sample_hidden_states)
-                    logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
-                    num_blk = logits.shape[0]
-                    draft_token_ids = self._dspark_draft_buffer[:num_blk]
-                    draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
-                    for idx in range(self.num_speculative_tokens):
-                        markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
-                        logits_bias = self.model.markov_bias(markov_emb)
-                        logits[:, idx].add_(logits_bias)
-                        draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
+                    draft_token_ids = self._sample_dspark_tokens(raw_logits)
             else:
                 logits = self.model.compute_logits(sample_hidden_states)
                 if lmhead_tp_enable():

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2263,7 +2263,11 @@ class NPUModelRunner(GPUModelRunner):
             logits = logits.to(self.device).to(logits_dtype)
 
         with record_function_or_nullcontext("sample_token"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
+            sampler_output = self._sample(
+                logits,
+                spec_decode_metadata,
+                scheduler_output.num_invalid_spec_tokens,
+            )
 
         if self.need_accepted_tokens:
             if self.sampling_done_event is None:
@@ -2446,8 +2450,53 @@ class NPUModelRunner(GPUModelRunner):
         )
         return async_output
 
+    def _get_spec_decode_draft_probs(
+        self,
+        spec_decode_metadata: SpecDecodeMetadata,
+        num_invalid_spec_tokens: dict[str, int] | None = None,
+    ) -> torch.Tensor | None:
+        if not num_invalid_spec_tokens:
+            return super()._get_spec_decode_draft_probs(spec_decode_metadata)
+        if self._draft_probs is None or self._draft_prob_req_ids is None:
+            return None
+
+        row_by_req_id = {
+            req_id: idx for idx, req_id in enumerate(self._draft_prob_req_ids)
+        }
+        draft_probs_rows: list[torch.Tensor] = []
+        for req_id, num_draft in zip(
+            self.input_batch.req_ids, spec_decode_metadata.num_draft_tokens
+        ):
+            if num_draft == 0:
+                continue
+            row_idx = row_by_req_id.get(req_id)
+            if row_idx is None:
+                if num_invalid_spec_tokens.get(req_id, 0) == num_draft:
+                    draft_probs_rows.append(
+                        self._draft_probs.new_zeros(
+                            (num_draft, self._draft_probs.shape[-1])
+                        )
+                    )
+                    continue
+                logger.warning(
+                    "Missing cached draft probabilities for request %s; "
+                    "falling back to legacy speculative rejection behavior.",
+                    req_id,
+                )
+                return None
+            draft_probs_rows.append(self._draft_probs[row_idx, :num_draft])
+
+        if not draft_probs_rows:
+            return None
+        return torch.cat(draft_probs_rows, dim=0).contiguous()
+
     # overwrite _sample for lmhead_tp_enable and need_accepted_tokens
-    def _sample(self, logits, spec_decode_metadata):
+    def _sample(
+        self,
+        logits,
+        spec_decode_metadata,
+        num_invalid_spec_tokens: dict[str, int] | None = None,
+    ):
         # Sample the next token and get logprobs if needed.
         self.input_batch.update_async_output_token_ids()
         sampling_metadata = self.input_batch.sampling_metadata
@@ -2467,7 +2516,10 @@ class NPUModelRunner(GPUModelRunner):
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
             max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             self.rejection_sampler.prepare_sampling(max_topk)
-        draft_probs = self._get_spec_decode_draft_probs(spec_decode_metadata)
+        draft_probs = self._get_spec_decode_draft_probs(
+            spec_decode_metadata,
+            num_invalid_spec_tokens,
+        )
         sampler_output = self.rejection_sampler(
             spec_decode_metadata,
             draft_probs,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2263,10 +2263,19 @@ class NPUModelRunner(GPUModelRunner):
             logits = logits.to(self.device).to(logits_dtype)
 
         with record_function_or_nullcontext("sample_token"):
+            # A newly transferred PD request can enter verification with only
+            # scheduler-inserted -1 drafts and no cached probability row.
+            fully_padded_draft_req_ids = {
+                req_id
+                for req_id, token_ids in (
+                    scheduler_output.scheduled_spec_decode_tokens.items()
+                )
+                if token_ids and all(token_id == -1 for token_id in token_ids)
+            }
             sampler_output = self._sample(
                 logits,
                 spec_decode_metadata,
-                scheduler_output.num_invalid_spec_tokens,
+                fully_padded_draft_req_ids,
             )
 
         if self.need_accepted_tokens:
@@ -2453,9 +2462,9 @@ class NPUModelRunner(GPUModelRunner):
     def _get_spec_decode_draft_probs(
         self,
         spec_decode_metadata: SpecDecodeMetadata,
-        num_invalid_spec_tokens: dict[str, int] | None = None,
+        fully_padded_draft_req_ids: set[str] | None = None,
     ) -> torch.Tensor | None:
-        if not num_invalid_spec_tokens:
+        if not fully_padded_draft_req_ids:
             return super()._get_spec_decode_draft_probs(spec_decode_metadata)
         if self._draft_probs is None or self._draft_prob_req_ids is None:
             return None
@@ -2471,7 +2480,7 @@ class NPUModelRunner(GPUModelRunner):
                 continue
             row_idx = row_by_req_id.get(req_id)
             if row_idx is None:
-                if num_invalid_spec_tokens.get(req_id, 0) == num_draft:
+                if req_id in fully_padded_draft_req_ids:
                     draft_probs_rows.append(
                         self._draft_probs.new_zeros(
                             (num_draft, self._draft_probs.shape[-1])
@@ -2495,7 +2504,7 @@ class NPUModelRunner(GPUModelRunner):
         self,
         logits,
         spec_decode_metadata,
-        num_invalid_spec_tokens: dict[str, int] | None = None,
+        fully_padded_draft_req_ids: set[str] | None = None,
     ):
         # Sample the next token and get logprobs if needed.
         self.input_batch.update_async_output_token_ids()
@@ -2518,7 +2527,7 @@ class NPUModelRunner(GPUModelRunner):
             self.rejection_sampler.prepare_sampling(max_topk)
         draft_probs = self._get_spec_decode_draft_probs(
             spec_decode_metadata,
-            num_invalid_spec_tokens,
+            fully_padded_draft_req_ids,
         )
         sampler_output = self.rejection_sampler(
             spec_decode_metadata,

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1516,6 +1516,8 @@ class NPUModelRunner(GPUModelRunner):
         target_model_batch_desc: BatchDescriptor = None,
     ) -> list[list[int]] | None:
         self._log_propose_draft_token_ids_entry(spec_decode_metadata, num_scheduled_tokens)
+        self._draft_probs = None
+        self._draft_prob_req_ids = None
 
         if not self.drafter:
             # Speculative decoding is not enabled.
@@ -1707,9 +1709,7 @@ class NPUModelRunner(GPUModelRunner):
                     else None
                 ),
             )
-            if get_pp_group().world_size > 1 and hasattr(
-                self.drafter, "take_last_draft_probs"
-            ):
+            if hasattr(self.drafter, "take_last_draft_probs"):
                 draft_probs = self.drafter.take_last_draft_probs()
                 if draft_probs is not None:
                     self._draft_probs = draft_probs
@@ -2467,11 +2467,7 @@ class NPUModelRunner(GPUModelRunner):
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
             max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             self.rejection_sampler.prepare_sampling(max_topk)
-        draft_probs = (
-            self._get_spec_decode_draft_probs(spec_decode_metadata)
-            if get_pp_group().world_size > 1
-            else None
-        )
+        draft_probs = self._get_spec_decode_draft_probs(spec_decode_metadata)
         sampler_output = self.rejection_sampler(
             spec_decode_metadata,
             draft_probs,


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #14368 to `releases/v0.26.0rc`.

- Enables probabilistic draft sampling for DSpark on Model Runner V1.
- Samples each draft token after applying its Markov correction and retains the resulting conditional draft probabilities for standard rejection sampling.
- Forwards cached draft probabilities through the V1 runner for both single-stage and pipeline-parallel deployments, including request reordering before verification.
- Rejects reduced-vocabulary DSpark configurations during V1 proposer initialization because the Markov bias and remapped target logits have incompatible vocabulary widths.
- Preserves the release-specific `enable_reduce_sample`, fine-grained LM-head, bonus-anchor, and Kimi-K3 MLA behavior. Model Runner V2 is outside the scope of this PR.

### Does this PR introduce _any_ user-facing change?

Yes. Full-vocabulary DSpark can use `draft_sample_method="probabilistic"` with Model Runner V1. Reduced-vocabulary DSpark on V1 now fails during initialization with a clear error.

### How was this patch tested?

Validated on Ascend dev1 with vLLM `v0.26.0`:

- `pytest -q tests/ut/spec_decode/test_dspark_proposer.py`: 34 passed
- `pytest -q tests/ut/worker/a2/test_model_runner_v1.py`: 25 passed
- `pytest -q tests/ut/spec_decode`: 162 passed, 13 skipped
- `python3 -m py_compile` for all changed Python files
- `bash format.sh ci`
- `git diff --check`
- End-to-end mix experiment on Ascend dev0: the average accepted length increased from 2.6 with greedy DSpark to 3.2 with probabilistic DSpark (+0.6, approximately +23.1%).

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
