### PR TITLE
[BugFix][PD] Bound proxy streams and release request leases

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -656,6 +656,14 @@
   tests:
     - tests/ut/
 # Single File
+- name: pd_proxy
+  optional: true
+  cpu_only: true
+  source_file_dependencies:
+    - examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+  tests:
+    - tests/ut/test_load_balance_proxy_server_example.py
+
 - name: dependency_documentation
   optional: true
   cpu_only: true

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -120,13 +120,14 @@ import heapq
 import ipaddress
 import json
 import logging
+import math
 import os
 import sys
 import tempfile
 import threading
 import time
 import uuid
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from multiprocessing.managers import BaseManager
@@ -209,6 +210,18 @@ class BackendServer:
 
 
 @dataclass
+class RequestLease:
+    request_id: str
+    started_at: float
+    last_progress_at: float
+    prefiller_key: str | None = None
+    prefiller_load: float = 0.0
+    decoder_key: str | None = None
+    decoder_load: float = 0.0
+    prefill_released: bool = False
+
+
+@dataclass
 class RolePools:
     """Per-role scheduling state: live servers, priority heap, and drain-isolated keys."""
 
@@ -262,6 +275,22 @@ def build_base_url(host: str, port: int) -> str:
     return f"{build_server_url(host, port)}/v1"
 
 
