### PR TITLE
[Bugfix][SpecDecode] Support probabilistic draft sampling on MRV1

### DIFF
--- a/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
+++ b/tests/ut/_310p/spec_decode/test_llm_base_proposer_310.py
@@ -37,6 +37,7 @@ class TestAscendSpecDecodeBaseProposer310(TestBase):
             multi_steps_attn_metadata,
             num_tokens,
             is_prefill=None,
+            sampling_metadata=None,
         ):
             flag_states.append(AscendRotaryEmbedding310._is_drafting_update_enabled)
             return torch.zeros(num_tokens, dtype=torch.long)

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -1619,7 +1619,7 @@ class TestEagleProposerPropose:
         sig_name = self.get_param_names(sig)
         assert sig_name == ['self', 'num_input_tokens', 'batch_size', 'token_indices_to_sample',
                             'target_positions', 'inputs_embeds', 'multi_steps_attn_metadata',
-                            'num_tokens', 'is_prefill'
+                            'num_tokens', 'is_prefill', 'sampling_metadata'
                         ]
 
 
@@ -2417,6 +2417,7 @@ class TestRunMergedDraft(TestBase):
             "multi_steps_attn_metadata",
             "num_tokens",
             "is_prefill",
+            "sampling_metadata",
         ]
         sig = inspect.signature(RunnerCls.maybe_pad_and_reduce)
         sig_name = self.get_param_names(sig)
@@ -2469,13 +2470,14 @@ class TestRunMergedDraft(TestBase):
     def test_run_merged_draft_eagle3_decode_prepares_each_forward_input(self):
         self.proposer.model = MockDraftModel(returns_tuple=True)
 
-        def compute_draft_token_ids(sample_hidden_states):
+        def compute_draft_token_ids(sample_hidden_states, sampling_metadata=None):
             self.proposer.model.logit_inputs.append(sample_hidden_states.clone())
             token_ids = sample_hidden_states[:, 0].to(torch.long)
             logits = torch.full((sample_hidden_states.shape[0], self.proposer.model.vocab_size), -1000.0)
             logits[torch.arange(sample_hidden_states.shape[0]), token_ids] = 1000.0
             logits = logits.argmax(dim=-1)
-            return logits
+            # Greedy path: no draft probabilities.
+            return logits, None
 
         self.proposer.compute_draft_token_ids = compute_draft_token_ids
         self.proposer.supports_mm_inputs = True

--- a/tests/ut/spec_decode/test_dflash2_proposer.py
+++ b/tests/ut/spec_decode/test_dflash2_proposer.py
@@ -216,8 +216,9 @@ def test_compute_draft_token_ids_uses_selector_and_anchor(monkeypatch):
     )
 
     hidden_states = torch.randn(num_reqs * num_steps, hidden)
-    tokens = proposer.compute_draft_token_ids(hidden_states)
+    tokens, probs = proposer.compute_draft_token_ids(hidden_states)
 
+    assert probs is None  # DFlash2 always drafts greedily.
     assert tokens.shape == (num_reqs * num_steps,)
     model.compute_candidates.assert_called_once()
     selector_args = model.model.candidate_selector.call_args[0]

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -407,10 +407,10 @@ class TestSetPerGroupAttnMetadata(_DSparkProposerTestBase):
 
 
 class TestDSparkInitValidation:
-    """``AscendDSparkProposer.__init__`` rejects probabilistic draft sampling
-    (unsupported on the v1 model runner) and, for the greedy path, allocates
-    the DSpark-specific draft/seed buffers and overrides the DFlash
-    query-token / cudagraph defaults."""
+    """``AscendDSparkProposer.__init__`` accepts probabilistic draft sampling
+    (supported via the per-step probability collection in
+    ``llm_base_proposer``), allocates the DSpark-specific draft/seed buffers
+    and overrides the DFlash query-token / cudagraph defaults."""
 
     @staticmethod
     def _make_vllm_config(
@@ -458,7 +458,7 @@ class TestDSparkInitValidation:
 
         monkeypatch.setattr(AscendDflashProposer, "__init__", _stub)
 
-    def test_probabilistic_rejected(self, monkeypatch):
+    def test_probabilistic_accepted(self, monkeypatch):
         device = torch.device("cpu")
         self._stub_dflash_init(
             monkeypatch,
@@ -474,8 +474,11 @@ class TestDSparkInitValidation:
             max_num_tokens=256,
             draft_sample_method="probabilistic",
         )
-        with pytest.raises(ValueError, match="probabilistic"):
-            AscendDSparkProposer(vllm_config, device)
+        # Probabilistic draft sampling is supported (per-step probabilities
+        # are collected in llm_base_proposer); init must not raise.
+        proposer = AscendDSparkProposer(vllm_config, device)
+        assert proposer._dspark_draft_buffer.shape == (16, 6)
+        assert proposer._dspark_seed_buffer.shape == (16,)
 
     def test_greedy_allocates_dspark_buffers(self, monkeypatch):
         device = torch.device("cpu")

--- a/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
+++ b/vllm_ascend/_310p/spec_decode/llm_base_proposer_310.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import torch
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm.v1.sample.metadata import SamplingMetadata
 
 from vllm_ascend._310p.ops.rotary_embedding import AscendRotaryEmbedding310
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
@@ -39,6 +40,7 @@ class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
         multi_steps_attn_metadata,
         num_tokens,
         is_prefill=None,
+        sampling_metadata: SamplingMetadata | None = None,
     ) -> torch.Tensor:
         AscendRotaryEmbedding310.set_rope_position_flag_310p(True)
         try:
@@ -52,6 +54,7 @@ class AscendSpecDecodeBaseProposer310(AscendSpecDecodeBaseProposer):
                 multi_steps_attn_metadata,
                 num_tokens,
                 is_prefill,
+                sampling_metadata,
             )
         finally:
             AscendRotaryEmbedding310.set_rope_position_flag_310p(False)

--- a/vllm_ascend/spec_decode/dflash2_proposer.py
+++ b/vllm_ascend/spec_decode/dflash2_proposer.py
@@ -3,6 +3,7 @@ from typing import Any
 import torch
 from torch import nn
 from vllm.config import VllmConfig
+from vllm.v1.sample.metadata import SamplingMetadata
 
 from vllm_ascend.ops.triton.spec_decode.utils import dflash2_greedy_selector_walk_kernel
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_properties_triton
@@ -78,7 +79,13 @@ class AscendDflash2Proposer(AscendDflashProposer):
         self.model.has_own_lm_head = False
         super()._maybe_share_lm_head(model)
 
-    def compute_draft_token_ids(self, hidden_states: torch.Tensor) -> torch.Tensor:
+    def compute_draft_token_ids(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        # DFlash2 always drafts greedily: probabilistic sampling is rejected in
+        # __init__, so draft probs are never produced here.
         num_sample = hidden_states.shape[0]
         num_steps = self.num_speculative_tokens
         if num_sample % num_steps != 0:
@@ -97,4 +104,4 @@ class AscendDflash2Proposer(AscendDflashProposer):
             hidden,
             anchor_token_ids,
         )
-        return greedy_select_path(candidate_ids, scores).reshape(-1)
+        return greedy_select_path(candidate_ids, scores).reshape(-1), None

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -34,11 +34,6 @@ class AscendDSparkProposer(AscendDflashProposer):
     ):
         super().__init__(vllm_config, device, runner=runner)
         assert vllm_config.speculative_config is not None
-        if vllm_config.speculative_config.draft_sample_method == "probabilistic":
-            raise ValueError(
-                "DSpark probabilistic draft sampling is not supported on the v1 "
-                "model runner; use greedy (the default) instead."
-            )
         self.sample_from_anchor = getattr(self.draft_model_config.hf_config, "sample_from_anchor", True)
         if self.sample_from_anchor:
             self.num_query_per_req = self.num_speculative_tokens

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -197,10 +197,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
             self.use_cuda_graph = False
 
-        # Probabilistic draft sampling (draft_sample_method="probabilistic")
-        # uses Gumbel/exponential noise that is not ACLGraph-safe. Force eager
-        # mode for the draft model when it is enabled, and reject incompatible
-        # option combinations early to avoid silent fallback to greedy.
         # NOTE: _enable_probabilistic_draft_probs is set by the upstream
         # SpecDecodeBaseProposer.__init__.
         if self._enable_probabilistic_draft_probs:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1267,9 +1267,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 if use_probabilistic and dspark_probs_list:
                     # Stack [K x [num_blk, V]] -> [num_blk, K, V] ->
                     # [num_blk * K, V] to match early_exit view logic.
