### PR TITLE
[Refactor] Reuse pre-allocated buffers to avoid padding allocations

### DIFF
--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -24,7 +24,6 @@ from typing import Any, cast
 
 import numpy as np
 import torch
-import torch.nn as nn
 import torch_npu
 from vllm.config import CUDAGraphMode
 from vllm.forward_context import get_forward_context
@@ -559,7 +558,7 @@ class NPUModelRunner310(NPUModelRunner):
             self.set_active_loras(self.input_batch, num_scheduled_tokens, num_sampled_tokens)
         if lmhead_tp_enable():
             max_num_reqs_across_dp = self.max_num_reqs * self.uniform_decode_query_len
-            logits_indices = nn.functional.pad(logits_indices, (0, max_num_reqs_across_dp - logits_indices.shape[0]))
+            logits_indices = self._pad_lmhead_tp_logits_indices(logits_indices, max_num_reqs_across_dp)
 
         return (
             logits_indices,

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -114,8 +114,10 @@ class AscendSFADSACPMetadataBuilder(AscendSFAMetadataBuilder):
         self.dsa_cp_actual_seq_lengths_key = torch.empty_like(self.dsa_cp_actual_seq_lengths_query)
         self.dsa_cp_spec_actual_seq_lengths_query: list[torch.Tensor] | None = None
         self.dsa_cp_spec_actual_seq_lengths_key: list[torch.Tensor] | None = None
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         if self.speculative_config:
             spec_token_num = self.speculative_config.num_speculative_tokens
+            max_num_tokens = max(max_num_tokens, max_num_reqs * (spec_token_num + 1))
             self.dsa_cp_spec_actual_seq_lengths_query = [
                 torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
                 for _ in range(spec_token_num)
@@ -124,6 +126,8 @@ class AscendSFADSACPMetadataBuilder(AscendSFAMetadataBuilder):
                 torch.zeros(max_num_reqs * (spec_token_num + 1) + 1, dtype=torch.int32, device=device)
                 for _ in range(spec_token_num)
             ]
+        max_num_tokens_pad = _round_up(max_num_tokens, vllm_config.parallel_config.tensor_parallel_size)
+        self._slot_mapping_pad_buffer = torch.empty(max_num_tokens_pad, dtype=torch.int32, device=device)
 
     def _prepare_parallel_metadata(
         self,
@@ -159,7 +163,9 @@ class AscendSFADSACPMetadataBuilder(AscendSFAMetadataBuilder):
             sin = nn.functional.pad(sin, (0, 0, 0, 0, 0, 0, 0, pad_size))
         pad_size_slot = num_tokens_pad - slot_mapping.shape[0]
         if pad_size_slot > 0:
-            slot_mapping = nn.functional.pad(slot_mapping, (0, pad_size_slot), value=-1)
+            self._slot_mapping_pad_buffer[: slot_mapping.shape[0]].copy_(slot_mapping)
+            self._slot_mapping_pad_buffer[slot_mapping.shape[0] : num_tokens_pad].fill_(-1)
+            slot_mapping = self._slot_mapping_pad_buffer[:num_tokens_pad]
         else:
             slot_mapping = slot_mapping[:num_tokens_pad]
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -264,20 +264,9 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             self.speculative_config is not None
             and self.speculative_config.disable_padded_drafter_batch
         )
-        capture_sizes = vllm_config.compilation_config.cudagraph_capture_sizes
-        if isinstance(capture_sizes, list) and capture_sizes:
-            capture_sizes = sorted(capture_sizes)
-            max_graph_input_size = (
-                max_num_reqs
-                if disable_padded_drafter_batch
-                else max_num_reqs * self.decode_threshold
-            )
-            max_graph_pad_size = next(
-                (size for size in capture_sizes if size >= max_graph_input_size),
-                capture_sizes[-1],
-            )
-        else:
-            max_graph_pad_size = max_num_reqs * self.decode_threshold
+        max_graph_pad_size = vllm_config.compilation_config.max_cudagraph_capture_size
+        if not isinstance(max_graph_pad_size, int):
+            max_graph_pad_size = scheduler_config.max_num_batched_tokens
         self._max_pad_num_reqs = (
             max_graph_pad_size
             if disable_padded_drafter_batch

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -260,7 +260,29 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
 
         max_num_reqs = scheduler_config.max_num_seqs
         num_mtp_draft_slots = max(self.decode_threshold - 2, 0) * max_num_reqs
-        self._max_pad_num_reqs = max_num_reqs
+        disable_padded_drafter_batch = (
+            self.speculative_config is not None
+            and self.speculative_config.disable_padded_drafter_batch
+        )
+        capture_sizes = vllm_config.compilation_config.cudagraph_capture_sizes
+        if isinstance(capture_sizes, list) and capture_sizes:
+            capture_sizes = sorted(capture_sizes)
+            max_graph_input_size = (
+                max_num_reqs
+                if disable_padded_drafter_batch
+                else max_num_reqs * self.decode_threshold
+            )
+            max_graph_pad_size = next(
+                (size for size in capture_sizes if size >= max_graph_input_size),
+                capture_sizes[-1],
+            )
+        else:
+            max_graph_pad_size = max_num_reqs * self.decode_threshold
+        self._max_pad_num_reqs = (
+            max_graph_pad_size
+            if disable_padded_drafter_batch
+            else max_graph_pad_size // self.decode_threshold
+        )
         self._max_pad_num_tokens = scheduler_config.max_num_batched_tokens + num_mtp_draft_slots
         self._pad_buffers: dict[str, torch.Tensor] = {}
 
@@ -294,6 +316,10 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         max_size: int,
         pad_value: int,
     ) -> torch.Tensor:
+        assert target_size <= max_size, (
+            f"Padding target size {target_size} exceeds "
+            f"the {key} buffer capacity {max_size}"
+        )
         buffer = self._pad_buffers.get(key)
         if buffer is None:
             buffer = tensor.new_empty((max_size,) + tensor.shape[1:])

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -258,6 +258,12 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                 got {self.decode_threshold}"
             )
 
