### PR TITLE
[BugFix][Quantization] Make MLA cache scale mapping idempotent

### DIFF
--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -616,6 +616,36 @@ class TestGetCacheScaleMapper(TestBase):
             "model.layers.1.mla_attn.mla_attn.indexer.k_rot",
         )
 
+    def test_mla_quant_mappings_are_idempotent(self):
+        config = AscendModelSlimConfig(
+            {
+                "fa_quant_type": "C8",
+                "layers.1.fa_k.scale": "C8",
+                "indexer_quant_type": "INT8",
+                "layers.1.indexer.quant_type": "INT8",
+            }
+        )
+        mapper = config.get_cache_scale_mapper()
+        suffixes = (
+            ".fa_q.scale",
+            ".fa_k.scale",
+            ".fa_v.scale",
+            ".fa_q.offset",
+            ".fa_k.offset",
+            ".fa_v.offset",
+            ".indexer.q_rot",
+            ".indexer.k_rot",
+        )
+
+        for suffix in suffixes:
+            with self.subTest(suffix=suffix):
+                original_name = f"model.layers.1.self_attn{suffix}"
+                expected_name = f"model.layers.1.self_attn.mla_attn.mla_attn{suffix}"
+                mapped_name = mapper._map_name(original_name)
+
+                self.assertEqual(mapped_name, expected_name)
+                self.assertEqual(mapper._map_name(mapped_name), expected_name)
+
 
 class TestApplyVllmMapper(TestBase):
     def test_apply_mapper_with_populated_quant_description(self):

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -586,6 +586,7 @@ class AscendModelSlimConfig(QuantizationConfig):
     def get_cache_scale_mapper(self) -> "WeightsMapper":
         """Upstream use staticmethod, but we need to use instance attribute"""
         suffix_map = {}
+        mla_quant_suffixes = []
         if self.enable_c8_quant:
             suffix_map.update(
                 {
@@ -596,26 +597,29 @@ class AscendModelSlimConfig(QuantizationConfig):
                 }
             )
         if self.enable_fa_quant:
-            suffix_map.update(
-                {
-                    ".fa_q.scale": ".mla_attn.mla_attn.fa_q.scale",
-                    ".fa_k.scale": ".mla_attn.mla_attn.fa_k.scale",
-                    ".fa_v.scale": ".mla_attn.mla_attn.fa_v.scale",
-                    ".fa_q.offset": ".mla_attn.mla_attn.fa_q.offset",
-                    ".fa_k.offset": ".mla_attn.mla_attn.fa_k.offset",
-                    ".fa_v.offset": ".mla_attn.mla_attn.fa_v.offset",
-                }
+            mla_quant_suffixes.extend(
+                [
+                    ".fa_q.scale",
+                    ".fa_k.scale",
+                    ".fa_v.scale",
+                    ".fa_q.offset",
+                    ".fa_k.offset",
+                    ".fa_v.offset",
+                ]
             )
         if self.enable_indexer_quant:
-            suffix_map.update(
-                {
-                    ".indexer.q_rot": ".mla_attn.mla_attn.indexer.q_rot",
-                    ".indexer.k_rot": ".mla_attn.mla_attn.indexer.k_rot",
-                }
-            )
-        if not suffix_map:
+            mla_quant_suffixes.extend([".indexer.q_rot", ".indexer.k_rot"])
+        if not suffix_map and not mla_quant_suffixes:
             return QuantizationConfig.get_cache_scale_mapper()
-        cache_scale_mapper = WeightsMapper(orig_to_new_suffix=suffix_map)
+
+        # AutoWeightsLoader can apply this mapper at multiple nested model
+        # levels. Do not prepend the MLA path when it is already present.
+        mla_attn_prefix = ".mla_attn.mla_attn"
+        regex_map = {
+            re.compile(rf"(?<!{re.escape(mla_attn_prefix)}){re.escape(suffix)}$"): f"{mla_attn_prefix}{suffix}"
+            for suffix in mla_quant_suffixes
+        }
+        cache_scale_mapper = WeightsMapper(orig_to_new_regex=regex_map, orig_to_new_suffix=suffix_map)
         return cache_scale_mapper | QuantizationConfig.get_cache_scale_mapper()
 
     def _has_quant_weight(self, prefix: str, packed_modules_mapping: Mapping[str, list[str]]) -> bool:


### PR DESCRIPTION
### What this PR does / why we need it?

ModelSlim's FA/indexer cache-scale mapper is not idempotent. Kimi-K2.5/Kimi-K2.6 uses nested `AutoWeightsLoader` instances for the outer Kimi model and inner DeepSeek language model, so mappings such as `.fa_k.offset -> .mla_attn.mla_attn.fa_k.offset` are applied twice. This produces a nonexistent parameter name with four `mla_attn` components and fails weight loading with `KeyError`.

This patch uses guarded regex mappings for FA and indexer quantization weights, adding the MLA path only when it is not already present. Existing C8 KV-cache mappings remain unchanged. A regression test covers all six FA scale/offset suffixes and both indexer suffixes after two mapper applications.

### Does this PR introduce _any_ user-facing change?

Yes. Quantized MLA models with nested weight loaders, including Kimi-K2.5/Kimi-K2.6 W4A8, no longer receive duplicated `mla_attn` prefixes while loading FA/indexer quantization weights.

### How was this patch tested?

- Added `TestGetCacheScaleMapper.test_mla_quant_mappings_are_idempotent` for all 8 FA/indexer suffix mappings after two applications.
- `python -m ruff check vllm_ascend/quantization/modelslim_config.py tests/ut/quantization/test_modelslim_config.py`
- `python -m ruff format --check vllm_ascend/quantization/modelslim_config.py tests/ut/quantization/test_modelslim_config.py`
- `python -m compileall -q vllm_ascend/quantization/modelslim_config.py tests/ut/quantization/test_modelslim_config.py`
- Direct mapper smoke test against the v0.26 `WeightsMapper`: all 8 mappings remained unchanged after a second application.

An NPU end-to-end run was not performed locally because this development machine does not have the Ascend runtime or A5 hardware.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
