### PR TITLE
[Feature][Model] Fuse Kimi K3 MLA decode prolog

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_prolog_v3.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_prolog_v3.py
@@ -14,6 +14,11 @@ def _skip_if_mla_prolog_v3_unavailable():
         pytest.skip("requires the npu_mla_prolog_v3 custom operator")
 
 
+def _rms_norm_reference(x: torch.Tensor, gamma: torch.Tensor, epsilon: float) -> torch.Tensor:
+    variance = x.float().square().mean(dim=-1, keepdim=True)
+    return (x.float() * torch.rsqrt(variance + epsilon) * gamma.float()).to(x.dtype)
+
+
 @torch.inference_mode()
 def test_mla_prolog_v3_native_bf16_head96():
     """Kimi K3 native bf16: head_num=96, q_lora=1536, kv_lora=512, D=128, Dr=64."""
@@ -77,6 +82,77 @@ def test_mla_prolog_v3_native_bf16_head96():
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+
+
+@torch.inference_mode()
+def test_mla_prolog_v3_kimi_k3_no_rope_matches_reference():
+    """K3 decode path keeps the positional slice in checkpoint order."""
+    _skip_if_mla_prolog_v3_unavailable()
+
+    token_num = 1
+    head_num = 96
+    hidden_size = 7168
+    q_lora_rank = 1536
+    kv_lora_rank = 512
+    qk_nope_head_dim = 128
+    qk_rope_head_dim = 64
+    block_size = 128
+    dtype = torch.bfloat16
+    rms_epsilon = 1e-5
+
+    token_x = torch.randn((token_num, hidden_size), dtype=dtype).npu()
+    weight_dq_nd = torch.randn((hidden_size, q_lora_rank), dtype=dtype).npu()
+    weight_uq_qr_nd = torch.randn(
+        (q_lora_rank, head_num * (qk_nope_head_dim + qk_rope_head_dim)),
+        dtype=dtype,
+    ).npu()
+    weight_dkv_kr_nd = torch.randn((hidden_size, kv_lora_rank + qk_rope_head_dim), dtype=dtype).npu()
+    weight_dq = torch_npu.npu_format_cast(weight_dq_nd.contiguous(), 29)
+    weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr_nd.contiguous(), 29)
+    weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr_nd.contiguous(), 29)
+    weight_uk = torch.randn((head_num, qk_nope_head_dim, kv_lora_rank), dtype=dtype).npu()
+    rmsnorm_gamma_cq = torch.randn((q_lora_rank,), dtype=dtype).npu()
+    rmsnorm_gamma_ckv = torch.randn((kv_lora_rank,), dtype=dtype).npu()
+    empty_rope = torch.empty((0, qk_rope_head_dim), dtype=dtype).npu()
+    kv_cache = torch.zeros((1, block_size, 1, kv_lora_rank), dtype=dtype).npu()
+    kr_cache = torch.zeros((1, block_size, 1, qk_rope_head_dim), dtype=dtype).npu()
+    cache_index = torch.zeros(token_num, dtype=torch.int64).npu()
+
+    ql_nope, q_pe, *_ = torch.ops._C_ascend.npu_mla_prolog_v3(
+        token_x,
+        weight_dq,
+        weight_uq_qr,
+        weight_uk,
+        weight_dkv_kr,
+        rmsnorm_gamma_cq,
+        rmsnorm_gamma_ckv,
+        empty_rope,
+        empty_rope,
+        kv_cache,
+        kr_cache,
+        cache_index=cache_index,
+        cache_mode="PA_BSND",
+    )
+
+    q_norm = _rms_norm_reference(token_x @ weight_dq_nd, rmsnorm_gamma_cq, rms_epsilon)
+    q_projection = (q_norm @ weight_uq_qr_nd).view(
+        token_num,
+        head_num,
+        qk_nope_head_dim + qk_rope_head_dim,
+    )
+    q_nope, q_pe_reference = q_projection.split([qk_nope_head_dim, qk_rope_head_dim], dim=-1)
+    ql_nope_reference = torch.bmm(
+        q_nope.transpose(0, 1),
+        weight_uk,
+    ).transpose(0, 1)
+    kv_projection = token_x @ weight_dkv_kr_nd
+    kv_nope, kr_reference = kv_projection.split([kv_lora_rank, qk_rope_head_dim], dim=-1)
+    kv_nope_reference = _rms_norm_reference(kv_nope, rmsnorm_gamma_ckv, rms_epsilon)
+
+    torch.testing.assert_close(ql_nope, ql_nope_reference, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(q_pe, q_pe_reference, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(kv_cache[0, 0, 0], kv_nope_reference[0], rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(kr_cache[0, 0, 0], kr_reference[0], rtol=2e-2, atol=2e-2)
 
 
 @torch.inference_mode()

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -19,9 +19,12 @@ from vllm_ascend.attention.mla_v1 import (
     AscendMLAPrefillMetadata,
     ChunkedContextMetadata,
     DecodeMLAPreprocessResult,
+    KIMI_K3_PROLOG_FULL_INT8_QUANT,
+    KIMI_K3_PROLOG_NO_QUANT,
     PrefillMLAPreprocessResult,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 
 
 class TestAscendMLABackend(TestBase):
@@ -1173,6 +1176,232 @@ class TestAscendMLAImpl(TestBase):
             use_mla_rope=False,
         )
         torch.testing.assert_close(output, projected)
+
+    def test_kimi_k3_prolog_v3_decode_uses_empty_rope_and_paged_caches(self):
+        self.impl.kimi_k3_prolog_v3_enabled = True
+        self.impl.num_heads = 2
+        self.impl.kv_lora_rank = 4
+        self.impl.qk_rope_head_dim = 3
+        self.impl.kimi_k3_weight_dq = torch.empty(1)
+        self.impl.kimi_k3_weight_uq_qr = torch.empty(1)
+        self.impl.kimi_k3_weight_uk = torch.empty(1)
+        self.impl.kimi_k3_weight_dkv_kr = torch.empty(1)
+        self.impl.q_a_layernorm = SimpleNamespace(
+            weight=SimpleNamespace(data=torch.ones(1)),
+            variance_epsilon=1e-6,
+        )
+        self.impl.kv_a_layernorm = SimpleNamespace(
+            weight=SimpleNamespace(data=torch.ones(1)),
+            variance_epsilon=1e-5,
+        )
+        hidden_states = torch.randn(2, 8)
+        kv_cache = (
+            torch.zeros(2, 4, 1, self.impl.kv_lora_rank),
+            torch.zeros(2, 4, 1, self.impl.qk_rope_head_dim),
+        )
+        attn_metadata = SimpleNamespace(
+            num_prefills=0,
+            num_decode_tokens=2,
+            slot_mapping=torch.tensor([3, 7], dtype=torch.int32),
+        )
+        ql_nope = torch.randn(2, self.impl.num_heads, self.impl.kv_lora_rank)
+        q_pe = torch.randn(2, self.impl.num_heads, self.impl.qk_rope_head_dim)
+        dequant_scale = torch.empty(0)
+
+        with (
+            patch(
+                "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
+                side_effect=lambda value, enabled: value,
+            ),
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_mla_prolog_v3",
+                return_value=(ql_nope, q_pe, dequant_scale, torch.empty(0), torch.empty(0)),
+                create=True,
+            ) as mock_prolog,
+        ):
+            result = self.impl._try_kimi_k3_prolog_v3_decode(
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                need_gather_q_kv=False,
+            )
+
+        assert result is not None
+        self.assertIs(result.k_nope, kv_cache[0])
+        self.assertIs(result.k_pe, kv_cache[1])
+        torch.testing.assert_close(result.ql_nope, ql_nope)
+        torch.testing.assert_close(result.q_pe, q_pe)
+        call_args = mock_prolog.call_args
+        self.assertEqual(call_args.args[7].numel(), 0)
+        self.assertEqual(call_args.args[8].numel(), 0)
+        self.assertEqual(call_args.kwargs["cache_mode"], "PA_BSND")
+        self.assertEqual(call_args.kwargs["cache_index"].dtype, torch.int64)
+        torch.testing.assert_close(call_args.kwargs["cache_index"], torch.tensor([3, 7], dtype=torch.int64))
+
+    def test_kimi_k3_prolog_v3_w8a8_decode_quantizes_input_and_passes_scales(self):
+        self.impl.kimi_k3_prolog_v3_enabled = True
+        self.impl.kimi_k3_prolog_v3_weight_quant_mode = KIMI_K3_PROLOG_FULL_INT8_QUANT
+        self.impl.num_heads = 2
+        self.impl.kv_lora_rank = 4
+        self.impl.qk_rope_head_dim = 3
+        self.impl.kimi_k3_weight_dq = torch.empty(1, dtype=torch.int8)
+        self.impl.kimi_k3_weight_uq_qr = torch.empty(1, dtype=torch.int8)
+        self.impl.kimi_k3_weight_uk = torch.empty(1)
+        self.impl.kimi_k3_weight_dkv_kr = torch.empty(1, dtype=torch.int8)
+        self.impl.kimi_k3_dequant_scale_w_dq = torch.ones(1, 4)
+        self.impl.kimi_k3_dequant_scale_w_uq_qr = torch.ones(1, 8)
+        self.impl.kimi_k3_dequant_scale_w_dkv_kr = torch.ones(1, 7)
+        self.impl.q_a_layernorm = SimpleNamespace(
+            weight=SimpleNamespace(data=torch.ones(1)),
+            variance_epsilon=1e-6,
+        )
+        self.impl.kv_a_layernorm = SimpleNamespace(
+            weight=SimpleNamespace(data=torch.ones(1)),
+            variance_epsilon=1e-5,
+        )
+        hidden_states = torch.randn(2, 8)
+        quantized_token_x = torch.randint(-128, 127, (2, 8), dtype=torch.int8)
+        dequant_scale_x = torch.ones(2)
+        kv_cache = (
+            torch.zeros(2, 4, 1, self.impl.kv_lora_rank),
+            torch.zeros(2, 4, 1, self.impl.qk_rope_head_dim),
+        )
+        attn_metadata = SimpleNamespace(
+            num_prefills=0,
+            num_decode_tokens=2,
+            slot_mapping=torch.tensor([3, 7], dtype=torch.int32),
+        )
+        ql_nope = torch.randn(2, self.impl.num_heads, self.impl.kv_lora_rank)
+        q_pe = torch.randn(2, self.impl.num_heads, self.impl.qk_rope_head_dim)
+
+        with (
+            patch(
+                "torch.ops.vllm.maybe_all_gather_and_maybe_unpad",
+                side_effect=lambda value, enabled: value,
+            ),
+            patch(
+                "vllm_ascend.attention.mla_v1.torch_npu.npu_dynamic_quant",
+                return_value=(quantized_token_x, dequant_scale_x),
+            ) as mock_dynamic_quant,
+            patch.object(
+                torch.ops._C_ascend,
+                "npu_mla_prolog_v3",
+                return_value=(ql_nope, q_pe, torch.empty(0), torch.empty(0), torch.empty(0)),
+                create=True,
+            ) as mock_prolog,
+        ):
+            result = self.impl._try_kimi_k3_prolog_v3_decode(
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                need_gather_q_kv=False,
+            )
+
+        assert result is not None
+        mock_dynamic_quant.assert_called_once_with(hidden_states.contiguous())
+        call_args = mock_prolog.call_args
+        self.assertIs(call_args.args[0], quantized_token_x)
+        self.assertEqual(call_args.kwargs["weight_quant_mode"], KIMI_K3_PROLOG_FULL_INT8_QUANT)
+        self.assertEqual(call_args.kwargs["kv_cache_quant_mode"], KIMI_K3_PROLOG_NO_QUANT)
+        torch.testing.assert_close(call_args.kwargs["dequant_scale_x"], dequant_scale_x.view(-1, 1))
+        self.assertIs(call_args.kwargs["dequant_scale_w_dq"], self.impl.kimi_k3_dequant_scale_w_dq)
+        self.assertIs(call_args.kwargs["dequant_scale_w_uq_qr"], self.impl.kimi_k3_dequant_scale_w_uq_qr)
+        self.assertIs(call_args.kwargs["dequant_scale_w_dkv_kr"], self.impl.kimi_k3_dequant_scale_w_dkv_kr)
+
+    def test_kimi_k3_prolog_v3_accepts_only_matching_w8a8_dynamic_linears(self):
+        quant_method = AscendW8A8DynamicLinearMethod()
+        self.impl.fused_qkv_a_proj = SimpleNamespace(
+            quant_method=SimpleNamespace(quant_method=quant_method),
+        )
+        self.impl.q_proj = SimpleNamespace(
+            quant_method=SimpleNamespace(quant_method=quant_method),
+        )
+
+        self.assertEqual(self.impl._get_kimi_k3_prolog_v3_weight_quant_mode(), KIMI_K3_PROLOG_FULL_INT8_QUANT)
+
+        self.impl.q_proj = SimpleNamespace(quant_method=UnquantizedLinearMethod())
+        self.assertIsNone(self.impl._get_kimi_k3_prolog_v3_weight_quant_mode())
+
+    def test_kimi_k3_prolog_v3_w8a8_prepares_nz_weights_and_scales(self):
+        self.impl.kimi_k3_prolog_v3_weight_quant_mode = KIMI_K3_PROLOG_FULL_INT8_QUANT
+        self.impl.q_lora_rank = 2
+        fused_weight = torch.arange(20, dtype=torch.int8).view(4, 5)
+        self.impl.fused_qkv_a_proj = SimpleNamespace(
+            weight=SimpleNamespace(data=fused_weight),
+            weight_scale=torch.tensor([0.5, 0.25, 0.125, 0.0625, 0.03125]),
+        )
+        q_proj_weight = torch.arange(12, dtype=torch.int8).view(4, 3)
+        self.impl.q_proj = SimpleNamespace(
+            weight=SimpleNamespace(data=q_proj_weight),
+            weight_scale=SimpleNamespace(data=torch.tensor([0.5, 0.25, 0.125])),
+        )
+        self.impl.W_UK_T = torch.ones(1, 1, 1)
+        self.impl.q_a_layernorm = object()
+        self.impl.kv_a_layernorm = object()
+
+        with patch(
+            "vllm_ascend.attention.mla_v1.torch_npu.npu_format_cast",
+            side_effect=lambda tensor, _: tensor,
+        ):
+            self.impl._prepare_kimi_k3_prolog_v3_weights()
+
+        torch.testing.assert_close(self.impl.kimi_k3_weight_dq, fused_weight[:, :2])
+        torch.testing.assert_close(self.impl.kimi_k3_weight_dkv_kr, fused_weight[:, 2:])
+        torch.testing.assert_close(self.impl.kimi_k3_weight_uq_qr, q_proj_weight)
+        torch.testing.assert_close(
+            self.impl.kimi_k3_dequant_scale_w_dq,
+            torch.tensor([[0.5, 0.25]], dtype=torch.float),
+        )
+        torch.testing.assert_close(
+            self.impl.kimi_k3_dequant_scale_w_dkv_kr,
+            torch.tensor([[0.125, 0.0625, 0.03125]], dtype=torch.float),
+        )
+        torch.testing.assert_close(
+            self.impl.kimi_k3_dequant_scale_w_uq_qr,
+            torch.tensor([[0.5, 0.25, 0.125]], dtype=torch.float),
+        )
+
+    def test_kimi_k3_prolog_v3_skips_prefill(self):
+        self.impl.kimi_k3_prolog_v3_enabled = True
+        attn_metadata = SimpleNamespace(
+            num_prefills=1,
+            num_decode_tokens=1,
+            slot_mapping=torch.tensor([0], dtype=torch.int32),
+        )
+
+        with patch.object(torch.ops._C_ascend, "npu_mla_prolog_v3", create=True) as mock_prolog:
+            result = self.impl._try_kimi_k3_prolog_v3_decode(
+                torch.randn(1, 8),
+                (torch.empty(1), torch.empty(1)),
+                attn_metadata,
+                need_gather_q_kv=False,
+            )
+
+        self.assertIsNone(result)
+        mock_prolog.assert_not_called()
+
+    def test_mla_preprocess_returns_kimi_k3_prolog_v3_decode_result(self):
+        decode_result = DecodeMLAPreprocessResult(
+            ql_nope=torch.empty(1),
+            q_pe=torch.empty(1),
+            k_nope=torch.empty(1),
+            k_pe=torch.empty(1),
+        )
+        self.impl._try_kimi_k3_prolog_v3_decode = MagicMock(return_value=decode_result)
+        attn_metadata = SimpleNamespace(num_decodes=1, num_prefills=0, num_decode_tokens=1)
+
+        with patch("vllm_ascend.attention.mla_v1.notify_kv_cache_written") as mock_notify:
+            result = self.impl._mla_preprocess(
+                "model.layers.0.self_attn.attn",
+                torch.empty(1, 8),
+                (torch.empty(1), torch.empty(1)),
+                attn_metadata,
+                need_gather_q_kv=False,
+            )
+
+        self.assertEqual(result, (decode_result, None))
+        mock_notify.assert_called_once_with("model.layers.0.self_attn.attn")
 
     @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
     @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -47,11 +47,13 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.memcache_comm_fence import record_attention_compute_start
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla, get_identity_cos_and_sin_mla
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.methods.w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
 from vllm_ascend.quantization.methods.w8a8_static import AscendW8A8LinearMethod
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import (
     ACL_FORMAT_FRACTAL_ND,
+    ACL_FORMAT_FRACTAL_NZ,
     AscendDeviceType,
     get_ascend_device_type,
     maybe_trans_nz,
@@ -67,6 +69,13 @@ BUILD_METADATA_STEP_PREFILL = 0
 BUILD_METADATA_STEP_DECODE = 1
 # token count limits within the mlapo operator
 MLAPO_MAX_SUPPORTED_TOKENS = 1024
+# Kimi K3's MLA dimensions supported by MlaPrologV3.
+KIMI_K3_PROLOG_Q_LORA_RANK = 1536
+KIMI_K3_PROLOG_KV_LORA_RANK = 512
+KIMI_K3_PROLOG_QK_NOPE_HEAD_DIM = 128
+KIMI_K3_PROLOG_QK_ROPE_HEAD_DIM = 64
+KIMI_K3_PROLOG_NO_QUANT = 0
+KIMI_K3_PROLOG_FULL_INT8_QUANT = 2
 # AttentionUpdate on A5 accepts at most 16 Local LSE/Output inputs. Keep the
 # effective FIA batch close to the 32 A5 vector cores without exceeding it.
 MLA_FIA_SPLIT_TARGET_BATCH = 32
@@ -922,6 +931,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.use_mla_rope = bool(kwargs.get("use_mla_rope", True))
         if self.use_output_gate and self.g_proj is None:
             raise ValueError("g_proj is required when MLA output gating is enabled")
+        self.kimi_k3_prolog_v3_enabled = False
+        self.kimi_k3_prolog_v3_weight_quant_mode = KIMI_K3_PROLOG_NO_QUANT
         self.vllm_config = get_current_vllm_config()
         self.kv_a_proj_with_mqa = kwargs.get("kv_a_proj_with_mqa")
         self.kv_a_layernorm = kwargs.get("kv_a_layernorm")
@@ -1133,6 +1144,144 @@ class AscendMLAImpl(MLAAttentionImpl):
         # Convert from (N, B, L) to (B, N, L)
         return ql_nope.transpose(0, 1), q_pe
 
+    @staticmethod
+    def _has_mla_prolog_v3_op() -> bool:
+        return hasattr(torch.ops, "_C_ascend") and hasattr(torch.ops._C_ascend, "npu_mla_prolog_v3")
+
+    @staticmethod
+    def _get_linear_quant_method(linear: torch.nn.Module) -> object | None:
+        quant_method = getattr(linear, "quant_method", None)
+        return getattr(quant_method, "quant_method", quant_method)
+
+    def _get_kimi_k3_prolog_v3_weight_quant_mode(self) -> int | None:
+        assert self.fused_qkv_a_proj is not None
+        fused_quant_method = self._get_linear_quant_method(self.fused_qkv_a_proj)
+        query_quant_method = self._get_linear_quant_method(self.q_proj)
+        if isinstance(fused_quant_method, UnquantizedLinearMethod) and isinstance(
+            query_quant_method,
+            UnquantizedLinearMethod,
+        ):
+            return KIMI_K3_PROLOG_NO_QUANT
+        if isinstance(fused_quant_method, AscendW8A8DynamicLinearMethod) and isinstance(
+            query_quant_method,
+            AscendW8A8DynamicLinearMethod,
+        ):
+            return KIMI_K3_PROLOG_FULL_INT8_QUANT
+        return None
+
+    def _supports_kimi_k3_prolog_v3(self, act_dtype: torch.dtype) -> bool:
+        """Return whether this layer can use the K3 decode-only PrologV3 path."""
+        text_config = self.vllm_config.model_config.hf_text_config
+        return (
+            getattr(text_config, "model_type", None) == "kimi_linear"
+            and not self.use_mla_rope
+            and self.num_kv_heads == 1
+            and self.q_lora_rank == KIMI_K3_PROLOG_Q_LORA_RANK
+            and self.kv_lora_rank == KIMI_K3_PROLOG_KV_LORA_RANK
+            and self.qk_nope_head_dim == KIMI_K3_PROLOG_QK_NOPE_HEAD_DIM
+            and self.qk_rope_head_dim == KIMI_K3_PROLOG_QK_ROPE_HEAD_DIM
+            and act_dtype == torch.bfloat16
+            and self.fused_qkv_a_proj is not None
+            and self.q_a_layernorm is not None
+            and self.kv_a_layernorm is not None
+            and self._get_kimi_k3_prolog_v3_weight_quant_mode() is not None
+            and get_ascend_device_type() in {AscendDeviceType.A2, AscendDeviceType.A3}
+            and self._has_mla_prolog_v3_op()
+        )
+
+    def _prepare_kimi_k3_prolog_v3_weights(self) -> None:
+        """Create PrologV3 weights without changing native MLA fallback weights."""
+        assert self.fused_qkv_a_proj is not None
+        assert self.q_a_layernorm is not None
+        assert self.kv_a_layernorm is not None
+
+        # Linear weights are stored as [output, input], while PrologV3 consumes
+        # [input, output] FRACTAL_NZ matrices.
+        if self.kimi_k3_prolog_v3_weight_quant_mode == KIMI_K3_PROLOG_NO_QUANT:
+            fused_weight = self.fused_qkv_a_proj.weight.data.T.contiguous()
+            weight_uq_qr = self.q_proj.weight.data.T.contiguous()
+        else:
+            fused_weight = self.fused_qkv_a_proj.weight.data
+            weight_uq_qr = self.q_proj.weight.data.contiguous()
+        weight_dq = fused_weight[:, : self.q_lora_rank].contiguous()
+        weight_dkv_kr = fused_weight[:, self.q_lora_rank :].contiguous()
+
+        self.kimi_k3_weight_dq = torch_npu.npu_format_cast(weight_dq, ACL_FORMAT_FRACTAL_NZ)
+        self.kimi_k3_weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, ACL_FORMAT_FRACTAL_NZ)
+        self.kimi_k3_weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, ACL_FORMAT_FRACTAL_NZ)
+        # Keep the ND copy because the generic fallback may convert W_UK_T to
+        # FRACTAL_NZ after this method returns.
+        self.kimi_k3_weight_uk = self.W_UK_T.contiguous()
+        if self.kimi_k3_prolog_v3_weight_quant_mode == KIMI_K3_PROLOG_FULL_INT8_QUANT:
+            q_scale = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()
+            kv_scale = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()
+            self.kimi_k3_dequant_scale_w_dq = q_scale.view(1, -1).to(torch.float)
+            self.kimi_k3_dequant_scale_w_dkv_kr = kv_scale.view(1, -1).to(torch.float)
+            self.kimi_k3_dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
+
+    def _try_kimi_k3_prolog_v3_decode(
+        self,
+        hidden_states: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        attn_metadata: M,
+        need_gather_q_kv: bool,
+    ) -> DecodeMLAPreprocessResult | None:
+        """Fuse K3's decode MLA prolog when token/cache layouts are exact."""
+        if not self.kimi_k3_prolog_v3_enabled or attn_metadata.num_prefills != 0:
+            return None
+
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        if num_decode_tokens == 0 or len(kv_cache) < 2:
+            return None
+        cache_index = attn_metadata.slot_mapping[:num_decode_tokens].reshape(-1).to(torch.int64)
+        token_x = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+            hidden_states.contiguous(),
+            need_gather_q_kv,
+        )
+        # The op writes one cache slot per input token. Keep padded graph
+        # buckets and distributed layouts on the proven native implementation.
+        if token_x.shape[0] != cache_index.shape[0]:
+            return None
+
+        empty_rope = token_x.new_empty((0, self.qk_rope_head_dim))
+        quant_kwargs: dict[str, object] = {
+            "weight_quant_mode": self.kimi_k3_prolog_v3_weight_quant_mode,
+            "kv_cache_quant_mode": KIMI_K3_PROLOG_NO_QUANT,
+        }
+        if self.kimi_k3_prolog_v3_weight_quant_mode == KIMI_K3_PROLOG_FULL_INT8_QUANT:
+            token_x, dequant_scale_x = torch_npu.npu_dynamic_quant(token_x.contiguous())
+            quant_kwargs.update(
+                dequant_scale_x=dequant_scale_x.view(-1, 1),
+                dequant_scale_w_dq=self.kimi_k3_dequant_scale_w_dq,
+                dequant_scale_w_uq_qr=self.kimi_k3_dequant_scale_w_uq_qr,
+                dequant_scale_w_dkv_kr=self.kimi_k3_dequant_scale_w_dkv_kr,
+            )
+        ql_nope, q_pe, dequant_scale_q_nope, _, _ = torch.ops._C_ascend.npu_mla_prolog_v3(
+            token_x,
+            self.kimi_k3_weight_dq,
+            self.kimi_k3_weight_uq_qr,
+            self.kimi_k3_weight_uk,
+            self.kimi_k3_weight_dkv_kr,
+            self.q_a_layernorm.weight.data,
+            self.kv_a_layernorm.weight.data,
+            empty_rope,
+            empty_rope,
+            kv_cache[0],
+            kv_cache[1],
+            cache_index=cache_index,
+            rmsnorm_epsilon_cq=self.q_a_layernorm.variance_epsilon,
+            rmsnorm_epsilon_ckv=self.kv_a_layernorm.variance_epsilon,
+            cache_mode="PA_BSND",
+            **quant_kwargs,
+        )
+        return DecodeMLAPreprocessResult(
+            ql_nope=ql_nope.view(-1, self.num_heads, self.kv_lora_rank),
+            q_pe=q_pe.view(-1, self.num_heads, self.qk_rope_head_dim),
+            k_nope=kv_cache[0],
+            k_pe=kv_cache[1],
+            dequant_scale_q_nope=dequant_scale_q_nope,
+        )
+
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         # NOTE: We currently do not support quant kv_b_proj.
         assert isinstance(self.kv_b_proj.quant_method, UnquantizedLinearMethod)
