### PR TITLE
[Refactor][DSA][4/N] modularize the indexer/compressor of dsa_v1

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -499,7 +499,7 @@
   base: spec_decode_base
   source_file_dependencies:
     - vllm_ascend/spec_decode/dspark_proposer.py
-    - vllm_ascend/models/deepseek_v4_dspark.py
+    - vllm_ascend/models/deepseek_v4/dspark.py
   tests:
     - tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py
     - tests/e2e/pull_request/eight_card/test_glm5_2.py

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -303,6 +303,8 @@
   source_file_dependencies:
     - vllm_ascend/models
   tests:
+    - tests/ut/models/test_deepseek_v4_compressor.py
+    - tests/ut/models/test_deepseek_v4_indexer.py
     - tests/ut/models/test_deepseek_v4_moe.py
     - tests/e2e/pull_request/four_card/test_deepseek_v4.py
 

--- a/tests/ut/attention/test_dsa_cp.py
+++ b/tests/ut/attention/test_dsa_cp.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from typing import Any
+
+from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
+
+
+class TestAscendDSACPLayerMetadata:
+    def test_routes_by_cache_prefix(self):
+        impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
+        impl.compress_ratio = 4
+        impl.swa_cache_layer = SimpleNamespace(prefix="swa_cache")
+        impl.compressor = SimpleNamespace(
+            state_cache=SimpleNamespace(prefix="compressor.state_cache")
+        )
+        impl.indexer = SimpleNamespace(
+            k_cache=SimpleNamespace(prefix="indexer.k_cache"),
+            compressor=SimpleNamespace(
+                state_cache=SimpleNamespace(prefix="indexer.compressor.state_cache")
+            ),
+        )
+        attention_metadata = object()
+        compressor_state_metadata = object()
+        indexer_cache_metadata = object()
+        indexer_state_metadata = object()
+        swa_metadata = object()
+
+        metadata: Any = {
+            "layer": attention_metadata,
+            "compressor.state_cache": compressor_state_metadata,
+            "indexer.k_cache": indexer_cache_metadata,
+            "indexer.compressor.state_cache": indexer_state_metadata,
+            "swa_cache": swa_metadata,
+        }
+        layer_metadata = impl._get_layer_metadata("layer", metadata)
+
+        assert layer_metadata.swa is swa_metadata
+        assert layer_metadata.compressor_cache is attention_metadata
+        assert layer_metadata.compressor_state is compressor_state_metadata
+        assert layer_metadata.indexer_cache is indexer_cache_metadata
+        assert layer_metadata.indexer_state is indexer_state_metadata

--- a/tests/ut/attention/test_dsa_cp.py
+++ b/tests/ut/attention/test_dsa_cp.py
@@ -11,14 +11,10 @@ class TestAscendDSACPLayerMetadata:
         impl = AscendDSACPImpl.__new__(AscendDSACPImpl)
         impl.compress_ratio = 4
         impl.swa_cache_layer = SimpleNamespace(prefix="swa_cache")
-        impl.compressor = SimpleNamespace(
-            state_cache=SimpleNamespace(prefix="compressor.state_cache")
-        )
+        impl.compressor = SimpleNamespace(state_cache=SimpleNamespace(prefix="compressor.state_cache"))
         impl.indexer = SimpleNamespace(
             k_cache=SimpleNamespace(prefix="indexer.k_cache"),
-            compressor=SimpleNamespace(
-                state_cache=SimpleNamespace(prefix="indexer.compressor.state_cache")
-            ),
+            compressor=SimpleNamespace(state_cache=SimpleNamespace(prefix="indexer.compressor.state_cache")),
         )
         attention_metadata = object()
         compressor_state_metadata = object()

--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -23,11 +23,17 @@ import torch
 from vllm_ascend.attention.dsa_v1 import (
     DSA_METADATA_BUFFER_SIZE,
     AscendDSAImpl,
+    AscendDSALayerMetadata,
     AscendDSAMetadata,
     AscendDSAMetadataBuilder,
     AscendDSAReqMetadata,
 )
 from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
+from vllm_ascend.models.deepseek_v4.indexer import (
+    AscendIndexerMetadata,
+    IndexerOverlapPlan,
+)
 
 
 def _make_builder(compressor_ratio: int = 4) -> AscendDSAMetadataBuilder:
@@ -555,12 +561,6 @@ def _make_impl() -> AscendDSAImpl:
             "vllm_ascend.attention.dsa_v1.get_ascend_config",
             return_value=SimpleNamespace(multistream_dsv4_dsa_overlap=False),
         ),
-        patch(
-            "vllm_ascend.attention.dsa_v1.get_current_vllm_config",
-            return_value=SimpleNamespace(
-                model_config=SimpleNamespace(hf_config=SimpleNamespace(use_index_cache=False))
-            ),
-        ),
     ):
         return AscendDSAImpl(
             n_heads=1,
@@ -587,6 +587,7 @@ def _make_impl() -> AscendDSAImpl:
             wo_b=linear,
             eps=1e-6,
             attn_sink=None,
+            swa_cache_layer=SimpleNamespace(prefix="swa_cache"),
         )
 
 
@@ -641,7 +642,7 @@ def test_forward_runs_mixed_prefill_and_decode_in_one_attention_call():
             layer_name="layer",
             hidden_states=hidden_states,
             kv_cache=(torch.empty(0),),
-            attn_metadata=[metadata],
+            attn_metadata={"swa_cache": metadata},
             output=output,
         )
 
@@ -651,7 +652,8 @@ def test_forward_runs_mixed_prefill_and_decode_in_one_attention_call():
     forward_attention.assert_called_once()
     call = forward_attention.call_args
     assert torch.equal(call.args[1], hidden_states)
-    assert call.args[3] == [metadata]
+    assert call.args[3].attention is None
+    assert call.args[3].swa is metadata
     assert not call.kwargs
 
 
@@ -739,11 +741,15 @@ def test_forward_attention_routes_unified_req_metadata(
         patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
         patch("vllm_ascend.attention.dsa_v1.record_attention_compute_start"),
     ):
+        layer_metadata = impl._get_layer_metadata(
+            "layer",
+            {"swa_cache": metadata},
+        )
         actual = impl._forward_attention(
             layer_name="layer",
             hidden_states=hidden_states,
             kv_cache=(torch.empty(0),),
-            attn_metadata=[metadata],
+            layer_metadata=layer_metadata,
         )
 
     assert actual is attention_output
@@ -765,3 +771,262 @@ def test_forward_attention_routes_unified_req_metadata(
         assert sparse_call.kwargs["cu_seqlens_ori_kv"] is req_metadata.query_start_loc
     else:
         assert "cu_seqlens_ori_kv" not in sparse_call.kwargs
+
+
+class TestAscendDSAComponentMetadata:
+    def test_routes_c4_metadata_by_cache_prefix(self):
+        impl = _make_impl()
+        impl.compress_ratio = 4
+        impl.compressor = SimpleNamespace(state_cache=SimpleNamespace(prefix="compressor.state_cache"))
+        impl.indexer = SimpleNamespace(
+            k_cache=SimpleNamespace(prefix="indexer.k_cache"),
+            compressor=SimpleNamespace(state_cache=SimpleNamespace(prefix="indexer.compressor.state_cache")),
+        )
+        attention_metadata = cast(Any, object())
+        compressor_state_metadata = cast(Any, object())
+        indexer_cache_metadata = cast(Any, object())
+        indexer_state_metadata = cast(Any, object())
+        swa_metadata = cast(Any, object())
+
+        actual = impl._get_layer_metadata(
+            "layer",
+            {
+                "layer": attention_metadata,
+                "compressor.state_cache": compressor_state_metadata,
+                "indexer.k_cache": indexer_cache_metadata,
+                "indexer.compressor.state_cache": indexer_state_metadata,
+                "swa_cache": swa_metadata,
+            },
+        )
+
+        assert actual.attention is attention_metadata
+        assert actual.swa is swa_metadata
+        assert actual.compressor is not None
+        assert actual.compressor.cache is attention_metadata
+        assert actual.compressor.state is compressor_state_metadata
+        assert actual.indexer is not None
+        assert actual.indexer.compressor.cache is indexer_cache_metadata
+        assert actual.indexer.compressor.state is indexer_state_metadata
+
+
+class TestAscendDSACompressedCacheRouting:
+    def test_c4_delegates_through_indexer_overlap_plan(self):
+        impl = _make_impl()
+        impl.compress_ratio = 4
+        impl.multistream_dsv4_dsa_overlap = False
+        compressed_kv = torch.ones((1, 1, 4))
+        compress_slot_mapping = torch.zeros((1, 2), dtype=torch.int32)
+        impl.compressor = MagicMock(return_value=(compressed_kv, compress_slot_mapping))
+        topk_indices = torch.tensor([[[1, 2, 3]]], dtype=torch.int32)
+        impl.indexer = MagicMock(return_value=topk_indices)
+        compressor_metadata = AscendCompressorMetadata(
+            cache=cast(Any, object()),
+            state=cast(Any, object()),
+        )
+        indexer_metadata = AscendIndexerMetadata(compressor=compressor_metadata)
+        layer_metadata = AscendDSALayerMetadata(
+            attention=cast(Any, object()),
+            swa=cast(Any, object()),
+            compressor=compressor_metadata,
+            indexer=indexer_metadata,
+        )
+        hidden_states = torch.ones((1, 4))
+        qr = torch.ones((1, 4))
+        kv_cache = (torch.empty(0),)
+        compress_kv_cache = torch.empty(0)
+        state_cache = torch.empty(0)
+
+        with patch.object(DeviceOperator, "dsa_kv_compress_scatter") as scatter:
+            actual = impl._update_compressed_caches_and_select_topk(
+                layer_name="model.layers.0.self_attn.attn",
+                hidden_states=hidden_states,
+                qr=qr,
+                kv_cache=kv_cache,
+                layer_metadata=layer_metadata,
+                qr_pertoken_scale=None,
+                compress_kv_cache=compress_kv_cache,
+                state_cache=state_cache,
+            )
+            indexer_call = impl.indexer.call_args
+            overlap_plan = indexer_call.kwargs["overlap_plan"]
+            actual_kv, actual_mapping = overlap_plan.compute_attention_compressed_kv()
+            overlap_plan.scatter_attention_compressed_kv(actual_kv, actual_mapping)
+
+        assert actual is topk_indices
+        assert indexer_call.kwargs["layer_name"] == "model.layers.0.self_attn.attn"
+        assert indexer_call.kwargs["hidden_states"] is hidden_states
+        assert indexer_call.kwargs["qr"] is qr
+        assert indexer_call.kwargs["kv_cache"] is kv_cache
+        assert indexer_call.kwargs["metadata"] is indexer_metadata
+        assert isinstance(overlap_plan, IndexerOverlapPlan)
+        assert overlap_plan.aux_stream is None
+        impl.compressor.assert_called_once_with(
+            hidden_states=hidden_states,
+            state_cache=state_cache,
+            metadata=compressor_metadata,
+        )
+        scatter.assert_called_once_with(
+            compress_kv_cache,
+            compressed_kv,
+            compress_slot_mapping,
+        )
+
+    def test_c128_delegates_directly_to_compressor(self):
+        impl = _make_impl()
+        impl.compress_ratio = 128
+        compressed_kv = torch.ones((1, 1, 4))
+        compress_slot_mapping = torch.zeros((1, 2), dtype=torch.int32)
+        impl.compressor = MagicMock(return_value=(compressed_kv, compress_slot_mapping))
+        compressor_metadata = AscendCompressorMetadata(
+            cache=cast(Any, object()),
+            state=cast(Any, object()),
+        )
+        layer_metadata = AscendDSALayerMetadata(
+            attention=cast(Any, object()),
+            swa=cast(Any, object()),
+            compressor=compressor_metadata,
+        )
+        hidden_states = torch.ones((1, 4))
+        state_cache = torch.empty(0)
+        compress_kv_cache = torch.empty(0)
+
+        with patch.object(DeviceOperator, "dsa_kv_compress_scatter") as scatter:
+            actual = impl._update_compressed_caches_and_select_topk(
+                layer_name="layer",
+                hidden_states=hidden_states,
+                qr=torch.ones((1, 4)),
+                kv_cache=(torch.empty(0),),
+                layer_metadata=layer_metadata,
+                qr_pertoken_scale=None,
+                compress_kv_cache=compress_kv_cache,
+                state_cache=state_cache,
+            )
+
+        assert actual is None
+        impl.compressor.assert_called_once_with(
+            hidden_states=hidden_states,
+            state_cache=state_cache,
+            metadata=compressor_metadata,
+        )
+        scatter.assert_called_once_with(
+            compress_kv_cache,
+            compressed_kv,
+            compress_slot_mapping,
+        )
+
+
+@pytest.mark.parametrize("compress_ratio", [4, 128])
+def test_forward_attention_sets_compressed_kv_args(compress_ratio: int):
+    impl = _make_impl()
+    impl.compress_ratio = compress_ratio
+    impl.multistream_dsv4_dsa_overlap = False
+    hidden_states = torch.ones((2, 4))
+    q = torch.ones((2, 1, 2))
+    qr = torch.ones((2, 2))
+    attention_output = torch.full((2, 1, 2), 9.0)
+    cos = torch.ones((2, 1, 1, 2))
+    sin = torch.zeros((2, 1, 1, 2))
+    query_start_loc = torch.tensor([0, 2], dtype=torch.int32)
+    seq_lens = torch.tensor([4], dtype=torch.int32)
+    common_req = AscendDSAReqMetadata(
+        block_table=torch.tensor([[1]], dtype=torch.int32),
+        seq_lens=seq_lens,
+        slot_mapping=None,
+        block_size=128,
+        query_start_loc=query_start_loc,
+        sin=cast(Any, {"layer": sin}),
+        cos=cast(Any, {"layer": cos}),
+        sas_metadata=torch.zeros(DSA_METADATA_BUFFER_SIZE, dtype=torch.int32),
+        cu_cmp_seqlen_list=torch.tensor([0, 1], dtype=torch.int32),
+    )
+    swa_req = AscendDSAReqMetadata(
+        block_table=torch.tensor([[5]], dtype=torch.int32),
+        seq_lens=seq_lens,
+        slot_mapping=torch.tensor([[0, 0], [0, 1]], dtype=torch.int32),
+        block_size=128,
+        query_start_loc=query_start_loc,
+    )
+    attention_metadata = AscendDSAMetadata(2, 0, 0, 1, req_metadata=common_req)
+    compressor_metadata = AscendCompressorMetadata(
+        cache=attention_metadata,
+        state=cast(Any, object()),
+    )
+    layer_metadata = AscendDSALayerMetadata(
+        attention=attention_metadata,
+        swa=AscendDSAMetadata(2, 0, 0, 1, req_metadata=swa_req),
+        compressor=compressor_metadata,
+    )
+    compress_kv_cache = torch.empty(0)
+    swa_kv_cache = torch.empty(0)
+    state_cache = torch.empty(0)
+    topk_indices = torch.tensor([[[1, 2, 3]]], dtype=torch.int32) if compress_ratio == 4 else None
+    sparse_attn_op = MagicMock(return_value=(attention_output,))
+
+    def add_extra_kwargs(extra_kwargs: dict[str, Any], **kwargs) -> None:
+        extra_kwargs.update(kwargs)
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "unpack_dsa_forward_kv_cache",
+            return_value=(
+                compress_kv_cache,
+                swa_kv_cache,
+                state_cache,
+                None,
+                None,
+                None,
+            ),
+        ),
+        patch.object(
+            impl,
+            "_mla_prolog_single_stream",
+            return_value=(q, qr, None),
+        ),
+        patch.object(
+            impl,
+            "_update_compressed_caches_and_select_topk",
+            return_value=topk_indices,
+        ) as update_compressed_caches,
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_op",
+            return_value=sparse_attn_op,
+        ),
+        patch.object(
+            DeviceOperator,
+            "get_dsa_sparse_attn_base_kwargs",
+            return_value={},
+        ),
+        patch.object(
+            DeviceOperator,
+            "add_dsa_sparse_attn_extra_kwargs",
+            side_effect=add_extra_kwargs,
+        ),
+        patch("vllm_ascend.attention.dsa_v1.notify_kv_cache_written"),
+        patch("vllm_ascend.attention.dsa_v1.record_attention_compute_start"),
+    ):
+        actual = impl._forward_attention(
+            "layer",
+            hidden_states,
+            (torch.empty(0),),
+            layer_metadata,
+        )
+
+    assert actual is attention_output
+    update_call = update_compressed_caches.call_args
+    assert update_call.kwargs["layer_name"] == "layer"
+    assert update_call.kwargs["hidden_states"] is hidden_states
+    assert update_call.kwargs["layer_metadata"] is layer_metadata
+    assert update_call.kwargs["compress_kv_cache"] is compress_kv_cache
+    assert update_call.kwargs["state_cache"] is state_cache
+    sparse_kwargs = sparse_attn_op.call_args.kwargs
+    assert sparse_kwargs["cmp_kv"] is compress_kv_cache
+    assert sparse_kwargs["cmp_block_table"] is common_req.block_table
+    assert sparse_kwargs["cmp_mask_mode"] == 3
+    assert sparse_kwargs["cmp_ratio"] == compress_ratio
+    assert sparse_kwargs["cu_seqlens_cmp_kv"] is common_req.cu_cmp_seqlen_list
+    if compress_ratio == 4:
+        assert sparse_kwargs["cmp_sparse_indices"] is topk_indices
+    else:
+        assert "cmp_sparse_indices" not in sparse_kwargs

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -66,6 +66,7 @@ class TestCompressorMetadata:
         assert args[4] is block_table
         assert args[5:] == (128, 7, 4, 3, 2)
 
+
 class TestCompressorForward:
     @pytest.mark.parametrize(
         ("compress_ratio", "overlap", "expected_coff"),
@@ -91,9 +92,7 @@ class TestCompressorForward:
             query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
             start_pos=torch.tensor([1], dtype=torch.int32),
         )
