### PR TITLE
[Ops][Feature] Enable MegaMoe for Kimi K3

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -84,7 +84,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `mc2_comm_alg`                      | str  | `""`    | set dispatch/combine op's `comm_alg` param, only supports `""/"fullmesh"/"hierarchy"/"fullmesh_v2"`. `"hierarchy"` is only supported by A2/A3, and `"fullmesh_v2"` is only supported by A3 now. |
 | `enable_mc2_hierarchy_comm`         | bool | `False` | Enable dispatch/combine op inter-node communication by ROCE. This param will be deprecated and be replaced by mc2_comm_alg = "hierarchy" |
 | `enable_prefill_mc2`                | bool | `False` | Whether to reserve mc2_token_capacity for prefill batches. When enabled, `max_num_batched_tokens` is used to calculate the mc2_token_capacity instead of the decode-only capacity. In this scenario, the recommended maximum value of `max_num_batched_tokens` is `tp_size * 512`. This is a temporary switch; once MC2 operators are complete for all scenarios, this switch will be removed and MC2 will be enabled by default. |
-| `mega_moe_max_tokens`               | int  | `65536` | Reference per-rank token capacity after dispatch in the fused MC2/MegaMoe path. It is passed as `dispatch_ffn_combine`'s `max_output_size` and CANN MegaMoe buffer's `max_recv_token_num`. If a rank's actual MoE load exceeds this value, precision degradation may occur. The absolute safe upper bound is `num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank)`, but using it directly can consume very large device memory. Tune this value based on actual expert load distribution. |
+| `mega_moe_max_tokens`               | int  | `6144` | Reference per-rank token capacity after dispatch in the fused MC2/MegaMoe path. It is passed as `dispatch_ffn_combine`'s `max_output_size` and CANN MegaMoe buffer's `max_recv_token_num`. If a rank's actual MoE load exceeds this value, precision degradation may occur. The absolute safe upper bound is `num_max_tokens_per_rank * int(self.token_dispatcher.ep_world_size) * min(num_topk, expert_per_rank)`, but using it directly can consume very large device memory. Tune this value based on actual expert load distribution. |
 | `enable_flashcomm1`                 | bool | `False` | Whether to enable FlashComm1 optimization. Can also be configured via the `VLLM_ASCEND_ENABLE_FLASHCOMM1` environment variable during the migration period. |
 | `msmonitor_use_daemon`              | bool | `False` | Whether to use daemon mode for msmonitor. Can also be configured via the `MSMONITOR_USE_DAEMON` environment variable during the migration period. |
 | `enable_mlapo`                      | bool | `True`  | Whether to enable MLAPO (Model Layer-wise Adaptive Parallel Optimization). Can also be configured via the `VLLM_ASCEND_ENABLE_MLAPO` environment variable during the migration period. |
@@ -96,6 +96,60 @@ The following table lists additional configuration options available in vLLM Asc
 | `rejection_sampler_config`          | dict | `{}`    | Configuration options for rejection sampler (block verify and entropy verify). |
 | `multistream_dsv4_dsa_overlap`      | bool | `True`  | Whether to enable dsa multi-stream overlap for DeepSeek V4.  |
 | `enable_reduce_sample`              | bool | `False` | Whether to enable reduce sample optimization to reduce communication and computation overheads in the tensor parallelism scenario. When enabled, logits are kept partitioned across TP ranks and only the small set of top-k candidate values/indices is communicated, instead of performing a full-vocabulary all-to-all/all-gather. |