@@ -1167,6 +1316,13 @@ class AscendMLAImpl(MLAAttentionImpl):
         else:
             self.W_UV.copy_(W_UV.transpose(0, 1).contiguous())
             self.W_UK_T.copy_(W_UK.permute(1, 2, 0).contiguous())
+
+        weight_quant_mode = self._get_kimi_k3_prolog_v3_weight_quant_mode() if self.fused_qkv_a_proj else None
+        self.kimi_k3_prolog_v3_enabled = self._supports_kimi_k3_prolog_v3(act_dtype)
+        if self.kimi_k3_prolog_v3_enabled:
+            assert weight_quant_mode is not None
+            self.kimi_k3_prolog_v3_weight_quant_mode = weight_quant_mode
+            self._prepare_kimi_k3_prolog_v3_weights()
 
         # TODO(zzzzwwjj): Currently, torch.ops._C_ascend.batch_matmul_transpose cannot support weight nz
         # self.W_UV = maybe_trans_nz(self.W_UV)
@@ -2041,6 +2197,16 @@ class AscendMLAImpl(MLAAttentionImpl):
         # decode_ql_nope, decode_q_pe, decode_k_pe, decode_k_nope
         # 4. Preprocess prefill tokens, write kv cache and get:
         # prefill_q_nope, prefill_q_pe, prefill_k_nope, prefill_k_pe, prefill_value
