### PR TITLE
[Refactor][310P] Refactor MoE mlp and quantization methods For 310P

### DIFF
--- a/tests/ut/_310p/fused_moe/test_moe_mlp_310.py
+++ b/tests/ut/_310p/fused_moe/test_moe_mlp_310.py
@@ -13,14 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import torch
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from tests.ut.base import TestBase
+from vllm_ascend._310p.fused_moe.fused_moe import AscendUnquantizedFusedMoEMethod310
 from vllm_ascend._310p.fused_moe.moe_comm_method import AllGatherCommImpl310
-from vllm_ascend._310p.fused_moe.moe_mlp import unified_apply_mlp
-from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEWeights
+from vllm_ascend._310p.fused_moe.moe_mlp import apply_moe_mlp
+from vllm_ascend._310p.quantization.methods.w8a8_dynamic import AscendW8A8DynamicFusedMoEMethod310
+from vllm_ascend.ops.fused_moe.dataclass.fused_experts import (
+    MoEWeights,
+    build_fused_experts_input,
+)
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
 from vllm_ascend.ops.fused_moe.dataclass.moe_quant import MoEQuantParams
 from vllm_ascend.quantization.quant_type import QuantType
@@ -36,142 +43,491 @@ def build_mlp_compute_input_fixture(
     w1_scale: torch.Tensor | None = None,
     w2_scale: torch.Tensor | None = None,
     group_list_type: int = 1,
+    layer=None,
+    activation: MoEActivation | str = MoEActivation.SILU,
+    topk_scales: torch.Tensor | None = None,
+    lora_context=None,
 ) -> MoEMlpComputeInput:
     return MoEMlpComputeInput(
         hidden_states=hidden_states,
         group_list=group_list,
         group_list_type=group_list_type,
         dynamic_scale=None,
-        topk_scales=None,
+        topk_scales=topk_scales,
         weights=MoEWeights(w1=w1, w2=w2, w1_scale=w1_scale, w2_scale=w2_scale),
         quant=MoEQuantParams(quant_type=QuantType.W8A8 if with_quant else QuantType.NONE),
         fusion=False,
-        activation="silu",
+        layer=layer,
+        activation=activation,
         need_trans=False,
         dynamic_eplb=False,
+        lora_context=lora_context,
     )
 
 
-class TestUnifiedApplyMLP310(TestBase):
-    @patch("vllm_ascend._310p.fused_moe.moe_comm_method.unified_apply_mlp")
-    def test_all_gather_apply_mlp_returns_common_tuple_contract(self, mock_unified_apply_mlp):
-        mlp_compute_input = MagicMock(spec=MoEMlpComputeInput)
-        mlp_output = torch.randn(10, 20, dtype=torch.float16)
-        mock_unified_apply_mlp.return_value = mlp_output
+class _UnquantLayer(SimpleNamespace):
+    """310P unquantized routed-expert layer (weights pre-transposed + NZ)."""
 
-        comm_impl = AllGatherCommImpl310.__new__(AllGatherCommImpl310)
+    def __init__(self, hidden: int, inter: int, experts: int = 2):
+        super().__init__(
+            w13_weight=torch.randn(experts, hidden, inter, dtype=torch.float16),
+            w2_weight=torch.randn(experts, inter, hidden, dtype=torch.float16),
+        )
 
-        output, before_gmm2_evt = comm_impl._apply_mlp(mlp_compute_input)
 
