### PR TITLE
[Doc][950DT] add Ascend 950DT DeepSeek-V4 deployment guides

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -24,6 +24,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 ### 3.1 Model Weight
 
 - `DeepSeek-V4-Flash-w8a8-mtp` (Quantized version): requires 1 Atlas 800 A3 (128GB × 8) node or 1 Atlas 800 A2 (64GB × 8) node. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/DeepSeek-V4-Flash-w8a8-mtp)
+- For Ascend 950DT servers, use the original [`DeepSeek-V4-Flash`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash) weights released by DeepSeek on Hugging Face. The Attention weights use MXFP8, while the MoE weights use MXFP4 with 4-bit weights and 8-bit activation computation (W4A8). No Ascend-specific quantization or weight conversion is required. Both the mixed-deployment example in Section 5.1 and the intra-server 1P1D example in Section 5.2.3 use one Ascend 950DT server (96GB × 8). The mixed deployment uses four NPUs, while the 1P1D deployment assigns four NPUs to Prefill and four NPUs to Decode.
 
 - DeepSeek released new DeepSeek-V4-Flash-DSpark weights on July 31, 2026. Download the quantized `DeepSeek-V4-Flash-0731-w8a8` weight from [ModelScope](https://www.modelscope.cn/models/Eco-Tech/DeepSeek-V4-Flash-0731-w8a8).
 
@@ -40,6 +41,42 @@ If you want to deploy a multi-node environment, you need to verify multi-node co
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
 
 **Attention**: DSpark is supported on both A2 and A3 in vLLM Ascend `v0.25.0` and later. Use the image `quay.io/ascend/vllm-ascend:DeepSeekV4-flash-0731` for A2 or the image `quay.io/ascend/vllm-ascend:DeepSeekV4-flash-0731-a3` for A3.
+
+=== "Ascend 950DT series"
+
+    Start the Docker container on each server.
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-950dt
+    export NAME=vllm-ascend
+
+    docker run --rm \
+        --name $NAME \
+        --net=host \
+        --shm-size=512g \
+        --device /dev/davinci0 \
+        --device /dev/davinci1 \
+        --device /dev/davinci2 \
+        --device /dev/davinci3 \
+        --device /dev/davinci4 \
+        --device /dev/davinci5 \
+        --device /dev/davinci6 \
+        --device /dev/davinci7 \
+        --device /dev/davinci_manager \
+        --device /dev/hisi_hdc \
+        --device /dev/ummu \
+        --device /dev/uburma \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /etc/hccl_rootinfo.json:/etc/hccl_rootinfo.json \
+        -v /etc/hixlep/:/etc/hixlep/ \
+        -v /root/.cache:/root/.cache \
+        -v /usr/local/sbin:/usr/local/sbin \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+        -itd $IMAGE bash
+    ```
 
 === "A3 series"
 
@@ -135,13 +172,13 @@ If you want to deploy a multi-node environment, you need to set up the environme
 
 !!! note
 
-    In this tutorial, we suppose you downloaded the model weight to `/root/.cache/modelscope/hub/models/vllm-ascend/`. Feel free to change it to your own path.
+    The A2/A3 examples assume that the model weights are stored in `/root/.cache/modelscope/hub/models/vllm-ascend/`. The Ascend 950DT examples use `/root/.cache/DeepSeek-V4-Flash` for the original Hugging Face weights. Feel free to change these paths to match your environment.
 
     It is recommended that the following service code be encapsulated in a .sh script file and executed in Bash mode.
 
 ### 5.1 Single-Node Online Deployment
 
-Single-node deployment completes both Prefill and Decode within the same node. The quantized model `DeepSeek-V4-Flash-w8a8-mtp` can be deployed on 1 Atlas 800 A3 (128GB × 8) or 1 Atlas 800 A2 (64GB × 8).
+Single-node deployment completes both Prefill and Decode within the same node. The quantized model `DeepSeek-V4-Flash-w8a8-mtp` can be deployed on 1 Atlas 800 A3 (128GB × 8) or 1 Atlas 800 A2 (64GB × 8). The original `DeepSeek-V4-Flash` weights can be deployed on 1 Ascend 950DT server (96GB × 8).
 
 === "A2 series"
 
@@ -310,19 +347,52 @@ Single-node deployment completes both Prefill and Decode within the same node. T
         }'
     ```
 
+=== "Ascend 950DT series"
+
+    Run the following script to execute mixed online inference on one Ascend 950DT server.
+
+    ```shell
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=10
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export HCCL_BUFFSIZE=1024
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
+
+    vllm serve /root/.cache/DeepSeek-V4-Flash \
+        --max-model-len 1048576 \
+        --safetensors-load-strategy prefetch \
+        --max-num-batched-tokens 4096 \
+        --served-model-name dsv4 \
+        --gpu-memory-utilization 0.9 \
+        --enable-expert-parallel \
+        --max-num-seqs 64 \
+        --port 8900 \
+        --block-size 32 \
+        --tokenizer-mode deepseek_v4 \
+        --tool-call-parser deepseek_v4 \
+        --enable-auto-tool-choice \
+        --reasoning-parser deepseek_v4 \
+        --data-parallel-size 4 \
+        --api-server-count 1 \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp"}' \
+        --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "enable_shared_expert_dp": true}'
+    ```
+
 Key Parameter Descriptions:
 
 - `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. Adjust it according to your actual scenario.
 - `--max-num-seqs` indicates the maximum number of requests that each DP group is allowed to process. If the number of requests sent to the service exceeds this limit, the excess requests will remain in a waiting state and will not be scheduled. Note that the time spent in the waiting state is also counted in metrics such as TTFT and TPOT. Therefore, when testing performance, it is generally recommended that `--max-num-seqs` * `--data-parallel-size` >= the actual total concurrency.
 - `--max-num-batched-tokens` is the maximum number of tokens processed in one scheduler step. A larger value can improve prefill efficiency but consumes more activation memory.
 - `--data-parallel-size` sets the global number of data parallel ranks, while `--tensor-parallel-size` sets the tensor parallel size within each DP rank. Configure them together according to the deployment topology and available NPUs.
+- On Ascend 950DT, DeepSeek-V4 does not currently support standalone tensor parallelism (TP-only). TP partitions only the `wq_b`, `wo_a`, and `wo_b` linear layers, so data parallelism is recommended. When TP is required, use it together with DSA-CP and enable FlashComm (`enable_flashcomm1`) and DSA-CP (`enable_dsa_cp`), as in the two-server DeepSeek-V4-Pro mixed deployment.
 - `--enable-expert-parallel` enables expert parallelism for MoE layers. Do not mix MoE tensor parallelism and expert parallelism in the same MoE layer.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
 - `--block-size` sets the KV cache block size. To enable the experimental 4K prefix cache hit support, change it from `128` to `32`.
-- `--quantization ascend` enables Ascend quantization for the W8A8 model.
-- `--speculative-config` configures speculative decoding to accelerate inference. Use `mtp` for Multi-Token Prediction (MTP) and `dspark` for DSpark models. When using DSpark, `num_speculative_tokens` must be at least 5 (check the checkpoint's `config.json`).
+- `--quantization ascend` enables Ascend quantization for the W8A8 model used in the A2 and A3 configurations. The original DeepSeek-V4-Flash weights used on Ascend 950DT do not require this option.
+- `--speculative-config` configures speculative decoding to accelerate inference. Use `mtp` for Multi-Token Prediction (MTP), `deepseek_mtp` for the native Ascend 950DT mixed-deployment example, and `dspark` for DSpark models. When using DSpark, `num_speculative_tokens` must be at least 5 (check the checkpoint's `config.json`).
 - `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full ACL graph execution in the decode phase to reduce scheduling latency.
-- `--additional-config` enables Ascend-specific optimizations. `enable_npugraph_ex` enables enhanced ACL graph execution, `enable_static_kernel: false` keeps static-kernel compilation disabled, `enable_cpu_binding` enables Ascend-native CPU binding, `enable_dsa_cp` enables DSA context parallelism, and `multistream_overlap_shared_expert` overlaps shared expert computation for better MoE throughput. DSA-CP depends on FlashComm1, and both options must be enabled explicitly.
+- `--additional-config` enables Ascend-specific optimizations. `enable_npugraph_ex` enables enhanced ACL graph execution, `enable_static_kernel: false` keeps static-kernel compilation disabled, `enable_cpu_binding` enables Ascend-native CPU binding, `enable_dsa_cp` enables DSA context parallelism, `enable_shared_expert_dp` enables data parallelism for shared experts, and `multistream_overlap_shared_expert` overlaps shared expert computation for better MoE throughput. DSA-CP depends on FlashComm1, and both options must be enabled explicitly.
 - `enable_flashcomm1` enables the FlashComm communication optimization.
 - `VLLM_PREFIX_CACHE_RETENTION_INTERVAL`: Controls the retention interval, in tokens, for prefix-cache checkpoints of hybrid attention layers. It is applicable to DeepSeek-V4 and takes effect only when prefix caching is enabled. Under KV-cache pressure, it can improve the effective prefix-cache hit rate for reusable long prefixes. The value must be a non-negative multiple of `--block-size`; for DeepSeek-V4-Flash, 128 times `--block-size` is recommended. Set it to `4096` when `--block-size` is `32`, or `16384` when `--block-size` is `128`.
 
@@ -361,7 +431,7 @@ In the standard single-node deployment mode, Prefill (prompt processing) and Dec
 
 PD (Prefill-Decode) separation addresses these issues by running Prefill and Decode on dedicated node groups, each configured independently. This architecture is recommended for production deployments with concurrent multi-user workloads, where stable latency and high throughput are both required.
 
-The following sections describe PD separation deployment on both Atlas 800 A3 (128GB × 8) and Atlas 800 A2 (64GB × 8) multi-node environments.
+The following sections describe PD separation deployment on Atlas 800 A3 nodes (128GB × 8), Atlas 800 A2 nodes (64GB × 8), and Ascend 950DT servers (96GB × 8).
 
 #### 5.2.1 A3 Series PD Separation Deployment
 
@@ -1061,6 +1131,164 @@ Before you start, please:
 
     The proxy is also implemented by referring to [Prefill-Decode Disaggregation (Deepseek)](../features/pd_disaggregation_mooncake_multi_node.md).
 
+#### 5.2.3 Ascend 950DT Series PD Separation Deployment
+
+This section shows an intra-server 1P1D deployment on one Ascend 950DT server (96GB × 8). The Prefill instance uses NPUs 0-3 with `DP4/TP1`, and the Decode instance uses NPUs 4-7 with `DP4/TP1`. You can add Prefill or Decode instances as needed based on the workload's input/output characteristics and service requirements. An expert-parallel size (`ep_size`) of 4 is recommended for each instance. The `prefill` and `decode` parallel settings in `--kv-transfer-config` must match the actual engine settings after scaling.
+
+Before starting the service, mount `/etc/hixlep/` into the container and replace `nic_name`, `local_ip`, and the model path with values from your environment.
+
+1. Prepare `run_prefill.sh`.
+
+    ```bash
+    #!/usr/bin/env bash
+    source /root/.bashrc
+
+    nic_name="xxx"
+    local_ip="xx.xx.xx.1"
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export HCCL_ALGO=level0:fullmesh
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=204
+    export HCCL_CONNECT_TIMEOUT=120
+    export HCCL_BUFFSIZE=512
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export ASCEND_LOCAL_COMM_RES_PATH=/etc/hixlep/
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=10
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
+
+    vllm serve /root/.cache/DeepSeek-V4-Flash \
+        --host $local_ip \
+        --port 8000 \
+        --data-parallel-size 4 \
+        --data-parallel-address $local_ip \
+        --data-parallel-rpc-port 12321 \
+        --tensor-parallel-size 1 \
+        --max-model-len 1048576 \
+        --max-num-batched-tokens 3072 \
+        --served-model-name dsv4 \
+        --gpu-memory-utilization 0.85 \
+        --enable-expert-parallel \
+        --max-num-seqs 8 \
+        --block-size 32 \
+        --api-server-count 1 \
+        --tokenizer-mode deepseek_v4 \
+        --tool-call-parser deepseek_v4 \
+        --enable-auto-tool-choice \
+        --reasoning-parser deepseek_v4 \
+        --trust-remote-code \
+        --enforce-eager \
+        --no-disable-hybrid-kv-cache-manager \
+        --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
+        --kv-transfer-config \
+        '{"kv_connector": "MooncakeHybridConnector",
+          "kv_role": "kv_producer",
+          "kv_port": "36010",
+          "engine_id": "1",
+          "kv_connector_extra_config": {
+            "prefill": {
+              "dp_size": 4,
+              "tp_size": 1
+            },
+            "decode": {
+              "dp_size": 4,
+              "tp_size": 1
+            },
+            "ascend_local_comm_res_path": "/etc/hixlep"
+          }
+        }' \
+        --additional-config '{"enable_cpu_binding": true}'
+    ```
+
+2. Prepare `run_decode.sh`.
+
+    ```bash
+    #!/usr/bin/env bash
+    source /root/.bashrc
+
+    nic_name="xxx"
+    local_ip="xx.xx.xx.1"
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export HCCL_ALGO=level0:fullmesh
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=2040
+    export HCCL_CONNECT_TIMEOUT=1200
+    export HCCL_BUFFSIZE=1024
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export ASCEND_LOCAL_COMM_RES_PATH=/etc/hixlep/
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=10
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export ASCEND_RT_VISIBLE_DEVICES=4,5,6,7
+
+    vllm serve /root/.cache/DeepSeek-V4-Flash \
+        --host $local_ip \
+        --port 8001 \
+        --data-parallel-size 4 \
+        --data-parallel-address $local_ip \
+        --data-parallel-rpc-port 12325 \
+        --tensor-parallel-size 1 \
+        --max-model-len 1048576 \
+        --max-num-batched-tokens 256 \
+        --served-model-name dsv4 \
+        --gpu-memory-utilization 0.92 \
+        --enable-expert-parallel \
+        --max-num-seqs 56 \
+        --block-size 32 \
+        --no-enable-prefix-caching \
+        --tokenizer-mode deepseek_v4 \
+        --tool-call-parser deepseek_v4 \
+        --enable-auto-tool-choice \
+        --reasoning-parser deepseek_v4 \
+        --trust-remote-code \
+        --no-disable-hybrid-kv-cache-manager \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 1, "method": "mtp", "enforce_eager": false}' \
+        --kv-transfer-config \
+        '{"kv_connector": "MooncakeHybridConnector",
+          "kv_role": "kv_consumer",
+          "kv_port": "36010",
+          "engine_id": "1",
+          "kv_connector_extra_config": {
+            "prefill": {
+              "dp_size": 4,
+              "tp_size": 1
+            },
+            "decode": {
+              "dp_size": 4,
+              "tp_size": 1
+            },
+            "ascend_local_comm_res_path": "/etc/hixlep"
+          }
+        }' \
+        --additional-config '{"enable_cpu_binding": true, "recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true}'
+    ```
+
+3. Start the Prefill and Decode services in separate terminals.
+
+    ```bash
+    # Prefill terminal
+    bash run_prefill.sh
+
+    # Decode terminal
+    bash run_decode.sh
+    ```
+
+4. Deploy the P-D disaggregation proxy.
+
+    Refer to [Prefill-Decode Disaggregation (Deepseek)](../features/pd_disaggregation_mooncake_multi_node.md) and configure the Prefill endpoint as `<local_ip>:8000` and the Decode endpoint as `<local_ip>:8001`.
+
 Key Parameter Descriptions:
 
 - `--no-disable-hybrid-kv-cache-manager` keeps the hybrid KV cache manager enabled. DeepSeek-V4 KV Pool deployments require this flag; otherwise, the service may OOM during startup.
@@ -1072,6 +1300,7 @@ Key Parameter Descriptions:
 - `MooncakeHybridConnector`: the KV transfer connector used for PD separation, transferring KV Cache between prefill and decode nodes.
 - `enable_shared_expert_dp: true`: enables data parallelism for shared experts, applicable to MoE models.
 - `VLLM_PREFIX_CACHE_RETENTION_INTERVAL`: Controls the retention interval, in tokens, for prefix-cache checkpoints of hybrid attention layers. It is applicable to DeepSeek-V4 and takes effect only when prefix caching is enabled. Under KV-cache pressure, it can improve the effective prefix-cache hit rate for reusable long prefixes. The value must be a non-negative multiple of `--block-size`; for DeepSeek-V4-Flash, 128 times `--block-size` is recommended. Set it to `4096` when `--block-size` is `32`, or `16384` when `--block-size` is `128`.
+- On Ascend 950DT, `ascend_local_comm_res_path` specifies the local communication resource directory used by the KV connector. The directory must be available at the same path in the container.
 
 Deployment Verification:
 
@@ -1079,7 +1308,7 @@ After the PD separation service is fully started, send a request through the pro
 
 Common Issues Tip: If you encounter issues with PD separation deployment, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
 
-#### 5.2.3 Ultra-Long Sequence Deployment
+#### 5.2.4 Ultra-Long Sequence Deployment
 
 For ultra-long sequence scenarios, support can be achieved by adjusting the PD (Prefill/Decode) ratio and the model parallelism strategy. For example, in a 1M sequence scenario, a 1\*4P-1\*4D ratio can be used, with the model parallelism set to DP4TP8 mode.
 
@@ -1149,18 +1378,23 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more
 |Scenario|Deployment Mode|*Total NPUs|Weight Version|Key Considerations|
 |--------|---------------|-----------|---------------|-------------------|
 |High Throughput|Single-Node Mixed|16 (A3)|DeepSeek-V4-Flash-w8a8-mtp|Use dp4 tp4 to balance memory capacity and compute efficiency|
+|High Throughput / Long Context (1M)|Single-Node Mixed|4 (Ascend 950DT)|DeepSeek-V4-Flash|Use dp4 tp1 with expert parallelism|
 |High Throughput|1P1D deployment|32 (A3)|DeepSeek-V4-Flash-w8a8-mtp|dp16 tp1 on both P and D nodes; balanced latency and throughput|
 |Long Context (1M)|Single-Node (A3)|8 (A3)|DeepSeek-V4-Flash-w8a8-mtp|Use dp4 tp4 to balance memory capacity and compute efficiency|
 |Long Context (1M)|1P1D deployment|32 (A3)|DeepSeek-V4-Flash-w8a8-mtp|dp16 tp1 on both P and D nodes; balanced latency and throughput|
+|Long Context (1M)|1P1D deployment|8 (Ascend 950DT)|DeepSeek-V4-Flash|Split one Ascend 950DT server into P and D groups; both groups use dp4 tp1|
 
 #### Table 2: Detailed Node Configuration
 
 |Scenario|Configuration|NPUs|TP|DP|Max Num Seqs|Max Num Batched Tokens|Max Model Len|MTP Speculation Num|
 |--------|-------------|-----|--|--|------------|----------------------|--------------|--------------------|
 |High Throughput (A3)|Server / Single Machine|8|4|4|64|10240|1048576|1|
+|Single-Node Mixed (Ascend 950DT)|Server / Single Machine|4|1|4|64|4096|1048576|1|
 |Long Context (1M, A3)|Server / Single Machine|8|4|4|64|10240|1048576|1|
 |PD Separation (A3)|Server-P Node|8|4|4|16|8192|1048576|1|
 |PD Separation (A3)|Server-D Node|8|1|16|60|120|1048576|1|
+|PD Separation (Ascend 950DT)|Prefill Group|4|1|4|8|3072|1048576|1|
+|PD Separation (Ascend 950DT)|Decode Group|4|1|4|56|256|1048576|1|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
 

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -24,6 +24,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 ### 3.1 Model Weight
 
 - `DeepSeek-V4-Pro-w4a8-mtp` (Quantized version): requires 2 Atlas 800 A3 (128GB × 8) nodes or 4 Atlas 800 A2 (64GB × 8) nodes. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/DeepSeek-V4-Pro-w4a8-mtp)
