### PR TITLE
[Refactor][MoE] Align Ascend shared experts with upstream lifecycle

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -99,7 +99,7 @@ def test_runner_310_installs_specialized_comm():
     moe_config = MagicMock()
     runner.moe_config = moe_config
     routed_experts = SimpleNamespace(quant_config=None, quant_method=None)
-    runner.ascend_shared_experts = SimpleNamespace(multistream_overlap=True)
+    runner._shared_experts = SimpleNamespace(multistream_overlap=True)
     comm_method = object()
 
     with (
@@ -116,7 +116,7 @@ def test_runner_310_installs_specialized_comm():
         )
 
         assert routed_experts.quant_method is None
-        assert runner.ascend_shared_experts.multistream_overlap is False
+        assert runner.shared_experts.multistream_overlap is False
         assert fused_moe_310_module._MoECommMethods[MoECommType.ALLGATHER] is comm_method
         parent_init.assert_called_once()
 
@@ -209,7 +209,7 @@ def test_shared_experts_part2_310_applies_optional_gate(with_gate):
         expert_gate=_Gate() if with_gate else None,
     )
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
-    shared_experts.layer = shared_experts_layer
+    shared_experts._layer = shared_experts_layer
     hidden_states = torch.randn(3, 4)
     shared_gate_up = torch.randn(3, 4)
 