+
+### Fused MC2 / MegaMoe prefill capacity
+
+`enable_fused_mc2` and `enable_prefill_mc2` control different behaviors:
+
+- `enable_fused_mc2=1` selects the fused MC2 path (`dispatch_ffn_combine` or MegaMoe).
+- `enable_prefill_mc2=true` sizes the MC2/MegaMoe token capacity from
+  `max_num_batched_tokens` instead of the decode-only ACL graph capacity. It
+  does not enable MegaMoe by itself.
+
+Enable `enable_prefill_mc2` when the fused path can process prefill or startup
+profiling batches larger than the decode-only capacity. Otherwise, the
+MegaMoe symmetric buffer can be initialized too small and CANN may fail during
+tiling with an error similar to:
+
+```text
+num_max_tokens_per_rank is invalid, should be >= bs(512), but got 16
+```
+
+For example, with `max_num_batched_tokens=8192`, TP=16, and a maximum decode
+graph size of 256:
+
+- decode-only sizing reserves `256 / 16 = 16` tokens per rank;
+- prefill sizing reserves `8192 / 16 = 512` tokens per rank.
+
+The second value is required if the startup profile or prefill forward passes
+512 tokens per rank. Keep `max_num_batched_tokens` no larger than
+`tp_size * 512`, as recommended for prefill MC2.
+
+```bash
+vllm serve <model> \
+  --tensor-parallel-size 16 \
+  --max-num-batched-tokens 8192 \
+  --enable-expert-parallel \
+  --additional-config \
+  '{"enable_fused_mc2":1,"enable_prefill_mc2":true,"multistream_overlap_shared_expert":false}'
+```
+
+When fused MC2 is disabled and the prefill batch exceeds the decode-only MC2
+capacity, the normal communication selector can fall back to AlltoAll instead
+of producing this MegaMoe buffer error. Therefore, `enable_prefill_mc2=false`
+does not necessarily fail when `enable_fused_mc2=0`; it means prefill MC2 is
+not reserved.
+
+Fused MC2 and `multistream_overlap_shared_expert` are mutually exclusive. The
+fused operator owns the dispatch, expert FFN, and combine schedule and does not
+expose the intermediate events required by shared-expert multi-stream overlap.
+When both are requested, vLLM Ascend keeps fused MC2 enabled and forces
+`multistream_overlap_shared_expert` to `false`.
+
+For PD disaggregation, enable prefill MC2 on P nodes that use fused MC2. It is
+normally unnecessary on D-only nodes, unless their startup/profile path also
+executes prefill-sized MegaMoe batches. Use identical capacity-related settings
+on every rank in the same distributed P or D group.
 
 The details of each configuration option are as follows:
 

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -179,6 +179,32 @@ def test_ascend_runner_promotes_runtime_state_to_buffer():
     assert dict(runner.named_buffers())["runtime_state"] is state
 
 
+def test_process_weights_after_loading_keeps_per_expert_nd_for_mega_moe(monkeypatch):
+    method = _build_unquantized_method()
+    layer = _build_weight_layer()
+    ascend_config = SimpleNamespace(enable_fused_mc2=1)
+    format_cast = MagicMock()
+
+    monkeypatch.setattr(fused_moe_module, "_MEGA_MOE_SUPPORTED", True)
+    monkeypatch.setattr(fused_moe_module, "get_ascend_config", lambda: ascend_config)
+    monkeypatch.setattr(fused_moe_module.torch_npu, "npu_format_cast", format_cast)
+    upstream_method_base = AscendUnquantizedFusedMoEMethod.__mro__[2]
+    monkeypatch.setattr(
+        upstream_method_base,
+        "process_weights_after_loading",
+        lambda self, layer: None,
+        raising=False,
+    )
+
+    method.process_weights_after_loading(layer)
+
+    assert len(layer.w13_weight_list) == layer.w13_weight.shape[0]
+    assert len(layer.w2_weight_list) == layer.w2_weight.shape[0]
+    assert all(weight.is_contiguous() for weight in layer.w13_weight_list)
+    assert all(weight.is_contiguous() for weight in layer.w2_weight_list)
+    format_cast.assert_not_called()
+
+
 @pytest.mark.parametrize("moe_comm_type", [MoECommType.ALLGATHER, MoECommType.FUSED_MC2])
 def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_comm_type):
     method = _build_unquantized_method()
@@ -190,6 +216,7 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
     moe_comm_method = MagicMock()
     moe_comm_method.fused_experts.return_value = routed_out
 