+- For Ascend 950DT servers, use the original [`DeepSeek-V4-Pro`](https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro) weights released by DeepSeek on Hugging Face. The Attention weights use MXFP8, while the MoE weights use MXFP4 with 4-bit weights and 8-bit activation computation (W4A8). No Ascend-specific quantization or weight conversion is required. The mixed deployment in Section 5.1 uses 2 Ascend 950DT servers (96GB × 8), while the 1P1D example in Section 5.2.3 uses 4 Prefill servers and 4 Decode servers.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`.
 
@@ -36,6 +37,42 @@ If you want to deploy a multi-node environment, you need to verify multi-node co
 ### 4.1 Docker Image Installation
 
 Select an image based on your machine type and start the docker image on your node, refer to [using docker](../../installation.md#set-up-using-docker).
+
+=== "Ascend 950DT series"
+
+    Start the Docker container on each server.
+
+    ```bash
+    export IMAGE=quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}-950dt
+    export NAME=vllm-ascend
+
+    docker run --rm \
+        --name $NAME \
+        --net=host \
+        --shm-size=512g \
+        --device /dev/davinci0 \
+        --device /dev/davinci1 \
+        --device /dev/davinci2 \
+        --device /dev/davinci3 \
+        --device /dev/davinci4 \
+        --device /dev/davinci5 \
+        --device /dev/davinci6 \
+        --device /dev/davinci7 \
+        --device /dev/davinci_manager \
+        --device /dev/hisi_hdc \
+        --device /dev/ummu \
+        --device /dev/uburma \
+        -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+        -v /etc/ascend_install.info:/etc/ascend_install.info \
+        -v /etc/hccl_rootinfo.json:/etc/hccl_rootinfo.json \
+        -v /etc/hixlep/:/etc/hixlep/ \
+        -v /root/.cache:/root/.cache \
+        -v /usr/local/sbin:/usr/local/sbin \
+        -v /usr/local/dcmi:/usr/local/dcmi \
+        -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+        -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+        -itd $IMAGE bash
+    ```
 
 === "A3 series"
 
@@ -127,13 +164,13 @@ If you want to deploy a multi-node environment, you need to set up the environme
 
 !!! note
 
-    In this tutorial, we suppose you downloaded the model weight to `/root/.cache/modelscope/hub/models/vllm-ascend/`. Feel free to change it to your own path.
+    The A2/A3 examples assume that the model weights are stored in `/root/.cache/modelscope/hub/models/vllm-ascend/`. The Ascend 950DT examples use `/root/.cache/DeepSeek-V4-Pro` for the original Hugging Face weights. Feel free to change these paths to match your environment.
 
     It is recommended that the following service code be encapsulated in a .sh script file and executed in Bash mode.
 
 ### 5.1 Multi-Node Online Deployment
 
-The quantized model `DeepSeek-V4-Pro-w4a8-mtp` requires at least 2 Atlas 800 A3 (128GB × 8) nodes or 4 Atlas 800 A2 (64GB × 8) nodes. Run the following scripts on each node respectively.
+The quantized model `DeepSeek-V4-Pro-w4a8-mtp` requires at least 2 Atlas 800 A3 (128GB × 8) nodes or 4 Atlas 800 A2 (64GB × 8) nodes. The mixed-deployment example for Ascend 950DT servers uses 2 servers (96GB × 8). Run the following scripts on each server respectively.
 
 === "A2 series"
 
@@ -407,6 +444,112 @@ The quantized model `DeepSeek-V4-Pro-w4a8-mtp` requires at least 2 Atlas 800 A3 
         "multistream_overlap_shared_expert":true}'
     ```
 
