### PR TITLE
[BugFix][Core] Fix first-layer SP AllGather for VL models based on input layout

### DIFF
--- a/tests/ut/ops/test_linear.py
+++ b/tests/ut/ops/test_linear.py
@@ -1,4 +1,5 @@
 import unittest
+from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -208,6 +209,74 @@ class TestColumnParallelOpDispatch(unittest.TestCase):
         self._patches[-1].start()
         self.assertIsNone(self._get_column_op("model.vision_model_proj.indexer_proj"))
         self.assertIsNone(self._get_column_op("model.vision_tower_encoder.qkv_proj"))
+
+
+class TestSequenceColumnParallelOp(unittest.TestCase):
+    def _apply_and_get_all_gather_label(
+        self,
+        *,
+        layer_idx: int,
+        is_vl_model: bool,
+        is_sp_sharded: bool,
+    ) -> bool:
+        from vllm_ascend.ops.linear_op import SequenceColumnParallelOp
+
+        layer = MagicMock()
+        layer.prefix = f"model.layers.{layer_idx}.self_attn.q_proj"
+        op = SequenceColumnParallelOp(layer)
+        op.prefix = layer.prefix
+        op.bias = None
+        op.skip_bias_add = False
+        op.gather_output = False
+        op.quant_method = MagicMock()
+        op.quant_method.apply.side_effect = lambda _layer, input_, _bias: input_
+        input_ = torch.randn(16, 8)
+        maybe_all_gather = MagicMock(side_effect=lambda x, *, label: x)
+        with (
+            patch("vllm_ascend.ops.linear_op.is_vl_model", return_value=is_vl_model),
+            patch(
+                "vllm_ascend.ops.linear_op._EXTRA_CTX",
+                SimpleNamespace(first_layer_input_is_sp_sharded=is_sp_sharded),
+            ),
+            patch.object(
+                torch.ops.vllm,
+                "maybe_all_gather_and_maybe_unpad",
+                maybe_all_gather,
+                create=True,
+            ),
+        ):
+            op.apply_impl(input_)
+
+        return maybe_all_gather.call_args.kwargs["label"]
+
+    def test_first_vl_attention_uses_layout_state_not_token_shape(self):
+        for is_sp_sharded, expected_label in ((True, True), (False, False)):
+            with self.subTest(is_sp_sharded=is_sp_sharded):
+                label = self._apply_and_get_all_gather_label(
+                    layer_idx=0,
+                    is_vl_model=True,
+                    is_sp_sharded=is_sp_sharded,
+                )
+
+                self.assertEqual(label, expected_label)
+
+    def test_first_non_vl_attention_keeps_all_gather(self):
+        label = self._apply_and_get_all_gather_label(
+            layer_idx=0,
+            is_vl_model=False,
+            is_sp_sharded=False,
+        )
+
+        self.assertTrue(label)
+
+    def test_non_first_vl_attention_keeps_all_gather(self):
+        label = self._apply_and_get_all_gather_label(
+            layer_idx=1,
+            is_vl_model=True,
+            is_sp_sharded=False,
+        )
+
+        self.assertTrue(label)
 
 
 class TestRowParallelOpDispatch(unittest.TestCase):

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 
 from vllm_ascend import ascend_forward_context as afc
-from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ascend_forward_context import FirstLayerInputSource, MoECommType
 
 
 @pytest.fixture(autouse=True)
@@ -15,6 +15,106 @@ def reset_mc2_tokens_capacity(monkeypatch):
         afc,
         "get_ascend_config",
         lambda: SimpleNamespace(enable_prefill_mc2=False, enable_fused_mc2=0),
