### PR TITLE
[BugFix][MRV2] Fix Qwen3.5 hybrid state metadata and cache safety

### DIFF
--- a/tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
+++ b/tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
@@ -16,6 +16,9 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import os
+from unittest.mock import patch
+
 import huggingface_hub
 from huggingface_hub import snapshot_download as hf_snapshot_download
 from vllm.assets.image import ImageAsset
@@ -23,15 +26,15 @@ from vllm.assets.image import ImageAsset
 from tests.e2e.conftest import VllmRunner, qwen_prompt, wait_until_npu_memory_free
 
 
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 @wait_until_npu_memory_free()
-def test_mamba_ssm_multimodal_reasoning_mtp_full_decode_only():
-    """Verify Mamba/SSM multimodal reasoning with MTP and full decode only."""
+def test_mrv2_mamba_ssm_multimodal_reasoning_mtp_full_decode_only():
+    """Verify MRV2 Mamba/SSM replay with MTP and graph-padded batches."""
     image = ImageAsset("cherry_blossom").pil_image.convert("RGB")
     img_questions = [
         "What is the content of this image?",
         "Describe the content of this image in detail.",
         "What's in the image?",
-        "Where is this image taken?",
     ]
     images = [image] * len(img_questions)
     prompts = qwen_prompt(img_questions)
