### PR TITLE
[Misc] Add code owner for quantization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -48,7 +48,7 @@
 # /vllm_ascend/model_loader
 /vllm_ascend/ops @zzzzwwjj @realliujiaxu
 # /vllm_ascend/patch
-# /vllm_ascend/quantization
+/vllm_ascend/quantization @kunpengW-code
 /vllm_ascend/sample @realliujiaxu
 # /vllm_ascend/spec_decode
 # /vllm_ascend/worker


### PR DESCRIPTION
### What this PR does / why we need it?

Add code owner for the `/vllm_ascend/quantization` directory to ensure that quantization-related changes are automatically routed to the appropriate reviewer

### Does this PR introduce _any_ user-facing change?

no

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
