### PR TITLE
[Bugfix] Fix bug that Megamoe might hang when handing a request

### DIFF
--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -2,10 +2,11 @@ import torch
 from vllm.config import ParallelConfig, get_current_vllm_config
 from vllm.distributed.parallel_state import GroupCoordinator, get_world_group, init_model_parallel_group
 
-from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_config import _MEGA_MOE_SUPPORTED, get_ascend_config
 
 # Currently, mc2 op need their own group coordinator.
 _MC2: GroupCoordinator | None = None
+_MC2_DRAFT: GroupCoordinator | None = None
 
 # Module specific tensor parallel groups
 _MLP_TP: GroupCoordinator | None = None
@@ -86,6 +87,17 @@ def init_ascend_model_parallel(
     global _MC2
     _MC2 = init_model_parallel_group(group_ranks, get_world_group().local_rank, backend, group_name="mc2")
 
+    # mc2 group draft model, only init when fused mc2 is enabled
+    if (
+        _MEGA_MOE_SUPPORTED
+        and get_ascend_config().enable_fused_mc2 == 1
+        and get_current_vllm_config().speculative_config
+    ):
+        global _MC2_DRAFT
+        _MC2_DRAFT = init_model_parallel_group(
+            group_ranks, get_world_group().local_rank, backend, group_name="mc2_draft"
+        )
+
     if get_ascend_config().eplb_config.dynamic_eplb:
         global _DYNAMIC_EPLB
         _DYNAMIC_EPLB = init_model_parallel_group(
@@ -135,12 +147,24 @@ def init_ascend_model_parallel(
 
 
 def model_parallel_initialized():
-    return _MC2 is not None
+    if (
+        _MEGA_MOE_SUPPORTED
+        and get_ascend_config().enable_fused_mc2 == 1
+        and get_current_vllm_config().speculative_config
+    ):
+        return _MC2 is not None and _MC2_DRAFT is not None
+    else:
+        return _MC2 is not None
 
 
 def get_mc2_group() -> GroupCoordinator:
     assert _MC2 is not None, "mc2 group is not initialized"
     return _MC2
+
+
+def get_mc2_draft_group() -> GroupCoordinator:
+    assert _MC2_DRAFT is not None, "mc2 draft group is not initialized"
+    return _MC2_DRAFT
 
 
 def get_mlp_tp_group() -> GroupCoordinator:
@@ -178,6 +202,16 @@ def destroy_ascend_model_parallel():
     if _MC2:
         _MC2.destroy()
     _MC2 = None
+
+    if (
+        _MEGA_MOE_SUPPORTED
+        and get_ascend_config().enable_fused_mc2 == 1
+        and get_current_vllm_config().speculative_config
+    ):
+        global _MC2_DRAFT
+        if _MC2_DRAFT:
+            _MC2_DRAFT.destroy()
+        _MC2_DRAFT = None
 
     global _MLP_TP
     if _MLP_TP:

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -24,7 +24,7 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_config import _MEGA_MOE_SUPPORTED, get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
-from vllm_ascend.distributed.parallel_state import get_mc2_group
+from vllm_ascend.distributed.parallel_state import get_mc2_draft_group, get_mc2_group
 from vllm_ascend.ops.fused_moe import moe_utils
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEFusedExpertsInput
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput, build_mlp_compute_input
@@ -259,9 +259,13 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
+        self._mega_moe_main_model_symm_buffer = None
+        self._mega_moe_main_model_weight_type = None
+        self._mega_moe_draft_model_symm_buffer = None
+        self._mega_moe_draft_model_weight_type = None
         if _MEGA_MOE_SUPPORTED:
-            self.mega_moe_symm_buffer = None
             self.get_symm_buffer_for_mega_moe, self.mega_moe = moe_utils.load_cann_mega_moe_ops()
+
         if get_ascend_config().enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
@@ -282,14 +286,16 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def _init_mega_moe_symm_buffer(
         self,
-        dispatch_quant_mode: int = 0,
-        dispatch_quant_out_dtype: torch.dtype | None = None,
+        fused_experts_input: MoEFusedExpertsInput,
+        group,
     ):
         # FusedMC2CommImpl always builds a TokenDispatcherWithMC2 (see
         # setup_moe_comm_method), which is where global_bs / ep_world_size live.
         # Assert it so mypy resolves those attributes off the base dispatcher.
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
-        group = get_mc2_group().device_group
+        dispatch_quant_mode, dispatch_quant_out_dtype, weight_type = moe_utils._get_cann_mega_moe_quant_settings(
+            fused_experts_input.quant.quant_type
+        )
         # The sym buffer is allocated by get_symm_buffer_for_mega_moe, a
         # collective handshake over the EP (mc2) group. Its shape params —
         # especially num_max_tokens_per_rank — MUST be identical on every EP
@@ -329,11 +335,11 @@ class FusedMC2CommImpl(MoECommMethod):
             num_max_tokens_per_rank,
             num_topk,
             hidden=self.moe_config.hidden_dim,
-            intermediate_hidden=2 * self.moe_config.intermediate_size_per_partition,
+            intermediate_hidden=self.moe_config.intermediate_size_per_partition,
             max_recv_token_num=max_recv_token_num,
             dispatch_quant_mode=dispatch_quant_mode,
             dispatch_quant_out_dtype=dispatch_quant_out_dtype,
-        )
+        ), weight_type
 
     def _apply_cann_mega_moe(
         self,
@@ -356,18 +362,6 @@ class FusedMC2CommImpl(MoECommMethod):
         # they are passed through as-is here. W8A8 weights are already int8 + FRACTAL_NZ, also as-is.
         weight_scales1 = fused_experts_input.weights.w1_scale
         weight_scales2 = fused_experts_input.weights.w2_scale
-        dispatch_quant_mode, dispatch_quant_out_dtype, weight_type = moe_utils._get_cann_mega_moe_quant_settings(
-            fused_experts_input.quant.quant_type
-        )
-
-        if self.mega_moe_symm_buffer is None:
-            self.mega_moe_symm_buffer = self._init_mega_moe_symm_buffer(
-                dispatch_quant_mode,
-                dispatch_quant_out_dtype,
-            )
-        else:
-            self.mega_moe_symm_buffer.dispatch_quant_mode = dispatch_quant_mode
-            self.mega_moe_symm_buffer.dispatch_quant_out_dtype = dispatch_quant_out_dtype
 
         activation_clamp = self.swiglu_limit if self.swiglu_limit > 0 else None
         x_active_mask = None
@@ -386,13 +380,47 @@ class FusedMC2CommImpl(MoECommMethod):
         l1_bias = fused_experts_input.weights.w1_scale_bias
         l2_bias = fused_experts_input.weights.w2_scale_bias
 
+        symm_buffer = None
+        weight_type = None
+        if _EXTRA_CTX.is_draft_model:
+            if self._mega_moe_draft_model_symm_buffer is None:
+                # MegaMoe need to used 2 communication group, one is for main model, the other one is for
+                # draft model. This additional group is for draft model. The get_hccl_comm_name function
+                # contains some communicator operations and needs to be called to initialize the
+                # corresponding communication group. This group only initialized when speculative decode
+                # is enabled.
+                draft_device_group = get_mc2_draft_group().device_group
+                draft_local_rank = torch.distributed.get_rank(group=draft_device_group)
+                draft_backend = draft_device_group._get_backend(torch.device("npu"))
+                self.moe_all_to_all_draft_group_name = draft_backend.get_hccl_comm_name(draft_local_rank)
+
+                self._mega_moe_draft_model_symm_buffer, self._mega_moe_draft_model_weight_type = (
+                    self._init_mega_moe_symm_buffer(
+                        fused_experts_input,
+                        draft_device_group,
+                    )
+                )
+            symm_buffer = self._mega_moe_draft_model_symm_buffer
+            weight_type = self._mega_moe_draft_model_weight_type
+        else:
+            if self._mega_moe_main_model_symm_buffer is None:
+                group = get_mc2_group().device_group
+                self._mega_moe_main_model_symm_buffer, self._mega_moe_main_model_weight_type = (
+                    self._init_mega_moe_symm_buffer(
+                        fused_experts_input,
+                        group,
+                    )
+                )
+            symm_buffer = self._mega_moe_main_model_symm_buffer
+            weight_type = self._mega_moe_main_model_weight_type
+
         out, expert_tokens = self.mega_moe(
             fused_experts_input.hidden_states,
             fused_experts_input.topk_ids.to(torch.int32),
             fused_experts_input.topk_weights.to(torch.float32),
             weight1,
             weight2,
-            self.mega_moe_symm_buffer,
+            symm_buffer,
             l1_weights_sf=weight_scales1,
             l2_weights_sf=weight_scales2,
             l1_bias=l1_bias,

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -44,7 +44,7 @@ def _normalize_backend(backend: str | Backend) -> str:
 
 def _resolve_reuse_domain(group_name: str) -> str:
     group_base_name = group_name.split(":")[0]
-    if "eplb" in group_base_name or group_base_name == "mc2":
+    if "eplb" in group_base_name or group_base_name in {"mc2", "mc2_draft"}:
         return group_base_name
     return "shared"
 

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -995,6 +995,7 @@ def get_hccl_config_for_pg_options(group_name: str) -> dict | None:
     # FIXME: Current mc2 operators only perform communication space partitioning
     # based on HCCL_BUFFSIZE configuration. Using pg_options with mc2 group would
     # result in memory misalignment problems.
+    # For mc2/mc2_draft group
     if group_name and "mc2" in group_name:
         return None
     hccl_config_map = {


### PR DESCRIPTION
### What this PR does / why we need it?
**Problem**: For some models like Qwen3.5-397B-A17B-w8a8-mtp, after the model is deployed and a request is sended, the vllm process will hang and an error will be reported after a period of time. This issue exists in some relatively large models that have draft models, and where the quantization methods of the draft model and the main model are inconsistent.
**Reason**: For mega moe, using only one single buffer for main model and draft model may raise an error, because they use the same communication group, which may cause memory trampling.
**Solution**:
1. Use 2 communication group. Add new communication group mc2_draft.
2. Use 2 buffer for MegaMoe
### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
Qwen3.5-397B-A17B-w8a8-mtp is tested and the hang problem is solved


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