+    )
+
+
+@pytest.mark.parametrize(
+    ("source", "flash_comm_v1_enabled", "is_draft_model", "expected"),
+    [
+        (FirstLayerInputSource.MODEL_EMBEDDING, True, False, True),
+        (FirstLayerInputSource.PRECOMPUTED_EMBEDDING, True, False, False),
+        (FirstLayerInputSource.NOT_APPLICABLE, True, False, False),
+        (FirstLayerInputSource.MODEL_EMBEDDING, False, False, False),
+        (FirstLayerInputSource.MODEL_EMBEDDING, True, True, False),
+    ],
+)
+def test_derive_first_layer_input_is_sp_sharded(
+    source,
+    flash_comm_v1_enabled,
+    is_draft_model,
+    expected,
+):
+    assert (
+        afc.derive_first_layer_input_is_sp_sharded(
+            source,
+            flash_comm_v1_enabled=flash_comm_v1_enabled,
+            is_draft_model=is_draft_model,
+        )
+        is expected
+    )
+
+
+def test_first_layer_input_source_scope_restores_after_exit_and_exception():
+    assert afc.get_first_layer_input_source() == FirstLayerInputSource.NOT_APPLICABLE
+
+    with afc.override_first_layer_input_source(FirstLayerInputSource.MODEL_EMBEDDING):
+        assert afc.get_first_layer_input_source() == FirstLayerInputSource.MODEL_EMBEDDING
+        with afc.override_first_layer_input_source(FirstLayerInputSource.PRECOMPUTED_EMBEDDING):
+            assert afc.get_first_layer_input_source() == FirstLayerInputSource.PRECOMPUTED_EMBEDDING
+        assert afc.get_first_layer_input_source() == FirstLayerInputSource.MODEL_EMBEDDING
+
+    assert afc.get_first_layer_input_source() == FirstLayerInputSource.NOT_APPLICABLE
+
+    with (
+        pytest.raises(RuntimeError, match="scope failure"),
+        afc.override_first_layer_input_source(FirstLayerInputSource.MODEL_EMBEDDING),
+    ):
+        raise RuntimeError("scope failure")
+
+    assert afc.get_first_layer_input_source() == FirstLayerInputSource.NOT_APPLICABLE
+
+
+@pytest.mark.parametrize(
+    ("is_first_pp_rank", "has_input_ids", "has_inputs_embeds", "expected"),
+    [
+        (True, True, False, FirstLayerInputSource.MODEL_EMBEDDING),
+        (True, False, True, FirstLayerInputSource.PRECOMPUTED_EMBEDDING),
+        (True, True, True, FirstLayerInputSource.PRECOMPUTED_EMBEDDING),
+        (False, True, False, FirstLayerInputSource.NOT_APPLICABLE),
+    ],
+)
+def test_infer_v1_first_layer_input_source(
+    is_first_pp_rank,
+    has_input_ids,
+    has_inputs_embeds,
+    expected,
+):
+    input_ids = torch.empty(1, dtype=torch.long) if has_input_ids else None
+    inputs_embeds = torch.empty(1, 4) if has_inputs_embeds else None
+
+    assert (
+        afc.infer_first_layer_input_source(
+            is_first_pp_rank=is_first_pp_rank,
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    ("is_first_pp_rank", "supports_mm_inputs", "is_encoder_decoder", "expected"),
+    [
+        (True, False, False, FirstLayerInputSource.MODEL_EMBEDDING),
+        (True, True, False, FirstLayerInputSource.PRECOMPUTED_EMBEDDING),
+        (True, True, True, FirstLayerInputSource.MODEL_EMBEDDING),
+        (False, True, False, FirstLayerInputSource.NOT_APPLICABLE),
+        (False, False, False, FirstLayerInputSource.NOT_APPLICABLE),
+    ],
+)
+def test_infer_mrv2_first_layer_input_source(
+    is_first_pp_rank,
+    supports_mm_inputs,
+    is_encoder_decoder,
+    expected,
+):
+    assert (
+        afc.infer_mrv2_first_layer_input_source(
+            is_first_pp_rank=is_first_pp_rank,
+            supports_mm_inputs=supports_mm_inputs,
+            is_encoder_decoder=is_encoder_decoder,
+        )
+        == expected
     )
 
 

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -8,7 +8,12 @@ from vllm.platforms import PlatformEnum
 from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
-from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
+from vllm_ascend.ascend_forward_context import (
+    FirstLayerInputSource,
+    MoECommType,
+    override_first_layer_input_source,
+    override_mrv2_in_profile_run,
+)
 from vllm_ascend.platform import NPUPlatform, _validate_eplb_config
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
@@ -460,6 +465,43 @@ class TestNPUPlatform(TestBase):
             )
 
         self.assertTrue(kwargs["in_profile_run"])