+        max_num_reqs = scheduler_config.max_num_seqs
+        num_mtp_draft_slots = max(self.decode_threshold - 2, 0) * max_num_reqs
+        self._max_pad_num_reqs = max_num_reqs
+        self._max_pad_num_tokens = scheduler_config.max_num_batched_tokens + num_mtp_draft_slots
+        self._pad_buffers: dict[str, torch.Tensor] = {}
+
         self.reorder_batch_threshold = self.decode_threshold
         self.rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
         self.cos_cache = None
@@ -279,6 +285,22 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         self.query_lens: torch.Tensor = None
         self.seq_lens: torch.Tensor = None
         self.attn_mask_builder = AttentionMaskBuilder(self.device)
+
+    def _pad_to_max_buffer(
+        self,
+        key: str,
+        tensor: torch.Tensor,
+        target_size: int,
+        max_size: int,
+        pad_value: int,
+    ) -> torch.Tensor:
+        buffer = self._pad_buffers.get(key)
+        if buffer is None:
+            buffer = tensor.new_empty((max_size,) + tensor.shape[1:])
+            self._pad_buffers[key] = buffer
+        buffer[: tensor.shape[0]].copy_(tensor)
+        buffer[tensor.shape[0] : target_size].fill_(pad_value)
+        return buffer[:target_size]
 
     @staticmethod
     def determine_chunked_prefill_workspace_size(vllm_config: VllmConfig) -> int:
@@ -604,35 +626,39 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                     num_reqs_pad_size, num_reqs, actual_seq_lengths_q
                 )
                 seq_lens_list = seq_lens_list + [0] * (self.graph_pad_size - self.num_decodes)
