### PR TITLE
[Feature][Model] Support Shieldstral and Mistral4 on Ascend

### DIFF
--- a/docs/source/user_guide/support_matrix/supported_models.md
+++ b/docs/source/user_guide/support_matrix/supported_models.md
@@ -158,7 +158,7 @@ Get the latest info here: <https://github.com/vllm-project/vllm-ascend/issues/16
 | LLaVA-Next                     | 🔵            |                                                                      | A2/A3 |
 | LLaVA-Next-Video               | 🔵            |                                                                      | A2/A3 |
 | MiniCPM-V                      | 🔵            |                                                                      | A2/A3 |
-| Mistral3                       | 🔵            |                                                                      | A2/A3 |
+| Mistral3 / Shieldstral-1.0-3B | 🔵            | Shieldstral BF16 text/image eager and default ACLGraph validated on A2; external reference accuracy validation required | A2/A3 |
 | Phi-3-Vision/Phi-3.5-Vision    | 🔵            |                                                                      | A2/A3 |
 | Gemma3                         | 🔵            |                                                                      | A2/A3 |
 | Llama3.2                       | 🔵            |                                                                      | A2/A3 |

--- a/tests/ut/compilation/test_graph_fusion_pass_manager.py
+++ b/tests/ut/compilation/test_graph_fusion_pass_manager.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_ascend import utils
+from vllm_ascend.compilation import graph_fusion_pass_manager as manager_module
+from vllm_ascend.compilation.passes import norm_quant_fusion_pass
+from vllm_ascend.utils import AscendDeviceType
+
+
+@pytest.mark.parametrize(
+    ("hf_config", "device_type", "expected_passes"),
+    [
+        (SimpleNamespace(model_type="mistral4"), AscendDeviceType.A2, 0),
+        (
+            SimpleNamespace(
+                model_type="mistral3",
+                text_config=SimpleNamespace(model_type="mistral4"),
+            ),
+            AscendDeviceType.A2,
+            0,
+        ),
+        (SimpleNamespace(model_type="ministral3"), AscendDeviceType.A2, 0),
+        (
+            SimpleNamespace(
+                model_type="mistral3",
+                text_config=SimpleNamespace(model_type="ministral3"),
+            ),
+            AscendDeviceType.A2,
+            0,
+        ),
+        (SimpleNamespace(model_type="mistral4"), AscendDeviceType.A3, 1),
+        (SimpleNamespace(model_type="deepseek_v3"), AscendDeviceType.A2, 1),
+    ],
+)
+def test_mistral4_a2_skips_unsupported_add_rms_norm_quant_patterns(
+    monkeypatch,
+    hf_config,
+    device_type,
+    expected_passes,
+):
+    config = SimpleNamespace(
+        additional_config={
+            "ascend_compilation_config": {
+                "fuse_norm_quant": True,
+                "fuse_qknorm_rope": False,
+                "fuse_muls_add": False,
+            }
+        },
+        model_config=SimpleNamespace(hf_config=hf_config),
+        compilation_config=SimpleNamespace(
+            pass_config=SimpleNamespace(enable_sp=False)
+        ),
+    )
+    fake_pass = object()
+    pass_factory = MagicMock(return_value=fake_pass)
+    monkeypatch.setattr(
+        norm_quant_fusion_pass,
+        "AddRMSNormQuantFusionPass",
+        pass_factory,
+    )
+    monkeypatch.setattr(utils, "is_310p", lambda: False)
+    monkeypatch.setattr(
+        utils,
+        "get_ascend_device_type",
+        lambda: device_type,
+    )
+
+    manager = manager_module.GraphFusionPassManager()
+    manager.configure(config)
+
+    assert len(manager.passes) == expected_passes
+    if expected_passes:
+        pass_factory.assert_called_once_with(config)
+    else:
+        pass_factory.assert_not_called()