+=== "Ascend 950DT series"
+
+    Set `node0_ip` to the service IP of Node0 on both servers.
+
+    **Node0**
+
+    ```bash
+    source /root/.bashrc
+
+    nic_name="xxx"
+    local_ip="xx.xx.xx.1"
+    node0_ip="xx.xx.xx.1"
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export HCCL_ALGO=level0:fullmesh
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=2040
+    export HCCL_CONNECT_TIMEOUT=1200
+    export HCCL_BUFFSIZE=512
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=10
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+    vllm serve /root/.cache/DeepSeek-V4-Pro \
+        --host $local_ip \
+        --port 8900 \
+        --data-parallel-size 2 \
+        --data-parallel-size-local 1 \
+        --data-parallel-start-rank 0 \
+        --data-parallel-address $node0_ip \
+        --data-parallel-rpc-port 6987 \
+        --tensor-parallel-size 8 \
+        --max-model-len 200000 \
+        --max-num-batched-tokens 8192 \
+        --served-model-name dsv4 \
+        --gpu-memory-utilization 0.94 \
+        --enable-expert-parallel \
+        --max-num-seqs 40 \
+        --block-size 128 \
+        --api-server-count 1 \
+        --tokenizer-mode deepseek_v4 \
+        --tool-call-parser deepseek_v4 \
+        --enable-auto-tool-choice \
+        --reasoning-parser deepseek_v4 \
+        --safetensors-load-strategy prefetch \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 3, "method": "mtp", "enforce_eager": true}' \
+        --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "multistream_dsa_preprocess": false, "dp_allreduce_on_npu": false, "enable_flashcomm1": true, "enable_dsa_cp": true}'
+    ```
+
+    **Node1**
+
+    ```bash
+    source /root/.bashrc
+
+    nic_name="xxx"
+    local_ip="xx.xx.xx.2"
+    node0_ip="xx.xx.xx.1"
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export HCCL_ALGO=level0:fullmesh
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=2040
+    export HCCL_CONNECT_TIMEOUT=1200
+    export HCCL_BUFFSIZE=512
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=10
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
+
+    vllm serve /root/.cache/DeepSeek-V4-Pro \
+        --data-parallel-size 2 \
+        --data-parallel-size-local 1 \
+        --data-parallel-start-rank 1 \
+        --data-parallel-address $node0_ip \
+        --data-parallel-rpc-port 6987 \
+        --tensor-parallel-size 8 \
+        --max-model-len 200000 \
+        --max-num-batched-tokens 8192 \
+        --served-model-name dsv4 \
+        --gpu-memory-utilization 0.94 \
+        --enable-expert-parallel \
+        --max-num-seqs 40 \
+        --block-size 128 \
+        --tokenizer-mode deepseek_v4 \
+        --tool-call-parser deepseek_v4 \
+        --enable-auto-tool-choice \
+        --reasoning-parser deepseek_v4 \
+        --safetensors-load-strategy prefetch \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 3, "method": "mtp", "enforce_eager": true}' \
+        --additional-config '{"enable_cpu_binding": true, "multistream_overlap_shared_expert": true, "multistream_dsa_preprocess": false, "dp_allreduce_on_npu": false, "enable_flashcomm1": true, "enable_dsa_cp": true}' \
+        --headless
+    ```
+
 Key Parameter Descriptions:
 
 - `--data-parallel-size` sets the global number of data parallel ranks, and `--data-parallel-size-local` sets the number of DP ranks on the current node.
