### PR TITLE
[CI] Trigger A3 tests on 560T runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,8 +7,11 @@ self-hosted-runner:
     - linux-aarch64-310p-4
     - linux-aarch64-a3-1
     - linux-aarch64-a3-2
+    - linux-aarch64-a3-2-
     - linux-aarch64-a3-4
+    - linux-aarch64-a3-4-
     - linux-aarch64-a3-8
+    - linux-aarch64-a3-8-
     - linux-aarch64-a3-0
     - linux-aarch64-a3-0-cn12-001
     - linux-aarch64-a5-0

--- a/.github/workflows/scripts/runner_label.json
+++ b/.github/workflows/scripts/runner_label.json
@@ -17,19 +17,19 @@
         "image_tag": "9.1.0-310p-ubuntu22.04-py3.12",
         "csrc_cache_target": "310p-arm64-ubuntu"
     },
-    "linux-aarch64-a3-2": {
+    "linux-aarch64-a3-2-": {
         "chip": "a3",
         "npu_num": 2,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-4": {
+    "linux-aarch64-a3-4-": {
         "chip": "a3",
         "npu_num": 4,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",
         "csrc_cache_target": "a3-arm64-ubuntu"
     },
-    "linux-aarch64-a3-8": {
+    "linux-aarch64-a3-8-": {
         "chip": "a3",
         "npu_num": 8,
         "image_tag": "9.1.0-a3-ubuntu22.04-py3.12",


### PR DESCRIPTION
### What this PR does / why we need it?

Add dashed A3 runner labels in `runner_label.json` so selected PR tests are routed to the 560T machine pool. Also whitelist the new labels in `actionlint.yaml`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m json.tool .github/workflows/scripts/runner_label.json`
- `git diff --check`
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