@@ -53,7 +56,9 @@ def test_mamba_ssm_multimodal_reasoning_mtp_full_decode_only():
         },
         compilation_config={
             "cudagraph_mode": "FULL_DECODE_ONLY",
-            "cudagraph_capture_sizes": [2, 4, 6, 8],
+            # Three requests with MTP1 schedule six decode tokens. Omitting
+            # capture size 6 forces replay on the padded size-8 graph.
+            "cudagraph_capture_sizes": [2, 4, 8],
         },
         speculative_config={
             "method": "mtp",
@@ -69,3 +74,13 @@ def test_mamba_ssm_multimodal_reasoning_mtp_full_decode_only():
         assert len(outputs) == len(prompts)
         for _, output_str in outputs:
             assert output_str, "Generated output should not be empty."
+
+        # Replay a smaller batch after the graph-padded three-request batch to
+        # catch stale query-start/state-index data in persistent GDN buffers.
+        replay_outputs = runner.generate_greedy(
+            prompts=prompts[:1],
+            images=images[:1],
+            max_tokens=16,
+        )
+        assert len(replay_outputs) == 1
+        assert replay_outputs[0][1], "Graph replay output should not be empty."

--- a/tests/ut/ops/test_gdn_attn_builder.py
+++ b/tests/ut/ops/test_gdn_attn_builder.py
@@ -589,6 +589,8 @@ def test_full_graph_non_spec_actual_seq_lengths_use_padded_builder_buffer():
 
     attn_metadata = builder.build(0, common_attn_metadata)
 
+    assert attn_metadata.num_actual_tokens == 4
+    assert attn_metadata.non_spec_state_indices_tensor.shape == (4,)
     assert torch.equal(
         attn_metadata.non_spec_query_start_loc,
         torch.tensor([0, 1, 2, 2, 2], dtype=torch.int32),

--- a/tests/ut/patch/worker/test_patch_mamba_utils_source.py
+++ b/tests/ut/patch/worker/test_patch_mamba_utils_source.py
@@ -6,6 +6,9 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+import torch
+
 ROOT = Path(__file__).resolve().parents[4]
 POSTPROCESS = ROOT / "vllm_ascend" / "ops" / "triton" / "mamba" / "postprocess.py"
 PATCH_MAMBA_UTILS = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_mamba_utils.py"
@@ -13,6 +16,14 @@ PATCH_MAMBA_UTILS = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_mamba_uti
 
 def _top_level_functions(path: Path) -> dict[str, ast.FunctionDef]:
     return {node.name: node for node in ast.parse(path.read_text()).body if isinstance(node, ast.FunctionDef)}
+
+
+def _load_tensor_view_from_data_ptr():
+    function = _top_level_functions(PATCH_MAMBA_UTILS)["_tensor_view_from_data_ptr"]
+    module = ast.fix_missing_locations(ast.Module(body=[function], type_ignores=[]))
+    namespace = {"torch": torch}
+    exec(compile(module, PATCH_MAMBA_UTILS, "exec"), namespace)
+    return namespace["_tensor_view_from_data_ptr"]
 
 
 def test_postprocess_keeps_only_existing_ascend_precision_kernel() -> None:
@@ -33,3 +44,28 @@ def test_patch_only_installs_existing_ascend_postprocess_kernel() -> None:
     assert "MambaBase.bind_kv_cache" not in patch_source
     assert "mamba_utils._copy_mamba_state_block" not in patch_source
     assert "mamba_utils.precopy_mamba_align_fused_kernel" not in patch_source
+
+
+def test_tensor_view_copy_is_bounded_by_logical_state_span() -> None:
+    tensor_view_from_data_ptr = _load_tensor_view_from_data_ptr()
+    backing = torch.arange(16, dtype=torch.float32)
+    state = torch.as_strided(
+        backing,
+        size=(2, 2),
+        stride=(4, 1),
+        storage_offset=2,
+    )
+
+    second_block = tensor_view_from_data_ptr(
+        state,
+        state[1].data_ptr(),
+        2,
+    )
+    assert torch.equal(second_block, backing[6:8])
+
+    with pytest.raises(RuntimeError, match="logical tensor span"):
+        tensor_view_from_data_ptr(
+            state,
+            state[1].data_ptr(),
+            3,
+        )

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -152,6 +152,15 @@ class TestAscendModelSlimConfig(TestBase):
             return_success=True,
         )
 
+    def test_modelslim_moe_weight_loader_is_not_wrapped_twice(self):
+        upstream_loader = MagicMock(return_value=True)
+        weight_loader = _make_modelslim_moe_weight_loader(upstream_loader)
+
+        self.assertIs(
+            _make_modelslim_moe_weight_loader(weight_loader),
+            weight_loader,
+        )
+
     def test_get_quant_method_for_moe_installs_modelslim_weight_loader(self):
         layer = RoutedExperts.__new__(RoutedExperts)
         torch.nn.Module.__init__(layer)

--- a/tests/ut/spec_decode/test_autoregressive_speculator.py
+++ b/tests/ut/spec_decode/test_autoregressive_speculator.py
@@ -1,0 +1,33 @@
+import torch
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+
+from vllm_ascend.attention.attention_v1 import AscendMetadata
+from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import (
+    AscendAutoRegressiveSpeculator,
+)
+
+
+def test_prefill_seq_lens_update_skips_gdn_metadata_in_hybrid_model():
+    speculator = AscendAutoRegressiveSpeculator.__new__(AscendAutoRegressiveSpeculator)
+    speculator.attn_architecture = "GQA"
+    attention_metadata = AscendMetadata(seq_lens=torch.tensor([3, 5]))
+    gdn_metadata = GDNAttentionMetadata(
+        num_prefills=0,
+        num_prefill_tokens=0,
+        num_decodes=2,
+        num_decode_tokens=2,
+        num_spec_decodes=0,
+        num_spec_decode_tokens=0,
+        num_actual_tokens=2,
+    )
+
+    speculator._ascend_update_seq_lens(
+        {
+            "model.layers.0.self_attn": attention_metadata,
+            "model.layers.1.linear_attn": gdn_metadata,
+        }
+    )
+
+    assert torch.equal(attention_metadata.seq_lens, torch.tensor([4, 6]))
+    assert attention_metadata.seq_len_list == [4, 6]
+    assert not hasattr(gdn_metadata, "seq_lens")

--- a/tests/ut/worker/test_aclgraph_utils_v2.py
+++ b/tests/ut/worker/test_aclgraph_utils_v2.py
@@ -1,0 +1,35 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from vllm_ascend.worker.v2.aclgraph_utils import (
+    ModelWithContext,
+    model_capture_wrapper,
+)
+
+
+def test_model_capture_wrapper_forwards_multimodal_embed_input_ids():
+    original_model = torch.nn.Module()
+    embedded_inputs = torch.randn(2, 4)
+    original_model.embed_input_ids = MagicMock(return_value=embedded_inputs)
+    speculator = SimpleNamespace(model=original_model)
+    input_ids = torch.tensor([1, 2])
+    multimodal_embeddings = [torch.randn(1, 4)]
+    is_multimodal = torch.tensor([True, False])
+
+    with model_capture_wrapper(speculator, is_draft_model_prefill=True):
+        assert isinstance(speculator.model, ModelWithContext)
+        result = speculator.model.embed_input_ids(
+            input_ids,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+
+    assert result is embedded_inputs
+    original_model.embed_input_ids.assert_called_once_with(
+        input_ids,
+        multimodal_embeddings=multimodal_embeddings,
+        is_multimodal=is_multimodal,
+    )
+    assert speculator.model is original_model

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -11,6 +11,9 @@ from vllm.v1.kv_cache_interface import (
     KVCacheTensor,
 )
 from vllm.v1.worker.gpu import attn_utils as upstream_attn_utils
+from vllm.v1.worker.gpu.model_states.mamba_hybrid import (
+    MambaHybridAttnMetadata,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.dsa_v1 import (
@@ -297,3 +300,37 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
     cache_name = "common_ratio_to_sas_metadata"
     assert calls[0][cache_name] is calls[1][cache_name]
     assert calls[1][cache_name]["first_group"] is True
+
+
+def test_mrv2_model_specific_is_prefilling_takes_precedence():
+    _, _, calls, attn_groups, kv_cache_config = _make_dsa_metadata_groups()
+    model_specific_is_prefilling = torch.tensor([True, False])
+
+    attn_utils.build_attn_metadata(
+        attn_groups=attn_groups,
+        num_reqs=2,
+        num_tokens=2,
+        query_start_loc_gpu=torch.tensor([0, 1, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 1, 2], dtype=torch.int32),
+        max_query_len=1,
+        seq_lens=torch.tensor([1, 1], dtype=torch.int32),
+        max_seq_len=1,
+        block_tables=(
+            torch.zeros((2, 1), dtype=torch.int32),
+            torch.zeros((2, 1), dtype=torch.int32),
+        ),
+        slot_mappings=torch.zeros((2, 2), dtype=torch.int32),
+        kv_cache_config=kv_cache_config,
+        seq_lens_np=np.array([1, 1], dtype=np.int32),
+        is_prefilling=torch.tensor([False, True]),
+        model_specific_attn_metadata=MambaHybridAttnMetadata(
+            is_prefilling=model_specific_is_prefilling,
+        ),
+    )
+
+    assert len(calls) == 2
+    for call in calls:
+        assert torch.equal(
+            call["common_attn_metadata"].is_prefilling,
+            model_specific_is_prefilling,
+        )

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -86,7 +86,7 @@ def test_mamba_model_state_inherits_upstream_state_management():
         (CUDAGraphMode.FULL, 4, 8),
     ],
 )
-def test_mamba_prepare_attn_merges_prefill_metadata_and_preserves_actual_tokens(
+def test_mamba_prepare_attn_merges_prefill_metadata_and_preserves_graph_tokens(
     cudagraph_mode,
     expected_num_reqs,
     expected_input_tokens,
@@ -129,7 +129,7 @@ def test_mamba_prepare_attn_merges_prefill_metadata_and_preserves_actual_tokens(
     )["linear_attn"]
 
     assert metadata.num_reqs == expected_num_reqs
-    assert metadata.num_actual_tokens == 5
+    assert metadata.num_actual_tokens == expected_input_tokens
     assert metadata.num_input_tokens == expected_input_tokens
     assert torch.equal(
         metadata.is_prefilling,

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -3,7 +3,10 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import numpy as np
+import pytest
 import torch
+from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -17,6 +20,7 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.worker.v2.attn_utils import (
     _allocate_kv_cache,
     _reshape_kv_cache_v2,
+    _reshape_mamba_kv_cache,
     get_kv_cache_spec,
 )
 from vllm_ascend.worker.v2.model_states import init_asecnd_model_state
@@ -63,10 +67,74 @@ def _group(spec: MambaSpec):
     )
 
 
+class _RecordingMetadataBuilder:
+    def build(self, common_prefix_len, common_attn_metadata, **kwargs):
+        del common_prefix_len, kwargs
+        return common_attn_metadata
+
+
 def test_mamba_model_state_inherits_upstream_state_management():
     assert issubclass(AscendMambaHybridModelState, MambaHybridModelState)
     assert AscendMambaHybridModelState.preprocess_state is MambaHybridModelState.preprocess_state
     assert AscendMambaHybridModelState.postprocess_state is MambaHybridModelState.postprocess_state
+
+
+@pytest.mark.parametrize(
+    ("cudagraph_mode", "expected_num_reqs", "expected_input_tokens"),
+    [
+        (CUDAGraphMode.NONE, 2, 5),
+        (CUDAGraphMode.FULL, 4, 8),
+    ],
+)
+def test_mamba_prepare_attn_merges_prefill_metadata_and_preserves_actual_tokens(
+    cudagraph_mode,
+    expected_num_reqs,
+    expected_input_tokens,
+):
+    state = AscendMambaHybridModelState.__new__(AscendMambaHybridModelState)
+    state.max_model_len = 8
+    state.vllm_config = SimpleNamespace(num_speculative_tokens=0)
+
+    spec = _mamba_spec()
+    builder = _RecordingMetadataBuilder()
+    group = SimpleNamespace(
+        kv_cache_group_id=0,
+        kv_cache_spec=spec,
+        layer_names=["linear_attn"],
+        get_metadata_builder=lambda _index: builder,
+    )
+    input_batch = SimpleNamespace(
+        num_reqs=2,
+        num_reqs_after_padding=4,
+        num_tokens=5,
+        num_tokens_after_padding=8,
+        query_start_loc_np=np.array([0, 2, 5, 5, 5], dtype=np.int32),
+        query_start_loc=torch.tensor([0, 2, 5, 5, 5], dtype=torch.int32),
+        num_scheduled_tokens=np.array([2, 3], dtype=np.int32),
+        seq_lens=torch.tensor([2, 3, 0, 0], dtype=torch.int32),
+        seq_lens_np=np.array([2, 3, 0, 0], dtype=np.int32),
+        is_prefilling_np=np.array([True, False]),
+        dcp_local_seq_lens=None,
+        positions=torch.arange(8, dtype=torch.int32),
+        attn_state=None,
+    )
+
+    metadata = state.prepare_attn(
+        input_batch=input_batch,
+        cudagraph_mode=cudagraph_mode,
+        block_tables=(torch.zeros((4, 1), dtype=torch.int32),),
+        slot_mappings=torch.zeros((1, 8), dtype=torch.int32),
+        attn_groups=[[group]],
+        kv_cache_config=_kv_cache_config(spec, num_blocks=1),
+    )["linear_attn"]
+
+    assert metadata.num_reqs == expected_num_reqs
+    assert metadata.num_actual_tokens == 5
+    assert metadata.num_input_tokens == expected_input_tokens
+    assert torch.equal(
+        metadata.is_prefilling,
+        torch.tensor([True, False, *([False] * (expected_num_reqs - 2))]),
+    )
 
 
 def test_prepare_inputs_propagates_padded_request_count():
@@ -135,6 +203,110 @@ def test_mamba_cache_reshape_returns_contiguous_state_tensors(_mock_config):
     assert ssm_state.is_contiguous()
     assert conv_state.data_ptr() == raw_cache.data_ptr()
     assert ssm_state.data_ptr() - raw_cache.data_ptr() == (conv_state.numel() * conv_state.element_size())
+
+
+def test_mamba_cache_reshape_rejects_unaligned_state_offset():
+    spec = MambaSpec(
+        block_size=1,
+        shapes=((1,), (1,)),
+        dtypes=(torch.float16, torch.float32),
+        page_size_padded=8,
+    )
+
+    with pytest.raises(ValueError, match=r"Mamba state 1 byte offset 2 is not aligned"):
+        _reshape_mamba_kv_cache(
+            torch.zeros(spec.page_size_bytes, dtype=torch.int8),
+            spec,
+        )
+
+
+@patch(
+    "vllm_ascend.worker.v2.attn_utils.get_current_vllm_config",
+    return_value=SimpleNamespace(kv_transfer_config=None),
+)
+def test_hybrid_attention_cache_rejects_unaligned_typed_view(_mock_config):
+    spec = FullAttentionSpec(
+        block_size=1,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float16,
+        page_size_padded=5,
+    )
+    backend = MagicMock()
+    backend.get_kv_cache_shape.return_value = (2, 1, 1, 1, 1)
+    group = SimpleNamespace(
+        kv_cache_group_id=0,
+        kv_cache_spec=spec,
+        layer_names=["full_attn"],
+        backend=backend,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[KVCacheTensor(size=5, shared_by=["full_attn"])],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=["full_attn"],
+                kv_cache_spec=spec,
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match=r"Attention K cache.*byte offset 1 is not aligned"):
+        _reshape_kv_cache_v2(
+            attn_groups=[group],
+            kv_cache_raw_tensors={"full_attn": torch.zeros(5, dtype=torch.int8)},
+            cache_dtype="auto",
+            kernel_block_sizes=[1],
+            shared_kv_cache_layers={},
+            kv_cache_config=kv_cache_config,
+        )
+
+
+@patch(
+    "vllm_ascend.worker.v2.attn_utils.get_current_vllm_config",
+    return_value=SimpleNamespace(kv_transfer_config=None),
+)
+def test_hybrid_cache_rejects_unsupported_packed_block_stride(_mock_config):
+    attention_spec = FullAttentionSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float16,
+        page_size_padded=20,
+    )
+    mamba_spec = MambaSpec(
+        block_size=4,
+        shapes=((2,), (4,)),
+        dtypes=(torch.float16, torch.float16),
+        page_size_padded=20,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[
+            KVCacheTensor(
+                size=40,
+                shared_by=["full_attn", "linear_attn"],
+                block_stride=20,
+            )
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                layer_names=["full_attn"],
+                kv_cache_spec=attention_spec,
+            ),
+            KVCacheGroupSpec(
+                layer_names=["linear_attn"],
+                kv_cache_spec=mamba_spec,
+            ),
+        ],
+    )
+
+    with pytest.raises(NotImplementedError, match="Packed block-stride KV cache layouts"):
+        _allocate_kv_cache(
+            kv_cache_config,
+            shared_layers={},
+            device=torch.device("cpu"),
+        )
 
 
 @patch(

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -37,7 +37,7 @@ def _batch_memcpy_triton(src_ptrs, dst_ptrs, sizes):
 def _tensor_view_from_data_ptr(state: torch.Tensor, start_addr: int, num_elements: int) -> torch.Tensor:
     byte_offset = start_addr - state.data_ptr()
     element_size = state.element_size()
-    if byte_offset < 0 or byte_offset % element_size != 0:
+    if byte_offset < 0 or byte_offset % element_size != 0 or num_elements < 0:
         raise RuntimeError("Invalid Mamba state copy pointer.")
 
     element_offset = byte_offset // element_size
@@ -45,15 +45,24 @@ def _tensor_view_from_data_ptr(state: torch.Tensor, start_addr: int, num_element
     # logical blocks can be separated by page padding. Flatten the underlying
     # storage from this state's first element instead of requiring the logical
     # state tensor itself to be contiguous.
+    if state.numel() == 0:
+        logical_storage_span = 0
+    else:
+        if any(stride < 0 for stride in state.stride()):
+            raise RuntimeError("Negative-stride Mamba state views are not supported.")
+        logical_storage_span = 1 + sum((size - 1) * stride for size, stride in zip(state.shape, state.stride()))
+
     storage_offset = state.storage_offset()
     storage_numel = state.untyped_storage().nbytes() // element_size
+    if storage_offset + logical_storage_span > storage_numel:
+        raise RuntimeError("Mamba state view exceeds its tensor storage.")
     flat_state = state.as_strided(
-        (storage_numel - storage_offset,),
+        (logical_storage_span,),
         (1,),
         storage_offset=storage_offset,
     )
     if element_offset + num_elements > flat_state.numel():
-        raise RuntimeError("Mamba state copy range exceeds tensor storage.")
+        raise RuntimeError("Mamba state copy range exceeds the logical tensor span.")
     return flat_state.narrow(0, element_offset, num_elements)
 
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -61,13 +61,14 @@ _MOE_WEIGHT_LOADER_NAME_MAP = {
     "w2_scale_bias": "w2_scale",
 }
 _MODELSLIM_MOE_WEIGHT_LOADER_MARKER = "_modelslim_moe_weight_loader"
+_MODELSLIM_MOE_WEIGHT_LOADER_SENTINEL = object()
 
 
 def _make_modelslim_moe_weight_loader(
     weight_loader: Callable[..., bool | None],
 ) -> Callable[..., bool | None]:
     """Map ModelSlim MoE scale-bias names to the upstream scale path."""
-    if getattr(weight_loader, _MODELSLIM_MOE_WEIGHT_LOADER_MARKER, False):
+    if getattr(weight_loader, _MODELSLIM_MOE_WEIGHT_LOADER_MARKER, None) is _MODELSLIM_MOE_WEIGHT_LOADER_SENTINEL:
         return weight_loader
 
     @wraps(weight_loader)
@@ -91,7 +92,11 @@ def _make_modelslim_moe_weight_loader(
             return_success=return_success,
         )
 
-    setattr(modelslim_moe_weight_loader, _MODELSLIM_MOE_WEIGHT_LOADER_MARKER, True)
+    setattr(
+        modelslim_moe_weight_loader,
+        _MODELSLIM_MOE_WEIGHT_LOADER_MARKER,
+        _MODELSLIM_MOE_WEIGHT_LOADER_SENTINEL,
+    )
     return modelslim_moe_weight_loader
 
 

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -60,12 +60,15 @@ _MOE_WEIGHT_LOADER_NAME_MAP = {
     "w13_scale_bias": "w13_scale",
     "w2_scale_bias": "w2_scale",
 }
+_MODELSLIM_MOE_WEIGHT_LOADER_MARKER = "_modelslim_moe_weight_loader"
 
 
 def _make_modelslim_moe_weight_loader(
     weight_loader: Callable[..., bool | None],
 ) -> Callable[..., bool | None]:
     """Map ModelSlim MoE scale-bias names to the upstream scale path."""
+    if getattr(weight_loader, _MODELSLIM_MOE_WEIGHT_LOADER_MARKER, False):
+        return weight_loader
 
     @wraps(weight_loader)
     def modelslim_moe_weight_loader(
@@ -88,6 +91,7 @@ def _make_modelslim_moe_weight_loader(
             return_success=return_success,
         )
 
+    setattr(modelslim_moe_weight_loader, _MODELSLIM_MOE_WEIGHT_LOADER_MARKER, True)
     return modelslim_moe_weight_loader
 
 

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -194,6 +194,12 @@ class ModelWithContext(nn.Module):
     def get_original_model(self):
         return self.original_model
 
+    def embed_input_ids(self, *args, **kwargs):
+        # Multimodal autoregressive speculators embed inputs through the model
+        # while capturing draft-model graphs. Keep this auxiliary model API
+        # available while the original model is wrapped with capture context.
+        return self.original_model.embed_input_ids(*args, **kwargs)
+
     def compute_logits(self, hidden_states: torch.Tensor):
         # draft model has `compute_logits`, which is not in ModelWithContext
         return self.original_model.compute_logits(hidden_states)

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -215,11 +215,16 @@ def build_attn_metadata(
         # Hybrid drafters can configure causality per KV cache group.
         group_causal = causal if isinstance(causal, bool) else causal.get(i, True)
 
-        common_attn_metadata_extra_kwargs = (
+        common_attn_metadata_extra_kwargs = dict(
             model_specific_attn_metadata.get_extra_common_attn_kwargs(i, num_reqs)
             if model_specific_attn_metadata is not None
             else {}
         )
+        # Model-specific metadata (for example MambaHybridAttnMetadata) can
+        # already provide is_prefilling. Merge Ascend's direct override into
+        # the same dictionary instead of passing the keyword twice.
+        if is_prefilling is not None:
+            common_attn_metadata_extra_kwargs["is_prefilling"] = is_prefilling
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=query_start_loc_gpu,
             query_start_loc_cpu=query_start_loc_cpu,
@@ -235,7 +240,6 @@ def build_attn_metadata(
             attn_state=attn_state,
             graph_pad_size=graph_pad_size,
             num_input_tokens=num_input_tokens,
-            is_prefilling=is_prefilling,
             max_seq_len=max_seq_len,
             causal=group_causal,
             **common_attn_metadata_extra_kwargs,
@@ -548,6 +552,12 @@ def _allocate_kv_cache(
     has_mamba = any(isinstance(spec, MambaSpec) for spec in layer_kv_cache_spec.values())
     has_attention = any(isinstance(spec, AttentionSpec) for spec in layer_kv_cache_spec.values())
     use_hybrid_layout = has_mamba and has_attention
+    if use_hybrid_layout and any(tensor.block_stride > 0 for tensor in kv_cache_config.kv_cache_tensors):
+        raise NotImplementedError(
+            "Packed block-stride KV cache layouts are not supported for "
+            "Ascend hybrid Attention/Mamba models. Disable cross-layer "
+            "KV-cache packing."
+        )
 
     for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
         if not kv_cache_tensor.shared_by:
@@ -669,7 +679,8 @@ def _reshape_mamba_kv_cache(
 ) -> list[torch.Tensor]:
     """Create the contiguous per-state views used by the Ascend v1 runner."""
     page_size_bytes = kv_cache_spec.page_size_bytes
-    assert raw_cache.numel() % page_size_bytes == 0
+    if raw_cache.numel() % page_size_bytes:
+        raise ValueError("Mamba cache allocation is not a whole number of pages.")
     num_blocks = raw_cache.numel() // page_size_bytes
 
     state_tensors: list[torch.Tensor] = []
@@ -679,18 +690,39 @@ def _reshape_mamba_kv_cache(
     # tensor1: [(kv_padding), conv, ...]
     # tensor2: [k,            ssm,  ...]
     # tensor3: [v,            (mamba_padding), ...]
-    for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
+    for state_index, (shape, dtype) in enumerate(zip(kv_cache_spec.shapes, kv_cache_spec.dtypes)):
         target_shape = (num_blocks, *shape)
-        end_idx = start_idx + torch.empty(
+        state = _view_cache_bytes(
+            raw_cache,
+            start_idx,
             target_shape,
-            device="meta",
-        ).numel() * get_dtype_size(dtype)
-        state = raw_cache[start_idx:end_idx].view(dtype).view(target_shape)
+            dtype,
+            f"Mamba state {state_index}",
+        )
         state_tensors.append(state)
-        start_idx = end_idx
+        start_idx += state.numel() * state.element_size()
 
-    assert start_idx <= raw_cache.numel()
     return state_tensors
+
+
+def _view_cache_bytes(
+    raw_cache: torch.Tensor,
+    byte_offset: int,
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    cache_name: str,
+) -> torch.Tensor:
+    """Build a typed cache view after validating its byte range and alignment."""
+    if raw_cache.element_size() != 1:
+        raise TypeError(f"{cache_name} raw cache must use a byte-addressable dtype.")
+    dtype_size = get_dtype_size(dtype)
+    num_bytes = torch.empty(shape, device="meta").numel() * dtype_size
+    end_offset = byte_offset + num_bytes
+    if byte_offset < 0 or end_offset > raw_cache.numel():
+        raise ValueError(f"{cache_name} view exceeds the raw cache allocation.")
+    if (raw_cache.data_ptr() + byte_offset) % dtype_size:
+        raise ValueError(f"{cache_name} byte offset {byte_offset} is not aligned to {dtype}.")
+    return raw_cache[byte_offset:end_offset].view(dtype).view(shape)
 
 
 def _reshape_kv_cache_v2(
@@ -851,10 +883,20 @@ def _reshape_kv_cache_v2(
                 k_size = torch.empty(k_shape, device="meta").numel() * get_dtype_size(k_dtype)
                 v_size = torch.empty(v_shape, device="meta").numel() * get_dtype_size(v_dtype)
                 kv_start = raw_cache.numel() - k_size - v_size
-                if kv_start < 0:
-                    raise ValueError(f"Attention cache views exceed the allocation for {layer_name}.")
-                k_cache = raw_cache[kv_start : kv_start + k_size].view(k_dtype).view(k_shape)
-                v_cache = raw_cache[kv_start + k_size :].view(v_dtype).view(v_shape)
+                k_cache = _view_cache_bytes(
+                    raw_cache,
+                    kv_start,
+                    k_shape,
+                    k_dtype,
+                    f"Attention K cache for {layer_name}",
+                )
+                v_cache = _view_cache_bytes(
+                    raw_cache,
+                    kv_start + k_size,
+                    v_shape,
+                    v_dtype,
+                    f"Attention V cache for {layer_name}",
+                )
                 kv_caches[layer_name] = (k_cache, v_cache)
 
     for layer_name, target_layer_name in shared_kv_cache_layers.items():

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -221,10 +221,9 @@ def build_attn_metadata(
             else {}
         )
         # Model-specific metadata (for example MambaHybridAttnMetadata) can
-        # already provide is_prefilling. Merge Ascend's direct override into
-        # the same dictionary instead of passing the keyword twice.
-        if is_prefilling is not None:
-            common_attn_metadata_extra_kwargs["is_prefilling"] = is_prefilling
+        # provide a padding-aware value, which takes precedence over the
+        # default supplied by the Ascend model state.
+        group_is_prefilling = common_attn_metadata_extra_kwargs.pop("is_prefilling", is_prefilling)
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=query_start_loc_gpu,
             query_start_loc_cpu=query_start_loc_cpu,
@@ -240,6 +239,7 @@ def build_attn_metadata(
             attn_state=attn_state,
             graph_pad_size=graph_pad_size,
             num_input_tokens=num_input_tokens,
+            is_prefilling=group_is_prefilling,
             max_seq_len=max_seq_len,
             causal=group_causal,
             **common_attn_metadata_extra_kwargs,

--- a/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
+++ b/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
@@ -53,10 +53,10 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
     ) -> dict[str, Any]:
         if cudagraph_mode == CUDAGraphMode.FULL:
             num_reqs = input_batch.num_reqs_after_padding
-            num_tokens = input_batch.num_tokens_after_padding
+            num_input_tokens = input_batch.num_tokens_after_padding
         else:
             num_reqs = input_batch.num_reqs
-            num_tokens = input_batch.num_tokens
+            num_input_tokens = input_batch.num_tokens
 
         is_prefilling = torch.zeros(num_reqs, dtype=torch.bool, device="cpu")
         is_prefilling[: input_batch.num_reqs] = torch.from_numpy(input_batch.is_prefilling_np)
@@ -87,7 +87,9 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
         self.attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
-            num_tokens=num_tokens,
+            num_tokens=num_input_tokens,
+            num_actual_tokens=input_batch.num_tokens,
+            num_input_tokens=num_input_tokens,
             query_start_loc_gpu=input_batch.query_start_loc,
             query_start_loc_cpu=torch.from_numpy(input_batch.query_start_loc_np),
             max_query_len=input_batch.num_scheduled_tokens.max().item(),

--- a/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
+++ b/vllm_ascend/worker/v2/model_states/mamba_hybrid.py
@@ -53,10 +53,10 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
     ) -> dict[str, Any]:
         if cudagraph_mode == CUDAGraphMode.FULL:
             num_reqs = input_batch.num_reqs_after_padding
-            num_input_tokens = input_batch.num_tokens_after_padding
+            num_tokens = input_batch.num_tokens_after_padding
         else:
             num_reqs = input_batch.num_reqs
-            num_input_tokens = input_batch.num_tokens
+            num_tokens = input_batch.num_tokens
 
         is_prefilling = torch.zeros(num_reqs, dtype=torch.bool, device="cpu")
         is_prefilling[: input_batch.num_reqs] = torch.from_numpy(input_batch.is_prefilling_np)
@@ -87,9 +87,11 @@ class AscendMambaHybridModelState(MambaHybridModelState, AscendModelState):
         self.attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
-            num_tokens=num_input_tokens,
-            num_actual_tokens=input_batch.num_tokens,
-            num_input_tokens=num_input_tokens,
+            # GDN FULL graph replay executes a statically padded token shape.
+            # Keep num_actual_tokens and num_input_tokens on that graph shape;
+            # the GDN builder uses the former to size and refresh its captured
+            # state-index and query-start buffers.
+            num_tokens=num_tokens,
             query_start_loc_gpu=input_batch.query_start_loc,
             query_start_loc_cpu=torch.from_numpy(input_batch.query_start_loc_np),
             max_query_len=input_batch.num_scheduled_tokens.max().item(),

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -35,10 +35,10 @@ from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import AutoRegressiveSpeculator
 from vllm.v1.worker.utils import AttentionGroup
 
-from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
+from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState, AscendMetadata
 from vllm_ascend.attention.dsa_v1 import AscendDSABackend
 from vllm_ascend.attention.indexer import AscendSFAIndexerBackend
-from vllm_ascend.attention.mla_v1 import AscendMLABackend
+from vllm_ascend.attention.mla_v1 import AscendMLABackend, AscendMLAMetadata
 from vllm_ascend.attention.sfa_v1 import AscendSFABackend
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata_wrapper
 from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
@@ -387,6 +387,11 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             return
         if attn_metadata is not None:
             for attn_meta in attn_metadata.values():
+                # Draft prefill reuses the target model's metadata. Hybrid
+                # models include GDN/SSM metadata in the same dictionary, but
+                # only GQA and MLA metadata use the FIA sequence-length fields.
+                if not isinstance(attn_meta, (AscendMetadata, AscendMLAMetadata)):
+                    continue
                 attn_meta.seq_lens = attn_meta.seq_lens + 1
                 attn_meta.seq_len_list = attn_meta.seq_lens.tolist()
 

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -393,7 +393,11 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 if not isinstance(attn_meta, (AscendMetadata, AscendMLAMetadata)):
                     continue
                 attn_meta.seq_lens = attn_meta.seq_lens + 1
-                attn_meta.seq_len_list = attn_meta.seq_lens.tolist()
+                # AscendMLAMetadata receives seq_len_list dynamically in the
+                # existing draft path, while AscendMetadata declares it as a
+                # dataclass field. Keep that behavior without pretending the
+                # MLA type statically owns the field.
+                cast(Any, attn_meta).seq_len_list = attn_meta.seq_lens.tolist()
 
     def _init_decode_draft_attn_metadatas(self, attn_metadata: dict[str, Any] | None, num_reqs_padded: int):
         """Initialize per-step decode attention metadata for graph mode."""


### PR DESCRIPTION
### What this PR does / why we need it?

This is a follow-up to #13350 for running hybrid Attention/Mamba models such as Qwen3.5 with ModelRunner V2 (`VLLM_USE_V2_MODEL_RUNNER=1`). It fixes metadata construction failures, preserves GDN FULL-graph replay semantics, and hardens hybrid-cache state handling.

#### 1. Merge `is_prefilling` without duplicate keywords

`MambaHybridAttnMetadata.get_extra_common_attn_kwargs()` already provides a padding-aware `is_prefilling`, while #14211 added a direct `is_prefilling` argument to the Ascend metadata builder. Expanding both values raises a duplicate-keyword `TypeError`.

The builder now removes `is_prefilling` from the model-specific dictionary and passes it exactly once. As in upstream vLLM, the model-specific padding-aware value takes precedence over the generic Ascend value.

#### 2. Preserve padded GDN token counts during FULL graph replay

GDN/Mamba FULL graph execution uses a static, token-padded graph shape. `AscendGDNAttentionMetadataBuilder` consumes `num_actual_tokens` to size and refresh persistent state-index and query-start buffers.

The Mamba hybrid model state therefore keeps both `num_actual_tokens` and `num_input_tokens` on `num_tokens_after_padding` in FULL mode, matching upstream `MambaHybridModelState`. Eager and non-FULL execution continue to use the unpadded scheduled-token count.

This supersedes the first revision of this PR, which incorrectly separated the two counts for the Mamba/GDN path and could make graph metadata shapes dynamic across capture and replay.

#### 3. Validate typed views of hybrid KV-cache storage

Mamba state and Attention K/V tensors are reinterpreted from a shared raw byte allocation. A common helper now validates:

- the raw allocation uses a one-byte dtype;
- the requested byte range remains inside the allocation;
- the resulting address is aligned for the target dtype.

Mamba state and hybrid Attention K/V reshaping both use this helper, producing explicit initialization errors instead of late `Tensor.view(dtype)` failures or unsafe views.

#### 4. Fail fast for unsupported packed hybrid layouts

The current Ascend hybrid runner implements the contiguous Attention/Mamba storage contract but not packed `KVCacheTensor.block_stride` semantics. Packed block-stride layouts are rejected for hybrid Attention/Mamba configurations instead of silently constructing incorrect cache views.

Standard Qwen3.5 hybrid cache layouts are unchanged. Cross-layer packing must remain disabled until the NPU kernels and state-copy path implement the packed layout.

#### 5. Bound Mamba fallback copies to the logical state span

The pointer-to-tensor helper used by the 310P fallback previously flattened the remainder of the entire backing storage. In a shared hybrid allocation, a bad range could reach another logical state or Attention cache region.

The helper now computes the storage span reachable from the state tensor's shape and strides, validates that span against the backing storage, and rejects copies outside it. Strided state tensors and internal page gaps remain supported.

#### 6. Make the ModelSlim MoE loader wrapper idempotent without false positives

Repeated quant-method resolution can encounter an already wrapped ModelSlim MoE loader. The wrapper now uses a module-private sentinel identity rather than a truthiness check.

The identity check is important for callable mocks and proxy objects: an arbitrary truthy attribute must not be mistaken for this wrapper's marker. This fixes the two CPU CI failures where `w13_scale_bias` and `w2_scale_bias` were not mapped to the upstream scale paths.

#### 7. Add MRV2 GDN graph-padding regression coverage

Unit tests now cover:

- model-specific `is_prefilling` precedence and duplicate-keyword avoidance;
- eager versus FULL Mamba model-state token-count semantics;
- the real `AscendGDNAttentionMetadataBuilder` padded state-index/query-start buffers;
- typed-view alignment and allocation bounds;
- unsupported packed block-stride layouts;
- logical-span bounds for pointer-based Mamba fallback copies;
- ModelSlim scale-name mapping and wrapper idempotency.

The existing Qwen3.5-0.8B NPU E2E test now explicitly sets `VLLM_USE_V2_MODEL_RUNNER=1`. It runs MTP1 with `FULL_DECODE_ONLY`, deliberately omits capture size 6 so a three-request/six-token decode replays on a padded size-8 graph, then replays a smaller batch to detect stale persistent GDN metadata.

#### 8. Forward multimodal embedding inputs through the graph-capture wrapper

The Qwen3.5 MRV2 E2E reached autoregressive MTP prefill FULL-graph capture, where upstream `_run_model()` calls `self.model.embed_input_ids(...)`. Ascend temporarily replaces `speculator.model` with `ModelWithContext`, but that wrapper did not expose the multimodal embedding helper, so engine initialization failed with `AttributeError: 'ModelWithContext' object has no attribute 'embed_input_ids'`.

`ModelWithContext.embed_input_ids(*args, **kwargs)` now forwards the complete call unchanged to the original model. An explicit method is used instead of a generic `__getattr__` proxy so that `torch.nn.Module` submodule and parameter lookup semantics remain intact.

A CPU unit test reproduces the capture-wrapper lifecycle and verifies the multimodal embeddings, mask, return tensor, and restoration of the original model.

#### 9. Keep GDN metadata out of the MTP FIA sequence-length update

After the graph-capture wrapper fix, both supported vLLM revisions reached the next line in Qwen3.5 MRV2 prefill capture and failed in `_ascend_update_seq_lens()`. Draft prefill reuses the target model's complete metadata dictionary; for a hybrid Qwen3.5 model that dictionary contains both ordinary Attention metadata and `GDNAttentionMetadata`.

The Ascend helper previously treated every entry as FIA/MLA metadata and unconditionally accessed `seq_lens`. GDN metadata intentionally has state-index and query-start fields instead, so this raised `AttributeError: 'GDNAttentionMetadata' object has no attribute 'seq_lens'`.

The update is now restricted to `AscendMetadata` and `AscendMLAMetadata`. GDN/SSM metadata remains owned by its builder and recurrent-state path. A CPU regression test uses the real GDN metadata class in a mixed Attention/GDN dictionary and verifies that Attention lengths advance while GDN remains untouched.

#### 10. Keep the dynamic MLA sequence-list update type-safe

`AscendMetadata` declares `seq_len_list`, while the existing draft MLA path attaches the same compatibility field to `AscendMLAMetadata` dynamically. Narrowing the metadata union in section 9 made mypy correctly reject a normal attribute assignment on the MLA branch even though the runtime behavior is intentional.

The assignment now uses the file's existing `cast(Any, ...)` mechanism only at this dynamic compatibility boundary. The concrete `isinstance` guard still controls which metadata objects can reach the update, so this changes no runtime behavior and does not weaken the GDN exclusion.

Related: #13350, #14211

### Does this PR introduce _any_ user-facing change?

Yes.

- Qwen3.5 and other hybrid Attention/Mamba models using MRV2 no longer fail from duplicate `is_prefilling` metadata.
- GDN FULL graph replay retains its required static padded token shape.
- Invalid typed cache views and unsupported packed hybrid layouts fail during initialization with actionable errors.
- ModelSlim MoE scale-bias weights continue to map correctly even when quant-method resolution is repeated.
- Qwen3.5 multimodal MTP FULL-graph capture keeps the model embedding API available while the draft model is wrapped.
- Hybrid MTP prefill advances FIA/MLA sequence lengths without treating GDN recurrent metadata as ordinary Attention metadata.

No public API or environment variable is added.

### How was this patch tested?

Local checks completed on the preceding head `07b244687`:

```text
ruff 0.14.0 check <all changed Python files>
All checks passed!

ruff 0.14.0 format --check <all changed Python files>
8 files already formatted

python -m compileall -q <all changed Python files>
compileall passed

git diff --check
passed
```

The first CI run on `d68a6bc33` executed 2,398 CPU tests for each supported vLLM revision. All MRV2/GDN/cache tests passed; the only two failures were the ModelSlim false-positive marker tests fixed by `07b244687`.

GitHub Actions run [31996800183](https://github.com/vllm-project/vllm-ascend/actions/runs/31996800183), job [95292048723](https://github.com/vllm-project/vllm-ascend/actions/runs/31996800183/job/95292048723?pr=14395), reached Qwen3.5 MRV2 autoregressive MTP FULL-graph capture but failed before generation because `ModelWithContext` did not forward `embed_input_ids`. Commit `166be3fb3` fixes that exact initialization path.

GitHub Actions run [32007816541](https://github.com/vllm-project/vllm-ascend/actions/runs/32007816541) was audited in full:

- The only PR-related test failure was `test_mrv2_mamba_ssm_multimodal_reasoning_mtp_full_decode_only` in A2 part 2/5 for both vLLM v0.27.1 and vLLM main. Both failed at the same unguarded GDN `seq_lens` access fixed by commit `49e7e9675`.
- Seven A3 matrix jobs and the failure-analysis job failed before checkout because GitHub codeload returned HTTP 429 while downloading `actions/checkout` or `runs-on/cache`.
- The cancelled A3-2 main job had passed its earlier tests and was terminated by the self-hosted custom container while loading a 56.87 GiB Qwen3-30B-A3B checkpoint; it contained no pytest assertion or Python exception related to this PR.
- `ci-gate` failed because the selected-test matrix failed. Coverage-upload cancellation/skipping was downstream of the matrix result.

GitHub Actions run [32117607389](https://github.com/vllm-project/vllm-ascend/actions/runs/32117607389) confirmed that the complete pre-commit hook set passed on `49e7e9675`. Its separate mypy step then rejected the intentionally dynamic `seq_len_list` assignment on `AscendMLAMetadata`; commit `9edb00c9b` fixes that static-type boundary without changing the runtime metadata filtering.

On the current head `9edb00c9b`, GitHub Actions run [32118365990](https://github.com/vllm-project/vllm-ascend/actions/runs/32118365990) has passed the complete pre-commit hooks, mypy on Python 3.10/3.11/3.12, coverage recommendation, and test selection. The selector includes both the new mixed Attention/GDN unit test and the Qwen3.5 MRV2 NPU E2E; the CPU/NPU execution matrix is still running.

The current head validates or schedules:

```bash
pytest -sv tests/ut/spec_decode/test_autoregressive_speculator.py
pytest -sv tests/ut/worker/test_aclgraph_utils_v2.py
pytest -sv tests/ut/worker/test_model_runner_v2_mamba.py
pytest -sv tests/ut/worker/test_attn_utils_v2.py
pytest -sv tests/ut/ops/test_gdn_attn_builder.py
pytest -sv tests/ut/patch/worker/test_patch_mamba_utils_source.py
pytest -sv tests/ut/quantization/test_modelslim_config.py
pytest -sv tests/e2e/pull_request/one_card/test_qwen3_5_0_8b.py
```

For commits `166be3fb3`, `49e7e9675`, and `9edb00c9b`, Ruff lint and `git diff --check` pass for their changed files; Python syntax compilation passed for the new source and test files. The local Windows host does not provide PyTorch/torch_npu or a full vLLM test environment, so the CPU unit execution and NPU E2E are delegated to the repository CI matrix.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