-        self.assertIs(output, mlp_output)
-        self.assertIsNone(before_gmm2_evt)
-        mock_unified_apply_mlp.assert_called_once_with(mlp_compute_input=mlp_compute_input)
+class _W8A8Layer(SimpleNamespace):
+    """310P W8A8 routed-expert layer (int8 weights + per-channel scales)."""
+
+    def __init__(self, hidden: int, inter: int, experts: int = 2):
+        super().__init__(
+            w13_weight=torch.randint(-8, 8, (experts, 2 * inter, hidden), dtype=torch.int8),
+            w2_weight=torch.randint(-8, 8, (experts, hidden, inter), dtype=torch.int8),
+            w13_weight_scale=torch.rand(experts, 2 * inter, dtype=torch.float32),
+            w2_weight_scale=torch.rand(experts, hidden, dtype=torch.float32),
+        )
+
+
+class TestApplyMoEMLP310(TestBase):
+    def test_fused_activation_path_dispatches_to_fused_hook(self):
+        quant_method = MagicMock()
+        quant_method.supports_fused_activation.return_value = True
+        quant_method.apply_gmm1_act_quant.return_value = (torch.randn(4, 8), None)
+        quant_method.apply_gmm2.return_value = torch.randn(4, 8)
+        mlp_compute_input = build_mlp_compute_input_fixture(
+            hidden_states=torch.randn(4, 8),
+            w1=torch.randn(2, 8, 16),
+            w2=torch.randn(2, 16, 8),
+            group_list=torch.tensor([4], dtype=torch.int64),
+            with_quant=True,
+        )
+
+        output, before_gmm2_evt = apply_moe_mlp(mlp_compute_input, quant_method)
+
+        quant_method.apply_gmm1_act_quant.assert_called_once_with(mlp_compute_input)
+        quant_method.apply_gmm1.assert_not_called()
+        quant_method.apply_act_quant.assert_not_called()
+        quant_method.apply_gmm2.assert_called_once()
+        self.assertIsNotNone(before_gmm2_evt)
+
+    def test_only_fused_path_is_used_for_supported_activation(self):
+        quant_method = MagicMock()
+        quant_method.supports_fused_activation.return_value = True
+        quant_method.apply_gmm1_act_quant.return_value = (torch.randn(4, 8), None)
+        quant_method.apply_gmm2.return_value = torch.randn(4, 8)
+        mlp_compute_input = build_mlp_compute_input_fixture(
+            hidden_states=torch.randn(4, 8),
+            w1=torch.randn(2, 8, 16),
+            w2=torch.randn(2, 16, 8),
+            group_list=torch.tensor([4], dtype=torch.int64),
+            with_quant=True,
+        )
+
+        output, before_gmm2_evt = apply_moe_mlp(mlp_compute_input, quant_method)
+
+        quant_method.apply_gmm1_act_quant.assert_called_once_with(mlp_compute_input)
+        # The separate gmm1 / act_quant hooks are no longer reachable on 310P.
+        quant_method.apply_gmm1.assert_not_called()
+        quant_method.apply_act_quant.assert_not_called()
+        quant_method.apply_gmm2.assert_called_once()
+        self.assertIsNotNone(before_gmm2_evt)
+
+    def test_unsupported_activation_is_rejected(self):
+        quant_method = MagicMock()
+        # 310P MoE only supports swiglu; the method reports no support for the
+        # requested activation.
+        quant_method.supports_fused_activation.return_value = False
+        for activation in (
+            MoEActivation.GELU,
+            MoEActivation.GELU_TANH,
+            MoEActivation.SWIGLUSTEP,
+            MoEActivation.SWIGLUOAI,
+            MoEActivation.SWIGLUOAI_UNINTERLEAVE,
+        ):
+            with self.subTest(activation=activation):
+                mlp_compute_input = build_mlp_compute_input_fixture(
+                    hidden_states=torch.randn(4, 8),
+                    w1=torch.randn(2, 8, 16),
+                    w2=torch.randn(2, 16, 8),
+                    group_list=torch.tensor([4], dtype=torch.int64),
+                    with_quant=False,
+                    activation=activation,
+                )
+                with self.assertRaises(NotImplementedError):
+                    apply_moe_mlp(mlp_compute_input, quant_method)
+
+        quant_method.apply_gmm1_act_quant.assert_not_called()
+        quant_method.apply_gmm2.assert_not_called()
+
+
+class TestUnquantHooks310(TestBase):
+    def _build_method_and_input(self):
+        layer = _UnquantLayer(hidden=8, inter=16)
+        method = AscendUnquantizedFusedMoEMethod310.__new__(AscendUnquantizedFusedMoEMethod310)
+        method.moe = SimpleNamespace(has_bias=False)
+        group_list = torch.tensor([2, 4], dtype=torch.int64)
+        mlp_compute_input = build_mlp_compute_input_fixture(
+            hidden_states=torch.randn(4, 8, dtype=torch.float16),
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            group_list=group_list,
+            with_quant=False,
+            group_list_type=0,
+            layer=layer,
+        )
+        return method, mlp_compute_input, layer
+
+    @patch("torch_npu.npu_swiglu")
+    @patch("torch_npu.npu_grouped_matmul", create=True)
+    def test_apply_gmm1_act_quant_matches_legacy_gmm1_swiglu(self, mock_npu_grouped_matmul, mock_npu_swiglu):
+        method, mlp_compute_input, layer = self._build_method_and_input()
+        mock_gmm1_out = torch.randn(4, 32, dtype=torch.float16)
+        mock_swiglu_out = torch.randn(4, 16, dtype=torch.float16)
+        mock_npu_grouped_matmul.return_value = [mock_gmm1_out]
+        mock_npu_swiglu.return_value = mock_swiglu_out
+
+        output, act_out_scale = method.apply_gmm1_act_quant(mlp_compute_input)
+
+        self.assertIs(output, mock_swiglu_out)
+        self.assertIsNone(act_out_scale)
+        mock_npu_grouped_matmul.assert_called_once_with(
+            x=[mlp_compute_input.hidden_states],
+            weight=[layer.w13_weight],
+            split_item=2,
+            group_list_type=0,
+            group_type=0,
+            group_list=mlp_compute_input.group_list,
+        )
+        mock_npu_swiglu.assert_called_once_with(mock_gmm1_out)
 
     @patch("torch_npu.npu_grouped_matmul", create=True)
+    def test_apply_gmm2_matches_legacy_gmm2(self, mock_npu_grouped_matmul):
+        method, mlp_compute_input, layer = self._build_method_and_input()
+        act_out = torch.randn(4, 32, dtype=torch.float16)
+        mock_gmm2_out = torch.randn(4, 8, dtype=torch.float16)
+        mock_npu_grouped_matmul.return_value = [mock_gmm2_out]
+
+        output = method.apply_gmm2(mlp_compute_input, act_out, None)
+
+        self.assertIs(output, mock_gmm2_out)
+        mock_npu_grouped_matmul.assert_called_once_with(
+            x=[act_out],
+            weight=[layer.w2_weight],
+            split_item=2,
+            group_list_type=0,
+            group_type=0,
+            group_list=mlp_compute_input.group_list,
+        )
+
+    def test_get_mlp_weights_returns_tuple_layout(self):
+        method, _, layer = self._build_method_and_input()
+        w1, w2 = method.get_mlp_weights(layer)
+        self.assertIs(w1, layer.w13_weight)
+        self.assertIs(w2, layer.w2_weight)
+
+    def test_supports_fused_activation_silu_only(self):
+        method, _, _ = self._build_method_and_input()
+        self.assertTrue(method.supports_fused_activation("silu"))
+        self.assertTrue(method.supports_fused_activation("swiglu"))
+        self.assertTrue(method.supports_fused_activation(MoEActivation.SILU))
+        self.assertFalse(method.supports_fused_activation(MoEActivation.GELU))
+
+
+class TestW8A8Hooks310(TestBase):
+    def _build_method_and_input(self):
+        layer = _W8A8Layer(hidden=8, inter=16)
+        method = AscendW8A8DynamicFusedMoEMethod310.__new__(AscendW8A8DynamicFusedMoEMethod310)
+        method.in_dtype = torch.float16
+        group_list = torch.tensor([2, 4], dtype=torch.int64)
+        mlp_compute_input = build_mlp_compute_input_fixture(
+            hidden_states=torch.randn(4, 8, dtype=torch.float16),
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            group_list=group_list,
+            with_quant=True,
+            group_list_type=0,
+            layer=layer,
+        )
+        return method, mlp_compute_input, layer
+
     @patch("torch_npu.npu_swiglu")
