### PR TITLE
[BugFix][P/D] Preserve exact token history across recompute retries

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -694,6 +694,7 @@
     - vllm_ascend/meta_registration.py
     - vllm_ascend/platform.py
     - vllm_ascend/profiling_config.py
+    - vllm_ascend/recompute_proxy.py
     - vllm_ascend/utils.py
     - setup.py
   tests:
@@ -704,6 +705,7 @@
     - tests/ut/test_logger.py
     - tests/ut/test_meta_registration.py
     - tests/ut/test_profiling_config.py
+    - tests/ut/test_recompute_proxy.py
     - tests/ut/test_utils.py
     - tests/ut/test_platform.py
     - tests/e2e/pull_request/one_card/test_qwen3_0_6b.py

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -137,6 +137,12 @@ import httpx
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
 
+from vllm_ascend.patch.recompute_proxy import (
+    RECOMPUTE_TOKEN_IDS_KEY,
+    RecomputeContext,
+    iter_sse_events,
+)
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -186,11 +192,6 @@ def update_cached_tokens_in_chunk(chunk_json: dict, cached_tokens: int | None) -
     usage["prompt_tokens_details"] = prompt_tokens_details
     prompt_tokens_details["cached_tokens"] = cached_tokens
     return True
-
-
-def encode_response_chunk(chunk_json: dict, is_sse: bool) -> bytes:
-    chunk = json.dumps(chunk_json, ensure_ascii=False).encode("utf-8")
-    return b"data: " + chunk + b"\n\n" if is_sse else chunk
 
 
 global_args: argparse.Namespace | None = None
@@ -817,6 +818,7 @@ def auth_headers(request_id: str) -> dict[str, str]:
 
 def build_prefill_request(req_data: dict) -> dict:
     payload = req_data.copy()
+    recompute_token_ids = (req_data.get("kv_transfer_params") or {}).get(RECOMPUTE_TOKEN_IDS_KEY)
     payload["kv_transfer_params"] = {
         "do_remote_decode": True,
         "do_remote_prefill": False,
@@ -825,7 +827,10 @@ def build_prefill_request(req_data: dict) -> dict:
         "remote_host": None,
         "remote_port": None,
     }
