### PR TITLE
[CI] Eplb nightly test split into v1/v2

### DIFF
--- a/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Qwen3-235B-W8A8-EPLB.yaml
@@ -10,7 +10,6 @@ env_common: &env_common
   OMP_NUM_THREADS: 1
   HCCL_BUFFSIZE: 1024
   SERVER_PORT: 8080
-  DYNAMIC_EPLB: true
 disaggregated_prefill:
   enabled: true
   prefiller_host_index: [0]
@@ -51,8 +50,27 @@ deployment:
                   }
             }
         }'
-        --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":50,"algorithm_execution_interval":5}}'
+    runner_configs:
+      v1:
+        envs:
+          DYNAMIC_EPLB: true
+        server_cmd_suffix: >
+          --additional-config
+          '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":50,"algorithm_execution_interval":5}}'
+      v2:
+        envs:
+          DYNAMIC_EPLB: false
+          EXPERT_MAP_RECORD: false
+        server_cmd_suffix: >
+          --enable-eplb
+          --eplb-config.window_size 50
+          --eplb-config.step_interval 50
+          --eplb-config.num_redundant_experts 16
+          --eplb-config.use_async true
+          --eplb-config.log_balancedness true
+          --eplb-config.log_balancedness_interval 1
+          --additional-config
+          '{"eplb_config": {"load_collection_phase":"prefill"}}'
 
   -
     envs:
@@ -88,6 +106,25 @@ deployment:
                   }
             }
         }'