-    def test_unified_apply_mlp_without_quantization_310(self, mock_npu_swiglu, mock_npu_grouped_matmul):
-        mock_gmm1_out = torch.randn(10, 40, dtype=torch.float16)
-        mock_gmm2_out = torch.randn(10, 20, dtype=torch.float16)
-        mock_npu_grouped_matmul.side_effect = [[mock_gmm1_out], [mock_gmm2_out]]
+    @patch("torch_npu.npu_quant_grouped_matmul_dequant", create=True)
+    def test_apply_gmm1_act_quant_matches_legacy_quant_apply_mlp(self, mock_quant_gmm, mock_npu_swiglu):
+        method, mlp_compute_input, layer = self._build_method_and_input()
+        mock_gmm1_out = torch.randn(4, 32, dtype=torch.float16)
+        mock_swiglu_out = torch.randn(4, 32, dtype=torch.float16)
+        mock_quant_gmm.return_value = mock_gmm1_out
+        mock_npu_swiglu.return_value = mock_swiglu_out
 
-        mock_npu_swiglu_output = torch.randn(10, 40, dtype=torch.float16)
-        mock_npu_swiglu.return_value = mock_npu_swiglu_output
+        output, act_out_scale = method.apply_gmm1_act_quant(mlp_compute_input)
 