+
+    def test_set_additional_forward_context_derives_first_layer_sp_layout(self):
+        vllm_config = TestNPUPlatform.mock_vllm_config()
+        vllm_config.use_v2_model_runner = True
+        cases = (
+            (FirstLayerInputSource.MODEL_EMBEDDING, True, True),
+            (FirstLayerInputSource.PRECOMPUTED_EMBEDDING, True, False),
+            (FirstLayerInputSource.MODEL_EMBEDDING, False, False),
+        )
+
+        for source, sp_enabled, expected in cases:
+            with (
+                self.subTest(source=source, sp_enabled=sp_enabled),
+                patch("vllm_ascend.platform.envs_vllm.VLLM_USE_V2_MODEL_RUNNER", True, create=True),
+                patch("vllm_ascend.platform.is_moe_model", return_value=True),
+                patch("vllm_ascend.platform.enable_sp", return_value=sp_enabled),
+                patch("vllm.distributed.get_tensor_model_parallel_world_size", return_value=2),
+                patch("vllm.distributed.get_dp_group", return_value=MagicMock(world_size=1)),
+                patch(
+                    "vllm_ascend.ascend_forward_context.select_moe_comm_method",
+                    return_value=MoECommType.ALLGATHER,
+                ),
+                patch("vllm_ascend.ascend_forward_context.get_mc2_mask", return_value=None),
+                patch(
+                    "vllm_ascend.ops.fused_moe.moe_comm_method.get_moe_comm_method",
+                    return_value=object(),
+                ),
+                override_first_layer_input_source(source),
+            ):
+                kwargs = self.platform.set_additional_forward_context(
+                    attn_metadata=None,
+                    vllm_config=vllm_config,
+                    dp_metadata=None,
+                    num_tokens=4,
+                )
+
+            self.assertIs(kwargs["first_layer_input_is_sp_sharded"], expected)
 
     @patch("vllm_ascend.quantization.utils.maybe_auto_detect_quantization")
     @patch("vllm_ascend.ascend_config.init_ascend_config")

--- a/tests/ut/worker/test_model_runner_v2_flashcomm.py
+++ b/tests/ut/worker/test_model_runner_v2_flashcomm.py
@@ -1,11 +1,19 @@
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 
+from vllm_ascend.ascend_forward_context import (
+    FirstLayerInputSource,
+    get_first_layer_input_source,
+)
+from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.model_runner import (
+    NPUModelRunner,
     flashcomm_dispatch_wrapper,
 )
 from vllm_ascend.worker.v2.sp_utils import (
@@ -99,3 +107,72 @@ def test_flashcomm_dense_threshold_and_moe_behavior():
         ),
     ):
         assert _flashcomm_enabled(config, 1)