-                num_block_pad_size = self.graph_pad_size - self.block_table.shape[0]
-                if num_block_pad_size > 0:
-                    block_table_padding = torch.zeros(
-                        (num_block_pad_size,) + self.block_table.shape[1:],
-                        dtype=self.block_table.dtype,
-                        device=self.block_table.device,
+                if self.graph_pad_size > self.block_table.shape[0]:
+                    self.block_table = self._pad_to_max_buffer(
+                        "block_table",
+                        self.block_table,
+                        self.graph_pad_size,
+                        self._max_pad_num_reqs,
+                        0,
                     )
-                    self.block_table = torch.cat([self.block_table, block_table_padding], dim=0)
             else:
-                num_token_pad_size = self.graph_pad_size - self.num_decode_tokens
                 num_reqs_pad_size = self.graph_pad_size // common_attn_metadata.decode_token_per_req - num_reqs
-                num_block_table_pad_size = (
-                    self.graph_pad_size // common_attn_metadata.decode_token_per_req - self.num_decodes
-                )
+                block_table_size = self.graph_pad_size // common_attn_metadata.decode_token_per_req
                 seq_lens_list = self.seq_lens.tolist() + [0] * num_reqs_pad_size
-                slot_padding = torch.full(
-                    (num_token_pad_size,), PAD_SLOT_ID, dtype=self.slot_mapping.dtype, device=self.slot_mapping.device
+                self.slot_mapping = self._pad_to_max_buffer(
+                    "slot_mapping",
+                    self.slot_mapping,
+                    self.graph_pad_size,
+                    self._max_pad_num_tokens,
+                    PAD_SLOT_ID,
                 )
-                self.slot_mapping = torch.cat([self.slot_mapping, slot_padding])
-                block_table_padding = torch.zeros(
-                    (num_block_table_pad_size,) + self.block_table.shape[1:],
-                    dtype=self.block_table.dtype,
-                    device=self.block_table.device,
+                self.block_table = self._pad_to_max_buffer(
+                    "block_table",
+                    self.block_table,
+                    block_table_size,
+                    self._max_pad_num_reqs,
+                    0,
                 )
-                self.block_table = torch.cat([self.block_table, block_table_padding], dim=0)
-                position_padding = torch.zeros(
-                    num_token_pad_size, dtype=input_positions.dtype, device=input_positions.device
+                input_positions = self._pad_to_max_buffer(
+                    "input_positions",
+                    input_positions,
+                    self.graph_pad_size,
+                    self._max_pad_num_tokens,
+                    0,
                 )
-                input_positions = torch.cat([input_positions, position_padding])
                 actual_seq_lengths_q = self.pad_actual_seq_len_q_mtp_enable_pad(
                     num_reqs_pad_size, num_reqs, actual_seq_lengths_q, common_attn_metadata
                 )

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import einops
 import torch
-import torch.nn.functional as F
 import torch_npu
 from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention  # type: ignore
 
@@ -72,6 +71,24 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         )
 
         self.enable_pad = self.head_size > MIN_PAD_SIZE and self.head_size < MAX_PAD_SIZE
+        self._qkv_pad_buffers: dict[str, torch.Tensor] = {}
+
+    def _pad_qkv_tensor(self, key: str, tensor: torch.Tensor, origin_head_dim: int) -> torch.Tensor:
+        buffer = self._qkv_pad_buffers.get(key)
+        if (
+            buffer is None
+            or buffer.shape[0] < tensor.shape[0]
+            or buffer.shape[1:-1] != tensor.shape[1:-1]
+            or buffer.dtype != tensor.dtype
+            or buffer.device != tensor.device
+        ):
+            buffer = tensor.new_empty((tensor.shape[0], *tensor.shape[1:-1], MAX_PAD_SIZE))
+            self._qkv_pad_buffers[key] = buffer
+
+        padded = buffer[: tensor.shape[0]]
+        padded[..., :origin_head_dim].copy_(tensor)
+        padded[..., origin_head_dim:].zero_()
+        return padded
 
     def _reshape_qkv_to_3d(
         self,
@@ -106,10 +123,9 @@ class AscendMMEncoderAttention(MMEncoderAttention):
         if not self.enable_pad:
             return q, k, v, None
         origin_head_dim = q.shape[-1]
-        pad_len = MAX_PAD_SIZE - origin_head_dim
-        q = F.pad(q, (0, pad_len), mode="constant", value=0)
-        k = F.pad(k, (0, pad_len), mode="constant", value=0)
-        v = F.pad(v, (0, pad_len), mode="constant", value=0)
+        q = self._pad_qkv_tensor("q", q, origin_head_dim)
+        k = self._pad_qkv_tensor("k", k, origin_head_dim)
+        v = self._pad_qkv_tensor("v", v, origin_head_dim)
         return q, k, v, origin_head_dim
 
     def _maybe_compute_cu_seqlens(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -224,6 +224,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.token_indices_to_sample = torch.zeros(
             self.vllm_config.scheduler_config.max_num_batched_tokens, dtype=torch.int32, device=device
         )
+        self._lmhead_tp_pad_buffers: dict[str, torch.Tensor] = {}
         metadata_lens = self.runner.max_num_tokens + 2 * self.runner.max_num_reqs
         num_mtp_draft_slots = max(self.num_speculative_tokens - 1, 0) * self.runner.max_num_reqs
         slot_mapping_lens = self.runner.max_num_tokens + num_mtp_draft_slots
@@ -265,6 +266,29 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.use_eagle = self.runner.use_eagle
         self.draft_window_size = None
         self.sliding_window = None
+
+    def _pad_lmhead_tp_tensor(
+        self,
+        key: str,
+        tensor: torch.Tensor,
+        target_size: int,
+        pad_value: float = 0,
+    ) -> torch.Tensor:
+        buffer = self._lmhead_tp_pad_buffers.get(key)
+        if (
+            buffer is None
+            or buffer.shape[0] < target_size
+            or buffer.shape[1:] != tensor.shape[1:]
+            or buffer.dtype != tensor.dtype
+            or buffer.device != tensor.device
+        ):
+            buffer = tensor.new_empty((target_size,) + tensor.shape[1:])
+            self._lmhead_tp_pad_buffers[key] = buffer
+
+        copy_size = min(tensor.shape[0], target_size)
+        buffer[:copy_size].copy_(tensor[:copy_size])
+        buffer[copy_size:target_size].fill_(pad_value)
+        return buffer[:target_size]
 
     def _raise_if_padded_drafter_batch_disabled_and_full_graph_enabled(self):
         if (
@@ -1126,8 +1150,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 ori_token_indices_to_sample = None
 
         if lmhead_tp_enable():
-            token_indices_to_sample = nn.functional.pad(
-                token_indices_to_sample, (0, max_num_reqs_across_dp - num_indices)
+            token_indices_to_sample = self._pad_lmhead_tp_tensor(
+                "token_indices_to_sample",
+                token_indices_to_sample,
+                max_num_reqs_across_dp,
             )
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
@@ -1322,9 +1348,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 max_num_reqs_across_dp = (
                     self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
                 )
-                token_indices_to_sample = nn.functional.pad(
+                token_indices_to_sample = self._pad_lmhead_tp_tensor(
+                    "token_indices_to_sample",
                     token_indices_to_sample,
-                    (0, max_num_reqs_across_dp - num_indices),
+                    max_num_reqs_across_dp,
                 )
 
             sample_hidden_states = last_hidden_states[token_indices_to_sample]
@@ -2145,13 +2172,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             token_indices_to_sample = token_indices_to_sample[:num_indices]
         else:
             # Padding to the target length.
-            pad_size = num_indices - tensor.shape[0]
             if is_logits:
                 # logits: shape [seq_len, vocab_size], Padding at the end of the seq dimension.
-                tensor = nn.functional.pad(tensor, (0, 0, 0, pad_size), value=-1e9)
+                tensor = self._pad_lmhead_tp_tensor("logits", tensor, num_indices, -1e9)
             else:
                 # draft_token_ids: shape [seq_len], Padding at the end
-                tensor = nn.functional.pad(tensor, (0, pad_size))
+                tensor = self._pad_lmhead_tp_tensor("draft_token_ids", tensor, num_indices)
             token_indices_to_sample = ori_token_indices_to_sample
 
         return tensor, token_indices_to_sample

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -896,9 +896,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.block_table_tensor, slicing_length
             )
             if self.method == "dflash":
-                common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, num_reqs_padded)
+                common_attn_metadata.seq_lens = self._copy_seq_lens_to_step_buffer(
+                    common_attn_metadata.seq_lens, num_reqs_padded, 0
+                )
             else:
-                common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
+                common_attn_metadata.seq_lens = self._copy_seq_lens_to_step_buffer(
+                    self.runner.seq_lens, num_reqs_padded, 0
+                )
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
                     self.runner.optimistic_seq_lens_cpu, num_reqs_padded
                 )
@@ -937,19 +941,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             inputs_embeds = None
 
-        # Update slot_mapping for different speculative.
-        # NOTE: Currently, we only remake the slot_mapping, because it's the
-        # only tensor which will be used in current FIA.
-        # Strictly speaking, `query_start_loc`, `seq_lens` should also have
-        # their memory allocated separately for each step just like `slot_mapping`.
+        # Keep step-0 attention inputs in their persistent metadata buffers.
         slot_mapping_lens = common_attn_metadata.slot_mapping.shape[0]
         self.slot_mapping_group[0][:slot_mapping_lens].copy_(common_attn_metadata.slot_mapping)
         self.slot_mapping_group[0][slot_mapping_lens:].fill_(-1)
         common_attn_metadata.slot_mapping = self.slot_mapping_group[0]
 
-        self.seq_lens_group[0][:num_reqs_padded].copy_(common_attn_metadata.seq_lens)
-        self.seq_lens_group[0][num_reqs_padded:].fill_(0)
-        common_attn_metadata.seq_lens = self.seq_lens_group[0][:num_reqs_padded]
+        common_attn_metadata.seq_lens = self._copy_seq_lens_to_step_buffer(
+            common_attn_metadata.seq_lens, num_reqs_padded, 0
+        )
 
         self.query_start_loc_group[0][: num_reqs_padded + 1].copy_(common_attn_metadata.query_start_loc)
         self.query_start_loc_group[0][num_reqs_padded + 1 :].fill_(0)
@@ -1588,7 +1588,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 common_attn_metadata.block_table_tensor = self._adjust_block_table_tensor(
                     common_attn_metadata.block_table_tensor, input_batch_size
                 )
-                common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, input_batch_size)
                 common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
                     common_attn_metadata.seq_lens_cpu, input_batch_size
                 )
@@ -1633,10 +1632,18 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # The loop part
         used_update_positions += 1
 
-        # Clone the data so that when calculating the data at position 2 and position 3
-        # in the merged graph, it does not affect position 1
+        seq_lens_size = (
+            input_batch_size
+            if draft_index == 1 and aclgraph_runtime_mode == CUDAGraphMode.FULL
+            else common_attn_metadata.seq_lens.shape[0]
+        )
+        common_attn_metadata.seq_lens = self._copy_seq_lens_to_step_buffer(
+            common_attn_metadata.seq_lens, seq_lens_size, draft_index
+        )
+
+        # Clone the remaining data so that when calculating the data at position
+        # 2 and position 3 in the merged graph, it does not affect position 1.
         # FIXME(lilinsiman)
-        common_attn_metadata.seq_lens = common_attn_metadata.seq_lens.clone()
         if common_attn_metadata.seq_lens_cpu is not None:
             common_attn_metadata.seq_lens_cpu = common_attn_metadata.seq_lens_cpu.clone()
         if common_attn_metadata._seq_lens_cpu is not None:
@@ -1732,10 +1739,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             self.slot_mapping_group[draft_index][slot_mapping.shape[0] :].fill_(PADDING_SLOT_ID)
             # Set the address of the attn_metadata.slot_mapping to the self.slot_mapping_group[idx]
             common_attn_metadata.slot_mapping = self.slot_mapping_group[draft_index]
-
-        self.seq_lens_group[draft_index][: common_attn_metadata.seq_lens.shape[0]].copy_(common_attn_metadata.seq_lens)
-        self.seq_lens_group[draft_index][common_attn_metadata.seq_lens.shape[0] :].fill_(0)
-        common_attn_metadata.seq_lens = self.seq_lens_group[draft_index][: common_attn_metadata.seq_lens.shape[0]]
 
         self.query_start_loc_group[draft_index][: common_attn_metadata.query_start_loc.shape[0]].copy_(
             common_attn_metadata.query_start_loc
@@ -2094,6 +2097,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             tensor = tensor[:desired_size]
         return tensor
+
+    def _copy_seq_lens_to_step_buffer(self, tensor, desired_size, draft_index):
+        buf = self.seq_lens_group[draft_index]
+        copy_size = min(tensor.shape[0], desired_size)
+        if tensor.data_ptr() != buf.data_ptr():
+            buf[:copy_size].copy_(tensor[:copy_size])
+        buf[copy_size:].zero_()
+        return buf[:desired_size]
 
     def _adjust_block_table_tensor(self, tensor, desired_size):
         if desired_size <= tensor.shape[0]:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -243,8 +243,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             for _ in range(self.num_speculative_tokens)
         ]
 
-        # DCP needs independent block-table tensors for the first and later steps.
-        # since final block table tensor is not ready in __init__, it is delayed until dummy_run
+        # The final block-table width is only available after profile run, so
+        # initialize the reusable graph-mode buffer in dummy_run.
         self.block_table_tensor_clone: torch.Tensor | None = None
 
         self._runnable = self._run_merged_draft
@@ -589,7 +589,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
         # init block table tensor clone is only available after profile run and is only used for graph mode
-        if self.dcp_size > 1 and self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
+        if self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
             self.block_table_tensor_clone = torch.zeros(
                 (
                     self.runner.max_num_tokens + 2 * self.runner.max_num_reqs,
@@ -892,7 +892,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             common_attn_metadata.query_start_loc = self.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs_padded + 1]
             slicing_length = num_reqs_padded * self.decode_threshold if self.dcp_size > 1 else num_reqs_padded
-            common_attn_metadata.block_table_tensor = self._adjust_tensor(
+            common_attn_metadata.block_table_tensor = self._adjust_block_table_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
             )
             if self.method == "dflash":
@@ -920,7 +920,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # In the below scenario, padding has been applied by _pad_query_start_loc_for_fia in the model runner.
             # We need to unpad here for eager mode to maintain compatibility.
             if not self.vllm_config.model_config.use_mla and self.dcp_size == 1:
-                common_attn_metadata.block_table_tensor = self._adjust_tensor(
+                common_attn_metadata.block_table_tensor = self._adjust_block_table_tensor(
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )
 
@@ -972,12 +972,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # FIXME(lilinsiman)
         if self.dcp_size > 1 and self.use_cuda_graph:
             assert self.block_table_tensor_clone is not None, "block_table_tensor_clone is not init"
-            self.block_table_tensor_clone[: common_attn_metadata.block_table_tensor.shape[0]] = (
-                common_attn_metadata.block_table_tensor
-            )
-            common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[
-                : common_attn_metadata.block_table_tensor.shape[0]
-            ]
+            src = common_attn_metadata.block_table_tensor
+            n = src.shape[0]
+            if src.data_ptr() != self.block_table_tensor_clone.data_ptr():
+                self.block_table_tensor_clone[:n].copy_(src, non_blocking=True)
+            common_attn_metadata.block_table_tensor = self.block_table_tensor_clone[:n]
         else:
             common_attn_metadata.block_table_tensor = common_attn_metadata.block_table_tensor.clone()
 
@@ -1586,7 +1585,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         if draft_index == 1:
             if aclgraph_runtime_mode == CUDAGraphMode.FULL:
                 common_attn_metadata.num_reqs = input_batch_size
-                common_attn_metadata.block_table_tensor = self._adjust_tensor(
+                common_attn_metadata.block_table_tensor = self._adjust_block_table_tensor(
                     common_attn_metadata.block_table_tensor, input_batch_size
                 )
                 common_attn_metadata.seq_lens = self._adjust_tensor(common_attn_metadata.seq_lens, input_batch_size)
@@ -2095,6 +2094,27 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         else:
             tensor = tensor[:desired_size]
         return tensor
+
+    def _adjust_block_table_tensor(self, tensor, desired_size):
+        if desired_size <= tensor.shape[0]:
+            return tensor[:desired_size]
+
+        buf = self.block_table_tensor_clone
+        if (
+            buf is None
+            or desired_size > buf.shape[0]
+            or tensor.shape[1:] != buf.shape[1:]
+            or tensor.dtype != buf.dtype
+            or tensor.device != buf.device
+        ):
+            return self._adjust_tensor(tensor, desired_size)
+        if tensor.data_ptr() == buf.data_ptr():
+            buf[tensor.shape[0] : desired_size].zero_()
+            return buf[:desired_size]
+        cur = tensor.shape[0]
+        buf[:cur].copy_(tensor, non_blocking=True)
+        buf[cur:desired_size].zero_()
+        return buf[:desired_size]
 
     def maybe_pad_and_reduce(
         self,

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -419,7 +419,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             common_attn_metadata.block_table_tensor = self._adjust_block_table_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
             )
-            common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
+            common_attn_metadata.seq_lens = self._copy_seq_lens_to_step_buffer(self.runner.seq_lens, num_reqs_padded, 0)
             common_attn_metadata.seq_lens_cpu = self._adjust_tensor(
                 self.runner.optimistic_seq_lens_cpu, num_reqs_padded
             )
@@ -452,9 +452,9 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             : common_attn_metadata.num_actual_tokens
         ]
 
-        self.seq_lens_group[0][:num_reqs_padded].copy_(common_attn_metadata.seq_lens)
-        self.seq_lens_group[0][num_reqs_padded:].fill_(0)
-        common_attn_metadata.seq_lens = self.seq_lens_group[0][:num_reqs_padded]
+        common_attn_metadata.seq_lens = self._copy_seq_lens_to_step_buffer(
+            common_attn_metadata.seq_lens, num_reqs_padded, 0
+        )
 
         self.query_start_loc_group[0][: num_reqs_padded + 1].copy_(common_attn_metadata.query_start_loc)
         self.query_start_loc_group[0][num_reqs_padded + 1 :].fill_(0)

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -228,7 +228,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
 
-        if self.dcp_size > 1 and self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
+        if self.use_cuda_graph and not is_profile and self.block_table_tensor_clone is None:
             self.block_table_tensor_clone = torch.zeros(
                 (
                     self.runner.max_num_tokens + 2 * self.runner.max_num_reqs,
@@ -416,7 +416,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             common_attn_metadata.query_start_loc = self.runner.query_start_loc.gpu[: num_reqs_padded + 1]
             common_attn_metadata.query_start_loc_cpu = self.runner.query_start_loc.cpu[: num_reqs_padded + 1]
             slicing_length = num_reqs_padded * self.decode_threshold if self.dcp_size > 1 else num_reqs_padded
-            common_attn_metadata.block_table_tensor = self._adjust_tensor(
+            common_attn_metadata.block_table_tensor = self._adjust_block_table_tensor(
                 common_attn_metadata.block_table_tensor, slicing_length
             )
             common_attn_metadata.seq_lens = self._adjust_tensor(self.runner.seq_lens, num_reqs_padded)
@@ -433,7 +433,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         else:
             num_reqs_padded = common_attn_metadata.num_reqs
             if not self.vllm_config.model_config.use_mla and self.dcp_size == 1:
-                common_attn_metadata.block_table_tensor = self._adjust_tensor(
+                common_attn_metadata.block_table_tensor = self._adjust_block_table_tensor(
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )
 

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -548,8 +548,10 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
             max_num_reqs_across_dp = (
                 self.vllm_config.scheduler_config.max_num_seqs * self.runner.uniform_decode_query_len
             )
-            token_indices_to_sample = torch.nn.functional.pad(
-                token_indices_to_sample, (0, max_num_reqs_across_dp - num_indices)
+            token_indices_to_sample = self._pad_lmhead_tp_tensor(
+                "token_indices_to_sample",
+                token_indices_to_sample,
+                max_num_reqs_across_dp,
             )
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -539,6 +539,7 @@ class NPUModelRunner(GPUModelRunner):
             reasoning_config = getattr(self.vllm_config, "reasoning_config", None),
         )
         self.num_draft_tokens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
+        self._lmhead_tp_logits_indices_buffer: torch.Tensor | None = None
         # here we use int32
         self.sampled_token_ids_pinned_cpu = torch.empty(
             (self.max_num_reqs, 1),
@@ -579,6 +580,26 @@ class NPUModelRunner(GPUModelRunner):
         if self.sparse_kv_offload_enabled:
             self._offload_req_ids_tensor = self._make_buffer(self.max_num_reqs, dtype=torch.int64)
             self._offload_token_to_req = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
+
+    def _pad_lmhead_tp_logits_indices(
+        self,
+        logits_indices: torch.Tensor,
+        target_size: int,
+    ) -> torch.Tensor:
+        buffer = self._lmhead_tp_logits_indices_buffer
+        if (
+            buffer is None
+            or buffer.shape[0] < target_size
+            or buffer.dtype != logits_indices.dtype
+            or buffer.device != logits_indices.device
+        ):
+            buffer = logits_indices.new_empty(target_size)
+            self._lmhead_tp_logits_indices_buffer = buffer
+
+        copy_size = min(logits_indices.shape[0], target_size)
+        buffer[:copy_size].copy_(logits_indices[:copy_size])
+        buffer[copy_size:target_size].zero_()
+        return buffer[:target_size]
 
     @property
     def use_dcp(self) -> bool:
@@ -1277,7 +1298,7 @@ class NPUModelRunner(GPUModelRunner):
             self.set_active_loras(self.input_batch, num_scheduled_tokens, num_sampled_tokens)
         if lmhead_tp_enable():
             max_num_reqs_across_dp = self.max_num_reqs * self.uniform_decode_query_len
-            logits_indices = nn.functional.pad(logits_indices, (0, max_num_reqs_across_dp - logits_indices.shape[0]))
+            logits_indices = self._pad_lmhead_tp_logits_indices(logits_indices, max_num_reqs_across_dp)
 
         return (
             logits_indices,


### PR DESCRIPTION
### What this PR does / why we need it?
This PR refactor several padding paths to reuse pre-allocated buffers instead of creating temporary tensors with pad, cat or clone. It reduces repeated NPU memory allocations and improves graph-mode memory stability without changing model behavior.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