@@ -228,7 +228,10 @@ def test_forward_impl_310_returns_current_runner_contract(monkeypatch, has_share
     router_logits = torch.randn(2, 3)
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
-    ascend_shared_experts = SimpleNamespace(forward=MagicMock(return_value=shared_out))
+    shared_experts = SimpleNamespace(
+        forward_with_events=MagicMock(),
+        output=shared_out,
+    )
     routed_events = FusedMoEEvents(
         before_routed_experts=None,
         after_routed_experts=None,
@@ -239,7 +242,7 @@ def test_forward_impl_310_returns_current_runner_contract(monkeypatch, has_share
     runner.routed_experts = SimpleNamespace(
         forward_impl=MagicMock(return_value=(routed_out, routed_events) if has_shared_experts else routed_out)
     )
-    runner.ascend_shared_experts = ascend_shared_experts if has_shared_experts else None
+    runner._shared_experts = shared_experts if has_shared_experts else None
     runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
     current_stream = MagicMock()
 
@@ -256,7 +259,7 @@ def test_forward_impl_310_returns_current_runner_contract(monkeypatch, has_share
         )
         assert result[0] is shared_out
         assert result[1] is routed_out
-        ascend_shared_experts.forward.assert_called_once()
+        shared_experts.forward_with_events.assert_called_once()
     else:
         runner.routed_experts.forward_impl.assert_called_once_with(
             hidden_states=hidden_states,
@@ -264,4 +267,4 @@ def test_forward_impl_310_returns_current_runner_contract(monkeypatch, has_share
             input_ids=None,
         )
         assert result is routed_out
-        ascend_shared_experts.forward.assert_not_called()
+        shared_experts.forward_with_events.assert_not_called()

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -7,6 +7,10 @@ import pytest
 import torch
 from torch import nn
 from torch.nn import functional as F
+from vllm.model_executor.layers.fused_moe.runner import (
+    shared_experts as vllm_shared_experts_module,
+)
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
@@ -358,7 +362,7 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
 )
 def test_runner_reduction_contract(monkeypatch, moe_comm_type, flash_comm_v1_enabled, expected):
     runner = AscendMoERunner.__new__(AscendMoERunner)
-    runner.ascend_shared_experts = SimpleNamespace(
+    runner._shared_experts = SimpleNamespace(
         parallel_mode=MagicMock(return_value=SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON)
     )
     shared_output = object()
@@ -390,7 +394,7 @@ def test_shared_output_reduction_depends_on_weight_layout(
     reduce_shared,
 ):
     runner = AscendMoERunner.__new__(AscendMoERunner)
-    runner.ascend_shared_experts = SimpleNamespace(parallel_mode=MagicMock(return_value=mode))
+    runner._shared_experts = SimpleNamespace(parallel_mode=MagicMock(return_value=mode))
     shared_output = torch.ones(2, 4)
     reduced_output = shared_output + 1
     all_reduce = MagicMock(return_value=reduced_output)
@@ -428,7 +432,7 @@ def test_local_shared_expert_dp_reduces_partial_routed_output(
     reduce_routed,
 ):
     runner = AscendMoERunner.__new__(AscendMoERunner)
-    runner.ascend_shared_experts = SimpleNamespace(parallel_mode=MagicMock(return_value=mode))
+    runner._shared_experts = SimpleNamespace(parallel_mode=MagicMock(return_value=mode))
     runner.routed_output_transform = None
     runner.moe_config = SimpleNamespace(
         is_sequence_parallel=False,
@@ -740,6 +744,137 @@ class _Gate(nn.Module):
         return torch.zeros((*hidden_states.shape[:-1], 1), dtype=hidden_states.dtype), None
 
 
+def _build_shared_experts_wrapper(monkeypatch, *, enable_dbo=False):
+    monkeypatch.setattr(
+        shared_experts_module,
+        "get_ascend_config",
+        lambda: SimpleNamespace(
+            multistream_overlap_shared_expert=False,
+            enable_shared_expert_dp=False,
+        ),
+    )
+    monkeypatch.setattr(shared_experts_module, "enable_sp_by_pass", lambda: False)
+    monkeypatch.setattr(
+        vllm_shared_experts_module.envs,
+        "VLLM_DISABLE_SHARED_EXPERTS_STREAM",
+        True,
+    )
+    layer = nn.Linear(4, 4)
+    moe_config = SimpleNamespace(
+        hidden_dim=4,
+        in_dtype=torch.float16,
+        swiglu_limit=None,
+        swiglu_alpha=None,
+        swiglu_beta=None,
+        is_sequence_parallel=False,
+        tp_group=SimpleNamespace(world_size=1, rank_in_group=0),
+    )
+    wrapper = AscendSharedExperts(
+        layer=layer,
+        moe_config=moe_config,
+        enable_dbo=enable_dbo,
+        mk_can_overlap_shared_experts=lambda: False,
+        quant_type=QuantType.NONE,
+        quant_method=SimpleNamespace(process_weights_after_loading=MagicMock()),
+    )
+    return wrapper, layer
+
+
+def test_shared_experts_inherits_upstream_and_registers_layer_once(monkeypatch):
+    shared_experts, layer = _build_shared_experts_wrapper(monkeypatch)
+    runner = nn.Module()
+    runner._shared_experts = shared_experts
+
+    assert issubclass(AscendSharedExperts, SharedExperts)
+    assert isinstance(shared_experts, nn.Module)
+    assert AscendSharedExperts.forward is SharedExperts.forward
+    assert shared_experts._layer is layer
+    assert not hasattr(shared_experts, "layer")
+    assert set(shared_experts.state_dict()) == {
+        "_layer.weight",
+        "_layer.bias",
+    }
+    assert sum(module is layer for _, module in shared_experts.named_modules()) == 1
+    assert set(runner.state_dict()) == {
+        "_shared_experts._layer.weight",
+        "_shared_experts._layer.bias",
+    }
+    assert "ascend_shared_experts" not in runner._modules
+    assert all(not name.startswith("ascend_shared_experts") for name, _ in runner.named_modules())
+
+
+def test_shared_experts_without_dbo_always_uses_slot_zero(monkeypatch):
+    shared_experts, _ = _build_shared_experts_wrapper(monkeypatch)
+    monkeypatch.setattr(
+        vllm_shared_experts_module,
+        "dbo_current_ubatch_id",
+        lambda: 1,
+    )
+    output = torch.randn(2, 4)
+    shared_experts._run_with_events = MagicMock(return_value=output)
+
+    shared_experts.forward_with_events(torch.randn(2, 4), MagicMock())
+
+    assert shared_experts._output[0] is output
+    assert shared_experts._output[1] is None
+    assert shared_experts.output is output
+    assert shared_experts._output == [None, None]
+
+
+def test_shared_experts_dbo_output_slots_are_isolated_and_cleared(
+    monkeypatch,
+):
+    shared_experts, _ = _build_shared_experts_wrapper(
+        monkeypatch,
+        enable_dbo=True,
+    )
+    current_ubatch_id = 0
+    monkeypatch.setattr(
+        vllm_shared_experts_module,
+        "dbo_current_ubatch_id",
+        lambda: current_ubatch_id,
+    )
+    outputs = [torch.randn(2, 4), torch.randn(2, 4)]
+    shared_experts._run_with_events = MagicMock(side_effect=outputs)
+    hidden_states = torch.randn(2, 4)
+    events = MagicMock()
+
+    shared_experts.forward_with_events(hidden_states, events)
+    current_ubatch_id = 1
+    shared_experts.forward_with_events(hidden_states, events)
+
+    current_ubatch_id = 0
+    assert shared_experts.output is outputs[0]
+    assert shared_experts._output[0] is None
+    assert shared_experts._output[1] is outputs[1]
+    current_ubatch_id = 1
+    assert shared_experts.output is outputs[1]
+    assert shared_experts._output == [None, None]
+
+
+def test_shared_experts_set_moe_config_updates_derived_state(monkeypatch):
+    shared_experts, _ = _build_shared_experts_wrapper(monkeypatch)
+    new_moe_config = SimpleNamespace(
+        hidden_dim=8,
+        in_dtype=torch.bfloat16,
+        swiglu_limit=2.0,
+        swiglu_alpha=1.5,
+        swiglu_beta=0.25,
+        is_sequence_parallel=True,
+        tp_group=SimpleNamespace(world_size=2, rank_in_group=1),
+    )
+
+    shared_experts._set_moe_config(new_moe_config)
+
+    assert shared_experts._moe_config is new_moe_config
+    assert shared_experts.hidden_size == 8
+    assert shared_experts.in_dtype is torch.bfloat16
+    assert shared_experts.swiglu_limit == 2.0
+    assert shared_experts.swiglu_alpha == 1.5
+    assert shared_experts.swiglu_beta == 0.25
+    assert shared_experts.weights_replicated is True
+
+
 @pytest.mark.parametrize("with_gate", [False, True])
 def test_shared_experts_part2_applies_optional_gate(with_gate):
     shared_experts_layer = SimpleNamespace(
@@ -748,7 +883,7 @@ def test_shared_experts_part2_applies_optional_gate(with_gate):
         expert_gate=_Gate() if with_gate else None,
     )
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
-    shared_experts.layer = shared_experts_layer
+    shared_experts._layer = shared_experts_layer
     hidden_states = torch.randn(3, 4)
     shared_gate_up = torch.randn(3, 4)
 
@@ -787,7 +922,7 @@ def test_shared_expert_parallel_mode_matches_activation_and_weight_layout(
 ):
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
     shared_experts.weights_replicated = weights_replicated
-    shared_experts.moe_config = SimpleNamespace(
+    shared_experts._moe_config = SimpleNamespace(
         is_sequence_parallel=native_sequence_parallel,
         tp_size=1,
         tp_rank=0,
@@ -812,7 +947,7 @@ def test_shared_expert_parallel_mode_matches_activation_and_weight_layout(
 def test_local_shared_expert_dp_pads_splits_gathers_and_unpads(num_tokens):
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
     tp_group = MagicMock(world_size=2, rank_in_group=1)
-    shared_experts.moe_config = SimpleNamespace(
+    shared_experts._moe_config = SimpleNamespace(
         tp_size=1,
         tp_rank=0,
         ep_size=2,
@@ -850,7 +985,7 @@ def test_flashcomm_tp_shared_expert_gathers_input_and_reduce_scatters_output(
 ):
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
     tp_group = MagicMock(world_size=2, rank_in_group=0)
-    shared_experts.moe_config = SimpleNamespace(tp_group=tp_group)
+    shared_experts._moe_config = SimpleNamespace(tp_group=tp_group)
     hidden_states = torch.ones(2, 4)
     gathered_states = torch.ones(4, 4)
     shared_out = torch.ones(num_shared_tokens, 4)
@@ -884,7 +1019,7 @@ def test_flashcomm_tp_shared_expert_gathers_input_and_reduce_scatters_output(
 
 def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
     shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
-    shared_experts.layer = SimpleNamespace(
+    shared_experts._layer = SimpleNamespace(
         gate_up_proj=SimpleNamespace(weight_scale=torch.ones(1)),
         down_proj=SimpleNamespace(weight_scale=torch.ones(1)),
     )
@@ -917,7 +1052,7 @@ def test_active_shared_expert_lora_uses_dense_wrappers(monkeypatch):
     shared_experts.set_lora_context(lora_context)
 
     with patch.object(shared_experts_module.torch_npu, "npu_dynamic_quant", create=True) as dynamic_quant:
-        output = shared_experts.forward(hidden_states, events)
+        output = shared_experts._run_with_events(hidden_states, events)
 
     assert output is shared_out
     dynamic_quant.assert_not_called()
@@ -931,7 +1066,7 @@ def test_set_lora_context_updates_experts(has_shared_experts):
     nn.Module.__init__(runner)
     runner.routed_experts = SimpleNamespace()
     shared_experts = MagicMock() if has_shared_experts else None
-    runner.ascend_shared_experts = shared_experts
+    runner._shared_experts = shared_experts
     lora_context = object()
 
     runner.set_lora_context(lora_context)
@@ -950,7 +1085,10 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     input_ids = torch.tensor([11, 22])
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
-    ascend_shared_experts = SimpleNamespace(forward=MagicMock(return_value=shared_out))
+    shared_experts = SimpleNamespace(
+        forward_with_events=MagicMock(),
+        output=shared_out,
+    )
     routed_events = FusedMoEEvents(
         before_routed_experts=None,
         after_routed_experts=None,
@@ -961,7 +1099,7 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     runner.routed_experts = SimpleNamespace(
         forward_impl=MagicMock(return_value=(routed_out, routed_events) if has_shared_experts else routed_out)
     )
-    runner.ascend_shared_experts = ascend_shared_experts if has_shared_experts else None
+    runner._shared_experts = shared_experts if has_shared_experts else None
     runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
     current_stream = MagicMock()
 
@@ -983,7 +1121,7 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
         )
         assert result[0] is shared_out
         assert result[1] is routed_out
-        ascend_shared_experts.forward.assert_called_once()
+        shared_experts.forward_with_events.assert_called_once()
     else:
         runner.routed_experts.forward_impl.assert_called_once_with(
             hidden_states=hidden_states,
@@ -991,4 +1129,4 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
             input_ids=input_ids,
         )
         assert result is routed_out
-        ascend_shared_experts.forward.assert_not_called()
+        shared_experts.forward_with_events.assert_not_called()

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -130,7 +130,6 @@ class AscendMoERunner310(AscendMoERunner):
             routed_scaling_factor=routed_scaling_factor,
         )
 
-        ascend_shared_experts = getattr(self, "ascend_shared_experts", None)
-        if ascend_shared_experts is not None:
-            ascend_shared_experts.multistream_overlap = False
+        if self.shared_experts is not None:
+            self.shared_experts.multistream_overlap = False
         _MoECommMethods[MoECommType.ALLGATHER] = AllGatherCommImpl310(self.moe_config)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import cast
+
 import torch
 import torch.nn.functional as F
 from vllm.distributed import (
@@ -75,17 +77,22 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             self.moe_config.ep_group = get_ep_group()
             self.moe_config.mc2_group = get_mc2_group()
 
-        self.ascend_shared_experts = None
         if shared_experts is not None:
             routed_experts.return_with_event = True
-            self.ascend_shared_experts = AscendSharedExperts(
-                shared_experts,
-                self.moe_config,
-                self.quant_type,
-                self._quant_method,
+            self._shared_experts = AscendSharedExperts(
+                layer=shared_experts,
+                moe_config=self.moe_config,
+                enable_dbo=enable_dbo,
+                mk_can_overlap_shared_experts=lambda: False,
+                quant_type=self.quant_type,
+                quant_method=self._quant_method,
             )
 
         setup_moe_comm_method(self.moe_config)
+
+    @property
+    def shared_experts(self) -> AscendSharedExperts | None:
+        return cast(AscendSharedExperts | None, self._shared_experts)
 
     @property
     def is_internal_router(self) -> bool:
@@ -101,8 +108,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
     @property
     def _fused_output_is_reduced(self) -> bool:
         # For MC2/ALLTOALL/FUSED_MC2 comm types, finalize() already includes
-        # TP all-reduce for the routed output, and AscendSharedExperts.forward
-        # handles it for the shared output. Signal this to the upstream
+        # TP all-reduce for the routed output, and the Ascend shared-expert
+        # path handles it for the shared output. Signal this to the upstream
         # MoERunner.forward() so _maybe_reduce_final_output does not apply a
         # second TP all-reduce (which would double-count the contributions).
         return _EXTRA_CTX.moe_comm_type in {
@@ -112,7 +119,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         } or (_EXTRA_CTX.moe_comm_type == MoECommType.ALLGATHER and _EXTRA_CTX.flash_comm_v1_enabled)
 
     def _get_shared_expert_parallel_mode(self) -> SharedExpertParallelMode:
-        shared_experts = getattr(self, "ascend_shared_experts", None)
+        shared_experts = self.shared_experts
         if shared_experts is None or not hasattr(shared_experts, "parallel_mode"):
             return SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF
         return shared_experts.parallel_mode()
@@ -190,8 +197,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
 
     def set_lora_context(self, lora_context):
         self.routed_experts._ascend_moe_lora_context = lora_context
-        if self.ascend_shared_experts is not None:
-            self.ascend_shared_experts.set_lora_context(lora_context)
+        if self.shared_experts is not None:
+            self.shared_experts.set_lora_context(lora_context)
 
     def _forward_impl(
         self,
@@ -201,7 +208,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         input_ids: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
         with self._sequence_parallel_context():
-            if self.ascend_shared_experts is None:
+            shared_experts = self.shared_experts
+            if shared_experts is None:
                 return self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -230,8 +238,9 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             fused_moe_events.before_routed_experts = before_routed_experts
             fused_moe_events.after_routed_experts = after_routed_experts
 
-            shared_out = self.ascend_shared_experts.forward(
+            shared_experts.forward_with_events(
                 hidden_states,
                 fused_moe_events,
             )
+            shared_out = shared_experts.output
             return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from functools import wraps
@@ -23,6 +24,7 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoEMethodBase
+from vllm.model_executor.layers.fused_moe.runner.shared_experts import SharedExperts
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -55,38 +57,34 @@ class SharedExpertParallelMode(Enum):
     FLASHCOMM_ON_SHARED_EXPERT_DP_ON = auto()  # Sharded activations, replicated weights.
 
 
-class AscendSharedExperts:
+class AscendSharedExperts(SharedExperts):
     """Ascend-owned shared expert executor.
 
-    Keep the original shared expert module registered on ``AscendMoERunner``
-    for checkpoint compatibility while moving split/overlap execution details
-    out of the runner.
+    Reuse the upstream module/config/output lifecycle while preserving the
+    Ascend event-driven split/overlap execution path.
     """
 
     def __init__(
         self,
         layer: torch.nn.Module,
         moe_config: FusedMoEConfig,
+        enable_dbo: bool,
+        mk_can_overlap_shared_experts: Callable[[], bool],
         quant_type: QuantType,
         quant_method: FusedMoEMethodBase,
     ):
-        self.layer = layer
-        self.moe_config = moe_config
-        self.hidden_size = moe_config.hidden_dim
-        self.in_dtype = moe_config.in_dtype
-        self.swiglu_limit = 0.0 if moe_config.swiglu_limit is None else moe_config.swiglu_limit
-        self.swiglu_alpha = 1.0 if moe_config.swiglu_alpha is None else moe_config.swiglu_alpha
-        self.swiglu_beta = 0.0 if moe_config.swiglu_beta is None else moe_config.swiglu_beta
+        super().__init__(
+            layer=layer,
+            moe_config=moe_config,
+            enable_dbo=enable_dbo,
+            mk_can_overlap_shared_experts=mk_can_overlap_shared_experts,
+        )
+        self._update_moe_config_derived_state(moe_config)
         self.quant_type = quant_type
         self.lora_context = None
         ascend_config = get_ascend_config()
         self.multistream_overlap = ascend_config.multistream_overlap_shared_expert
-        # Native MoE sequence parallelism and the SP compiler pass also build
-        # shared-expert linears with replicated weights. Keep this weight-layout
-        # state independent from the runtime FlashComm decision.
-        self.weights_replicated = (
-            ascend_config.enable_shared_expert_dp or moe_config.is_sequence_parallel or enable_sp_by_pass()
-        )
+        self._update_weights_replicated(moe_config)
 
         if self.multistream_overlap:
             # Wrap the quant_method's process_weights_after_loading to validate that
@@ -103,6 +101,27 @@ class AscendSharedExperts:
 
             quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore
 
+    def _update_moe_config_derived_state(self, moe_config: FusedMoEConfig) -> None:
+        self.hidden_size = moe_config.hidden_dim
+        self.in_dtype = moe_config.in_dtype
+        self.swiglu_limit = 0.0 if moe_config.swiglu_limit is None else moe_config.swiglu_limit
+        self.swiglu_alpha = 1.0 if moe_config.swiglu_alpha is None else moe_config.swiglu_alpha
+        self.swiglu_beta = 0.0 if moe_config.swiglu_beta is None else moe_config.swiglu_beta
+
+    def _update_weights_replicated(self, moe_config: FusedMoEConfig) -> None:
+        ascend_config = get_ascend_config()
+        # Native MoE sequence parallelism and the SP compiler pass also build
+        # shared-expert linears with replicated weights. Keep this weight-layout
+        # state independent from the runtime FlashComm decision.
+        self.weights_replicated = (
+            ascend_config.enable_shared_expert_dp or moe_config.is_sequence_parallel or enable_sp_by_pass()
+        )
+
+    def _set_moe_config(self, new_moe_config: FusedMoEConfig) -> None:
+        self._moe_config = new_moe_config
+        self._update_moe_config_derived_state(new_moe_config)
+        self._update_weights_replicated(new_moe_config)
+
     def set_lora_context(self, lora_context) -> None:
         self.lora_context = lora_context
 
@@ -112,7 +131,7 @@ class AscendSharedExperts:
             torch.rand(10, self.hidden_size, device="npu", dtype=self.in_dtype) * 2 - 1
         )  # Random input for testing, scoped to [-1, 1]
 
-        integrated_out = self.layer(test_input)
+        integrated_out = self._layer(test_input)
         part1_out = self.part1(test_input)
         split_out = self.part2(test_input, part1_out)
 
@@ -138,16 +157,16 @@ class AscendSharedExperts:
         )
 
     def part1(self, hidden_states: torch.Tensor):
-        shared_gate_up, _ = self.layer.gate_up_proj(hidden_states)  # type: ignore
+        shared_gate_up, _ = self._layer.gate_up_proj(hidden_states)  # type: ignore
         return shared_gate_up
 
     def part2(self, hidden_states: torch.Tensor, shared_gate_up: torch.Tensor):
-        shared_act = self.layer.act_fn(shared_gate_up)  # type: ignore
-        shared_out, _ = self.layer.down_proj(shared_act)  # type: ignore
+        shared_act = self._layer.act_fn(shared_gate_up)  # type: ignore
+        shared_out, _ = self._layer.down_proj(shared_act)  # type: ignore
 
         # Qwen3-Next specific gating mechanism
-        if hasattr(self.layer, "expert_gate") and self.layer.expert_gate is not None:
-            gate_out, _ = self.layer.expert_gate(hidden_states)  # type: ignore
+        if hasattr(self._layer, "expert_gate") and self._layer.expert_gate is not None:
+            gate_out, _ = self._layer.expert_gate(hidden_states)  # type: ignore
             shared_out = F.sigmoid(gate_out) * shared_out
         return shared_out
 
@@ -156,12 +175,12 @@ class AscendSharedExperts:
         # EP rewrites FusedMoEParallelConfig.tp_size to 1 because each routed
         # expert is local. Shared-expert linears still span the physical TP
         # group, so their layout must be derived from that group instead.
-        tp_size = self.moe_config.tp_group.world_size
+        tp_size = self._moe_config.tp_group.world_size
         if tp_size <= 1:
             return SharedExpertParallelMode.FLASHCOMM_OFF_SHARED_EXPERT_DP_OFF
 
         activations_sharded = (
-            _EXTRA_CTX.flash_comm_v1_enabled or self.moe_config.is_sequence_parallel or enable_sp_by_pass()
+            _EXTRA_CTX.flash_comm_v1_enabled or self._moe_config.is_sequence_parallel or enable_sp_by_pass()
         )
         if activations_sharded and self.weights_replicated:
             return SharedExpertParallelMode.FLASHCOMM_ON_SHARED_EXPERT_DP_ON
@@ -178,7 +197,7 @@ class AscendSharedExperts:
         original_num_tokens = hidden_states.shape[0]
         # See parallel_mode(): moe_config.tp_size describes routed experts in
         # EP, while this token split follows the shared-expert TP group.
-        tp_group = self.moe_config.tp_group
+        tp_group = self._moe_config.tp_group
         tp_size = tp_group.world_size
         pad_size = (tp_size - original_num_tokens % tp_size) % tp_size
         if pad_size > 0:
@@ -196,7 +215,7 @@ class AscendSharedExperts:
         metadata: tuple[int, int],
     ) -> torch.Tensor:
         original_num_tokens, pad_size = metadata
-        shared_out = self.moe_config.tp_group.all_gather(shared_out, dim=0)
+        shared_out = self._moe_config.tp_group.all_gather(shared_out, dim=0)
         if pad_size > 0:
             shared_out = shared_out[:original_num_tokens]
         return shared_out
@@ -213,9 +232,23 @@ class AscendSharedExperts:
         pad_size = _EXTRA_CTX.pad_size
         if pad_size > 0:
             shared_out = F.pad(shared_out, (0, 0, 0, pad_size))
-        return self.moe_config.tp_group.reduce_scatter(shared_out, dim=0)
+        return self._moe_config.tp_group.reduce_scatter(shared_out, dim=0)
 
-    def forward(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
+    def forward_with_events(
+        self,
+        hidden_states: torch.Tensor,
+        fused_moe_evts: FusedMoEEvents,
+    ) -> None:
+        output_idx = self._output_idx
+        assert self._output[output_idx] is None
+        self._output[output_idx] = self._run_with_events(hidden_states, fused_moe_evts)
+        assert self._output[output_idx] is not None
+
+    def _run_with_events(
+        self,
+        hidden_states: torch.Tensor,
+        fused_moe_evts: FusedMoEEvents,
+    ) -> torch.Tensor:
         mode = self.parallel_mode()
         local_dp_metadata = None
 
@@ -243,8 +276,8 @@ class AscendSharedExperts:
             # Only used for int quantization
             has_quantized_shared_without_lora = (
                 not has_lora(self.lora_context)
-                and hasattr(self.layer.gate_up_proj, "weight_scale")
-                and hasattr(self.layer.down_proj, "weight_scale")
+                and hasattr(self._layer.gate_up_proj, "weight_scale")
+                and hasattr(self._layer.down_proj, "weight_scale")
             )
             if has_quantized_shared_without_lora and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
                 original_dtype = hidden_states.dtype
@@ -256,8 +289,8 @@ class AscendSharedExperts:
                 maybe_wait_event(fused_moe_evts.after_routed_experts)
                 hidden_states = torch_npu.npu_quant_matmul(
                     quantized_x,
-                    self.layer.gate_up_proj.weight,
-                    self.layer.gate_up_proj.weight_scale,
+                    self._layer.gate_up_proj.weight,
+                    self._layer.gate_up_proj.weight_scale,
                     pertoken_scale=None,
                     bias=None,
                     output_dtype=torch.int32,
@@ -267,7 +300,7 @@ class AscendSharedExperts:
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
                     x=hidden_states,
-                    weight_scale=self.layer.gate_up_proj.weight_scale_fp32,
+                    weight_scale=self._layer.gate_up_proj.weight_scale_fp32,
                     activation_scale=pertoken_scale,
                     bias=None,
                     quant_scale=None,
@@ -288,8 +321,8 @@ class AscendSharedExperts:
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = torch_npu.npu_quant_matmul(
                     quantized_x,
-                    self.layer.down_proj.weight,
-                    self.layer.down_proj.weight_scale,
+                    self._layer.down_proj.weight,
+                    self._layer.down_proj.weight_scale,
                     pertoken_scale=swiglu_out_scale,
                     bias=None,
                     output_dtype=original_dtype,
@@ -304,7 +337,7 @@ class AscendSharedExperts:
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)
-                hidden_states = self.layer.gate_up_proj((quantized_x, pertoken_scale))[0]
+                hidden_states = self._layer.gate_up_proj((quantized_x, pertoken_scale))[0]
                 # Execute activation concurrently with gmm2.
                 maybe_wait_event(fused_moe_evts.before_gmm2)
                 quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
@@ -318,7 +351,7 @@ class AscendSharedExperts:
                 # Execute the down projection concurrently with the combine
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = self.layer.down_proj((quantized_x, swiglu_out_scale))[0]
+                shared_out = self._layer.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
                 # Ensure the shared experts wait for hidden_states to be ready.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)


### PR DESCRIPTION
### What this PR does / why we need it?

This PR aligns the Ascend shared-expert wrapper with the upstream vLLM
`SharedExperts` lifecycle while preserving the existing Ascend execution path.

- make `AscendSharedExperts` inherit upstream `SharedExperts`
- reuse upstream module registration, MoE config ownership, and DBO output slots
- keep the Ascend event-driven stream, quantization, LoRA, FlashComm, shared-DP,
  and TP communication behavior
- remove the parallel `ascend_shared_experts` wrapper from `AscendMoERunner`
- keep 310P shared-expert multistream disabled
- add regression coverage for module registration, checkpoint keys, DBO slot
  isolation, config updates, LoRA, runner contracts, and 310P behavior

This avoids the previous split ownership where the shared-expert module was
registered through the upstream wrapper but executed and managed through a
second Ascend-only wrapper. It also leaves the upstream
`forward(input, SharedExpertsOrder)` contract intact and exposes a separate
Ascend event entry point.

Related to #13220.

### Does this PR introduce _any_ user-facing change?

No. This is a behavior-preserving internal lifecycle and ownership refactor.

### How was this patch tested?

- `env PYTHONPATH=/tmp/vllm-ascend-test-deps python -m pytest -q tests/ut/ops/test_fused_moe.py tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py`
  - 71 passed
- Python-file pre-commit hooks passed, including Ruff check/format, codespell,
  typos, secret scanning, and repository-local Python checks
- `git diff --check`

NPU E2E was not available in the local environment. The draft still needs NPU
validation for multistream eager/ACLGraph, W8A8/W4A8/W4A8MXFP paths, TP2 BF16,
FlashComm, and shared-expert DP communication combinations.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
