### PR TITLE
[BugFix] Fix bug that aclnnSwigluGroupQuant uses a unaccepted argument

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -863,6 +863,17 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         dst_type=situ_dst_type,
                     )
                 else:
+                    # aclnnSwigluGroupQuant does not accept glu_alpha/glu_bias:
+                    # the MXFP kernel computes the plain swish(x)*x activation.
+                    # Fail loudly instead of silently dropping a non-default
+                    # alpha/beta configured on the shared experts.
+                    if fused_moe_evts.swiglu_alpha != 1.0 or fused_moe_evts.swiglu_beta != 0.0:
+                        raise NotImplementedError(
+                            "npu_swiglu_group_quant does not support swiglu_alpha/"
+                            "swiglu_beta on the MXFP shared-expert path; got "
+                            f"alpha={fused_moe_evts.swiglu_alpha}, "
+                            f"beta={fused_moe_evts.swiglu_beta}."
+                        )
                     quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
                         hidden_states,
                         topk_weight=None,
@@ -870,8 +881,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         dst_type=torch.float8_e4m3fn,
                         quant_mode=2,
                         clamp_value=fused_moe_evts.swiglu_limit,
-                        glu_alpha=fused_moe_evts.swiglu_alpha,
-                        glu_bias=fused_moe_evts.swiglu_beta,
                     )
                 # Execute the down projection concurrently with the combine
                 # communication.


### PR DESCRIPTION
…roup_quant

aclnnSwigluGroupQuant does not accept glu_alpha/glu_bias, so the MXFP shared-expert path crashed with "Unknown keyword argument 'glu_alpha'". Remove the two kwargs to match the W4A8MXFP main path in device_op.py, and fail loudly when a non-default alpha/beta is configured instead of silently computing the plain swish(x)*x activation.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
