### PR TITLE
[BugFix]Fix dsv4 quant name issue

### DIFF
--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -145,7 +145,7 @@ class DeepseekV4DSparkModel(nn.Module):
         _model_quant_cfg = getattr(config, "quantization_config", None)
         _main_proj_qconfig = (
             vllm_config.quant_config
-            if _model_quant_cfg is not None and _model_quant_cfg.get("quant_method") == "deepseek_v4_fp8"
+            if _model_quant_cfg is not None and _model_quant_cfg.get("quant_method") == "fp8"
             else None
         )
         self.main_proj = ReplicatedLinear(

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -145,7 +145,7 @@ class DeepseekV4DSparkModel(nn.Module):
         _model_quant_cfg = getattr(config, "quantization_config", None)
         _main_proj_qconfig = (
             vllm_config.quant_config
-            if _model_quant_cfg is not None and _model_quant_cfg.get("quant_method") == "fp8"
+            if _model_quant_cfg is not None and _model_quant_cfg.get("quant_method") == "deepseek_v4_fp8"
             else None
         )
         self.main_proj = ReplicatedLinear(

--- a/vllm_ascend/models/deepseek_v4/mtp.py
+++ b/vllm_ascend/models/deepseek_v4/mtp.py
@@ -287,7 +287,7 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
             if "rotary_emb.inv_freq" in name:
                 continue
 
-            if self.quant_config is not None and self.quant_config.get_name() == "fp8":
+            if self.quant_config is not None and self.quant_config.get_name() == "deepseek_v4_fp8":
                 if name == "embed.weight":
                     name = "mtp.0.emb.tok_emb.weight"
 


### PR DESCRIPTION
### What this PR does / why we need it?
PR https://github.com/vllm-project/vllm-ascend/issues/13651 refactors the fp8 configuration, inheriting the native implementation of vllm, but leaves some issues of mismatched quantization names. This PR addresses a naming mismatch in the fp8 quantization configuration for DeepSeek V4 models. By updating the expected quantization method identifier, the changes ensure that the model correctly identifies and applies the appropriate  weight loading.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