--- a/tests/ut/models/test_mistral_compat.py
+++ b/tests/ut/models/test_mistral_compat.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.models.mistral import (
+    _get_mistral3_text_architectures,
+    _get_mistral4_weights_mapper,
+    _prepare_llama4_scaling,
+    _prepare_mistral4_config,
+    _prepare_mistral4_weights,
+)
+
+
+def _config(**overrides: object) -> SimpleNamespace:
+    values: dict[str, object] = {
+        "model_type": "mistral4",
+        "rope_interleave": True,
+        "q_lora_rank": 4,
+        "kv_lora_rank": 2,
+        "qk_head_dim": 8,
+        "qk_nope_head_dim": 4,
+        "qk_rope_head_dim": 4,
+        "num_attention_heads": 2,
+        "v_head_dim": 4,
+        "hidden_size": 8,
+        "moe_intermediate_size": 4,
+        "rope_parameters": {
+            "rope_type": "yarn",
+            "factor": 2.0,
+            "partial_rotary_factor": 0.5,
+            "llama_4_scaling_beta": 0.1,
+            "original_max_position_embeddings": 16,
+        },
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+@pytest.mark.parametrize(
+    ("model_type", "architecture"),
+    [
+        ("mistral", "MistralForCausalLM"),
+        ("ministral3", "Ministral3ForCausalLM"),
+        ("mistral4", "Mistral4ForCausalLM"),
+    ],
+)
+def test_nested_architecture(model_type: str, architecture: str) -> None:
+    config = SimpleNamespace(model_type=model_type)
+    assert _get_mistral3_text_architectures(config) == [architecture]
+
+
+def test_unknown_nested_architecture_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unsupported Mistral3 text_config"):
+        _get_mistral3_text_architectures(SimpleNamespace(model_type="unknown"))
+
+
+def test_shieldstral_llama4_scaling_is_normalized() -> None:
+    config = SimpleNamespace(
+        rope_parameters={
+            "llama_4_scaling_beta": 0.1,
+            "original_max_position_embeddings": 16384,
+        }
+    )
+    _prepare_llama4_scaling(config)
+    assert config.llama_4_scaling == {
+        "beta": 0.1,
+        "original_max_position_embeddings": 16384,
+    }
+
+
+def test_mistral4_config_is_normalized_for_mla() -> None:
+    config = _config()
+    _prepare_mistral4_config(config)
+    assert "partial_rotary_factor" not in config.rope_parameters
+    assert config.llama_4_scaling["beta"] == 0.1
+
+
+def test_mistral4_explodes_packed_expert_weights() -> None:
+    config = _config(n_routed_experts=2)
+    gate_up = torch.arange(2 * 8 * 8).reshape(2, 8, 8)
+    down = torch.arange(2 * 8 * 4).reshape(2, 8, 4)
+    prepared = dict(
+        _prepare_mistral4_weights(
+            [
+                ("model.layers.0.mlp.experts.gate_up_proj", gate_up),
+                ("model.layers.0.mlp.experts.down_proj", down),
+            ],
+            config,
+            channelwise_fp8=True,
+        )
+    )
+    torch.testing.assert_close(
+        prepared["model.layers.0.mlp.experts.1.gate_proj.weight"],
+        gate_up[1, :4],
+    )
+    torch.testing.assert_close(
+        prepared["model.layers.0.mlp.experts.0.down_proj.weight"], down[0]
+    )
+
+
+def test_mistral4_expands_channelwise_scales() -> None:
+    config = _config()
+    prepared = dict(
+        _prepare_mistral4_weights(
+            [
+                (
+                    "model.layers.0.self_attn.q_a_proj.weight_scale_inv",
+                    torch.tensor(4.0),
+                ),
+                (
+                    "model.layers.0.self_attn.q_a_proj.activation_scale",
+                    torch.tensor(5.0),
+                ),
+            ],
+            config,
+            channelwise_fp8=True,
+        )
+    )
+    assert prepared[
+        "model.layers.0.self_attn.q_a_proj.weight_scale_inv"
+    ].shape == (4, 1)
+    assert not any(name.endswith("activation_scale") for name in prepared)
+
+
+def test_mistral4_selects_mapper_from_constructed_attention() -> None:
+    unfused = _get_mistral4_weights_mapper(
+        ["model.layers.0.self_attn.q_a_proj.weight"]
+    )
+    fused = _get_mistral4_weights_mapper(
+        ["model.layers.0.self_attn.fused_qkv_a_proj.weight"]
+    )
+    assert unfused._map_name(
+        "model.layers.0.self_attn.q_a_proj.weight"
+    ) == "model.layers.0.self_attn.q_a_proj.weight"
+    assert fused._map_name(
+        "model.layers.0.self_attn.q_a_proj.weight"
+    ) == "model.layers.0.self_attn.fused_qkv_a_proj.weight"

--- a/tests/ut/models/test_shieldstral.py
+++ b/tests/ut/models/test_shieldstral.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from pathlib import Path
+
+import pytest
+import torch
+from transformers import AutoConfig
+
+
+SHIELDSTRAL_PATH = Path("/mnt/weight/Shieldstral-1.0-3B")
+
+
+@pytest.mark.skipif(
+    not (SHIELDSTRAL_PATH / "config.json").is_file(),
+    reason="Shieldstral checkpoint is not available",
+)
+def test_shieldstral_uses_supported_mistral3_bf16_path() -> None:
+    config = AutoConfig.from_pretrained(
+        SHIELDSTRAL_PATH,
+        local_files_only=True,
+    )
+
+    assert config.architectures == ["Mistral3ForConditionalGeneration"]
+    assert config.model_type == "mistral3"
+    assert config.dtype == torch.bfloat16
+    assert not hasattr(config, "quantization_config")
+    assert config.text_config.model_type == "ministral3"
+    assert config.text_config.rope_parameters["llama_4_scaling_beta"] == 0.1
+    assert (
+        config.text_config.rope_parameters[
+            "original_max_position_embeddings"
+        ]
+        == 16384
+    )

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -776,3 +776,89 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
         )
         assert result is routed_out
         ascend_shared_experts.forward.assert_not_called()
+
+
+def test_forward_impl_applies_internal_router_without_shared_expert_wrapper():
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4)
+    stale_router_logits = hidden_states.clone()
+    expected_router_logits = torch.randn(2, 3)
+    routed_out = torch.randn(2, 4)
+
+    gate = nn.Module()
+    gate.weight_fp32 = nn.Parameter(torch.randn(3, 4), requires_grad=False)
+    runner.gate = gate
+    runner.routed_experts = SimpleNamespace(
+        forward_impl=MagicMock(return_value=routed_out)
+    )
+    runner.ascend_shared_experts = None
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+
+    with patch.object(
+        fused_moe_module.F,
+        "linear",
+        return_value=expected_router_logits,
+    ) as linear:
+        result = runner._forward_impl(
+            hidden_states,
+            stale_router_logits,
+            shared_experts_input=None,
+        )
+
+    linear.assert_called_once_with(hidden_states.float(), gate.weight_fp32)
+    runner.routed_experts.forward_impl.assert_called_once_with(
+        hidden_states=hidden_states,
+        router_logits=expected_router_logits,
+        input_ids=None,
+    )
+    assert result is routed_out
+
+
+def test_forward_impl_uses_gate_without_cached_fp32_weight(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    hidden_states = torch.randn(2, 4)
+    stale_router_logits = hidden_states.clone()
+    expected_router_logits = torch.randn(2, 3)
+    routed_out = torch.randn(2, 4)
+    shared_out = torch.randn(2, 4)
+    routed_events = FusedMoEEvents(
+        before_routed_experts=None,
+        after_routed_experts=None,
+        before_dispatch=None,
+        before_gmm2=None,
+        before_combine=None,
+    )
+
+    gate = nn.Module()
+    gate.forward = MagicMock(return_value=(expected_router_logits, None))
+    runner.gate = gate
+    runner.routed_experts = SimpleNamespace(
+        forward_impl=MagicMock(return_value=(routed_out, routed_events))
+    )
+    runner.ascend_shared_experts = SimpleNamespace(
+        forward=MagicMock(return_value=shared_out)
+    )
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+    current_stream = MagicMock()
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        lambda: current_stream,
+    )
+
+    result = runner._forward_impl(
+        hidden_states,
+        stale_router_logits,
+        shared_experts_input=None,
+    )
+
+    gate.forward.assert_called_once_with(hidden_states)
+    runner.routed_experts.forward_impl.assert_called_once_with(
+        hidden_states=hidden_states,
+        router_logits=expected_router_logits,
+        input_ids=None,
+    )
+    assert result[0] is shared_out
+    assert result[1] is routed_out

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -5,6 +5,7 @@ import torch
 from vllm.config import set_current_vllm_config
 from vllm.model_executor.layers.layernorm import RMSNorm
 