+    if recompute_token_ids is not None:
+        payload["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] = recompute_token_ids
     payload["stream"] = False
+    payload["return_token_ids"] = False
     payload["max_tokens"] = 1
     payload["min_tokens"] = 1
     if "max_completion_tokens" in payload:
@@ -955,8 +960,11 @@ async def assign_instances(
         raise
 
     response_json = response.json()
+    recompute_token_ids = (req_data.get("kv_transfer_params") or {}).get(RECOMPUTE_TOKEN_IDS_KEY)
     kv_transfer_params = response_json.get("kv_transfer_params", {})
     if kv_transfer_params:
+        if recompute_token_ids is not None:
+            kv_transfer_params[RECOMPUTE_TOKEN_IDS_KEY] = recompute_token_ids
         req_data["kv_transfer_params"] = kv_transfer_params
     prefiller_cached_tokens = extract_cached_tokens(response_json)
 
@@ -1001,27 +1009,15 @@ async def handle_completions_impl(api: str, request: Request):
         req_data = await request.json()
         req_body = await request.body()
         request_length = len(req_body)
+        recompute_context = RecomputeContext.from_request(req_data)
         instance_info = await assign_instances(api, req_data, request_length, is_initial_request=True)
-        stream_flag = bool(req_data.get("stream", False))
-        chat_flag = "messages" in req_data
-
-        if "prompt" in req_data:
-            origin_prompt = req_data["prompt"]
-        elif chat_flag:
-            messages = req_data["messages"]
-            origin_prompt = messages[0].get("content", "")
-        else:
-            origin_prompt = ""
-        origin_max_tokens = req_data.get("max_tokens", 16)
+        stream_flag = recompute_context.stream
 
         async def generate_stream():
             nonlocal instance_info
             nonlocal request_released
-            generated_token = ""
             released_kv = False
-            retry_count = 0
             retry = True
-            completion_tokens = 0
             reported_prefiller_cached_tokens = instance_info.prefiller_cached_tokens
 
             async def release_prefill_kv_once() -> None:
@@ -1032,77 +1028,72 @@ async def handle_completions_impl(api: str, request: Request):
                     )
                     released_kv = True
 
+            async def response_chunks(decoder_client: httpx.AsyncClient):
+                async for chunk in stream_service_response(
+                    decoder_client,
+                    api,
+                    req_data,
+                    request_id=instance_info.request_id,
+                    max_retries=args.max_retries,
+                    base_delay=args.retry_delay,
+                ):
+                    if not released_kv and chunk:
+                        await release_prefill_kv_once()
+                    yield chunk
+
             try:
                 while retry:
                     retry = False
                     decoder_client = await runtime.get_client(ServerRole.DECODE, instance_info.decoder_key)
-                    async for chunk in stream_service_response(
-                        decoder_client,
-                        api,
-                        req_data,
-                        request_id=instance_info.request_id,
-                        max_retries=args.max_retries,
-                        base_delay=args.retry_delay,
-                    ):
-                        if not released_kv and chunk:
-                            await release_prefill_kv_once()
-                        try:
-                            chunk_str = chunk.decode("utf-8").strip()
-                        except UnicodeDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk)
-                            yield chunk
-                            continue
-                        if not chunk_str:
-                            continue
-                        is_sse = chunk_str.startswith("data: ")
-                        if is_sse:
-                            chunk_str = chunk_str[len("data: ") :]
-                        try:
-                            chunk_json = json.loads(chunk_str)
-                        except json.JSONDecodeError:
-                            logger.debug("Skipping chunk: %s", chunk_str)
-                            yield chunk
-                            continue
-                        choices = chunk_json.get("choices", [])
-                        if not choices or not stream_flag:
-                            if update_cached_tokens_in_chunk(chunk_json, reported_prefiller_cached_tokens):
-                                chunk = encode_response_chunk(chunk_json, is_sse)
-                                if not choices:
-                                    yield chunk
-                                    continue
+                    chunks = response_chunks(decoder_client)
+                    if stream_flag:
+                        async for event in iter_sse_events(chunks):
+                            data_lines = [line[5:].lstrip() for line in event.splitlines() if line.startswith(b"data:")]
+                            if not data_lines:
+                                yield event
+                                continue
+                            data = b"\n".join(data_lines)
+                            if data == b"[DONE]":
+                                yield event
+                                continue
+                            try:
+                                payload = json.loads(data)
+                            except json.JSONDecodeError:
+                                logger.debug("Skipping SSE event: %s", event)
+                                yield event
+                                continue
+                            update_cached_tokens_in_chunk(payload, reported_prefiller_cached_tokens)
 
-                        choice = choices[0]
-                        delta = choice.get("delta") or {}
-                        message = choice.get("message") or {}
-                        content = delta.get("content") or message.get("content") or choice.get("text") or ""
-                        generated_token += content
+                            if recompute_context.observe_response(payload):
+                                recompute_context.prepare_retry(req_data)
+                                request_length = len(json.dumps(req_data).encode("utf-8"))
+                                instance_info = await reassign_instances(api, req_data, request_length, instance_info)
+                                released_kv = False
+                                retry = True
+                                break
 
-                        stop_reason = choice.get("stop_reason")
-                        usage = chunk_json.get("usage", {})
-                        completion_tokens = (
-                            (completion_tokens + 1)
-                            if stream_flag
-                            else (completion_tokens + usage.get("completion_tokens", 0))
-                        )
-                        if stop_reason == "recomputed":
-                            retry = True
-                            retry_count += 1
-                            if chat_flag:
-                                messages[0]["content"] = origin_prompt + generated_token
-                            else:
-                                req_data["prompt"] = origin_prompt + generated_token
-                            req_data["max_tokens"] = origin_max_tokens - completion_tokens + retry_count
-                            tmp_request_length = len(json.dumps(req_data).encode("utf-8"))
-                            instance_info = await reassign_instances(api, req_data, tmp_request_length, instance_info)
+                            client_payload = recompute_context.response_for_client(payload)
+                            if client_payload is not None:
+                                yield (
+                                    "data: "
+                                    + json.dumps(client_payload, ensure_ascii=False, separators=(",", ":"))
+                                    + "\n\n"
+                                ).encode("utf-8")
+                    else:
+                        body = b"".join([chunk async for chunk in chunks])
+                        payload = json.loads(body)
+                        update_cached_tokens_in_chunk(payload, reported_prefiller_cached_tokens)
+                        if recompute_context.observe_response(payload):
+                            recompute_context.prepare_retry(req_data)
+                            request_length = len(json.dumps(req_data).encode("utf-8"))
+                            instance_info = await reassign_instances(api, req_data, request_length, instance_info)
                             released_kv = False