+
+
+def test_mrv2_runner_source_accounts_for_pp_rank():
+    runner = object.__new__(NPUModelRunner)
+    runner.supports_mm_inputs = True
+    runner.model_config = SimpleNamespace(is_encoder_decoder=False)
+
+    runner.is_first_pp_rank = True
+    assert runner.get_first_layer_input_source() == FirstLayerInputSource.PRECOMPUTED_EMBEDDING
+
+    runner.is_first_pp_rank = False
+    assert runner.get_first_layer_input_source() == FirstLayerInputSource.NOT_APPLICABLE
+
+
+def test_mrv2_execute_restores_input_source_after_exception():
+    runner = object.__new__(NPUModelRunner)
+    runner.vllm_config = _config()
+
+    with (
+        patch.object(
+            runner,
+            "get_first_layer_input_source",
+            return_value=FirstLayerInputSource.MODEL_EMBEDDING,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.model_runner.flashcomm_dispatch_wrapper",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "vllm_ascend.worker.v2.model_runner.GPUModelRunner.execute_model",
+            side_effect=RuntimeError("forward failure"),
+        ),
+        pytest.raises(RuntimeError, match="forward failure"),
+    ):
+        runner.execute_model(MagicMock())
+
+    assert get_first_layer_input_source() == FirstLayerInputSource.NOT_APPLICABLE
+
+
+def test_mrv2_graph_capture_uses_runner_input_source():
+    manager = object.__new__(ModelAclGraphManager)
+    manager.model_runner = MagicMock()
+    manager.model_runner.get_first_layer_input_source.return_value = FirstLayerInputSource.PRECOMPUTED_EMBEDDING
+
+    def capture(*args, **kwargs):
+        assert get_first_layer_input_source() == FirstLayerInputSource.PRECOMPUTED_EMBEDDING
+
+    with (
+        patch(
+            "vllm_ascend.worker.v2.aclgraph_utils.communicator_switch",
+            return_value=nullcontext(),
+        ),
+        patch(
+            "vllm_ascend.worker.v2.aclgraph_utils.ModelCudaGraphManager.capture",
+            side_effect=capture,
+        ),
+    ):
+        manager.capture(
+            torch.nn.Identity(),
+            MagicMock(),
+            MagicMock(),
+            None,
+            MagicMock(),
+            [],
+            MagicMock(),
+        )
+
+    manager.model_runner.get_first_layer_input_source.assert_called_once_with()
+    assert get_first_layer_input_source() == FirstLayerInputSource.NOT_APPLICABLE

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -29,9 +29,17 @@ class MoECommType(Enum):
     FUSED_MC2 = 3
 
 
+class FirstLayerInputSource(Enum):
+    MODEL_EMBEDDING = "model_embedding"
+    PRECOMPUTED_EMBEDDING = "precomputed_embedding"
+    NOT_APPLICABLE = "not_applicable"
+
+
 _MRV2_IN_PROFILE_RUN: ContextVar[bool] = ContextVar("_MRV2_IN_PROFILE_RUN", default=False)
-
-
+_FIRST_LAYER_INPUT_SOURCE: ContextVar[FirstLayerInputSource] = ContextVar(
+    "_FIRST_LAYER_INPUT_SOURCE",
+    default=FirstLayerInputSource.NOT_APPLICABLE,
+)
 _MEGA_MOE_TOKENS_PER_RANK_LIMIT = 4096
 _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT = 512
 _MC2_TOKENS_PER_RANK_LIMIT = 512
@@ -58,6 +66,56 @@ def get_mrv2_in_profile_run() -> bool:
 
 
 @contextmanager
