### PR TITLE
[CI][Test] Add case_key to postprocess testEnv

### DIFF
--- a/tests/e2e/nightly/scripts/result_postprocess.py
+++ b/tests/e2e/nightly/scripts/result_postprocess.py
@@ -113,6 +113,7 @@ def merge_postprocess_payload(
     result: Any,
     *,
     testcase_name: str,
+    case_key: str,
     suite_name: str | None = None,
 ) -> dict[str, Any]:
     """Deep-copy preset and patch nested fields per the preset JSON schema."""
@@ -128,13 +129,13 @@ def merge_postprocess_payload(
         payload["testcase_info"] = testcase_info
 
     testcase_info["featureFullName"] = suite_name or resolve_suite_name()
-    testcase_info["Testcase_Name"] = testcase_name
 
     test_env = testcase_info.get("testEnv")
     if not isinstance(test_env, dict):
         test_env = {}
         testcase_info["testEnv"] = test_env
 
+    test_env["case_key"] = case_key
     test_env["yaml_name"] = testcase_name
     test_env["request_rate"] = case_config.get("request_rate", 0)
     if "max_out_len" in case_config:
@@ -230,6 +231,7 @@ def postprocess_one_benchmark(
         case_config,
         result,
         testcase_name=resolved_name,
+        case_key=case_key,
     )
 
     safe_job = _safe_name(job_name or "benchmark")


### PR DESCRIPTION
### What this PR does / why we need it?
Nightly/weekly YAML configs under `_benchmarks` may define multiple cases (e.g. `acc_aime2025`, `perf`). The case key was already passed into result postprocess for output filenames, but was not written into the uploaded JSON.

This PR:
- Writes `testEnv.case_key` with the `_benchmarks` case name
- Stops overwriting `testcase_info.Testcase_Name`, so the preset JSON value is preserved

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
by running a test

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
