### PR TITLE
[Doc][Misc] Update Ascend environment for Qwen3 and MiniMax-M2/M3

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -170,15 +170,11 @@ Notes:
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export TASK_QUEUE_ENABLE=1
-
-export VLLM_ASCEND_BALANCE_SCHEDULING=0
 
 vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --served-model-name "MiniMax-M2.7" \
@@ -189,7 +185,8 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --additional-config '{"enable_cpu_binding":true,
                           "enable_fused_mc2":true,
-                          "weight_nz_mode":true}' \
+                          "weight_nz_mode":true,
+                          "VLLM_ASCEND_BALANCE_SCHEDULING":0}' \
     --enable-expert-parallel \
     --tensor-parallel-size 4 \
     --data-parallel-size 4 \
@@ -219,12 +216,8 @@ export HCCL_BUFFSIZE=512
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
-export TASK_QUEUE_ENABLE=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_INTRA_PCIE_ENABLE=1
 export HCCL_INTRA_ROCE_ENABLE=0
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 
 vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --served-model-name MiniMax-M2.7 \
@@ -278,13 +271,11 @@ local_ip="<your_ip>"
 
 export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
 
 export HCCL_BUFFSIZE=1024
 export HCCL_OP_EXPANSION_MODE="AIV"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
@@ -292,8 +283,6 @@ sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-export TASK_QUEUE_ENABLE=1
-export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 export PYTHONHASHSEED=0
 
 export ASCEND_RT_VISIBLE_DEVICES=$1
@@ -316,7 +305,8 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --quantization ascend \
     --enforce-eager \
     --speculative_config '{"method": "eagle3", "model": "/path/to/weight/Eagle3/", "num_speculative_tokens": 1}' \
-    --additional-config '{"enable_cpu_binding":true}' \
+    --additional-config '{"enable_cpu_binding":true,
+                        "VLLM_ASCEND_ENABLE_FUSED_MC2":1}' \
     --kv-transfer-config \
         '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_producer",
@@ -339,13 +329,11 @@ local_ip="<your_ip>"
 
 export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
 
 export HCCL_BUFFSIZE=2048
 export HCCL_OP_EXPANSION_MODE="AIV"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
@@ -353,8 +341,6 @@ sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-export TASK_QUEUE_ENABLE=1
-export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 export PYTHONHASHSEED=0
 
 export ASCEND_RT_VISIBLE_DEVICES=$1
@@ -378,7 +364,8 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
     --speculative_config '{"method": "eagle3", "model": "/path/to/weight/Eagle3/", "num_speculative_tokens": 3}' \