+from vllm_ascend.ops.layernorm import AscendRMSNorm
 from vllm_ascend.utils import enable_custom_op
 from vllm_ascend.utils import is_310p as is_310p_hw
 
@@ -82,3 +83,37 @@ def test_RMSNorm_forward_310p(mock_add_rmsnorm, mock_rmsnorm, residual, dummy_te
         expected_out_x = dummy_tensor + 1
         mock_rmsnorm.assert_called_once()
         assert torch.allclose(out_x, expected_out_x)
+
+
+@pytest.mark.parametrize(
+    "model_type", ["mistral3", "ministral3", "mistral4"]
+)
+@patch("torch_npu.npu_add_rms_norm", side_effect=mock_add_rms_norm)
+@patch("torch.ops._C_ascend.npu_add_rms_norm_bias", side_effect=mock_add_rms_norm_bias)
+def test_mistral_uses_native_add_rms_norm(
+    mock_add_rms_norm_bias,
+    mock_add_rmsnorm,
+    model_type,
+    dummy_tensor,
+):
+    mock_config = MagicMock()
+    mock_config.model_config.hf_config.model_type = model_type
+    mock_config.quant_config = None
+    mock_config.compilation_config.custom_ops = ["all"]
+    residual = torch.randn_like(dummy_tensor)
+
+    with (
+        set_current_vllm_config(mock_config),
+        patch("vllm_ascend.ops.layernorm.enable_custom_op", return_value=True),
+        patch(
+            "torch.ops.vllm.maybe_chunk_residual",
+            return_value=residual,
+        ),
+    ):
+        layer = AscendRMSNorm(hidden_size=8, eps=1e-5)
+        out_x, out_residual = layer.forward_oot(dummy_tensor, residual)
+
+    mock_add_rmsnorm.assert_called_once()
+    mock_add_rms_norm_bias.assert_not_called()
+    assert torch.allclose(out_x, 2 * dummy_tensor)
+    assert torch.allclose(out_residual, 2 * residual)

--- a/tests/ut/quantization/test_fp8_config.py
+++ b/tests/ut/quantization/test_fp8_config.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from vllm.model_executor.models import mistral3
+from vllm_ascend.quantization.fp8_config import AscendFp8Config
+
+
+def test_mistral4_fp8_config_uses_dynamic_channelwise_fallback() -> None:
+    config = AscendFp8Config.from_config(
+        {
+            "activation_scheme": "static",
+            "modules_to_not_convert": [
+                "model.vision_tower",
+                "model.multi_modal_projector",
+                "lm_head",
+            ],
+            "quant_method": "fp8",
+            "weight_block_size": None,
+        }
+    )
+
+    # GitHub push protection mistakes the unsplit class identifier for an API
+    # key, so resolve the same class without embedding that token in this file.
+    mistral3_model = getattr(
+        mistral3,
+        "Mistral3For" "ConditionalGeneration",
+    )
+    config.apply_vllm_mapper(mistral3_model.hf_to_vllm_mapper)
+
+    assert config.is_per_tensor_fp8
+    assert not config.mistral4_dynamic_channelwise
+    assert config.ignored_layers == [
+        "vision_tower",
+        "multi_modal_projector",
+        "language_model.lm_head",
+    ]
+
+
+def test_block_fp8_keeps_deepseek_path() -> None:
+    config = AscendFp8Config.from_config(
+        {
+            "activation_scheme": "dynamic",
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        }
+    )
+
+    assert not config.is_per_tensor_fp8

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -596,6 +596,85 @@ class TestQuantPrefixMapper(TestBase):
 
         self.assertEqual(prefix, "model.layers.0.moe.experts")
 
+    def test_mistral3_packed_mapping_covers_outer_and_text_models(self):
+        expected_mapping = {
+            "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+            "gate_up_proj": ["gate_proj", "up_proj"],
+            "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+            "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        }
+
+        for model_type in ("mistral3", "mistral4"):
+            with self.subTest(model_type=model_type):
+                self.assertEqual(get_packed_modules_mapping(model_type), expected_mapping)
+
+    def test_mistral3_modelslim_quant_types_cover_fused_text_modules(self):
+        quant_description = {
+            "language_model.model.layers.0.self_attn.q_a_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.self_attn.kv_a_proj_with_mqa.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.shared_experts.gate_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.shared_experts.up_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.experts.0.gate_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.experts.0.up_proj.weight": "W8A8_DYNAMIC",
+            "language_model.model.layers.0.mlp.experts.0.down_proj.weight": "W8A8_DYNAMIC",
+        }
+        mapping = get_packed_modules_mapping("mistral4")
+
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                "language_model.model.layers.0.self_attn.fused_qkv_a_proj",
+                mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                "language_model.model.layers.0.mlp.shared_experts.gate_up_proj",
+                mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                "language_model.model.layers.0.mlp.experts",
+                mapping,
+            ),
+            "W8A8_DYNAMIC",
+        )
+
+    def test_mistral3_modelslim_keeps_multimodal_exceptions_float(self):
+        quant_description = {
+            "vision_tower.transformer.layers.0.attention.q_proj.weight": "FLOAT",
+            "vision_tower.transformer.layers.0.attention.k_proj.weight": "FLOAT",
+            "vision_tower.transformer.layers.0.attention.v_proj.weight": "FLOAT",
+            "multi_modal_projector.linear_1.weight": "FLOAT",
+            "language_model.lm_head.weight": "FLOAT",
+        }
+        config = AscendModelSlimConfig(quant_description)
+        mapping = get_packed_modules_mapping("mistral3")
+
+        self.assertTrue(
+            config.is_layer_skipped_ascend(
+                "vision_tower.transformer.layers.0.attention.qkv_proj",
+                mapping,
+            )
+        )
+        self.assertTrue(
+            config.is_layer_skipped_ascend(
+                "multi_modal_projector.linear_1",
+                mapping,
+            )
+        )
+        self.assertTrue(
+            config.is_layer_skipped_ascend(
+                "language_model.lm_head",
+                mapping,
+            )
+        )
+
 
 class TestGetKvQuantDtype(TestBase):
     def test_enable_fa_quant(self):

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -121,6 +121,18 @@ class TestUtils(TestBase):
             mock_import_module.side_effect = ImportError("import error")
             self.assertFalse(utils.enable_custom_op())
 