-        --additional-config
-        '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":600,"algorithm_execution_interval":50}}'
+    runner_configs:
+      v1:
+        envs:
+          DYNAMIC_EPLB: true
+        server_cmd_suffix: >
+          --additional-config
+          '{"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":600,"algorithm_execution_interval":50}}'
+      v2:
+        envs:
+          DYNAMIC_EPLB: false
+          EXPERT_MAP_RECORD: false
+        server_cmd_suffix: >
+          --enable-eplb
+          --eplb-config.window_size 50
+          --eplb-config.step_interval 50
+          --eplb-config.num_redundant_experts 16
+          --eplb-config.use_async true
+          --eplb-config.log_balancedness true
+          --eplb-config.log_balancedness_interval 1
+          --additional-config
+          '{"eplb_config": {"load_collection_phase":"decode"}}'
 benchmarks:

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/multi_node_config.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/multi_node_config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import regex as re
+from vllm import envs as envs_vllm
 
 from tests.e2e.nightly.multi_node.scripts.utils import (
     get_available_port,
@@ -282,6 +283,36 @@ class MultiNodeConfigLoader:
         if missing:
             raise KeyError(f"Missing required config fields: {missing}")
 
+    @staticmethod
+    def _resolve_runner_deployment(deploy: dict[str, Any], use_v2_model_runner: bool) -> tuple[str, dict[str, Any]]:
+        """Merge the selected model-runner overrides into one deployment."""
+        cmd = deploy.get("server_cmd", "")
+        envs = dict(deploy["envs"])
+        runner_configs = deploy.get("runner_configs")
+        if runner_configs is None:
+            return cmd, envs
+        if not isinstance(runner_configs, dict):
+            raise TypeError("deployment.runner_configs must be a mapping")
+
+        runner_name = "v2" if use_v2_model_runner else "v1"
+        if runner_name not in runner_configs:
+            raise KeyError(f"deployment.runner_configs.{runner_name} is required")
+        runner_config = runner_configs[runner_name]
+        if not isinstance(runner_config, dict):
+            raise TypeError(f"deployment.runner_configs.{runner_name} must be a mapping")
+
+        runner_envs = runner_config.get("envs", {})
+        if not isinstance(runner_envs, dict):
+            raise TypeError(f"deployment.runner_configs.{runner_name}.envs must be a mapping")
+        envs.update(runner_envs)
+
+        cmd_suffix = runner_config.get("server_cmd_suffix", "")
+        if not isinstance(cmd_suffix, str):
+            raise TypeError(f"deployment.runner_configs.{runner_name}.server_cmd_suffix must be a string")
+        if cmd_suffix:
+            cmd = f"{cmd.rstrip()}\n{cmd_suffix.lstrip()}"
+        return cmd, envs
+
     @classmethod
     def _parse_nodes(cls, cfg: dict) -> list[NodeInfo]:
         num_nodes = cfg["num_nodes"]
@@ -297,15 +328,15 @@ class MultiNodeConfigLoader:
         cluster_ips = cls._resolve_cluster_ips(cfg, num_nodes)
 
         nodes: list[NodeInfo] = []
+        use_v2_model_runner = bool(envs_vllm.VLLM_USE_V2_MODEL_RUNNER)
         for idx, deploy in enumerate(deployments):
-            cmd = deploy.get("server_cmd", "")
-            envs = deploy["envs"]
+            cmd, deployment_envs = cls._resolve_runner_deployment(deploy, use_v2_model_runner=use_v2_model_runner)
             nodes.append(
                 NodeInfo(
                     index=idx,
                     ip=cluster_ips[idx],
                     server_cmd=cmd,
-                    envs=envs,
+                    envs=deployment_envs,
                     headless="--headless" in cmd,
                 )
             )

--- a/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
+++ b/tests/e2e/nightly/multi_node/internal_dp/scripts/test_multi_node.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from typing import Any
 
+os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+
 import pytest
 import vllm
 

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-235B-A22B-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-235B-A22B-W8A8.yaml
@@ -73,12 +73,36 @@ test_cases:
     model: "vllm-ascend/Qwen3-235B-A22B-W8A8"
     envs:
       <<: *envs
-      DYNAMIC_EPLB: "true"
     server_cmd: *server_cmd
     server_cmd_extra:
-      - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": "true", "expert_heat_collection_interval": 600, "algorithm_execution_interval": 50, "num_redundant_experts": 16, "eplb_policy_type": 2}}'
       - "--compilation-config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+    runner_configs:
+      v1:
+        envs:
+          DYNAMIC_EPLB: "true"
+        server_cmd_extra:
+          - "--additional-config"
+          - '{"eplb_config": {"dynamic_eplb": true, "expert_heat_collection_interval": 600, "algorithm_execution_interval": 50, "num_redundant_experts": 16, "eplb_policy_type": 2}}'
+      v2:
+        envs:
+          DYNAMIC_EPLB: "false"
+          EXPERT_MAP_RECORD: "false"
+        server_cmd_extra:
+          - "--enable-eplb"
+          - "--eplb-config.window_size"
+          - "50"
+          - "--eplb-config.step_interval"
+          - "50"
+          - "--eplb-config.num_redundant_experts"
+          - "16"
+          - "--eplb-config.use_async"
+          - "false"
+          - "--eplb-config.log_balancedness"
+          - "true"
+          - "--eplb-config.log_balancedness_interval"
+          - "1"
+          - "--additional-config"
+          - '{"eplb_config": {"load_collection_phase": "all"}}'
     benchmarks:
       <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/scripts/single_node_config.py
+++ b/tests/e2e/nightly/single_node/models/scripts/single_node_config.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import regex as re
 import yaml
+from vllm import envs as envs_vllm
 from vllm.utils.network_utils import get_open_port
 
 CONFIG_BASE_PATH = os.getenv("CONFIG_BASE_PATH") or "tests/e2e/nightly/single_node/models/configs"
@@ -165,10 +166,45 @@ class SingleNodeConfigLoader:
             if not isinstance(case["name"], str) or not case["name"].strip():
                 raise ValueError("test case field 'name' must be a non-empty string")
 
+    @staticmethod
+    def _resolve_runner_case(case: dict[str, Any]) -> dict[str, Any]:
+        """Merge the selected model-runner overrides into one test case."""
+        runner_configs = case.get("runner_configs")
+        if runner_configs is None:
+            return case
+        if not isinstance(runner_configs, dict):
+            raise TypeError("test case runner_configs must be a mapping")
+
+        runner_name = "v2" if bool(envs_vllm.VLLM_USE_V2_MODEL_RUNNER) else "v1"
+        if runner_name not in runner_configs:
+            raise KeyError(f"test case runner_configs.{runner_name} is required")
+        runner_config = runner_configs[runner_name]
+        if not isinstance(runner_config, dict):
+            raise TypeError(f"test case runner_configs.{runner_name} must be a mapping")
+
+        runner_envs = runner_config.get("envs", {})
+        if not isinstance(runner_envs, dict):
+            raise TypeError(f"test case runner_configs.{runner_name}.envs must be a mapping")
+        runner_server_cmd_extra = runner_config.get("server_cmd_extra", [])
+        if not isinstance(runner_server_cmd_extra, list):
+            raise TypeError(f"test case runner_configs.{runner_name}.server_cmd_extra must be a list")
+
+        resolved_case = dict(case)
+        resolved_case.pop("runner_configs")
+        envs = dict(case.get("envs", {}))
+        envs.update(runner_envs)
+        resolved_case["envs"] = envs
+        resolved_case["server_cmd_extra"] = [
+            *case.get("server_cmd_extra", []),
+            *runner_server_cmd_extra,
+        ]
+        return resolved_case
+
     @classmethod
     def _parse_test_cases(cls, cases: list[dict[str, Any]]) -> list[SingleNodeConfig]:
         result: list[SingleNodeConfig] = []
         for case in cases:
+            case = cls._resolve_runner_case(case)
             server_cmd = case.get("server_cmd", [])
             server_cmd_extra = case.get("server_cmd_extra", [])
             full_cmd = list(server_cmd) + list(server_cmd_extra)

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from typing import Any
 
+os.environ["VLLM_USE_V2_MODEL_RUNNER"] = "1"
+
 import openai
 import psutil
 import pytest

--- a/tests/ut/test_multi_node_config.py
+++ b/tests/ut/test_multi_node_config.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import pytest
+
+from tests.e2e.nightly.multi_node.internal_dp.scripts.multi_node_config import MultiNodeConfigLoader
+
+
+@pytest.fixture
+def deployment() -> dict:
+    return {
+        "envs": {"SERVER_PORT": 8080},
+        "server_cmd": "vllm serve model --enable-expert-parallel",
+        "runner_configs": {
+            "v1": {
+                "envs": {"DYNAMIC_EPLB": True},
+                "server_cmd_suffix": '--additional-config \'{"eplb_config":{"dynamic_eplb":true}}\'',
+            },
+            "v2": {
+                "envs": {"DYNAMIC_EPLB": False},
+                "server_cmd_suffix": "--enable-eplb --eplb-config.use_async true",
+            },
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("use_v2_model_runner", "expected_env", "expected_arg", "unexpected_arg"),
+    [
+        (False, True, "dynamic_eplb", "--enable-eplb"),
+        (True, False, "--enable-eplb", "dynamic_eplb"),
+    ],
+)
+def test_resolve_runner_deployment(
+    deployment: dict,
+    use_v2_model_runner: bool,
+    expected_env: bool,
+    expected_arg: str,
+    unexpected_arg: str,
+) -> None:
+    cmd, envs = MultiNodeConfigLoader._resolve_runner_deployment(deployment, use_v2_model_runner=use_v2_model_runner)
+
+    assert cmd.startswith("vllm serve model")
+    assert expected_arg in cmd
+    assert unexpected_arg not in cmd
+    assert envs["DYNAMIC_EPLB"] is expected_env
+    assert envs["SERVER_PORT"] == 8080
+    assert deployment["envs"] == {"SERVER_PORT": 8080}
+
+
+def test_resolve_runner_deployment_without_overrides() -> None:
+    deployment = {
+        "envs": {"SERVER_PORT": 8080},
+        "server_cmd": "vllm serve model",
+    }
+
+    assert MultiNodeConfigLoader._resolve_runner_deployment(deployment, True) == (
+        "vllm serve model",
+        {"SERVER_PORT": 8080},
+    )
+
+
+def test_resolve_runner_deployment_requires_selected_runner(deployment: dict) -> None:
+    del deployment["runner_configs"]["v2"]
+
+    with pytest.raises(KeyError, match=r"runner_configs\.v2"):
+        MultiNodeConfigLoader._resolve_runner_deployment(deployment, True)


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces support for model-runner-specific configurations (v1 and v2) in multi-node end-to-end tests. It refactors the configuration loader to dynamically resolve and merge environment variables and command-line suffixes based on whether the V2 model runner is enabled. This allows running tests with different EPLB configurations for V1 and V2 runners.

Feedback on the changes:
1. In `multi_node_config.py`, appending the command suffix with a newline (`\n`) instead of a space might break command execution if run directly in a shell. It is recommended to use a space separator instead.
2. Accessing `envs_vllm.VLLM_USE_V2_MODEL_RUNNER` directly could raise an `AttributeError` on older vLLM versions. It is safer to use `getattr(envs_vllm, "VLLM_USE_V2_MODEL_RUNNER", False)`.

### Does this PR introduce _any_ user-facing change?
No, this change only affects internal end-to-end and nightly testing configurations.

### How was this patch tested?
Unit tests were added in `tests/ut/test_multi_node_config.py` to verify the resolution of runner deployments with and without overrides, as well as error handling for missing runner configurations.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