-                    draft_probs_step0 = (
-                        torch.stack(dspark_probs_list, dim=1).view(-1, logits.shape[-1]).contiguous()
-                    )
+                    draft_probs_step0 = torch.stack(dspark_probs_list, dim=1).view(-1, logits.shape[-1]).contiguous()
 
                 # Dynamic verify-length path, implemented in DynamicSpecScheduler
                 # Only the dspark method is handled here since it relies on

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1233,7 +1233,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # directly for target-space rejection sampling. The upstream
                 # compute_draft_token_ids guard falls back to greedy in this case;
                 # mirror that here since this autoregressive loop bypasses it.
-                # TODO: implement d2t scatter (like upstream speculator) to enable
+                # implement d2t scatter (like upstream speculator) to enable
                 # probabilistic sampling with vocab remapping.
                 dspark_has_vocab_mapping = getattr(self.model, "draft_id_to_target_id", None) is not None
                 use_probabilistic = self._enable_probabilistic_draft_probs and not dspark_has_vocab_mapping
@@ -1301,6 +1301,10 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         # Early exit if there is only one draft token to be generated.
         if self.num_speculative_tokens == 1 or self.parallel_drafting:
+            if draft_probs_step0 is not None:
+                self._last_draft_probs = draft_probs_step0.view(
+                    -1, self.num_speculative_tokens, draft_probs_step0.shape[-1]
+                ).contiguous()
             if self.method == "dspark":
                 return draft_token_ids[:, 1:]
             else:

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1176,7 +1176,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         draft_probs_step0: torch.Tensor | None = None
         if getattr(self, "use_dflash2_selector", False):
-            draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
+            # DFlash2 always drafts greedily (probabilistic is rejected in
+            # its __init__), so draft_probs_step0 is always None here.
+            draft_token_ids, draft_probs_step0 = self.compute_draft_token_ids(sample_hidden_states, sampling_metadata)
             if lmhead_tp_enable():
                 draft_token_ids, token_indices_to_sample = self._align_tensor_and_indices(
                     draft_token_ids,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -197,6 +197,20 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
             self.use_cuda_graph = False
 
+        # Probabilistic draft sampling (draft_sample_method="probabilistic")
+        # uses Gumbel/exponential noise that is not ACLGraph-safe. Force eager
+        # mode for the draft model when it is enabled, and reject incompatible
+        # option combinations early to avoid silent fallback to greedy.
+        # NOTE: _enable_probabilistic_draft_probs is set by the upstream
+        # SpecDecodeBaseProposer.__init__.
+        if self._enable_probabilistic_draft_probs:
+            if self.use_local_argmax_reduction:
+                raise ValueError(
+                    "use_local_argmax_reduction is not compatible with draft_sample_method='probabilistic'."
+                )
+            if self.use_heterogeneous_vocab:
+                raise ValueError("use_heterogeneous_vocab is not compatible with draft_sample_method='probabilistic'.")
+
         # TODO: Remove it when the bug of fx-graph is solved
         self.maybe_eager_context: AbstractContextManager[Any] = nullcontext()
         if not self.use_cuda_graph and enable_sp(vllm_config):
@@ -1020,6 +1034,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "multi_steps_attn_metadata": multi_steps_attn_metadata,
                 "num_tokens": num_tokens,
                 "is_prefill": is_prefill_batch,
+                "sampling_metadata": sampling_metadata,
             }
             runnable = cast(Callable[..., Any], self._runnable)
             run_draft: Callable[[], Any] = partial(runnable, **model_inputs)
@@ -1032,20 +1047,59 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 self._update_full_graph_params_if_needed(forward_context, num_input_tokens, multi_steps_attn_metadata)
         return draft_token_ids
 
