### PR TITLE
[BugFix][Ops] Remove unsupported SwiGLU group quant arguments

### DIFF
--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -870,8 +870,6 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         dst_type=torch.float8_e4m3fn,
                         quant_mode=2,
                         clamp_value=fused_moe_evts.swiglu_limit,
-                        glu_alpha=fused_moe_evts.swiglu_alpha,
-                        glu_bias=fused_moe_evts.swiglu_beta,
                     )
                 # Execute the down projection concurrently with the combine
                 # communication.


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #13149 to `releases/v0.26.0rc`.

PR #12835 added `glu_alpha` and `glu_bias` keyword arguments to the W4A8MXFP shared-expert call to `npu_swiglu_group_quant`, but these arguments are not part of the operator schema.

This PR only removes those two keyword arguments.

### Does this PR introduce _any_ user-facing change?

Yes. The W4A8MXFP shared-expert path no longer passes unsupported arguments to `npu_swiglu_group_quant`.

### How was this patch tested?

- `git diff --check`
- `uvx ruff check vllm_ascend/ops/fused_moe/fused_moe.py`
- `python -m py_compile vllm_ascend/ops/fused_moe/fused_moe.py`

No test was added because this is intentionally limited to reverting the two unsupported arguments introduced by PR #12835.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