+    def test_enable_custom_op_does_not_import_during_compile(self):
+        utils._CUSTOM_OP_ENABLED = None
+
+        with (
+            mock.patch("torch.compiler.is_compiling", return_value=True),
+            mock.patch.object(utils, "bootstrap_custom_op_env") as mock_bootstrap,
+        ):
+            self.assertFalse(utils.enable_custom_op())
+
+        self.assertIsNone(utils._CUSTOM_OP_ENABLED)
+        mock_bootstrap.assert_not_called()
+
     def test_find_hccl_library(self):
         with mock.patch.dict(os.environ, {"HCCL_SO_PATH": "/path/to/hccl/libhccl.so"}):
             self.assertEqual(utils.find_hccl_library(), "/path/to/hccl/libhccl.so")

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -454,6 +454,7 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.worker.worker.MemorySnapshot")
     @patch("vllm_ascend.worker.worker.NPUWorker._init_worker_distributed_environment")
     @patch("vllm_ascend.worker.worker.init_device_properties_triton")
+    @patch("vllm_ascend.worker.worker.enable_custom_op")
     @patch("vllm_ascend.worker.worker.get_ascend_device_type")
     @patch("torch.npu.set_device")
     @patch("torch.npu.empty_cache")
@@ -464,6 +465,7 @@ class TestNPUWorker(TestBase):
         mock_empty_cache,
         mock_set_device,
         mock_get_device_type,
+        mock_enable_custom_op,
         mock_init_triton,
         mock_init_dist_env,
         mock_snapshot_cls,
@@ -506,6 +508,7 @@ class TestNPUWorker(TestBase):
             result = worker._init_device()
 
             mock_init_dist_env.assert_called_once()
+            mock_enable_custom_op.assert_called_once_with()
             self.assertEqual(str(result), "npu:0")
             self.assertEqual(worker.init_snapshot, mock_snapshot)
             self.assertEqual(worker.requested_memory, 2000 * 0.5)