-        state_req_metadata = SimpleNamespace(
-            block_table=torch.tensor([[3]], dtype=torch.int32)
-        )
+        state_req_metadata = SimpleNamespace(block_table=torch.tensor([[3]], dtype=torch.int32))
         metadata = AscendCompressorMetadata(
             cache=SimpleNamespace(req_metadata=cache_req_metadata),
             state=SimpleNamespace(req_metadata=state_req_metadata),
@@ -104,9 +103,7 @@ class TestCompressorForward:
         compress_sin = torch.zeros((1, 1, 2))
         slot_mapping = torch.tensor([[0, 1]], dtype=torch.int32)
         compressed_kv = torch.ones((1, 1, 4))
-        compute_metadata = MagicMock(
-            return_value=(compress_cos, compress_sin, slot_mapping)
-        )
+        compute_metadata = MagicMock(return_value=(compress_cos, compress_sin, slot_mapping))
         compressor._compute_metadata = compute_metadata
 
         with patch.object(
@@ -153,9 +150,7 @@ class TestCompressorStateCache:
         cache.block_size = 8
         cache.dtype = torch.float32
         cache.sliding_window = 64
-        vllm_config = SimpleNamespace(
-            cache_config=SimpleNamespace(block_size=128)
-        )
+        vllm_config = SimpleNamespace(cache_config=SimpleNamespace(block_size=128))
 
         spec = cache.get_kv_cache_spec(vllm_config)
 

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.models.deepseek_v4.compressor import (
+    AscendCompressorMetadata,
+    AscendCompressorStateCache,
+    Compressor,
+)
+
+
+class TestCompressorMetadata:
+    def test_compute_metadata_flattens_rotary_inputs(self):
+        compressor = Compressor.__new__(Compressor)
+        torch.nn.Module.__init__(compressor)
+        compressor.compress_ratio = 4
+        full_cos = torch.arange(8).view(2, 1, 1, 4)
+        full_sin = -full_cos
+        query_start_loc = torch.tensor([0, 2, 4], dtype=torch.int32)
+        start_pos = torch.tensor([1, 3], dtype=torch.int32)
+        block_table = torch.tensor([[0], [1]], dtype=torch.int32)
+        metadata = SimpleNamespace(
+            full_compress_cos=full_cos,
+            full_compress_sin=full_sin,
+            query_start_loc=query_start_loc,
+            start_pos=start_pos,
+            block_table=block_table,
+            block_size=128,
+            num_compressed_tokens=3,
+            num_reqs_actual=2,
+        )
+        result_cos = torch.ones((3, 4))
+        result_sin = torch.zeros((3, 4))
+        slot_mapping = torch.tensor([[0, 1]], dtype=torch.int32)
+
+        with (
+            patch.object(
+                DeviceOperator,
+                "get_dsa_compressor_slot_mapping_format",
+                return_value=7,
+            ) as get_slot_format,
+            patch.object(
+                torch.ops._C_ascend,
+                "compressor_metadata",
+                create=True,
+                return_value=(result_cos, result_sin, slot_mapping),
+            ) as metadata_op,
+        ):
+            actual = compressor._compute_metadata(metadata)
+
+        assert actual[0] is result_cos
+        assert actual[1] is result_sin
+        assert actual[2] is slot_mapping
+        get_slot_format.assert_called_once_with()
+        args = metadata_op.call_args.args
+        assert torch.equal(args[0], full_cos.view(2, 4))
+        assert torch.equal(args[1], full_sin.view(2, 4))
+        assert args[2] is query_start_loc
+        assert args[3] is start_pos
+        assert args[4] is block_table
+        assert args[5:] == (128, 7, 4, 3, 2)
+
+class TestCompressorForward:
+    @pytest.mark.parametrize(
+        ("compress_ratio", "overlap", "expected_coff"),
+        [(4, True, 2), (128, False, 1)],
+    )
+    def test_routes_cache_and_state_metadata(
+        self,
+        compress_ratio: int,
+        overlap: bool,
+        expected_coff: int,
+    ):
+        compressor = Compressor.__new__(Compressor)
+        torch.nn.Module.__init__(compressor)
+        compressor.overlap = overlap
+        compressor.compress_ratio = compress_ratio
+        compressor.rope_head_dim = 2
+        compressor.norm_eps = 1e-6
+        compressor.ape = torch.ones((compress_ratio, 4))
+        compressor.wkv = SimpleNamespace(weight=torch.ones((4, 4)))
+        compressor.wgate = SimpleNamespace(weight=torch.ones((4, 4)))
+        compressor.norm = SimpleNamespace(weight=torch.ones(4))
+        cache_req_metadata = SimpleNamespace(
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            start_pos=torch.tensor([1], dtype=torch.int32),
+        )
+        state_req_metadata = SimpleNamespace(
+            block_table=torch.tensor([[3]], dtype=torch.int32)
+        )
+        metadata = AscendCompressorMetadata(
+            cache=SimpleNamespace(req_metadata=cache_req_metadata),
+            state=SimpleNamespace(req_metadata=state_req_metadata),
+        )
+        hidden_states = torch.ones((2, 4))
+        state_cache = torch.ones((1, 2, 1, 4))
+        compress_cos = torch.ones((1, 1, 2))
+        compress_sin = torch.zeros((1, 1, 2))
+        slot_mapping = torch.tensor([[0, 1]], dtype=torch.int32)
+        compressed_kv = torch.ones((1, 1, 4))
+        compute_metadata = MagicMock(
+            return_value=(compress_cos, compress_sin, slot_mapping)
+        )
+        compressor._compute_metadata = compute_metadata
+
+        with patch.object(
+            torch.ops._C_ascend,
+            "compressor",
+            create=True,
+            return_value=compressed_kv,
+        ) as compressor_op:
+            actual_kv, actual_slot_mapping = compressor(
+                hidden_states=hidden_states,
+                state_cache=state_cache,
+                metadata=metadata,
+            )
+
+        assert actual_kv is compressed_kv
+        assert actual_slot_mapping is slot_mapping
+        compute_metadata.assert_called_once_with(cache_req_metadata)
+        call = compressor_op.call_args
+        assert call.args[0] is hidden_states
+        assert torch.equal(call.args[3], state_cache.squeeze(-2))
+        assert call.kwargs["state_block_table"] is state_req_metadata.block_table
+        assert call.kwargs["cu_seqlens"] is cache_req_metadata.query_start_loc
+        assert call.kwargs["start_pos"] is cache_req_metadata.start_pos
+        assert call.kwargs["cmp_ratio"] == compress_ratio
+        assert call.kwargs["coff"] == expected_coff
+
+
+class TestCompressorStateCache:
+    @pytest.mark.parametrize(
+        ("state_dim", "compress_ratio", "padding_index"),
+        [(2 * 256, 4, 0), (2 * 1024, 4, 1), (2 * 512, 128, 1)],
+    )
+    def test_cache_spec_selects_expected_page_padding(
+        self,
+        state_dim: int,
+        compress_ratio: int,
+        padding_index: int,
+    ):
+        from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+
+        cache = AscendCompressorStateCache.__new__(AscendCompressorStateCache)
+        cache.state_dim = state_dim
+        cache.compress_ratio = compress_ratio
+        cache.block_size = 8
+        cache.dtype = torch.float32
+        cache.sliding_window = 64
+        vllm_config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=128)
+        )
+
+        spec = cache.get_kv_cache_spec(vllm_config)
+
+        assert spec.block_size == 8
+        assert spec.head_size == state_dim
+        assert spec.sliding_window == 64
+        assert spec.page_size_padded == DSV4_BLOCK_SIZES[128][1][padding_index]

--- a/tests/ut/models/test_deepseek_v4_indexer.py
+++ b/tests/ut/models/test_deepseek_v4_indexer.py
@@ -127,8 +127,17 @@ class TestIndexerForward:
         execution_order: list[str] = []
         topk_indices = torch.tensor([[[1, 2, 3]], [[4, 5, 6]]])
         indexer_q = torch.ones((2, 2, 4))
-        serial_select = MagicMock(side_effect=lambda *args: execution_order.append("select") or topk_indices)
-        multistream_compute = MagicMock(side_effect=lambda *args: execution_order.append("compute") or indexer_q)
+
+        def select_serial(*args: Any) -> torch.Tensor:
+            execution_order.append("select")
+            return topk_indices
+
+        def compute_multistream(*args: Any) -> torch.Tensor:
+            execution_order.append("compute")
+            return indexer_q
+
+        serial_select = MagicMock(side_effect=select_serial)
+        multistream_compute = MagicMock(side_effect=compute_multistream)
 
         def select_multistream(*args: Any) -> torch.Tensor:
             execution_order.append("select_start")

--- a/tests/ut/models/test_deepseek_v4_indexer.py
+++ b/tests/ut/models/test_deepseek_v4_indexer.py
@@ -1,0 +1,313 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.device.device_op import DeviceOperator
+from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
+from vllm_ascend.models.deepseek_v4.indexer import (
+    AscendIndexerMetadata,
+    AscendIndexerOps,
+    DeepseekV4Indexer,
+    IndexerOverlapPlan,
+    hadamard_linear,
+    hadamard_scale,
+    rotate_activation,
+)
+
+
+def _make_indexer(topk_indices_buffer: torch.Tensor | None) -> DeepseekV4Indexer:
+    indexer = DeepseekV4Indexer.__new__(DeepseekV4Indexer)
+    torch.nn.Module.__init__(indexer)
+    indexer.topk_indices_buffer = topk_indices_buffer
+    return indexer
+
+
+class TestHadamardTransform:
+    def test_linear_pads_and_scale_restores_original_shape(self):
+        value = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+        hadamard = torch.eye(4)
+
+        projected, original_shape, original_dim = hadamard_linear(value, hadamard)
+        actual = hadamard_scale(
+            projected,
+            original_shape,
+            original_dim,
+            scale=2.0,
+        )
+
+        assert projected.shape == (2, 4)
+        assert original_shape == value.shape
+        assert original_dim == 3
+        assert torch.equal(actual, value * 2)
+
+    def test_rotate_activation_uses_original_dimension_scale(self):
+        value = torch.tensor([[1.0, 2.0, 3.0]])
+
+        actual = rotate_activation(value, torch.eye(4))
+
+        torch.testing.assert_close(actual, value * (3**-0.5))
+
+
+class TestIndexerMetadata:
+    def test_returns_cache_request_metadata_and_hadamard(self):
+        request_metadata = object()
+        hadamard = torch.eye(4)
+        metadata = AscendIndexerMetadata(
+            compressor=AscendCompressorMetadata(
+                cache=SimpleNamespace(
+                    req_metadata=request_metadata,
+                    hadamard=hadamard,
+                ),
+                state=object(),
+            )
+        )
+
+        actual_metadata, actual_hadamard = DeepseekV4Indexer._get_indexer_cache_metadata(metadata)
+
+        assert actual_metadata is request_metadata
+        assert actual_hadamard is hadamard
+
+
+class TestIndexerTopKCache:
+    def test_update_and_read_respect_offset_and_singleton_head(self):
+        buffer = torch.full((4, 3), -1, dtype=torch.int32)
+        indexer = _make_indexer(buffer)
+        topk_indices = torch.tensor([[[1, 2, 3]], [[4, 5, 6]]], dtype=torch.int32)
+
+        indexer._update_cached_topk_indices(topk_indices, offset=1)
+        actual = indexer._get_cached_topk_indices(num_tokens=2, offset=1)
+
+        assert actual.shape == (2, 1, 3)
+        assert torch.equal(actual, topk_indices)
+        assert torch.equal(buffer[0], torch.full((3,), -1, dtype=torch.int32))
+        assert torch.equal(buffer[3], torch.full((3,), -1, dtype=torch.int32))
+
+    def test_read_requires_buffer(self):
+        indexer = _make_indexer(None)
+
+        with pytest.raises(RuntimeError, match="topk_indices_buffer is required"):
+            indexer._get_cached_topk_indices(num_tokens=1)
+
+    def test_update_rejects_non_singleton_head_dimension(self):
+        indexer = _make_indexer(torch.full((2, 3), -1, dtype=torch.int32))
+        topk_indices = torch.ones((2, 2, 3), dtype=torch.int32)
+
+        with pytest.raises(ValueError, match="singleton head dimension"):
+            indexer._update_cached_topk_indices(topk_indices)
+
+
+def _make_forward_metadata() -> tuple[AscendIndexerMetadata, torch.Tensor, torch.Tensor]:
+    cos = torch.arange(4).view(2, 1, 1, 2)
+    sin = -cos
+    request_metadata = SimpleNamespace(cos={"layer": cos}, sin={"layer": sin})
+    metadata = AscendIndexerMetadata(
+        compressor=AscendCompressorMetadata(
+            cache=SimpleNamespace(
+                req_metadata=request_metadata,
+                hadamard=torch.eye(4),
+            ),
+            state=object(),
+        )
+    )
+    return metadata, cos, sin
+
+
+class TestIndexerForward:
+    @pytest.mark.parametrize("use_multistream", [False, True])
+    def test_routes_serial_and_multistream_paths(self, use_multistream: bool):
+        indexer = _make_indexer(None)
+        indexer.skip_topk = False
+        indexer.use_index_cache = False
+        execution_order: list[str] = []
+        topk_indices = torch.tensor([[[1, 2, 3]], [[4, 5, 6]]])
+        indexer_q = torch.ones((2, 2, 4))
+        serial_select = MagicMock(side_effect=lambda *args: execution_order.append("select") or topk_indices)
+        multistream_compute = MagicMock(side_effect=lambda *args: execution_order.append("compute") or indexer_q)
+
+        def select_multistream(*args: Any) -> torch.Tensor:
+            execution_order.append("select_start")
+            args[-1]()
+            execution_order.append("select_end")
+            return topk_indices
+
+        multistream_select = MagicMock(side_effect=select_multistream)
+        indexer._select_topk_serial = serial_select
+        indexer._cv_compute_query_and_update_cache_multistream = multistream_compute
+        indexer._select_topk_multistream = multistream_select
+        metadata, cos, sin = _make_forward_metadata()
+        compressed_kv = torch.ones((1, 1, 4))
+        slot_mapping = torch.zeros((1, 2), dtype=torch.int32)
+
+        def compute_attention_compressed_kv() -> tuple[torch.Tensor, torch.Tensor]:
+            execution_order.append("compute_attention_compressed_kv")
+            return compressed_kv, slot_mapping
+
+        def scatter_attention_compressed_kv(
+            actual_compressed_kv: torch.Tensor,
+            actual_slot_mapping: torch.Tensor,
+        ) -> None:
+            assert actual_compressed_kv is compressed_kv
+            assert actual_slot_mapping is slot_mapping
+            execution_order.append("scatter_attention_compressed_kv")
+
+        actual = indexer(
+            layer_name="layer",
+            hidden_states=torch.ones((2, 4)),
+            qr=torch.ones((2, 4)),
+            kv_cache=(torch.empty(0),),
+            metadata=metadata,
+            overlap_plan=IndexerOverlapPlan(
+                compute_attention_compressed_kv=compute_attention_compressed_kv,
+                scatter_attention_compressed_kv=scatter_attention_compressed_kv,
+                aux_stream=object() if use_multistream else None,
+            ),
+        )
+
+        assert actual is topk_indices
+        indexer_call = multistream_compute.call_args if use_multistream else serial_select.call_args
+        assert indexer_call.args[3] is metadata
+        assert torch.equal(indexer_call.args[4], cos)
+        assert torch.equal(indexer_call.args[5], sin)
+        if use_multistream:
+            assert execution_order == [
+                "compute",
+                "compute_attention_compressed_kv",
+                "select_start",
+                "scatter_attention_compressed_kv",
+                "select_end",
+            ]
+            serial_select.assert_not_called()
+        else:
+            assert execution_order == [
+                "select",
+                "compute_attention_compressed_kv",
+                "scatter_attention_compressed_kv",
+            ]
+            multistream_compute.assert_not_called()
+            multistream_select.assert_not_called()
+
+    def test_skip_topk_reuses_cache_and_updates_attention_cache(self):
+        topk_indices_buffer = torch.tensor(
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            dtype=torch.int32,
+        )
+        indexer = _make_indexer(topk_indices_buffer)
+        indexer.skip_topk = True
+        indexer.use_index_cache = True
+        indexer._select_topk_serial = MagicMock()
+        indexer._cv_compute_query_and_update_cache_multistream = MagicMock()
+        indexer._select_topk_multistream = MagicMock()
+        metadata, _, _ = _make_forward_metadata()
+        compressed_kv = torch.ones((1, 1, 4))
+        slot_mapping = torch.zeros((1, 2), dtype=torch.int32)
+        compute = MagicMock(return_value=(compressed_kv, slot_mapping))
+        scatter = MagicMock()
+
+        actual = indexer(
+            layer_name="layer",
+            hidden_states=torch.ones((2, 4)),
+            qr=torch.ones((2, 4)),
+            kv_cache=(torch.empty(0),),
+            metadata=metadata,
+            overlap_plan=IndexerOverlapPlan(
+                compute_attention_compressed_kv=compute,
+                scatter_attention_compressed_kv=scatter,
+                aux_stream=object(),
+            ),
+        )
+
+        assert torch.equal(actual, topk_indices_buffer[:2].unsqueeze(1))
+        indexer._select_topk_serial.assert_not_called()
+        indexer._cv_compute_query_and_update_cache_multistream.assert_not_called()
+        indexer._select_topk_multistream.assert_not_called()
+        compute.assert_called_once_with()
+        assert scatter.call_count == 1
+        assert scatter.call_args.args[0] is compressed_kv
+        assert scatter.call_args.args[1] is slot_mapping
+
+
+class TestIndexerOps:
+    def test_quantize_scatter_then_select_topk(self):
+        indexer_ops = AscendIndexerOps(index_topk=3)
+        key_cache = torch.empty((1, 1, 1, 4), dtype=torch.int8)
+        scale_cache = torch.empty((1, 1, 1, 1), dtype=torch.float16)
+        full_cache = torch.empty((1, 1, 1, 4), dtype=torch.uint8)
+        query = torch.ones((2, 2, 4))
+        quantized_query = torch.ones((2, 2, 4), dtype=torch.int8)
+        query_scale = torch.ones((2, 2), dtype=torch.float16)
+        key = torch.ones((1, 1, 4))
+        weights = torch.ones((2, 2))
+        slot_mapping = torch.zeros((1, 2), dtype=torch.int32)
+        topk_indices = torch.tensor([[[1, 2, 3]]], dtype=torch.int32)
+        metadata = SimpleNamespace(
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            seq_lens=torch.tensor([4], dtype=torch.int32),
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            qli_metadata=torch.empty(0, dtype=torch.int32),
+        )
+
+        with (
+            patch.object(
+                DeviceOperator,
+                "indexer_quant_scatter",
+                return_value=(quantized_query, query_scale, key, None),
+            ) as quant_scatter,
+            patch.object(
+                DeviceOperator,
+                "prepare_dsa_indexer_weights",
+                side_effect=lambda value: value,
+            ),
+            patch.object(
+                DeviceOperator,
+                "prepare_dsa_indexer_query_scale",
+                side_effect=lambda value: value,
+            ),
+            patch.object(
+                DeviceOperator,
+                "prepare_dsa_indexer_key_scale",
+                side_effect=lambda value: value,
+            ),
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_vllm_quant_lightning_indexer",
+                create=True,
+                return_value=(topk_indices, None),
+            ) as qli,
+        ):
+            actual = indexer_ops.quantize_update_cache_and_select_topk(
+                query,
+                key,
+                weights,
+                key_cache,
+                scale_cache,
+                full_cache,
+                slot_mapping,
+                metadata,
+            )
+
+        assert actual is topk_indices
+        quant_scatter.assert_called_once_with(
+            query,
+            key,
+            key_cache,
+            scale_cache,
+            full_cache,
+            slot_mapping,
+        )
+        qli_kwargs = qli.call_args.kwargs
+        assert qli_kwargs["query"] is quantized_query
+        assert qli_kwargs["key"] is key_cache
+        assert qli_kwargs["key_dequant_scale"] is scale_cache
+        assert torch.equal(
+            qli_kwargs["actual_seq_lengths_query"],
+            metadata.query_start_loc[1:],
+        )
+        assert qli_kwargs["actual_seq_lengths_key"] is metadata.seq_lens
+        assert qli_kwargs["block_table"] is metadata.block_table
+        assert qli_kwargs["metadata"] is metadata.qli_metadata

