### PR TITLE
[BugFix][PD] Order SFA PD notification after the KV scatter

### DIFF
--- a/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
+++ b/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import threading
+import time
 from concurrent.futures import Future
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -34,6 +35,9 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h.protocol import (  #
     SendTask,
     SfaPDProducerReqMeta,
     infer_sfa_component_group_ids,
+)
+from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h import (  # noqa: E402
+    read_thread as read_thread_module,
 )
 from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h.read_thread import (  # noqa: E402
     ConsumerReadState,
@@ -848,6 +852,40 @@ def test_send_thread_falls_back_to_device_sync_when_no_event_is_available():
 
     device_sync.assert_called_once()
     stream.wait_event.assert_not_called()
+
+
+def test_await_destinations_returns_once_the_worker_registers():
+    # P can prefill and notify inside the gap between D advertising a request
+    # and the next forward step recording its destination blocks.
+    thread = _make_read_thread()
+    thread._stop_event = threading.Event()
+    thread._state.dest_blocks_by_req.clear()
+
+    def register_late():
+        time.sleep(0.05)
+        thread._state.dest_blocks_by_req["req-late"] = ([1], [2])
+
+    registrar = threading.Thread(target=register_late)
+    registrar.start()
+    try:
+        thread._await_destinations(["req-late"])
+    finally:
+        registrar.join()
+
+    assert "req-late" in thread._state.dest_blocks_by_req
+
+
+def test_await_destinations_gives_up_after_the_timeout():
+    thread = _make_read_thread()
+    thread._stop_event = threading.Event()
+    thread._state.dest_blocks_by_req.clear()
+
+    with patch.object(read_thread_module, "DEST_REGISTRATION_TIMEOUT_SECONDS", 0.01):
+        thread._await_destinations(["req-never"])
+
+    # Returning lets the read itself raise the missing-destination error, so a
+    # request that truly never registers still fails rather than hanging.
+    assert "req-never" not in thread._state.dest_blocks_by_req
 
 
 def test_record_p_save_event_returns_the_event_for_the_task():

--- a/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
+++ b/tests/ut/kv_offload/test_sfa_pd_rd2h_connector.py
@@ -12,6 +12,7 @@ import pytest
 pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
+import torch  # noqa: E402
 from vllm.distributed.kv_transfer.kv_connector.factory import (  # noqa: E402
     KVConnectorFactory,
 )
@@ -712,6 +713,154 @@ def test_send_thread_slices_each_group_at_chunk_boundaries():
     assert sent_message[3] == [("req-0", [11], [20], 1, 0)]
     assert sent_message[5] == 0
     assert sent_message[6] == 1
+
+
+def _make_scatter_wait_send_thread() -> MembPullSendingThread:
+    layer_name = "model.layers.0.self_attn"
+    thread = MembPullSendingThread.__new__(MembPullSendingThread)
+    thread._state = ProducerSendState(
+        last_layer_idx=0,
+        main_group_idx=1,
+        indexer_group_idx=0,
+        block_sizes=(32, 16),
+        layer_metadata={
+            layer_name: LayerMetadata(
+                tensor_group_idx=[1, 1, 0],
+                kv_caches_base_addr=[1000, 2000, 3000],
+                block_len=[10, 20, 5],
+                block_size_scale=[1, 1, 1],
+                main_tensor_count=2,
+                has_indexer=True,
+            )
+        },
+        layer_storage_slots={0: (0, 1)},
+        p_session="p-session",
+    )
+    thread.last_layer_idx = 0
+    thread._p_save_events = {}
+    thread._pending_reads_by_layer = {}
+    thread._storage_read_errors = {}
+    thread.storage_send_done_events = [threading.Event(), threading.Event()]
+    for event in thread.storage_send_done_events:
+        event.set()
+    thread._mf_meta_sent_paths = {"tcp://127.0.0.1:1234"}
+    thread._ensure_dealer = MagicMock(return_value=MagicMock())  # type: ignore[method-assign]
+    return thread
+
+
+def _make_scatter_wait_req_meta() -> SfaPDProducerReqMeta:
+    return SfaPDProducerReqMeta(
+        local_block_ids=[[7], [3, 4]],
+        token_ids=[],
+        remote_block_ids=[],
+        remote_block_size=[],
+        remote_engine_id=None,
+        remote_host="127.0.0.1",
+        remote_port=1234,
+        remote_te_rpc_port=None,
+        remote_layer_metadata=None,
+        metaserver=None,
+        remote_tp_size=None,
+        remote_pcp_size=None,
+        remote_dcp_size=None,
+        chunk_finish=True,
+        local_transed_tokens=0,
+        local_computed_tokens=32,
+    )
+
+
+def test_send_thread_waits_for_scatter_through_its_own_stream():
+    # Event.synchronize() does not wait on an event recorded by the forward
+    # thread, so D would pull blocks the scatter had not filled yet.
+    thread = _make_scatter_wait_send_thread()
+    encoder = MagicMock()
+    encoder.encode.side_effect = lambda value: value
+    scatter_event = MagicMock()
+    stream = MagicMock()
+
+    with (
+        patch.object(torch.npu, "current_stream", return_value=stream),
+        patch.object(torch.npu, "synchronize") as device_sync,
+    ):
+        thread._process_send_task(
+            SendTask(
+                send_request={"req-0": _make_scatter_wait_req_meta()},
+                layer_idx=0,
+                layer_name="model.layers.0.self_attn",
+                wait_event=scatter_event,
+            ),
+            encoder,
+        )
+
+    stream.wait_event.assert_called_once_with(scatter_event)
+    stream.synchronize.assert_called_once()
+    scatter_event.synchronize.assert_not_called()
+    device_sync.assert_not_called()
+
+
+def test_send_thread_prefers_the_task_event_over_the_layer_keyed_map():
+    # Pre-attention dispatch keeps two steps in flight; the map is keyed by
+    # layer alone and so cannot tell this step's event from the other's.
+    thread = _make_scatter_wait_send_thread()
+    encoder = MagicMock()
+    encoder.encode.side_effect = lambda value: value
+    this_step, other_step = MagicMock(), MagicMock()
+    thread._p_save_events = {0: other_step}
+    stream = MagicMock()
+
+    with (
+        patch.object(torch.npu, "current_stream", return_value=stream),
+        patch.object(torch.npu, "synchronize"),
+    ):
+        thread._process_send_task(
+            SendTask(
+                send_request={"req-0": _make_scatter_wait_req_meta()},
+                layer_idx=0,
+                layer_name="model.layers.0.self_attn",
+                wait_event=this_step,
+            ),
+            encoder,
+        )
+
+    stream.wait_event.assert_called_once_with(this_step)
+    assert thread._p_save_events == {}
+
+
+def test_send_thread_falls_back_to_device_sync_when_no_event_is_available():
+    # A missing event must never be read as "nothing to wait for".
+    thread = _make_scatter_wait_send_thread()
+    encoder = MagicMock()
+    encoder.encode.side_effect = lambda value: value
+    stream = MagicMock()
+
+    with (
+        patch.object(torch.npu, "current_stream", return_value=stream),
+        patch.object(torch.npu, "synchronize") as device_sync,
+    ):
+        thread._process_send_task(
+            SendTask(
+                send_request={"req-0": _make_scatter_wait_req_meta()},
+                layer_idx=0,
+                layer_name="model.layers.0.self_attn",
+            ),
+            encoder,
+        )
+
+    device_sync.assert_called_once()
+    stream.wait_event.assert_not_called()
+
+
+def test_record_p_save_event_returns_the_event_for_the_task():
+    thread = MembPullSendingThread.__new__(MembPullSendingThread)
+    thread._p_save_events = {}
+    event = MagicMock()
+
+    with patch.object(torch.npu, "Event", return_value=event):
+        returned = thread.record_p_save_event(3)
+
+    assert returned is event
+    event.record.assert_called_once()
+    assert thread._p_save_events[3] is event
 
 
 @pytest.mark.parametrize("all_groups", [False, True])

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1668,6 +1668,12 @@ class AscendSFAImpl(MLAAttentionImpl):
         if kv_cache is not None:
             notify_kv_cache_written(self.layer_name or "")
 
+        if kv_cache is not None and self.is_kv_producer:
+            # Record once this layer's scatters are on the stream. The event was
+            # only ever constructed, so a PD connector waiting on it to learn the
+            # cache is written waited on a never-recorded event.
+            attn_metadata.reshape_cache_event.record()
+
         # Open the prefetch gate for every SFA layer. Some GLM-5.2 layers
         # reuse cached top-k indices and have no indexer, so recording this
         # inside indexer_select_post_process would leave their gate closed.

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/read_thread.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/read_thread.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import math
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -25,6 +26,12 @@ from vllm_ascend.distributed.kv_transfer.kv_p2p.sfa_pd_rd2h.protocol import (
 
 READ_THREAD_POLL_TIMEOUT_MS = 100
 THREAD_SHUTDOWN_TIMEOUT_SECONDS = 5.0
+# D advertises a request from the scheduler as soon as its blocks are
+# allocated, but the worker only records the destination when the next forward
+# step calls start_load_kv. P can prefill and send READ_READY inside that gap,
+# so wait for the registration instead of failing the pull.
+DEST_REGISTRATION_TIMEOUT_SECONDS = 120.0
+DEST_REGISTRATION_POLL_SECONDS = 0.005
 
 
 @dataclass
@@ -249,6 +256,7 @@ class MembPullReadThread(threading.Thread):
                                     "MF_META was not received from this P connection before READ_READY_BATCH"
                                 )
                             if read_reqs:
+                                self._await_destinations(entry[0] for entry in read_reqs)
                                 self._do_read_batch(
                                     layer_name,
                                     read_reqs,
@@ -294,6 +302,35 @@ class MembPullReadThread(threading.Thread):
             if sock is not None:
                 sock.close(linger=0)
             ctx.destroy(linger=0)
+
+    def _await_destinations(self, ext_req_ids) -> None:
+        """Block until every request in this batch has its D-side destination.
+
+        Failing instead would abort a pull that is merely early: D itself
+        advertised these requests, so the registration is already on its way
+        from the next forward step. A request that never registers still ends
+        in the same failure, just after the wait.
+        """
+        pending = [
+            ext_id for ext_id in ext_req_ids if ext_id not in self._state.dest_blocks_by_req
+        ]
+        if not pending:
+            return
+        deadline = time.monotonic() + DEST_REGISTRATION_TIMEOUT_SECONDS
+        while not self._stop_event.is_set():
+            pending = [
+                ext_id for ext_id in pending if ext_id not in self._state.dest_blocks_by_req
+            ]
+            if not pending:
+                return
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "MembPull D still has no destination blocks for %s after %.0fs",
+                    pending,
+                    DEST_REGISTRATION_TIMEOUT_SECONDS,
+                )
+                return
+            time.sleep(DEST_REGISTRATION_POLL_SECONDS)
 
     def stop(self, timeout: float = THREAD_SHUTDOWN_TIMEOUT_SECONDS) -> None:
         self._stop_event.set()

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/send_thread.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/send_thread.py
@@ -161,10 +161,16 @@ class MembPullSendingThread(threading.Thread):
         if self.is_alive():
             logger.warning("MembPull send thread did not stop within %.1f seconds", timeout)
 
-    def record_p_save_event(self, layer_idx: int) -> None:
+    def record_p_save_event(self, layer_idx: int) -> Any:
+        """Record KV-scatter completion for one layer of one step.
+
+        Returned so the caller can attach it to the matching ``SendTask``; the
+        layer-keyed map is kept only as a fallback for callers that do not.
+        """
         evt = torch.npu.Event()
         evt.record()
         self._p_save_events[layer_idx] = evt
+        return evt
 
     def mark_layer_pending(self, layer_idx: int) -> None:
         """Close all gates protecting storage written by ``layer_idx``."""
@@ -174,11 +180,26 @@ class MembPullSendingThread(threading.Thread):
 
     def _process_send_task(self, send_task: SendTask, encoder: msgspec.msgpack.Encoder) -> None:
         layer_idx = send_task.layer_idx
-        p_save_event = self._p_save_events.pop(layer_idx, None)
-        if p_save_event is not None:
-            p_save_event.synchronize()
-        elif send_task.wait_event is not None:
-            send_task.wait_event.synchronize()
+        # Notifying D before this layer's KV scatter lands makes it pull the
+        # block's previous contents -- the last request's KV, since blocks are
+        # reused. Prefer the task's own event; the layer-keyed map cannot tell
+        # two in-flight steps apart, and a missing event must never be read as
+        # "nothing to wait for".
+        wait_event = send_task.wait_event or self._p_save_events.pop(layer_idx, None)
+        if wait_event is not None:
+            # Event.synchronize() does not wait on an event recorded by the
+            # model-forward thread; waiting through this thread's stream does.
+            stream = torch.npu.current_stream()
+            stream.wait_event(wait_event)
+            stream.synchronize()
+        else:
+            logger.warning(
+                "MembPull P has no KV-scatter event for layer %d; falling back to a "
+                "device sync before notifying D.",
+                layer_idx,
+            )
+            torch.npu.synchronize()
+        self._p_save_events.pop(layer_idx, None)
         layer_name = send_task.layer_name
 
         # Group this layer's notifications by D-side endpoint so requests for

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/sfa_pd_rd2h/worker.py
@@ -721,10 +721,16 @@ class SFAPDRD2HProducerWorker:
         layer_group_indices = set(self.layer_metadata[resolved_layer_name].tensor_group_idx)
         if self._has_memfabric_pull_target(connector_metadata, layer_idx, layer_group_indices):
             self.kv_send_layer_thread.mark_layer_pending(layer_idx)
-        # Fresh compute-stream event right after the scatter; it supersedes the
-        # layer-end wait_event in the send thread.
-        self.kv_send_layer_thread.record_p_save_event(layer_idx)
-        self._enqueue_layer_send(resolved_layer_name, layer_idx, connector_metadata)
+        # Fresh compute-stream event right after the scatter, carried by the
+        # task: dispatching pre-attention puts two steps in flight, and a
+        # layer-keyed lookup cannot tell one step's event from the other's.
+        save_event = self.kv_send_layer_thread.record_p_save_event(layer_idx)
+        self._enqueue_layer_send(
+            resolved_layer_name,
+            layer_idx,
+            connector_metadata,
+            wait_event=save_event,
+        )
 
     def save_kv_layer(
         self,
@@ -757,22 +763,11 @@ class SFAPDRD2HProducerWorker:
         layer_group_indices = set(self.layer_metadata[resolved_layer_name].tensor_group_idx)
         if self._has_memfabric_pull_target(connector_metadata, layer_idx, layer_group_indices):
             send_thread.mark_layer_pending(layer_idx)
-        # Fallback path (attention hook did not fire for this layer): record
-        # scatter completion now and pick the reshape/event to wait on.
-        send_thread.record_p_save_event(layer_idx)
-        layer_attn_metadata = None
-        if self.use_mla and hasattr(attn_metadata, "__getitem__"):
-            try:
-                layer_attn_metadata = attn_metadata[resolved_layer_name]
-            except Exception:
-                layer_attn_metadata = None
-        if layer_attn_metadata is not None and hasattr(layer_attn_metadata, "reshape_cache_event"):
-            wait_event = layer_attn_metadata.reshape_cache_event
-        elif hasattr(attn_metadata, "reshape_cache_event"):
-            wait_event = attn_metadata.reshape_cache_event
-        else:
-            wait_event = torch.npu.Event()
-            wait_event.record()
+        # Fallback path (attention hook did not fire for this layer). Recorded
+        # at layer end, so it already covers this layer's scatter, and carried
+        # by the task: the attn metadata's reshape event is shared across
+        # layers and steps and cannot identify this dispatch.
+        wait_event = send_thread.record_p_save_event(layer_idx)
         self._enqueue_layer_send(resolved_layer_name, layer_idx, connector_metadata, wait_event=wait_event)
         self.current_layer += 1
 


### PR DESCRIPTION
### What this PR does / why we need it?
On the SFA pull-mode PD path, every request after the first decoded the *previous* request's context: its answer reproduced the previous prompt's needle, and often its text verbatim.

P notified D that a layer's blocks were ready before that layer's KV scatter had actually landed, so D pulled whatever the blocks still held. Blocks are recycled LIFO, so what they held was the previous request's KV, read at the same logical offsets -- hence a coherent shift by one rather than noise. The first request was always right because its blocks had no earlier content to read.

Measured on 910B3 by checksumming the same P-side block twice, at the layer-0 notification and again at the last layer: the bytes differed, and D's pool contained the earlier value byte for byte.

Three defects combined to remove the ordering:

* The send thread waited with ``Event.synchronize()`` on an event recorded by the model-forward thread, which returns immediately without waiting. Waiting through this thread's own stream (``wait_event`` + ``synchronize``) does block. This is the one that actually breaks the guarantee: with it fixed, 16/16 needle requests are correct where the old path gave 1/6.
* The pre-attention dispatch path enqueued its task with no wait event at all and relied on a map keyed by layer alone. With two steps in flight one step's task can drain the other's entry, after which the send thread found nothing to wait on and treated that as nothing to wait for. The event is now carried by the task that owns it, and a missing event degrades to a device sync with a warning instead of silently skipping the wait.
* ``AscendSFAImpl`` constructed ``reshape_cache_event`` but never recorded it, so consumers waiting on it -- including the mooncake layerwise connector -- were waiting on an unrecorded event. It is now recorded once this layer's main and indexer scatters are on the stream.

### Does this PR introduce _any_ user-facing change?
No, SFA pull-mode PD is not in prod. 

### How was this patch tested?
Validated on 4x Atlas 800I A2 with GLM-5.3 w4a8: 12/12 unique-content needle requests correct with no instrumentation present, against a reproducible failure from the second request onward before the change. Added unit tests.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
