### PR TITLE
feat(ascend-store): allow ubshmem transfer protocol

### DIFF
--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -108,6 +108,18 @@ class TestMooncakeStoreConfig(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_from_file_allows_ubshmem(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"protocol": "ubshmem"}, f)
+            f.flush()
+            path = f.name
+
+        try:
+            cfg = MooncakeStoreConfig.from_file(path)
+            self.assertEqual(cfg.protocol, "ubshmem")
+        finally:
+            os.unlink(path)
+
     def test_from_file_ssd_offload(self):
         ssd_path = TestMooncakeStoreConfig._writable_ssd_path()
         self.addCleanup(lambda: os.rmdir(ssd_path))
@@ -325,6 +337,17 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         b.store.batch_is_exist.return_value = [1, 0]
         result = b.exists(["k1", "k2"])
         self.assertEqual(result, [1, 0])
+
+    def test_init_rejects_unknown_protocol(self):
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend."
+            "mooncake_backend.MooncakeStoreConfig.load_from_env",
+            return_value=MagicMock(protocol="badproto"),
+        ):
+            from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import MooncakeBackend
+
+            with self.assertRaises(NotImplementedError):
+                MooncakeBackend(MagicMock())
 
     def test_put(self):
         b = self._make_backend()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -63,7 +63,7 @@ class MooncakeBackend(Backend):
     def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False, contribute_memory: bool = True):
         self.parallel_config = parallel_config
         self.config = MooncakeStoreConfig.load_from_env()
-        if self.config.protocol != "ascend":
+        if self.config.protocol not in {"ascend", "ubshmem"}:
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
 
         self.store: Any | None = None
@@ -119,7 +119,7 @@ class MooncakeBackend(Backend):
         # and only can be used for 800 I/T A3 series.
         # Required supporting hardware versions are as follows:
         if not self._use_fabric_mem:
-            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
+            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None, protocol=self.config.protocol)
             self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
             ret = store.setup(
                 local_hostname=self.local_seg,
@@ -173,7 +173,7 @@ class MooncakeBackend(Backend):
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
         if not self._use_fabric_mem:
             local_hostname = get_ip()
-            global_te.get_transfer_engine(local_hostname, device_name=None)
+            global_te.get_transfer_engine(local_hostname, device_name=None, protocol=self.config.protocol)
             global_te.register_buffer(ptrs, lengths)
 
     def exists(self, keys: list[str]) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
@@ -4,11 +4,12 @@ import threading
 class GlobalTE:
     def __init__(self):
         self.transfer_engine = None
+        self.transfer_protocol: str | None = None
         self.is_register_buffer: bool = False
         self.transfer_engine_lock = threading.Lock()
         self.register_buffer_lock = threading.Lock()
 
-    def get_transfer_engine(self, hostname: str, device_name: str | None):
+    def get_transfer_engine(self, hostname: str, device_name: str | None, protocol: str = "ascend"):
         if self.transfer_engine is None:
             with self.transfer_engine_lock:
                 # Double-Checked Locking
@@ -23,9 +24,15 @@ class GlobalTE:
                         ) from e
                     self.transfer_engine = TransferEngine()
                     device_name = device_name if device_name is not None else ""
-                    ret_value = self.transfer_engine.initialize(hostname, "P2PHANDSHAKE", "ascend", device_name)
+                    ret_value = self.transfer_engine.initialize(hostname, "P2PHANDSHAKE", protocol, device_name)
                     if ret_value != 0:
                         raise RuntimeError(f"TransferEngine initialization failed with ret_value: {ret_value}")
+                    self.transfer_protocol = protocol
+        elif self.transfer_protocol != protocol:
+            raise RuntimeError(
+                f"TransferEngine protocol mismatch: existing={self.transfer_protocol!r}, requested={protocol!r}."
+                " Rebuild with a single protocol per process."
+            )
         return self.transfer_engine
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):


### PR DESCRIPTION
## Summary
Enable AscendStore to select Mooncake transfer protocol dynamically and allow `ubshmem`.

This PR keeps existing behavior for `ascend` by default and only changes the transport protocol plumbing path in the Mooncake-backed AscendStore path.

## Changes
- `vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine`
  - extend `GlobalTE.get_transfer_engine()` to accept `protocol` (default `"ascend"`) instead of hardcoding.
  - initialize `TransferEngine` using the requested protocol.
  - record initialized protocol and reject protocol mismatch on reuse.

- `vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend`
  - allow `protocol` values `{"ascend", "ubshmem"}` in `MooncakeBackend`.
  - pass `self.config.protocol` into `global_te.get_transfer_engine(...)` for setup and buffer registration.

- Tests (`tests/ut/distributed/ascend_store/test_backend.py`)
  - add config parsing assertion for `protocol="ubshmem"`.
  - add init-time rejection test for unknown protocol.

## Why now
This is the minimal vLLM-Ascend transport fix to enable UBShmem usage without changing put/get paths.

## Validation
- `python3 -m py_compile vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py tests/ut/distributed/ascend_store/test_backend.py`

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