--- a/tests/ut/models/test_deepseek_v4_moe.py
+++ b/tests/ut/models/test_deepseek_v4_moe.py
@@ -14,7 +14,7 @@ from vllm.model_executor.layers.fused_moe.router.router_factory import (
     create_fused_moe_router,
 )
 
-from vllm_ascend.models import deepseek_v4 as deepseek_v4_module
+from vllm_ascend.models.deepseek_v4 import model as deepseek_v4_module
 
 
 class _FakeGate(nn.Module):

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -87,7 +87,7 @@ def _patch_select_moe_comm_method_deps(
 def test_deepseek_v4_forward_passes_input_ids_to_layers(monkeypatch):
     from vllm.forward_context import ForwardContext, override_forward_context
 
-    from vllm_ascend.models import deepseek_v4
+    from vllm_ascend.models.deepseek_v4 import model as deepseek_v4
 
     monkeypatch.setattr(afc.envs_vllm, "VLLM_USE_V2_MODEL_RUNNER", True)
     monkeypatch.setattr(

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -18,7 +18,7 @@ from vllm_ascend.attention.dsa_v1 import (
     AscendDSAMetadataBuilder,
 )
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
-from vllm_ascend.models import deepseek_v4
+from vllm_ascend.models.deepseek_v4 import indexer as deepseek_v4_indexer
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.v2 import attn_utils
 from vllm_ascend.worker.v2.model_states.default import AscendModelState
@@ -63,7 +63,9 @@ def test_mrv2_initializes_dsv4_cache_only_layer(
         quant_config=None,
     )
 
-    cache_layer = deepseek_v4.AscendDeepseekV4IndexerCache.__new__(deepseek_v4.AscendDeepseekV4IndexerCache)
+    cache_layer = deepseek_v4_indexer.AscendDeepseekV4IndexerCache.__new__(
+        deepseek_v4_indexer.AscendDeepseekV4IndexerCache
+    )
     torch.nn.Module.__init__(cache_layer)
     cache_layer.head_dim = 128
     cache_layer.dtype = torch.int8
@@ -72,7 +74,7 @@ def test_mrv2_initializes_dsv4_cache_only_layer(
     cache_layer.kv_cache = torch.tensor([])
 
     monkeypatch.setattr(
-        deepseek_v4,
+        deepseek_v4_indexer,
         "get_ascend_device_type",
         lambda: device_type,
     )

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1629,7 +1629,9 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 **common_attn_kwargs,
             )[0]
         elif self.compress_ratio == 4:
-            assert compressor_attn_metadata.req_metadata is not None
+            assert compressor_attn_metadata is not None
+            compressor_req_metadata = compressor_attn_metadata.req_metadata
+            assert compressor_req_metadata is not None
             DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
@@ -1639,13 +1641,15 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 cmp_kv=compress_kv_cache,
                 cmp_sparse_indices=compress_topk_idxs,
                 ori_block_table=swa_metadata.req_metadata.block_table,
-                cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
+                cmp_block_table=compressor_req_metadata.block_table,
                 metadata=req_metadata.sas_metadata,
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]
         else:
-            assert compressor_attn_metadata.req_metadata is not None
+            assert compressor_attn_metadata is not None
+            compressor_req_metadata = compressor_attn_metadata.req_metadata
+            assert compressor_req_metadata is not None
             DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
                 common_attn_kwargs, cu_seqlens_cmp_kv=req_metadata.cu_cmp_seqlen_list
             )
@@ -1654,8 +1658,8 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 ori_kv=swa_kv_cache,
                 cmp_kv=compress_kv_cache,
                 ori_block_table=swa_metadata.req_metadata.block_table,
-                cmp_block_table=compressor_attn_metadata.req_metadata.block_table,
-                metadata=compressor_attn_metadata.req_metadata.sas_metadata,
+                cmp_block_table=compressor_req_metadata.block_table,
+                metadata=compressor_req_metadata.sas_metadata,
                 cmp_mask_mode=3,
                 **common_attn_kwargs,
             )[0]

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1,6 +1,6 @@
 import math
 from dataclasses import dataclass
-from typing import Any, ClassVar, TypeVar
+from typing import Any, ClassVar, TypeAlias
 
 import torch
 import torch.distributed as dist
@@ -145,7 +145,16 @@ class AscendDSAMetadata:
     start_pos: torch.Tensor | None = None
 
 
-M = TypeVar("M", bound=AscendDSAMetadata)
+DSACPMetadataDict: TypeAlias = dict[str, AscendDSAMetadata]
+
+
+@dataclass(frozen=True)
+class AscendDSACPLayerMetadata:
+    swa: AscendDSAMetadata
+    compressor_cache: AscendDSAMetadata | None = None
+    compressor_state: AscendDSAMetadata | None = None
+    indexer_cache: AscendDSAMetadata | None = None
+    indexer_state: AscendDSAMetadata | None = None
 
 
 class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
@@ -1087,6 +1096,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
         self.indexer = kwargs.get("indexer")
         self.compressor = kwargs.get("compressor")
+        self.swa_cache_layer = kwargs.get("swa_cache_layer")
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
@@ -1126,6 +1136,36 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             self.compressor_wgate = self.compressor.wgate
             self.compressor_norm = self.compressor.norm
             self.compressor_norm_eps = self.compressor.norm_eps
+
+    def _get_layer_metadata(
+        self,
+        attn_layer_name: str,
+        attn_metadata: DSACPMetadataDict,
+    ) -> AscendDSACPLayerMetadata:
+        assert self.swa_cache_layer is not None
+        swa_metadata = attn_metadata[self.swa_cache_layer.prefix]
+        compressor_cache_metadata = None
+        compressor_state_metadata = None
+        indexer_cache_metadata = None
+        indexer_state_metadata = None
+
+        if self.compress_ratio > 1:
+            assert self.compressor is not None
+            compressor_cache_metadata = attn_metadata[attn_layer_name]
+            compressor_state_metadata = attn_metadata[self.compressor.state_cache.prefix]
+            if self.compress_ratio == 4:
+                assert self.indexer is not None
+                assert self.indexer.compressor is not None
+                indexer_cache_metadata = attn_metadata[self.indexer.k_cache.prefix]
+                indexer_state_metadata = attn_metadata[self.indexer.compressor.state_cache.prefix]
+
+        return AscendDSACPLayerMetadata(
+            swa=swa_metadata,
+            compressor_cache=compressor_cache_metadata,
+            compressor_state=compressor_state_metadata,
+            indexer_cache=indexer_cache_metadata,
+            indexer_state=indexer_state_metadata,
+        )
 
     def _compute_compressor_metadata(
         self,
@@ -1295,7 +1335,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         layer_name,
         hidden_states: torch.Tensor,  # query in unified attn
         kv_cache: tuple[torch.Tensor],
-        attn_metadata: list[M],
+        attn_metadata: DSACPMetadataDict,
         need_gather_q_kv: bool = False,
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
@@ -1303,13 +1343,15 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         if attn_metadata is None:
             # Profiling run.
             return output.fill_(0)
-        if not isinstance(attn_metadata, list):
-            attn_metadata = [attn_metadata]
+        layer_metadata = self._get_layer_metadata(layer_name, attn_metadata)
+        common_attn_metadata = layer_metadata.compressor_cache
+        if common_attn_metadata is None:
+            common_attn_metadata = layer_metadata.swa
         wait_for_kv_layer_from_connector(layer_name)
         full_gather_wo_a_enabled = (
             self.tp_size > 1
             and self.enable_dsa_cp_with_o_proj_tp
-            and attn_metadata[0].attn_state
+            and common_attn_metadata.attn_state
             not in {
                 AscendAttentionState.DecodeOnly,
                 AscendAttentionState.SpecDecoding,
@@ -1319,14 +1361,14 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             layer_name,
             hidden_states,
             kv_cache,
-            attn_metadata,
+            layer_metadata,
             need_gather_q_kv,
             full_gather_wo_a_enabled,
         )
         o_proj_input = self._restore_tp_head_layout(
             local_attn_output,
             layer_name,
-            attn_metadata[0],
+            common_attn_metadata,
             skip_all_to_all=full_gather_wo_a_enabled,
         )
         num_tokens = o_proj_input.shape[0]
@@ -1389,7 +1431,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         layer_name,
         hidden_states_local: torch.Tensor,
         kv_cache: tuple,
-        attn_metadata: list[M],
+        layer_metadata: AscendDSACPLayerMetadata,
         need_gather_q_kv: bool = False,
         full_gather_wo_a_enabled: bool = False,
     ):
@@ -1397,13 +1439,10 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         (compress_kv_cache, swa_kv_cache, state_cache, _, _, _) = DeviceOperator.unpack_dsa_forward_kv_cache(
             kv_cache, self.compress_ratio
         )
-        if self.compress_ratio == 4:
-            (compressor_attn_metadata, compressor_kv_state_metadata, _, _, swa_metadata) = attn_metadata
-        elif self.compress_ratio == 128:
-            (compressor_attn_metadata, compressor_kv_state_metadata, swa_metadata) = attn_metadata
-        else:
-            (swa_metadata,) = attn_metadata
-        common_attn_metadata = attn_metadata[0]
+        swa_metadata = layer_metadata.swa
+        common_attn_metadata = layer_metadata.compressor_cache
+        if common_attn_metadata is None:
+            common_attn_metadata = swa_metadata
 
         hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states_local, need_gather_q_kv)
 
@@ -1497,20 +1536,26 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
         compress_topk_idxs = None
         if self.compress_ratio > 1:
+            compressor_attn_metadata = layer_metadata.compressor_cache
+            compressor_kv_state_metadata = layer_metadata.compressor_state
+            assert compressor_attn_metadata is not None
+            assert compressor_kv_state_metadata is not None
             assert compressor_attn_metadata.req_metadata is not None
             assert compressor_kv_state_metadata.req_metadata is not None
             if self.compress_ratio == 4:
+                assert layer_metadata.indexer_cache is not None
+                assert layer_metadata.indexer_state is not None
                 self._update_indexer_cache(
                     x=hidden_states_cache,
                     kv_cache=kv_cache,
-                    attn_metadata=attn_metadata,
+                    metadata=layer_metadata,
                     actual_seq_lengths_query=actual_seq_lengths_query,
                 )
                 compress_topk_idxs = self._indexer_select_topk(
                     x=hidden_states_local,
                     qr=qr_local,
                     kv_cache=kv_cache,
-                    attn_metadata=attn_metadata,
+                    metadata=layer_metadata,
                     cos=local_cos,
                     sin=local_sin,
                     actual_seq_lengths_query=local_seq_lengths_query,
@@ -1620,7 +1665,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         self,
         local_attn_output: torch.Tensor,
         layer_name: str,
-        attn_metadata: M,
+        attn_metadata: AscendDSAMetadata,
         skip_all_to_all: bool = False,
     ) -> torch.Tensor:
         assert attn_metadata.req_metadata is not None
@@ -1652,13 +1697,14 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         self,
         x: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
-        attn_metadata: list[M],
+        metadata: AscendDSACPLayerMetadata,
         actual_seq_lengths_query: torch.Tensor,
     ) -> None:
         (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
             DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
         )
-        (_, _, indexer_kv_state_metadata, indexer_kv_scale_metadata, _) = attn_metadata
+        indexer_kv_state_metadata = metadata.indexer_state
+        indexer_kv_scale_metadata = metadata.indexer_cache
         coff = 2 if self.compressor_overlap else 1
         assert indexer_kv_scale_metadata is not None
         assert indexer_kv_state_metadata is not None
@@ -1712,7 +1758,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         x: torch.Tensor,
         qr: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
-        attn_metadata: list[M],
+        metadata: AscendDSACPLayerMetadata,
         cos: torch.Tensor,
         sin: torch.Tensor,
         actual_seq_lengths_query: torch.Tensor,
@@ -1720,7 +1766,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         qr_pertoken_scale: torch.Tensor = None,
     ):
         (_, indexer_k_cache, indexer_scale_cache, _) = DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
