### PR TITLE
[Bugfix] Use getattr for `sliding_window` to cover None cases

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -871,7 +871,7 @@ class AscendAttentionBackendImpl(AttentionImpl):
                         # Keep the captured block_tables tensor on this affected path.
                         # Non-SWA models preserve the original behavior and continue to refresh
                         # block_tables from attn_metadata.
-                        if not hasattr(vllm_config.model_config.hf_text_config, "sliding_window"):
+                        if not getattr(vllm_config.model_config.hf_text_config, "sliding_window", None):
                             block_tables = attn_metadata[metadata_key].block_tables
                     layer_count += 1
 


### PR DESCRIPTION
### What this PR does / why we need it?
Use getattr to check `sliding_window` with default None, so falsy values are handled correctly.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
Verified by testers.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