-                            break
-                        if retry_count > 0 and not stream_flag:
-                            if chat_flag:
-                                choice["message"]["content"] = generated_token
-                            else:
-                                choice["text"] = generated_token
-                            chunk = encode_response_chunk(chunk_json, is_sse)
-                        yield chunk
+                            retry = True
+                            continue
+
+                        client_payload = recompute_context.response_for_client(payload)
+                        if client_payload is not None:
+                            yield json.dumps(client_payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
             except asyncio.CancelledError:
                 logger.warning(
                     "Streaming from decoder %s:%s was cancelled; releasing request %s resources",

--- a/tests/ut/test_recompute_proxy.py
+++ b/tests/ut/test_recompute_proxy.py
@@ -1,0 +1,316 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+import asyncio
+import copy
+import json
+from typing import Any
+
+import pytest
+
+from vllm_ascend.patch.recompute_proxy import (
+    RECOMPUTE_TOKEN_IDS_KEY,
+    RecomputeContext,
+    iter_sse_events,
+    replace_rendered_chat_inputs,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+async def _chunks(parts: list[bytes]):
+    for part in parts:
+        yield part
+
+
+def test_iter_sse_events_handles_split_and_coalesced_chunks() -> None:
+    first = 'data: {"choices":[{"delta":{"reasoning":"think 中"}}]}\n\n'
+    second = 'data: {"choices":[{"delta":{"content":"answer"}}]}\n\n'
+    encoded = (first + second).encode()
+    han_offset = encoded.index("中".encode())
+    chunks = [
+        encoded[: han_offset + 1],
+        encoded[han_offset + 1 : len(first.encode()) + 8],
+        encoded[len(first.encode()) + 8 :],
+    ]
+
+    async def collect_events() -> list[bytes]:
+        return [event async for event in iter_sse_events(_chunks(chunks))]
+
+    events = asyncio.run(collect_events())
+
+    assert events == [first.encode(), second.encode()]
+
+
+def test_iter_sse_events_handles_split_crlf() -> None:
+    event = b'data: {"choices": []}\r\n\r\n'
+
+    async def collect_events() -> list[bytes]:
+        return [event async for event in iter_sse_events(_chunks([event[:-3], event[-3:]]))]
+
+    assert asyncio.run(collect_events()) == [b'data: {"choices": []}\n\n']
+
+
+def test_recompute_uses_exact_tokens_without_mutating_messages() -> None:
+    request: dict[str, Any] = {
+        "messages": [
+            {"role": "system", "content": "Answer carefully."},
+            {"role": "user", "content": "What was my first question?"},
+            {"role": "assistant", "content": "You asked about arithmetic."},
+            {"role": "user", "content": "What is 2 + 2?"},
+        ],
+        "stream": True,
+        "max_completion_tokens": 8,
+    }
+    original_messages = copy.deepcopy(request["messages"])
+    context = RecomputeContext.from_request(request)
+
+    context.observe_response({"prompt_token_ids": [1, 2, 3], "choices": []})
+    context.observe_response(
+        {
+            "choices": [
+                {
+                    "delta": {"reasoning": "2 + 2 is 4."},
+                    "token_ids": [10, 11],
+                    "finish_reason": None,
+                }
+            ]
+        }
+    )
+    recomputed = context.observe_response(
+        {
+            "choices": [
+                {
+                    "delta": {},
+                    "token_ids": [],
+                    "finish_reason": "stop",
+                    "stop_reason": "recomputed",
+                }
+            ]
+        }
+    )
+
+    assert recomputed
+    context.prepare_retry(request)
+    assert request["messages"] == original_messages
+    assert request["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] == [1, 2, 3, 10, 11]
+    assert request["max_completion_tokens"] == 6
+    assert request["return_token_ids"] is True
+
+
+def test_two_recomputes_extend_the_same_token_history() -> None:
+    request: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": True,
+        "max_tokens": 10,
+    }
+    context = RecomputeContext.from_request(request)
+    context.observe_response({"prompt_token_ids": [1, 2], "choices": []})
+    context.observe_response({"choices": [{"delta": {"reasoning": "R1"}, "token_ids": [3], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+    assert request["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] == [1, 2, 3]
+
+    context.observe_response({"prompt_token_ids": [1, 2, 3], "choices": []})
+    context.observe_response({"choices": [{"delta": {"content": "C1"}, "token_ids": [4, 5], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+
+    assert request["kv_transfer_params"][RECOMPUTE_TOKEN_IDS_KEY] == [1, 2, 3, 4, 5]
+    assert request["max_tokens"] == 7
+
+
+def test_retry_rejects_changed_token_history() -> None:
+    request = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": True,
+        "max_completion_tokens": 4,
+    }
+    context = RecomputeContext.from_request(request)
+    context.observe_response({"prompt_token_ids": [1, 2], "choices": []})
+    context.observe_response({"choices": [{"delta": {"content": "C1"}, "token_ids": [3], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+
+    assert request["max_completion_tokens"] == 3
+    with pytest.raises(RuntimeError, match="exact token history"):
+        context.observe_response({"prompt_token_ids": [1, 2, 99], "choices": []})
+
+
+def test_nonstream_recompute_merges_one_logical_response() -> None:
+    request = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": False,
+        "max_tokens": 6,
+    }
+    context = RecomputeContext.from_request(request)
+    first = {
+        "id": "attempt-a",
+        "model": "model",
+        "prompt_token_ids": [1, 2],
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "reasoning": "R1", "content": "C1"},
+                "token_ids": [3, 4],
+                "finish_reason": "stop",
+                "stop_reason": "recomputed",
+            }
+        ],
+        "usage": {"prompt_tokens": 2, "completion_tokens": 2, "total_tokens": 4},
+    }
+    assert context.observe_response(first)
+    context.prepare_retry(request)
+
+    final = {
+        "id": "attempt-b",
+        "model": "model",
+        "prompt_token_ids": [1, 2, 3, 4],
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "reasoning": "R2", "content": "C2"},
+                "token_ids": [5, 6],
+                "finish_reason": "stop",
+                "stop_reason": None,
+            }
+        ],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+    }
+    assert not context.observe_response(final)
+    client_payload = context.response_for_client(final)
+
+    assert client_payload["choices"][0]["message"] == {
+        "role": "assistant",
+        "reasoning": "R1R2",
+        "content": "C1C2",
+    }
+    assert "token_ids" not in client_payload["choices"][0]
+    assert "prompt_token_ids" not in client_payload
+    assert client_payload["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 4,
+        "total_tokens": 6,
+    }
+
+
+def test_replace_rendered_chat_inputs_uses_internal_token_prefix() -> None:
+    request = type(
+        "Request",
+        (),
+        {
+            "kv_transfer_params": {RECOMPUTE_TOKEN_IDS_KEY: [7, 8, 9]},
+            "cache_salt": "salt",
+        },
+    )()
+    conversation = [{"role": "user", "content": "unchanged"}]
+    result = replace_rendered_chat_inputs(request, (conversation, [{"prompt_token_ids": [1]}]))
+
+    assert result[0] is conversation
+    assert result[1] == [
+        {
+            "type": "token",
+            "prompt_token_ids": [7, 8, 9],
+            "cache_salt": "salt",
+        }
+    ]
+    assert RECOMPUTE_TOKEN_IDS_KEY not in request.kv_transfer_params
+
+
+def test_stream_response_hides_internal_token_ids_and_rewrites_usage() -> None:
+    request = {
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "max_tokens": 6,
+    }
+    context = RecomputeContext.from_request(request)
+    initial_role = {
+        "id": "attempt-a",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "model",
+        "prompt_token_ids": [1, 2],
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": ""},
+                "token_ids": None,
+                "finish_reason": None,
+            }
+        ],
+    }
+    context.observe_response(initial_role)
+    client_initial_role = context.response_for_client(initial_role)
+    assert client_initial_role == {
+        "id": "attempt-a",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "model",
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": ""},
+                "finish_reason": None,
+            }
+        ],
+    }
+    context.observe_response({"choices": [{"delta": {"reasoning": "R1"}, "token_ids": [3, 4], "stop_reason": None}]})
+    assert context.observe_response({"choices": [{"delta": {}, "token_ids": [], "stop_reason": "recomputed"}]})
+    context.prepare_retry(request)
+
+    retry_role = {
+        "id": "attempt-b",
+        "object": "chat.completion.chunk",
+        "created": 2,
+        "model": "model",
+        "prompt_token_ids": [1, 2, 3, 4],
+        "choices": [
+            {
+                "delta": {"role": "assistant", "content": ""},
+                "token_ids": None,
+                "finish_reason": None,
+            }
+        ],
+    }
+    context.observe_response(retry_role)
+    assert context.response_for_client(retry_role) is None
+
+    content = {
+        "id": "attempt-b",
+        "object": "chat.completion.chunk",
+        "created": 2,
+        "model": "model",
+        "choices": [{"delta": {"content": "C2"}, "token_ids": [5], "finish_reason": None}],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 1, "total_tokens": 5},
+    }
+    context.observe_response(content)
+    client_payload = context.response_for_client(content)
+    assert client_payload["id"] == "attempt-a"
+    assert client_payload["created"] == 1
+    assert client_payload["choices"][0] == {"delta": {"content": "C2"}, "finish_reason": None}
+    assert client_payload["usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+
+    # Ensure rewritten payloads remain serializable as SSE JSON.
+    json.dumps(client_payload)
+
+    terminal = {
+        "id": "attempt-b",
+        "object": "chat.completion.chunk",
+        "created": 2,
+        "model": "model",
+        "choices": [
+            {
+                "delta": {},
+                "finish_reason": "stop",
+                "stop_reason": None,
+                "token_ids": [],
+            }
+        ],
+    }
+    context.observe_response(terminal)
+    client_terminal = context.response_for_client(terminal)
+    assert client_terminal["id"] == "attempt-a"
+    assert client_terminal["choices"] == [{"delta": {}, "finish_reason": "stop", "stop_reason": None}]

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1161,3 +1161,18 @@
 #       Remove this patch once vllm-ascend's bundled PyTorch >= 2.13.0
 #       (which, like upstream, allows eps >= 0 for inference).
 #
+# ** 35. File: platform/patch_recompute_chat.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.renderers.online_renderer.OnlineRenderer.render_chat`
+#    Why:
+#       P/D recompute retries must resume from exact token IDs. Rebuilding chat
+#       messages changes role placement and applies the chat template again.
+#    How:
+#       Replace the rendered engine input only when the proxy supplies its
+#       internal recompute token prefix through KV transfer parameters.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm-ascend/issues/13466
+#    Future Plan:
+#       Remove this patch when upstream vLLM exposes a token-native internal
+#       resume input for chat-completion P/D proxies.
+#

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -28,6 +28,7 @@ if not is_310p():
 else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
+import vllm_ascend.patch.platform.patch_recompute_chat  # noqa
 
 import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa

--- a/vllm_ascend/patch/platform/patch_recompute_chat.py
+++ b/vllm_ascend/patch/platform/patch_recompute_chat.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+from functools import wraps
+
+from vllm.renderers.online_renderer import OnlineRenderer
+
+from vllm_ascend.patch.recompute_proxy import replace_rendered_chat_inputs
+
+_ORIGINAL_RENDER_CHAT_ATTR = "_ascend_original_recompute_render_chat"
+
+if not hasattr(OnlineRenderer, _ORIGINAL_RENDER_CHAT_ATTR):
+    setattr(
+        OnlineRenderer,
+        _ORIGINAL_RENDER_CHAT_ATTR,
+        OnlineRenderer.render_chat,
+    )
+
+
+@wraps(getattr(OnlineRenderer, _ORIGINAL_RENDER_CHAT_ATTR))
+async def _render_chat_with_recompute_tokens(
+    self: OnlineRenderer,
+    request,
+    *,
+    skip_mm_cache: bool = False,
+):
+    original = getattr(type(self), _ORIGINAL_RENDER_CHAT_ATTR)
+    result = await original(self, request, skip_mm_cache=skip_mm_cache)
+    return replace_rendered_chat_inputs(request, result)
+
+
+OnlineRenderer.render_chat = _render_chat_with_recompute_tokens

--- a/vllm_ascend/patch/recompute_proxy.py
+++ b/vllm_ascend/patch/recompute_proxy.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+from __future__ import annotations
+
+import copy
+from collections.abc import AsyncIterable, AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+RECOMPUTE_TOKEN_IDS_KEY = "_vllm_ascend_recompute_token_ids"
+_STREAM_METADATA_KEYS = ("id", "object", "created", "model")
+
+
+async def iter_sse_events(chunks: AsyncIterable[bytes]) -> AsyncIterator[bytes]:
+    buffer = b""
+    async for chunk in chunks:
+        buffer += chunk
+        buffer = buffer.replace(b"\r\n", b"\n")
+        while b"\n\n" in buffer:
+            event, buffer = buffer.split(b"\n\n", 1)
+            if event:
+                yield event + b"\n\n"
+    if buffer.strip():
+        yield buffer
+
+
+def _is_recomputed(payload: dict[str, Any]) -> bool:
+    return any(choice.get("stop_reason") == "recomputed" for choice in payload.get("choices", []))
+
+
+@dataclass
+class RecomputeContext:
+    stream: bool
+    return_token_ids: bool
+    max_tokens_field: str
+    max_tokens: int
+    prompt_token_ids: list[int] | None = None
+    output_token_ids: list[int] = field(default_factory=list)
+    retry_count: int = 0
+    _message: dict[str, Any] = field(default_factory=dict)
+    _stream_metadata: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_request(cls, request: dict[str, Any]) -> RecomputeContext:
+        max_tokens_field = "max_completion_tokens" if request.get("max_completion_tokens") is not None else "max_tokens"
+        context = cls(
+            stream=bool(request.get("stream", False)),
+            return_token_ids=bool(request.get("return_token_ids", False)),
+            max_tokens_field=max_tokens_field,
+            max_tokens=request.get(max_tokens_field) or 16,
+        )
+        request["return_token_ids"] = True
+        return context
+
+    def observe_response(self, payload: dict[str, Any]) -> bool:
+        if self.stream and not self._stream_metadata:
+            self._stream_metadata = {key: payload[key] for key in _STREAM_METADATA_KEYS if key in payload}
+
+        prompt_token_ids = payload.get("prompt_token_ids")
+        if prompt_token_ids is not None:
+            if self.prompt_token_ids is None:
+                self.prompt_token_ids = list(prompt_token_ids)
+            else:
+                expected_token_ids = self.prompt_token_ids + self.output_token_ids
+                if prompt_token_ids != expected_token_ids:
+                    raise RuntimeError("Recompute retry did not preserve the exact token history")
+
+        choices = payload.get("choices", [])
+        if choices:
+            choice = choices[0]
+            self.output_token_ids.extend(choice.get("token_ids") or [])
+            if not self.stream:
+                self._merge_message(choice.get("message") or {})
+
+        recomputed = _is_recomputed(payload)
+        if recomputed:
+            self.retry_count += 1
+        return recomputed
+
+    def _merge_message(self, message: dict[str, Any]) -> None:
+        for key, value in message.items():
+            if value is None:
+                continue
+            if key == "role":
+                self._message[key] = value
+            elif isinstance(value, str) and isinstance(self._message.get(key), str):
+                self._message[key] += value
+            elif key not in self._message:
+                self._message[key] = copy.deepcopy(value)
+
+    def prepare_retry(self, request: dict[str, Any]) -> None:
+        if self.prompt_token_ids is None:
+            raise RuntimeError("Recompute response did not include prompt_token_ids")
+
+        token_ids = self.prompt_token_ids + self.output_token_ids
+        if "messages" in request:
+            request["kv_transfer_params"] = {RECOMPUTE_TOKEN_IDS_KEY: token_ids}
+        else:
+            request["prompt"] = token_ids
+            request.pop("kv_transfer_params", None)
+        request[self.max_tokens_field] = self.max_tokens - len(self.output_token_ids)
+        request["return_token_ids"] = True
+
+    def response_for_client(self, payload: dict[str, Any]) -> dict[str, Any] | None:
+        if _is_recomputed(payload):
+            return None
+
+        result = copy.deepcopy(payload)
+        if self.stream:
+            result.update(self._stream_metadata)
+        choices = result.get("choices", [])
+        if self.stream and self.retry_count and any((choice.get("delta") or {}).get("role") for choice in choices):
+            return None
+
+        if not self.stream and choices:
+            choices[0]["message"] = copy.deepcopy(self._message)
+            if self.return_token_ids:
+                choices[0]["token_ids"] = self.output_token_ids.copy()
+
+        if self.return_token_ids:
+            if not self.stream and self.prompt_token_ids is not None:
+                result["prompt_token_ids"] = self.prompt_token_ids.copy()
+        else:
+            result.pop("prompt_token_ids", None)
+            for choice in choices:
+                choice.pop("token_ids", None)
+
+        usage = result.get("usage")
+        if usage is not None and self.prompt_token_ids is not None:
+            prompt_tokens = len(self.prompt_token_ids)
+            completion_tokens = len(self.output_token_ids)
+            usage["prompt_tokens"] = prompt_tokens
+            usage["completion_tokens"] = completion_tokens
+            usage["total_tokens"] = prompt_tokens + completion_tokens
+        return result
+
+
+def replace_rendered_chat_inputs(request: Any, result: Any) -> Any:
+    kv_transfer_params = request.kv_transfer_params or {}
+    token_ids = kv_transfer_params.pop(RECOMPUTE_TOKEN_IDS_KEY, None)
+    if token_ids is None or not isinstance(result, tuple):
+        return result
+
+    conversation, engine_inputs = result
+    if len(engine_inputs) != 1:
+        return result
+
+    engine_input = dict(engine_inputs[0])
+    engine_input["type"] = "token"
+    engine_input["prompt_token_ids"] = list(token_ids)
+    engine_input["cache_salt"] = request.cache_salt
+    engine_input.pop("prompt", None)
+    return conversation, [engine_input]


### PR DESCRIPTION
### What this PR does / why we need it?

Ports #13524 to `main` while preserving the original PR's private retry-token transport and renderer replacement as closely as the current APIs allow.

When the decode-side recompute scheduler returns `stop_reason="recomputed"`, the proxy must resume from the exact original prompt token IDs plus every emitted output-token delta. Reconstructing the retry from parsed response text can change the token sequence, corrupt chat roles, and omit reasoning output.

This port:

- requests prompt and output token IDs internally from the decode side;
- resumes from the exact token prefix carried in the private `_vllm_ascend_recompute_token_ids` field;
- keeps the renderer input replacement from #13524, adapted from the removed v0.23 `OpenAIServingRender` API to the current `OnlineRenderer` API;
- removes the private field after rendering so it does not enter KV-transfer metadata;
- parses streaming responses by SSE event framing;
- preserves one client-visible response identity and assistant stream across retries;
- accounts for remaining generation budget and usage from token counts;
- preserves the current cached-token usage reporting behavior.

Although the vLLM revision used by `main` has a native `prompt_token_ids` reuse path, this port intentionally retains the original PR's private transport contract to minimize behavioral differences from #13524.

Related: #13466

### Does this PR introduce _any_ user-facing change?

Yes. Chat and completion requests reassigned after decode-side recomputation continue from their exact generated-token history. Internal token fields and retry-only chunks remain hidden unless the client requested token IDs.

### How was this patch tested?

Added `tests/ut/test_recompute_proxy.py` covering SSE framing, exact token history, repeated recomputes, non-stream response merging, renderer input replacement, response identity, usage accounting, and token-field visibility.

Local checks:

```bash
python3 -m py_compile \
  examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py \
  vllm_ascend/recompute_proxy.py \
  vllm_ascend/patch/platform/patch_recompute_chat.py \
  tests/ut/test_recompute_proxy.py

git diff --check origin/main..HEAD
```

Direct state-machine and renderer-replacement smoke assertions also passed. Full pytest and Ruff were not run locally because this environment does not have vLLM, pytest, or Ruff installed; PR CI is required. The original v0.23 patch's real-model NPU A/B validation is documented in #13524.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