-        (_, _, _, indexer_kv_scale_metadata, _) = attn_metadata
+        indexer_kv_scale_metadata = metadata.indexer_cache
         assert indexer_kv_scale_metadata is not None
 
         if (

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1097,6 +1097,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         self.indexer = kwargs.get("indexer")
         self.compressor = kwargs.get("compressor")
         self.swa_cache_layer = kwargs.get("swa_cache_layer")
+        assert self.swa_cache_layer is not None
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -4,9 +4,8 @@ from typing import TYPE_CHECKING, Any, TypeAlias
 
 import torch
 import torch.distributed as dist
-import torch.nn.functional as F
 import torch_npu
-from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.config import VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import (
@@ -31,6 +30,8 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.distributed.parallel_state import get_otp_group
+from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata
+from vllm_ascend.models.deepseek_v4.indexer import AscendIndexerMetadata, IndexerOverlapPlan
 from vllm_ascend.ops.cv_linear import CVLinearWrapper
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
 from vllm_ascend.ops.rope_dsv4 import get_cos_and_sin_dsa, get_full_cos_and_sin_dsa
@@ -69,66 +70,13 @@ def dsv4_dsa_overlap_stream() -> torch.npu.Stream:
     return _DSV4_DSA_OVERLAP_STREAM
 
 
-# mypy: disable-error-code="has-type"
-
-
-def hadamard_transform_ref(
-    x: torch.Tensor,
-    hadamard: torch.Tensor,
-    scale: float = 1.0,
-):
-    x_shape = x.shape
-    dim = x.shape[-1]
-    x = x.reshape(-1, dim)
-    log_dim = math.ceil(math.log2(dim))
-    dim_padded = 2**log_dim
-    if dim != dim_padded:
-        x = F.pad(x, (0, dim_padded - dim))
-    out = F.linear(x, hadamard)
-    out = out * scale
-    return out[..., :dim].reshape(*x_shape)
-
-
-def rotate_activation(x: torch.Tensor, hadamard: torch.Tensor) -> torch.Tensor:
-    hidden_size = x.size(-1)
-    return hadamard_transform_ref(x, hadamard=hadamard, scale=hidden_size**-0.5)
-
-
-def hadamard_linear(x: torch.Tensor, hadamard: torch.Tensor) -> tuple[torch.Tensor, tuple[int, ...], int]:
-    """
-    Part 1 of rotate_activation: Execute F.linear (matrix multiplication).
-    This runs in main stream, parallel with aux_stream kv_scatter.
-
-    Returns:
-        Tuple of (linear_output, original_shape, original_dim)
-    """
-    x_shape = x.shape
-    dim = x.shape[-1]
-    x = x.reshape(-1, dim)
-    log_dim = math.ceil(math.log2(dim))
-    dim_padded = 2**log_dim
-    if dim != dim_padded:
-        x = F.pad(x, (0, dim_padded - dim))
-    out = F.linear(x, hadamard)
-    return out, x_shape, dim
-
-
-def hadamard_scale(out: torch.Tensor, x_shape: tuple[int, ...], dim: int, scale: float = 1.0) -> torch.Tensor:
-    """
-    Part 2 of rotate_activation: Execute scale multiplication and reshape.
-    This runs in main stream after aux_stream completes.
-    """
-    out = out * scale
-    return out[..., :dim].reshape(*x_shape)
-
-
 def _is_w8a8_dynamic(linear) -> bool:
     """True iff ``linear`` is wired up with ``AscendW8A8DynamicLinearMethod``."""
-    qm = getattr(linear, "quant_method", None)
-    if qm is None or isinstance(qm, AscendUnquantizedLinearMethod):
+    quant_method = getattr(linear, "quant_method", None)
+    if quant_method is None or isinstance(quant_method, AscendUnquantizedLinearMethod):
         return False
-    inner = getattr(qm, "quant_method", None)
-    return isinstance(inner, AscendW8A8DynamicLinearMethod)
+    inner_method = getattr(quant_method, "quant_method", None)
+    return isinstance(inner_method, AscendW8A8DynamicLinearMethod)
 
 
 class AscendDSABackend(AttentionBackend):
@@ -228,7 +176,15 @@ class AscendDSAMetadata:
     hadamard: torch.Tensor | None = None
 
 
-DSAMetadataList: TypeAlias = list[AscendDSAMetadata]
+DSAMetadataDict: TypeAlias = dict[str, AscendDSAMetadata]
+
+
+@dataclass(frozen=True)
+class AscendDSALayerMetadata:
+    attention: AscendDSAMetadata | None
+    swa: AscendDSAMetadata
+    compressor: AscendCompressorMetadata | None = None
+    indexer: AscendIndexerMetadata | None = None
 
 
 def _require_req_metadata(metadata: AscendDSAMetadata) -> AscendDSAReqMetadata:
@@ -965,6 +921,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         self.indexer = kwargs.get("indexer")
         self.compressor = kwargs.get("compressor")
+        self.swa_cache_layer = kwargs.get("swa_cache_layer")
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]
@@ -975,46 +932,41 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         ascend_config = get_ascend_config()
         self.multistream_dsv4_dsa_overlap = ascend_config.multistream_dsv4_dsa_overlap
-        self.vllm_config = get_current_vllm_config()
 
-        # indexer param
-        if self.indexer is not None:
-            self.indexer_heads: int = self.indexer.n_heads
-            self.inderxer_dim: int = self.indexer.head_dim
-            self.inderxer_wq_b = self.indexer.wq_b
-            self.cv_inderxer_wq_b = CVLinearWrapper(self.inderxer_wq_b)
-            self.weights_proj = self.indexer.weights_proj
-            self.indexer_softmax_scale = self.inderxer_dim**-0.5
+    def _get_layer_metadata(
+        self,
+        attn_layer_name: str,
+        attn_metadata: DSAMetadataDict,
+    ) -> AscendDSALayerMetadata:
+        assert self.swa_cache_layer is not None
+        swa_metadata = attn_metadata[self.swa_cache_layer.prefix]
+        attention_metadata = None
+        compressor_metadata = None
+        indexer_metadata = None
 
-            # indexer_compressor
-            self.indexcom_ape = self.indexer.compressor.ape
-            self.indexcom_wkv = self.indexer.compressor.wkv
-            self.indexcom_wgate = self.indexer.compressor.wgate
-            self.indexcom_norm = self.indexer.compressor.norm
+        if self.compress_ratio > 1:
+            assert self.compressor is not None
+            attention_metadata = attn_metadata[attn_layer_name]
+            compressor_metadata = AscendCompressorMetadata(
+                cache=attention_metadata,
+                state=attn_metadata[self.compressor.state_cache.prefix],
+            )
+            if self.compress_ratio == 4:
+                assert self.indexer is not None
+                assert self.indexer.compressor is not None
+                indexer_cache_metadata = attn_metadata[self.indexer.k_cache.prefix]
+                indexer_metadata = AscendIndexerMetadata(
+                    compressor=AscendCompressorMetadata(
+                        cache=indexer_cache_metadata,
+                        state=attn_metadata[self.indexer.compressor.state_cache.prefix],
+                    ),
+                )
 
-            self.indexcom_head_dim = self.indexer.compressor.head_dim
-            self.indexcom_rotate = self.indexer.compressor.rotate
-            self.index_topk = self.indexer.index_topk
-
-        # compress param
-        if self.compressor is not None:
-            self.compressor_overlap = self.compressor.overlap
-
-            self.compressor_ape = self.compressor.ape
-            self.compressor_wkv = self.compressor.wkv
-            self.compressor_wgate = self.compressor.wgate
-            self.compressor_norm = self.compressor.norm
-            self.compressor_norm_eps = self.compressor.norm_eps
-
-        # IndexCache: skip_topk indicates this layer reuses topk from a previous
-        # indexer-bearing layer; use_index_cache marks whether the buffer must
-        # be kept fresh on non-skip layers so downstream skip layers can read.
-        self.skip_topk = kwargs.get("skip_topk", False)
-        self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
-        self.use_index_cache = self.skip_topk or getattr(
-            self.vllm_config.model_config.hf_config,
-            "use_index_cache",
-            False,
+        return AscendDSALayerMetadata(
+            attention=attention_metadata,
+            swa=swa_metadata,
+            compressor=compressor_metadata,
+            indexer=indexer_metadata,
         )
 
     @staticmethod
@@ -1029,81 +981,12 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         # dsa does not need to update graph params
         pass
 
-    def _get_indexcache_topk_indices(self, num_tokens: int, offset: int = 0) -> torch.Tensor:
-        if self.topk_indices_buffer is None:
-            raise RuntimeError("IndexCache requires topk_indices_buffer when skip_topk is enabled.")
-        topk_indices = self.topk_indices_buffer[offset : offset + num_tokens]
-        if topk_indices.dim() == 2:
-            topk_indices = topk_indices.unsqueeze(1)
-        return topk_indices
-
-    def _update_indexcache_topk_indices(self, topk_indices: torch.Tensor, offset: int = 0) -> None:
-        if self.topk_indices_buffer is None:
-            return
-        num_tokens = topk_indices.shape[0]
-        topk_tokens = topk_indices.shape[-1]
-        topk_indices_to_cache = topk_indices
-        topk_indices_buffer = self.topk_indices_buffer[offset : offset + num_tokens, :topk_tokens]
-        if topk_indices_to_cache.dim() == 3 and topk_indices_buffer.dim() == 2:
-            assert topk_indices_to_cache.shape[1] == 1
-            topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
-        topk_indices_buffer.copy_(topk_indices_to_cache)
-
-    def _compute_compressor_metadata(
-        self,
-        metadata: AscendDSAReqMetadata,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        assert metadata.full_compress_cos is not None
-        assert metadata.full_compress_sin is not None
-        assert metadata.num_compressed_tokens is not None
-        assert metadata.start_pos is not None
-        assert metadata.num_reqs_actual is not None
-        full_compress_cos = metadata.full_compress_cos.view(
-            metadata.full_compress_cos.shape[0],
-            metadata.full_compress_cos.shape[-1],
-        )
-        full_compress_sin = metadata.full_compress_sin.view(
-            metadata.full_compress_sin.shape[0],
-            metadata.full_compress_sin.shape[-1],
-        )
-        return torch.ops._C_ascend.compressor_metadata(
-            full_compress_cos,
-            full_compress_sin,
-            metadata.query_start_loc,
-            metadata.start_pos,
-            metadata.block_table,
-            metadata.block_size,
-            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
-            self.compress_ratio,
-            metadata.num_compressed_tokens,
-            metadata.num_reqs_actual,
-        )
-
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         # Attention impls are not walked by vllm's process_weights_after_loading
         # dispatcher (only LinearMethodBase subclasses are). OTP buffers are
         # allocated lazily on the first _forward_o_proj call, which always runs
         # before ACL graph capture (profiling run triggers it).
         pass
-
-    # TODO: cast to bfloat16 to speed up
-    def rope_single(self, x, cos, sin, inverse=False):
-        if inverse:
-            sin = -sin
-        tnd_layout = 1
-        if len(x.shape) == 3:
-            num_tokens, num_heads, rotary_dim = x.shape
-        else:
-            tnd_layout = 0
-            _, num_tokens, num_heads, rotary_dim = x.shape
-        x_rot = torch_npu.npu_rotary_mul(
-            x.reshape(num_tokens, num_heads, 1, rotary_dim), cos, sin, rotary_mode="interleave"
-        )
-        if tnd_layout:
-            x = x_rot.reshape(num_tokens, -1, rotary_dim)
-        else:
-            x = x_rot.reshape(1, num_tokens, -1, rotary_dim)
-        return x
 
     def _forward_o_proj(self, o_proj_input: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
         num_tokens = o_proj_input.shape[0]
@@ -1219,7 +1102,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         layer_name,
         hidden_states: torch.Tensor,  # query in unified attn
         kv_cache: tuple[torch.Tensor, ...] | None,
-        attn_metadata: DSAMetadataList,
+        attn_metadata: DSAMetadataDict,
         need_gather_q_kv: bool = False,
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
@@ -1239,9 +1122,11 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             else:
                 output.fill_(0)
             return output
-        if not isinstance(attn_metadata, list):
-            attn_metadata = [attn_metadata]
-        actual_tokens = attn_metadata[0].num_actual_tokens
+        layer_metadata = self._get_layer_metadata(layer_name, attn_metadata)
+        common_attn_metadata = layer_metadata.attention
+        if common_attn_metadata is None:
+            common_attn_metadata = layer_metadata.swa
+        actual_tokens = common_attn_metadata.num_actual_tokens
 
         # Process for Flash Comm V1
         hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(hidden_states, need_gather_q_kv)
@@ -1249,12 +1134,12 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         o_proj_input = torch.empty(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
         assert kv_cache is not None, "kv_cache tensor tuple must be provided."
         wait_for_kv_layer_from_connector(layer_name)
-        req_metadata = _require_req_metadata(attn_metadata[0])
+        req_metadata = _require_req_metadata(common_attn_metadata)
         o_proj_input[:actual_tokens] = self._forward_attention(
             layer_name,
             hidden_states[:actual_tokens],
             kv_cache,
-            attn_metadata,
+            layer_metadata,
         )
         cos = req_metadata.cos[layer_name]
         sin = req_metadata.sin[layer_name]
@@ -1273,6 +1158,82 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
 
         return output_padded
+
+    def _mla_prolog_single_stream(self, hidden_states, cos, sin, swa_kv_cache, slot_mapping):
+        """Run the MLA prolog on the current stream."""
+        share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
+        if share_hs_quant:
+            hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
+            q_a = torch_npu.npu_quant_matmul(
+                hs_int8,
+                self.wq_a.weight,
+                self.wq_a.weight_scale,
+                pertoken_scale=hs_pertoken_scale,
+                bias=self.wq_a.bias,
+                output_dtype=hidden_states.dtype,
+            )
+        else:
+            q_a = self.wq_a(hidden_states)
+
+        # q
+        if _is_w8a8_dynamic(self.wq_b):
+            qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
+                q_a, self.q_norm.weight, epsilon=self.eps
+            )
+            q = torch_npu.npu_quant_matmul(
+                qr,
+                self.wq_b.weight,
+                self.wq_b.weight_scale,
+                pertoken_scale=qr_pertoken_scale,
+                bias=self.wq_b.bias,
+                output_dtype=hidden_states.dtype,
+            ).unflatten(-1, (self.n_local_heads, self.head_dim))
+        else:
+            qr = self.q_norm(q_a)
+            q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
+            qr_pertoken_scale = None
+        q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
+
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            q.unsqueeze(1),
+            cos,
+            sin,
+            rotary_mode="interleave",
+            partial_slice=[self.nope_head_dim, self.head_dim],
+        )
+
+        # win kv & tok_dis
+        if share_hs_quant:
+            kv = torch_npu.npu_quant_matmul(
+                hs_int8,
+                self.wkv.weight,
+                self.wkv.weight_scale,
+                pertoken_scale=hs_pertoken_scale,
+                bias=self.wkv.bias,
+                output_dtype=hidden_states.dtype,
+            )
+        else:
+            kv = self.wkv(hidden_states)
+        kv = self.kv_norm(kv)
+        assert self.rope_head_dim is not None
+        kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
+
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            kv.unsqueeze(1),
+            cos,
+            sin,
+            rotary_mode="interleave",
+            partial_slice=[self.nope_head_dim, self.head_dim],
+        )
+
+        # swa exec kv
+        DeviceOperator.dsa_kv_compress_scatter(
+            swa_kv_cache,
+            kv,
+            slot_mapping,
+        )
+
+        return q, qr, qr_pertoken_scale
 
     def _mla_prolog_multistream(self, hidden_states, cos, sin, swa_kv_cache, slot_mapping, is_prefill=False):
         """3-block multi-stream: 3-stage CV parallel + serial tail
@@ -1371,34 +1332,90 @@ class AscendDSAImpl(AttentionImplBase[Any]):
 
         return q, qr, qr_pertoken_scale
 
+    def _update_compressed_caches_and_select_topk(
+        self,
+        layer_name: str,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        layer_metadata: AscendDSALayerMetadata,
+        qr_pertoken_scale: torch.Tensor | None,
+        compress_kv_cache: torch.Tensor,
+        state_cache: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Update compressed caches and return Indexer top-k indices."""
+        assert self.compressor is not None
+        assert layer_metadata.compressor is not None
+
+        if self.compress_ratio == 4:
+            assert self.indexer is not None
+            assert layer_metadata.indexer is not None
+            def compute_attention_compressed_kv() -> tuple[torch.Tensor, torch.Tensor]:
+                return self.compressor(
+                    hidden_states=hidden_states,
+                    state_cache=state_cache,
+                    metadata=layer_metadata.compressor,
+                )
+
+            def scatter_attention_compressed_kv(
+                compressed_kv: torch.Tensor,
+                compress_slot_mapping: torch.Tensor,
+            ) -> None:
+                if compressed_kv.shape[0] > 0:
+                    DeviceOperator.dsa_kv_compress_scatter(
+                        compress_kv_cache,
+                        compressed_kv,
+                        compress_slot_mapping,
+                    )
+
+            overlap_plan = IndexerOverlapPlan(
+                compute_attention_compressed_kv=compute_attention_compressed_kv,
+                scatter_attention_compressed_kv=scatter_attention_compressed_kv,
+                aux_stream=dsv4_dsa_overlap_stream() if self.multistream_dsv4_dsa_overlap else None,
+            )
+            return self.indexer(
+                hidden_states=hidden_states,
+                qr=qr,
+                kv_cache=kv_cache,
+                metadata=layer_metadata.indexer,
+                overlap_plan=overlap_plan,
+                layer_name=layer_name,
+                qr_pertoken_scale=qr_pertoken_scale,
+            )
+
+        compressed_kv, compress_slot_mapping = self.compressor(
+            hidden_states=hidden_states,
+            state_cache=state_cache,
+            metadata=layer_metadata.compressor,
+        )
+        if compressed_kv.shape[0] > 0:
+            DeviceOperator.dsa_kv_compress_scatter(
+                compress_kv_cache,
+                compressed_kv,
+                compress_slot_mapping,
+            )
+        return None
+
     def _forward_attention(
         self,
         layer_name,
         hidden_states: torch.Tensor,
         kv_cache: tuple[torch.Tensor, ...],
-        attn_metadata: DSAMetadataList,
+        layer_metadata: AscendDSALayerMetadata,
     ) -> torch.Tensor:
-        (compress_kv_cache, swa_kv_cache, state_cache, indexer_k_cache, indexer_scale_cache, _) = (
-            DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
-        )
+        (
+            compress_kv_cache,
+            swa_kv_cache,
+            state_cache,
+            _,
+            _,
+            _,
+        ) = DeviceOperator.unpack_dsa_forward_kv_cache(kv_cache, self.compress_ratio)
 
-        compressor_attn_metadata = None
-        compressor_kv_state_metadata = None
-        indexer_kv_scale_metadata = None
-        if self.compress_ratio == 4:
-            # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
-            (compressor_attn_metadata, compressor_kv_state_metadata, _, indexer_kv_scale_metadata, swa_metadata) = (
-                attn_metadata
-            )
-            common_attn_metadata = compressor_attn_metadata
-        elif self.compress_ratio == 128:
-            # sorted keys: [attn, compressor.state_cache, swa_cache]
-            (compressor_attn_metadata, compressor_kv_state_metadata, swa_metadata) = attn_metadata
-            common_attn_metadata = compressor_attn_metadata
-        else:
-            # sorted keys: [swa_cache]
-            (swa_metadata,) = attn_metadata
-            common_attn_metadata = swa_metadata
+        common_attn_metadata = layer_metadata.attention
+        if common_attn_metadata is None:
+            common_attn_metadata = layer_metadata.swa
+        swa_metadata = layer_metadata.swa
 
         common_metadata = _require_req_metadata(common_attn_metadata)
         swa_req_metadata = _require_req_metadata(swa_metadata)
@@ -1421,607 +1438,73 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 is_prefill=has_prefill,
             )
         else:
-            # mlaprolog
-            share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
-            if share_hs_quant:
-                hs_int8, hs_pertoken_scale = torch_npu.npu_dynamic_quant(hidden_states)
-                q_a = torch_npu.npu_quant_matmul(
-                    hs_int8,
-                    self.wq_a.weight,
-                    self.wq_a.weight_scale,
-                    pertoken_scale=hs_pertoken_scale,
-                    bias=self.wq_a.bias,
-                    output_dtype=hidden_states.dtype,
-                )
-            else:
-                q_a = self.wq_a(hidden_states)
-
-            # q
-            if _is_w8a8_dynamic(self.wq_b):
-                qr, qr_pertoken_scale = torch.ops._C_ascend.npu_rms_norm_dynamic_quant(
-                    q_a, self.q_norm.weight, epsilon=self.eps
-                )
-                q = torch_npu.npu_quant_matmul(
-                    qr,
-                    self.wq_b.weight,
-                    self.wq_b.weight_scale,
-                    pertoken_scale=qr_pertoken_scale,
-                    bias=self.wq_b.bias,
-                    output_dtype=hidden_states.dtype,
-                ).unflatten(-1, (self.n_local_heads, self.head_dim))
-            else:
-                qr = self.q_norm(q_a)
-                q = self.wq_b(qr).unflatten(-1, (self.n_local_heads, self.head_dim))
-                qr_pertoken_scale = None
-            q = DeviceOperator.apply_dsa_q_rms(q, self.eps, self.q_norm_without_weight)
-
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
-                q.unsqueeze(1),
+            q, qr, qr_pertoken_scale = self._mla_prolog_single_stream(
+                hidden_states,
                 cos,
                 sin,
-                rotary_mode="interleave",
-                partial_slice=[self.nope_head_dim, self.head_dim],
-            )
-            # win kv & tok_dis
-            if share_hs_quant:
-                kv = torch_npu.npu_quant_matmul(
-                    hs_int8,
-                    self.wkv.weight,
-                    self.wkv.weight_scale,
-                    pertoken_scale=hs_pertoken_scale,
-                    bias=self.wkv.bias,
-                    output_dtype=hidden_states.dtype,
-                )
-            else:
-                kv = self.wkv(hidden_states)
-            kv = self.kv_norm(kv)
-            assert self.rope_head_dim is not None
-            kv = kv.view(-1, 1, self.nope_head_dim + self.rope_head_dim)
-
-            torch.ops._C_ascend.inplace_partial_rotary_mul(
-                kv.unsqueeze(1),
-                cos,
-                sin,
-                rotary_mode="interleave",
-                partial_slice=[self.nope_head_dim, self.head_dim],
-            )
-
-            # swa exec kv
-            DeviceOperator.dsa_kv_compress_scatter(
                 swa_kv_cache,
-                kv,
                 swa_req_metadata.slot_mapping,
             )
 
         compress_topk_idxs = None
-        indexer_q = None
         compressor_metadata = None
         if self.compress_ratio > 1:
-            assert compressor_attn_metadata is not None
-            assert compressor_kv_state_metadata is not None
-            compressor_metadata = _require_req_metadata(compressor_attn_metadata)
-            compressor_state_metadata = _require_req_metadata(compressor_kv_state_metadata)
-            if self.compress_ratio == 4:
-                assert indexer_kv_scale_metadata is not None
-                if self.skip_topk:
-                    compress_topk_idxs = self._get_indexcache_topk_indices(
-                        num_tokens,
-                    )
-                elif self.multistream_dsv4_dsa_overlap:
-                    indexer_q = self.cv_indexer_select_qli(
-                        x=hidden_states,
-                        qr=qr,
-                        kv_cache=kv_cache,
-                        attn_metadata=attn_metadata,
-                        cos=cos,
-                        sin=sin,
-                        actual_seq_lengths_query=actual_seq_lengths_query,
-                        qr_pertoken_scale=qr_pertoken_scale,
-                    )
-                else:
-                    compress_topk_idxs = self.indexer_select_qli(
-                        x=hidden_states,
-                        qr=qr,
-                        kv_cache=kv_cache,
-                        attn_metadata=attn_metadata,
-                        cos=cos,
-                        sin=sin,
-                        actual_seq_lengths_query=actual_seq_lengths_query,
-                        qr_pertoken_scale=qr_pertoken_scale,
-                    )
-
-            coff = 2 if self.compressor_overlap else 1
-            compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(compressor_metadata)
-            compressed_kv = torch.ops._C_ascend.compressor(
-                hidden_states,
-                self.compressor_wkv.weight,
-                self.compressor_wgate.weight,
-                state_cache.squeeze(-2),
-                self.compressor_ape,
-                self.compressor_norm.weight,
-                compress_sin.view(-1, compress_sin.shape[-1]),
-                compress_cos.view(-1, compress_cos.shape[-1]),
-                state_block_table=compressor_state_metadata.block_table,
-                cu_seqlens=actual_seq_lengths_query,
-                seqused=None,
-                start_pos=common_metadata.start_pos,
-                rope_head_dim=self.rope_head_dim,
-                cmp_ratio=self.compress_ratio,
-                coff=coff,
-                norm_eps=self.compressor_norm_eps,
-                rotary_mode=2,
-                cache_mode=1,
+            compressor_metadata = layer_metadata.compressor
+            assert compressor_metadata is not None
+            compress_topk_idxs = self._update_compressed_caches_and_select_topk(
+                layer_name=layer_name,
+                hidden_states=hidden_states,
+                qr=qr,
+                kv_cache=kv_cache,
+                layer_metadata=layer_metadata,
+                qr_pertoken_scale=qr_pertoken_scale,
+                compress_kv_cache=compress_kv_cache,
+                state_cache=state_cache,
             )
-
-            run_multistream_indexer = (
-                self.multistream_dsv4_dsa_overlap and self.compress_ratio == 4 and not self.skip_topk
-            )
-            if run_multistream_indexer:
-                assert indexer_q is not None
-                main_stream = torch.npu.current_stream()
-                aux_stream = dsv4_dsa_overlap_stream()
-                e_compressed_kv_done = main_stream.record_event()
-                with npu_stream_switch(aux_stream, enabled=True):
-                    torch.npu.current_stream().wait_event(e_compressed_kv_done)
-                    weights_proj_output = self.weights_proj(hidden_states)
-                q_quant, q_scale = DeviceOperator.indexer_quantize_query(indexer_q)
-
-            if compressed_kv.shape[0] > 0:
-                DeviceOperator.dsa_kv_compress_scatter(compress_kv_cache, compressed_kv, compress_slot_mapping)
-
-            if run_multistream_indexer:
-                assert indexer_kv_scale_metadata is not None
-                main_stream.wait_stream(aux_stream)
-                weights = weights_proj_output * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
-                indexer_scale_metadata = _require_req_metadata(indexer_kv_scale_metadata)
-                compress_topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
-                    query=q_quant,
-                    key=indexer_k_cache,
-                    weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-                    query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-                    key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-                    actual_seq_lengths_query=indexer_scale_metadata.query_start_loc[1:],
-                    actual_seq_lengths_key=indexer_scale_metadata.seq_lens,
-                    block_table=indexer_scale_metadata.block_table,
-                    metadata=indexer_scale_metadata.qli_metadata,
-                    query_quant_mode=0,
-                    key_quant_mode=0,
-                    layout_query="TND",
-                    layout_key="PA_BSND",
-                    sparse_count=self.index_topk,
-                    sparse_mode=3,
-                    pre_tokens=(1 << 63) - 1,
-                    next_tokens=(1 << 63) - 1,
-                    cmp_ratio=4,
-                    return_value=False,
-                )
-
-            if self.compress_ratio == 4 and self.use_index_cache:
-                assert compress_topk_idxs is not None
-                self._update_indexcache_topk_indices(compress_topk_idxs)
 
         notify_kv_cache_written(layer_name)
         record_attention_compute_start()
         attn_op = DeviceOperator.get_dsa_sparse_attn_op()
-        extra_attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
+        attn_kwargs: dict = DeviceOperator.get_dsa_sparse_attn_base_kwargs()
         if has_prefill:
             DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                extra_attn_kwargs, cu_seqlens_ori_kv=actual_seq_lengths_query
+                attn_kwargs,
+                cu_seqlens_ori_kv=actual_seq_lengths_query,
             )
         if self.compress_ratio > 1:
             DeviceOperator.add_dsa_sparse_attn_extra_kwargs(
-                extra_attn_kwargs,
+                attn_kwargs,
                 cu_seqlens_cmp_kv=common_metadata.cu_cmp_seqlen_list,
             )
 
