### PR TITLE
[Feature][Model] Add Qwen3-Omni DSpark support on Ascend

### DIFF
--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -49,6 +49,10 @@ def register_model():
     )
     ModelRegistry.register_model("Qwen3DSparkModel", "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM")
     ModelRegistry.register_model(
+        "Qwen3OmniDSparkModel",
+        "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM",
+    )
+    ModelRegistry.register_model(
         "DFlash2DraftModel",
         "vllm_ascend.models.qwen3_dflash2:DFlash2Qwen3ForCausalLM",
     )


### PR DESCRIPTION
### What this PR does / why we need it?

Depends on vllm-project/vllm#52560.

This PR completes the Ascend/NPU registration required for Qwen3-Omni DSpark framework support:

- registers the checkpoint architecture `Qwen3OmniDSparkModel`;
- maps it to the existing `AscendQwen3DSparkForCausalLM` runtime;
- reuses the existing Ascend Qwen3 DSpark confidence-head, FC-rotation, and weight-loading implementation selected by the dependent vLLM support.

The Qwen3-Omni checkpoint keeps its dedicated architecture name and configuration contract. No behavior-free Ascend wrapper is added because the Ascend execution and weight-loading path is the same as the existing Qwen3 DSpark runtime.

This is a framework registration PR. A compatible trained Qwen3-Omni DSpark checkpoint is not currently available, so this PR does not claim Qwen3-Omni acceptance-rate, accuracy, performance, eager-mode, or ACLGraph results.

AI assistance disclosure: this patch was prepared with OpenAI Codex assistance and reviewed against the dependent vLLM changes.

### Does this PR introduce _any_ user-facing change?

Yes. After the dependent vLLM support is available, a draft checkpoint whose architecture is `Qwen3OmniDSparkModel` can resolve to the existing Ascend Qwen3 DSpark runtime. Existing Qwen3 DSpark behavior and command-line options are unchanged.

### How was this patch tested?

Local static checks:

```bash
ruff check vllm_ascend/models/__init__.py tests/ut/model_executor/test_qwen3_dspark.py
ruff format --check vllm_ascend/models/__init__.py tests/ut/model_executor/test_qwen3_dspark.py
git diff --check
```

Results:

- Ruff check: passed.
- Ruff format check: passed.
- `git diff --check`: passed.

The focused Qwen3 DSpark test cannot be collected in this local macOS environment because `torch_npu` is unavailable. It remains covered by the standard vLLM-Ascend CI environment.

No Qwen3-Omni DSpark E2E test is added in this PR because no compatible trained checkpoint is currently available. A converted Qwen3 checkpoint would only be a shape/loading surrogate and would not provide a valid Qwen3-Omni DSpark behavioral E2E. Eager/ACLGraph correctness, acceptance, memory, and throughput coverage should be added with the real checkpoint in a follow-up.

- dependent vLLM PR: https://github.com/vllm-project/vllm/pull/52560

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