+    monkeypatch.setattr(fused_moe_module, "_MEGA_MOE_SUPPORTED", True)
     monkeypatch.setattr(
         fused_moe_module,
         "_EXTRA_CTX",
@@ -229,6 +256,10 @@ def test_unquantized_apply_builds_current_fused_experts_input(monkeypatch, moe_c
     if moe_comm_type == MoECommType.FUSED_MC2:
         assert fused_input.weights.w1[0] is layer.w13_weight
         assert fused_input.weights.w2[0] is layer.w2_weight
+        assert fused_input.weights.w1_scale is None
+        assert fused_input.weights.w2_scale is None
+        assert fused_input.weights.w1_scale_bias is None
+        assert fused_input.weights.w2_scale_bias is None
     else:
         assert fused_input.weights.w1 is layer.w13_weight
         assert fused_input.weights.w2 is layer.w2_weight

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -5,12 +6,12 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ops.activation import SituActivationConfig
+from vllm_ascend.ops.fused_moe import comm_utils
 from vllm_ascend.ops.fused_moe.moe_comm_method import (
     AllGatherCommImpl,
     AlltoAllCommImpl,
     FusedMC2CommImpl,
     MC2CommImpl,
-    MoECommMethod,
 )
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
     MoEAllGatherCombineMetadata,
@@ -29,7 +30,7 @@ class TestMoECommMethod(TestBase):
         self.mock_ascend_config = MagicMock()
         self.mock_ascend_config.ascend_fusion_config.fusion_ops_gmmswigluquant = False
         self.mock_ascend_config.enable_fused_mc2 = False
-        self.mock_ascend_config.mega_moe_max_tokens = 65536
+        self.mock_ascend_config.mega_moe_max_tokens = 6144
         self.mock_ascend_config.scheduler_config.recompute_scheduler_enable = False
         self._patch_get_ascend_config = patch(
             "vllm_ascend.ops.fused_moe.moe_comm_method.get_ascend_config",
@@ -112,8 +113,27 @@ class TestMoECommMethod(TestBase):
         self.assertEqual(call_args.kwargs["max_recv_token_num"], 1024)
         mock_warning_once.assert_not_called()
 
-    def test_fused_mc2_situ_falls_back_to_decomposed_mc2_pipeline(self):
+    def test_cann_mega_moe_maps_kimi_situ_activation(self):
+        activation, params = comm_utils.get_cann_mega_moe_activation_settings(
+            SituActivationConfig(beta=4.0, linear_beta=25.0)
+        )
+
+        self.assertEqual(activation, "situglu")
+        self.assertEqual(params, {"beta": 4.0, "linear_beta": 25.0})
+
+    def test_cann_mega_moe_forwards_kimi_situ_to_operator(self):
         comm_impl = object.__new__(FusedMC2CommImpl)
+        comm_impl.token_dispatcher = MagicMock(spec=TokenDispatcherWithMC2)
+        comm_impl.token_dispatcher.global_bs = 1
+        comm_impl.token_dispatcher.max_num_tokens_per_rank = 2
+        comm_impl.mega_moe_symm_buffer = SimpleNamespace(
+            dispatch_quant_mode=0,
+            dispatch_quant_out_dtype=None,
+        )
+        comm_impl._mega_moe_supports_situ = True
+        expected = torch.randn(2, 4)
+        expert_tokens = torch.ones(2, dtype=torch.int32)
+        comm_impl.mega_moe = MagicMock(return_value=(expected, expert_tokens))
         fused_input = MoEFusedExpertsInput(
             hidden_states=torch.randn(2, 4),
             topk_weights=torch.ones(2, 1),
@@ -131,13 +151,63 @@ class TestMoECommMethod(TestBase):
             quant=MoEQuantParams(),
             activation=SituActivationConfig(beta=4.0, linear_beta=25.0),
         )
-        expected = object()
 
-        with patch.object(MoECommMethod, "fused_experts", return_value=expected) as mock_decomposed:
-            result = comm_impl.fused_experts(fused_input)
+        result, result_expert_tokens = comm_impl._apply_cann_mega_moe(
+            fused_input,
+            fused_input.topk_ids,
+            is_decode_only_node=False,
+        )
 
         self.assertIs(result, expected)
-        mock_decomposed.assert_called_once_with(fused_input)
+        self.assertIs(result_expert_tokens, expert_tokens)
+        call = comm_impl.mega_moe.call_args
+        self.assertEqual(call.kwargs["activation"], "situglu")
+        self.assertEqual(call.kwargs["activation_params"], {"beta": 4.0, "linear_beta": 25.0})
+        self.assertIsNone(call.kwargs["l1_weights_sf"])
+        self.assertIsNone(call.kwargs["l2_weights_sf"])
+
+    def test_cann_mega_moe_maps_default_silu_to_swiglu(self):
+        self.assertEqual(comm_utils.get_cann_mega_moe_activation_settings("silu"), ("swiglu", None))
+
+    def test_cann_mega_moe_preserves_swigluoai_default(self):
+        self.assertEqual(
+            comm_utils.get_cann_mega_moe_activation_settings("swigluoai_uninterleave"),
+            ("swiglu", None),
+        )
+
+    def test_cann_mega_moe_accepts_unquantized_weights(self):
+        self.assertEqual(comm_utils._get_cann_mega_moe_quant_settings(QuantType.NONE), (0, None, None))
+
+    def test_cann_mega_moe_detects_situ_api(self):
+        def mega_moe(*args, activation="swiglu", activation_params=None):
+            return activation, activation_params
+
+        def legacy_mega_moe(*args, activation_clamp=None):
+            return activation_clamp
+
+        self.assertTrue(comm_utils.cann_mega_moe_supports_situ(mega_moe))
+        self.assertFalse(comm_utils.cann_mega_moe_supports_situ(legacy_mega_moe))
+
+    @patch("vllm_ascend.ops.fused_moe.moe_comm_method.get_mc2_group")
+    def test_cann_mega_moe_caps_max_recv_tokens(self, mock_get_mc2_group):
+        comm_impl = object.__new__(FusedMC2CommImpl)
+        comm_impl.moe_config = self.moe_config
+        comm_impl.moe_config.num_experts = 384
+        comm_impl.moe_config.experts_per_token = 8
+        comm_impl.moe_config.hidden_dim = 4096
+        comm_impl.moe_config.intermediate_size_per_partition = 1024
+        comm_impl.token_dispatcher = MagicMock(spec=TokenDispatcherWithMC2)
+        comm_impl.token_dispatcher.global_bs = 32768
+        comm_impl.token_dispatcher.ep_world_size = 64
+        comm_impl.token_dispatcher.ep_rank_id = 0
+        comm_impl.get_symm_buffer_for_mega_moe = MagicMock(return_value=object())
+        mock_get_mc2_group.return_value.device_group = MagicMock()
+
+        comm_impl._init_mega_moe_symm_buffer(2, torch.int8, is_decode_only_node=False)
+
+        call = comm_impl.get_symm_buffer_for_mega_moe.call_args
+        self.assertEqual(call.args[2], 512)
+        self.assertEqual(call.kwargs["max_recv_token_num"], 6144)
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -108,9 +108,8 @@ class TestAscendConfig(TestBase):
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertFalse(ascend_config.multistream_overlap_shared_expert)
         self.assertFalse(ascend_config.enable_kv_nz)
-        self.assertEqual(ascend_config.mega_moe_max_tokens, 65536)
-
         ascend_compilation_config = ascend_config.ascend_compilation_config
+        self.assertEqual(ascend_config.mega_moe_max_tokens, 6144)
         self.assertTrue(ascend_compilation_config.fuse_norm_quant)
 
         ascend_fusion_config = ascend_config.ascend_fusion_config

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -32,6 +32,8 @@ def _make_vllm_config(
     max_cudagraph_capture_size: int = 0,
     max_num_batched_tokens: int = 0,
     hidden_size: int = 2048,
+    routed_expert_hidden_size: int | None = None,
+    routed_expert_intermediate_size: int | None = None,
     kv_connector: str | None = None,
     kv_role: str | None = None,
     recompute_scheduler_enable: bool = False,
@@ -46,6 +48,10 @@ def _make_vllm_config(
         hf_text_config_attrs["num_experts_per_tok"] = num_experts_per_tok
     hf_text_config_attrs["hidden_size"] = hidden_size
 
+    if routed_expert_hidden_size is not None:
+        hf_text_config_attrs["routed_expert_hidden_size"] = routed_expert_hidden_size
+    if routed_expert_intermediate_size is not None:
+        hf_text_config_attrs["routed_expert_intermediate_size"] = routed_expert_intermediate_size
     model_config = SimpleNamespace(
         hf_text_config=SimpleNamespace(**hf_text_config_attrs),
         get_num_experts=lambda: num_experts,
@@ -375,6 +381,11 @@ def test_select_moe_comm_method_a3_quant_w4a8(
     ("num_tokens", "ep_world_size", "expected"),
     [
         (128, 8, MoECommType.FUSED_MC2),
+        (128, 16, MoECommType.FUSED_MC2),
+        (128, 32, MoECommType.FUSED_MC2),
+        (128, 64, MoECommType.FUSED_MC2),
+        (128, 128, MoECommType.FUSED_MC2),
+        (128, 129, MoECommType.MC2),
     ],
 )
 def test_select_moe_comm_method_a3_quant_w8a8(
@@ -383,6 +394,7 @@ def test_select_moe_comm_method_a3_quant_w8a8(
     ep_world_size,
     expected,
 ):
+    monkeypatch.setattr(afc, "_CANN_OPS_TRANSFORMER_AVAILABLE", True)
     _patch_select_moe_comm_method_deps(
         monkeypatch,
         device_type=afc.AscendDeviceType.A3,
@@ -395,6 +407,29 @@ def test_select_moe_comm_method_a3_quant_w8a8(
     vllm_config = _make_vllm_config(quant_type="w8a8")
 
     assert afc.select_moe_comm_method(num_tokens, vllm_config) == expected
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "routed_expert_hidden_size", "routed_expert_intermediate_size", "expected"),
+    [
+        (7168, 3584, 3072, True),
+        (7168, 768, 3072, False),
+        (768, None, None, False),
+    ],
+)
+def test_cann_megamoe_supported_by_config_uses_routed_hidden_size(
+    hidden_size,
+    routed_expert_hidden_size,
+    routed_expert_intermediate_size,
+    expected,
+):
+    vllm_config = _make_vllm_config(
+        hidden_size=hidden_size,
+        routed_expert_hidden_size=routed_expert_hidden_size,
+        routed_expert_intermediate_size=routed_expert_intermediate_size,
+    )
+
+    assert afc.is_megamoe_supported_by_config(vllm_config) == expected
 
 
 @pytest.mark.parametrize(

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -29,7 +29,11 @@ _CANN_OPS_TRANSFORMER_AVAILABLE = importlib.util.find_spec("cann_ops_transformer
 
 def is_megamoe_supported_by_config(vllm_config) -> bool:
     hf_text_config = vllm_config.model_config.hf_text_config
-    hidden_size = getattr(hf_text_config, "hidden_size", None)
+    # Latent-MoE models such as Kimi K3 project tokens before dispatch, so
+    # MegaMoe sees routed_expert_hidden_size rather than the model width.
+    hidden_size = getattr(hf_text_config, "routed_expert_hidden_size", None)
+    if hidden_size is None:
+        hidden_size = getattr(hf_text_config, "hidden_size", None)
     if hidden_size is None and hasattr(vllm_config.model_config, "get_hidden_size"):
         hidden_size = vllm_config.model_config.get_hidden_size()
     if hidden_size is None:
@@ -47,7 +51,9 @@ def is_megamoe_supported_by_config(vllm_config) -> bool:
     # For CANN 9.1.0 MegaMoe tiling requires intermediate_size in the closed
     # range [1024, 3072] and a multiple of 512. This constraint may be removed
     # in CANN 9.2.0
-    moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
+    moe_intermediate_size = getattr(hf_text_config, "routed_expert_intermediate_size", None)
+    if moe_intermediate_size is None:
+        moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
     if moe_intermediate_size is None:
         return False
     return moe_intermediate_size >= 1024 and moe_intermediate_size <= 3072 and moe_intermediate_size % 512 == 0
@@ -332,8 +338,9 @@ class AscendConfig:
         # This is a reference value: if the actual per-rank received token
         # count exceeds it, tokens may be truncated, causing precision
         # degradation. Do not set it too large because workspace memory scales
-        # linearly with this value. Default 65536.
-        self.mega_moe_max_tokens = additional_config.get("mega_moe_max_tokens", 65536)
+        # linearly with this value. Default 6144, an empirically validated
+        # capacity for Kimi K3 that avoids the much larger worst-case buffer.
+        self.mega_moe_max_tokens = additional_config.get("mega_moe_max_tokens", 6144)
         if not isinstance(self.mega_moe_max_tokens, int):
             raise ValueError(
                 f"mega_moe_max_tokens must be an integer, got {type(self.mega_moe_max_tokens).__name__}: "

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -30,6 +30,7 @@ class MoECommType(Enum):
 
 
 _MRV2_IN_PROFILE_RUN: ContextVar[bool] = ContextVar("_MRV2_IN_PROFILE_RUN", default=False)
+_CANN_MEGAMOE_EP_SIZE_LIMIT = 128
 _MEGA_MOE_TOKENS_PER_RANK_LIMIT = 4096
 _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT = 512
 _MC2_TOKENS_PER_RANK_LIMIT = 512
@@ -91,7 +92,7 @@ def use_cann_megamoe(vllm_config: VllmConfig) -> bool:
         and get_ascend_config().enable_fused_mc2 == 1
         and is_moe_model(vllm_config)
         and vllm_config.parallel_config.enable_expert_parallel
-        and 1 < get_ep_group().world_size <= 64
+        and 1 < get_ep_group().world_size <= _CANN_MEGAMOE_EP_SIZE_LIMIT
         and getattr(vllm_config, "lora_config", None) is None
         and is_megamoe_supported_by_config(vllm_config)
     )

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -92,7 +92,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # 0, or not set: default ALLTOALL and MC2 will be used.
     # 1: ALLTOALL and MC2 might be replaced by `dispatch_ffn_combine/mega_moe` operator.
     # `dispatch_ffn_combine` can be used only for moe layer with W8A8, EP<=32, non-mtp, non-dynamic-eplb.
-    # `mega_moe` can be used only for moe layer with W8A8/W4A8/bf16(none quant), EP<=64, non-dynamic-eplb.
+    # `mega_moe` can be used only for moe layer with W8A8/W4A8/bf16(none quant), EP<=128, non-dynamic-eplb.
     "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
     # DEPRECATED: VLLM_ASCEND_BALANCE_SCHEDULING env var will be removed in a future release.
     # Use --additional-config '{"enable_balance_scheduling": true}' instead.

--- a/vllm_ascend/ops/fused_moe/comm_utils.py
+++ b/vllm_ascend/ops/fused_moe/comm_utils.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 from importlib import import_module
 
 import torch
@@ -22,13 +23,14 @@ import torch.distributed
 import torch.distributed as dist
 import torch_npu
 
+from vllm_ascend.ops.activation import SituActivationConfig
 from vllm_ascend.quantization.quant_type import QuantType
 
 COMM_STREAM = None
 
 _CANN_ACL_INT8 = 258
 _CANN_ACL_INT4 = 285
-_CANN_MEGA_MOE_QUANT_MODE_None = 0
+_CANN_MEGA_MOE_QUANT_MODE_NONE = 0
 _CANN_MEGA_MOE_QUANT_MODE_INT8 = 2
 
 
@@ -120,6 +122,30 @@ def load_cann_mega_moe_ops():
     return get_symm_buffer_for_mega_moe, mega_moe
 
 
+def cann_mega_moe_supports_situ(mega_moe) -> bool:
+    """Whether the installed torch extension exposes SiTU parameters."""
+    try:
+        parameters = inspect.signature(mega_moe).parameters
+    except (TypeError, ValueError):
+        return False
+    return "activation" in parameters and "activation_params" in parameters
+
+
+def get_cann_mega_moe_activation_settings(
+    activation: str | SituActivationConfig | None,
+) -> tuple[str, dict[str, float] | None]:
+    """Translate vLLM activation metadata to the CANN MegaMoE API."""
+    if isinstance(activation, SituActivationConfig):
+        activation_params = {"beta": activation.beta}
+        if activation.linear_beta is not None:
+            activation_params["linear_beta"] = activation.linear_beta
+        return "situglu", activation_params
+    # Preserve the previous MegaMoe default for the internal SwiGLU-OAI marker.
+    if activation in (None, "silu", "swiglu", "swigluoai_uninterleave"):
+        return "swiglu", None
+    raise RuntimeError(f"CANN MegaMoe does not support activation {activation!r} in this integration.")
+
+
 def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int | None, int | None]:
     # Returns (dispatch_quant_mode, dispatch_quant_out_dtype, weight_type).
     # The current custom op package still requires explicit INT4 for W4A8
@@ -137,7 +163,9 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
     if quant_type == QuantType.W4A8:
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT4)
     if quant_type == QuantType.NONE:
-        return (_CANN_MEGA_MOE_QUANT_MODE_None, None, None)
+        return (_CANN_MEGA_MOE_QUANT_MODE_NONE, None, None)
     raise RuntimeError(
-        f"MegaMoe integration supports W8A8/W4A8/BF16 on A2/A3 MegaMoe platforms. Unsupported quant type: {quant_type}."
+        "MegaMoe integration supports BF16, W8A8/W4A8 INT on A2/A3, and MXFP on FP8-capable "
+        "MegaMoe platforms. "
+        f"Unsupported quant type: {quant_type}."
     )

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -138,12 +138,8 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         w2_data = self._maybe_pad_weight(layer.w2_weight.data).transpose(1, 2).contiguous()
         layer.w2_weight.data = w2_data
 
-        # TODO: Current dispatch_ffn_combine/mega_moe fusion operator ONLY supports NZ format.
-        # Therefore, we must cast weights to NZ when fusion is enabled.
-        # Once the underlying dispatch_ffn_combine/mega_moe operator is updated to support
-        # ND format (or other formats), remove this specific 'if' check and the forced
-        # npu_format_cast. At that point, the operator should be able to handle weights
-        # in their native format without explicit casting here.
+        # MegaMoe consumes one ND tensor per BF16 expert, while the legacy
+        # dispatch_ffn_combine path requires a single FRACTAL_NZ tensor.
         enable_fused_mc2 = get_ascend_config().enable_fused_mc2
         if enable_fused_mc2:
             use_megamoe = use_cann_megamoe(get_current_vllm_config())
@@ -243,16 +239,8 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
             activation = "swigluoai_uninterleave"
 
         moe_comm_method = _EXTRA_CTX.moe_comm_method
-        # NOTE: In the MoECommType.FUSED_MC2 branch, we wrap weights (w1, w2) into lists
-        # and provide dummy scales (w1_scale, w2_scale). This is required because:
-        # The underlying Ascend fused operator (e.g., dispatch_ffn_combine/mega_moe) expects
-        # inputs in a list format.
-        # TODO: Passing an empty tensor as scale for float (BF16) cases is semantically
-        # incorrect. The ideal solution is to pass None. However, if the underlying
-        # dispatch_ffn_combine/mega_moe C++ operator does not support None for the scale argument
-        # (due to signature constraints), we are forced to use a placeholder empty tensor.
-        # This TODO tracks the requirement to update the C++ operator to accept Optional[Tensor]
-        # or None for scales in non-quantized scenarios.
+        # Both fused paths consume expert weight lists. MegaMoe accepts None scales for BF16;
+        # only the legacy dispatch_ffn_combine interface needs placeholder scale tensors.
         w13_weight_list = getattr(layer, "w13_weight_list", None)
         w2_weight_list = getattr(layer, "w2_weight_list", None)
         has_split_weight_lists = isinstance(w13_weight_list, list) and isinstance(w2_weight_list, list)

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -25,7 +25,6 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 from vllm_ascend.ascend_config import _CANN_OPS_TRANSFORMER_AVAILABLE, get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
-from vllm_ascend.ops.activation import SituActivationConfig
 from vllm_ascend.ops.fused_moe import comm_utils
 from vllm_ascend.ops.fused_moe.moe_mlp import unified_apply_mlp
 from vllm_ascend.ops.fused_moe.moe_runtime_args import (
@@ -283,10 +282,11 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
+        self.mega_moe_symm_buffer = None
+        self._mega_moe_supports_situ = False
         if _CANN_OPS_TRANSFORMER_AVAILABLE:
-            self.mega_moe_symm_buffer = None
             self.get_symm_buffer_for_mega_moe, self.mega_moe = comm_utils.load_cann_mega_moe_ops()
-
+            self._mega_moe_supports_situ = comm_utils.cann_mega_moe_supports_situ(self.mega_moe)
         if get_ascend_config().enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
@@ -368,7 +368,6 @@ class FusedMC2CommImpl(MoECommMethod):
             getattr(self.token_dispatcher, "ep_world_size", "?"),
             self.token_dispatcher.global_bs,
         )
-
         return self.get_symm_buffer_for_mega_moe(
             group,
             num_experts,
@@ -410,8 +409,29 @@ class FusedMC2CommImpl(MoECommMethod):
         # CheckWeight2Input). The op prototype also REQUIRES FRACTAL_NZ per expert. The W4A8 quant
         # method therefore builds per-expert int8 + FRACTAL_NZ lists (cann_mega_moe_*_weight_list) and
         # they are passed through as-is here. W8A8 weights are already int8 + FRACTAL_NZ, also as-is.
-        weight_scales1 = fused_experts_input.weights.w1_scale
-        weight_scales2 = fused_experts_input.weights.w2_scale
+        weight_scales1 = (
+            None if fused_experts_input.weights.w1_scale is None else to_list(fused_experts_input.weights.w1_scale)
+        )
+        weight_scales2 = (
+            None if fused_experts_input.weights.w2_scale is None else to_list(fused_experts_input.weights.w2_scale)
+        )
+        # MegaMoe requires per-expert weight scales to be 1-D. The W4A8 method
+        # squeezes w13 scales but leaves w2 scales as [1, hidden]; drop the
+        # leading singleton dim so CheckWeightScaleInput passes. Guarded to the
+        # [1, N] per-channel case to avoid flattening genuine per-group scales.
+        if weight_scales1 is not None:
+            weight_scales1 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales1]
+        if weight_scales2 is not None:
+            weight_scales2 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales2]
+
+        activation, activation_params = comm_utils.get_cann_mega_moe_activation_settings(
+            fused_experts_input.activation
+        )
+        if activation == "situglu" and not self._mega_moe_supports_situ:
+            raise RuntimeError(
+                "Kimi K3 MegaMoe requires a cann_ops_transformer build with SiTUGLU support "
+                "(ops-transformer commit 0a5860c or newer)."
+            )
 
         activation_clamp = fused_experts_input.swiglu_limit if fused_experts_input.swiglu_limit > 0 else None
         x_active_mask = None
@@ -430,6 +450,10 @@ class FusedMC2CommImpl(MoECommMethod):
         l1_bias = fused_experts_input.weights.w1_scale_bias
         l2_bias = fused_experts_input.weights.w2_scale_bias
 
+        activation_kwargs = {}
+        if self._mega_moe_supports_situ:
+            activation_kwargs["activation"] = activation
+            activation_kwargs["activation_params"] = activation_params
         dispatch_quant_mode, dispatch_quant_out_dtype, weight_type = comm_utils._get_cann_mega_moe_quant_settings(
             fused_experts_input.quant.quant_type
         )
@@ -457,6 +481,7 @@ class FusedMC2CommImpl(MoECommMethod):
             l2_bias=l2_bias,
             x_active_mask=x_active_mask,
             activation_clamp=activation_clamp,
+            **activation_kwargs,
             weight1_type=weight_type,
             weight2_type=weight_type,
         )
@@ -471,11 +496,6 @@ class FusedMC2CommImpl(MoECommMethod):
         self,
         fused_experts_input: MoEFusedExpertsInput,
     ):
-        # SiTU is implemented by the generic MoE path. Keep other activations
-        # on the upstream MegaMoE path, including unquantized shared experts.
-        if isinstance(fused_experts_input.activation, SituActivationConfig):
-            return super().fused_experts(fused_experts_input)
-
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2), (
             "token_dispatcher must be an instance of TokenDispatcherWithMC2."
         )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds MegaMoe support for Kimi K2.5/Kimi3 on Ascend NPUs.

The main changes include:

- Integrates the CANN `npu_mega_moe` operator into the Kimi MoE execution path.
- Supports the W4A8 quantized MoE path.
- Handles Kimi-specific activation parameters, routed hidden size, and expert-parallel configuration.
- Supports 16, 32, 64, and 128 experts.
- Adds the required prefill MC2 capacity calculation for Kimi.
- Disables shared-expert multi-stream overlap when MegaMoe is enabled because these two paths use incompatible communication and execution scheduling.

This enables Kimi deployments to use the fused MegaMoe communication-computation path instead of executing MoE communication and expert computation separately.

MegaMoe can be enabled with:

```bash
--additional-config '{
  "enable_fused_mc2": 1,
  "enable_prefill_mc2": true,
  "multistream_overlap_shared_expert": false
}'
```

### Does this PR introduce *any* user-facing change?

Yes.

When `enable_fused_mc2` is enabled for Kimi models, the Ascend MoE implementation uses the CANN MegaMoe operator.

For prefill or mixed P/D deployments, `enable_prefill_mc2` must also be enabled so that the required token capacity is calculated correctly. `multistream_overlap_shared_expert` must be disabled when MegaMoe is enabled.

The default behavior remains unchanged when fused MC2 is not enabled.

### How was this patch tested?

The MegaMoe-related unit tests were run on an Ascend environment with CANN 9.2.0.

The tests cover:

- MegaMoe operator dispatch.
- Activation and activation-parameter handling.
- BF16 weight handling.
- Routed hidden-size calculation.
- Expert-parallel configuration.
- Kimi-specific fused MC2 behavior.

Test result:

```text
21 passed
```

A four-node mixed deployment test was also performed. The model successfully reached the CANN MegaMoe operator during NPU graph capture, confirming that the Kimi MegaMoe dispatch path was active.

The end-to-end service did not reach API readiness because the current deployment configuration ran out of NPU HBM during graph capture with `max_model_len=135000`. This is a deployment memory-capacity issue and is independent of the MegaMoe unit-test results.

- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