+        prolog_decode_result = self._try_kimi_k3_prolog_v3_decode(
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            need_gather_q_kv,
+        )
+        if prolog_decode_result is not None:
+            notify_kv_cache_written(layer_name)
+            return prolog_decode_result, None
+
         has_decode = attn_metadata.num_decodes > 0
         has_prefill = attn_metadata.num_prefills > 0
         if self.fused_qkv_a_proj is not None:


### PR DESCRIPTION
### What this PR does / why we need it?

- Route eligible Kimi-K3 BF16 and W8A8 dynamic decode-only MLA requests through `npu_mla_prolog_v3` on Ascend A2/A3.
- Detect the quantization methods used by both MLA projection layers and enable PrologV3 only when they consistently use BF16 or `AscendW8A8DynamicLinearMethod`.
- For W8A8 dynamic, dynamically quantize the input tokens and pass the input/weight dequantization scales to PrologV3 with full INT8 weight quantization mode.
- Prepare dedicated FRACTAL_NZ PrologV3 weights and split the fused projection scales without changing the weights used by the native MLA path.
- Pass empty RoPE tensors for K3's no-RoPE positional slice and reuse the paged KV caches.
- Preserve the native MLA path for prefill, mixed requests, mismatched/unsupported quantization methods, unsupported layouts, and unavailable custom operators.

This change requires the arch22 custom operator support from #13844 to be built and installed on the target environment.

### Does this PR introduce _any_ user-facing change?

Yes. On A2/A3 installations that include the MlaPrologV3 custom OPP, eligible Kimi-K3 BF16 and W8A8 dynamic decode requests use the fused MLA preprocessing path. Other requests retain the existing native MLA behavior.

### How was this patch tested?

- `python -m py_compile vllm_ascend/attention/mla_v1.py tests/ut/attention/a2/test_mla_v1.py tests/e2e/nightly/single_node/ops/singlecard_ops/test_mla_prolog_v3.py`
- Added unit coverage for no-RoPE arguments, paged-cache routing, cache-index conversion, decode routing, and prefill fallback.
- Added W8A8 dynamic unit coverage for quantization-method gating, input dynamic quantization, INT8 quantization modes, dequantization-scale forwarding, and FRACTAL_NZ weight/scale preparation.
- Added numerical regression coverage comparing the Kimi-K3 no-RoPE PrologV3 output with the reference computation.
- A2/A3 runtime tests were not run locally because this environment lacks PyTorch, pytest, NPU hardware, and the #13844 arch22 OPP build.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485