### PR TITLE
[vllm-ascend] Thread Mooncake protocol into P2P transfer engine init

### DIFF
--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -108,6 +108,18 @@ class TestMooncakeStoreConfig(unittest.TestCase):
         finally:
             os.unlink(path)
 
+    def test_from_file_allows_ubshmem(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({"protocol": "ubshmem"}, f)
+            f.flush()
+            path = f.name
+
+        try:
+            cfg = MooncakeStoreConfig.from_file(path)
+            self.assertEqual(cfg.protocol, "ubshmem")
+        finally:
+            os.unlink(path)
+
     def test_from_file_ssd_offload(self):
         ssd_path = TestMooncakeStoreConfig._writable_ssd_path()
         self.addCleanup(lambda: os.rmdir(ssd_path))
@@ -325,6 +337,17 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         b.store.batch_is_exist.return_value = [1, 0]
         result = b.exists(["k1", "k2"])
         self.assertEqual(result, [1, 0])
+
+    def test_init_rejects_unknown_protocol(self):
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend."
+            "mooncake_backend.MooncakeStoreConfig.load_from_env",
+            return_value=MagicMock(protocol="badproto"),
+        ):
+            from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import MooncakeBackend
+
+            with self.assertRaises(NotImplementedError):
+                MooncakeBackend(MagicMock())
 
     def test_put(self):
         b = self._make_backend()

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -94,6 +94,15 @@ class RemotePortInfo(TypedDict):
     host: str
 
 
+def _get_mooncake_protocol(vllm_config: VllmConfig) -> str:
+    """Resolve Mooncake protocol from kv connector extra config."""
+    mooncake_cfg = vllm_config.kv_transfer_config.get_from_extra_config("mooncake", {})
+    protocol = mooncake_cfg.get("protocol", "ascend")
+    if protocol not in {"ascend", "ubshmem"}:
+        raise ValueError(f"Unsupported mooncake protocol: {protocol!r}")
+    return protocol
+
+
 class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     engine_id: str
     te_rpc_port: int
@@ -2068,9 +2077,11 @@ class MooncakeConnectorWorker:
         self.handshake_port = self.side_channel_port + device_index
         self.sockets: dict = {}
         device_name = str(torch.npu.current_device()) if self.pp_size > 1 else None
+        transfer_protocol = _get_mooncake_protocol(vllm_config)
         self.engine = global_te.get_transfer_engine(
             self.side_channel_host,
             device_name=device_name,
+            protocol=transfer_protocol,
         )
         self.te_rpc_port = self.engine.get_rpc_port()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -79,6 +79,15 @@ class RemotePortInfo(TypedDict):
     host: str
 
 
+def _get_mooncake_protocol(vllm_config: VllmConfig) -> str:
+    """Resolve Mooncake protocol from kv connector extra config."""
+    mooncake_cfg = vllm_config.kv_transfer_config.get_from_extra_config("mooncake", {})
+    protocol = mooncake_cfg.get("protocol", "ascend")
+    if protocol not in {"ascend", "ubshmem"}:
+        raise ValueError(f"Unsupported mooncake protocol: {protocol!r}")
+    return protocol
+
+
 class MooncakeAgentMetadata(msgspec.Struct, omit_defaults=True, dict=True):
     engine_id: str
     te_rpc_port: int
@@ -1585,7 +1594,11 @@ class MooncakeConnectorWorker:
         device_index = self.pp_rank * self.tp_size + self.tp_rank
         self.handshake_port = self.side_channel_port + device_index
         self.sockets: dict = {}
-        self.engine = global_te.get_transfer_engine(self.side_channel_host, device_name=None)
+        self.engine = global_te.get_transfer_engine(
+            self.side_channel_host,
+            device_name=None,
+            protocol=_get_mooncake_protocol(vllm_config),
+        )
         self.te_rpc_port = self.engine.get_rpc_port()
 
         # Background thread for sending or receiving KV caches.

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -84,6 +84,15 @@ DONE_SENDING_MSG = b"done_sending_msg"
 FAILED_SENDING_MSG = b"failed_sending_msg"
 
 
+def _get_mooncake_protocol(vllm_config: VllmConfig) -> str:
+    """Resolve Mooncake protocol from kv connector extra config."""
+    mooncake_cfg = vllm_config.kv_transfer_config.get_from_extra_config("mooncake", {})
+    protocol = mooncake_cfg.get("protocol", "ascend")
+    if protocol not in {"ascend", "ubshmem"}:
+        raise ValueError(f"Unsupported mooncake protocol: {protocol!r}")
+    return protocol
+
+
 @dataclass
 class LayerMetadata:
     tensor_group_idx: list[int]
