### PR TITLE
[Performance][KDA] Compose and overlap gate projections

### DIFF
--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -34,6 +34,11 @@ def test_kimi_k3_model_declares_checkpoint_packing_contract():
         "k_proj",
         "v_proj",
     ]
+    assert AscendKimiK3ForCausalLM.packed_modules_mapping["fused_bfg_proj"] == [
+        "b_proj",
+        "f_a_proj",
+        "g_proj",
+    ]
     assert AscendKimiK3ForCausalLM.packed_modules_mapping["experts"] == [
         "experts.0.w1",
         "experts.0.w3",
@@ -63,6 +68,45 @@ def test_kimi_k3_loads_qkv_checkpoint_shards_into_fused_linear():
 
     assert [call.args[2] for call in fused_weight.weight_loader.call_args_list] == ["q", "k", "v"]
     assert loaded == {"layers.0.self_attn.fused_qkv.weight"}
+
+
+def test_kimi_k3_loads_bfg_checkpoint_shards_into_fused_linear():
+    model = KimiK3TextModel.__new__(KimiK3TextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(num_experts=0)
+    model.layers = nn.ModuleList([nn.Module()])
+    model.layers[0].self_attn = nn.Module()
+    model.layers[0].self_attn.fused_bfg_proj = nn.Module()
+
+    fused_weight = nn.Parameter(torch.empty(1))
+    fused_weight.weight_loader = MagicMock()
+    f_a_weight = nn.Parameter(torch.empty(1))
+    f_a_weight.weight_loader = MagicMock()
+    f_b_weight = nn.Parameter(torch.empty(1))
+    f_b_weight.weight_loader = MagicMock()
+    model.layers[0].self_attn.fused_bfg_proj.register_parameter("weight", fused_weight)
+    model.layers[0].self_attn.fused_bfg_proj.register_parameter("f_a_weight", f_a_weight)
+    model.layers[0].self_attn.fused_bfg_proj.register_parameter("f_b_weight", f_b_weight)
+    weights = [
+        (f"layers.0.self_attn.{name}.weight", torch.empty(1))
+        for name in ("b_proj", "f_a_proj", "f_b_proj", "g_proj")
+    ]
+
+    with (
+        patch("vllm_ascend.models.kimi_k3.get_spec_layer_idx_from_weight_name", return_value=None),
+        patch("vllm_ascend.models.kimi_k3.fused_moe_make_expert_params_mapping", return_value=[]),
+        patch("vllm_ascend.models.kimi_k3.is_pp_missing_parameter", return_value=False),
+    ):
+        loaded = model.load_weights(weights)
+
+    assert [call.args[2] for call in fused_weight.weight_loader.call_args_list] == [0, 2]
+    assert f_a_weight.weight_loader.call_args.args[2] is None
+    assert f_b_weight.weight_loader.call_args.args[2] is None
+    assert loaded == {
+        "layers.0.self_attn.fused_bfg_proj.weight",
+        "layers.0.self_attn.fused_bfg_proj.f_a_weight",
+        "layers.0.self_attn.fused_bfg_proj.f_b_weight",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -31,7 +31,9 @@ from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm_ascend.ops.kimi_kda import (
     _PACKED_CONV_WEIGHT_NAME,
     AscendKimiGatedDeltaNetAttention,
+    _KDAFusedBFGLinear,
     _load_a_log,
+    _require_kimi_k3_full_rank_gate,
     _zero_padded_spec_output,
 )
 from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
@@ -59,6 +61,42 @@ class _RecordingLinear(nn.Module):
     def forward(self, input_: torch.Tensor):
         self.input = input_
         return self.output, None
+
+
+class _RecordingStream:
+    def __init__(self, name: str, event_names: list[str], trace: list[str]) -> None:
+        self.name = name
+        self.event_names = iter(event_names)
+        self.trace = trace
+
+    def record_event(self) -> str:
+        event = next(self.event_names)
+        self.trace.append(f"{self.name}.record:{event}")
+        return event
+
+    def wait_event(self, event: str) -> None:
+        self.trace.append(f"{self.name}.wait:{event}")
+
+
+class _RecordingTensor:
+    def __init__(self, name: str, trace: list[str]) -> None:
+        self.name = name
+        self.trace = trace
+
+    def record_stream(self, stream: _RecordingStream) -> None:
+        self.trace.append(f"{self.name}.record_stream:{stream.name}")
+
+
+class _RecordingStreamSwitch:
+    def __init__(self, stream: _RecordingStream, trace: list[str]) -> None:
+        self.stream = stream
+        self.trace = trace
+
+    def __enter__(self) -> None:
+        self.trace.append(f"enter:{self.stream.name}")
+
+    def __exit__(self, *args) -> None:
+        self.trace.append(f"exit:{self.stream.name}")
 
 
 def _make_conv_pack_attention(
@@ -188,40 +226,186 @@ def test_zero_padded_spec_output_supports_multiple_real_and_dummy_rows():
     assert masked.device == output.device
 
 
-def test_staged_bfg_projection_preserves_original_outputs():
+def test_kimi_k3_kda_requires_full_rank_gate():
+    _require_kimi_k3_full_rank_gate({"use_full_rank_gate": True})
+    with pytest.raises(ValueError, match="requires use_full_rank_gate=true"):
+        _require_kimi_k3_full_rank_gate({"use_full_rank_gate": False})
+
+
+@pytest.mark.parametrize("f_b_is_local", [False, True])
+def test_fused_bfg_linear_composes_f_and_packs_bfg(f_b_is_local: bool):
+    with (
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size", return_value=4),
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_rank", return_value=2),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_rank", return_value=2),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", return_value=4),
+    ):
+        linear = _KDAFusedBFGLinear(
+            hidden_size=6,
+            num_heads=8,
+            head_dim=3,
+            tp_size=4,
+            quant_config=None,
+            prefix="model.layers.0.self_attn.fused_bfg_proj",
+        )
+
+    linear.weight.data.zero_()
+    b_weight = torch.arange(8 * 6, dtype=linear.weight.dtype).reshape(8, 6)
+    f_a_weight = torch.arange(3 * 6, dtype=linear.weight.dtype).reshape(3, 6) + 100
+    global_f_b_weight = torch.arange(24 * 3, dtype=linear.weight.dtype).reshape(24, 3) + 200
+    local_f_b_weight = global_f_b_weight[12:18]
+    g_weight = torch.arange(24 * 6, dtype=linear.weight.dtype).reshape(24, 6) + 200
+
+    linear.weight.weight_loader(linear.weight, b_weight, 0)
+    linear.f_a_weight.weight_loader(linear.f_a_weight, f_a_weight)
+    with patch("vllm_ascend.ops.kimi_kda.get_tensor_model_parallel_rank", return_value=2):
+        linear.f_b_weight.weight_loader(
+            linear.f_b_weight,
+            local_f_b_weight if f_b_is_local else global_f_b_weight,
+        )
+    linear.weight.weight_loader(linear.weight, g_weight, 2)
+
+    expected_f = torch.matmul(
+        local_f_b_weight.float(),
+        f_a_weight.float(),
+    ).to(linear.weight.dtype)
+    assert tuple(linear.weight.shape) == (14, 6)
+    torch.testing.assert_close(linear.weight[:2], b_weight[4:6])
+    torch.testing.assert_close(linear.weight[2:8], expected_f)
+    torch.testing.assert_close(linear.weight[8:], g_weight[12:18])
+
+
+def test_fused_bfg_linear_recomposes_f_after_source_reload():
+    with (
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_world_size", return_value=1),
+        patch("vllm.model_executor.layers.linear.get_tensor_model_parallel_rank", return_value=0),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_rank", return_value=0),
+        patch("vllm.model_executor.parameter.get_tensor_model_parallel_world_size", return_value=1),
+    ):
+        linear = _KDAFusedBFGLinear(
+            hidden_size=4,
+            num_heads=2,
+            head_dim=2,
+            tp_size=1,
+            quant_config=None,
+            prefix="model.layers.0.self_attn.fused_bfg_proj",
+        )
+
+    linear.weight.data.zero_()
+    first_f_a = torch.arange(8, dtype=linear.weight.dtype).reshape(2, 4)
+    first_f_b = torch.arange(8, dtype=linear.weight.dtype).reshape(4, 2)
+    linear.f_a_weight.weight_loader(linear.f_a_weight, first_f_a)
+    torch.testing.assert_close(linear.weight[2:6], torch.zeros_like(linear.weight[2:6]))
+    linear.f_b_weight.weight_loader(linear.f_b_weight, first_f_b)
+    torch.testing.assert_close(linear.weight[2:6], first_f_b.float() @ first_f_a.float())
+
+    reloaded_f_a = first_f_a + 10
+    reloaded_f_b = first_f_b + 20
+    linear.f_a_weight.weight_loader(linear.f_a_weight, reloaded_f_a)
+    linear.f_b_weight.weight_loader(linear.f_b_weight, reloaded_f_b)
+    torch.testing.assert_close(
+        linear.weight[2:6],
+        reloaded_f_b.float() @ reloaded_f_a.float(),
+    )
+
+
+def test_fused_bfg_projection_preserves_staged_outputs():
     attention = AscendKimiGatedDeltaNetAttention.__new__(AscendKimiGatedDeltaNetAttention)
     nn.Module.__init__(attention)
-    attention.use_full_rank_gate = True
     attention.head_dim = 3
+    attention._fused_bfg_output_sizes = (2, 6, 6)
 
     hidden_states = torch.randn(4, 5)
-    beta_output = torch.arange(8, dtype=torch.float32).reshape(4, 2)
-    f_a_output = torch.arange(12, dtype=torch.float32).reshape(4, 3)
-    f_b_output = torch.arange(24, dtype=torch.float32).reshape(4, 6)
-    g_output = torch.arange(24, dtype=torch.float32).reshape(4, 6) + 100
-    attention.b_proj = _RecordingLinear(beta_output)
-    attention.f_a_proj = _RecordingLinear(f_a_output)
-    attention.f_b_proj = _RecordingLinear(f_b_output)
-    attention.g_proj = _RecordingLinear(g_output)
+    fused_output = torch.arange(56, dtype=torch.float32).reshape(4, 14)
+    attention.fused_bfg_proj = _RecordingLinear(fused_output)
 
     beta, raw_gate, output_gate = attention._project_bfg(hidden_states)
 
-    torch.testing.assert_close(beta, beta_output)
-    torch.testing.assert_close(attention.f_b_proj.input, f_a_output)
-    torch.testing.assert_close(raw_gate, f_b_output)
-    torch.testing.assert_close(output_gate, g_output)
+    torch.testing.assert_close(beta, fused_output[:, :2])
+    torch.testing.assert_close(raw_gate, fused_output[:, 2:8])
+    torch.testing.assert_close(output_gate, fused_output[:, 8:])
 
     beta, raw_gate, output_gate = attention._postprocess_bfg(
         beta,
         raw_gate,
         output_gate,
     )
-    torch.testing.assert_close(beta, beta_output.sigmoid().unsqueeze(0))
+    torch.testing.assert_close(beta, fused_output[:, :2].sigmoid().unsqueeze(0))
     torch.testing.assert_close(
         raw_gate,
-        f_b_output.reshape(4, 2, 3).unsqueeze(0),
+        fused_output[:, 2:8].reshape(4, 2, 3).unsqueeze(0),
     )
-    torch.testing.assert_close(output_gate, g_output.reshape(4, 2, 3))
+    torch.testing.assert_close(output_gate, fused_output[:, 8:].reshape(4, 2, 3))
+
+
+def test_overlapped_qkv_bfg_has_two_bidirectional_event_joins():
+    attention = AscendKimiGatedDeltaNetAttention.__new__(AscendKimiGatedDeltaNetAttention)
+    nn.Module.__init__(attention)
+    trace: list[str] = []
+    main_stream = _RecordingStream(
+        "main",
+        ["hidden_ready", "quant_ready", "qkv_ready"],
+        trace,
+    )
+    bfg_stream = _RecordingStream(
+        "bfg",
+        ["bfg_projection_ready", "bfg_ready"],
+        trace,
+    )
+    hidden_states = _RecordingTensor("hidden", trace)
+    raw_bfg = tuple(_RecordingTensor(name, trace) for name in ("beta_raw", "raw_gate_raw", "gate_raw"))
+    processed_bfg = tuple(_RecordingTensor(name, trace) for name in ("beta", "raw_gate", "output_gate"))
+    quantized_qkv = object()
+    qkv = object()
+
+    attention._project_bfg = MagicMock(
+        side_effect=lambda _: (trace.append("project_bfg"), raw_bfg)[1],
+    )
+    attention._quantize_fused_qkv = MagicMock(
+        side_effect=lambda _: (trace.append("dynamic_quant"), quantized_qkv)[1],
+    )
+    attention._matmul_fused_qkv = MagicMock(
+        side_effect=lambda _: (trace.append("qkv_matmul"), qkv)[1],
+    )
+    attention._postprocess_bfg = MagicMock(
+        side_effect=lambda *_: (trace.append("postprocess_bfg"), processed_bfg)[1],
+    )
+
+    with (
+        patch("vllm_ascend.ops.kimi_kda.torch.npu.current_stream", return_value=main_stream),
+        patch("vllm_ascend.ops.kimi_kda._kda_bfg_stream", return_value=bfg_stream),
+        patch(
+            "vllm_ascend.ops.kimi_kda.npu_stream_switch",
+            side_effect=lambda stream: _RecordingStreamSwitch(stream, trace),
+        ),
+    ):
+        actual = attention._run_overlapped_qkv_bfg(hidden_states)
+
+    assert actual == (qkv, *processed_bfg)
+    assert trace == [
+        "main.record:hidden_ready",
+        "hidden.record_stream:bfg",
+        "enter:bfg",
+        "bfg.wait:hidden_ready",
+        "project_bfg",
+        "bfg.record:bfg_projection_ready",
+        "exit:bfg",
+        "dynamic_quant",
+        "main.record:quant_ready",
+        "main.wait:bfg_projection_ready",
+        "qkv_matmul",
+        "main.record:qkv_ready",
+        "enter:bfg",
+        "bfg.wait:quant_ready",
+        "postprocess_bfg",
+        "bfg.record:bfg_ready",
+        "bfg.wait:qkv_ready",
+        "exit:bfg",
+        "beta.record_stream:main",
+        "raw_gate.record_stream:main",
+        "output_gate.record_stream:main",
+        "main.wait:bfg_ready",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/ops/test_kimi_kda.py
+++ b/tests/ut/ops/test_kimi_kda.py
@@ -15,7 +15,7 @@
 # This file is a part of the vllm-ascend project.
 
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -34,6 +34,12 @@ from vllm_ascend.ops.kimi_kda import (
     _load_a_log,
     _zero_padded_spec_output,
 )
+from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
+    AscendW4A8MXFPDynamicLinearMethod,
+)
+from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
 
 
 class _NoopQuantMethod(QuantizeMethodBase):
@@ -42,6 +48,17 @@ class _NoopQuantMethod(QuantizeMethodBase):
 
     def apply(self, layer: nn.Module, *args, **kwargs) -> torch.Tensor:
         raise NotImplementedError
+
+
+class _RecordingLinear(nn.Module):
+    def __init__(self, output: torch.Tensor) -> None:
+        super().__init__()
+        self.output = output
+        self.input: torch.Tensor | None = None
+
+    def forward(self, input_: torch.Tensor):
+        self.input = input_
+        return self.output, None
 
 
 def _make_conv_pack_attention(
@@ -169,6 +186,111 @@ def test_zero_padded_spec_output_supports_multiple_real_and_dummy_rows():
     assert masked.shape == output.shape
     assert masked.dtype == output.dtype
     assert masked.device == output.device
+
+
+def test_staged_bfg_projection_preserves_original_outputs():
+    attention = AscendKimiGatedDeltaNetAttention.__new__(AscendKimiGatedDeltaNetAttention)
+    nn.Module.__init__(attention)
+    attention.use_full_rank_gate = True
+    attention.head_dim = 3
+
+    hidden_states = torch.randn(4, 5)
+    beta_output = torch.arange(8, dtype=torch.float32).reshape(4, 2)
+    f_a_output = torch.arange(12, dtype=torch.float32).reshape(4, 3)
+    f_b_output = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+    g_output = torch.arange(24, dtype=torch.float32).reshape(4, 6) + 100
+    attention.b_proj = _RecordingLinear(beta_output)
+    attention.f_a_proj = _RecordingLinear(f_a_output)
+    attention.f_b_proj = _RecordingLinear(f_b_output)
+    attention.g_proj = _RecordingLinear(g_output)
+
+    beta, raw_gate, output_gate = attention._project_bfg(hidden_states)
+
+    torch.testing.assert_close(beta, beta_output)
+    torch.testing.assert_close(attention.f_b_proj.input, f_a_output)
+    torch.testing.assert_close(raw_gate, f_b_output)
+    torch.testing.assert_close(output_gate, g_output)
+
+    beta, raw_gate, output_gate = attention._postprocess_bfg(
+        beta,
+        raw_gate,
+        output_gate,
+    )
+    torch.testing.assert_close(beta, beta_output.sigmoid().unsqueeze(0))
+    torch.testing.assert_close(
+        raw_gate,
+        f_b_output.reshape(4, 2, 3).unsqueeze(0),
+    )
+    torch.testing.assert_close(output_gate, g_output.reshape(4, 2, 3))
+
+
+@pytest.mark.parametrize(
+    "quant_method_type",
+    [
+        AscendW4A8MXFPDynamicLinearMethod,
+        AscendW8A8MXFP8DynamicLinearMethod,
+    ],
+)
+def test_fused_qkv_splits_mxfp_dynamic_quant_from_matmul(quant_method_type):
+    attention = AscendKimiGatedDeltaNetAttention.__new__(
+        AscendKimiGatedDeltaNetAttention,
+    )
+    nn.Module.__init__(attention)
+    inner_quant_method = quant_method_type.__new__(quant_method_type)
+    adapter = SimpleNamespace(
+        quant_method=inner_quant_method,
+        apply=MagicMock(return_value=torch.randn(4, 18)),
+    )
+    attention.fused_qkv = SimpleNamespace(quant_method=adapter)
+    hidden_states = torch.randn(4, 6, dtype=torch.bfloat16)
+    quantized = torch.empty(4, 6, dtype=torch.float8_e4m3fn)
+    dynamic_scale = torch.empty(4, 1, dtype=torch.uint8)
+
+    with patch(
+        "vllm_ascend.ops.kimi_kda.torch_npu.npu_dynamic_mx_quant",
+        return_value=(quantized, dynamic_scale),
+    ) as dynamic_quant:
+        qkv_input = attention._quantize_fused_qkv(hidden_states)
+
+    assert isinstance(qkv_input, tuple)
+    assert qkv_input[0] is quantized
+    assert qkv_input[1] is dynamic_scale
+    dynamic_quant.assert_called_once_with(hidden_states, dst_type=torch.float8_e4m3fn)
+
+    output = attention._matmul_fused_qkv(qkv_input)
+
+    assert output is adapter.apply.return_value
+    adapter.apply.assert_called_once_with(attention.fused_qkv, qkv_input, bias=None)
+
+
+def test_fused_qkv_keeps_non_mxfp_quantization_in_linear_apply():
+    attention = AscendKimiGatedDeltaNetAttention.__new__(
+        AscendKimiGatedDeltaNetAttention,
+    )
+    nn.Module.__init__(attention)
+    adapter = SimpleNamespace(
+        quant_method=object(),
+        apply=MagicMock(return_value=torch.randn(4, 18)),
+    )
+    attention.fused_qkv = SimpleNamespace(quant_method=adapter)
+    hidden_states = torch.randn(4, 6)
+
+    with patch(
+        "vllm_ascend.ops.kimi_kda.torch_npu.npu_dynamic_mx_quant",
+    ) as dynamic_quant:
+        qkv_input = attention._quantize_fused_qkv(hidden_states)
+
+    assert qkv_input is hidden_states
+    dynamic_quant.assert_not_called()
+
+    output = attention._matmul_fused_qkv(qkv_input)
+
+    assert output is adapter.apply.return_value
+    adapter.apply.assert_called_once_with(
+        attention.fused_qkv,
+        hidden_states,
+        bias=None,
+    )
 
 
 def test_output_norm_gate_uses_kda_fused_triton_kernel():

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -1184,6 +1184,15 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
             (".fused_qkv", ".k_proj", "k"),
             (".fused_qkv", ".v_proj", "v"),
         ]
+        if any(".fused_bfg_proj." in name for name in params_dict):
+            stacked_params_mapping.extend(
+                [
+                    (".fused_bfg_proj", ".b_proj", 0),
+                    (".fused_bfg_proj.f_a_weight", ".f_a_proj.weight", None),
+                    (".fused_bfg_proj.f_b_weight", ".f_b_proj.weight", None),
+                    (".fused_bfg_proj", ".g_proj", 2),
+                ]
+            )
         stacked_params_mapping.extend(
             [
                 (".gate_up_proj", ".gate_proj", 0),
@@ -1260,6 +1269,9 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
 class AscendKimiK3ForCausalLM(nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid):
     packed_modules_mapping = {
         "fused_qkv": ["q_proj", "k_proj", "v_proj"],
+        # f_a_proj remains the checkpoint-side quantization metadata alias for
+        # the offline-composed f_proj shard. Both F source projections are FLOAT.
+        "fused_bfg_proj": ["b_proj", "f_a_proj", "g_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
         "experts": ["experts.0.w1", "experts.0.w3", "experts.0.w2"],
         "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -1178,15 +1178,20 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
         self,
         weights: Iterable[tuple[str, torch.Tensor] | tuple[str, torch.Tensor, dict[str, Any]]],
     ) -> set[str]:
-        stacked_params_mapping = [
+        params_dict = dict(self.named_parameters())
+        stacked_params_mapping: list[tuple[str, str, str | int | None]] = [
             (".fused_qkv", ".q_proj", "q"),
             (".fused_qkv", ".k_proj", "k"),
             (".fused_qkv", ".v_proj", "v"),
-            (".gate_up_proj", ".gate_proj", 0),
-            (".gate_up_proj", ".up_proj", 1),
-            (".fused_qkv_a_proj", ".q_a_proj", 0),
-            (".fused_qkv_a_proj", ".kv_a_proj_with_mqa", 1),
         ]
+        stacked_params_mapping.extend(
+            [
+                (".gate_up_proj", ".gate_proj", 0),
+                (".gate_up_proj", ".up_proj", 1),
+                (".fused_qkv_a_proj", ".q_a_proj", 0),
+                (".fused_qkv_a_proj", ".kv_a_proj_with_mqa", 1),
+            ]
+        )
         expert_params_mapping = fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="w1",
@@ -1194,7 +1199,6 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
             ckpt_up_proj_name="w3",
             num_experts=self.config.num_experts,
         )
-        params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
 
         for args in weights:
@@ -1211,11 +1215,15 @@ class KimiK3TextModel(nn.Module, EagleModelMixin):
                     continue
                 if ".experts." in name and name not in params_dict:
                     continue
-                name = name.replace(weight_name, param_name)
-                if name.endswith(".bias") and name not in params_dict:
+                packed_name = name.replace(weight_name, param_name)
+                if packed_name.endswith(".bias") and packed_name not in params_dict:
                     continue
-                if is_pp_missing_parameter(name, self):
+                if is_pp_missing_parameter(packed_name, self):
+                    name = packed_name
                     break
+                if packed_name not in params_dict:
+                    continue
+                name = packed_name
                 param = params_dict[name]
                 param.weight_loader(param, loaded_weight, shard_id)
                 break

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -26,6 +26,7 @@ from collections.abc import Callable
 from functools import partial, wraps
 
 import torch
+import torch_npu
 from einops import rearrange
 from vllm.config import VllmConfig
 from vllm.distributed import get_pcp_group, get_tensor_model_parallel_rank
@@ -35,7 +36,11 @@ try:
     from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd  # type: ignore[import-not-found]
 except ModuleNotFoundError:
     from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
-from vllm.model_executor.layers.linear import ColumnParallelLinear, QKVParallelLinear
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+)
 from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
     KimiGatedDeltaNetAttention,
 )
@@ -50,7 +55,13 @@ from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
 from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
 from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
 from vllm_ascend.ops.triton.kda.kda import fused_kda_gate
-from vllm_ascend.utils import is_vl_model, parse_layer_idx
+from vllm_ascend.quantization.methods.w4a8_mxfp4 import (
+    AscendW4A8MXFPDynamicLinearMethod,
+)
+from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
+from vllm_ascend.utils import is_vl_model, npu_stream_switch, parse_layer_idx
 
 apply_kda_rms_norm_sigmoid_gate: (
     Callable[
@@ -69,6 +80,91 @@ if HAS_TRITON:
 _KDA_CHUNK_SIZE = 64
 _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
 _FUSED_QKV_NAME = "fused_qkv"
+_FUSED_BFG_NAME = "fused_bfg_proj"
+_F_A_SHARD_ID = 1
+_KDA_QUANT_STREAM: torch.npu.Stream | None = None
+
+
+def _kda_quant_stream() -> torch.npu.Stream:
+    global _KDA_QUANT_STREAM
+    if _KDA_QUANT_STREAM is None:
+        _KDA_QUANT_STREAM = torch_npu.npu.Stream()
+    return _KDA_QUANT_STREAM
+
+
+class _KDAFusedBFGLinear(MergedColumnParallelLinear):
+    """Fuse KDA's float B, F-A, and output-gate projections.
+
+    ``b_proj`` and ``g_proj`` are column-parallel, while ``f_a_proj`` is
+    replicated. Represent the replicated output as ``head_dim * tp_size`` in
+    the logical merged matrix so every rank still owns one complete
+    ``head_dim`` slice. Its checkpoint shard is copied verbatim into that local
+    slice instead of being narrowed by TP rank.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        num_heads: int,
+        head_dim: int,
+        tp_size: int,
+        quant_config,
+        prefix: str,
+    ) -> None:
+        projection_size = num_heads * head_dim
+        super().__init__(
+            input_size=hidden_size,
+            output_sizes=[
+                num_heads,
+                head_dim * tp_size,
+                projection_size,
+            ],
+            bias=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        if self.tp_size != tp_size:
+            raise ValueError(f"KDA fused BFG TP mismatch: layer={self.tp_size}, attention={tp_size}")
+
+    def _load_replicated_f_a_shard(
+        self,
+        param: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+    ) -> None:
+        output_dim = getattr(param, "output_dim", None)
+        if output_dim is None:
+            raise ValueError("KDA fused f_a_proj requires an output-sharded parameter")
+        shard_offset = sum(self.output_sizes[:_F_A_SHARD_ID]) // self.tp_size
+        shard_size = self.output_sizes[_F_A_SHARD_ID] // self.tp_size
+        param_shard = param.data.narrow(output_dim, shard_offset, shard_size)
+        if param_shard.shape != loaded_weight.shape:
+            raise ValueError(
+                "KDA fused f_a_proj checkpoint shape mismatch: "
+                f"expected {tuple(param_shard.shape)}, got {tuple(loaded_weight.shape)}"
+            )
+        param_shard.copy_(loaded_weight)
+
+    def weight_loader(
+        self,
+        param: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        if loaded_shard_id == _F_A_SHARD_ID:
+            self._load_replicated_f_a_shard(param, loaded_weight)
+            return
+        super().weight_loader(param, loaded_weight, loaded_shard_id)
+
+    def weight_loader_v2(
+        self,
+        param: torch.nn.Parameter,
+        loaded_weight: torch.Tensor,
+        loaded_shard_id: tuple[int, ...] | int | None = None,
+    ) -> None:
+        if loaded_shard_id == _F_A_SHARD_ID:
+            self._load_replicated_f_a_shard(param, loaded_weight)
+            return
+        super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
 
 
 def _zero_padded_spec_output(
@@ -185,6 +281,8 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             quant_config=self.quant_config,
             prefix=f"{prefix}.{_FUSED_QKV_NAME}",
         )
+        if getattr(fused_qkv, "custom_op", None) is not None:
+            raise ValueError("KDA fused QKV split requires a communication-free linear")
         del self.q_proj
         del self.k_proj
         del self.v_proj
@@ -265,19 +363,42 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             not self.is_vl_first_layer,
         )
         num_tokens = hidden_states.size(0)
-        qkv = self.fused_qkv(hidden_states)[0]
-        projection_size = self.local_num_heads * self.head_dim
-        q, k, v = qkv.split([projection_size] * 3, dim=-1)
-
-        beta = self.b_proj(hidden_states)[0].float().sigmoid().unsqueeze(0)
-        raw_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
-        raw_gate = rearrange(raw_gate, "n (h d) -> 1 n h d", d=self.head_dim)
 
         if self.use_full_rank_gate:
-            output_gate = self.g_proj(hidden_states)[0]
+            main_stream = torch.npu.current_stream()
+            quant_stream = _kda_quant_stream()
+            hidden_states_ready = main_stream.record_event()
+            hidden_states.record_stream(quant_stream)
+            with npu_stream_switch(quant_stream):
+                torch.npu.current_stream().wait_event(hidden_states_ready)
+                quantized_qkv = self._quantize_fused_qkv(hidden_states)
+                quant_ready = torch.npu.current_stream().record_event()
+
+            raw_bfg = self._project_bfg(hidden_states)
+            bfg_projection_ready = main_stream.record_event()
+            for tensor in raw_bfg:
+                tensor.record_stream(quant_stream)
+            with npu_stream_switch(quant_stream):
+                torch.npu.current_stream().wait_event(bfg_projection_ready)
+                beta, raw_gate, output_gate = self._postprocess_bfg(*raw_bfg)
+                bfg_ready = torch.npu.current_stream().record_event()
+
+            main_stream.wait_event(quant_ready)
+            if isinstance(quantized_qkv, tuple):
+                for tensor in quantized_qkv:
+                    tensor.record_stream(main_stream)
+            qkv = self._matmul_fused_qkv(quantized_qkv)
+            for tensor in (beta, raw_gate, output_gate):
+                tensor.record_stream(main_stream)
         else:
-            output_gate = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
-        output_gate = rearrange(output_gate, "n (h d) -> n h d", d=self.head_dim)
+            qkv = self._matmul_fused_qkv(self._quantize_fused_qkv(hidden_states))
+            beta, raw_gate, output_gate = self._postprocess_bfg(*self._project_bfg(hidden_states))
+
+        if self.use_full_rank_gate:
+            main_stream.wait_event(bfg_ready)
+
+        projection_size = self.local_num_heads * self.head_dim
+        q, k, v = qkv.split([projection_size] * 3, dim=-1)
 
         core_attn_out = torch.zeros(
             (1, num_tokens, self.local_num_heads, self.head_dim),
@@ -296,6 +417,68 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         core_attn_out = self._apply_output_norm_gate(core_attn_out, output_gate)
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
+
+    def _project_bfg(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        beta = self.b_proj(hidden_states)[0]
+        f_a = self.f_a_proj(hidden_states)[0]
+        raw_gate = self.f_b_proj(f_a)[0]
+        if self.use_full_rank_gate:
+            output_gate = self.g_proj(hidden_states)[0]
+        else:
+            output_gate = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
+        return beta, raw_gate, output_gate
+
+    def _postprocess_bfg(
+        self,
+        beta: torch.Tensor,
+        raw_gate: torch.Tensor,
+        output_gate: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        beta = beta.float().sigmoid().unsqueeze(0)
+        raw_gate = rearrange(raw_gate, "n (h d) -> 1 n h d", d=self.head_dim)
+        output_gate = rearrange(output_gate, "n (h d) -> n h d", d=self.head_dim)
+        return beta, raw_gate, output_gate
+
+    def _quantize_fused_qkv(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        quant_method = self.fused_qkv.quant_method
+        inner_quant_method = getattr(quant_method, "quant_method", quant_method)
+        # Both MXFP tuple paths preserve this model's two-dimensional BF16
+        # contract and skip their internal dynamic quantization.
+        if (
+            isinstance(
+                inner_quant_method,
+                (
+                    AscendW4A8MXFPDynamicLinearMethod,
+                    AscendW8A8MXFP8DynamicLinearMethod,
+                ),
+            )
+            and hidden_states.dtype == torch.bfloat16
+            and hidden_states.ndim == 2
+        ):
+            return torch_npu.npu_dynamic_mx_quant(
+                hidden_states,
+                dst_type=torch.float8_e4m3fn,
+            )
+        return hidden_states
+
+    def _matmul_fused_qkv(
+        self,
+        qkv_input: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        quant_method = self.fused_qkv.quant_method
+        if quant_method is None:
+            raise RuntimeError("KDA fused QKV quantization method is not initialized")
+        return quant_method.apply(
+            self.fused_qkv,
+            qkv_input,
+            bias=None,
+        )
 
     def _apply_output_norm_gate(
         self,

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -81,25 +81,24 @@ _KDA_CHUNK_SIZE = 64
 _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
 _FUSED_QKV_NAME = "fused_qkv"
 _FUSED_BFG_NAME = "fused_bfg_proj"
-_F_A_SHARD_ID = 1
-_KDA_QUANT_STREAM: torch.npu.Stream | None = None
+_F_PROJ_SHARD_ID = 1
+_KDA_BFG_STREAM: torch.npu.Stream | None = None
 
 
-def _kda_quant_stream() -> torch.npu.Stream:
-    global _KDA_QUANT_STREAM
-    if _KDA_QUANT_STREAM is None:
-        _KDA_QUANT_STREAM = torch_npu.npu.Stream()
-    return _KDA_QUANT_STREAM
+def _kda_bfg_stream() -> torch.npu.Stream:
+    global _KDA_BFG_STREAM
+    if _KDA_BFG_STREAM is None:
+        _KDA_BFG_STREAM = torch_npu.npu.Stream()
+    return _KDA_BFG_STREAM
 
 
 class _KDAFusedBFGLinear(MergedColumnParallelLinear):
-    """Fuse KDA's float B, F-A, and output-gate projections.
+    """Fuse KDA's float B, composed F, and output-gate projections.
 
-    ``b_proj`` and ``g_proj`` are column-parallel, while ``f_a_proj`` is
-    replicated. Represent the replicated output as ``head_dim * tp_size`` in
-    the logical merged matrix so every rank still owns one complete
-    ``head_dim`` slice. Its checkpoint shard is copied verbatim into that local
-    slice instead of being narrowed by TP rank.
+    The checkpoint stores ``f_a_proj`` and ``f_b_proj`` separately. Keep both
+    source weights as staging parameters so initial loading and later reloads
+    can derive ``f_proj = f_b_proj @ f_a_proj`` offline. The derived F shard is
+    column-parallel like ``f_b_proj`` and is packed between B and G.
     """
 
     def __init__(
@@ -116,7 +115,7 @@ class _KDAFusedBFGLinear(MergedColumnParallelLinear):
             input_size=hidden_size,
             output_sizes=[
                 num_heads,
-                head_dim * tp_size,
+                projection_size,
                 projection_size,
             ],
             bias=False,
@@ -125,46 +124,90 @@ class _KDAFusedBFGLinear(MergedColumnParallelLinear):
         )
         if self.tp_size != tp_size:
             raise ValueError(f"KDA fused BFG TP mismatch: layer={self.tp_size}, attention={tp_size}")
+        local_projection_size = projection_size // tp_size
+        self.f_a_weight = torch.nn.Parameter(
+            self.weight.new_empty((head_dim, hidden_size)),
+            requires_grad=False,
+        )
+        self.f_b_weight = torch.nn.Parameter(
+            self.weight.new_empty((local_projection_size, head_dim)),
+            requires_grad=False,
+        )
+        self.f_a_weight.weight_loader = self._load_f_a_weight
+        self.f_b_weight.weight_loader = self._load_f_b_weight
+        self._f_a_loaded = False
+        self._f_b_loaded = False
 
-    def _load_replicated_f_a_shard(
+    def _load_f_a_weight(
         self,
         param: torch.nn.Parameter,
         loaded_weight: torch.Tensor,
+        _loaded_shard_id: tuple[int, ...] | int | None = None,
     ) -> None:
-        output_dim = getattr(param, "output_dim", None)
-        if output_dim is None:
-            raise ValueError("KDA fused f_a_proj requires an output-sharded parameter")
-        shard_offset = sum(self.output_sizes[:_F_A_SHARD_ID]) // self.tp_size
-        shard_size = self.output_sizes[_F_A_SHARD_ID] // self.tp_size
-        param_shard = param.data.narrow(output_dim, shard_offset, shard_size)
-        if param_shard.shape != loaded_weight.shape:
+        if param.shape != loaded_weight.shape:
             raise ValueError(
-                "KDA fused f_a_proj checkpoint shape mismatch: "
-                f"expected {tuple(param_shard.shape)}, got {tuple(loaded_weight.shape)}"
+                "KDA f_a_proj checkpoint shape mismatch: "
+                f"expected {tuple(param.shape)}, got {tuple(loaded_weight.shape)}"
             )
-        param_shard.copy_(loaded_weight)
+        param.data.copy_(loaded_weight)
+        self._f_a_loaded = True
+        self._maybe_fuse_f_proj()
 
-    def weight_loader(
+    def _load_f_b_weight(
         self,
         param: torch.nn.Parameter,
         loaded_weight: torch.Tensor,
-        loaded_shard_id: tuple[int, ...] | int | None = None,
+        _loaded_shard_id: tuple[int, ...] | int | None = None,
     ) -> None:
-        if loaded_shard_id == _F_A_SHARD_ID:
-            self._load_replicated_f_a_shard(param, loaded_weight)
-            return
-        super().weight_loader(param, loaded_weight, loaded_shard_id)
+        if loaded_weight.shape == param.shape:
+            local_weight = loaded_weight
+        else:
+            expected_shape = (param.shape[0] * self.tp_size, param.shape[1])
+            if loaded_weight.shape != expected_shape:
+                raise ValueError(
+                    "KDA f_b_proj checkpoint shape mismatch: "
+                    f"expected {expected_shape} or {tuple(param.shape)}, "
+                    f"got {tuple(loaded_weight.shape)}"
+                )
+            tp_rank = get_tensor_model_parallel_rank()
+            local_weight = loaded_weight.narrow(
+                0,
+                tp_rank * param.shape[0],
+                param.shape[0],
+            )
+        param.data.copy_(local_weight)
+        self._f_b_loaded = True
+        self._maybe_fuse_f_proj()
 
-    def weight_loader_v2(
-        self,
-        param: torch.nn.Parameter,
-        loaded_weight: torch.Tensor,
-        loaded_shard_id: tuple[int, ...] | int | None = None,
-    ) -> None:
-        if loaded_shard_id == _F_A_SHARD_ID:
-            self._load_replicated_f_a_shard(param, loaded_weight)
+    @torch.no_grad()
+    def _maybe_fuse_f_proj(self) -> None:
+        if not self._f_a_loaded or not self._f_b_loaded:
             return
-        super().weight_loader_v2(param, loaded_weight, loaded_shard_id)
+        output_dim = getattr(self.weight, "output_dim", None)
+        if output_dim is None:
+            raise ValueError("KDA fused f_proj requires an output-sharded parameter")
+        shard_offset = sum(self.output_sizes[:_F_PROJ_SHARD_ID]) // self.tp_size
+        shard_size = self.output_sizes[_F_PROJ_SHARD_ID] // self.tp_size
+        param_shard = self.weight.data.narrow(
+            output_dim,
+            shard_offset,
+            shard_size,
+        )
+        fused_weight = torch.matmul(
+            self.f_b_weight.float(),
+            self.f_a_weight.float(),
+        ).to(dtype=param_shard.dtype)
+        if fused_weight.shape != param_shard.shape:
+            raise ValueError(
+                "KDA composed f_proj shape mismatch: "
+                f"expected {tuple(param_shard.shape)}, got {tuple(fused_weight.shape)}"
+            )
+        param_shard.copy_(fused_weight)
+
+
+def _require_kimi_k3_full_rank_gate(kda_config) -> None:
+    if not bool(kda_config.get("use_full_rank_gate", False)):
+        raise ValueError("Ascend Kimi-K3 KDA requires use_full_rank_gate=true")
 
 
 def _zero_padded_spec_output(
@@ -265,7 +308,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
 
         kda_config = config.linear_attn_config
         assert kda_config is not None, "linear_attn_config must be set"
-        self.use_full_rank_gate = bool(kda_config.get("use_full_rank_gate", False))
+        _require_kimi_k3_full_rank_gate(kda_config)
         gate_lower_bound = kda_config.get("gate_lower_bound")
         self.gate_lower_bound = float(gate_lower_bound) if gate_lower_bound is not None else None
 
@@ -295,16 +338,25 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
 
         # vLLM 0.23 builds the legacy low-rank output gate unconditionally.
         # Replace it with the checkpoint-compatible full-rank projection for K3.
-        if self.use_full_rank_gate:
-            del self.g_a_proj
-            del self.g_b_proj
-            self.g_proj = ColumnParallelLinear(
-                self.hidden_size,
-                self.head_dim * self.num_heads,
-                bias=False,
-                quant_config=self.quant_config,
-                prefix=f"{prefix}.g_proj",
-            )
+        del self.g_a_proj
+        del self.g_b_proj
+        del self.b_proj
+        del self.f_a_proj
+        del self.f_b_proj
+        self.fused_bfg_proj = _KDAFusedBFGLinear(
+            hidden_size=self.hidden_size,
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            tp_size=self.tp_size,
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.{_FUSED_BFG_NAME}",
+        )
+        projection_size = self.local_num_heads * self.head_dim
+        self._fused_bfg_output_sizes = (
+            self.local_num_heads,
+            projection_size,
+            projection_size,
+        )
 
         # The upstream class used FusedRMSNormGated's default epsilon.  K3's
         # checkpoint config is authoritative and uses the sigmoid gate path.
@@ -364,38 +416,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         )
         num_tokens = hidden_states.size(0)
 
-        if self.use_full_rank_gate:
-            main_stream = torch.npu.current_stream()
-            quant_stream = _kda_quant_stream()
-            hidden_states_ready = main_stream.record_event()
-            hidden_states.record_stream(quant_stream)
-            with npu_stream_switch(quant_stream):
-                torch.npu.current_stream().wait_event(hidden_states_ready)
-                quantized_qkv = self._quantize_fused_qkv(hidden_states)
-                quant_ready = torch.npu.current_stream().record_event()
-
-            raw_bfg = self._project_bfg(hidden_states)
-            bfg_projection_ready = main_stream.record_event()
-            for tensor in raw_bfg:
-                tensor.record_stream(quant_stream)
-            with npu_stream_switch(quant_stream):
-                torch.npu.current_stream().wait_event(bfg_projection_ready)
-                beta, raw_gate, output_gate = self._postprocess_bfg(*raw_bfg)
-                bfg_ready = torch.npu.current_stream().record_event()
-
-            main_stream.wait_event(quant_ready)
-            if isinstance(quantized_qkv, tuple):
-                for tensor in quantized_qkv:
-                    tensor.record_stream(main_stream)
-            qkv = self._matmul_fused_qkv(quantized_qkv)
-            for tensor in (beta, raw_gate, output_gate):
-                tensor.record_stream(main_stream)
-        else:
-            qkv = self._matmul_fused_qkv(self._quantize_fused_qkv(hidden_states))
-            beta, raw_gate, output_gate = self._postprocess_bfg(*self._project_bfg(hidden_states))
-
-        if self.use_full_rank_gate:
-            main_stream.wait_event(bfg_ready)
+        qkv, beta, raw_gate, output_gate = self._run_overlapped_qkv_bfg(hidden_states)
 
         projection_size = self.local_num_heads * self.head_dim
         q, k, v = qkv.split([projection_size] * 3, dim=-1)
@@ -418,18 +439,53 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
         output[:] = self.o_proj(core_attn_out)[0]
 
+    def _run_overlapped_qkv_bfg(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run QKV and BFG as two explicitly joined overlap stages."""
+        main_stream = torch.npu.current_stream()
+        bfg_stream = _kda_bfg_stream()
+
+        hidden_states_ready = main_stream.record_event()
+        hidden_states.record_stream(bfg_stream)
+        with npu_stream_switch(bfg_stream):
+            bfg_stream.wait_event(hidden_states_ready)
+            raw_bfg = self._project_bfg(hidden_states)
+            bfg_projection_ready = bfg_stream.record_event()
+
+        quantized_qkv = self._quantize_fused_qkv(hidden_states)
+        quant_ready = main_stream.record_event()
+
+        # Stage 1 join: both stage-2 branches start only after DynamicQuant and
+        # the fused BFG projection have completed.
+        main_stream.wait_event(bfg_projection_ready)
+        qkv = self._matmul_fused_qkv(quantized_qkv)
+        qkv_ready = main_stream.record_event()
+
+        with npu_stream_switch(bfg_stream):
+            bfg_stream.wait_event(quant_ready)
+            beta, raw_gate, output_gate = self._postprocess_bfg(*raw_bfg)
+            bfg_ready = bfg_stream.record_event()
+            # Stage 2 join from the auxiliary side. This wait is deliberately
+            # queued after bfg_ready so the reciprocal main-stream wait below
+            # cannot form a cycle.
+            bfg_stream.wait_event(qkv_ready)
+
+        for tensor in (beta, raw_gate, output_gate):
+            tensor.record_stream(main_stream)
+        main_stream.wait_event(bfg_ready)
+        return qkv, beta, raw_gate, output_gate
+
     def _project_bfg(
         self,
         hidden_states: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        beta = self.b_proj(hidden_states)[0]
-        f_a = self.f_a_proj(hidden_states)[0]
-        raw_gate = self.f_b_proj(f_a)[0]
-        if self.use_full_rank_gate:
-            output_gate = self.g_proj(hidden_states)[0]
-        else:
-            output_gate = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
-        return beta, raw_gate, output_gate
+        fused_bfg = self.fused_bfg_proj(hidden_states)[0]
+        return fused_bfg.split(
+            self._fused_bfg_output_sizes,
+            dim=-1,
+        )
 
     def _postprocess_bfg(
         self,


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3 KDA applies B, F, and output-gate projections to the same hidden states. This revision removes the runtime F-A -> F-B projection chain and overlaps the complete float BFG path with the quantized QKV path.

This change:

- composes checkpoint weights offline as `f_proj.weight = f_b_proj.weight @ f_a_proj.weight`;
- keeps the original F-A/F-B source weights as small staging parameters so initial load and later weight reloads can rebuild the composed weight;
- packs `b_proj`, the composed `f_proj`, and full-rank `g_proj` into one `MergedColumnParallelLinear`;
- splits the merged output directly into beta, raw F gate, and output gate;
- runs the BFG GEMM, split, `beta.float().sigmoid()`, and reshape vector work on one auxiliary NPU stream;
- runs QKV MXFP8 dynamic quantization and quantized matmul on the main stream in parallel;
- closes the dependency chain with main-stream input-ready event -> auxiliary wait -> auxiliary BFG-ready event -> main-stream wait before KDA;
- leaves the legacy low-rank gate path unchanged when full-rank gating is disabled.

The checkpoint schema and API/configuration surface remain unchanged. The composed F projection changes BF16 rounding order compared with two sequential GEMMs, so model-level accuracy must be checked before merge.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Runtime behavior changes only for Kimi K3 KDA layers using the existing full-rank gate configuration.

### How was this patch tested?

- No new or updated UT was added for this revision, per the requested scope.
- `ruff check`, `ruff format --check`, Python syntax compilation, and `git diff --check` passed for the changed source files.
- One-card Ascend 950DT micro-validation on green-52-220 in `kimi_k3_test` passed using PR head `3b9321605`:
  - composed F weight max abs error: `0.0`;
  - merged BFG output vs composed-weight reference max abs error: `0.0`;
  - MXFP8 dynamic quant + quantized QKV matmul completed on the main stream;
  - BFG cube/vector work completed on a distinct auxiliary stream with the full event wait/record closure;
  - beta/raw-gate/output-gate/QKV outputs had expected shapes and were finite.
- The same random BF16 microcase measured max abs difference `2.0` between the composed one-GEMM F output and the original two-GEMM output. This is recorded as an expected rounding-order change, not an accuracy conclusion.
- No vLLM service was started and no inference or benchmark request was sent.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
