### PR TITLE
[BugFix][MRV2] Fix graph batch routing for FULL_DECODE_ONLY

### DIFF
--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -572,7 +572,10 @@ class NPUModelRunner(GPUModelRunner):
         """
         # TODO: need refactor later, related to vllm PR #34043 this pr delete func
         # relax_for_mixed_batch_cudagraphs, num_reqs no longer equals the actual number of requests.
-        if cudagraph_runtime_mode == CUDAGraphMode.FULL:
+        if (
+            cudagraph_runtime_mode == CUDAGraphMode.FULL
+            and self.compilation_config.cudagraph_mode == CUDAGraphMode.FULL
+        ):
             num_reqs_padded = num_reqs
         else:
             num_reqs_padded = batch_desc_num_reqs if batch_desc_num_reqs is not None else num_reqs


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes request padding for Model Runner v2 with 'FULL_DECODE_ONLY'.
Runtime 'FULL' execution previously reset 'num_reqs_padded' to the actual request count, discarding the captured graph descriptor size. The fix only applies this behaviour to configured 'FULL' mode, allowing 'FULL_DECODE_ONLY' to retain the correct padded request count.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
 Run on Machines.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