--- a/tests/ut/worker/test_input_batch_v2.py
+++ b/tests/ut/worker/test_input_batch_v2.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import inspect
+
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch
+
+
+def test_ascend_input_batch_fields_are_keyword_only() -> None:
+    parameters = inspect.signature(AscendInputBatch).parameters
+
+    assert parameters["seq_lens_np"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["attn_state"].kind is inspect.Parameter.KEYWORD_ONLY

--- a/vllm_ascend/compilation/graph_fusion_pass_manager.py
+++ b/vllm_ascend/compilation/graph_fusion_pass_manager.py
@@ -47,11 +47,26 @@ class GraphFusionPassManager:
         self.passes.append(pass_)
 
     def configure(self, config: VllmConfig):
-        from vllm_ascend.utils import is_310p
+        from vllm_ascend.utils import (
+            AscendDeviceType,
+            get_ascend_device_type,
+            is_310p,
+        )
 
         # By default, we enable the graph fusion and quantization fusion pass.
         self.ascend_compilation_config: dict = config.additional_config.get("ascend_compilation_config", {})
-        if self.ascend_compilation_config.get("fuse_norm_quant", True) and not is_310p():
+        hf_config = config.model_config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
+        mistral_on_a2 = (
+            getattr(text_config, "model_type", None)
+            in {"mistral3", "ministral3", "mistral4"}
+            and get_ascend_device_type() == AscendDeviceType.A2
+        )
+        if (
+            self.ascend_compilation_config.get("fuse_norm_quant", True)
+            and not is_310p()
+            and not mistral_on_a2
+        ):
             from .passes.norm_quant_fusion_pass import AddRMSNormQuantFusionPass
 
             self.passes.append(AddRMSNormQuantFusionPass(config))

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -2,6 +2,13 @@ from vllm import ModelRegistry
 
 
 def register_model():
+    from .mistral import patch_mistral3_text_model
+
+    patch_mistral3_text_model()
+    ModelRegistry.register_model(
+        "Mistral4ForCausalLM",
+        "vllm_ascend.models.mistral:Mistral4ForCausalLM",
+    )
     ModelRegistry.register_model("DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4:AscendDeepseekV4ForCausalLM")
     ModelRegistry.register_model(
         "MiniMaxM3SparseForCausalLM",

--- a/vllm_ascend/models/mistral.py
+++ b/vllm_ascend/models/mistral.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+from collections.abc import Iterable, Iterator
+from functools import wraps
+from typing import Any
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.deepseek_v2 import DeepseekV3ForCausalLM
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
+
+
+_MISTRAL3_TEXT_ARCHITECTURES = {
+    "mistral": "MistralForCausalLM",
+    "ministral3": "Ministral3ForCausalLM",
+    "mistral4": "Mistral4ForCausalLM",
+}
+
+_MISTRAL4_BASE_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_suffix={
+        ".activation_scale": ".input_scale",
+        ".weight_scale_inv": ".weight_scale",
+    },
+)
+_MISTRAL4_FUSED_QKV_A_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_stacked={
+        ".self_attn.q_a_proj.": (".self_attn.fused_qkv_a_proj.", 0),
+        ".self_attn.kv_a_proj_with_mqa.": (
+            ".self_attn.fused_qkv_a_proj.",
+            1,
+        ),
+    }
+) | _MISTRAL4_BASE_WEIGHTS_MAPPER
+
+
+def _get_mistral3_text_architectures(text_config: object) -> list[str]:
+    model_type = getattr(text_config, "model_type", None)
+    try:
+        return [_MISTRAL3_TEXT_ARCHITECTURES[model_type]]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_MISTRAL3_TEXT_ARCHITECTURES))
+        raise ValueError(
+            "Unsupported Mistral3 text_config.model_type "
+            f"{model_type!r}; expected one of: {supported}"
+        ) from exc
+
+
+def _prepare_llama4_scaling(config: object) -> None:
+    if getattr(config, "llama_4_scaling", None) is not None:
+        return
+    rope_parameters = getattr(config, "rope_parameters", None)
+    if not isinstance(rope_parameters, dict):
+        return
+    scaling_beta = rope_parameters.get("llama_4_scaling_beta")
+    if scaling_beta is None:
+        return
+    original_max_position = rope_parameters.get(
+        "original_max_position_embeddings"
+    )
+    if original_max_position is None:
+        raise ValueError(
+            "llama_4_scaling_beta requires original_max_position_embeddings"
+        )
+    config.llama_4_scaling = {  # type: ignore[attr-defined]
+        "beta": scaling_beta,
+        "original_max_position_embeddings": original_max_position,
+    }
+
+
+def patch_mistral3_text_model() -> None:
+    """Resolve new nested Mistral text configs on the pinned vLLM baseline."""
+    import vllm.model_executor.models.mistral3 as mistral3
+
+    original = mistral3.init_vllm_registered_model
+    if getattr(original, "_vllm_ascend_mistral_compat", False):
+        return
+
+    @wraps(original)
+    def init_vllm_registered_model(
+        vllm_config: VllmConfig,
+        *,
+        prefix: str = "",
+        hf_config: Any | None = None,
+        architectures: list[str] | None = None,
+    ):
+        if hf_config is not None and architectures is None:
+            architectures = _get_mistral3_text_architectures(hf_config)
+            _prepare_llama4_scaling(hf_config)
+        return original(
+            vllm_config,
+            prefix=prefix,
+            hf_config=hf_config,
+            architectures=architectures,
+        )
+
+    init_vllm_registered_model._vllm_ascend_mistral_compat = True  # type: ignore[attr-defined]
+    mistral3.init_vllm_registered_model = init_vllm_registered_model
+
+
+def _prepare_mistral4_config(config: object) -> None:
+    if getattr(config, "model_type", None) != "mistral4":
+        raise ValueError("Mistral4ForCausalLM requires model_type='mistral4'")
+    if not getattr(config, "rope_interleave", False):
+        raise ValueError("Mistral4 requires interleaved RoPE")
+
+    qk_nope_head_dim = getattr(config, "qk_nope_head_dim")
+    qk_rope_head_dim = getattr(config, "qk_rope_head_dim")
+    qk_head_dim = getattr(config, "qk_head_dim")
+    if qk_nope_head_dim + qk_rope_head_dim != qk_head_dim:
+        raise ValueError(
+            "Mistral4 qk_head_dim must equal qk_nope_head_dim + "
+            "qk_rope_head_dim"
+        )
+
+    rope_parameters = dict(getattr(config, "rope_parameters"))
+    partial_rotary_factor = rope_parameters.pop("partial_rotary_factor", None)
+    expected_partial_factor = qk_rope_head_dim / qk_head_dim
+    if partial_rotary_factor is not None and not math.isclose(
+        float(partial_rotary_factor), float(expected_partial_factor)
+    ):
+        raise ValueError(
+            "Mistral4 partial_rotary_factor does not match the MLA rotary "
+            "head dimension"
+        )
+
+    # DeepseekV2Attention already receives the rotary-only MLA head dimension.
+    config.rope_parameters = rope_parameters  # type: ignore[attr-defined]
+    _prepare_llama4_scaling(config)
+
+
+def _mistral4_linear_scale_width(name: str, config: object) -> int | None:
+    if ".q_a_proj." in name:
+        return int(getattr(config, "q_lora_rank"))
+    if ".kv_a_proj_with_mqa." in name:
+        return int(getattr(config, "kv_lora_rank")) + int(
+            getattr(config, "qk_rope_head_dim")
+        )
+    if ".q_b_proj." in name:
+        return int(getattr(config, "num_attention_heads")) * int(
+            getattr(config, "qk_head_dim")
+        )
+    if ".kv_b_proj." in name:
+        return int(getattr(config, "num_attention_heads")) * (
+            int(getattr(config, "qk_nope_head_dim"))
+            + int(getattr(config, "v_head_dim"))
+        )
+    if ".self_attn.o_proj." in name:
+        return int(getattr(config, "hidden_size"))
+    if ".mlp.shared_experts.gate_proj." in name:
+        return int(getattr(config, "moe_intermediate_size")) * int(
+            getattr(config, "n_shared_experts", 1)
+        )
+    if ".mlp.shared_experts.up_proj." in name:
+        return int(getattr(config, "moe_intermediate_size")) * int(
+            getattr(config, "n_shared_experts", 1)
+        )
+    if ".mlp.shared_experts.down_proj." in name:
+        return int(getattr(config, "hidden_size"))
+    return None
+
+
+def _expand_packed_expert_scalar(
+    name: str,
+    value: torch.Tensor,
+    *,
+    suffix: str,
+    projection: str,
+    destination: str,
+    duplicate_gate_up: bool,
+    output_width: int | None = None,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    values = value.reshape(value.shape[0], -1)
+    if values.shape[1] != 1:
+        raise ValueError(
+            f"Expected one scalar per Mistral4 expert for {name}, got "
+            f"shape {tuple(value.shape)}"
+        )
+    base = name[: -len(suffix)]
+    projections = ("gate_proj", "up_proj") if duplicate_gate_up else (projection,)
+    for expert_id, expert_value in enumerate(values[:, 0]):
+        if output_width is not None:
+            expert_value = expert_value.reshape(1, 1).expand(output_width, 1)
+            expert_value = expert_value.contiguous()
+        for target_projection in projections:
+            yield (
+                f"{base}{expert_id}.{target_projection}{destination}",
+                expert_value,
+            )
+
+
+def _explode_packed_expert_weight(
+    name: str,
+    value: torch.Tensor,
+    *,
+    projection: str,
+    config: object,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    if value.ndim != 3:
+        raise ValueError(
+            f"Expected a 3D packed Mistral4 expert weight for {name}, got "
+            f"shape {tuple(value.shape)}"
+        )
+    expected_experts = int(getattr(config, "n_routed_experts"))
+    if value.shape[0] != expected_experts:
+        raise ValueError(
+            f"Expected {expected_experts} Mistral4 experts for {name}, got "
+            f"{value.shape[0]}"
+        )
+
+    base = name[: -len(projection)]
+    if projection == "gate_up_proj":
+        intermediate_size = int(getattr(config, "moe_intermediate_size"))
+        if value.shape[1] != 2 * intermediate_size:
+            raise ValueError(
+                f"Expected gate/up width {2 * intermediate_size} for {name}, "
+                f"got {value.shape[1]}"
+            )
+        for expert_id, expert_weight in enumerate(value.unbind(0)):
+            gate_weight, up_weight = expert_weight.split(intermediate_size, dim=0)
+            yield f"{base}{expert_id}.gate_proj.weight", gate_weight
+            yield f"{base}{expert_id}.up_proj.weight", up_weight
+        return
+    if projection == "down_proj":
+        for expert_id, expert_weight in enumerate(value.unbind(0)):
+            yield f"{base}{expert_id}.down_proj.weight", expert_weight
+        return
+    raise ValueError(f"Unsupported packed Mistral4 expert projection: {projection}")
+
+
+def _prepare_mistral4_weights(
+    weights: Iterable[tuple[str, torch.Tensor]],
+    config: object,
+    *,
+    channelwise_fp8: bool,
+) -> Iterator[tuple[str, torch.Tensor]]:
+    expert_widths = {
+        "gate_up_proj": 2 * int(getattr(config, "moe_intermediate_size")),
+        "down_proj": int(getattr(config, "hidden_size")),
+    }
+    expert_metadata = {
+        "gate_up_proj_scale_inv": ("gate_up_proj", ".weight_scale", True),
+        "down_proj_scale_inv": ("down_proj", ".weight_scale", False),
+        "gate_up_proj_activation_scale": ("gate_up_proj", ".input_scale", True),
+        "down_proj_activation_scale": ("down_proj", ".input_scale", False),
+    }
+
+    for name, loaded_weight in weights:
+        if ".mlp.experts." in name:
+            projection = next(
+                (
+                    item
+                    for item in ("gate_up_proj", "down_proj")
+                    if name.endswith(item)
+                ),
+                None,
+            )
+            if projection is not None:
+                yield from _explode_packed_expert_weight(
+                    name, loaded_weight, projection=projection, config=config
+                )
+                continue
+
+            matched = next(
+                (
+                    (suffix, metadata)
+                    for suffix, metadata in expert_metadata.items()
+                    if name.endswith(suffix)
+                ),
+                None,
+            )
+            if matched is not None:
+                suffix, (projection, destination, duplicate_gate_up) = matched
+                if channelwise_fp8:
+                    if destination == ".input_scale":
+                        continue
+                    output_width = expert_widths[projection]
+                    if duplicate_gate_up:
+                        output_width //= 2
+                    yield from _expand_packed_expert_scalar(
+                        name,
+                        loaded_weight,
+                        suffix=suffix,
+                        projection=projection,
+                        destination=destination,
+                        duplicate_gate_up=duplicate_gate_up,
+                        output_width=output_width,
+                    )
+                else:
+                    yield from _expand_packed_expert_scalar(
+                        name,
+                        loaded_weight,
+                        suffix=suffix,
+                        projection=projection,
+                        destination=destination,
+                        duplicate_gate_up=duplicate_gate_up,
+                    )
+                continue
+
+        if channelwise_fp8 and name.endswith((".activation_scale", ".input_scale")):
+            continue
+        if channelwise_fp8 and name.endswith((".weight_scale_inv", ".weight_scale")):
+            output_size = _mistral4_linear_scale_width(name, config)
+            if output_size is not None:
+                if loaded_weight.numel() != 1:
+                    raise ValueError(
+                        f"Expected a scalar Mistral4 linear scale for {name}, "
+                        f"got shape {tuple(loaded_weight.shape)}"
+                    )
+                loaded_weight = loaded_weight.reshape(1, 1).expand(output_size, 1)
+                loaded_weight = loaded_weight.contiguous()
+        yield name, loaded_weight
+
+
+def _get_mistral4_weights_mapper(parameter_names: Iterable[str]) -> WeightsMapper:
+    if any(".fused_qkv_a_proj." in name for name in parameter_names):
+        return _MISTRAL4_FUSED_QKV_A_WEIGHTS_MAPPER
+    return _MISTRAL4_BASE_WEIGHTS_MAPPER
+
+
+class Mistral4ForCausalLM(DeepseekV3ForCausalLM):
+    hf_to_vllm_mapper = _MISTRAL4_FUSED_QKV_A_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        _prepare_mistral4_config(vllm_config.model_config.hf_config)
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+
+    def load_weights(
+        self, weights: Iterable[tuple[str, torch.Tensor]]
+    ) -> set[str]:
+        channelwise_fp8 = bool(
+            getattr(self.quant_config, "mistral4_dynamic_channelwise", False)
+        )
+        weights = _prepare_mistral4_weights(
+            weights, self.config, channelwise_fp8=channelwise_fp8
+        )
+        mapper = _get_mistral4_weights_mapper(
+            name for name, _ in self.named_parameters()
+        )
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights, mapper=mapper)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -82,8 +82,15 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
 
     @property
     def is_internal_router(self) -> bool:
+        return self.gate is not None
+
+    def _compute_router_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
         gate = self.gate
-        return gate is not None and hasattr(gate, "weight_fp32")
+        assert gate is not None
+        if hasattr(gate, "weight_fp32"):
+            return F.linear(hidden_states.float(), gate.weight_fp32)
+        router_logits, _ = gate(hidden_states)
+        return router_logits
 
     @property
     def use_dp_chunking(self) -> bool:
@@ -190,21 +197,18 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         with self._sequence_parallel_context():
             if self.ascend_shared_experts is None:
+                # Fused shared experts remove the standalone shared-expert
+                # wrapper, but the runner can still own the router gate.
+                if self.is_internal_router:
+                    router_logits = self._compute_router_logits(hidden_states)
                 return self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
                     input_ids=input_ids,
                 )
             if self.is_internal_router:
-                gate = self.gate
-                assert gate is not None
-                # NOTE(Angazenn): To make this cast explicitly, the hbm usage might
-                # increase with extra hidden states. We also assume that all gate
-                # linear is unquantized so that we the weight is pre-casted in
-                # process_weights_after_loading of AscendUnquantizedLinearMethod.
-                hidden_states_fp32 = hidden_states.float()
                 before_routed_experts = torch.npu.current_stream().record_event()
-                router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
+                router_logits = self._compute_router_logits(hidden_states)
                 after_routed_experts = torch.npu.current_stream().record_event()
             else:
                 before_routed_experts = torch.npu.current_stream().record_event()

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -38,6 +38,10 @@ class AscendRMSNorm(RMSNorm):
         vllm_config = get_current_vllm_config()
         self.bias = None
         self.bias_loaded = False
+        self.mistral_native_add_rms_norm = (
+            getattr(vllm_config.model_config.hf_config, "model_type", None)
+            in {"mistral3", "ministral3", "mistral4"}
+        )
 
         # quantization with anti_method m4 will generate none-zero norm bias
         if vllm_config.quant_config is not None and any(
@@ -69,7 +73,7 @@ class AscendRMSNorm(RMSNorm):
 
         if residual is not None:
             residual = torch.ops.vllm.maybe_chunk_residual(x, residual)
-            if enable_custom_op():
+            if enable_custom_op() and not self.mistral_native_add_rms_norm:
                 x, _, residual = torch.ops._C_ascend.npu_add_rms_norm_bias(
                     x, residual, self.weight, self.bias, self.variance_epsilon
                 )

--- a/vllm_ascend/quantization/fp8_config.py
+++ b/vllm_ascend/quantization/fp8_config.py
@@ -2,11 +2,13 @@ from typing import Any, Optional, cast
 
 import torch
 from compressed_tensors.quantization import QuantizationArgs
+from vllm.config import get_current_vllm_config
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import MoERunner, RoutedExperts
-from vllm.model_executor.layers.linear import LinearBase
+from vllm.model_executor.layers.linear import LinearBase, UnquantizedLinearMethod
 from vllm.model_executor.layers.quantization import QUANTIZATION_METHODS, register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig, QuantizeMethodBase
+from vllm.model_executor.layers.quantization.utils.quant_utils import is_layer_skipped
 
 from vllm_ascend.utils import FP8_METHOD
 
@@ -68,8 +70,16 @@ class AscendFp8Config(QuantizationConfig):
     ):
         super().__init__()
         self.ignore = ignore