+def positive_finite_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0 or not math.isfinite(parsed):
+        raise argparse.ArgumentTypeError("timeout must be a positive finite number")
+    return parsed
+
+
+def build_http_timeout(args: argparse.Namespace) -> httpx.Timeout:
+    return httpx.Timeout(
+        connect=args.connect_timeout,
+        write=args.write_timeout,
+        pool=args.pool_timeout,
+        read=args.read_timeout,
+    )
+
+
 class SharedProxyScheduler:
     """Centralized mutable scheduling state shared by all uvicorn workers.
 
@@ -272,7 +301,7 @@ class SharedProxyScheduler:
 
     def __init__(self, prefiller_instances, decoder_instances):
         self._lock = threading.RLock()
-        self.request_num = 0
+        self.active_requests: dict[str, RequestLease] = {}
         self.waiting_nodes: dict[str, tuple[str, tuple[str, int], int]] = {}
         self._pools: dict[ServerRole, RolePools] = {
             ServerRole.PREFILL: RolePools(),
@@ -295,6 +324,10 @@ class SharedProxyScheduler:
     @property
     def decoders(self) -> dict[str, BackendServer]:
         return self._pool(ServerRole.DECODE).servers
+
+    @property
+    def request_num(self) -> int:
+        return len(self.active_requests)
 
     def _next_ordinal(self) -> int:
         ordinal = self._ordinal
@@ -370,11 +403,22 @@ class SharedProxyScheduler:
 
     def healthcheck(self) -> dict[str, Any]:
         with self._lock:
+            now = time.monotonic()
+            oldest_request_age = max(
+                (now - lease.started_at for lease in self.active_requests.values()),
+                default=0.0,
+            )
+            max_request_idle = max(
+                (now - lease.last_progress_at for lease in self.active_requests.values()),
+                default=0.0,
+            )
             return {
                 "status": "ok",
                 "prefill_instances": len(self.prefillers),
                 "decode_instances": len(self.decoders),
                 "request_num": self.request_num,
+                "oldest_request_age_seconds": oldest_request_age,
+                "max_request_idle_seconds": max_request_idle,
             }
 
     def _pick_server(
@@ -407,48 +451,101 @@ class SharedProxyScheduler:
             return
         entry = self._pool(role).servers[key]
         if active_tokens:
-            entry.active_tokens -= load
+            entry.active_tokens = max(0.0, entry.active_tokens - load)
         if kv_cache:
             entry.active_kv_cache = max(0.0, entry.active_kv_cache - load)
         self._push_heap(role, key)
 
-    def begin_request(self, load: float) -> dict[str, Any]:
+    def begin_request(self, request_id: str, load: float) -> dict[str, Any]:
         """Pick a prefiller, reserve KV pressure, and count this as an active request."""
         with self._lock:
+            if request_id in self.active_requests:
+                raise RuntimeError(f"Request lease {request_id} already exists")
             picked = self._pick_server(ServerRole.PREFILL, load, kv_cache=True)
-            self.request_num += 1
+            now = time.monotonic()
+            self.active_requests[request_id] = RequestLease(
+                request_id=request_id,
+                started_at=now,
+                last_progress_at=now,
+                prefiller_key=picked["key"],
+                prefiller_load=load,
+            )
             return picked
 
-    def reserve_prefill_kv(self, load: float) -> dict[str, Any]:
+    def reserve_prefill_kv(self, request_id: str, load: float) -> dict[str, Any]:
         """Pick a prefiller for recompute without bumping the active request count."""
         with self._lock:
-            return self._pick_server(ServerRole.PREFILL, load, kv_cache=True)
+            lease = self.active_requests[request_id]
+            if lease.prefiller_key is not None:
+                raise RuntimeError(f"Request lease {request_id} already has a prefiller")
+            picked = self._pick_server(ServerRole.PREFILL, load, kv_cache=True)
+            lease.prefiller_key = picked["key"]
+            lease.prefiller_load = load
+            lease.prefill_released = False
+            return picked
 
-    def pick_decoder(self, load: float) -> dict[str, Any]:
+    def pick_decoder(self, request_id: str, load: float) -> dict[str, Any]:
         with self._lock:
-            return self._pick_server(ServerRole.DECODE, load, active_tokens=True)
+            lease = self.active_requests[request_id]
+            if lease.decoder_key is not None:
+                raise RuntimeError(f"Request lease {request_id} already has a decoder")
+            picked = self._pick_server(ServerRole.DECODE, load, active_tokens=True)
+            lease.decoder_key = picked["key"]
+            lease.decoder_load = load
+            return picked
 
-    def release_prefill_kv(self, key: str, load: float) -> None:
+    def release_prefill_kv(self, request_id: str) -> None:
         with self._lock:
-            self._release_load(ServerRole.PREFILL, key, load, kv_cache=True)
+            lease = self.active_requests.get(request_id)
+            if lease is None or lease.prefill_released:
+                return
+            self._release_load(
+                ServerRole.PREFILL,
+                lease.prefiller_key,
+                lease.prefiller_load,
+                kv_cache=True,
+            )
+            lease.prefill_released = True
 
-    def release_decoder(self, key: str, load: float) -> None:
-        with self._lock:
-            self._release_load(ServerRole.DECODE, key, load, active_tokens=True)
+    def _release_lease_reservations(self, lease: RequestLease) -> None:
+        if not lease.prefill_released:
+            self._release_load(
+                ServerRole.PREFILL,
+                lease.prefiller_key,
+                lease.prefiller_load,
+                kv_cache=True,
+            )
+        self._release_load(
+            ServerRole.DECODE,
+            lease.decoder_key,
+            lease.decoder_load,
+            active_tokens=True,
+        )
+        lease.prefiller_key = None
+        lease.prefiller_load = 0.0
+        lease.decoder_key = None
+        lease.decoder_load = 0.0
+        lease.prefill_released = True
 
-    def finish_request(
-        self,
-        prefiller_key: str | None,
-        prefiller_load: float,
-        decoder_key: str | None,
-        decoder_load: float,
-        release_prefill_kv: bool,
-    ) -> None:
+    def release_attempt(self, request_id: str) -> None:
         with self._lock:
-            if release_prefill_kv:
-                self._release_load(ServerRole.PREFILL, prefiller_key, prefiller_load, kv_cache=True)
-            self._release_load(ServerRole.DECODE, decoder_key, decoder_load, active_tokens=True)
-            self.request_num = max(0, self.request_num - 1)
+            lease = self.active_requests.get(request_id)
+            if lease is not None:
+                self._release_lease_reservations(lease)
+
+    def finish_request(self, request_id: str) -> bool:
+        with self._lock:
+            lease = self.active_requests.pop(request_id, None)
+            if lease is None:
+                return False
+            self._release_lease_reservations(lease)
+            return True
+
+    def mark_request_progress(self, request_id: str) -> None:
+        with self._lock:
+            lease = self.active_requests.get(request_id)
+            if lease is not None:
+                lease.last_progress_at = time.monotonic()
 
     def get_waiting_nodes(self) -> dict[str, tuple[str, tuple[str, int], int]]:
         with self._lock:
@@ -541,8 +638,9 @@ SchedulerManager.register("get_scheduler", callable=_shared_scheduler_proxy)
 
 
 class WorkerRuntime:
-    def __init__(self, scheduler: Any):
+    def __init__(self, scheduler: Any, timeout: httpx.Timeout | None = None):
         self.scheduler = scheduler
+        self.timeout = timeout or httpx.Timeout(connect=10, write=30, pool=10, read=300)
         self._clients: dict[ServerRole, dict[str, httpx.AsyncClient]] = {
             ServerRole.PREFILL: {},
             ServerRole.DECODE: {},
@@ -580,7 +678,7 @@ class WorkerRuntime:
             if key in clients:
                 continue
             clients[key] = httpx.AsyncClient(
-                timeout=None,
+                timeout=self.timeout,
                 base_url=build_base_url(host, port),
                 limits=httpx.Limits(max_connections=100000, max_keepalive_connections=100000),
             )
@@ -679,6 +777,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--retry-delay", type=float, default=0.001, help="Base delay (seconds) for exponential backoff retries"
     )
+    parser.add_argument("--connect-timeout", type=positive_finite_float, default=10.0)
+    parser.add_argument("--write-timeout", type=positive_finite_float, default=30.0)
+    parser.add_argument("--pool-timeout", type=positive_finite_float, default=10.0)
+    parser.add_argument("--read-timeout", type=positive_finite_float, default=300.0)
     parser.add_argument(
         "--max-waiting-retries", type=int, default=3, help="Maximum number of retries for waiting nodes to be started"
     )
@@ -763,7 +865,7 @@ async def lifespan(_app: FastAPI):
         scheduler = connect_shared_scheduler(args.port)
     else:
         scheduler = _ensure_scheduler(args)
-    runtime = WorkerRuntime(scheduler)
+    runtime = WorkerRuntime(scheduler, build_http_timeout(args))
     await runtime.sync_clients()
     snapshot = scheduler.get_snapshot()
     logger.info(
@@ -796,11 +898,19 @@ def with_cancellation(handler_func):
     @functools.wraps(handler_func)
     async def wrapper(*args, **kwargs):
         request = kwargs["request"]
+        # Cache the body before starting the disconnect listener. Both
+        # ``Request.body()`` and ``listen_for_disconnect`` consume the ASGI
+        # receive channel, so running them concurrently can split the body
+        # between two consumers and leave the handler waiting forever.
+        await request.body()
         handler_task = asyncio.create_task(handler_func(*args, **kwargs))
         cancellation_task = asyncio.create_task(listen_for_disconnect(request))
         done, pending = await asyncio.wait([handler_task, cancellation_task], return_when=asyncio.FIRST_COMPLETED)
         for task in pending:
             task.cancel()
+        for task in pending:
+            with suppress(asyncio.CancelledError):
+                await task
         if handler_task in done:
             return handler_task.result()
         return None
@@ -870,15 +980,17 @@ async def stream_service_response_with_retry(
 ):
     headers = auth_headers(request_id)
     for attempt in range(1, max_retries + 1):
+        chunk_sent = False
         try:
             async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
                 response.raise_for_status()
-                first_chunk_sent = False
                 async for chunk in response.aiter_bytes():
-                    first_chunk_sent = True
+                    chunk_sent = True
                     yield chunk
                 return
         except (httpx.RequestError, httpx.HTTPStatusError) as exc:
+            if chunk_sent:
+                raise
             if attempt < max_retries:
                 logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
@@ -886,9 +998,8 @@ async def stream_service_response_with_retry(
                 logger.error("All %s attempts failed for streaming %s.", max_retries, endpoint)
                 raise exc
         except Exception as exc:
-            if "first_chunk_sent" in locals() and first_chunk_sent:
-                logger.error("Streaming to client interrupted after response started: %s", exc)
-                return
+            if chunk_sent:
+                raise
             if attempt < max_retries:
                 logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
                 await asyncio.sleep(base_delay * (2 ** (attempt - 1)))
@@ -899,32 +1010,38 @@ async def stream_service_response_with_retry(
 
 async def _abort_prefill_selection(
     runtime: WorkerRuntime,
-    prefiller_key: str,
-    prefiller_score: float,
+    request_id: str,
     *,
     is_initial_request: bool,
 ) -> None:
     if is_initial_request:
-        await runtime.schedule("finish_request", prefiller_key, prefiller_score, None, 0.0, release_prefill_kv=True)
+        await _run_cleanup(runtime, "finish_request", request_id)
     else:
-        await runtime.schedule("release_prefill_kv", prefiller_key, prefiller_score)
+        await _run_cleanup(runtime, "release_attempt", request_id)
 
 
-async def _finish_instance(runtime: WorkerRuntime, info: InstanceInfo, *, release_prefill_kv: bool) -> None:
-    await runtime.schedule(
-        "finish_request",
-        info.prefiller_key,
-        info.prefiller_score,
-        info.decoder_key,
-        info.decoder_score,
-        release_prefill_kv,
-    )
+async def _run_cleanup(runtime: WorkerRuntime, method: str, request_id: str) -> None:
+    cleanup_task = asyncio.create_task(runtime.schedule(method, request_id))
+    cancellation: asyncio.CancelledError | None = None
+    while not cleanup_task.done():
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError as exc:
+            cancellation = exc
+    cleanup_task.result()
+    if cancellation is not None:
+        raise cancellation
+
+
+async def _finish_request(runtime: WorkerRuntime, request_id: str) -> None:
+    await _run_cleanup(runtime, "finish_request", request_id)
 
 
 async def assign_instances(
     api: str,
     req_data: Any,
     request_length: int,
+    request_id: str,
     *,
     is_initial_request: bool,
 ) -> InstanceInfo:
@@ -932,9 +1049,8 @@ async def assign_instances(
     args = get_global_args()
     prefiller_score = calculate_prefill_score(request_length)
     decoder_score = calculate_decode_score(request_length)
-    request_id = next_req_id()
     pick_prefill = "begin_request" if is_initial_request else "reserve_prefill_kv"
-    prefiller = await runtime.schedule(pick_prefill, prefiller_score)
+    prefiller = await runtime.schedule(pick_prefill, request_id, prefiller_score)
     prefiller_key = prefiller["key"]
 
     try:
@@ -946,35 +1062,28 @@ async def assign_instances(
             max_retries=args.max_retries,
             base_delay=args.retry_delay,
         )
-    except Exception:
-        await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
+        response_json = response.json()
+        kv_transfer_params = response_json.get("kv_transfer_params", {})
+        if kv_transfer_params:
+            req_data["kv_transfer_params"] = kv_transfer_params
+        prefiller_cached_tokens = extract_cached_tokens(response_json)
+        decoder = await runtime.schedule("pick_decoder", request_id, decoder_score)
+        prefiller_client = await runtime.get_client(ServerRole.PREFILL, prefiller_key)
+        decoder_client = await runtime.get_client(ServerRole.DECODE, decoder["key"])
+        logger.debug("Using %s %s", prefiller_client.base_url, decoder_client.base_url)
+        return InstanceInfo(
+            request_id=request_id,
+            prefiller_key=prefiller_key,
+            prefiller_score=prefiller_score,
+            decoder_key=decoder["key"],
+            decoder_score=decoder_score,
+            decoder_host=decoder["host"],
+            decoder_port=decoder["port"],
+            prefiller_cached_tokens=prefiller_cached_tokens,
+        )
+    except (Exception, asyncio.CancelledError):
+        await _abort_prefill_selection(runtime, request_id, is_initial_request=is_initial_request)
         raise
-
-    response_json = response.json()
-    kv_transfer_params = response_json.get("kv_transfer_params", {})
-    if kv_transfer_params:
-        req_data["kv_transfer_params"] = kv_transfer_params
-    prefiller_cached_tokens = extract_cached_tokens(response_json)
-
-    try:
-        decoder = await runtime.schedule("pick_decoder", decoder_score)
-    except Exception:
-        await _abort_prefill_selection(runtime, prefiller_key, prefiller_score, is_initial_request=is_initial_request)
-        raise
-
-    prefiller_client = await runtime.get_client(ServerRole.PREFILL, prefiller_key)
-    decoder_client = await runtime.get_client(ServerRole.DECODE, decoder["key"])
-    logger.debug("Using %s %s", prefiller_client.base_url, decoder_client.base_url)
-    return InstanceInfo(
-        request_id=request_id,
-        prefiller_key=prefiller_key,
-        prefiller_score=prefiller_score,
-        decoder_key=decoder["key"],
-        decoder_score=decoder_score,
-        decoder_host=decoder["host"],
-        decoder_port=decoder["port"],
-        prefiller_cached_tokens=prefiller_cached_tokens,
-    )
 
 
 async def reassign_instances(
@@ -984,20 +1093,34 @@ async def reassign_instances(
     previous_instance: InstanceInfo,
 ) -> InstanceInfo:
     runtime = get_runtime()
-    await runtime.schedule("release_prefill_kv", previous_instance.prefiller_key, previous_instance.prefiller_score)
-    await runtime.schedule("release_decoder", previous_instance.decoder_key, previous_instance.decoder_score)
-    return await assign_instances(api, req_data, request_length, is_initial_request=False)
+    await runtime.schedule("release_attempt", previous_instance.request_id)
+    return await assign_instances(
+        api,
+        req_data,
+        request_length,
+        previous_instance.request_id,
+        is_initial_request=False,
+    )
 
 
 async def handle_completions_impl(api: str, request: Request):
     runtime = get_runtime()
     args = get_global_args()
-    request_released = False
+    request_id = next_req_id()
+    lease_started = False
+    downstream_started = False
     try:
         req_data = await request.json()
         req_body = await request.body()
         request_length = len(req_body)
-        instance_info = await assign_instances(api, req_data, request_length, is_initial_request=True)
+        instance_info = await assign_instances(
+            api,
+            req_data,
+            request_length,
+            request_id,
+            is_initial_request=True,
+        )
+        lease_started = True
         stream_flag = bool(req_data.get("stream", False))
         chat_flag = "messages" in req_data
 
@@ -1012,21 +1135,26 @@ async def handle_completions_impl(api: str, request: Request):
 
         async def generate_stream():
             nonlocal instance_info
-            nonlocal request_released
             generated_token = ""
             released_kv = False
             retry_count = 0
             retry = True
             completion_tokens = 0
             reported_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
+            last_progress_report = 0.0
 
             async def release_prefill_kv_once() -> None:
                 nonlocal released_kv
                 if not released_kv:
-                    await runtime.schedule(
-                        "release_prefill_kv", instance_info.prefiller_key, instance_info.prefiller_score
-                    )
+                    await runtime.schedule("release_prefill_kv", request_id)
                     released_kv = True
+
+            async def report_progress() -> None:
+                nonlocal last_progress_report
+                now = time.monotonic()
+                if now - last_progress_report >= 1.0:
+                    await runtime.schedule("mark_request_progress", request_id)
+                    last_progress_report = now
 
             try:
                 while retry:
@@ -1040,6 +1168,7 @@ async def handle_completions_impl(api: str, request: Request):
                         max_retries=args.max_retries,
                         base_delay=args.retry_delay,
                     ):
+                        await report_progress()
                         if not released_kv and chunk:
                             await release_prefill_kv_once()
                         try:
@@ -1107,6 +1236,14 @@ async def handle_completions_impl(api: str, request: Request):
                     instance_info.request_id,
                 )
                 raise
+            except httpx.TimeoutException as exc:
+                if not downstream_started:
+                    raise
+                logger.warning(
+                    "Decoder stream timed out after the response started for request %s: %s",
+                    request_id,
+                    exc,
+                )
             except Exception as exc:
                 logger.error(
                     "Error during streaming from decoder %s:%s: %s while handling request %s; releasing prefiller KV",
@@ -1116,27 +1253,72 @@ async def handle_completions_impl(api: str, request: Request):
                     instance_info.request_id,
                 )
             finally:
-                await _finish_instance(runtime, instance_info, release_prefill_kv=not released_kv)
-                released_kv = True
-                request_released = True
+                await _finish_request(runtime, request_id)
 
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
-        return StreamingResponse(generate_stream(), media_type=media_type)
+        upstream_stream = generate_stream()
+        try:
+            first_chunk = await anext(upstream_stream)
+        except StopAsyncIteration:
+            await upstream_stream.aclose()
+            return Response(content=b"", media_type=media_type)
+        except httpx.TimeoutException:
+            await upstream_stream.aclose()
+            return JSONResponse(
+                status_code=504,
+                content={
+                    "error": {
+                        "message": "Upstream request timed out",
+                        "type": "upstream_timeout",
+                    }
+                },
+            )
+        except asyncio.CancelledError:
+            await upstream_stream.aclose()
+            raise
+        except Exception:
+            await upstream_stream.aclose()
+            raise
+
+        async def response_stream():
+            nonlocal downstream_started
+            downstream_started = True
+            try:
+                yield first_chunk
+                async for chunk in upstream_stream:
+                    yield chunk
+            finally:
+                await upstream_stream.aclose()
+
+        return StreamingResponse(response_stream(), media_type=media_type)
+    except asyncio.CancelledError:
+        if lease_started:
+            await _finish_request(runtime, request_id)
+        raise
     except Exception as e:
         import traceback
 
         exc_info = sys.exc_info()
         print(f"Error occurred in disagg prefill proxy server - {api} endpoint")
         print("".join(traceback.format_exception(*exc_info)))
-        if not request_released and "instance_info" in locals():
-            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
-            request_released = True
+        if lease_started:
+            await _finish_request(runtime, request_id)
         if isinstance(e, httpx.HTTPStatusError) and e.response is not None:
             try:
                 err_body = e.response.json()
             except Exception:
                 err_body = {"error": {"message": e.response.text or "upstream error"}}
             return JSONResponse(err_body, status_code=e.response.status_code)
+        if isinstance(e, httpx.TimeoutException):
+            return JSONResponse(
+                status_code=504,
+                content={
+                    "error": {
+                        "message": "Upstream request timed out",
+                        "type": "upstream_timeout",
+                    }
+                },
+            )
         raise
 
 

--- a/tests/ut/test_load_balance_proxy_server_example.py
+++ b/tests/ut/test_load_balance_proxy_server_example.py
@@ -1,0 +1,442 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import importlib.util
+import json
+import sys
+from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager, suppress
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from starlette.requests import Request
+from starlette.responses import StreamingResponse
+
+EXAMPLE_PATH = (
+    Path(__file__).parents[2] / "examples" / "disaggregated_prefill_v1" / "load_balance_proxy_server_example.py"
+)
+SPEC = importlib.util.spec_from_file_location("load_balance_proxy_server_example_under_test", EXAMPLE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+proxy: Any = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = proxy
+SPEC.loader.exec_module(proxy)
+
+Responder = Callable[[asyncio.StreamReader, asyncio.StreamWriter], Awaitable[None]]
+
+
+class FakeRequest:
+    def __init__(self, payload: dict):
+        self._payload = payload
+        self._body = json.dumps(payload).encode()
+        self.disconnect = asyncio.Event()
+
+    async def json(self) -> dict:
+        return self._payload.copy()
+
+    async def body(self) -> bytes:
+        return self._body
+
+    async def receive(self) -> dict:
+        await self.disconnect.wait()
+        return {"type": "http.disconnect"}
+
+
+class TcpBackend:
+    def __init__(self, responders: Responder | list[Responder]):
+        self.responders = responders if isinstance(responders, list) else [responders]
+        self.connection_count = 0
+        self._tasks: set[asyncio.Task] = set()
+        self.server: asyncio.Server | None = None
+
+    async def start(self) -> None:
+        self.server = await asyncio.start_server(self._handle, "127.0.0.1", 0)
+
+    @property
+    def port(self) -> int:
+        assert self.server is not None
+        return self.server.sockets[0].getsockname()[1]
+
+    async def _handle(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        task = asyncio.current_task()
+        assert task is not None
+        self._tasks.add(task)
+        index = min(self.connection_count, len(self.responders) - 1)
+        self.connection_count += 1
+        try:
+            await read_http_request(reader)
+            await self.responders[index](reader, writer)
+        except (asyncio.IncompleteReadError, ConnectionError):
+            pass
+        finally:
+            writer.close()
+            with suppress(ConnectionError):
+                await writer.wait_closed()
+            self._tasks.discard(task)
+
+    async def close(self) -> None:
+        if self.server is not None:
+            self.server.close()
+            await self.server.wait_closed()
+        for task in list(self._tasks):
+            task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+
+
+async def read_http_request(reader: asyncio.StreamReader) -> None:
+    headers = await reader.readuntil(b"\r\n\r\n")
+    content_length = 0
+    for line in headers.split(b"\r\n"):
+        if line.lower().startswith(b"content-length:"):
+            content_length = int(line.split(b":", 1)[1])
+    if content_length:
+        await reader.readexactly(content_length)
+
+
+def json_responder(payload: dict) -> Responder:
+    async def respond(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        body = json.dumps(payload).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+            + str(len(body)).encode()
+            + b"\r\nConnection: close\r\n\r\n"
+            + body
+        )
+        await writer.drain()
+
+    return respond
+
+
+def chunked_responder(chunks: list[bytes], *, stall: bool = False, disconnected=None) -> Responder:
+    async def respond(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n"
+            b"Transfer-Encoding: chunked\r\nConnection: keep-alive\r\n\r\n"
+        )
+        for chunk in chunks:
+            writer.write(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
+            await writer.drain()
+        if stall:
+            await reader.read()
+            if disconnected is not None:
+                disconnected.set()
+        else:
+            writer.write(b"0\r\n\r\n")
+            await writer.drain()
+
+    return respond
+
+
+async def hung_responder(_reader: asyncio.StreamReader, _writer: asyncio.StreamWriter) -> None:
+    await asyncio.Event().wait()
+
+
+async def close_without_response(_reader: asyncio.StreamReader, _writer: asyncio.StreamWriter) -> None:
+    return
+
+
+@asynccontextmanager
+async def proxy_harness(
+    decoder_responders: Responder | list[Responder],
+    *,
+    read_timeout: float = 0.1,
+    max_retries: int = 1,
+):
+    prefill = TcpBackend(json_responder({"kv_transfer_params": {}}))
+    decoder = TcpBackend(decoder_responders)
+    await prefill.start()
+    await decoder.start()
+    scheduler = proxy.SharedProxyScheduler([("127.0.0.1", prefill.port)], [("127.0.0.1", decoder.port)])
+    args = argparse.Namespace(
+        max_retries=max_retries,
+        retry_delay=0.001,
+        connect_timeout=0.1,
+        write_timeout=0.1,
+        pool_timeout=0.1,
+        read_timeout=read_timeout,
+    )
+    test_runtime = proxy.WorkerRuntime(scheduler, proxy.build_http_timeout(args))
+    proxy.runtime = test_runtime
+    proxy.global_args = args
+    try:
+        await test_runtime.sync_clients()
+        yield scheduler, decoder
+    finally:
+        await test_runtime.close()
+        proxy.runtime = None
+        proxy.global_args = None
+        await prefill.close()
+        await decoder.close()
+
+
+async def make_request(payload: dict | None = None):
+    return await proxy.handle_completions_impl(
+        "/completions",
+        FakeRequest(payload or {"model": "test", "prompt": "hi", "max_tokens": 1}),
+    )
+
+
+async def response_body(response) -> bytes:
+    if not isinstance(response, StreamingResponse):
+        return response.body
+
+    async def collect() -> bytes:
+        return b"".join([chunk async for chunk in response.body_iterator])
+
+    return await asyncio.wait_for(collect(), timeout=1.0)
+
+
+def assert_loads_released(scheduler: Any) -> None:
+    health = scheduler.healthcheck()
+    assert health["request_num"] == 0
+    assert health["oldest_request_age_seconds"] == 0.0
+    assert health["max_request_idle_seconds"] == 0.0
+    assert all(server.active_kv_cache == 0 for server in scheduler.prefillers.values())
+    assert all(server.active_tokens == 0 for server in scheduler.decoders.values())
+
+
+@pytest.mark.asyncio
+async def test_hung_response_headers_return_504_and_finalize_tainted_instance():
+    async with proxy_harness(hung_responder) as (scheduler, decoder):
+        request_task = asyncio.create_task(make_request())
+        await asyncio.wait_for(wait_for_request_count(scheduler, 1), timeout=1.0)
+        scheduler.remove_instances(proxy.ServerRole.DECODE, [("127.0.0.1", decoder.port)])
+
+        response = await asyncio.wait_for(request_task, timeout=1.0)
+
+        assert response.status_code == 504
+        assert json.loads(response.body) == {
+            "error": {
+                "message": "Upstream request timed out",
+                "type": "upstream_timeout",
+            }
+        }
+        assert_loads_released(scheduler)
+        scheduler.finalize_tainted_instances()
+        assert scheduler.decoders == {}
+
+
+async def wait_for_request_count(scheduler: Any, expected: int) -> None:
+    while scheduler.healthcheck()["request_num"] != expected:
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_timeout_after_first_sse_chunk_does_not_retry_or_duplicate():
+    chunk = b'data: {"choices":[{"text":"one"}]}\n\n'
+    async with proxy_harness(chunked_responder([chunk], stall=True)) as (scheduler, decoder):
+        response = await asyncio.wait_for(make_request({"prompt": "hi", "stream": True}), timeout=1.0)
+        body = await response_body(response)
+
+        assert body == chunk
+        assert decoder.connection_count == 1
+        assert_loads_released(scheduler)
+
+
+@pytest.mark.asyncio
+async def test_client_disconnect_cancels_upstream_and_releases_load():
+    disconnected = asyncio.Event()
+    chunk = b'data: {"choices":[{"text":"one"}]}\n\n'
+    async with proxy_harness(
+        chunked_responder([chunk], stall=True, disconnected=disconnected),
+        read_timeout=5.0,
+    ) as (scheduler, _decoder):
+        response = await asyncio.wait_for(make_request({"prompt": "hi", "stream": True}), timeout=1.0)
+        disconnect = asyncio.Event()
+        sent_bodies: list[bytes] = []
+
+        async def receive():
+            await disconnect.wait()
+            return {"type": "http.disconnect"}
+
+        async def send(message):
+            if message["type"] == "http.response.body":
+                sent_bodies.append(message.get("body", b""))
+                disconnect.set()
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "POST",
+            "scheme": "http",
+            "path": "/v1/completions",
+            "raw_path": b"/v1/completions",
+            "query_string": b"",
+            "headers": [],
+            "client": ("127.0.0.1", 1),
+            "server": ("127.0.0.1", 2),
+        }
+        await asyncio.wait_for(response(scope, receive, send), timeout=1.0)
+        await asyncio.wait_for(disconnected.wait(), timeout=1.0)
+
+        assert b"".join(sent_bodies) == chunk
+        assert_loads_released(scheduler)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_before_response_headers_cancels_handler_and_upstream(monkeypatch):
+    upstream_cancelled = asyncio.Event()
+    original_stream = proxy.stream_service_response_with_retry
+
+    async def observed_stream(*args, **kwargs):
+        try:
+            async for chunk in original_stream(*args, **kwargs):
+                yield chunk
+        except asyncio.CancelledError:
+            upstream_cancelled.set()
+            raise
+
+    monkeypatch.setattr(proxy, "stream_service_response_with_retry", observed_stream)
+    async with proxy_harness(hung_responder, read_timeout=5.0) as (scheduler, decoder):
+        request = FakeRequest({"prompt": "hi", "stream": True})
+        handler = asyncio.create_task(proxy.handle_completions(request=request))
+        await asyncio.wait_for(wait_for_request_count(scheduler, 1), timeout=1.0)
+        await asyncio.wait_for(wait_for_connection_count(decoder, 1), timeout=1.0)
+
+        request.disconnect.set()
+
+        assert await asyncio.wait_for(handler, timeout=1.0) is None
+        await asyncio.wait_for(upstream_cancelled.wait(), timeout=1.0)
+        assert_loads_released(scheduler)
+
+
+@pytest.mark.asyncio
+async def test_disconnect_listener_does_not_compete_for_chunked_request_body():
+    messages = [
+        {"type": "http.request", "body": b'{"prompt":', "more_body": True},
+        {"type": "http.request", "body": b'"hi"}', "more_body": False},
+    ]
+    receive_calls = 0
+    body_messages_received = 0
+    active_receivers = 0
+    max_active_receivers = 0
+
+    async def receive():
+        nonlocal active_receivers, body_messages_received
+        nonlocal max_active_receivers, receive_calls
+        active_receivers += 1
+        max_active_receivers = max(max_active_receivers, active_receivers)
+        try:
+            await asyncio.sleep(0)
+            receive_calls += 1
+            if messages:
+                message = messages.pop(0)
+                body_messages_received += 1
+                return message
+            await asyncio.Event().wait()
+        finally:
+            active_receivers -= 1
+
+    request = Request(
+        {"type": "http", "method": "POST", "path": "/v1/completions", "headers": []},
+        receive,
+    )
+
+    @proxy.with_cancellation
+    async def read_json(*, request):
+        return await request.json()
+
+    result = await asyncio.wait_for(read_json(request=request), timeout=1.0)
+
+    assert result == {"prompt": "hi"}
+    assert receive_calls == 3
+    assert body_messages_received == 2
+    assert max_active_receivers == 1
+
+
+async def wait_for_connection_count(backend: TcpBackend, expected: int) -> None:
+    while backend.connection_count != expected:
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_normal_non_streaming_and_sse_responses_succeed():
+    non_stream = {"choices": [{"text": "ok"}], "usage": {"completion_tokens": 1}}
+    async with proxy_harness(json_responder(non_stream)) as (scheduler, _decoder):
+        response = await asyncio.wait_for(make_request(), timeout=1.0)
+        response_json = json.loads(await response_body(response))
+        assert response_json["choices"] == non_stream["choices"]
+        assert response_json["usage"]["completion_tokens"] == 1
+        assert response_json["usage"]["prompt_tokens_details"]["cached_tokens"] == 0
+        assert_loads_released(scheduler)
+
+    sse = b'data: {"choices":[{"text":"ok"}]}\n\n'
+    async with proxy_harness(chunked_responder([sse])) as (scheduler, _decoder):
+        response = await asyncio.wait_for(make_request({"prompt": "hi", "stream": True}), timeout=1.0)
+        assert await response_body(response) == sse
+        assert_loads_released(scheduler)
+
+
+@pytest.mark.asyncio
+async def test_retry_before_first_chunk_recovers():
+    body = {"choices": [{"text": "recovered"}]}
+    async with proxy_harness([close_without_response, json_responder(body)], max_retries=2) as (scheduler, decoder):
+        response = await asyncio.wait_for(make_request(), timeout=1.0)
+
+        assert json.loads(await response_body(response)) == body
+        assert decoder.connection_count == 2
+        assert_loads_released(scheduler)
+
+
+def test_finish_request_is_idempotent_and_health_reports_lease_age():
+    scheduler = proxy.SharedProxyScheduler([("127.0.0.1", 1)], [("127.0.0.1", 2)])
+    scheduler.begin_request("request-id", 12.0)
+    scheduler.pick_decoder("request-id", 8.0)
+    scheduler.release_prefill_kv("request-id")
+    scheduler.release_prefill_kv("request-id")
+
+    health = scheduler.healthcheck()
+    assert health["request_num"] == 1
+    assert health["oldest_request_age_seconds"] >= 0.0
+    assert health["max_request_idle_seconds"] >= 0.0
+    assert scheduler.finish_request("request-id") is True
+    assert scheduler.finish_request("request-id") is False
+    assert_loads_released(scheduler)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_finishes_before_repeated_cancellation_is_propagated():
+    class BlockingRuntime:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.release = asyncio.Event()
+            self.finished = False
+
+        async def schedule(self, _method, _request_id):
+            self.started.set()
+            await self.release.wait()
+            self.finished = True
+
+    test_runtime = BlockingRuntime()
+    cleanup = asyncio.create_task(proxy._run_cleanup(test_runtime, "finish_request", "request-id"))
+    await asyncio.wait_for(test_runtime.started.wait(), timeout=1.0)
+
+    cleanup.cancel()
+    await asyncio.sleep(0)
+    cleanup.cancel()
+    await asyncio.sleep(0)
+    test_runtime.release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(cleanup, timeout=1.0)
+    assert test_runtime.finished is True
+
+
+def test_timeout_cli_defaults_and_validation(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["proxy"])
+    args = proxy.parse_args()
+    assert (args.connect_timeout, args.write_timeout, args.pool_timeout, args.read_timeout) == (
+        10.0,
+        30.0,
+        10.0,
+        300.0,
+    )
+    for invalid in ("0", "-1", "nan", "inf", "-inf"):
+        with pytest.raises(argparse.ArgumentTypeError):
+            proxy.positive_finite_float(invalid)
+
+    timeout = proxy.build_http_timeout(args)
+    assert timeout == httpx.Timeout(connect=10, write=30, pool=10, read=300)


### PR DESCRIPTION
### What this PR does / why we need it?

The regular PD load-balancing proxy currently creates HTTPX clients with
`timeout=None`. If an upstream accepts a request but never returns response
headers, or sends one streaming chunk and then stops making progress, the
request can remain active indefinitely and retain Prefill/Decode load.

This PR:

- adds positive, finite CLI timeouts for connect, write, pool, and read
  inactivity (`10s`, `30s`, `10s`, and `300s` by default);
- tracks each active request as a scheduler-owned lease, making Prefill
  release, retry reassignment, and final cleanup idempotent;
- prefetches the first upstream chunk before sending downstream response
  headers, returning a structured `504 upstream_timeout` response if the
  upstream times out first;
- stops retrying after any response bytes have been emitted, so a stalled SSE
  stream cannot duplicate output;
- caches the downstream request body before starting disconnect monitoring so
  the handler and listener never compete for the ASGI receive channel;
- cancels and awaits request/upstream work on downstream disconnect while
  shielding final lease cleanup, including across repeated cancellation; and
- adds `oldest_request_age_seconds` and `max_request_idle_seconds` to
  `/healthcheck` for diagnostics without adding a watchdog.

Fixes #14123

### Does this PR introduce _any_ user-facing change?

Yes. The proxy gains four timeout CLI flags:

- `--connect-timeout` (default: `10`)
- `--write-timeout` (default: `30`)
- `--pool-timeout` (default: `10`)
- `--read-timeout` (default: `300`)

A timeout before downstream response headers now returns HTTP 504 with:

```json
{"error":{"message":"Upstream request timed out","type":"upstream_timeout"}}
```

The existing `/healthcheck` fields are unchanged and two request-age fields
are added. Both are `0.0` when no request is active.

### How was this patch tested?

The bug was reproduced on vllm-ascend main at
`dd6805d846bdac9474f3a4d59fdadb99beda8aca` with deterministic localhost TCP
Prefill/Decode fakes. Before the fix, a hung Decode stream exceeded a 0.25s
safety deadline while `/healthcheck` still reported `request_num: 1`.

The same fake backends now cover:

- no response headers -> bounded 504 and zero reservations;
- one SSE chunk followed by a stall -> one chunk, no retry/duplication;
- disconnect before and after the first response chunk -> upstream task
  cancellation and completed cleanup;
- chunked downstream request bodies -> single-consumer ASGI receive handling;
- repeated cancellation during cleanup -> cleanup finishes before cancellation
  is propagated;
- duplicate finalization -> exactly one release and no negative load;
- tainted instance finalization after timeout;
- normal JSON and SSE responses; and
- recovery from a retryable failure before the first chunk.

Validation used the vLLM commit pinned by current vllm-ascend main
(`58d3918e3ea0a544ffedadad2ba84559e9c51d8f`):

```bash
pytest -q tests/ut/test_load_balance_proxy_server_example.py
pytest -q --noconftest .github/workflows/scripts/test_select_tests.py
ruff check examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/test_load_balance_proxy_server_example.py
ruff format --check examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/test_load_balance_proxy_server_example.py
python -m py_compile examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py tests/ut/test_load_balance_proxy_server_example.py
git diff --check
python .github/workflows/scripts/coverage.py
```

The focused proxy suite passes 10 tests. The coverage check confirms the test
file is selected as a CPU UT and does not require an NPU `estimated_times`
entry.

The full A3 multi-1P1D + MemCache topology from the issue was not available
locally and remains for upstream CI or maintainer validation.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