@@ -1169,7 +1178,11 @@ class MooncakeLayerwiseConnectorWorker:
         self.handshake_port = self.side_channel_port + self.tp_rank
         self.sockets: dict = {}
         logger.info("Initializing Mooncake work %s", engine_id)
-        self.engine = global_te.get_transfer_engine(self.side_channel_host, device_name=None)
+        self.engine = global_te.get_transfer_engine(
+            self.side_channel_host,
+            device_name=None,
+            protocol=_get_mooncake_protocol(vllm_config),
+        )
         self.te_rpc_port = self.engine.get_rpc_port()
 
         # Background thread for sending or receiving KV caches.

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -63,7 +63,7 @@ class MooncakeBackend(Backend):
     def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False, contribute_memory: bool = True):
         self.parallel_config = parallel_config
         self.config = MooncakeStoreConfig.load_from_env()
-        if self.config.protocol != "ascend":
+        if self.config.protocol not in {"ascend", "ubshmem"}:
             raise NotImplementedError(f"MooncakeBackend does not support protocol {self.config.protocol!r}.")
 
         self.store: Any | None = None
@@ -119,7 +119,7 @@ class MooncakeBackend(Backend):
         # and only can be used for 800 I/T A3 series.
         # Required supporting hardware versions are as follows:
         if not self._use_fabric_mem:
-            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None)
+            transfer_engine = global_te.get_transfer_engine(local_hostname, device_name=None, protocol=self.config.protocol)
             self.local_seg = local_hostname + ":" + str(transfer_engine.get_rpc_port())
             ret = store.setup(
                 local_hostname=self.local_seg,
@@ -173,7 +173,7 @@ class MooncakeBackend(Backend):
     def register_buffer(self, ptrs: list[int], lengths: list[int]):
         if not self._use_fabric_mem:
             local_hostname = get_ip()
-            global_te.get_transfer_engine(local_hostname, device_name=None)
+            global_te.get_transfer_engine(local_hostname, device_name=None, protocol=self.config.protocol)
             global_te.register_buffer(ptrs, lengths)
 
     def exists(self, keys: list[str]) -> list[int]:

--- a/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
+++ b/vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py
@@ -4,11 +4,12 @@ import threading
 class GlobalTE:
     def __init__(self):
         self.transfer_engine = None
+        self.transfer_protocol: str | None = None
         self.is_register_buffer: bool = False
         self.transfer_engine_lock = threading.Lock()
         self.register_buffer_lock = threading.Lock()
 
-    def get_transfer_engine(self, hostname: str, device_name: str | None):
+    def get_transfer_engine(self, hostname: str, device_name: str | None, protocol: str = "ascend"):
         if self.transfer_engine is None:
             with self.transfer_engine_lock:
                 # Double-Checked Locking
@@ -23,9 +24,15 @@ class GlobalTE:
                         ) from e
                     self.transfer_engine = TransferEngine()
                     device_name = device_name if device_name is not None else ""
-                    ret_value = self.transfer_engine.initialize(hostname, "P2PHANDSHAKE", "ascend", device_name)
+                    ret_value = self.transfer_engine.initialize(hostname, "P2PHANDSHAKE", protocol, device_name)
                     if ret_value != 0:
                         raise RuntimeError(f"TransferEngine initialization failed with ret_value: {ret_value}")
+                    self.transfer_protocol = protocol
+        elif self.transfer_protocol != protocol:
+            raise RuntimeError(
+                f"TransferEngine protocol mismatch: existing={self.transfer_protocol!r}, requested={protocol!r}."
+                " Rebuild with a single protocol per process."
+            )
         return self.transfer_engine
 
     def register_buffer(self, ptrs: list[int], sizes: list[int]):


### PR DESCRIPTION
## Summary
- Add Mooncake protocol resolution from `kv_transfer_config.kv_connector_extra_config.mooncake.protocol` in P2P connectors.
- Pass protocol into `global_te.get_transfer_engine(...)` for:
  - `mooncake_connector`
  - `mooncake_hybrid_connector`
  - `mooncake_layerwise_connector`
- Accept only `ascend`/`ubshmem`; default remains `ascend` for backward compatibility.

## Why
P2P path already supports multiple Mooncake protocols via transfer-engine API, but `vllm-ascend` currently initializes it without protocol in P2P paths, which can force protocol mismatches with U-CUDA/UBShmem deployment paths.

## Scope
- **PR2 only:** protocol threading for Mooncake P2P connectors.
- No pool/store semantics or non-P2P data path changes.

## Validation
- Static diff verification in this repo branch.
- Integration runtime validation is pending in infra-enabled test window.