+def override_first_layer_input_source(source: FirstLayerInputSource):
+    token = _FIRST_LAYER_INPUT_SOURCE.set(source)
+    try:
+        yield
+    finally:
+        _FIRST_LAYER_INPUT_SOURCE.reset(token)
+
+
+def get_first_layer_input_source() -> FirstLayerInputSource:
+    return _FIRST_LAYER_INPUT_SOURCE.get()
+
+
+def infer_first_layer_input_source(
+    *,
+    is_first_pp_rank: bool,
+    input_ids: torch.Tensor | None,
+    inputs_embeds: torch.Tensor | None,
+) -> FirstLayerInputSource:
+    if not is_first_pp_rank:
+        return FirstLayerInputSource.NOT_APPLICABLE
+    if inputs_embeds is not None:
+        return FirstLayerInputSource.PRECOMPUTED_EMBEDDING
+    if input_ids is not None:
+        return FirstLayerInputSource.MODEL_EMBEDDING
+    return FirstLayerInputSource.NOT_APPLICABLE
+
+
+def infer_mrv2_first_layer_input_source(
+    *,
+    is_first_pp_rank: bool,
+    supports_mm_inputs: bool,
+    is_encoder_decoder: bool,
+) -> FirstLayerInputSource:
+    if not is_first_pp_rank:
+        return FirstLayerInputSource.NOT_APPLICABLE
+    if supports_mm_inputs and not is_encoder_decoder:
+        return FirstLayerInputSource.PRECOMPUTED_EMBEDDING
+    return FirstLayerInputSource.MODEL_EMBEDDING
+
+
+def derive_first_layer_input_is_sp_sharded(
+    source: FirstLayerInputSource,
+    *,
+    flash_comm_v1_enabled: bool,
+    is_draft_model: bool,
+) -> bool:
+    return source == FirstLayerInputSource.MODEL_EMBEDDING and flash_comm_v1_enabled and not is_draft_model
+
+
+@contextmanager
 def set_ascend_forward_context(
     attn_metadata: Any,
     vllm_config: VllmConfig,
@@ -74,6 +132,7 @@ def set_ascend_forward_context(
     draft_attn_metadatas=None,
     has_sinks=False,
     eplb_heat_collection_status: bool = False,
+    first_layer_input_source: FirstLayerInputSource = FirstLayerInputSource.NOT_APPLICABLE,
 ):
     """A context manager that stores the current forward context,
     can be attention metadata, etc.
@@ -158,6 +217,11 @@ def set_ascend_forward_context(
         forward_context.model_instance = model_instance
         forward_context.is_draft_model = is_draft_model
         forward_context.is_draft_model_prefill = False
+        forward_context.first_layer_input_is_sp_sharded = derive_first_layer_input_is_sp_sharded(
+            first_layer_input_source,
+            flash_comm_v1_enabled=flash_comm_v1_enabled,
+            is_draft_model=is_draft_model,
+        )
 
         if num_tokens is None and attn_metadata is not None:
             num_tokens = attn_metadata.num_actual_tokens
@@ -397,6 +461,7 @@ class _ExtraForwardContextProxy:
         "padded_num_tokens",
         "sinks",
         "eplb_heat_collection_status",
+        "first_layer_input_is_sp_sharded",
     )
 
     def check_extra_attr(self, name: str):

--- a/vllm_ascend/ops/linear_op.py
+++ b/vllm_ascend/ops/linear_op.py
@@ -298,7 +298,8 @@ class SequenceColumnParallelOp(CustomColumnParallelOp):
 
         # Matrix multiply.
         assert self.quant_method is not None
-        need_all_gather = not (extract_layer_index(self.layer.prefix) == 0 and is_vl_model() and "attn" in self.prefix)
+        is_first_vl_attention = extract_layer_index(self.layer.prefix) == 0 and is_vl_model() and "attn" in self.prefix
+        need_all_gather = not is_first_vl_attention or bool(_EXTRA_CTX.first_layer_input_is_sp_sharded)
         input_ = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(input_, label=need_all_gather)
         output_parallel = self.quant_method.apply(self.layer, input_, bias)
 

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -426,6 +426,8 @@ class NPUPlatform(Platform):
         """
         # NOTE(Ronald1995): avoid circular import.
         from vllm_ascend.ascend_forward_context import (
+            derive_first_layer_input_is_sp_sharded,
+            get_first_layer_input_source,
             get_mc2_mask,
             get_mrv2_in_profile_run,
             select_moe_comm_method,
@@ -528,6 +530,11 @@ class NPUPlatform(Platform):
             "in_profile_run": in_profile_run,
             "padded_num_tokens": padded_num_tokens,
             "sinks": sinks,
+            "first_layer_input_is_sp_sharded": derive_first_layer_input_is_sp_sharded(
+                get_first_layer_input_source(),
+                flash_comm_v1_enabled=flash_comm_v1_enabled,
+                is_draft_model=is_draft_model,
+            ),
         }
 
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -196,6 +196,7 @@ from vllm_ascend.worker.utils import AscendKVBlockZeroer
 from vllm_ascend.ascend_forward_context import (  # isort: skip
     MoECommType,
     get_mc2_tokens_capacity,
+    infer_first_layer_input_source,
     select_moe_comm_method,
     set_ascend_forward_context,
     set_mc2_mask,
@@ -2079,6 +2080,11 @@ class NPUModelRunner(GPUModelRunner):
                 num_tokens_padded,
                 intermediate_tensors,
             )
+            first_layer_input_source = infer_first_layer_input_source(
+                is_first_pp_rank=get_pp_group().is_first_rank,
+                input_ids=input_ids,
+                inputs_embeds=inputs_embeds,
+            )
 
             # update global cos, sin
             update_cos_sin(positions)
@@ -2118,6 +2124,7 @@ class NPUModelRunner(GPUModelRunner):
                 skip_compiled=has_encoder_input,
                 has_sinks=self._has_sinks,
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
+                first_layer_input_source=first_layer_input_source,
             ),
             self.maybe_get_kv_connector_output(
                 scheduler_output,
@@ -3382,6 +3389,11 @@ class NPUModelRunner(GPUModelRunner):
             else:
                 input_ids = self.input_ids.gpu[:num_tokens_padded]
                 inputs_embeds = None
+            first_layer_input_source = infer_first_layer_input_source(
+                is_first_pp_rank=get_pp_group().is_first_rank,
+                input_ids=input_ids,
+                inputs_embeds=inputs_embeds,
+            )
 
             if self.uses_mrope:
                 positions = self.mrope_positions.gpu[:, :num_tokens_padded]
@@ -3441,6 +3453,7 @@ class NPUModelRunner(GPUModelRunner):
                 model_instance=self.model,
                 has_sinks = self._has_sinks,
                 eplb_heat_collection_status=self.eplb_heat_collection_status if self.dynamic_eplb else False,
+                first_layer_input_source=first_layer_input_source,
             ):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -35,7 +35,12 @@ from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
 from vllm.v1.worker.utils import AttentionGroup
 
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.ascend_forward_context import (
+    _EXTRA_CTX,
+    derive_first_layer_input_is_sp_sharded,
+    get_first_layer_input_source,
+    override_first_layer_input_source,
+)
 from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
 from vllm_ascend.worker.v2.utils import communicator_switch
 
