### PR TITLE
[BugFix] Fix vllm_version_is for dev builds with local version segments

### DIFF
--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -197,6 +197,14 @@ class TestUtils(TestBase):
         with mock.patch("vllm.__version__", "2.0.0"):
             self.assertTrue(utils.vllm_version_is.__wrapped__("2.0.0"))
             self.assertFalse(utils.vllm_version_is.__wrapped__("1.0.0"))
+        # Dev builds with local segments (e.g. "0.26.0+empty") should match
+        # their release version ("0.26.0"), not fail due to strict ==.
+        with mock.patch("vllm.__version__", "0.26.0+empty"):
+            self.assertTrue(utils.vllm_version_is.__wrapped__("0.26.0"))
+            self.assertFalse(utils.vllm_version_is.__wrapped__("0.27.1"))
+        with mock.patch("vllm.__version__", "0.27.1+empty"):
+            self.assertFalse(utils.vllm_version_is.__wrapped__("0.26.0"))
+            self.assertTrue(utils.vllm_version_is.__wrapped__("0.27.1"))
         # Test caching takes effect
         utils.vllm_version_is.cache_clear()
         utils.vllm_version_is("1.0.0")

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -584,7 +584,11 @@ def vllm_version_is(target_vllm_version: str):
 
         vllm_version = vllm.__version__
     try:
-        return Version(vllm_version) == Version(target_vllm_version)
+        # Compare base versions only, ignoring local segments (e.g. "0.26.0+empty"
+        # must match "0.26.0"). Dev builds carry "+empty" or similar local labels
+        # which cause strict == to return False, leading to wrong code paths
+        # (e.g. patch_fused_moe.py accessing FusedMoEFactory on vllm 0.26.0).
+        return Version(vllm_version).base_version == Version(target_vllm_version).base_version
     except InvalidVersion:
         raise ValueError(
             f"Invalid vllm version {vllm_version} found. A dev version of vllm "


### PR DESCRIPTION
## What this PR does / why we need it?

`vllm_version_is()` used strict `Version ==` comparison, which returns `False` for dev builds with local segments (e.g. `"0.26.0+empty" != "0.26.0"`). This caused `patch_fused_moe.py` to access the wrong MoE factory attribute (`FusedMoEFactory` instead of `FusedMoE`) on vllm 0.26.0 dev builds, crashing all A3 E2E tests with:

```
AttributeError: module 'vllm.model_executor.layers.fused_moe.layer' has no attribute 'FusedMoEFactory'. Did you mean: 'FusedMoERouter'?
```

**Root cause**: The nightly-ci A3 image ships `vllm 0.26.0+empty` (dev build). `packaging.version.Version("0.26.0+empty") == Version("0.26.0")` returns `False` because the local segment `+empty` breaks strict equality. This affects all 84 `vllm_version_is` call sites.

**Fix**: Compare `Version.base_version` (strips local segments) so that `"0.26.0+empty"` matches `"0.26.0"`.

## Does this PR introduce any user-facing change?

No. Internal version detection fix only.

## How was this patch tested?

- Unit tests added in `test_vllm_version_is` for local-segment versions (`0.26.0+empty`, `0.27.1+empty`)
- Existing tests pass (no behavior change for release versions without local segments)

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