@@ -414,6 +557,7 @@ Key Parameter Descriptions:
 - `--data-parallel-address` specifies the IP address of the data parallel master node (Node0). It must be consistent across all nodes.
 - `--data-parallel-rpc-port` is the DP RPC port. Use the same value on all nodes and ensure the port is available.
 - `--tensor-parallel-size` sets the tensor parallel size within each DP rank. Configure it together with the DP sizes according to the deployment topology and available NPUs.
+- On Ascend 950DT, DeepSeek-V4 does not currently support standalone tensor parallelism (TP-only). TP partitions only the `wq_b`, `wo_a`, and `wo_b` linear layers, so data parallelism is recommended. When TP is required, use it together with DSA-CP and enable FlashComm (`enable_flashcomm1`) and DSA-CP (`enable_dsa_cp`), as in the two-server DeepSeek-V4-Pro mixed deployment.
 - `--enable-expert-parallel` enables expert parallelism for MoE layers. Do not mix MoE tensor parallelism and expert parallelism in the same MoE layer.
 - `--headless` (used on non-master nodes) disables the API server on the node, since only the master node serves requests.
 - `--max-model-len` specifies the maximum context length. Adjust it according to your actual scenario.
@@ -421,11 +565,11 @@ Key Parameter Descriptions:
 - `--max-num-batched-tokens` is the maximum number of tokens processed in one scheduler step. A larger value can improve prefill efficiency but consumes more activation memory.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
 - `--block-size` sets the KV cache block size. To enable the experimental 4K prefix cache hit support, change it from `128` to `32`.