-        if self.compress_ratio <= 1:
-            if swa_req_metadata.dspark_swa_indices is not None:
-                extra_attn_kwargs["ori_sparse_indices"] = swa_req_metadata.dspark_swa_indices
-            return attn_op(
-                q,
-                ori_kv=swa_kv_cache,
-                ori_block_table=swa_req_metadata.block_table,
-                cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
-                sinks=self.attn_sink,
-                metadata=common_metadata.sas_metadata,
-                softmax_scale=self.softmax_scale,
-                cmp_ratio=max(self.compress_ratio, 1),
-                ori_mask_mode=4,
-                ori_win_left=ori_win_left,
-                ori_win_right=ori_win_right,
-                layout_q="TND",
-                layout_kv="PA_ND",
-                **extra_attn_kwargs,
-            )[0]
-
-        assert compressor_metadata is not None
-        if self.compress_ratio == 4:
-            return attn_op(
-                q,
-                ori_kv=swa_kv_cache,
-                cmp_kv=compress_kv_cache,
-                cmp_sparse_indices=compress_topk_idxs,
-                ori_block_table=swa_req_metadata.block_table,
-                cmp_block_table=compressor_metadata.block_table,
-                cu_seqlens_q=actual_seq_lengths_query,
-                seqused_kv=actual_seq_lengths_key,
-                sinks=self.attn_sink,
-                metadata=common_metadata.sas_metadata,
-                softmax_scale=self.softmax_scale,
-                cmp_ratio=self.compress_ratio,
-                ori_mask_mode=4,
-                cmp_mask_mode=3,
-                ori_win_left=ori_win_left,
-                ori_win_right=ori_win_right,
-                layout_q="TND",
-                layout_kv="PA_ND",
-                **extra_attn_kwargs,
-            )[0]
-
-        return attn_op(
-            q,
+        attn_kwargs.update(
             ori_kv=swa_kv_cache,
-            cmp_kv=compress_kv_cache,
             ori_block_table=swa_req_metadata.block_table,
-            cmp_block_table=compressor_metadata.block_table,
             cu_seqlens_q=actual_seq_lengths_query,
             seqused_kv=actual_seq_lengths_key,
             sinks=self.attn_sink,
             metadata=common_metadata.sas_metadata,
             softmax_scale=self.softmax_scale,
-            cmp_ratio=self.compress_ratio,
+            cmp_ratio=max(self.compress_ratio, 1),
             ori_mask_mode=4,
-            cmp_mask_mode=3,
             ori_win_left=ori_win_left,
             ori_win_right=ori_win_right,
             layout_q="TND",
             layout_kv="PA_ND",
-            **extra_attn_kwargs,
-        )[0]
-
-    def _indexer_qkv_prepare(
-        self,
-        x: torch.Tensor,
-        qr: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, ...],
-        attn_metadata: DSAMetadataList,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        actual_seq_lengths_query: torch.Tensor,
-        qr_pertoken_scale: torch.Tensor = None,
-    ):
-        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
         )
-        (
-            _,
-            _,
-            indexer_kv_state_metadata,
-            indexer_kv_scale_metadata,
-            _,
-        ) = attn_metadata
 
-        if (
-            _is_w8a8_dynamic(self.inderxer_wq_b)
-            and qr_pertoken_scale is not None
-            and get_ascend_device_type() not in {AscendDeviceType.A5}
-        ):
-            q = torch_npu.npu_quant_matmul(
-                qr,
-                self.inderxer_wq_b.weight,
-                self.inderxer_wq_b.weight_scale,
-                pertoken_scale=qr_pertoken_scale,
-                bias=self.inderxer_wq_b.bias,
-                output_dtype=x.dtype,
+        if self.compress_ratio <= 1:
+            if swa_req_metadata.dspark_swa_indices is not None:
+                attn_kwargs["ori_sparse_indices"] = swa_req_metadata.dspark_swa_indices
+        else:
+            assert compressor_metadata is not None
+            attn_kwargs.update(
+                cmp_kv=compress_kv_cache,
+                cmp_block_table=common_metadata.block_table,
+                cmp_mask_mode=3,
             )
-        else:
-            q = self.inderxer_wq_b(qr)
-        q = q.view(-1, self.indexer_heads, self.indexcom_head_dim)  # [T, N, D]
+            if self.compress_ratio == 4:
+                assert compress_topk_idxs is not None
+                attn_kwargs["cmp_sparse_indices"] = compress_topk_idxs
 
-        torch.ops._C_ascend.inplace_partial_rotary_mul(
-            q.unsqueeze(1),
-            cos,
-            sin,
-            rotary_mode="interleave",
-            partial_slice=[self.indexcom_head_dim - self.rope_head_dim, self.indexcom_head_dim],
-        )
-
-        q = rotate_activation(q, indexer_kv_scale_metadata.hadamard)
-        coff = 2 if self.compressor_overlap else 1
-
-        indexer_state_metadata = _require_req_metadata(indexer_kv_state_metadata)
-        indexer_scale_metadata = _require_req_metadata(indexer_kv_scale_metadata)
-        kv_block_table = indexer_state_metadata.block_table
-        start_pos = indexer_scale_metadata.start_pos
-        compressed_cos, compressed_sin, indexer_slot_mapping = self._compute_compressor_metadata(indexer_scale_metadata)
-
-        kv = torch.ops._C_ascend.compressor(
-            x,
-            self.indexcom_wkv.weight,
-            self.indexcom_wgate.weight,
-            indexer_state_cache.squeeze(-2),
-            self.indexcom_ape,
-            self.indexcom_norm.weight,
-            compressed_sin.view(-1, compressed_sin.shape[-1]),
-            compressed_cos.view(-1, compressed_cos.shape[-1]),
-            state_block_table=kv_block_table,
-            cu_seqlens=actual_seq_lengths_query,
-            seqused=None,
-            start_pos=start_pos,
-            rope_head_dim=self.rope_head_dim,
-            cmp_ratio=self.compress_ratio,
-            coff=coff,
-            norm_eps=self.compressor_norm_eps,
-            rotary_mode=2,
-            cache_mode=1,
-        )
-
-        if kv.numel() == 0:
-            kv = None
-        elif self.indexcom_rotate:
-            kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
-
-        return (
-            q,
-            kv,
-            indexer_k_cache,
-            indexer_scale_cache,
-            indexer_full_cache,
-            indexer_kv_scale_metadata,
-            indexer_slot_mapping,
-        )
-
-    def _indexer_qli_finish(
-        self,
-        q: torch.Tensor,
-        kv: torch.Tensor | None,
-        weights: torch.Tensor,
-        indexer_k_cache: torch.Tensor,
-        indexer_scale_cache: torch.Tensor,
-        indexer_full_cache: torch.Tensor | None,
-        indexer_kv_scale_metadata,
-        indexer_slot_mapping: torch.Tensor,
-    ):
-        q, q_scale, _, _ = self._indexer_quant_scatter(
-            q,
-            kv,
-            indexer_k_cache,
-            indexer_scale_cache,
-            indexer_full_cache,
-            indexer_slot_mapping,
-        )
-        return self._indexer_qli(
-            q,
-            weights,
-            q_scale,
-            indexer_k_cache,
-            indexer_scale_cache,
-            indexer_kv_scale_metadata,
-        )
-
-    def _indexer_quant_scatter(
-        self,
-        q: torch.Tensor,
-        kv: torch.Tensor | None,
-        indexer_k_cache: torch.Tensor,
-        indexer_scale_cache: torch.Tensor,
-        indexer_full_cache: torch.Tensor | None,
-        slot_mapping: torch.Tensor,
-    ):
-        return DeviceOperator.indexer_quant_scatter(
-            q, kv, indexer_k_cache, indexer_scale_cache, indexer_full_cache, slot_mapping
-        )
-
-    def _indexer_qli(
-        self,
-        q: torch.Tensor,
-        weights: torch.Tensor,
-        q_scale: torch.Tensor,
-        indexer_k_cache: torch.Tensor,
-        indexer_scale_cache: torch.Tensor,
-        indexer_kv_scale_metadata,
-    ):
-        indexer_metadata = _require_req_metadata(indexer_kv_scale_metadata)
-        qlens = indexer_metadata.query_start_loc[1:]
-        kvlens = indexer_metadata.seq_lens
-        block_table = indexer_metadata.block_table
-        qli_metadata = indexer_metadata.qli_metadata
-
-        topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
-            query=q,
-            key=indexer_k_cache,
-            weights=DeviceOperator.prepare_dsa_indexer_weights(weights),
-            query_dequant_scale=DeviceOperator.prepare_dsa_indexer_query_scale(q_scale),
-            key_dequant_scale=DeviceOperator.prepare_dsa_indexer_key_scale(indexer_scale_cache),
-            actual_seq_lengths_query=qlens,
-            actual_seq_lengths_key=kvlens,
-            block_table=block_table,
-            metadata=qli_metadata,
-            query_quant_mode=0,
-            key_quant_mode=0,
-            layout_query="TND",
-            layout_key="PA_BSND",
-            sparse_count=self.index_topk,
-            sparse_mode=3,
-            pre_tokens=(1 << 63) - 1,
-            next_tokens=(1 << 63) - 1,
-            cmp_ratio=4,
-            return_value=False,
-        )
-        return topk_idxs
-
-    def indexer_select_qli(
-        self,
-        x: torch.Tensor,
-        qr: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, ...],
-        attn_metadata: DSAMetadataList,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        actual_seq_lengths_query: torch.Tensor,
-        qr_pertoken_scale: torch.Tensor = None,
-    ):
-        q, kv, ik, isc, ifc, isc_meta, indexer_slot_mapping = self._indexer_qkv_prepare(
-            x,
-            qr,
-            kv_cache,
-            attn_metadata,
-            cos,
-            sin,
-            actual_seq_lengths_query,
-            qr_pertoken_scale,
-        )
-
-        weights = self.weights_proj(x) * (self.indexer_softmax_scale * self.indexer_heads**-0.5)
-
-        return self._indexer_qli_finish(
-            q,
-            kv,
-            weights,
-            ik,
-            isc,
-            ifc,
-            isc_meta,
-            indexer_slot_mapping,
-        )
-
-    def cv_indexer_select_qli(
-        self,
-        x: torch.Tensor,
-        qr: torch.Tensor,
-        kv_cache: tuple[torch.Tensor, ...],
-        attn_metadata: DSAMetadataList,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        actual_seq_lengths_query: torch.Tensor,
-        qr_pertoken_scale: torch.Tensor = None,
-    ):
-        """
-        Multistream version: 4-block segmentation, main stream and aux stream
-        alternate submission to achieve V/C engine parallel
-
-        Core strategy:
-        - Part0: Main pre-compute qr_quant[V] + compressor[C/mixed] + kv_hadamard[V]
-        - Part1: Main matmul[C] ∥ Aux kv_quant[V] + scatter_k_cache[AIV]
-        - Part2: Main rope[V] (serial)
-        - Part3: Main q_hadamard[C] ∥ Aux scatter_scale_cache[AIV]
-        - Part4: Caller runs weights_proj + q_quant + indexer
-        """
-        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
-            DeviceOperator.unpack_dsa_indexer_kv_cache(kv_cache)
-        )
-        # sorted keys: [attn, compressor.state_cache, indexer.compressor.state_cache, indexer.k_cache, swa_cache]
-        (_, _, indexer_kv_state_metadata, indexer_kv_scale_metadata, _) = attn_metadata
-
-        main_stream = torch.npu.current_stream()
-        aux_stream = dsv4_dsa_overlap_stream()
-
-        # ===== Part0: Pre-compute on main =====
-        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
-            qr_quant_ready = qr
-            qr_scale_ready = qr_pertoken_scale
-        else:
-            qr_quant_ready, qr_scale_ready = self.cv_inderxer_wq_b.quantize(qr)
-
-        coff = 2 if self.compressor_overlap else 1
-
-        indexer_state_metadata = _require_req_metadata(indexer_kv_state_metadata)
-        indexer_scale_metadata = _require_req_metadata(indexer_kv_scale_metadata)
-        kv_block_table = indexer_state_metadata.block_table
-        start_pos = indexer_scale_metadata.start_pos
-        compressed_cos, compressed_sin, slot_mapping_indexer = self._compute_compressor_metadata(indexer_scale_metadata)
-
-        kv = torch.ops._C_ascend.compressor(
-            x,
-            self.indexcom_wkv.weight,
-            self.indexcom_wgate.weight,
-            indexer_state_cache.squeeze(-2),
-            self.indexcom_ape,
-            self.indexcom_norm.weight,
-            compressed_sin.view(-1, compressed_sin.shape[-1]),
-            compressed_cos.view(-1, compressed_cos.shape[-1]),
-            state_block_table=kv_block_table,
-            cu_seqlens=actual_seq_lengths_query,
-            seqused=None,
-            start_pos=start_pos,
-            rope_head_dim=self.rope_head_dim,
-            cmp_ratio=self.compress_ratio,
-            coff=coff,
-            norm_eps=self.compressor_norm_eps,
-            rotary_mode=2,
-            cache_mode=1,
-        )
-
-        if kv.numel() == 0:
-            kv = None
-        elif self.indexcom_rotate:
-            kv = rotate_activation(kv, indexer_kv_scale_metadata.hadamard)
-
-        # ===== Part1: matmul[C] ∥ kv_quant[V] + scatter_k_cache[AIV] =====
-        # Record event before main stream operations for aux_stream to wait
-        e_kv_ready = main_stream.record_event()
-
-        # Aux: kv_quant + scatter_k_cache (parallel with main matmul + rope)
-        if kv is not None:
-            with npu_stream_switch(aux_stream, enabled=True):
-                torch.npu.current_stream().wait_event(e_kv_ready)
-                kv, kv_scale = DeviceOperator.indexer_quant_scatter_part1(
-                    kv, indexer_k_cache, indexer_full_cache, slot_mapping_indexer
-                )
-
-        # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
-        if _is_w8a8_dynamic(self.inderxer_wq_b) and qr_pertoken_scale is not None:
-            q = torch_npu.npu_quant_matmul(
-                qr_quant_ready,
-                self.inderxer_wq_b.weight,
-                self.inderxer_wq_b.weight_scale,
-                pertoken_scale=qr_scale_ready,
-                bias=self.inderxer_wq_b.bias,
-                output_dtype=x.dtype,
-            )
-        else:
-            q = self.cv_inderxer_wq_b.matmul(qr_quant_ready, qr_scale_ready)  # qr_matmul
-
-        if kv is not None:
-            main_stream.wait_stream(aux_stream)
-
-        q = q.view(-1, self.indexer_heads, self.indexcom_head_dim)
-
-        # ===== Part2: rope[V] (main only) =====
-        torch.ops._C_ascend.inplace_partial_rotary_mul(  # rope
-            q.unsqueeze(1),
-            cos,
-            sin,
-            rotary_mode="interleave",
-            partial_slice=[self.indexcom_head_dim - self.rope_head_dim, self.indexcom_head_dim],
-        )
-
-        # Wait for aux_stream kv_scatter to complete before proceeding
-        if kv is not None:
-            main_stream.wait_stream(aux_stream)
-
-        e_rope_done = main_stream.record_event()
-
-        # ===== Part3: q_hadamard[C] ∥ scatter_scale_cache[AIV] =====
-        # Note: On A5, indexer_compress_epilog_v2 in Part1 handles both k_cache
-        # and scale_cache in one fused operation, so Part3 is skipped
-        # (kv_scale is None on A5 from indexer_quant_scatter_part1).
-        if kv is not None and kv_scale is not None:
-            with npu_stream_switch(aux_stream, enabled=True):
-                torch.npu.current_stream().wait_event(e_rope_done)
-                DeviceOperator.dsa_indexer_scatter_scale_part3(kv_scale, indexer_scale_cache, slot_mapping_indexer)
-
-        # Main: q_hadamard[Part1 - linear] (directly submit, C/AIV different engines dispatch naturally)
-        # Part1: F.linear - parallel with aux_stream kv_scatter
-        hidden_size = q.size(-1)
-        q_linear, q_shape, q_dim = hadamard_linear(q, indexer_kv_scale_metadata.hadamard)
-
-        if kv is not None:
-            main_stream.wait_stream(aux_stream)
-
-        # Main: q_hadamard[Part2 - scale] (after aux_stream completes)
-        # Part2: scale * reshape - dot multiplication
-        q = hadamard_scale(q_linear, q_shape, q_dim, scale=hidden_size**-0.5)
-
-        return q
+        return attn_op(q, **attn_kwargs)[0]

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1344,7 +1344,8 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         state_cache: torch.Tensor,
     ) -> torch.Tensor | None:
         """Update compressed caches and return Indexer top-k indices."""