-        hidden_states = torch.randn(10, 20, dtype=torch.float16)
-        w1 = torch.randn(5, 20, 40, dtype=torch.float16)
-        w2 = torch.randn(5, 40, 20, dtype=torch.float16)
-        group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
-
-        result = unified_apply_mlp(
-            mlp_compute_input=build_mlp_compute_input_fixture(
-                hidden_states=hidden_states,
-                w1=w1,
-                w2=w2,
-                group_list=group_list,
-                with_quant=False,
-            )
+        self.assertIs(output, mock_swiglu_out)
+        self.assertIsNone(act_out_scale)
+        # Legacy quant_apply_mlp called: quant gmm1 -> swiglu (no explicit
+        # activation quant; gmm2 re-quantizes internally).
+        mock_quant_gmm.assert_called_once_with(
+            x=mlp_compute_input.hidden_states,
+            quantized_weight=layer.w13_weight,
+            weight_scale=layer.w13_weight_scale,
+            group_list=mlp_compute_input.group_list,
+            quant_mode="pertoken",
         )
+        mock_npu_swiglu.assert_called_once_with(mock_gmm1_out)
 
-        self.assertEqual(mock_npu_grouped_matmul.call_count, 2)
-        mock_npu_grouped_matmul.assert_has_calls(
-            [
-                call(
-                    x=[hidden_states], weight=[w1], split_item=2, group_list_type=1, group_type=0, group_list=group_list
-                ),
-                call(
-                    x=[mock_npu_swiglu_output],
-                    weight=[w2],
-                    split_item=2,
-                    group_list_type=1,
-                    group_type=0,
-                    group_list=group_list,
-                ),
-            ],
-            any_order=True,
+    @patch("torch_npu.npu_quant_grouped_matmul_dequant", create=True)
+    def test_apply_gmm2_matches_legacy_gmm2(self, mock_quant_gmm):
+        method, mlp_compute_input, layer = self._build_method_and_input()
+        act_out = torch.randn(4, 32, dtype=torch.float16)
+        mock_gmm2_out = torch.randn(4, 8, dtype=torch.float16)
+        mock_quant_gmm.return_value = mock_gmm2_out
+
+        output = method.apply_gmm2(mlp_compute_input, act_out, None)
+
+        self.assertIs(output, mock_gmm2_out)
+        mock_quant_gmm.assert_called_once_with(
+            x=act_out,
+            quantized_weight=layer.w2_weight,
+            weight_scale=layer.w2_weight_scale,
+            group_list=mlp_compute_input.group_list,
+            quant_mode="pertoken",
         )
-        mock_npu_swiglu.assert_called_once()
-        mock_npu_swiglu.assert_called_with(mock_gmm1_out)
-
-        self.assertEqual(result.shape, hidden_states.shape)
-        self.assertEqual(result.dtype, torch.float16)
 
     @patch("torch.cumsum")
     @patch("torch_npu.npu_quant_grouped_matmul_dequant", create=True)
-    @patch("torch_npu.npu_swiglu")
-    def test_unified_apply_mlp_with_quantization_310(
-        self, mock_npu_swiglu, mock_npu_quant_grouped_matmul_dequant, mock_cumsum
-    ):
-        mock_cumsum_out = torch.arange(0, 10, dtype=torch.int64)
-        mock_cumsum.return_value = mock_cumsum_out
-        mock_gmm1_out = torch.randn(10, 40, dtype=torch.float16)
-        mock_gmm2_out = torch.randn(10, 20, dtype=torch.float16)
-        mock_npu_quant_grouped_matmul_dequant.side_effect = [mock_gmm1_out, mock_gmm2_out]
-
-        mock_npu_swiglu_output = torch.randn(10, 40, dtype=torch.float16)
-        mock_npu_swiglu.return_value = mock_npu_swiglu_output
-
-        hidden_states = torch.randn(10, 20, dtype=torch.float16)
-        w1 = torch.randn(5, 20, 40, dtype=torch.float16)
-        w1_scale = torch.rand(5, 40, dtype=torch.float32)
-        w2 = torch.randn(5, 40, 20, dtype=torch.float16)
-        w2_scale = torch.rand(5, 40, dtype=torch.float32)
-        group_list = torch.tensor([2, 4, 6, 8, 10], dtype=torch.int64)
-
-        result = unified_apply_mlp(
-            mlp_compute_input=build_mlp_compute_input_fixture(
-                hidden_states=hidden_states,
-                w1=w1,
-                w2=w2,
-                group_list=group_list,
-                with_quant=True,
-                w1_scale=w1_scale,
-                w2_scale=w2_scale,
-            )
+    def test_group_list_type_1_converts_to_cumsum_once(self, mock_quant_gmm, mock_cumsum):
+        layer = _W8A8Layer(hidden=8, inter=16)
+        method = AscendW8A8DynamicFusedMoEMethod310.__new__(AscendW8A8DynamicFusedMoEMethod310)
+        method.in_dtype = torch.float16
+        count_group_list = torch.tensor([2, 2], dtype=torch.int64)
+        cumsum_group_list = torch.tensor([2, 4], dtype=torch.int64)
+        mock_cumsum.return_value = cumsum_group_list
+        mlp_compute_input = build_mlp_compute_input_fixture(
+            hidden_states=torch.randn(4, 8, dtype=torch.float16),
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            group_list=count_group_list,
+            with_quant=True,
+            group_list_type=1,
+            layer=layer,
         )
 
-        mock_cumsum.assert_called_once()
-        self.assertEqual(mock_npu_quant_grouped_matmul_dequant.call_count, 2)
-        mock_npu_quant_grouped_matmul_dequant.assert_has_calls(
+        method.apply_gmm1_act_quant(mlp_compute_input)
+        method.apply_gmm2(mlp_compute_input, torch.randn(4, 32), None)
+
+        # Both gmm1 and gmm2 must receive the SAME converted group_list, and
+        # cumsum must be applied once per call (not accumulated twice).
+        self.assertEqual(mock_cumsum.call_count, 2)
+        for call_args in mock_quant_gmm.call_args_list:
+            self.assertIs(call_args.kwargs["group_list"], cumsum_group_list)
+
+    def test_supports_fused_activation_silu_only(self):
+        method = AscendW8A8DynamicFusedMoEMethod310.__new__(AscendW8A8DynamicFusedMoEMethod310)
+        self.assertTrue(method.supports_fused_activation("silu"))
+        self.assertTrue(method.supports_fused_activation(MoEActivation.SILU))
+        self.assertFalse(method.supports_fused_activation("gelu"))
+        self.assertFalse(method.supports_fused_activation(MoEActivation.GELU))
+        self.assertFalse(method.supports_fused_activation(MoEActivation.SWIGLUOAI_UNINTERLEAVE))
+
+    def test_get_mlp_weights_returns_moeweights_payload(self):
+        method, _, layer = self._build_method_and_input()
+        weights = method.get_mlp_weights(layer)
+        self.assertIsInstance(weights, MoEWeights)
+        self.assertIs(weights.w1, layer.w13_weight)
+        self.assertIs(weights.w1_scale, layer.w13_weight_scale)
+        self.assertIs(weights.w2, layer.w2_weight)
+        self.assertIs(weights.w2_scale, layer.w2_weight_scale)
+
+
+class TestApplyMoeMLPFullChain310(TestBase):
+    """End-to-end dispatch through real 310P methods with mocked NPU kernels.
+
+    Asserts the kernel invocation sequence is identical to the pre-refactor
+    ``unified_apply_mlp`` (quant/unquant) implementations.
+    """
+
+    def test_unquant_chain_matches_legacy_unified_apply_mlp(self):
+        layer = _UnquantLayer(hidden=8, inter=16)
+        method = AscendUnquantizedFusedMoEMethod310.__new__(AscendUnquantizedFusedMoEMethod310)
+        method.moe = SimpleNamespace(has_bias=False)
+        mlp_compute_input = build_mlp_compute_input_fixture(
+            hidden_states=torch.randn(4, 8, dtype=torch.float16),
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            group_list=torch.tensor([2, 4], dtype=torch.int64),
+            with_quant=False,
+            group_list_type=0,
+            layer=layer,
+        )
+        gmm1_out = torch.randn(4, 32, dtype=torch.float16)
+        gmm2_out = torch.randn(4, 8, dtype=torch.float16)
+
+        with (
+            patch("torch_npu.npu_grouped_matmul", create=True) as mock_gmm,
+            patch("torch_npu.npu_swiglu") as mock_swiglu,
+        ):
+            mock_gmm.side_effect = [[gmm1_out], [gmm2_out]]
+            mock_swiglu.return_value = torch.randn(4, 32, dtype=torch.float16)
+
+            output, _ = apply_moe_mlp(mlp_compute_input, method)
+
+        self.assertEqual(mock_gmm.call_count, 2)
+        self.assertEqual(mock_swiglu.call_count, 1)
+        mock_gmm.assert_has_calls(
             [
                 call(
-                    x=hidden_states,
-                    quantized_weight=w1,
-                    weight_scale=w1_scale,
-                    group_list=mock_cumsum_out,
+                    x=[mlp_compute_input.hidden_states],
+                    weight=[layer.w13_weight],
+                    split_item=2,
+                    group_list_type=0,
+                    group_type=0,
+                    group_list=mlp_compute_input.group_list,
+                ),
+                call(
+                    x=[mock_swiglu.return_value],
+                    weight=[layer.w2_weight],
+                    split_item=2,
+                    group_list_type=0,
+                    group_type=0,
+                    group_list=mlp_compute_input.group_list,
+                ),
+            ],
+            any_order=True,
+        )
+        self.assertEqual(output.shape, mlp_compute_input.hidden_states.shape)
+
+    def test_quant_chain_matches_legacy_unified_apply_mlp(self):
+        layer = _W8A8Layer(hidden=8, inter=16)
+        method = AscendW8A8DynamicFusedMoEMethod310.__new__(AscendW8A8DynamicFusedMoEMethod310)
+        method.in_dtype = torch.float16
+        mlp_compute_input = build_mlp_compute_input_fixture(
+            hidden_states=torch.randn(4, 8, dtype=torch.float16),
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            w1_scale=layer.w13_weight_scale,
+            w2_scale=layer.w2_weight_scale,
+            group_list=torch.tensor([2, 4], dtype=torch.int64),
+            with_quant=True,
+            group_list_type=0,
+            layer=layer,
+        )
+        gmm1_out = torch.randn(4, 32, dtype=torch.float16)
+        gmm2_out = torch.randn(4, 8, dtype=torch.float16)
+
+        with (
+            patch("torch_npu.npu_quant_grouped_matmul_dequant", create=True) as mock_quant_gmm,
+            patch("torch_npu.npu_swiglu") as mock_swiglu,
+        ):
+            mock_quant_gmm.side_effect = [gmm1_out, gmm2_out]
+            mock_swiglu.return_value = torch.randn(4, 32, dtype=torch.float16)
+
+            output, _ = apply_moe_mlp(mlp_compute_input, method)
+
+        self.assertEqual(mock_quant_gmm.call_count, 2)
+        self.assertEqual(mock_swiglu.call_count, 1)
+        mock_quant_gmm.assert_has_calls(
+            [
+                call(
+                    x=mlp_compute_input.hidden_states,
+                    quantized_weight=layer.w13_weight,
+                    weight_scale=layer.w13_weight_scale,
+                    group_list=mlp_compute_input.group_list,
                     quant_mode="pertoken",
                 ),
                 call(
-                    x=mock_npu_swiglu_output,
-                    quantized_weight=w2,
-                    weight_scale=w2_scale,
-                    group_list=mock_cumsum_out,
+                    x=mock_swiglu.return_value,
+                    quantized_weight=layer.w2_weight,
+                    weight_scale=layer.w2_weight_scale,
+                    group_list=mlp_compute_input.group_list,
                     quant_mode="pertoken",
                 ),
             ],
             any_order=True,
         )
-        mock_npu_swiglu.assert_called_once()
-        mock_npu_swiglu.assert_called_with(mock_gmm1_out)
+        self.assertEqual(output.shape, mlp_compute_input.hidden_states.shape)
 
-        self.assertEqual(result.shape, hidden_states.shape)
-        self.assertEqual(result.dtype, torch.float16)
+
+class TestAllGatherCommImpl310FusedExperts(TestBase):
+    def _build_comm_and_input(self):
+        comm = AllGatherCommImpl310.__new__(AllGatherCommImpl310)
+        comm.moe_config = SimpleNamespace(
+            activation=MoEActivation.SILU,
+            swiglu_limit=0.0,
+            swiglu_alpha=1.0,
+            swiglu_beta=0.0,
+            # Upstream reads these from the moe config (no getattr default).
+            activation_situ_beta=None,
+            activation_situ_linear_beta=None,
+        )
+        comm.token_dispatcher = MagicMock()
+        hidden_states = torch.randn(4, 8, dtype=torch.float16)
+        topk_weights = torch.rand(4, 1, dtype=torch.float16)
+        topk_ids = torch.tensor([[0], [1], [0], [1]], dtype=torch.int32)
+        fused_experts_input = build_fused_experts_input(
+            hidden_states=hidden_states,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            layer=SimpleNamespace(),
+            quant_type=QuantType.NONE,
+            dynamic_eplb=False,
+        )
+        dispatch_output = SimpleNamespace(
+            hidden_states=hidden_states,
+            group_list=torch.tensor([2, 2], dtype=torch.int64),
+            group_list_type=0,
+            dynamic_scale=None,
+            topk_scales=None,
+            combine_metadata=SimpleNamespace(
+                topk_weights=topk_weights,
+                expanded_row_idx=None,
+                restore_shape=hidden_states.shape,
+            ),
+        )
+        comm.token_dispatcher.token_dispatch.return_value = dispatch_output
+        comm.token_dispatcher.token_combine.return_value = hidden_states
+        return comm, fused_experts_input, hidden_states
+
+    def test_fused_experts_dispatches_apply_moe_mlp_with_quant_method(self):
+        comm, fused_experts_input, hidden_states = self._build_comm_and_input()
+        quant_method = MagicMock()
+        mlp_output = torch.randn(4, 8, dtype=torch.float16)
+        before_gmm2_evt = object()
+
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_comm_method._EXTRA_CTX") as mock_ctx,
+            patch("vllm_ascend.ops.fused_moe.moe_comm_method.apply_moe_mlp") as mock_apply_mlp,
+            patch(
+                "vllm_ascend.ops.fused_moe.dataclass.moe_mlp.enable_fusion_gmmswigluquant",
+                return_value=False,
+            ),
+        ):
+            mock_ctx.moe_comm_method = object()
+            mock_apply_mlp.return_value = (mlp_output, before_gmm2_evt)
+            result = comm.fused_experts(fused_experts_input=fused_experts_input, quant_method=quant_method)
+
+        self.assertIs(result.routed_out, hidden_states)
+        self.assertIs(result.before_gmm2_evt, before_gmm2_evt)
+        mock_apply_mlp.assert_called_once()
+        self.assertIs(mock_apply_mlp.call_args.args[1], quant_method)
+        # The MLP compute input must carry the routed-expert layer so hooks can
+        # read the weights from it.
+        self.assertIs(mock_apply_mlp.call_args.args[0].layer, fused_experts_input.layer)
+        comm.token_dispatcher.token_combine.assert_called_once_with(
+            hidden_states=mlp_output,
+            combine_metadata=comm.token_dispatcher.token_dispatch.return_value.combine_metadata,
+        )
+
+    def test_fused_experts_without_quant_method_raises_not_implemented(self):
+        comm, fused_experts_input, _ = self._build_comm_and_input()
+        with (
+            patch("vllm_ascend.ops.fused_moe.moe_comm_method._EXTRA_CTX") as mock_ctx,
+            patch(
+                "vllm_ascend.ops.fused_moe.dataclass.moe_mlp.enable_fusion_gmmswigluquant",
+                return_value=False,
+            ),
+        ):
+            mock_ctx.moe_comm_method = object()
+            with self.assertRaises(NotImplementedError):
+                comm.fused_experts(fused_experts_input=fused_experts_input)

--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -190,6 +190,11 @@ def test_unquantized_apply_310_uses_preselected_experts():
     assert fused_experts_input.topk_ids is topk_ids
     assert fused_experts_input.routing.expert_map is expert_map
     assert fused_experts_input.routing.apply_router_weight_on_input is True
+    # Post-refactor contract: the layer is carried on the input so the MLP
+    # gmm hooks can read the weights, and the method passes itself as the
+    # quant_method dispatcher.
+    assert fused_experts_input.layer is layer
+    assert comm_method.fused_experts.call_args.kwargs["quant_method"] is method
 
 
 class _Projection(nn.Module):

--- a/tests/ut/_310p/quantization/test_w8a8_dynamic_moe_310.py
+++ b/tests/ut/_310p/quantization/test_w8a8_dynamic_moe_310.py
@@ -68,3 +68,8 @@ def test_w8a8_dynamic_moe_apply_310_uses_preselected_experts():
     assert fused_experts_input.topk_ids is topk_ids
     assert fused_experts_input.routing.expert_map is expert_map
     assert fused_experts_input.routing.apply_router_weight_on_input is True
+    # Post-refactor contract: weights are read from the layer by the MLP gmm
+    # hooks, and the method dispatches itself as quant_method.
+    assert fused_experts_input.layer is layer
+    assert fused_experts_input.activation == "silu"
+    assert comm_method.fused_experts.call_args.kwargs["quant_method"] is method

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 import torch
+import torch_npu
 from vllm.model_executor.layers.fused_moe import SharedExperts
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import build_fused_experts_input
+from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
 from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
 from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
@@ -31,6 +33,16 @@ from .moe_comm_method import AllGatherCommImpl310
 
 
 class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
+    """Unquantized MoE method with 310P-specific kernels.
+
+    The MLP stage is orchestrated by ``apply_moe_mlp`` through the same
+    gmm1 / act_quant / gmm2 hooks as the quantized schemes. This class
+    duck-types the hook interface instead of inheriting ``AscendMoEScheme``
+    because it must extend the upstream ``UnquantizedFusedMoEMethod``.
+    """
+
+    quant_type = QuantType.NONE
+
     def __init__(self, moe: FusedMoEConfig = None):
         super().__init__(moe=moe)
 
@@ -54,6 +66,46 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
         w2_data = maybe_trans_nz(w2_data)
         layer.w2_weight = torch.nn.Parameter(w2_data, requires_grad=False)
 
+    def supports_fused_activation(self, activation) -> bool:
+        """310P MoE only supports the swiglu (silu) activation."""
+        return getattr(activation, "value", activation) in ("silu", "swiglu")
+
+    def get_mlp_weights(self, layer):
+        """Standard MLP-layout weights, returned as a ``(w1, w2)`` tuple."""
+        return layer.w13_weight, layer.w2_weight
+
+    def apply_gmm1_act_quant(self, mlp_compute_input: MoEMlpComputeInput):
+        """Fused gmm1 (gate/up projection) + swiglu, no activation quant."""
+        layer = mlp_compute_input.layer
+        assert layer is not None
+        w1, _ = self.get_mlp_weights(layer)
+        # 310P weights are pre-transposed to (E, hidden, inter) + NZ in
+        # ``process_weights_after_loading``, so no ``need_trans`` handling is
+        # required here (310P never sets ``need_trans``).
+        gate_up_out = torch_npu.npu_grouped_matmul(
+            x=[mlp_compute_input.hidden_states],
+            weight=[w1],
+            split_item=2,
+            group_list_type=mlp_compute_input.group_list_type,
+            group_type=0,
+            group_list=mlp_compute_input.group_list,
+        )[0]
+        return torch_npu.npu_swiglu(gate_up_out), None
+
+    def apply_gmm2(self, mlp_compute_input: MoEMlpComputeInput, hidden_states, act_out_scale):
+        """down projection (gmm2)."""
+        layer = mlp_compute_input.layer
+        assert layer is not None
+        _, w2 = self.get_mlp_weights(layer)
+        return torch_npu.npu_grouped_matmul(
+            x=[hidden_states],
+            weight=[w2],
+            split_item=2,
+            group_list_type=mlp_compute_input.group_list_type,
+            group_type=0,
+            group_list=mlp_compute_input.group_list,
+        )[0]
+
     def apply(
         self,
         layer: "AscendRoutedExperts",
@@ -71,8 +123,7 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
                 hidden_states=x,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
+                layer=layer,
                 quant_type=QuantType.NONE,
                 dynamic_eplb=False,
                 expert_map=layer.ascend_expert_map,
@@ -82,6 +133,7 @@ class AscendUnquantizedFusedMoEMethod310(UnquantizedFusedMoEMethod):
                 pertoken_scale=layer.ascend_pertoken_scale,
                 activation=layer.activation,
             ),
+            quant_method=self,
         )
         return final_hidden_states
 

--- a/vllm_ascend/_310p/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/_310p/fused_moe/moe_comm_method.py
@@ -15,12 +15,8 @@
 # This file is a part of the vllm-ascend project.
 from __future__ import annotations
 
-from typing import Any
-
-from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
 from vllm_ascend.ops.fused_moe.moe_comm_method import AllGatherCommImpl
 
-from .moe_mlp import unified_apply_mlp
 from .token_dispatcher import TokenDispatcherWithAllGather310
 
 
@@ -38,9 +34,6 @@ class AllGatherCommImpl310(AllGatherCommImpl):
     def __init__(self, moe_config):
         super().__init__(moe_config)
         self.use_fusion_ops = False
-
-    def _apply_mlp(self, mlp_compute_input: MoEMlpComputeInput) -> Any:
-        return unified_apply_mlp(mlp_compute_input=mlp_compute_input), None
 
     def _get_token_dispatcher(self):
         return TokenDispatcherWithAllGather310(

--- a/vllm_ascend/_310p/fused_moe/moe_mlp.py
+++ b/vllm_ascend/_310p/fused_moe/moe_mlp.py
@@ -14,89 +14,30 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 
-
 import torch
-import torch_npu
 
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
 
 
-def quant_apply_mlp(
-    hidden_states: torch.Tensor,
-    w1: torch.Tensor,
-    w1_scale: torch.Tensor,
-    w2: torch.Tensor,
-    w2_scale: torch.Tensor,
-    group_list: torch.Tensor,
-    group_list_type: int = 1,
-) -> torch.Tensor:
-    if group_list_type == 1:
-        # Convert group_list to cumulative sum format if group_list is count format
-        group_list = torch.cumsum(group_list, dim=0)
+def apply_moe_mlp(
+    mlp_compute_input: MoEMlpComputeInput,
+    quant_method,
+) -> tuple[torch.Tensor, torch.npu.Event]:
+    """
+    Unified MoE MLP entry (310P).
 
-    hidden_states = torch_npu.npu_quant_grouped_matmul_dequant(
-        x=hidden_states, quantized_weight=w1, weight_scale=w1_scale, group_list=group_list, quant_mode="pertoken"
-    )
-    hidden_states = torch_npu.npu_swiglu(hidden_states)
-    hidden_states = torch_npu.npu_quant_grouped_matmul_dequant(
-        x=hidden_states, quantized_weight=w2, weight_scale=w2_scale, group_list=group_list, quant_mode="pertoken"
-    )
-    return hidden_states
+    310P MoE only supports the swiglu (silu) activation, so every method
+    implements the fused ``gmm1 + swiglu (+ quant)`` path and the separate
+    ``apply_gmm1`` / ``apply_act_quant`` hooks are not used.
+    """
 
+    if not quant_method.supports_fused_activation(mlp_compute_input.activation):
+        activation = mlp_compute_input.activation
+        act_name = getattr(activation, "value", activation)
+        raise NotImplementedError(f"310P MoE only supports the swiglu (silu) activation, but got {act_name}.")
 
-def unquant_apply_mlp(
-    hidden_states: torch.Tensor, w1: torch.Tensor, w2: torch.Tensor, group_list: torch.Tensor, group_list_type: int = 1
-) -> torch.Tensor:
-    gate_up_out = torch_npu.npu_grouped_matmul(
-        x=[hidden_states],
-        weight=[w1],
-        split_item=2,
-        group_list_type=group_list_type,
-        group_type=0,
-        group_list=group_list,
-    )[0]
-    act_out = torch_npu.npu_swiglu(gate_up_out)
+    hidden_states, act_out_scale = quant_method.apply_gmm1_act_quant(mlp_compute_input)
 
-    hidden_states = torch_npu.npu_grouped_matmul(
-        x=[act_out],
-        weight=[w2],
-        split_item=2,
-        group_list_type=group_list_type,
-        group_type=0,
-        group_list=group_list,
-    )[0]
-    return hidden_states
-
-
-def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
-    hidden_states = mlp_compute_input.hidden_states
-    w1 = mlp_compute_input.weights.w1
-    w2 = mlp_compute_input.weights.w2
-    w1_scale = mlp_compute_input.weights.w1_scale
-    w2_scale = mlp_compute_input.weights.w2_scale
-    group_list = mlp_compute_input.group_list
-    group_list_type = mlp_compute_input.group_list_type
-    assert isinstance(w1, torch.Tensor)
-    assert isinstance(w2, torch.Tensor)
-
-    if mlp_compute_input.quant.is_quant:
-        assert isinstance(w1_scale, torch.Tensor)
-        assert isinstance(w2_scale, torch.Tensor)
-        assert w1_scale is not None and w2_scale is not None
-        return quant_apply_mlp(
-            hidden_states=hidden_states,
-            w1=w1,
-            w1_scale=w1_scale,
-            w2=w2,
-            w2_scale=w2_scale,
-            group_list=group_list,
-            group_list_type=group_list_type,
-        )
-
-    return unquant_apply_mlp(
-        hidden_states=hidden_states,
-        w1=w1,
-        w2=w2,
-        group_list=group_list,
-        group_list_type=group_list_type,
-    )
+    before_gmm2_evt = torch.npu.current_stream().record_event()
+    hidden_states = quant_method.apply_gmm2(mlp_compute_input, hidden_states, act_out_scale)
+    return hidden_states, before_gmm2_evt

--- a/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/_310p/quantization/methods/w8a8_dynamic.py
@@ -23,7 +23,8 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed import get_ep_group
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
-from vllm_ascend.ops.fused_moe.dataclass.fused_experts import build_fused_experts_input
+from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEWeights, build_fused_experts_input
+from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import MoEMlpComputeInput
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
 from vllm_ascend.quantization.methods.base import AscendMoEScheme, QuantType
 from vllm_ascend.utils import maybe_trans_nz
@@ -42,6 +43,11 @@ class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
 
     # Declare the quantization type for this scheme
     quant_type: QuantType = QuantType.W8A8
+    # Activation quant dtype used by the MLP gmm hooks.
+    act_quant_type: torch.dtype = torch.int8
+    # 310P gmm1+swiglu+quant is fused inside npu_quant_grouped_matmul_dequant
+    # + npu_swiglu, so silu is handled by ``apply_gmm1_act_quant``.
+    fused_activations = frozenset({"silu"})
 
     def __init__(self):
         self.ep_group = get_ep_group()
@@ -94,8 +100,7 @@ class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
                 hidden_states=x,
                 topk_weights=topk_weights,
                 topk_ids=topk_ids,
-                w1=layer.w13_weight,
-                w2=layer.w2_weight,
+                layer=layer,
                 quant_type=self.quant_type,
                 dynamic_eplb=False,
                 expert_map=layer.ascend_expert_map,
@@ -103,11 +108,71 @@ class AscendW8A8DynamicFusedMoEMethod310(AscendMoEScheme):
                 mc2_mask=layer.ascend_mc2_mask,
                 apply_router_weight_on_input=layer.apply_router_weight_on_input,
                 pertoken_scale=layer.ascend_pertoken_scale,
-                w1_scale=layer.w13_weight_scale,
-                w2_scale=layer.w2_weight_scale,
+                activation=getattr(layer, "activation", "silu"),
             ),
+            quant_method=self,
         )
         return final_hidden_states
+
+    def _get_group_list(self, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
+        """Return the cumulative-sum group_list expected by 310P kernels."""
+        group_list = mlp_compute_input.group_list
+        if mlp_compute_input.group_list_type == 1:
+            # Convert group_list to cumulative sum format if group_list is count format
+            group_list = torch.cumsum(group_list, dim=0)
+        return group_list
+
+    def _get_mlp_weights(self, layer: torch.nn.Module) -> tuple:
+        """Return (w1, w1_scale, w2, w2_scale) in the standard MLP layout."""
+        return (
+            layer.w13_weight,
+            layer.w13_weight_scale,
+            layer.w2_weight,
+            layer.w2_weight_scale,
+        )
+
+    def get_mlp_weights(self, layer: torch.nn.Module) -> MoEWeights:
+        """Standard MLP-layout weights (w1/w2 with their scales)."""
+        w1, w1_scale, w2, w2_scale = self._get_mlp_weights(layer)
+        return MoEWeights(
+            w1=w1,
+            w2=w2,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+        )
+
+    def apply_gmm1_act_quant(self, mlp_compute_input: MoEMlpComputeInput):
+        """Fused gmm1 (quant + dequant) + swiglu via 310P kernels.
+
+        ``npu_quant_grouped_matmul_dequant`` quantizes the hidden states to
+        int8 internally (``quant_mode="pertoken"``) and dequantizes the gmm1
+        output, so the activation scale is not needed by ``apply_gmm2``.
+        """
+        layer = mlp_compute_input.layer
+        assert layer is not None
+        w1, w1_scale, _, _ = self._get_mlp_weights(layer)
+        hidden_states = torch_npu.npu_quant_grouped_matmul_dequant(
+            x=mlp_compute_input.hidden_states,
+            quantized_weight=w1,
+            weight_scale=w1_scale,
+            group_list=self._get_group_list(mlp_compute_input),
+            quant_mode="pertoken",
+        )
+        hidden_states = torch_npu.npu_swiglu(hidden_states)
+        return hidden_states, None
+
+    def apply_gmm2(self, mlp_compute_input: MoEMlpComputeInput, hidden_states, act_out_scale):
+        """down projection (gmm2, quant + dequant)."""
+        layer = mlp_compute_input.layer
+        assert layer is not None
+        _, _, w2, w2_scale = self._get_mlp_weights(layer)
+        return torch_npu.npu_quant_grouped_matmul_dequant(
+            x=hidden_states,
+            quantized_weight=w2,
+            weight_scale=w2_scale,
+            group_list=self._get_group_list(mlp_compute_input),
+            quant_mode="pertoken",
+        )
 
     def process_weights_after_loading(self, layer):
         layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)


### PR DESCRIPTION
### What this PR does / why we need it?
Come from https://github.com/vllm-project/vllm-ascend/pull/13773
In that PR, they refactor moe_mlp's methods into differnet quantization method, so this RP,we refactor moe-mlp and quantization methods for 310p.
### Does this PR introduce _any_ user-facing change?
No，this is an internal refactor of the fused-moe and method for 310p and its test coverage.
### How was this patch tested?
The following models are tested and can be curled successfully:
300I DUO:
Qwen3.5-35B-A3B-mtp

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