-- `--quantization ascend` enables Ascend quantization for the W4A8 model.
+- `--quantization ascend` enables Ascend quantization for the W4A8 model used in the A2 and A3 configurations. The original DeepSeek-V4-Pro weights used on Ascend 950DT do not require this option.
 - `--speculative-config` configures the MTP (Multi-Token Prediction) speculative decoding to accelerate inference.
 - `--compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'` enables full ACL graph execution in the decode phase to reduce scheduling latency.
 - `--additional-config` enables Ascend-specific optimizations. `enable_npugraph_ex` enables enhanced ACL graph execution, `enable_static_kernel: false` keeps static-kernel compilation disabled, `enable_cpu_binding` enables Ascend-native CPU binding, `enable_shared_expert_dp` enables data parallelism for shared experts, and `multistream_overlap_shared_expert` overlaps shared expert computation for better MoE throughput.
-- `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` enables the FlashComm communication optimization.
+- `VLLM_ASCEND_ENABLE_FLASHCOMM1=1` enables FlashComm in the A2 and A3 configurations. The Ascend 950DT TP+DSA-CP configuration enables it with `enable_flashcomm1: true` in `--additional-config`.
 
 Common Issues Tip: If you encounter issues, please refer to the [Public FAQ](https://docs.vllm.ai/projects/ascend/en/latest/faqs.html) for troubleshooting.
 
@@ -457,7 +601,7 @@ We recommend using Mooncake for deployment: [Mooncake](../features/pd_disaggrega
 
 In the standard deployment mode, Prefill (prompt processing) and Decode (token generation) tasks run on the same set of NPUs. PD (Prefill-Decode) separation addresses this by running Prefill and Decode on dedicated node groups, each configured independently. This architecture is recommended for production deployments with concurrent multi-user workloads, where stable latency and high throughput are both required.
 
-The following sections describe PD separation deployment on both Atlas 800 A3 (128GB × 8) and Atlas 800 A2 (64GB × 8) multi-node environments.
+The following sections describe PD separation deployment in multi-node environments using Atlas 800 A3 nodes (128GB × 8), Atlas 800 A2 nodes (64GB × 8), or Ascend 950DT servers (96GB × 8).
 
 #### 5.2.1 A3 Series PD Separation Deployment
 
@@ -1160,6 +1304,313 @@ Before you start, please:
 
     Refer to [Prefill-Decode Disaggregation (Deepseek)](../features/pd_disaggregation_mooncake_multi_node.md) to deploy the P-D disaggregation proxy.
 
+#### 5.2.3 Ascend 950DT Series PD Separation Deployment
+
+This section shows a logical 1P1D deployment on Ascend 950DT servers. The Prefill group uses 4 servers and the Decode group uses 4 servers. Each group contains 32 DP ranks with `DP32/TP1`; every server starts 8 local DP ranks. The `prefill` and `decode` settings in `--kv-transfer-config` must therefore both use `dp_size: 32` and `tp_size: 1`.
+
+Before you start, mount `/etc/hixlep/` into the container and complete the following steps:
+
+1. Prepare the script `launch_online_dp.py` on each node.
+
+    ```python
+    import argparse
+    import multiprocessing
+    import os
+    import subprocess
+    import sys
+
+    def parse_args():
+        parser = argparse.ArgumentParser()
+        parser.add_argument(
+            "--dp-size",
+            type=int,
+            required=True,
+            help="Data parallel size."
+        )
+        parser.add_argument(
+            "--tp-size",
+            type=int,
+            default=1,
+            help="Tensor parallel size."
+        )
+        parser.add_argument(
+            "--dp-size-local",
+            type=int,
+            default=-1,
+            help="Local data parallel size."
+        )
+        parser.add_argument(
+            "--dp-rank-start",
+            type=int,
+            default=0,
+            help="Starting rank for data parallel."
+        )
+        parser.add_argument(
+            "--dp-address",
+            type=str,
+            required=True,
+            help="IP address for data parallel master node."
+        )
+        parser.add_argument(
+            "--dp-rpc-port",
+            type=str,
+            default=12345,
+            help="Port for data parallel master node."
+        )
+        parser.add_argument(
+            "--vllm-start-port",
+            type=int,
+            default=9000,
+            help="Starting port for the engine."
+        )
+        return parser.parse_args()
+
+    args = parse_args()
+    dp_size = args.dp_size
+    tp_size = args.tp_size
+    dp_size_local = args.dp_size_local
+    if dp_size_local == -1:
+        dp_size_local = dp_size
+    dp_rank_start = args.dp_rank_start
+    dp_address = args.dp_address
+    dp_rpc_port = args.dp_rpc_port
+    vllm_start_port = args.vllm_start_port
+
+    def run_command(visible_devices, dp_rank, vllm_engine_port):
+        command = [
+            "bash",
+            "./run_dp_template.sh",
+            visible_devices,
+            str(vllm_engine_port),
+            str(dp_size),
+            str(dp_rank),
+            dp_address,
+            dp_rpc_port,
+            str(tp_size),
+        ]
+        subprocess.run(command, check=True)
+
+    if __name__ == "__main__":
+        template_path = "./run_dp_template.sh"
+        if not os.path.exists(template_path):
+            print(f"Template file {template_path} does not exist.")
+            sys.exit(1)
+
+        processes = []
+        num_cards = dp_size_local * tp_size
+        for i in range(dp_size_local):
+            dp_rank = dp_rank_start + i
+            vllm_engine_port = vllm_start_port + i
+            visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
+            process = multiprocessing.Process(target=run_command,
+                                            args=(visible_devices, dp_rank,
+                                                    vllm_engine_port))
+            processes.append(process)
+            process.start()
+
+        for process in processes:
+            process.join()
+    ```
+
+2. Prepare `run_dp_template.sh` on each Prefill node.
+
+    ```bash
+    #!/usr/bin/env bash
+    source /root/.bashrc
+
+    nic_name="xxx"
+    local_ip="xx.xx.xx.x"
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export HCCL_ALGO=level0:fullmesh
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=2040
+    export HCCL_CONNECT_TIMEOUT=1200
+    export HCCL_BUFFSIZE=512
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=10
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export ASCEND_RT_VISIBLE_DEVICES=$1
+
+    vllm serve /root/.cache/DeepSeek-V4-Pro \
+        --host $local_ip \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --max-model-len 1048576 \
+        --max-num-batched-tokens 4096 \
+        --served-model-name dsv4 \
+        --gpu-memory-utilization 0.85 \
+        --enable-expert-parallel \
+        --max-num-seqs 8 \
+        --block-size 32 \
+        --tokenizer-mode deepseek_v4 \
+        --tool-call-parser deepseek_v4 \
+        --enable-auto-tool-choice \
+        --reasoning-parser deepseek_v4 \
+        --trust-remote-code \
+        --enforce-eager \
+        --no-disable-hybrid-kv-cache-manager \
+        --speculative-config '{"num_speculative_tokens": 1, "method": "mtp"}' \
+        --kv-transfer-config \
+        '{"kv_connector": "MooncakeHybridConnector",
+          "kv_role": "kv_producer",
+          "kv_port": "36010",
+          "engine_id": "1",
+          "kv_connector_extra_config": {
+            "prefill": {
+              "dp_size": 32,
+              "tp_size": 1
+            },
+            "decode": {
+              "dp_size": 32,
+              "tp_size": 1
+            },
+            "ascend_local_comm_res_path": "/etc/hixlep"
+          }
+        }' \
+        --additional-config '{"enable_cpu_binding": true}'
+    ```
+
+3. Prepare `run_dp_template.sh` on each Decode node.
+
+    ```bash
+    #!/usr/bin/env bash
+    source /root/.bashrc
+
+    nic_name="xxx"
+    local_ip="xx.xx.xx.x"
+
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export HCCL_ALGO=level0:fullmesh
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=2040
+    export HCCL_CONNECT_TIMEOUT=1200
+    export HCCL_BUFFSIZE=1024
+    export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+    export OMP_PROC_BIND=false
+    export OMP_NUM_THREADS=10
+    export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+    export ASCEND_RT_VISIBLE_DEVICES=$1
+
+    vllm serve /root/.cache/DeepSeek-V4-Pro \
+        --host $local_ip \
+        --port $2 \
+        --data-parallel-size $3 \
+        --data-parallel-rank $4 \
+        --data-parallel-address $5 \
+        --data-parallel-rpc-port $6 \
+        --tensor-parallel-size $7 \
+        --max-model-len 1048576 \
+        --max-num-batched-tokens 256 \
+        --served-model-name dsv4 \
+        --gpu-memory-utilization 0.92 \
+        --enable-expert-parallel \
+        --max-num-seqs 32 \
+        --block-size 32 \
+        --no-enable-prefix-caching \
+        --tokenizer-mode deepseek_v4 \
+        --tool-call-parser deepseek_v4 \
+        --enable-auto-tool-choice \
+        --reasoning-parser deepseek_v4 \
+        --trust-remote-code \
+        --no-disable-hybrid-kv-cache-manager \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --speculative-config '{"num_speculative_tokens": 3, "method": "mtp", "enforce_eager": false}' \
+        --kv-transfer-config \
+        '{"kv_connector": "MooncakeHybridConnector",
+          "kv_role": "kv_consumer",
+          "kv_port": "36010",
+          "engine_id": "1",
+          "kv_connector_extra_config": {
+            "prefill": {
+              "dp_size": 32,
+              "tp_size": 1
+            },
+            "decode": {
+              "dp_size": 32,
+              "tp_size": 1
+            },
+            "ascend_local_comm_res_path": "/etc/hixlep"
+          }
+        }' \
+        --additional-config '{"enable_cpu_binding": true, "recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true}'
+    ```
+
+4. Start the server with the following command on each node. Set `local_ip` in `run_dp_template.sh` to the current node IP before starting the service.
+
+    1. Prefill node 0
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 0 --dp-address xx.xx.xx.1 --dp-rpc-port 12321 --vllm-start-port 8000
+        ```
+
+    2. Prefill node 1
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 8 --dp-address xx.xx.xx.1 --dp-rpc-port 12321 --vllm-start-port 8000
+        ```
+
+    3. Prefill node 2
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 16 --dp-address xx.xx.xx.1 --dp-rpc-port 12321 --vllm-start-port 8000
+        ```
+
+    4. Prefill node 3
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 24 --dp-address xx.xx.xx.1 --dp-rpc-port 12321 --vllm-start-port 8000
+        ```
+
+    5. Decode node 0
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 0 --dp-address xx.xx.xx.5 --dp-rpc-port 12325 --vllm-start-port 8000
+        ```
+
+    6. Decode node 1
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 8 --dp-address xx.xx.xx.5 --dp-rpc-port 12325 --vllm-start-port 8000
+        ```
+
+    7. Decode node 2
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 16 --dp-address xx.xx.xx.5 --dp-rpc-port 12325 --vllm-start-port 8000
+        ```
+
+    8. Decode node 3
+
+        ```shell
+        # change ip to your own
+        python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 8 --dp-rank-start 24 --dp-address xx.xx.xx.5 --dp-rpc-port 12325 --vllm-start-port 8000
+        ```
+
+5. Deploy the P-D disaggregation proxy.
+
+    Refer to [Prefill-Decode Disaggregation (Deepseek)](../features/pd_disaggregation_mooncake_multi_node.md) and register all Prefill and Decode engine endpoints started above. Each node uses ports 8000 through 8007.
+
 Key Parameter Descriptions:
 
 - `--no-disable-hybrid-kv-cache-manager` keeps the hybrid KV cache manager enabled. DeepSeek-V4 KV Pool deployments require this flag; otherwise, the service may OOM during startup.
@@ -1171,6 +1622,7 @@ Key Parameter Descriptions:
 - `recompute_scheduler_enable: true`: enables the recomputation scheduler. When the KV Cache of the decode node is insufficient, requests will be sent to the prefill node to recompute the KV Cache. In the PD separation scenario, enable this configuration only on decode nodes.
 - `MooncakeHybridConnector`: the KV transfer connector used for PD separation, transferring KV Cache between prefill and decode nodes.
 - `enable_shared_expert_dp: true`: enables data parallelism for shared experts, applicable to MoE models.
+- On Ascend 950DT, `ascend_local_comm_res_path` specifies the local communication resource directory used by the KV connector. The directory must be available at the same path in the container.
 
 Deployment Verification:
 
@@ -1245,6 +1697,8 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more
 |High Throughput|1P1D deployment|64 (A3)|DeepSeek-V4-Pro-w4a8-mtp|dp16 tp2 or dp2 tp16, depending on memory and concurrency|
 |Long Context (1M)|Single-Node Mixed|32 (A3)|DeepSeek-V4-Pro-w4a8-mtp|Use dp2 tp16 to balance memory capacity and compute efficiency|
 |Long Context (1M)|1P1D deployment|64 (A3)|DeepSeek-V4-Pro-w4a8-mtp|dp2 tp16 on both P and D nodes; balanced latency and throughput|
+|High Throughput|Multi-Node Mixed|16 (Ascend 950DT)|DeepSeek-V4-Pro|Use dp2 tp8 across two Ascend 950DT servers|
+|Long Context (1M)|1P1D deployment|64 (Ascend 950DT)|DeepSeek-V4-Pro|Use dp32 tp1 on both P and D groups|
 
 #### Table 2: Detailed Node Configuration
 
@@ -1253,6 +1707,9 @@ Refer to [vllm benchmark](https://docs.vllm.ai/en/latest/benchmarking/) for more
 |Multi-Node (A3)|Node0 / Node1|8|16|2|32|4096|135000|1|
 |PD Separation (A3)|Prefill Node|8|16|2|16|4096|131072|1|
 |PD Separation (A3)|Decode Node|8|2|16|60|120|131072|1|
+|Multi-Node (Ascend 950DT)|Node0 / Node1|16|8|2|40|8192|200000|3|
+|PD Separation (Ascend 950DT)|Prefill Group|32|1|32|8|4096|1048576|1|
+|PD Separation (Ascend 950DT)|Decode Group|32|1|32|32|256|1048576|3|
 
 > For complete startup commands and parameter descriptions, please refer to the deployment examples in [Chapter 5](#5-online-service-deployment).
 


### PR DESCRIPTION
Port the DeepSeek-V4 Flash and Pro deployment documentation from releases/v0.23.0 to main while preserving main-specific MkDocs, DSpark, and configuration updates.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
