### PR TITLE
[BugFix][v0.26.0][Model] Propagate DeepSeek V4 routed SwiGLU limit

### DIFF
--- a/tests/ut/model_executor/test_deepseek_v4.py
+++ b/tests/ut/model_executor/test_deepseek_v4.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+from torch import nn
+
+from vllm_ascend.models import deepseek_v4
+
+
+class StubModule(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+
+def test_routed_moe_receives_configured_swiglu_limit(monkeypatch):
+    fused_moe_kwargs = {}
+
+    class StubFusedMoE(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            fused_moe_kwargs.update(kwargs)
+
+    monkeypatch.setattr(deepseek_v4, "FusedMoE", StubFusedMoE)
+    monkeypatch.setattr(deepseek_v4, "ReplicatedLinear", StubModule)
+    monkeypatch.setattr(deepseek_v4, "DeepseekV2MLP", StubModule)
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(
+        deepseek_v4,
+        "get_ep_group",
+        lambda: SimpleNamespace(device_group=SimpleNamespace(size=lambda: 1), rank_in_group=0),
+    )
+    monkeypatch.setattr(deepseek_v4, "get_ascend_config", lambda: SimpleNamespace(mix_placement=False))
+    monkeypatch.setattr(deepseek_v4.rocm_aiter_ops, "is_fused_moe_enabled", lambda: False)
+    monkeypatch.setattr(deepseek_v4.rocm_aiter_ops, "is_fusion_moe_shared_experts_enabled", lambda: False)
+
+    config = SimpleNamespace(
+        hidden_act="silu",
+        hidden_size=16,
+        moe_intermediate_size=8,
+        n_group=1,
+        n_routed_experts=8,
+        n_shared_experts=1,
+        norm_topk_prob=True,
+        num_experts_per_tok=2,
+        num_hash_layers=0,
+        routed_scaling_factor=2.5,
+        scoring_func="sigmoid",
+        swiglu_limit=10.0,
+        topk_group=1,
+    )
+    parallel_config = SimpleNamespace(
+        enable_eplb=False,
+        eplb_config=SimpleNamespace(num_redundant_experts=0),
+        use_sequence_parallel_moe=False,
+    )
+
+    deepseek_v4.DeepseekV4MoE(config, parallel_config, prefix="model.layers.1.mlp")
+
+    assert fused_moe_kwargs["swiglu_limit"] == config.swiglu_limit

--- a/vllm_ascend/models/deepseek_v4.py
+++ b/vllm_ascend/models/deepseek_v4.py
@@ -450,6 +450,7 @@ class DeepseekV4MoE(nn.Module):
             # DeepSeek V4: normalize top-k weights, then scale routed output.
             # AITER applies routed_scaling_factor internally.
             routed_scaling_factor=self.routed_scaling_factor,
+            swiglu_limit=self.swiglu_limit,
             e_score_correction_bias=self.gate.e_score_correction_bias,
             enable_eplb=self.enable_eplb,
             num_redundant_experts=self.n_redundant_experts,


### PR DESCRIPTION
### What this PR does / why we need it?

Ports #14364 to `releases/v0.26.0rc`.

DeepSeek V4 reads `config.swiglu_limit` and already passes it to the shared expert, but the Ascend model adapter does not pass it to routed experts. Checkpoints with `swiglu_limit=10.0` therefore execute routed experts without the required gate/up clamp.

This PR:

- passes `self.swiglu_limit` to the routed `FusedMoE` constructor;
- adds the focused unit test from #14364.

Fixes #14363

### Does this PR introduce _any_ user-facing change?

Yes. It restores the DeepSeek V4 routed-expert activation contract for checkpoints that configure a SwiGLU limit.

### How was this patch tested?

Local checks used the vLLM commit paired with this branch:

```bash
PYTHONPATH=$VLLM_SOURCE pytest -q tests/ut/model_executor/test_deepseek_v4.py
# 1 passed

ruff check vllm_ascend/models/deepseek_v4.py tests/ut/model_executor/test_deepseek_v4.py
# All checks passed!

python -m py_compile vllm_ascend/models/deepseek_v4.py tests/ut/model_executor/test_deepseek_v4.py
git diff --check upstream/releases/v0.26.0rc...HEAD
```

The port is file-for-file equivalent to #14364 for the two changed files. The real-weight BF16/W8A8 causal validation is documented in #14364 and was not rerun on this port head. That evidence showed the routed clamp recovering BF16 q0081 top-1 from `0/2` to `2/2`, and W8A8 historical top-1 from `12/47` to `44/47`.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
