### PR TITLE
[CI] Re-enable DeepSeek V4 test

### DIFF
--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -25,7 +25,6 @@ from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
 
 
-@pytest.mark.skip("Temporarily skip this DeepSeek V4 test.")
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",


### PR DESCRIPTION
### What this PR does / why we need it?

The bug that previously required the DeepSeek V4 test to be temporarily skipped has been fixed. Remove the skip added in #14189 to re-enable the test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m py_compile tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py`
- `git diff --check`

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