-        assert self.compressor is not None
+        compressor = self.compressor
+        assert compressor is not None
         assert layer_metadata.compressor is not None
 
         if self.compress_ratio == 4:
@@ -1352,7 +1353,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
             assert layer_metadata.indexer is not None
 
             def compute_attention_compressed_kv() -> tuple[torch.Tensor, torch.Tensor]:
-                return self.compressor(
+                return compressor(
                     hidden_states=hidden_states,
                     state_cache=state_cache,
                     metadata=layer_metadata.compressor,
@@ -1384,7 +1385,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
                 qr_pertoken_scale=qr_pertoken_scale,
             )
 
-        compressed_kv, compress_slot_mapping = self.compressor(
+        compressed_kv, compress_slot_mapping = compressor(
             hidden_states=hidden_states,
             state_cache=state_cache,
             metadata=layer_metadata.compressor,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1350,6 +1350,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         if self.compress_ratio == 4:
             assert self.indexer is not None
             assert layer_metadata.indexer is not None
+
             def compute_attention_compressed_kv() -> tuple[torch.Tensor, torch.Tensor]:
                 return self.compressor(
                     hidden_states=hidden_states,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -922,6 +922,7 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         self.indexer = kwargs.get("indexer")
         self.compressor = kwargs.get("compressor")
         self.swa_cache_layer = kwargs.get("swa_cache_layer")
+        assert self.swa_cache_layer is not None
 
         self.wo_a = kwargs["wo_a"]
         self.wo_b = kwargs["wo_b"]

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -2,7 +2,9 @@ from vllm import ModelRegistry
 
 
 def register_model():
-    ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
+    ModelRegistry.register_model(
+        "DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4.model:AscendDeepseekV4ForCausalLM"
+    )
     ModelRegistry.register_model(
         "MiniMaxM3SparseForCausalLM",
         "vllm_ascend.models.minimax_m3:MiniMaxM3SparseForCausalLM",
@@ -11,10 +13,10 @@ def register_model():
         "MiniMaxM3SparseForConditionalGeneration",
         "vllm_ascend.models.minimax_m3:MiniMaxM3SparseForConditionalGeneration",
     )
-    ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4_mtp:DeepSeekV4MTP")
+    ModelRegistry.register_model("DeepSeekV4MTPModel", "vllm_ascend.models.deepseek_v4.mtp:DeepSeekV4MTP")
     ModelRegistry.register_model(
         "DSparkDraftModel",
-        "vllm_ascend.models.deepseek_v4_dspark:DSparkDeepseekV4ForCausalLM",
+        "vllm_ascend.models.deepseek_v4.dspark:DSparkDeepseekV4ForCausalLM",
     )
     ModelRegistry.register_model(
         "LlamaForCausalLMVwnEagle3", "vllm_ascend.models.llama_eagle3_vwn:Eagle3VwnLlamaForCausalLM"

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Adapted from
+# https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/models/llama/modeling_llama.py
+# Copyright 2023 The vLLM team.
+# Copyright 2023 DeepSeek-AI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import typing
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+from transformers import DeepseekV2Config, DeepseekV3Config
+from vllm.config import CacheConfig, VllmConfig
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.models.deepseek_v4.compressor import CompressorStateCache
+from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
+from vllm.v1.kv_cache_interface import KVCacheSpec
+
+from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
+
+
+class AscendCompressorStateCache(CompressorStateCache):
+    def __init__(
+        self,
+        state_dim: int,
+        dtype: torch.dtype,
+        compress_ratio: int,
+        block_size: int,
+        prefix: str,
+    ):
+        super().__init__(state_dim, dtype, compress_ratio, prefix)
+        self.compress_ratio = compress_ratio
+        self.block_size = block_size
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+
+        pads = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][1]
+        page_size_padded = pads[0] if self.state_dim == 2 * 256 and self.compress_ratio == 4 else pads[1]
+
+        return AscendSlidingWindowMLASpec(
+            block_size=self.block_size,
+            num_kv_heads=1,
+            head_size=self.state_dim,
+            dtype=self.dtype,
+            sliding_window=self.sliding_window,
+            alignment=None,
+            page_size_padded=page_size_padded,
+        )
+
+    def forward(self): ...
+
+    def get_attn_backend(self):
+        from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+
+        return AscendDSABackend
+
+
+@dataclass(frozen=True)
+class AscendCompressorMetadata:
+    """Request metadata for the compressed KV and compressor state caches."""
+
+    cache: typing.Any
+    state: typing.Any
+
+
+class Compressor(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        config: DeepseekV2Config | DeepseekV3Config | DeepseekV4Config,
+        compress_ratio: int = 4,
+        head_dim: int = 512,
+        rotate: bool = False,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+
+        self.vllm_config = vllm_config
+        self.config = config
+        self.dim = config.hidden_size
+        self.head_dim = head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.nope_head_dim = head_dim - config.qk_rope_head_dim
+        self.compress_ratio = compress_ratio
+        self.overlap = compress_ratio == 4
+        self.rotate = rotate
+        self.norm_eps = config.rms_norm_eps
+        self.coff = 1 + self.overlap
+
+        self.ape = nn.Parameter(torch.empty(compress_ratio, self.coff * self.head_dim, dtype=torch.float32))
+        self.wkv = ReplicatedLinear(
+            self.dim,
+            self.coff * self.head_dim,
+            bias=False,
+            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            prefix=f"{prefix}.wkv",
+            return_bias=False,
+        )
+        self.wgate = ReplicatedLinear(
+            self.dim,
+            self.coff * self.head_dim,
+            bias=False,
+            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
+            prefix=f"{prefix}.wgate",
+            return_bias=False,
+        )
+
+        # A5 compressor kernel needs float for norm_weight input
+        norm_dtype = torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else None
+        self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
+
+        state_dtype = torch.float32
+        # TODO(zyj): change following codes if block_size is configurable & refactor the magic numbers
+        if compress_ratio == 4:
+            self.state_cache = AscendCompressorStateCache(
+                state_dim=2 * self.coff * self.head_dim,  # kv_state + score_state
+                dtype=state_dtype,
+                compress_ratio=compress_ratio,
+                prefix=f"{prefix}.state_cache",
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][2],  # type: ignore[union-attr]
+            )
+        elif compress_ratio == 128:
+            self.state_cache = AscendCompressorStateCache(
+                state_dim=2 * self.head_dim,  # kv_state + score_state
+                dtype=state_dtype,
+                compress_ratio=compress_ratio,
+                prefix=f"{prefix}.state_cache",
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][3],  # type: ignore[union-attr]
+            )
+        else:
+            raise ValueError(
+                f"Only support compress_ratio in [4, 128]. Got unsupported compress_ratio: {compress_ratio}"
+            )
+
+    def _compute_metadata(
+        self,
+        metadata: typing.Any,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        from vllm_ascend.device.device_op import DeviceOperator
+
+        assert metadata.full_compress_cos is not None
+        assert metadata.full_compress_sin is not None
+        assert metadata.num_compressed_tokens is not None
+        assert metadata.start_pos is not None
+        assert metadata.num_reqs_actual is not None
+        full_compress_cos = metadata.full_compress_cos.view(
+            metadata.full_compress_cos.shape[0],
+            metadata.full_compress_cos.shape[-1],
+        )
+        full_compress_sin = metadata.full_compress_sin.view(
+            metadata.full_compress_sin.shape[0],
+            metadata.full_compress_sin.shape[-1],
+        )
+        return torch.ops._C_ascend.compressor_metadata(
+            full_compress_cos,
+            full_compress_sin,
+            metadata.query_start_loc,
+            metadata.start_pos,
+            metadata.block_table,
+            metadata.block_size,
+            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+            self.compress_ratio,
+            metadata.num_compressed_tokens,
+            metadata.num_reqs_actual,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        state_cache: torch.Tensor,
+        metadata: AscendCompressorMetadata,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        compressor_metadata = metadata.cache.req_metadata
+        state_metadata = metadata.state.req_metadata
+        assert compressor_metadata is not None
+        assert state_metadata is not None
+        compress_cos, compress_sin, slot_mapping = self._compute_metadata(compressor_metadata)
+        compressed_kv = torch.ops._C_ascend.compressor(
+            hidden_states,
+            self.wkv.weight,
+            self.wgate.weight,
+            state_cache.squeeze(-2),
+            self.ape,
+            self.norm.weight,
+            compress_sin.view(-1, compress_sin.shape[-1]),
+            compress_cos.view(-1, compress_cos.shape[-1]),
+            state_block_table=state_metadata.block_table,
+            cu_seqlens=compressor_metadata.query_start_loc,
+            seqused=None,
+            start_pos=compressor_metadata.start_pos,
+            rope_head_dim=self.rope_head_dim,
+            cmp_ratio=self.compress_ratio,
+            coff=2 if self.overlap else 1,
+            norm_eps=self.norm_eps,
+            rotary_mode=2,
+            cache_mode=1,
+        )
+        return compressed_kv, slot_mapping

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -94,7 +94,8 @@ class Compressor(nn.Module):
         compress_ratio: int = 4,
         head_dim: int = 512,
         rotate: bool = False,
-        cache_config: CacheConfig | None = None,
+        *,
+        cache_config: CacheConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
@@ -143,7 +144,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][2],  # type: ignore[union-attr]
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][2],
             )
         elif compress_ratio == 128:
             self.state_cache = AscendCompressorStateCache(
@@ -151,7 +152,7 @@ class Compressor(nn.Module):
                 dtype=state_dtype,
                 compress_ratio=compress_ratio,
                 prefix=f"{prefix}.state_cache",
-                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][3],  # type: ignore[union-attr]
+                block_size=DSV4_BLOCK_SIZES[cache_config.block_size][0][3],
             )
         else:
             raise ValueError(

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -33,7 +33,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.model_executor.models.utils import PPMissingLayer, maybe_prefix
 
-from vllm_ascend.models.deepseek_v4 import (
+from vllm_ascend.models.deepseek_v4.model import (
     DeepseekV2DecoderLayer,
     DeepseekV2MixtureOfExperts,
     DeepseekV4MoE,

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -424,6 +424,8 @@ class DeepseekV4Indexer(nn.Module):
         )
         _, hadamard = self._get_indexer_cache_metadata(metadata)
         main_stream = torch.npu.current_stream()
+        compressor = self.compressor
+        assert compressor is not None
 
         # ===== Part0: Pre-compute on main =====
         if _is_w8a8_dynamic(self.wq_b) and qr_pertoken_scale is not None:
@@ -432,14 +434,14 @@ class DeepseekV4Indexer(nn.Module):
         else:
             qr_quant_ready, qr_scale_ready = self.cv_wq_b.quantize(qr)
 
-        kv, slot_mapping_indexer = self.compressor(
+        kv, slot_mapping_indexer = compressor(
             hidden_states=hidden_states,
             state_cache=indexer_state_cache,
             metadata=metadata.compressor,
         )
         if kv.numel() == 0:
             kv = None
-        elif self.compressor.rotate:
+        elif compressor.rotate:
             kv = rotate_activation(kv, hadamard)
 
         # ===== Part1: matmul[C] ∥ kv_quant[V] + scatter_k_cache[AIV] =====
@@ -567,6 +569,8 @@ class DeepseekV4Indexer(nn.Module):
             self.ops.unpack_dsa_indexer_kv_cache(kv_cache)
         )
         cache_metadata, hadamard = self._get_indexer_cache_metadata(metadata)
+        compressor = self.compressor
+        assert compressor is not None
 
         if (
             _is_w8a8_dynamic(self.wq_b)
@@ -594,14 +598,14 @@ class DeepseekV4Indexer(nn.Module):
         )
 
         q = rotate_activation(q, hadamard)
-        kv, indexer_slot_mapping = self.compressor(
+        kv, indexer_slot_mapping = compressor(
             hidden_states=x,
             state_cache=indexer_state_cache,
             metadata=metadata.compressor,
         )
         if kv.numel() == 0:
             kv = None
-        elif self.compressor.rotate:
+        elif compressor.rotate:
             kv = rotate_activation(kv, hadamard)
 
         return (

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -1,0 +1,648 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Adapted from
+# https://github.com/huggingface/transformers/blob/v4.28.0/src/transformers/models/llama/modeling_llama.py
+# Copyright 2023 The vLLM team.
+# Copyright 2023 DeepSeek-AI and the HuggingFace Inc. team. All rights reserved.
+#
+# This code is based on EleutherAI's GPT-NeoX library and the GPT-NeoX
+# and OPT implementations in this library. It has been modified from its
+# original forms to accommodate minor architectural differences compared
+# to GPT-NeoX and OPT used by the Meta AI team that trained the model.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import math
+import typing
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+import torch_npu
+from torch import nn
+from transformers import DeepseekV2Config, DeepseekV3Config
+from vllm.config import CacheConfig, VllmConfig
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.models.deepseek_v4.attention import DeepseekV4IndexerCache
+from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
+from vllm.v1.kv_cache_interface import KVCacheSpec
+
+from vllm_ascend.models.deepseek_v4.compressor import AscendCompressorMetadata, Compressor
+from vllm_ascend.ops.cv_linear import CVLinearWrapper
+from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
+from vllm_ascend.utils import (
+    AscendDeviceType,
+    get_ascend_device_type,
+    npu_stream_switch,
+)
+
+
+def hadamard_linear(x: torch.Tensor, hadamard: torch.Tensor) -> tuple[torch.Tensor, tuple[int, ...], int]:
+    x_shape = x.shape
+    dim = x.shape[-1]
+    x = x.reshape(-1, dim)
+    dim_padded = 2 ** math.ceil(math.log2(dim))
+    if dim != dim_padded:
+        x = F.pad(x, (0, dim_padded - dim))
+    return F.linear(x, hadamard), x_shape, dim
+
+
+def hadamard_scale(out: torch.Tensor, x_shape: tuple[int, ...], dim: int, scale: float = 1.0) -> torch.Tensor:
+    """Scale and reshape the output of hadamard_linear."""
+    out = out * scale
+    return out[..., :dim].reshape(*x_shape)
+
+
+def rotate_activation(x: torch.Tensor, hadamard: torch.Tensor) -> torch.Tensor:
+    out, x_shape, dim = hadamard_linear(x, hadamard)
+    return (out * dim**-0.5)[..., :dim].reshape(*x_shape)
+
+
+def _is_w8a8_dynamic(linear) -> bool:
+    """True iff ``linear`` is wired up with ``AscendW8A8DynamicLinearMethod``."""
+    quant_method = getattr(linear, "quant_method", None)
+    if quant_method is None or isinstance(quant_method, AscendUnquantizedLinearMethod):
+        return False
+    inner_method = getattr(quant_method, "quant_method", None)
+    return isinstance(inner_method, AscendW8A8DynamicLinearMethod)
+
+
+class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
+    def __init__(
+        self,
+        head_dim: int,
+        dtype: torch.dtype,
+        prefix: str,
+        cache_config: CacheConfig,
+        compress_ratio: int = 1,
+    ):
+        super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        if get_ascend_device_type() in {AscendDeviceType.A5}:
+            self.dtype = torch.float8_e4m3fn
+            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
+
+        from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+        from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+
+        block_size = DSV4_BLOCK_SIZES[vllm_config.cache_config.block_size][0][0]
+        return AscendMLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=self.head_dim,
+            dtype=self.dtype,
+            model_version="deepseek_v4",
+            compress_ratio=self.compress_ratio,
+            cache_dtype_str=self.cache_config.cache_dtype,
+            scale_dim=1 if self.head_dim == 128 else 0,
+            scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
+        )
+
+    def forward(self): ...
+
+    def get_attn_backend(self):
+        from vllm_ascend.attention.dsa_v1 import AscendDSABackend
+
+        return AscendDSABackend
+
+
+@dataclass(frozen=True)
+class AscendIndexerMetadata:
+    compressor: AscendCompressorMetadata
+
+
+@dataclass(frozen=True)
+class IndexerOverlapPlan:
+    """Main-attention compressor work scheduled around Indexer selection."""
+
+    compute_attention_compressed_kv: typing.Callable[[], tuple[torch.Tensor, torch.Tensor]]
+    scatter_attention_compressed_kv: typing.Callable[[torch.Tensor, torch.Tensor], None]
+    aux_stream: torch.npu.Stream | None = None
+
+
+class AscendIndexerOps:
+    def __init__(self, index_topk: int) -> None:
+        from vllm_ascend.device.device_op import DeviceOperator
+
+        self.device_operator = DeviceOperator
+        self.index_topk = index_topk
+
+    def unpack_dsa_indexer_kv_cache(self, kv_cache: tuple[torch.Tensor, ...]):
+        return self.device_operator.unpack_dsa_indexer_kv_cache(kv_cache)
+
+    def quantize_query(self, query: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.device_operator.indexer_quantize_query(query)
+
+    def quantize_key_and_update_cache(
+        self,
+        key: torch.Tensor,
+        key_cache: torch.Tensor,
+        full_cache: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+    ):
+        return self.device_operator.indexer_quant_scatter_part1(
+            key,
+            key_cache,
+            full_cache,
+            slot_mapping,
+        )
+
+    def update_scale_cache(
+        self,
+        key_scale: torch.Tensor,
+        scale_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        self.device_operator.dsa_indexer_scatter_scale_part3(
+            key_scale,
+            scale_cache,
+            slot_mapping,
+        )
+
+    def select_topk(
+        self,
+        query: torch.Tensor,
+        weights: torch.Tensor,
+        query_scale: torch.Tensor,
+        key_cache: torch.Tensor,
+        scale_cache: torch.Tensor,
+        metadata: typing.Any,
+    ) -> torch.Tensor:
+        topk_idxs, _ = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer(
+            query=query,
+            key=key_cache,
+            weights=self.device_operator.prepare_dsa_indexer_weights(weights),
+            query_dequant_scale=self.device_operator.prepare_dsa_indexer_query_scale(query_scale),
+            key_dequant_scale=self.device_operator.prepare_dsa_indexer_key_scale(scale_cache),
+            actual_seq_lengths_query=metadata.query_start_loc[1:],
+            actual_seq_lengths_key=metadata.seq_lens,
+            block_table=metadata.block_table,
+            metadata=metadata.qli_metadata,
+            query_quant_mode=0,
+            key_quant_mode=0,
+            layout_query="TND",
+            layout_key="PA_BSND",
+            sparse_count=self.index_topk,
+            sparse_mode=3,
+            pre_tokens=(1 << 63) - 1,
+            next_tokens=(1 << 63) - 1,
+            cmp_ratio=4,
+            return_value=False,
+        )
+        return topk_idxs
+
+    def quantize_update_cache_and_select_topk(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor | None,
+        weights: torch.Tensor,
+        key_cache: torch.Tensor,
+        scale_cache: torch.Tensor,
+        full_cache: torch.Tensor | None,
+        slot_mapping: torch.Tensor,
+        metadata: typing.Any,
+    ) -> torch.Tensor:
+        query, query_scale, _, _ = self.device_operator.indexer_quant_scatter(
+            query,
+            key,
+            key_cache,
+            scale_cache,
+            full_cache,
+            slot_mapping,
+        )
+        return self.select_topk(
+            query,
+            weights,
+            query_scale,
+            key_cache,
+            scale_cache,
+            metadata,
+        )
+
+
+class DeepseekV4Indexer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        config: DeepseekV2Config | DeepseekV3Config | DeepseekV4Config,
+        compress_ratio: int,
+        skip_topk: bool,
+        use_index_cache: bool,
+        quant_config: QuantizationConfig | None,
+        cache_config: CacheConfig | None,
+        prefix: str = "",
+        topk_indices_buffer: torch.Tensor | None = None,
+    ):
+        super().__init__()
+        self.vllm_config = vllm_config
+        self.config = config
+        self.n_heads = config.index_n_heads
+        self.head_dim = config.index_head_dim
+        self.rope_head_dim = config.qk_rope_head_dim
+        self.index_topk = config.index_topk
+        self.q_lora_rank = config.q_lora_rank
+        self.softmax_scale = self.head_dim**-0.5
+        self.compress_ratio = compress_ratio
+        self.skip_topk = skip_topk
+        self.use_index_cache = use_index_cache
+
+        self.wq_b = ReplicatedLinear(
+            self.q_lora_rank,
+            self.n_heads * self.head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wq_b",
+            return_bias=False,
+        )
+
+        self.cv_wq_b = CVLinearWrapper(self.wq_b)
+        self.topk_indices_buffer = topk_indices_buffer
+        if self.skip_topk and self.topk_indices_buffer is None:
+            raise ValueError("skip_topk requires topk_indices_buffer")
+        self.ops = AscendIndexerOps(index_topk=self.index_topk)
+        self.weights_proj = ReplicatedLinear(
+            config.hidden_size,
+            self.n_heads,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.weights_proj",
+            return_bias=False,
+        )
+        ascend_device_type = get_ascend_device_type()
+        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.int8
+
+        if self.compress_ratio == 4:
+            # TODO(cmq): change the dtype of cache
+            self.k_cache = AscendDeepseekV4IndexerCache(
+                head_dim=self.head_dim,
+                dtype=k_dtype,
+                prefix=f"{prefix}.k_cache",
+                cache_config=cache_config,
+                compress_ratio=self.compress_ratio,
+            )
+        self.compressor = None
+        if self.compress_ratio > 1:
+            self.compressor = Compressor(
+                vllm_config,
+                config,
+                self.compress_ratio,
+                head_dim=self.head_dim,
+                rotate=True,
+                quant_config=quant_config,
+                cache_config=cache_config,
+                prefix=f"{prefix}.compressor",
+            )  # Compressor(4, 128)
+
+    @staticmethod
+    def _get_indexer_cache_metadata(
+        metadata: AscendIndexerMetadata,
+    ) -> tuple[typing.Any, torch.Tensor]:
+        cache_metadata = metadata.compressor.cache
+        cache_req_metadata = cache_metadata.req_metadata
+        hadamard = cache_metadata.hadamard
+        assert cache_req_metadata is not None
+        assert hadamard is not None
+        return cache_req_metadata, hadamard
+
+    def _get_cached_topk_indices(self, num_tokens: int, offset: int = 0) -> torch.Tensor:
+        if self.topk_indices_buffer is None:
+            raise RuntimeError("topk_indices_buffer is required to read cached TopK indices")
+        topk_indices = self.topk_indices_buffer[offset : offset + num_tokens]
+        if topk_indices.dim() == 2:
+            topk_indices = topk_indices.unsqueeze(1)
+        return topk_indices
+
+    def _update_cached_topk_indices(self, topk_indices: torch.Tensor, offset: int = 0) -> None:
+        if self.topk_indices_buffer is None:
+            return
+        num_tokens = topk_indices.shape[0]
+        topk_tokens = topk_indices.shape[-1]
+        topk_indices_to_cache = topk_indices
+        topk_indices_buffer = self.topk_indices_buffer[offset : offset + num_tokens, :topk_tokens]
+        if topk_indices_to_cache.dim() == 3 and topk_indices_buffer.dim() == 2:
+            if topk_indices_to_cache.shape[1] != 1:
+                raise ValueError("TopK indices must have a singleton head dimension")
+            topk_indices_to_cache = topk_indices_to_cache.squeeze(1)
+        topk_indices_buffer.copy_(topk_indices_to_cache)
+
+    def forward(
+        self,
+        layer_name: str,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        metadata: AscendIndexerMetadata,
+        overlap_plan: IndexerOverlapPlan,
+        *,
+        qr_pertoken_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        num_tokens = hidden_states.shape[0]
+        cache_metadata, _ = self._get_indexer_cache_metadata(metadata)
+        cos = cache_metadata.cos[layer_name][:num_tokens]
+        sin = cache_metadata.sin[layer_name][:num_tokens]
+        aux_stream = overlap_plan.aux_stream
+        if self.skip_topk:
+            topk_indices = self._get_cached_topk_indices(num_tokens)
+        elif aux_stream is not None:
+            indexer_q = self._cv_compute_query_and_update_cache_multistream(
+                hidden_states,
+                qr,
+                kv_cache,
+                metadata,
+                cos,
+                sin,
+                aux_stream,
+                qr_pertoken_scale,
+            )
+            compressed_kv, compress_slot_mapping = overlap_plan.compute_attention_compressed_kv()
+            topk_indices = self._select_topk_multistream(
+                hidden_states,
+                indexer_q,
+                kv_cache,
+                metadata,
+                aux_stream,
+                lambda: overlap_plan.scatter_attention_compressed_kv(
+                    compressed_kv,
+                    compress_slot_mapping,
+                ),
+            )
+        else:
+            topk_indices = self._select_topk_serial(
+                hidden_states,
+                qr,
+                kv_cache,
+                metadata,
+                cos,
+                sin,
+                qr_pertoken_scale,
+            )
+
+        if self.skip_topk or aux_stream is None:
+            compressed_kv, compress_slot_mapping = overlap_plan.compute_attention_compressed_kv()
+            overlap_plan.scatter_attention_compressed_kv(compressed_kv, compress_slot_mapping)
+
+        if self.use_index_cache:
+            self._update_cached_topk_indices(topk_indices)
+        return topk_indices
+
+    def _cv_compute_query_and_update_cache_multistream(
+        self,
+        hidden_states: torch.Tensor,
+        qr: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        metadata: AscendIndexerMetadata,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        aux_stream: torch.npu.Stream,
+        qr_pertoken_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """
+        Compute the Indexer query and update its cache.
+
+        The internal multistream strategy keeps the original four-part layout:
+        - Part0: Main pre-compute qr_quant[V] + compressor[C/mixed] + kv_hadamard[V]
+        - Part1: Main matmul[C] ∥ Aux kv_quant[V] + scatter_k_cache[AIV]
+        - Part2: Main rope[V] (serial)
+        - Part3: Main q_hadamard[C] ∥ Aux scatter_scale_cache[AIV]
+        """
+        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
+            self.ops.unpack_dsa_indexer_kv_cache(kv_cache)
+        )
+        _, hadamard = self._get_indexer_cache_metadata(metadata)
+        main_stream = torch.npu.current_stream()
+
+        # ===== Part0: Pre-compute on main =====
+        if _is_w8a8_dynamic(self.wq_b) and qr_pertoken_scale is not None:
+            qr_quant_ready = qr
+            qr_scale_ready = qr_pertoken_scale
+        else:
+            qr_quant_ready, qr_scale_ready = self.cv_wq_b.quantize(qr)
+
+        kv, slot_mapping_indexer = self.compressor(
+            hidden_states=hidden_states,
+            state_cache=indexer_state_cache,
+            metadata=metadata.compressor,
+        )
+        if kv.numel() == 0:
+            kv = None
+        elif self.compressor.rotate:
+            kv = rotate_activation(kv, hadamard)
+
+        # ===== Part1: matmul[C] ∥ kv_quant[V] + scatter_k_cache[AIV] =====
+        # Record event before main stream operations for aux_stream to wait
+        e_kv_ready = main_stream.record_event()
+
+        # Aux: kv_quant + scatter_k_cache (parallel with main matmul + rope)
+        if kv is not None:
+            with npu_stream_switch(aux_stream, enabled=True):
+                torch.npu.current_stream().wait_event(e_kv_ready)
+                kv, kv_scale = self.ops.quantize_key_and_update_cache(
+                    kv,
+                    indexer_k_cache,
+                    indexer_full_cache,
+                    slot_mapping_indexer,
+                )
+
+        # Main: matmul q from qr (directly submit, V/C different engines dispatch naturally)
+        if _is_w8a8_dynamic(self.wq_b) and qr_pertoken_scale is not None:
+            q = torch_npu.npu_quant_matmul(
+                qr_quant_ready,
+                self.wq_b.weight,
+                self.wq_b.weight_scale,
+                pertoken_scale=qr_scale_ready,
+                bias=self.wq_b.bias,
+                output_dtype=hidden_states.dtype,
+            )
+        else:
+            q = self.cv_wq_b.matmul(qr_quant_ready, qr_scale_ready)  # qr_matmul
+
+        if kv is not None:
+            main_stream.wait_stream(aux_stream)
+
+        q = q.view(-1, self.n_heads, self.head_dim)
+
+        # ===== Part2: rope[V] (main only) =====
+        torch.ops._C_ascend.inplace_partial_rotary_mul(  # rope
+            q.unsqueeze(1),
+            cos,
+            sin,
+            rotary_mode="interleave",
+            partial_slice=[self.head_dim - self.rope_head_dim, self.head_dim],
+        )
+
+        # Wait for aux_stream kv_scatter to complete before proceeding
+        if kv is not None:
+            main_stream.wait_stream(aux_stream)
+
+        e_rope_done = main_stream.record_event()
+
+        # ===== Part3: q_hadamard[C] ∥ scatter_scale_cache[AIV] =====
+        # Note: On A5, indexer_compress_epilog_v2 in Part1 handles both k_cache
+        # and scale_cache in one fused operation, so Part3 is skipped
+        # (kv_scale is None on A5 from indexer_quant_scatter_part1).
+        if kv is not None and kv_scale is not None:
+            with npu_stream_switch(aux_stream, enabled=True):
+                torch.npu.current_stream().wait_event(e_rope_done)
+                self.ops.update_scale_cache(
+                    kv_scale,
+                    indexer_scale_cache,
+                    slot_mapping_indexer,
+                )
+
+        # Main: q_hadamard[Part1 - linear] (directly submit, C/AIV different engines dispatch naturally)
+        # Part1: F.linear - parallel with aux_stream kv_scatter
+        hidden_size = q.size(-1)
+        q_linear, q_shape, q_dim = hadamard_linear(q, hadamard)
+
+        if kv is not None:
+            main_stream.wait_stream(aux_stream)
+
+        # Main: q_hadamard[Part2 - scale] (after aux_stream completes)
+        # Part2: scale * reshape - dot multiplication
+        q = hadamard_scale(q_linear, q_shape, q_dim, scale=hidden_size**-0.5)
+
+        return q
+
+    def _select_topk_multistream(
+        self,
+        hidden_states: torch.Tensor,
+        indexer_q: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        metadata: AscendIndexerMetadata,
+        aux_stream: torch.npu.Stream,
+        scatter_attention_compressed_kv: typing.Callable[[], None],
+    ) -> torch.Tensor:
+        """Overlap Indexer selection inputs with caller-provided main-stream work."""
+        main_stream = torch.npu.current_stream()
+        weights_proj_start = main_stream.record_event()
+        with npu_stream_switch(aux_stream, enabled=True):
+            torch.npu.current_stream().wait_event(weights_proj_start)
+            weights_proj_output = self.weights_proj(hidden_states)
+            weights_proj_done = torch.npu.current_stream().record_event()
+
+        q_quant, q_scale = self.ops.quantize_query(indexer_q)
+        # Enqueue only independent Vector/AIV work on the current main stream;
+        # do not switch streams or launch Cube work that would contend with the
+        # auxiliary weights projection.
+        scatter_attention_compressed_kv()
+        main_stream.wait_event(weights_proj_done)
+
+        (_, indexer_k_cache, indexer_scale_cache, _) = self.ops.unpack_dsa_indexer_kv_cache(kv_cache)
+        cache_metadata, _ = self._get_indexer_cache_metadata(metadata)
+        weights = weights_proj_output * (self.softmax_scale * self.n_heads**-0.5)
+        return self.ops.select_topk(
+            q_quant,
+            weights,
+            q_scale,
+            indexer_k_cache,
+            indexer_scale_cache,
+            cache_metadata,
+        )
+
+    def _indexer_qkv_prepare(
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        metadata: AscendIndexerMetadata,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        qr_pertoken_scale: torch.Tensor | None = None,
+    ):
+        (indexer_state_cache, indexer_k_cache, indexer_scale_cache, indexer_full_cache) = (
+            self.ops.unpack_dsa_indexer_kv_cache(kv_cache)
+        )
+        cache_metadata, hadamard = self._get_indexer_cache_metadata(metadata)
+
+        if (
+            _is_w8a8_dynamic(self.wq_b)
+            and qr_pertoken_scale is not None
+            and get_ascend_device_type() not in {AscendDeviceType.A5}
+        ):
+            q = torch_npu.npu_quant_matmul(
+                qr,
+                self.wq_b.weight,
+                self.wq_b.weight_scale,
+                pertoken_scale=qr_pertoken_scale,
+                bias=self.wq_b.bias,
+                output_dtype=x.dtype,
+            )
+        else:
+            q = self.wq_b(qr)
+        q = q.view(-1, self.n_heads, self.head_dim)  # [T, N, D]
+
+        torch.ops._C_ascend.inplace_partial_rotary_mul(
+            q.unsqueeze(1),
+            cos,
+            sin,
+            rotary_mode="interleave",
+            partial_slice=[self.head_dim - self.rope_head_dim, self.head_dim],
+        )
+
+        q = rotate_activation(q, hadamard)
+        kv, indexer_slot_mapping = self.compressor(
+            hidden_states=x,
+            state_cache=indexer_state_cache,
+            metadata=metadata.compressor,
+        )
+        if kv.numel() == 0:
+            kv = None
+        elif self.compressor.rotate:
+            kv = rotate_activation(kv, hadamard)
+
+        return (
+            q,
+            kv,
+            indexer_k_cache,
+            indexer_scale_cache,
+            indexer_full_cache,
+            cache_metadata,
+            indexer_slot_mapping,
+        )
+
+    def _select_topk_serial(
+        self,
+        x: torch.Tensor,
+        qr: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        metadata: AscendIndexerMetadata,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        qr_pertoken_scale: torch.Tensor | None = None,
+    ):
+        q, kv, ik, isc, ifc, cache_metadata, indexer_slot_mapping = self._indexer_qkv_prepare(
+            x,
+            qr,
+            kv_cache,
+            metadata,
+            cos,
+            sin,
+            qr_pertoken_scale,
+        )
+
+        weights = self.weights_proj(x) * (self.softmax_scale * self.n_heads**-0.5)
+
+        return self.ops.quantize_update_cache_and_select_topk(
+            q,
+            kv,
+            weights,
+            ik,
+            isc,
+            ifc,
+            indexer_slot_mapping,
+            cache_metadata,
+        )

--- a/vllm_ascend/models/deepseek_v4/indexer.py
+++ b/vllm_ascend/models/deepseek_v4/indexer.py
@@ -243,7 +243,7 @@ class DeepseekV4Indexer(nn.Module):
         skip_topk: bool,
         use_index_cache: bool,
         quant_config: QuantizationConfig | None,
-        cache_config: CacheConfig | None,
+        cache_config: CacheConfig,
         prefix: str = "",
         topk_indices_buffer: torch.Tensor | None = None,
     ):

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -30,7 +30,6 @@ from itertools import islice
 
 import torch
 import torch.nn.functional as F
-import torch_npu
 from torch import nn
 from transformers import DeepseekV2Config, DeepseekV3Config
 from vllm._aiter_ops import rocm_aiter_ops
@@ -70,8 +69,6 @@ from vllm.model_executor.models.utils import (
     maybe_prefix,
     sequence_parallel_chunk,
 )
-from vllm.models.deepseek_v4.attention import DeepseekV4IndexerCache  # type: ignore[import-not-found,no-redef]
-from vllm.models.deepseek_v4.compressor import CompressorStateCache  # type: ignore[import-not-found,no-redef]
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
@@ -80,6 +77,8 @@ from vllm.v1.kv_cache_interface import KVCacheSpec
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
+from vllm_ascend.models.deepseek_v4.compressor import Compressor
+from vllm_ascend.models.deepseek_v4.indexer import DeepseekV4Indexer
 from vllm_ascend.ops.dsa import AscendDeepseekSparseAttention, DSAModules
 from vllm_ascend.ops.rope_dsv4 import ComplexExpRotaryEmbedding
 from vllm_ascend.ops.triton.mul_add import muls_add_triton
@@ -92,91 +91,6 @@ from vllm_ascend.utils import (
 )
 
 
-def _get_ascend_dsa_backend():
-    # Keep this lazy to avoid vLLM model-inspection circular imports.
-    from vllm_ascend.attention.dsa_v1 import AscendDSABackend
-
-    return AscendDSABackend
-
-
-def _dsv4_block_sizes():
-    # Lazy import to avoid the circular import chain (layer -> dsa_v1 ->
-    # attention_v1 -> device_op) hit during vLLM subprocess model inspection.
-    from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
-
-    return DSV4_BLOCK_SIZES
-
-
-class AscendCompressorStateCache(CompressorStateCache):
-    def __init__(
-        self,
-        state_dim: int,
-        dtype: torch.dtype,
-        compress_ratio: int,
-        block_size: int,
-        prefix: str,
-    ):
-        super().__init__(state_dim, dtype, compress_ratio, prefix)
-        self.compress_ratio = compress_ratio
-        self.block_size = block_size
-
-    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        pads = _dsv4_block_sizes()[vllm_config.cache_config.block_size][1]
-        page_size_padded = pads[0] if self.state_dim == 2 * 256 and self.compress_ratio == 4 else pads[1]
-
-        return AscendSlidingWindowMLASpec(
-            block_size=self.block_size,
-            num_kv_heads=1,
-            head_size=self.state_dim,
-            dtype=self.dtype,
-            sliding_window=self.sliding_window,
-            alignment=None,
-            page_size_padded=page_size_padded,
-        )
-
-    def forward(self): ...
-
-    def get_attn_backend(self):
-        return _get_ascend_dsa_backend()
-
-
-class AscendDeepseekV4IndexerCache(DeepseekV4IndexerCache):
-    def __init__(
-        self,
-        head_dim: int,
-        dtype: torch.dtype,
-        prefix: str,
-        cache_config: CacheConfig,
-        compress_ratio: int = 1,
-    ):
-        super().__init__(head_dim, dtype, prefix, cache_config, compress_ratio)
-
-    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
-        if get_ascend_device_type() in {AscendDeviceType.A5}:
-            self.dtype = torch.float8_e4m3fn
-            vllm_config.cache_config.cache_dtype = "float8_e4m3fn"
-
-        from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
-
-        block_size = _dsv4_block_sizes()[vllm_config.cache_config.block_size][0][0]
-        return AscendMLAAttentionSpec(
-            block_size=block_size,
-            num_kv_heads=1,
-            head_size=self.head_dim,
-            dtype=self.dtype,
-            model_version="deepseek_v4",
-            compress_ratio=self.compress_ratio,
-            cache_dtype_str=self.cache_config.cache_dtype,
-            scale_dim=1 if self.head_dim == 128 else 0,
-            scale_dtype=torch.float if get_ascend_device_type() in {AscendDeviceType.A5} else torch.float16,
-        )
-
-    def forward(self): ...
-
-    def get_attn_backend(self):
-        return _get_ascend_dsa_backend()
-
-
 class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
     def __init__(
         self,
@@ -187,9 +101,11 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
         cache_config: CacheConfig,
     ):
         super().__init__(head_dim, window_size, torch.uint8, prefix, cache_config)
+        from vllm_ascend.models.layer.attention.layer import DSV4_BLOCK_SIZES
+
         self.dtype = dtype
 
-        self.block_size = _dsv4_block_sizes()[cache_config.block_size][0][1]
+        self.block_size = DSV4_BLOCK_SIZES[cache_config.block_size][0][1]
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
         if get_ascend_device_type() in {AscendDeviceType.A5}:
@@ -210,29 +126,9 @@ class AscendDeepseekV4SWACache(VllmDeepseekV4SWACache):
     def forward(self): ...
 
     def get_attn_backend(self):
-        return _get_ascend_dsa_backend()
+        from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 
-
-def hadamard_transform_ref(x: torch.Tensor, scale=1.0):
-    from scipy.linalg import hadamard  # type: ignore[import-untyped]
-
-    if hadamard is None:
-        raise ImportError("Please install scipy")
-    x_shape = x.shape
-    dim = x.shape[-1]
-    x = x.reshape(-1, dim)
-    log_dim = math.ceil(math.log2(dim))
-    dim_padded = 2**log_dim
-    if dim != dim_padded:
-        x = F.pad(x, (0, dim_padded - dim))
-    out = F.linear(x, torch.tensor(hadamard(dim_padded, dtype=float), dtype=x.dtype, device=x.device))
-    out = out * scale
-    return out[..., :dim].reshape(*x_shape)
-
-
-def rotate_activation(x: torch.Tensor) -> torch.Tensor:
-    hidden_size = x.size(-1)
-    return hadamard_transform_ref(x, scale=hidden_size**-0.5)
+        return AscendDSABackend
 
 
 def precompute_freqs_cis_cpu(dim, seqlen, original_seq_len, base, factor, beta_fast, beta_slow) -> torch.Tensor:
@@ -540,186 +436,6 @@ def _get_llama_4_scaling(
     return scaling[..., None, None]
 
 
-class Indexer(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        config: DeepseekV2Config | DeepseekV3Config | DeepseekV4Config,
-        compress_ratio: int,
-        quant_config: QuantizationConfig | None,
-        cache_config: CacheConfig | None,
-        prefix: str = "",
-    ):
-        super().__init__()
-        self.vllm_config = vllm_config
-        self.config = config
-        self.n_heads = config.index_n_heads
-        self.head_dim = config.index_head_dim
-        self.rope_head_dim = config.qk_rope_head_dim
-        self.index_topk = config.index_topk
-        self.q_lora_rank = config.q_lora_rank
-        self.softmax_scale = self.head_dim**-0.5
-        self.compress_ratio = compress_ratio
-
-        self.wq_b = ReplicatedLinear(
-            self.q_lora_rank,
-            self.n_heads * self.head_dim,
-            bias=False,
-            quant_config=quant_config,
-            prefix=f"{prefix}.wq_b",
-            return_bias=False,
-        )
-
-        self.weights_proj = ReplicatedLinear(
-            config.hidden_size,
-            self.n_heads,
-            bias=False,
-            quant_config=None,
-            prefix=f"{prefix}.weights_proj",
-            return_bias=False,
-        )
-        ascend_device_type = get_ascend_device_type()
-        k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.int8
-
-        if self.compress_ratio == 4:
-            # TODO(cmq): change the dtype of cache
-            self.k_cache = AscendDeepseekV4IndexerCache(
-                head_dim=self.head_dim,
-                dtype=k_dtype,
-                prefix=f"{prefix}.k_cache",
-                cache_config=cache_config,
-                compress_ratio=self.compress_ratio,
-            )
-        self.compressor = None
-        if self.compress_ratio > 1:
-            self.compressor = Compressor(
-                vllm_config,
-                config,
-                self.compress_ratio,
-                head_dim=self.head_dim,
-                rotate=True,
-                quant_config=quant_config,
-                cache_config=cache_config,
-                prefix=f"{prefix}.compressor",
-            )  # Compressor(4, 128)
-
-    def forward(self, hidden_states: torch.Tensor, qr: torch.Tensor, positions, rotary_emb) -> torch.Tensor:
-        return
-
-
-class Compressor(nn.Module):
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        config: DeepseekV2Config | DeepseekV3Config | DeepseekV4Config,
-        compress_ratio: int = 4,
-        head_dim: int = 512,
-        rotate: bool = False,
-        cache_config: CacheConfig | None = None,
-        quant_config: QuantizationConfig | None = None,
-        prefix: str = "",
-    ):
-        super().__init__()
-        self.vllm_config = vllm_config
-        self.config = config
-        self.dim = config.hidden_size
-        self.head_dim = head_dim
-        self.rope_head_dim = config.qk_rope_head_dim
-        self.nope_head_dim = head_dim - config.qk_rope_head_dim
-        self.compress_ratio = compress_ratio
-        self.overlap = compress_ratio == 4
-        self.rotate = rotate
-        self.norm_eps = config.rms_norm_eps
-        self.coff = 1 + self.overlap
-
-        self.ape = nn.Parameter(torch.empty(compress_ratio, self.coff * self.head_dim, dtype=torch.float32))
-        self.wkv = ReplicatedLinear(
-            self.dim,
-            self.coff * self.head_dim,
-            bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
-            prefix=f"{prefix}.wkv",
-            return_bias=False,
-        )
-        self.wgate = ReplicatedLinear(
-            self.dim,
-            self.coff * self.head_dim,
-            bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
-            prefix=f"{prefix}.wgate",
-            return_bias=False,
-        )
-
-        # A5 compressor kernel needs float for norm_weight input
-        norm_dtype = torch.float32 if get_ascend_device_type() == AscendDeviceType.A5 else None
-        self.norm = RMSNorm(self.head_dim, config.rms_norm_eps, dtype=norm_dtype)
-
-        state_dtype = torch.float32
-        # TODO(zyj): change following codes if block_size is configurable & refactor the magic numbers
-        if compress_ratio == 4:
-            self.state_cache = AscendCompressorStateCache(
-                state_dim=2 * self.coff * self.head_dim,  # kv_state + score_state
-                dtype=state_dtype,
-                compress_ratio=compress_ratio,
-                prefix=f"{prefix}.state_cache",
-                block_size=_dsv4_block_sizes()[cache_config.block_size][0][2],  # type: ignore[union-attr]
-            )
-        elif compress_ratio == 128:
-            self.state_cache = AscendCompressorStateCache(
-                state_dim=2 * self.head_dim,  # kv_state + score_state
-                dtype=state_dtype,
-                compress_ratio=compress_ratio,
-                prefix=f"{prefix}.state_cache",
-                block_size=_dsv4_block_sizes()[cache_config.block_size][0][3],  # type: ignore[union-attr]
-            )
-        else:
-            raise ValueError(
-                f"Only support compress_ratio in [4, 128]. Got unsupported compress_ratio: {compress_ratio}"
-            )
-
-    def overlap_transform(self, tensor: torch.Tensor, value=0):
-        b, s, _, _ = tensor.size()
-        ratio, d = self.compress_ratio, self.head_dim
-        new_tensor = tensor.new_full((b, s, 2 * ratio, d), value)
-        new_tensor[:, :, ratio:] = tensor[:, :, :, d:]
-        new_tensor[:, 1:, :ratio] = tensor[:, :-1, :, :d]
-        return new_tensor
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        start_pos: int,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-    ) -> torch.Tensor:
-        pass
-
-    def rope_single(
-        self,
-        x: torch.Tensor,
-        cos: torch.Tensor,
-        sin: torch.Tensor,
-        inverse: bool = False,
-    ) -> torch.Tensor:
-        dtype = x.dtype
-        if inverse:
-            sin = sin * -1
-        tnd_layout = 1
-        if len(x.shape) == 3:
-            num_tokens, num_heads, rotary_dim = x.shape
-        else:
-            tnd_layout = 0
-            _, num_tokens, num_heads, rotary_dim = x.shape
-        x_rot = torch_npu.npu_rotary_mul(
-            x.reshape(num_tokens, num_heads, 1, rotary_dim).to(torch.float32), cos, sin, rotary_mode="interleave"
-        )
-        if tnd_layout:
-            x = x_rot.reshape(num_tokens, -1, rotary_dim)
-        else:
-            x = x_rot.reshape(1, num_tokens, -1, rotary_dim)
-        return x.to(dtype)
-
-
 class DeepseekV4Attention(nn.Module):
     def __init__(
         self,
@@ -822,7 +538,28 @@ class DeepseekV4Attention(nn.Module):
         )
 
         self.compressor: Compressor | None = None
-        self.indexer: Indexer | None = None
+        self.indexer: DeepseekV4Indexer | None = None
+
+        use_index_cache = getattr(config, "use_index_cache", False)
+
+        # IndexCache: decide whether this layer reuses topk from a previous
+        # indexer-bearing layer. Refer: https://arxiv.org/abs/2603.12201
+        # Only meaningful when this layer actually owns an Indexer (c4) and
+        # IndexCache is enabled via hf-overrides. MTP layers are excluded
+        # because spec_decode shares topk_indices_buffer at the model level
+        # only, leaving impl-level references stale.
+        skip_topk = False
+        if self.compress_ratio == 4 and use_index_cache and ".mtp." not in prefix:
+            compress_ratios = getattr(config, "compress_ratios", None) or []
+            indexer_seq_idx = sum(1 for r in compress_ratios[:config_layer_idx] if r == 4)
+            pattern = getattr(config, "index_topk_pattern", None)
+            freq = getattr(config, "index_topk_freq", 1)
+            if pattern is None:
+                skip_topk = max(indexer_seq_idx - 1, 0) % freq != 0
+            else:
+                assert pattern[0] == "F", "index_topk_pattern must start with 'F'"
+                if 0 <= indexer_seq_idx < len(pattern):
+                    skip_topk = pattern[indexer_seq_idx] == "S"
 
         if self.compress_ratio > 1:
             self.compressor = Compressor(
@@ -836,33 +573,17 @@ class DeepseekV4Attention(nn.Module):
             )  # Compressor(4, 128)
 
             if self.compress_ratio == 4:
-                self.indexer = Indexer(
+                self.indexer = DeepseekV4Indexer(
                     vllm_config,
                     config,
                     self.compress_ratio,
+                    skip_topk=skip_topk,
+                    use_index_cache=use_index_cache,
                     quant_config=quant_config,
                     cache_config=cache_config,
                     prefix=f"{prefix}.indexer",
+                    topk_indices_buffer=topk_indices_buffer,
                 )
-
-        # IndexCache: decide whether this layer reuses topk from a previous
-        # indexer-bearing layer. Refer: https://arxiv.org/abs/2603.12201
-        # Only meaningful when this layer actually owns an Indexer (c4) and
-        # IndexCache is enabled via hf-overrides. MTP layers are excluded
-        # because spec_decode shares topk_indices_buffer at the model level
-        # only, leaving impl-level references stale.
-        skip_topk = False
-        if self.compress_ratio == 4 and getattr(config, "use_index_cache", False) and ".mtp." not in prefix:
-            compress_ratios = getattr(config, "compress_ratios", None) or []
-            indexer_seq_idx = sum(1 for r in compress_ratios[:config_layer_idx] if r == 4)
-            pattern = getattr(config, "index_topk_pattern", None)
-            freq = getattr(config, "index_topk_freq", 1)
-            if pattern is None:
-                skip_topk = max(indexer_seq_idx - 1, 0) % freq != 0
-            else:
-                assert pattern[0] == "F", "index_topk_pattern must start with 'F'"
-                if 0 <= indexer_seq_idx < len(pattern):
-                    skip_topk = pattern[indexer_seq_idx] == "S"
 
         ascend_device_type = get_ascend_device_type()
         k_dtype = torch.float8_e4m3fn if ascend_device_type == AscendDeviceType.A5 else torch.bfloat16
@@ -887,8 +608,6 @@ class DeepseekV4Attention(nn.Module):
             indexer=self.indexer,
             compressor=self.compressor,
             swa_cache_layer=swa_cache_layer,
-            topk_indices_buffer=topk_indices_buffer,
-            skip_topk=skip_topk,
         )
 
         self.dsa_attn = AscendDeepseekSparseAttention(

--- a/vllm_ascend/models/deepseek_v4/mtp.py
+++ b/vllm_ascend/models/deepseek_v4/mtp.py
@@ -23,14 +23,13 @@ from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.utils import enable_dsa_cp
-
-from .deepseek_v4 import (
+from vllm_ascend.models.deepseek_v4.model import (
     DeepseekV2DecoderLayer,
     DeepseekV2MixtureOfExperts,
     DeepseekV4MoE,
     get_spec_layer_idx_from_weight_name,
 )
+from vllm_ascend.utils import enable_dsa_cp
 
 
 class SharedHead(nn.Module):

--- a/vllm_ascend/ops/dsa.py
+++ b/vllm_ascend/ops/dsa.py
@@ -54,9 +54,7 @@ class DSAModules:
     indexer: torch.nn.Module | None
     compressor: torch.nn.Module | None
     swa_cache_layer: torch.nn.Module
-    topk_indices_buffer: torch.Tensor | None
     indexer_rotary_emb: torch.nn.Module | None = None
-    skip_topk: bool = False
 
 
 class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
@@ -108,9 +106,7 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
         self.attn_sink = dsa_modules.attn_sink
         self.indexer = dsa_modules.indexer
         self.compressor = dsa_modules.compressor
-        self.topk_indices_buffer = dsa_modules.topk_indices_buffer
         self.indexer_rotary_emb = dsa_modules.indexer_rotary_emb
-        self.skip_topk = dsa_modules.skip_topk
         self.prefix = prefix
 
         self.swa_cache_layer = dsa_modules.swa_cache_layer
@@ -146,8 +142,6 @@ class AscendDeepseekSparseAttention(MultiHeadLatentAttentionWrapper):
             attn_sink=self.attn_sink,
             eps=self.eps,
             swa_cache_layer=self.swa_cache_layer,
-            skip_topk=self.skip_topk,
-            topk_indices_buffer=self.topk_indices_buffer,
         )
 
         compilation_config = get_current_vllm_config().compilation_config
@@ -184,10 +178,7 @@ def dsa_forward(
 ) -> None:
     forward_context: ForwardContext = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
-    if forward_context.attn_metadata:
-        attn_metadata = filter_metadata(forward_context.attn_metadata, self.prefix)
-    else:
-        attn_metadata = forward_context.attn_metadata
+    attn_metadata = forward_context.attn_metadata
 
     if attn_metadata is None:
         # Profiling run: forward() handles OTP by running _forward_o_proj on a
@@ -219,11 +210,6 @@ direct_register_custom_op(
     fake_impl=dsa_forward_fake,
     dispatch_key="PrivateUse1",
 )
-
-
-def filter_metadata(metadata, prefix):
-    # filter using prefix, sort by key for deterministic order
-    return [v for k, v in sorted(metadata.items()) if k.startswith(prefix)]
 
 
 def _build_kv_cache(self, forward_context):

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -50,7 +50,7 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
     prepare_sparse_kv_offload_mtp_dummy_metadata,
 )
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
-from vllm_ascend.models.deepseek_v4_dspark import DSparkDeepseekV4ForCausalLM
+from vllm_ascend.models.deepseek_v4.dspark import DSparkDeepseekV4ForCausalLM
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
 from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num


### PR DESCRIPTION
### What this PR does / why we need it?
The main focus is on layering the indexer and compressor logic in dsa_v1.
1. Create a new directory named "deepseek_v4" inside the "models" folder, and place all the related files for deepseek_v4 in this directory. The directory structure is as follows: vllm_ascend/models/deepseek_v4/
├── __init__.py
├── compressor.py
├── dspark.py
├── indexer.py
├── model.py
└── mtp.py
2. The indexer and compressor logic were separated out and placed in the models/deepseek_v4 directory. The dsa_v1 directly calls the indexer() or compressor() to execute the model forward.
3. New UT (unit test) cases were added for supervision.

gpqa precision：
| dataset | version | metric | mode | vllm-api-general-chat |
|----- | ----- | ----- | ----- | -----|
| GPQA_diamond | b1ed2c | accuracy | gen | 88.38 |

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
