### PR TITLE
[CI] Push estimated-times branch to vllm-ascend-ci fork

### DIFF
--- a/.github/workflows/schedule_update_estimated_times.yaml
+++ b/.github/workflows/schedule_update_estimated_times.yaml
@@ -191,18 +191,23 @@ jobs:
             git diff .github/workflows/scripts/test_config.yaml
           fi
 
+      - name: Setup git remote
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote add fork "https://github.com/vllm-ascend-ci/vllm-ascend.git"
+
       - name: Commit and push
         if: steps.check.outputs.changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           BRANCH="auto/update-estimated-times-${{ github.run_id }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add .github/workflows/scripts/test_config.yaml
           git commit -s -m "[CI] Auto-update estimated test times in test_config.yaml"
-          git push origin "$BRANCH"
+          git push -f fork "$BRANCH"
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "Pushed branch: $BRANCH"
 
@@ -212,14 +217,15 @@ jobs:
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           BRANCH: auto/update-estimated-times-${{ github.run_id }}
+          PR_HEAD: vllm-ascend-ci:auto/update-estimated-times-${{ github.run_id }}
         with:
           github-token: ${{ secrets.PAT_TOKEN }}
           script: |
             try {
               const pr = await github.rest.pulls.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                head: process.env.BRANCH,
+                owner: 'vllm-project',
+                repo: 'vllm-ascend',
+                head: process.env.PR_HEAD,
                 base: 'main',
                 title: '[CI] Auto-update estimated test times in test_config.yaml',
                 body: '## Summary\n\n' +


### PR DESCRIPTION

### What this PR does / why we need it?

- Add fork remote (vllm-ascend-ci/vllm-ascend) instead of pushing to origin
- Push auto-update branch to the fork, not the main repo
- Create PR from vllm-ascend-ci fork to vllm-project/vllm-ascend main

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
