### PR TITLE
[Doc][Misc] Temporarily use temporary image names for Qwen3.8

### DIFF
--- a/docs/source/tutorials/models/Qwen3.8-2.4T-A95B.md
+++ b/docs/source/tutorials/models/Qwen3.8-2.4T-A95B.md
@@ -71,7 +71,7 @@ Select the A3 image and start the docker image on each node. Refer to
 
 ```{code-block} bash
   :substitutions:
-export IMAGE=quay.io/ascend/vllm-ascend:|vllm_ascend_version|-a3
+export IMAGE=quay.io/ascend/vllm-ascend:qwen3.8-a3
 export NAME=vllm-ascend
 
 docker run --rm \

--- a/docs/source/tutorials/models/Qwen3.8-27B.md
+++ b/docs/source/tutorials/models/Qwen3.8-27B.md
@@ -45,7 +45,7 @@ Select an image based on your machine type and start the docker image on your no
     Start the docker image on each node.
 
     ```bash
-    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a3
+    export IMAGE=quay.io/ascend/vllm-ascend:qwen3.8-a3
     export NAME=vllm-ascend
 
     docker run --rm \
@@ -86,7 +86,7 @@ Select an image based on your machine type and start the docker image on your no
     Start the docker image on each node.
 
     ```bash
-    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-a5
+    export IMAGE=quay.io/ascend/vllm-ascend:qwen3.8-a5
     export NAME=vllm-ascend
 
     docker run --rm \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR temporarily updates the Docker image tags in the Qwen3.8 documentation (`Qwen3.8-2.4T-A95B.md` and `Qwen3.8-27B.md`) to use the temporary image names `qwen3.8-a3` and `qwen3.8-a5` instead of the version placeholders. This is needed because the official images for Qwen3.8 are not yet released under the standard versioned tags.

### Does this PR introduce _any_ user-facing change?

No, this is a documentation-only update.

### How was this patch tested?

Documentation changes only, no functional code changes.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