-    --additional-config '{"enable_cpu_binding":true}' \
+    --additional-config '{"enable_cpu_binding":true,
+                        "VLLM_ASCEND_ENABLE_FUSED_MC2":1}' \
     --kv-transfer-config \
         '{"kv_connector": "MooncakeConnectorV1",
         "kv_role": "kv_consumer",
@@ -600,7 +587,7 @@ The following optimizations are enabled by default and require no additional con
 | Optimization Technique | Applicable Scenarios | Enablement Method | Technical Principle | Precautions |
 | ---------------------- | -------------------- | ----------------- | ------------------- | ----------- |
 | Fused MC2 | TP ≥ 4 scenarios | `--additional-config '{"enable_fused_mc2": true}'` | Fuses multiple communication and computation operations | Recommended for A3; not applicable for A2 |
-| Balanced Scheduling | High DP scenarios | `export VLLM_ASCEND_BALANCE_SCHEDULING=1` | Enhances scheduling capacity between prefill and decode | Currently disabled by default (`0`). Set to `1` only when concurrency ≈ DP × max-num-seqs. Disable for long-context scenarios |
+| Balanced Scheduling | High DP scenarios | `--additional-config '{"VLLM_ASCEND_BALANCE_SCHEDULING": 1}'` | Enhances scheduling capacity between prefill and decode | Currently disabled by default (`0`). Set to `1` only when concurrency ≈ DP × max-num-seqs. Disable for long-context scenarios |
 | EAGLE3 Speculative Decoding | All scenarios | `--speculative_config '{"method": "eagle3", "model": "/path/to/Eagle3/", "num_speculative_tokens": 3}'` | Uses a draft model to predict future tokens | 1–3 tokens for long context; 3 tokens for short context |
 | jemalloc Preload | All scenarios | `export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2` | Replaces default memory allocator to reduce fragmentation | Ensure jemalloc is installed in the container |
 

--- a/docs/source/tutorials/models/MiniMax-M3.md
+++ b/docs/source/tutorials/models/MiniMax-M3.md
@@ -117,7 +117,7 @@ Single-node deployment completes both Prefill and Decode within the same node. B
 === "BF16 Deployment"
 
   ```bash
-  export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
@@ -150,7 +150,7 @@ Single-node deployment completes both Prefill and Decode within the same node. B
 === "W8A8 Deployment"
 
   ```bash
-  export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
@@ -204,17 +204,10 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
   export GLOO_SOCKET_IFNAME="$IFNAME"
-  export TP_SOCKET_IFNAME="$IFNAME"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export VLLM_ENGINE_READY_TIMEOUT_S=3600
-  export HCCL_CONNECT_TIMEOUT=7200
-  export ASCEND_CONNECT_TIMEOUT=10000
-  export ASCEND_TRANSFER_TIMEOUT=10000
-  export VLLM_RPC_TIMEOUT=1800000
   export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
-  export TASK_QUEUE_ENABLE=1
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
   vllm serve ${WEIGHT_PATH} \
@@ -247,17 +240,10 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
   export GLOO_SOCKET_IFNAME="$IFNAME"
-  export TP_SOCKET_IFNAME="$IFNAME"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export VLLM_ENGINE_READY_TIMEOUT_S=3600
-  export HCCL_CONNECT_TIMEOUT=7200
-  export ASCEND_CONNECT_TIMEOUT=10000
-  export ASCEND_TRANSFER_TIMEOUT=10000
-  export VLLM_RPC_TIMEOUT=1800000
   export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
-  export TASK_QUEUE_ENABLE=1
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
   vllm serve ${WEIGHT_PATH} \
@@ -293,16 +279,10 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
   export GLOO_SOCKET_IFNAME="$IFNAME"
-  export TP_SOCKET_IFNAME="$IFNAME"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export VLLM_ENGINE_READY_TIMEOUT_S=3600
-  export HCCL_CONNECT_TIMEOUT=7200
-  export ASCEND_CONNECT_TIMEOUT=10000
-  export ASCEND_TRANSFER_TIMEOUT=10000
-  export VLLM_RPC_TIMEOUT=1800000
-  export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-  export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+  export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 
@@ -337,16 +317,10 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
   export GLOO_SOCKET_IFNAME="$IFNAME"
-  export TP_SOCKET_IFNAME="$IFNAME"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export VLLM_ENGINE_READY_TIMEOUT_S=3600
-  export HCCL_CONNECT_TIMEOUT=7200
-  export ASCEND_CONNECT_TIMEOUT=10000
-  export ASCEND_TRANSFER_TIMEOUT=10000
-  export VLLM_RPC_TIMEOUT=1800000
-  export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-  export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+  export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 

--- a/docs/source/tutorials/models/Qwen3-235B-A22B.md
+++ b/docs/source/tutorials/models/Qwen3-235B-A22B.md
@@ -207,9 +207,6 @@ Atlas 800I A2/A3:
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 export HCCL_BUFFSIZE=512
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export TASK_QUEUE_ENABLE=1
 
 vllm serve your_model_path \
     --host <host_ip> \
@@ -327,20 +324,17 @@ local_ip="<your_ip>"
 
 export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
 
 export HCCL_BUFFSIZE=512
 export HCCL_OP_EXPANSION_MODE="AIV"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export TASK_QUEUE_ENABLE=1
 export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
 export ASCEND_RT_VISIBLE_DEVICES=$1
@@ -391,22 +385,18 @@ local_ip="<your_ip>"
 
 export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
 export HCCL_BUFFSIZE=1024
 export HCCL_OP_EXPANSION_MODE="AIV"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export TASK_QUEUE_ENABLE=1
 export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-export VLLM_TORCH_PROFILER_WITH_STACK=0
 export ASCEND_RT_VISIBLE_DEVICES=$1
 
 vllm serve "/data/weights/Qwen3-235B-A22B-w8a8-rot" \
@@ -455,22 +445,18 @@ local_ip="<your_ip>"
 
 export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
-export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
 export HCCL_BUFFSIZE=1024
 export HCCL_OP_EXPANSION_MODE="AIV"
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export TASK_QUEUE_ENABLE=1
 export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-export VLLM_TORCH_PROFILER_WITH_STACK=0
 export ASCEND_RT_VISIBLE_DEVICES=$1
 
 vllm serve "/data/weights/Qwen3-235B-A22B-w8a8-rot" \
@@ -746,20 +732,17 @@ Single-node PD hybrid deployment optimized for maximum throughput on Atlas 800I 
 ```bash
 export HCCL_IF_IP=<node_ip>
 export GLOO_SOCKET_IFNAME=<ifname>
-export TP_SOCKET_IFNAME=<ifname>
 export HCCL_SOCKET_IFNAME=<ifname>
 
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export TASK_QUEUE_ENABLE=1
 
 vllm serve your_model_path \
     --served-model-name qwen3 \
@@ -790,20 +773,17 @@ Single-node PD hybrid deployment optimized for low latency with speculative deco
 ```bash
 export HCCL_IF_IP=<node_ip>
 export GLOO_SOCKET_IFNAME=<ifname>
-export TP_SOCKET_IFNAME=<ifname>
 export HCCL_SOCKET_IFNAME=<ifname>
 
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export TASK_QUEUE_ENABLE=1
 
 vllm serve your_model_path \
     --served-model-name qwen3 \
@@ -835,20 +815,17 @@ Single-node PD hybrid deployment optimized for long context with Context Paralle
 ```bash
 export HCCL_IF_IP=<node_ip>
 export GLOO_SOCKET_IFNAME=<ifname>
-export TP_SOCKET_IFNAME=<ifname>
 export HCCL_SOCKET_IFNAME=<ifname>
 
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-export OMP_NUM_THREADS=1
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export TASK_QUEUE_ENABLE=1
 
 vllm serve your_model_path \
     --served-model-name qwen3 \

--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -229,8 +229,6 @@ Single-node deployment completes both Prefill and Decode within the same node, s
     export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
     export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
     export HCCL_BUFFSIZE=1024
-    export OMP_PROC_BIND=false
-    export OMP_NUM_THREADS=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve your_model_path \
@@ -521,8 +519,6 @@ vllm bench serve \
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -557,8 +553,6 @@ vllm serve your_model_path \
 export ASCEND_RT_VISIBLE_DEVICES=0
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -592,8 +586,6 @@ vllm serve your_model_path \
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \

--- a/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
@@ -190,8 +190,6 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -449,8 +447,6 @@ vllm bench serve \
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -485,8 +481,6 @@ vllm serve your_model_path \
 export ASCEND_RT_VISIBLE_DEVICES=0
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -520,8 +514,6 @@ vllm serve your_model_path \
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -232,7 +232,6 @@ Single-node deployment completes both Prefill and Decode within the same node, s
     ```bash
     export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export TASK_QUEUE_ENABLE=1
     export HCCL_OP_EXPANSION_MODE="AIV"
 
     vllm serve your_model_path \
@@ -252,8 +251,6 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 
     ```bash
     export ASCEND_RT_VISIBLE_DEVICES=0,1
-    export VLLM_USE_V1=1
-    export TASK_QUEUE_ENABLE=1
     export HCCL_BUFFSIZE=1024
     vllm serve your_model_path \
         --port 8004 \
@@ -525,7 +522,6 @@ For detailed parameter descriptions, please refer to the deployment examples in 
 ```bash
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
@@ -550,7 +546,6 @@ vllm serve your_model_path \
 ```bash
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
@@ -576,7 +571,6 @@ vllm serve your_model_path \
 ```bash
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export TASK_QUEUE_ENABLE=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates and cleans up the recommended Ascend environment variables for Qwen3 and MiniMax-M2/M3 models. 

- Removes redundant or obsolete environment variables (such as `OMP_NUM_THREADS`, `TASK_QUEUE_ENABLE`, `VLLM_ASCEND_BALANCE_SCHEDULING`, `TP_SOCKET_IFNAME`, and various timeout variables). 

- Standardizes the format of environment variables (e.g., removing unnecessary quotes from `PYTORCH_NPU_ALLOC_CONF=expandable_segments:True`). 

- Adjusts execution timeouts to more reasonable defaults (e.g., reducing `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS` from `30000` to `3000`).

### Does this PR introduce _any_ user-facing change?
No, These are Documentation-only updates.
### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