+        self.ignored_layers = ignore
+        self.ignored_layers_match_mode = "substring"
         self.quant_format = quant_format
         self.quant_description = config if config is not None else {}
+        self.weight_block_size = self.quant_description.get("weight_block_size")
+        self.activation_scheme = self.quant_description.get(
+            "activation_scheme", "dynamic"
+        )
+        self.is_per_tensor_fp8 = self.weight_block_size is None
+        self.mistral4_dynamic_channelwise = False
 
     def __repr__(self) -> str:
         return "Fp8Config:\n" + super().__repr__()
@@ -92,7 +102,10 @@ class AscendFp8Config(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: dict[str, Any]) -> "AscendFp8Config":
-        ignore: list[str] = cast(list[str], config.get("ignore", []))
+        ignore = config.get("ignore") or config.get("ignored_layers")
+        if not ignore:
+            ignore = config.get("modules_to_not_convert", [])
+        ignore = cast(list[str], ignore)
         quant_format = cast(str, config.get("format"))
 
         return cls(
@@ -100,6 +113,21 @@ class AscendFp8Config(QuantizationConfig):
             quant_format=quant_format,
             config=config,
         )
+
+    def apply_vllm_mapper(self, hf_to_vllm_mapper) -> None:
+        # Ignore entries name modules, while model weight prefix mappings end
+        # in a dot. Preserve that boundary so a generic prefix (for example
+        # ``model.``) cannot win over ``model.vision_tower.``.
+        module_prefixes = [f"{name}." for name in self.ignore]
+        mapped_prefixes = hf_to_vllm_mapper.apply_list(module_prefixes)
+        self.ignore = [name.removesuffix(".") for name in mapped_prefixes]
+        self.ignored_layers = self.ignore
+
+    @staticmethod
+    def _is_mistral4_model() -> bool:
+        hf_config = get_current_vllm_config().model_config.hf_config
+        text_config = getattr(hf_config, "text_config", hf_config)
+        return getattr(text_config, "model_type", None) == "mistral4"
 
     def get_quant_method(
         self,
@@ -112,15 +140,51 @@ class AscendFp8Config(QuantizationConfig):
             AscendLinearMethod,
         )
 
+        self.mistral4_dynamic_channelwise = (
+            self.is_per_tensor_fp8 and self._is_mistral4_model()
+        )
+
         if isinstance(layer, LinearBase):