-    def compute_draft_token_ids(self, hidden_states: torch.Tensor):
+    def _sample_draft_from_logits(
+        self,
+        logits: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Sample draft tokens from logits.
+
+        Delegates to the upstream ``_sample_from_logits`` which handles
+        temperature alignment (repeat_interleave for parallel drafting) and
+        Gumbel-max sampling via ``compute_probs_and_sample_next_token``.
+
+        When ``sampling_metadata`` is None (e.g. during ``dummy_run`` /
+        profile run), greedy argmax is used and ``draft_probs`` is None.
+        """
+        if sampling_metadata is None:
+            if self._enable_probabilistic_draft_probs:
+                logger.warning(
+                    "draft_sample_method='probabilistic' is enabled but "
+                    "sampling_metadata is None (expected during dummy_run "
+                    "or profile run). Falling back to greedy argmax; "
+                    "draft_probs will not be produced."
+                )
+            return logits.argmax(dim=-1), None
+
+        return super()._sample_from_logits(logits, sampling_metadata)
+
+    def compute_draft_token_ids(
+        self,
+        hidden_states: torch.Tensor,
+        sampling_metadata: SamplingMetadata | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """Compute draft token ids (and optionally draft probs).
+
+        Returns (draft_token_ids, draft_probs) where draft_probs is None when
+        probabilistic sampling is disabled, all-greedy, or vocab remapping
+        prevents lossless probability export.
+        """
         if self.method in ("eagle3", "dflash", "dspark"):
             logits = self.model.logits_processor(self.model.lm_head, hidden_states)
             if not hasattr(self.model, "draft_id_to_target_id") or self.model.draft_id_to_target_id is None:
-                return greedy_sample(logits)
+                return self._sample_draft_from_logits(logits, sampling_metadata)
+            # With vocab remapping, draft probs live in draft-vocab space and
+            # cannot be used directly for target-space rejection sampling.
+            # Fall back to greedy.
             logits = logits.contiguous()
             next_token = greedy_sample(logits)
             bias = torch.index_select(self.model.draft_id_to_target_id, dim=0, index=next_token.view(-1)).view(
                 next_token.shape
             )
-            return next_token + bias
+            return next_token + bias, None
         else:
             logits = self.model.compute_logits(hidden_states)
-            return greedy_sample(logits)
+            return self._sample_draft_from_logits(logits, sampling_metadata)
 
     def _run_merged_draft(
         self,
@@ -1057,7 +1111,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         multi_steps_attn_metadata,
         num_tokens,
         is_prefill=None,
+        sampling_metadata: SamplingMetadata | None = None,
     ) -> torch.Tensor:
+        # Reset cached draft probs from the previous propose call.
+        self._last_draft_probs = None
+        # Fallback for dummy_run / profile run where sampling_metadata is not
+        # passed explicitly. In probabilistic mode this triggers a warning in
+        # _sample_draft_from_logits and falls back to greedy argmax.
+        if sampling_metadata is None and self.runner is not None:
+            sampling_metadata = self.runner.input_batch.sampling_metadata
         # The lifecycle of `input_ids`, `positions`, `hidden_states` runs through all
         # speculative tokens' proposings. `model_input_ids`, `model_positions` and
         # `model_hidden_states` represent the speculative model inputs.
@@ -1116,6 +1178,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         sample_hidden_states = last_hidden_states[token_indices_to_sample]
 
+        draft_probs_step0: torch.Tensor | None = None
         if getattr(self, "use_dflash2_selector", False):
             draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
             if lmhead_tp_enable():
@@ -1128,7 +1191,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
         elif get_ascend_config().enable_reduce_sample:
             if self.method in ("eagle3", "dflash", "mtp"):
-                draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
+                draft_token_ids, draft_probs_step0 = self.compute_draft_token_ids(
+                    sample_hidden_states, sampling_metadata
+                )
                 if lmhead_tp_enable():
                     draft_token_ids, token_indices_to_sample = self._align_tensor_and_indices(
                         draft_token_ids,
@@ -1137,6 +1202,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         ori_token_indices_to_sample,
                         is_logits=False,
                     )
+                    if draft_probs_step0 is not None and num_indices < draft_probs_step0.shape[0]:
+                        draft_probs_step0 = draft_probs_step0[:num_indices]
             else:
                 logits = self.model.compute_logits(sample_hidden_states)
                 if lmhead_tp_enable():
@@ -1152,7 +1219,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         ori_token_indices_to_sample,
                         is_logits=True,
                     )
-                draft_token_ids = logits.argmax(dim=-1)
+                draft_token_ids, draft_probs_step0 = self._sample_draft_from_logits(logits, sampling_metadata)
         else:
             if self.method == "dspark":
                 # Dspark speculation requires autoregressive applications of MarkovHead and ConfidenceHead.
@@ -1161,16 +1228,48 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
                 # `sample_hidden_states` has been all-gathered to full.
                 # `markov_emb` should also be full to match it.
+                # When the draft model has a reduced vocab (draft_id_to_target_id),
+                # draft logits/probs live in draft-vocab space and cannot be used
+                # directly for target-space rejection sampling. The upstream
+                # compute_draft_token_ids guard falls back to greedy in this case;
+                # mirror that here since this autoregressive loop bypasses it.
+                # TODO: implement d2t scatter (like upstream speculator) to enable
+                # probabilistic sampling with vocab remapping.
+                dspark_has_vocab_mapping = getattr(self.model, "draft_id_to_target_id", None) is not None
+                use_probabilistic = self._enable_probabilistic_draft_probs and not dspark_has_vocab_mapping
+                if self._enable_probabilistic_draft_probs and dspark_has_vocab_mapping:
+                    logger.warning_once(
+                        "draft_sample_method='probabilistic' is disabled for dspark "
+                        "with vocab remapping (draft_id_to_target_id): draft probs "
+                        "are in draft-vocab space and incompatible with target-space "
+                        "rejection sampling. Falling back to greedy."
+                    )
                 raw_logits = self.model.compute_logits(sample_hidden_states)
                 logits = raw_logits.view(-1, self.num_speculative_tokens, raw_logits.shape[-1])
                 num_blk = logits.shape[0]
                 draft_token_ids = self._dspark_draft_buffer[:num_blk]
                 draft_token_ids[:, 0].copy_(self._dspark_seed_buffer[:num_blk])
+                dspark_probs_list: list[torch.Tensor] = []
                 for idx in range(self.num_speculative_tokens):
                     markov_emb = self.model.markov_embed(draft_token_ids[:, idx])
                     logits_bias = self.model.markov_bias(markov_emb)
                     logits[:, idx].add_(logits_bias)
-                    draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
+                    if use_probabilistic:
+                        # Use probabilistic sampling instead of argmax.
+                        # logits[:, idx] is [num_blk, V], matching
+                        # batch_size for per-request temperature.
+                        token_ids, probs = self._sample_draft_from_logits(logits[:, idx], sampling_metadata)
+                        draft_token_ids[:, idx + 1].copy_(token_ids)
+                        if probs is not None:
+                            dspark_probs_list.append(probs)
+                    else:
+                        draft_token_ids[:, idx + 1].copy_(logits[:, idx].argmax(dim=-1))
+                if use_probabilistic and dspark_probs_list:
+                    # Stack [K x [num_blk, V]] -> [num_blk, K, V] ->
+                    # [num_blk * K, V] to match early_exit view logic.
+                    draft_probs_step0 = (
+                        torch.stack(dspark_probs_list, dim=1).view(-1, logits.shape[-1]).contiguous()
+                    )
 
                 # Dynamic verify-length path, implemented in DynamicSpecScheduler
                 # Only the dspark method is handled here since it relies on
@@ -1192,7 +1291,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                         ori_token_indices_to_sample,
                         is_logits=True,
                     )
-                draft_token_ids = logits.argmax(dim=-1)
+                draft_token_ids, draft_probs_step0 = self._sample_draft_from_logits(logits, sampling_metadata)
 
                 # Dynamic verify-length path for head-free DFlash only.
                 if hasattr(self, "dynamic_spec") and self.dynamic_spec is not None:
@@ -1221,6 +1320,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             (self.num_speculative_tokens, *draft_token_ids.shape), dtype=draft_token_ids.dtype, device=self.device
         )
         draft_token_ids_tensor[0] = draft_token_ids
+        draft_probs_list = [draft_probs_step0] if draft_probs_step0 is not None else None
         if self.uses_mrope:
             positions = self.mrope_positions[:, token_indices_to_sample]
         else:
@@ -1321,12 +1421,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 )
 
             sample_hidden_states = last_hidden_states[token_indices_to_sample]
+            draft_probs_step: torch.Tensor | None = None
             if get_ascend_config().enable_reduce_sample:
                 if self.method in ("eagle3", "dflash", "dspark", "mtp"):
-                    draft_token_ids = self.compute_draft_token_ids(sample_hidden_states)
+                    draft_token_ids, draft_probs_step = self.compute_draft_token_ids(
+                        sample_hidden_states, sampling_metadata
+                    )
                     if lmhead_tp_enable() and num_indices < draft_token_ids.shape[0]:
                         draft_token_ids = draft_token_ids[:num_indices]
                         token_indices_to_sample = token_indices_to_sample[:num_indices]
+                        if draft_probs_step is not None:
+                            draft_probs_step = draft_probs_step[:num_indices]
                 else:
                     logits = self.model.compute_logits(sample_hidden_states)
                     if lmhead_tp_enable():
@@ -1337,20 +1442,27 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     if lmhead_tp_enable() and num_indices < logits.shape[0]:
                         logits = logits[:num_indices]
                         token_indices_to_sample = token_indices_to_sample[:num_indices]
-                    draft_token_ids = logits.argmax(dim=-1)
+                    draft_token_ids, draft_probs_step = self._sample_draft_from_logits(logits, sampling_metadata)
             else:
                 logits = self.model.compute_logits(sample_hidden_states)
                 if lmhead_tp_enable() and num_indices < logits.shape[0]:
                     logits = logits[:num_indices]
                     token_indices_to_sample = token_indices_to_sample[:num_indices]
-                draft_token_ids = logits.argmax(dim=-1)
+                draft_token_ids, draft_probs_step = self._sample_draft_from_logits(logits, sampling_metadata)
 
             # TODO(wenlong): get more than one token for tree attention
             hidden_states = hidden_states[:batch_size]
             draft_token_ids_tensor[draft_index + 1] = draft_token_ids
+            if draft_probs_list is not None:
+                if draft_probs_step is not None:
+                    draft_probs_list.append(draft_probs_step)
+                else:
+                    draft_probs_list = None
 
         # [batch_size, num_speculative_tokens]
         draft_token_ids = draft_token_ids_tensor.swapaxes(0, 1)
+        if draft_probs_list is not None:
+            self._last_draft_probs = torch.stack(draft_probs_list, dim=1).contiguous()
         return draft_token_ids
 
     def set_inputs_first_pass(

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -14,7 +14,6 @@ from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec, UniformTypeKVCacheSpecs
 from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.spec_decode.llm_base_proposer import compute_probs_and_sample_next_token
 from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
 from vllm.v1.worker.utils import AttentionGroup
 
@@ -187,10 +186,12 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         logits: torch.Tensor | None = None
         if get_ascend_config().enable_reduce_sample and self.method == "mtp":
             if not hasattr(self.model.model, "compute_logits"):
-                draft_token_ids = self.compute_draft_token_ids(hidden_states)
+                draft_token_ids, draft_probs = self.compute_draft_token_ids(hidden_states, sampling_metadata)
                 if lmhead_tp_enable() and num_indices < draft_token_ids.shape[0]:
                     draft_token_ids = draft_token_ids[:num_indices]
-                return draft_token_ids, None
+                    if draft_probs is not None:
+                        draft_probs = draft_probs[:num_indices]
+                return draft_token_ids, draft_probs
             logits = self.model.compute_logits(hidden_states, spec_step_idx=spec_step_idx)
             if lmhead_tp_enable():
                 # Defensive: mutually exclusive with enable_reduce_sample at startup (ascend_config.py).
@@ -202,9 +203,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
 
         if lmhead_tp_enable() and num_indices < logits.shape[0]:
             logits = logits[:num_indices]
-        if not self._enable_probabilistic_draft_probs or sampling_metadata.all_greedy:
-            return logits.argmax(dim=-1), None
-        return compute_probs_and_sample_next_token(logits, sampling_metadata)
+        return self._sample_draft_from_logits(logits, sampling_metadata)
 
     @torch.inference_mode()
     def dummy_run(
@@ -495,6 +494,7 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
                 "multi_steps_attn_metadata": multi_steps_attn_metadata,
                 "num_tokens": num_tokens,
                 "is_prefill": attn_metadata_i.num_prefills,
+                "sampling_metadata": sampling_metadata,
             }
             run_draft = partial(self._runnable, **model_inputs)
             if self.enable_enpu:
@@ -515,10 +515,11 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         multi_steps_attn_metadata,
         num_tokens,
         is_prefill=None,
+        sampling_metadata: SamplingMetadata | None = None,
     ) -> torch.Tensor:
         """Base MTP execution flow with Step3.5 step-aware layer/head selection."""
         self._last_draft_probs = None
-        sampling_metadata = self.runner.input_batch.sampling_metadata
+        # sampling_metadata fallback is handled by the parent class.
         model_input_ids = self.input_ids[:num_input_tokens]
         model_positions = self._get_positions(num_input_tokens)
         model_kwargs = {

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1471,6 +1471,11 @@ class NPUModelRunner(GPUModelRunner):
     ) -> list[list[int]] | None:
         self._log_propose_draft_token_ids_entry(spec_decode_metadata, num_scheduled_tokens)
 
+        # Reset cached draft probs from the previous step so that stale data
+        # is never used when the drafter does not produce fresh probabilities.
+        self._draft_probs = None
+        self._draft_prob_req_ids = None
+
         if not self.drafter:
             # Speculative decoding is not enabled.
             draft_token_ids = None
@@ -1668,9 +1673,7 @@ class NPUModelRunner(GPUModelRunner):
                 num_scheduled_tokens=num_scheduled_tokens,
                 num_rejected_tokens_gpu=num_rejected_tokens_gpu,
             )
-            if get_pp_group().world_size > 1 and hasattr(
-                self.drafter, "take_last_draft_probs"
-            ):
+            if hasattr(self.drafter, "take_last_draft_probs"):
                 draft_probs = self.drafter.take_last_draft_probs()
                 if draft_probs is not None:
                     self._draft_probs = draft_probs
@@ -2460,11 +2463,7 @@ class NPUModelRunner(GPUModelRunner):
         if self.input_batch.sampling_metadata.top_k is not None and get_ascend_config().enable_reduce_sample:
             max_topk = self.input_batch.top_k_cpu[self.input_batch.top_k_cpu < logits.shape[1]].max()
             self.rejection_sampler.prepare_sampling(max_topk)
-        draft_probs = (
-            self._get_spec_decode_draft_probs(spec_decode_metadata)
-            if get_pp_group().world_size > 1
-            else None
-        )
+        draft_probs = self._get_spec_decode_draft_probs(spec_decode_metadata)
         sampler_output = self.rejection_sampler(
             spec_decode_metadata,
             draft_probs,


### PR DESCRIPTION
### What this PR does / why we need it?
vllm：https://github.com/vllm-project/vllm/pull/40269
This pull request enables support for probabilistic draft sampling (`draft_sample_method='probabilistic'`) in Ascend speculative decoding. It updates the proposer classes (`llm_base_proposer.py`, `step3p5.py`) to accept and propagate `sampling_metadata` to retrieve draft probabilities, and integrates this with the model runner. Additionally, it removes the previous restriction on DSpark probabilistic draft sampling.

Feedback on the implementation:
- In `llm_base_proposer.py`, `logger.warning_once` is called but does not exist on standard loggers, which will cause an `AttributeError` at runtime.
- In `llm_base_proposer.py`, `draft_probs_step0` must be properly aligned using `_align_tensor_and_indices` when tensor parallelism is enabled to avoid shape mismatches.

### Does this PR introduce _any_ user-facing change?
Yes, users can now use `draft_sample_method='probabilistic'` with Ascend speculative decoding.

### How was this patch tested?
Tested via existing speculative decoding tests and verified with the new probabilistic sampling path.

### How was this patch tested?
pass https://github.com/vllm-project/vllm-ascend/actions/runs/32640733392/job/97209084690?pr=14485

https://github.com/vllm-project/vllm-ascend/actions/runs/32471684844/job/96741786987?pr=14485


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
