### PR TITLE
[Bugfix][v0.25.1rc] Enable Marconi-style admission policy for hybrid prefix caching

### DIFF
--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -416,6 +416,7 @@ class AscendHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         cache_hit_blocks = tuple(blocks if blocks is not None else [] for blocks in hit_blocks_by_group)
         if vllm_version_is("0.25.1"):
+            self.num_uncached_common_prefix_tokens = longest_hit_length - hit_length
             return cache_hit_blocks, hit_length
         return cache_hit_blocks, hit_length, longest_hit_length - hit_length
 


### PR DESCRIPTION
### What this PR does / why we need it?

Upstream vLLM PR [#37898](https://github.com/vllm-project/vllm/pull/37898) introduced a Marconi-style admission policy for hybrid models (e.g. Qwen3.5/Qwen3.6) on v0.25.1. The scheduler reads `coordinator.num_uncached_common_prefix_tokens` to detect shared-prefix junction points and truncate the prefill chunk so that Mamba/SSM states are materialized and cached at those positions.
However, `AscendHybridKVCacheCoordinator.find_longest_cache_hit()` in the v0.25.1 code path returns `(cache_hit_blocks, hit_length)` **without setting** `self.num_uncached_common_prefix_tokens`. As a result, the scheduler's `getattr(coordinator, "num_uncached_common_prefix_tokens", 0)` always evaluates to 0, and the Marconi admission condition (`num_uncached_common_prefix_tokens >= block_size`) is never satisfied.

Since upstream vLLM has already implemented this functionality, I believe vLLM-Ascend should align with it accordingly.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?
#### Unit Test

```
pytest -v \
tests/ut/patch/platform/test_prefix_cache_cp_patches.py \
tests/ut/test_compressed_prefix_cache.py \
tests/ut/distributed/ascend_store/test_coordinator.py \
tests/ut/core/test_recompute_scheduler.py \
tests/ut/core/test_batch_job_aware_scheduler.py 
```
110 passed, 15 warnings

vLLM version: v0.25.1
vLLM main: https://github.com/vllm-project/vllm/commit/752a3a504485790a2e8491cacbb35c137339ad34

#### E2E

Tested on 910C/A3 (Qwen3.6-27B, TP=4, max-num-seqs=32, max-num-batched-tokens=20480, enable-prefix-caching):

releases/v0.25.1rc:

| Input | Prefix | Concurrency | TTFT (ms) | Prefix Hit Rate (avg)% |
|---|---|---|---|---|
| 8192 | 5120 | 4 | 982.9 | 0.0 |
| 8192 | 5120 | 8 | 875.5 | 17.1 |
| 8192 | 7168 | 4 | 979.2 | 0.0 |
| 8192 | 7168 | 8 | 673.0 | 50.9 |
| 20480 | 9216 | 8 | 2333.9 | 0.0 |
| 20480 | 12288 | 8 | 2347.1 | 0.0 |
| 32768 | 13824 | 4 | 3242.6 | 12.2 |

This PR:

| Input | Prefix | Concurrency | TTFT (ms) | Prefix Hit Rate (avg)% |
|---|---|---|---|---|
| 8192 | 5120 | 4 | 737.9 | 34.3 |
| 8192 | 5120 | 8 | 758.2 | 34.6 |
| 8192 | 7168 | 4 | 406.4 | 69.2 |
| 8192 | 7168 | 8 | 426.5 | 69.4 |
| 20480 | 9216 | 8 | 1692.2 | 34.7 |
| 20480 | 12288 | 8 | 1434.1 | 48.4 |
| 32768 | 13824 | 4 | 2508.0 | 33.8 |


- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