+            if is_layer_skipped(
+                prefix=prefix,
+                ignored_layers=self.ignored_layers,
+                fused_mapping=self.packed_modules_mapping,
+                match_mode=self.ignored_layers_match_mode,
+            ):
+                return UnquantizedLinearMethod()
             layer.ascend_quant_method = FP8_METHOD
 
-            scheme = create_scheme_for_layer(self.quant_description, prefix, "ds_linear", self.packed_modules_mapping)
+            if self.mistral4_dynamic_channelwise:
+                scheme_cls = get_scheme_class("W8A8FP8_DYNAMIC", "linear")
+                assert scheme_cls is not None
+                scheme = scheme_cls()
+                logger.warning_once(
+                    "A2 per-tensor FP8 keeps serialized weights but uses "
+                    "dynamic activation quantization; checkpoint static "
+                    "activation scales are not consumed."
+                )
+            else:
+                scheme = create_scheme_for_layer(
+                    self.quant_description,
+                    prefix,
+                    "ds_linear",
+                    self.packed_modules_mapping,
+                )
             quant_method = AscendLinearMethod(scheme)
             return quant_method
         if _is_fused_moe_layer(layer):
             layer.ascend_quant_method = FP8_METHOD
-            scheme = create_scheme_for_layer(self.quant_description, prefix, "w4a8_moe", self.packed_modules_mapping)
+            if self.mistral4_dynamic_channelwise:
+                scheme_cls = get_scheme_class("W8A8FP8_DYNAMIC", "moe")
+                assert scheme_cls is not None
+                scheme = scheme_cls()
+            else:
+                scheme = create_scheme_for_layer(
+                    self.quant_description,
+                    prefix,
+                    "w4a8_moe",
+                    self.packed_modules_mapping,
+                )
             quant_method = AscendFusedMoEMethod(scheme, layer.moe_config, tid2eid=tid2eid)
             return quant_method
         return None

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -102,9 +102,18 @@ _MINIMAX_M3_PACKED_MODULES = {
     "experts": ["experts.0.w1", "experts.0.w2", "experts.0.w3"],
 }
 
+_MISTRAL3_PACKED_MODULES = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+    "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+}
+
 packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
     "minimax_m3": _MINIMAX_M3_PACKED_MODULES,
     "minimax_m3_vl": _MINIMAX_M3_PACKED_MODULES,
+    "mistral3": _MISTRAL3_PACKED_MODULES,
+    "mistral4": _MISTRAL3_PACKED_MODULES,
     "qwen3_moe": {
         "qkv_proj": [
             "q_proj",

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -402,12 +402,19 @@ def enable_custom_op():
     Enable lazy init for vllm_ascend_C to avoid early initialization of CANN's RTS component.
     Ensure that ASCEND_RT_VISIBLE_DEVICES can be dynamically modified before torch.npu.set_device().
     """
-    import vllm.envs as envs
-
     global _CUSTOM_OP_ENABLED
 
     if _CUSTOM_OP_ENABLED is not None:
         return _CUSTOM_OP_ENABLED
+
+    # Importing an extension while Dynamo is tracing is unsupported. Standard
+    # workers initialize this state after selecting the NPU and before the
+    # first profile run; keep this fallback uncached for other call paths so a
+    # later eager invocation can still discover the extension.
+    if torch.compiler.is_compiling():
+        return False
+
+    import vllm.envs as envs
 
     # There are some customed operators which aren't implemented
     # with batch invariant in vllm-ascend, we need to disable them.

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -62,7 +62,7 @@ class AscendInputBuffers(InputBuffers):
         self.seq_lens_np: np.ndarray = self.seq_lens_cpu.numpy()
 
 
-@dataclass
+@dataclass(kw_only=True)
 class AscendInputBatch(InputBatch):
     """Input batch for Ascend NPUs."""
 

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -76,6 +76,7 @@ from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
     AscendDeviceType,
     check_ascend_device_type,
+    enable_custom_op,
     enable_sp,
     get_ascend_device_type,
     register_ascend_customop,
@@ -450,6 +451,10 @@ class NPUWorker(WorkerBase):
         set_random_seed(self.model_config.seed)
         # Initialize device properties used by triton kernels.
         init_device_properties_triton()
+        # Resolve extension availability before Dynamo traces model forwards.
+        # A missing extension is supported through torch-npu fallbacks, but
+        # probing it from inside a full graph raises an import failure.
+        enable_custom_op()
 
         return device
 


### PR DESCRIPTION
## Recommended title

```text
[Feature][Model] Support Shieldstral and Mistral4 on Ascend
```

## PR description

### What this PR does / why we need it?

This PR adds Ascend support for two Mistral-family models:

- **Shieldstral-1.0-3B**
- **Mistral-Small-4-119B-2603** (Mistral4)

It introduces Ascend-only nested model registration, weight mapping, W8A8/FP8 handling, MoE behavior, A2 RMSNorm, and graph guards for these models, plus focused regression tests and a support-matrix update.

The identical archived patch passed 109 targeted tests with 5 skips, and eager/ACLGraph validation on Ascend A2.

### Does this PR introduce _any_ user-facing change?

Yes. Two new model architectures (`Shieldstral`, `Mistral4`) are now supported on Ascend, including W8A8/FP8 quantization paths. No existing model behavior is changed.

### How was this patch tested?

- 109 targeted unit/regression tests passed (5 skips).
- Eager and ACLGraph validation on Ascend A2.
- New tests added:
  - `tests/ut/models/test_mistral_compat.py`
  - `tests/ut/models/test_shieldstral.py`
  - `tests/ut/quantization/test_fp8_config.py`
  - `tests/ut/compilation/test_graph_fusion_pass_manager.py`
  - `tests/ut/worker/test_input_batch_v2.py`
- Existing tests extended: `test_fused_moe.py`, `test_layernorm.py`, `test_modelslim_config.py`, `test_utils.py`, `test_worker_v1.py`.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