@@ -152,7 +157,10 @@ class ModelAclGraphManager(ModelCudaGraphManager):
     ) -> None:
         """Capture CUDA graphs for model forward pass."""
         model = ModelWithContext(model)
-        with communicator_switch():
+        with (
+            communicator_switch(),
+            override_first_layer_input_source(self.model_runner.get_first_layer_input_source()),
+        ):
             return super().capture(
                 model,
                 model_state,
@@ -186,6 +194,11 @@ class ModelWithContext(nn.Module):
             _EXTRA_CTX.capturing = True
         if self.is_draft_model:
             _EXTRA_CTX.is_draft_model = True
+            _EXTRA_CTX.first_layer_input_is_sp_sharded = derive_first_layer_input_is_sp_sharded(
+                get_first_layer_input_source(),
+                flash_comm_v1_enabled=bool(_EXTRA_CTX.flash_comm_v1_enabled),
+                is_draft_model=True,
+            )
         if self.is_draft_model_prefill:
             _EXTRA_CTX.is_draft_model_prefill = True
 

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -43,8 +43,11 @@ from vllm.v1.worker.gpu.model_runner import (
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import (
+    FirstLayerInputSource,
     MoECommType,
     get_mc2_tokens_capacity,
+    infer_mrv2_first_layer_input_source,
+    override_first_layer_input_source,
     override_mrv2_in_profile_run,
     select_moe_comm_method,
     set_mc2_mask,
@@ -221,6 +224,13 @@ class NPUModelRunner(GPUModelRunner):
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
 
+    def get_first_layer_input_source(self) -> FirstLayerInputSource:
+        return infer_mrv2_first_layer_input_source(
+            is_first_pp_rank=self.is_first_pp_rank,
+            supports_mm_inputs=self.supports_mm_inputs,
+            is_encoder_decoder=self.model_config.is_encoder_decoder,
+        )
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -230,7 +240,10 @@ class NPUModelRunner(GPUModelRunner):
         skip_attn_for_dummy_run: bool = False,
         is_profile: bool = False,
     ):
-        with flashcomm_dispatch_wrapper(self.vllm_config):
+        with (
+            override_first_layer_input_source(self.get_first_layer_input_source()),
+            flashcomm_dispatch_wrapper(self.vllm_config),
+        ):
             output = super().execute_model(
                 scheduler_output,
                 intermediate_tensors=intermediate_tensors,


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #14410

This PR fixes incorrect first-layer Sequence Parallelism (SP) AllGather behavior for vision-language (VL) models when FlashComm1 is enabled.

Currently, `SequenceColumnParallelOp` skips the first-layer attention AllGather based on the static model architecture:

```python
need_all_gather = not (
    extract_layer_index(self.layer.prefix) == 0
    and is_vl_model()
    and "attn" in self.prefix
)
```

However, `is_vl_model()` only indicates that the model architecture supports multimodal inputs. It does not describe the runtime layout of the tensor entering the first language-model layer.

For VL models, the first-layer input can come from two different paths:

1. **Model embedding path**

   In text-only configurations such as `--language-model-only`, the model receives `input_ids` and computes embeddings internally.

   With FlashComm1/SP enabled, the embedding output is ReduceScatter-ed before entering the first transformer layer:

   ```text
   model embedding
       |
       v
   [N, hidden]
       |
       | SP ReduceScatter
       v
   [N / TP, hidden]
       |
       | first-layer AllGather required
       v
   [N, hidden]
   ```

2. **Precomputed embedding path**

   For normal multimodal execution, the model runner can provide precomputed `inputs_embeds`.

   The first language-model layer already receives the full token sequence:

   ```text
   precomputed inputs_embeds
       |
       v
   [N, hidden]
       |
       | first-layer AllGather must be skipped
       v
   [N, hidden]
   ```

Therefore, neither always skipping nor always performing the first-layer AllGather is correct.

#### Changes in this PR

This PR introduces an explicit first-layer input provenance/layout state instead of inferring the layout from tensor shape or model architecture.

It adds:

- `FirstLayerInputSource`
  - `MODEL_EMBEDDING`
  - `PRECOMPUTED_EMBEDDING`
  - `NOT_APPLICABLE`
- `first_layer_input_is_sp_sharded` in the Ascend forward context.
- Input-source propagation for both V1 and Model Runner V2.
- Scoped `ContextVar` handling so the input-source state is restored correctly across normal execution, nested contexts, exceptions, and graph capture.
- Correct handling of PP non-first ranks and draft models.
- First-layer `SequenceColumnParallelOp` now performs AllGather only when the runtime input is actually SP-sharded.

The resulting first-layer decision is:

```text
MODEL_EMBEDDING + FlashComm1/SP + non-draft
    -> first_layer_input_is_sp_sharded=True
    -> AllGather

PRECOMPUTED_EMBEDDING
    -> first_layer_input_is_sp_sharded=False
    -> skip AllGather
```

The fix is framework-level and does not contain MiniMax-M3- or Qwen3.5-specific branches.

It also intentionally avoids using tensor-shape heuristics. Shape equality is not sufficient to determine whether a tensor is SP-sharded, for example during single-token decode or DP token imbalance.

### Does this PR introduce _any_ user-facing change?

Yes.

VL models using FlashComm1/SP now correctly handle both model-embedding and precomputed-embedding first-layer inputs.

This fixes text-only inference for affected VL models while preserving the existing multimodal path where the first-layer input is already full-sequence.

There is no API or configuration interface change.

### How was this patch tested?

#### Unit and existing E2E tests

The following tests were run:

```bash
python -m pytest -q tests/ut/test_ascend_forward_context.py
# 41 passed

python -m pytest -q tests/ut/ops/test_linear.py
# 18 passed

python -m pytest -q tests/ut/test_platform.py
# 66 passed, 1 skipped

python -m pytest -q tests/ut/worker/test_model_runner_v2_flashcomm.py
# 6 passed

python -m pytest -q tests/ut/ops/test_vocab_parallel_embedding.py
# 7 passed

python -m pytest -q tests/e2e/pull_request/two_card/test_sequence_parallelism_moe.py
# 3 passed
```

Total:

```text
141 passed, 1 skipped
```

The new regression tests cover:

- model embedding + SP enabled -> sharded
- precomputed embedding + SP enabled -> not sharded
- model embedding + SP disabled -> not sharded
- draft model -> not sharded
- PP non-first rank -> not applicable
- same tensor shape with different input provenance -> different AllGather decisions
- first-layer VL attention behavior
- non-first-layer and non-VL collective behavior
- scoped `ContextVar` restoration after nested contexts and exceptions
- V1 and Model Runner V2 input-source inference
- Model Runner V2 execution and graph-capture source propagation

#### Hardware validation: MiniMax-M3

Configuration:

```text
TP=4
PP=2
DP=2
FlashComm1=ON
SP=ON
eager mode
```

**Text-only path (`image=0`, `video=0`)**

The first-layer input is produced by the model embedding and is SP-sharded:

```text
first_layer_input_is_sp_sharded=True
need_all_gather=True
```

Observed shape restoration included:

```text
profile:
16   -> 64
512  -> 2048

real request prefill:
46   -> 184

decode:
1    -> 4
```

The service started successfully and a real text request returned successfully.

**Multimodal path (`image=1`, `video=0`)**

The first-layer input comes from precomputed embeddings:

```text
first_layer_input_is_sp_sharded=False
need_all_gather=False
```

The token dimension remained unchanged across the first-layer collective decision:

```text
64   -> 64
2048 -> 2048
```

A real image request succeeded.

A text-only request sent to the same multimodal-capable service also succeeded without restarting the server.

Note: the MiniMax-M3 image-enabled validation used the independent shared-vision-tower pruning fix from #14210 as a prerequisite. That change is not included in this PR.

#### Hardware validation: Qwen3.5

Configuration:

```text
Qwen3.5-35B-A3B-W8A8
TP=2
EP enabled
FlashComm1=ON
eager mode
```

**Language-model-only path**

Using:

```text
--language-model-only
multistream_overlap_shared_expert=false
```

The first-layer input was correctly identified as SP-sharded:

```text
first_layer_input_is_sp_sharded=True
need_all_gather=True
```

Observed shapes included:

```text
64   -> 128
1024 -> 2048
```

The service started successfully and a real text request returned successfully.

**Normal multimodal path**

Using:

```text
--limit-mm-per-prompt '{"image":1,"video":0}'
```

The first-layer input was correctly identified as non-sharded:

```text
first_layer_input_is_sp_sharded=False
need_all_gather=False
```

Observed shapes remained unchanged:

```text
128   -> 128
16384 -> 16384
```

The service started successfully.

Both a real image request and a real text request returned HTTP 200 with correct outputs.

This cross-model validation confirms that the first-layer collective decision follows the runtime input provenance/layout rather than model-specific logic or request modality.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
