### PR TITLE
[Misc][KV Pool] Improve AscendStoreConnector diagnostics

### DIFF
--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -345,8 +345,10 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         ) as mock_logger:
             b.put(["k1"], [[100]], [[10]])  # Should log error but not raise
         error_log = _format_log_call(mock_logger.error.call_args)
+        self.assertIn("event=kv pool backend put failed", error_log)
         self.assertIn("RuntimeError", error_log)
         self.assertIn("backend fail", error_log)
+        self.assertEqual(mock_logger.debug.call_args.args[-1], ["k1"])
 
     def test_get(self):
         b = self._make_backend()
@@ -367,8 +369,10 @@ class TestMooncakeBackendMethods(unittest.TestCase):
         ) as mock_logger:
             b.get(["k1"], [[100]], [[10]])
         error_log = _format_log_call(mock_logger.error.call_args)
+        self.assertIn("event=kv pool backend get failed", error_log)
         self.assertIn("RuntimeError", error_log)
         self.assertIn("backend fail", error_log)
+        self.assertEqual(mock_logger.debug.call_args.args[-1], ["k1"])
 
     def test_register_buffer(self):
         b = self._make_backend()

--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -96,6 +96,18 @@ class TestKVPoolScheduler(unittest.TestCase):
         return config
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.logger")
+    def test_init_logs_scheduler_config(self, mock_logger, mock_client_cls):
+        KVPoolScheduler(self._make_config(block_size=16), use_layerwise=False)
+
+        messages = [call.args[0] for call in mock_logger.info.call_args_list]
+        self.assertIn(
+            "event=kv pool scheduler configured backend=%s page_size_bytes=%d "
+            "use_layerwise=%s use_gva_layerwise=%s load_async=%s",
+            messages,
+        )
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_consumer_no_load(self, mock_client_cls):
         config = self._make_config(kv_role="kv_consumer")
         scheduler = KVPoolScheduler(config, use_layerwise=False)
@@ -114,7 +126,8 @@ class TestKVPoolScheduler(unittest.TestCase):
         self.assertEqual(result, (0, False))
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
-    def test_get_num_new_matched_tokens_hit(self, mock_client_cls):
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.logger")
+    def test_get_num_new_matched_tokens_hit(self, mock_logger, mock_client_cls):
         config = self._make_config(block_size=16)
         scheduler = KVPoolScheduler(config, use_layerwise=False)
         mock_client_cls.return_value.lookup.return_value = 48
@@ -135,6 +148,9 @@ class TestKVPoolScheduler(unittest.TestCase):
             [0],
             hbm_hit_tokens=16,
         )
+        self.assertEqual(mock_logger.info.call_count, 2)
+        self.assertIn("event=kv pool lookup completed", mock_logger.info.call_args_list[0].args[0])
+        self.assertIn("event=kv pool load spec created", mock_logger.info.call_args_list[1].args[0])
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.LookupKeyClient")
     def test_get_num_new_matched_tokens_all_hit(self, mock_client_cls):
@@ -1305,6 +1321,20 @@ class TestKVPoolSchedulerGetLayerwiseGvaHitTokens(unittest.TestCase):
         request.block_hashes = [b"\xaa"]
         result = scheduler._get_layerwise_gva_hit_tokens(request, 16, 0)
         self.assertEqual(result, 0)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler.logger")
+    def test_result_count_mismatch_logs_structured_error(self, mock_logger):
+        scheduler = self._make_scheduler()
+        scheduler.store_scheduler.batch_get_key_info.return_value = []
+
+        request = MagicMock()
+        request.block_hashes = [b"\xaa"]
+        result = scheduler._get_layerwise_gva_hit_tokens(request, 16, 0)
+
+        self.assertEqual(result, 0)
+        message = mock_logger.error.call_args.args[0]
+        self.assertIn("event=kv pool lookup result invalid", message)
+        self.assertIn("reason=result_count_mismatch", message)
 
     def test_with_computed_tokens(self):
         scheduler = self._make_scheduler()

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -768,8 +768,14 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
     def test_lookup_scheduler_exception(self):
         worker = self._make_worker()
         worker.m_store.exists.side_effect = Exception("fail")
-        result = worker.lookup_scheduler(32, ["h0", "h1"], use_layerwise=False)
+        with patch(
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.logger"
+        ) as mock_logger:
+            result = worker.lookup_scheduler(32, ["h0", "h1"], use_layerwise=False)
         self.assertEqual(result, 0)
+        mock_logger.exception.assert_called_once()
+        self.assertIn("event=kv pool exists failed", mock_logger.exception.call_args.args[0])
+        self.assertIn("reason=backend_exists_exception", mock_logger.exception.call_args.args[0])
 
     def test_lookup_layerwise(self):
         worker = self._make_worker()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -212,7 +212,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         metadata = self._get_connector_metadata()
         self._current_step_has_real_forward = forward_context is not None
         logger.debug(
-            "KV pool connector start_load_kv metadata_requests=%d specs=%s",
+            "event=kv pool load started request_count=%d request_details=%s",
             len(metadata.requests),
             [
                 (

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -73,6 +73,11 @@ class MemcacheBackend(Backend):
             self._register_buffers_if_needed()
 
     def _setup_store(self):
+        started_at = time.perf_counter()
+        logger.info(
+            "event=kv pool backend init started backend=memcache rank_id=%d",
+            self.local_rank,
+        )
         try:
             from memcache_hybrid import DistributedObjectStore  # type: ignore
         except ImportError as e:
@@ -87,14 +92,36 @@ class MemcacheBackend(Backend):
         try:
             res = store.init(self.local_rank, init_bm=self._init_bm)
         except ValueError as e:
-            logger.error("Configuration loading failed. error=%s. Check memcache config and environment.", e)
+            logger.error(
+                "event=kv pool backend init failed backend=memcache rank_id=%d "
+                "duration_ms=%.3f reason=%s error_type=%s "
+                "next_action=check_memcache_config_and_environment",
+                self.local_rank,
+                (time.perf_counter() - started_at) * 1e3,
+                e,
+                type(e).__name__,
+            )
             raise
         except Exception as exc:
-            logger.error("Store initialization failed. error=%s. Check memcache setup and dependencies.", exc)
+            logger.error(
+                "event=kv pool backend init failed backend=memcache rank_id=%d "
+                "duration_ms=%.3f reason=%s error_type=%s "
+                "next_action=check_memcache_setup_and_dependencies",
+                self.local_rank,
+                (time.perf_counter() - started_at) * 1e3,
+                exc,
+                type(exc).__name__,
+            )
             raise
 
         assert res == 0
         time.sleep(MEMCACHE_THREAD_START_WAIT_S)
+        logger.info(
+            "event=kv pool backend init succeeded backend=memcache rank_id=%d "
+            "duration_ms=%.3f",
+            self.local_rank,
+            (time.perf_counter() - started_at) * 1e3,
+        )
         return store
 
     @classmethod
@@ -174,12 +201,12 @@ class MemcacheBackend(Backend):
     def get(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
             logger.error(
-                "Failed to get %d keys out of %d. Store is not initialized; "
-                "call put() first to trigger initialization.",
+                "event=kv pool backend get failed backend=memcache "
+                "failed_keys=%d key_count=%d reason=store_not_initialized "
+                "next_action=call_put_to_initialize_store",
                 len(key),
                 len(key),
             )
-            logger.debug("Failed to get key details. keys=%s", key)
             return
         assert self.store is not None
         try:
@@ -189,22 +216,26 @@ class MemcacheBackend(Backend):
             if failed_count:
                 error_codes = sorted(set(failed_codes))
                 logger.error(
-                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
+                    "event=kv pool backend get failed backend=memcache "
+                    "failed_keys=%d key_count=%d error_codes=%s reason=backend_returned_error "
+                    "next_action=check_key_existence_and_memory_state",
                     failed_count,
                     len(key),
                     error_codes,
                 )
-                logger.debug("Failed to get key details. keys=%s, result=%s", key, res)
+                logger.debug("event=kv pool backend get keys sample_keys=%s", key[:3])
             return res
         except Exception as e:
             logger.error(
-                "Failed to get %d keys out of %d. type=%s, error=%s. Check store state and network.",
+                "event=kv pool backend get failed backend=memcache "
+                "failed_keys=%d key_count=%d error_type=%s reason=%s "
+                "next_action=check_store_state_and_network",
                 len(key),
                 len(key),
                 type(e).__name__,
                 e,
             )
-            logger.debug("Failed to get key details. keys=%s", key)
+            logger.debug("event=kv pool backend get keys sample_keys=%s", key[:3])
             return None
 
     def put(self, key: list[str], addr: list[list[int]], size: list[list[int]]):
@@ -217,22 +248,26 @@ class MemcacheBackend(Backend):
             if failed_count:
                 error_codes = sorted(set(failed_codes))
                 logger.error(
-                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
+                    "event=kv pool backend put failed backend=memcache "
+                    "failed_keys=%d key_count=%d error_codes=%s reason=backend_returned_error "
+                    "next_action=check_memory_and_store_capacity",
                     failed_count,
                     len(key),
                     error_codes,
                 )
-                logger.debug("Failed to put key details. keys=%s, result=%s", key, res)
+                logger.debug("event=kv pool backend put keys sample_keys=%s", key[:3])
                 if self._lazy_init:
                     logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
             logger.error(
-                "Failed to put %d keys out of %d. type=%s, error=%s. Check store state and memory.",
+                "event=kv pool backend put failed backend=memcache "
+                "failed_keys=%d key_count=%d error_type=%s reason=%s "
+                "next_action=check_store_state_and_memory",
                 len(key),
                 len(key),
                 type(e).__name__,
                 e,
             )
-            logger.debug("Failed to put key details. keys=%s", key)
+            logger.debug("event=kv pool backend put keys sample_keys=%s", key[:3])
             if self._lazy_init:
                 logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -200,41 +200,45 @@ class MooncakeBackend(Backend):
             if failed_count:
                 error_codes = sorted(set(failed_codes))
                 logger.error(
-                    "Failed to put %d keys out of %d. error_codes=%s. Check memory and store capacity.",
+                    "event=kv pool backend put failed backend=mooncake "
+                    "failed_keys=%d key_count=%d error_codes=%s reason=backend_returned_error "
+                    "next_action=check_memory_and_store_capacity",
                     failed_count,
                     len(keys),
                     error_codes,
                 )
-                logger.debug("Failed to put key details. keys=%s, result=%s", keys, res)
+                logger.debug("event=kv pool backend put result key_count=%d result_count=%d", len(keys), len(res))
+                logger.debug("event=kv pool backend put keys sample_keys=%s", keys[:3])
                 if self._lazy_init:
                     logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
         except Exception as e:
             logger.error(
-                "Failed to put %d keys out of %d. type=%s, error=%s. Check store state and memory.",
+                "event=kv pool backend put failed backend=mooncake "
+                "failed_keys=%d key_count=%d error_type=%s reason=%s "
+                "next_action=check_store_state_and_memory",
                 len(keys),
                 len(keys),
                 type(e).__name__,
                 e,
             )
-            logger.debug("Failed to put key details. keys=%s", keys)
+            logger.debug("event=kv pool backend put keys sample_keys=%s", keys[:3])
             if self._lazy_init:
                 logger.warning("First DSV4(compress) request failure is expected. This is normal behavior.")
 
     def get(self, keys: list[str], addrs: list[list[int]], sizes: list[list[int]]):
         if self._lazy_init and not self._store_initialized:
             logger.error(
-                "Failed to get %d keys out of %d. Store is not initialized; "
-                "call put() first to trigger initialization.",
+                "event=kv pool backend get failed backend=mooncake "
+                "failed_keys=%d key_count=%d reason=store_not_initialized "
+                "next_action=call_put_to_initialize_store",
                 len(keys),
                 len(keys),
             )
-            logger.debug("Failed to get key details. keys=%s", keys)
             return
         assert self.store is not None
         logger.debug(
-            "MooncakeBackend.get enter keys=%d sample_keys=%s",
+            "event=kv pool backend get started backend=mooncake key_count=%d",
             len(keys),
-            keys[:3],
         )
         try:
             res = self.store.batch_get_into_multi_buffers(keys, addrs, sizes)
@@ -244,25 +248,29 @@ class MooncakeBackend(Backend):
             error_codes = sorted(set(failed_codes))
             if failed_count:
                 logger.error(
-                    "Failed to get %d keys out of %d. error_codes=%s. Check key existence and memory state.",
+                    "event=kv pool backend get failed backend=mooncake "
+                    "failed_keys=%d key_count=%d error_codes=%s reason=backend_returned_error "
+                    "next_action=check_key_existence_and_memory_state",
                     failed_count,
                     len(keys),
                     error_codes,
                 )
-                logger.debug("Failed to get key details. keys=%s, result=%s", keys, res_list)
+                logger.debug("event=kv pool backend get keys sample_keys=%s", keys[:3])
             for i, value in enumerate(res_list):
                 if value > 0:
                     res_list[i] = 0
             return res_list
         except Exception as e:
             logger.error(
-                "Failed to get %d keys out of %d. type=%s, error=%s. Check store state and network.",
+                "event=kv pool backend get failed backend=mooncake "
+                "failed_keys=%d key_count=%d error_type=%s reason=%s "
+                "next_action=check_store_state_and_network",
                 len(keys),
                 len(keys),
                 type(e).__name__,
                 e,
             )
-            logger.debug("Failed to get key details. keys=%s", keys)
+            logger.debug("event=kv pool backend get keys sample_keys=%s", keys[:3])
             return None
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -481,7 +481,15 @@ class KVTransferThread(threading.Thread):
                 direction,
             )
             if res != 0:
-                logger.error("[KVPOOL] batch_copy %s FAILED res=%d", dir_name, res)
+                logger.error(
+                    "event=kv pool batch copy failed operation=%s "
+                    "status_code=%d block_count=%d bytes=%d reason=batch_copy_returned_error "
+                    "next_action=check_memcache_store_and_transfer_path",
+                    dir_name,
+                    res,
+                    len(split_gvas),
+                    int(split_sizes.sum()),
+                )
                 return res
         return 0
 
@@ -510,10 +518,11 @@ class KVTransferThread(threading.Thread):
             except Exception as e:
                 self._fatal_error = e
                 logger.error(
-                    "Error in KVCacheTransferThread(%s). type=%s, error=%s. Check thread state and request processing.",
+                    "event=kv pool transfer thread failed task_id=%s "
+                    "reason=%s error_type=%s next_action=check_thread_state_and_request_processing",
                     self.name,
-                    type(e).__name__,
                     e,
+                    type(e).__name__,
                 )
                 return
 
@@ -539,8 +548,10 @@ class KVTransferThread(threading.Thread):
                 exists_list[index] = value == 1
             return exists_list
         except Exception as e:
-            logger.error(
-                "Remote connection failed in lookup. type=%s, error=%s. Check network and remote store.",
+            logger.exception(
+                "event=kv pool exists failed operation=exists "
+                "reason=backend_exists_exception error_type=%s error=%s "
+                "next_action=check_backend_exists_implementation",
                 type(e).__name__,
                 e,
             )
@@ -682,7 +693,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
             try:
                 self.worker._store_kv_tp_mismatch(req_meta)
             except Exception:
-                logger.exception("Failed to store KV cache for TP-mismatch request %s", req_id)
+                logger.exception(
+                    "event=kv pool save failed req_id=%s "
+                    "reason=tp_mismatch_store_exception error_code=KV_POOL_SAVE_FAILED",
+                    req_id,
+                )
             finally:
                 remaining = self.get_stored_request_count(req_id)
                 if remaining == 0:
@@ -703,7 +718,11 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 return
             self._handle_stored_request(req_meta)
         except Exception:
-            logger.exception("Failed to store KV cache for request %s", req_id)
+            logger.exception(
+                "event=kv pool save failed req_id=%s "
+                "reason=store_exception error_code=KV_POOL_SAVE_FAILED",
+                req_id,
+            )
         finally:
             remaining = self.dec_stored_request(req_id) if tracked_request else None
             if tracked_request and remaining == 0:
@@ -721,7 +740,7 @@ class KVCacheStoreSendingThread(KVTransferThread):
         try:
             store_masks = self.token_database.store_mask(token_len, req_meta.num_prompt_tokens)
         except AssertionError as exc:
-            logger.debug("Skip AscendStore store mask for unaligned request %s: %s", req_id, exc)
+            logger.debug("Skip KV pool store mask for unaligned request %s: %s", req_id, exc)
             store_masks = None
         load_spec = req_meta.load_spec
         skip_start = load_spec.vllm_cached_tokens if load_spec is not None else 0
@@ -925,7 +944,12 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             load_spec = req_meta.load_spec
             req_id = req_meta.req_id
             if load_spec is None:
-                logger.error("KV pool async recv request %s has no load spec; skip load.", req_id)
+                logger.error(
+                    "event=kv pool load spec missing req_id=%s "
+                    "reason=missing_load_spec error_code=KV_POOL_LOAD_SPEC_MISSING "
+                    "next_action=check_scheduler_connector_metadata",
+                    req_id,
+                )
                 self.set_finished_request(req_id)
                 return
 
@@ -1235,7 +1259,10 @@ class KVCacheStoreKeyLayerRecvingThread(KVTransferThread):
 
     def _wait_for_save(self, layer_id: int) -> None:
         while not self.layer_save_finished_events[layer_id].wait(timeout=10):
-            logger.info("Layerwise %d save wait timed out, keep waiting before load", layer_id)
+            logger.info(
+                "event=kv pool layer save waiting layer_id=%d",
+                layer_id,
+            )
         logger.debug("Key-based layer save event cleared: layer %d", layer_id)
         self.layer_save_finished_events[layer_id].clear()
 
@@ -1249,7 +1276,10 @@ class KVCacheStoreKeyLayerRecvingThread(KVTransferThread):
 
         if data.attention_start_gate is not None:
             while not data.attention_start_gate.wait(timeout=10):
-                logger.info("Layerwise %d load waits for attention compute start", layer_id)
+                logger.info(
+                    "event=kv pool attention start waiting layer_id=%d",
+                    layer_id,
+                )
 
         key_list = []
         addr_list = []
@@ -1552,7 +1582,10 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
 
         if wait_for_save is not None:
             while not self.layer_save_finished_events[wait_for_save].wait(timeout=10):
-                logger.info("Layerwise %d save wait timed out, keep waiting before load", wait_for_save)
+                logger.info(
+                    "event=kv pool layer save waiting layer_id=%d",
+                    wait_for_save,
+                )
             # Non-saving TP ranks have no D2H task to synchronize the event.
             # Their CPU save-finished signal only means the event was recorded;
             # wait for the NPU work before reusing the local HBM buffer.
@@ -1588,7 +1621,10 @@ class KVCacheStoreLayerRecvingThread(KVTransferThread):
 
         if attention_start_gate is not None:
             while not attention_start_gate.wait(timeout=10):
-                logger.info("Layerwise %d load waits for attention compute start", layer_id)
+                logger.info(
+                    "event=kv pool attention start waiting layer_id=%d",
+                    layer_id,
+                )
 
         all_load_keys: list[str] = []
         all_req_ids: set[str] = set()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -165,10 +165,18 @@ class KVPoolScheduler:
         self.tp_mismatch = tp_mismatch_info.enabled
 
         self.page_size_bytes = page_size_bytes
-        logger.info("KV pool page_size_bytes: %d", page_size_bytes)
         backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
         self.backend_name = backend_name.lower()
         self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
+        logger.info(
+            "event=kv pool scheduler configured backend=%s page_size_bytes=%d "
+            "use_layerwise=%s use_gva_layerwise=%s load_async=%s",
+            self.backend_name,
+            self.page_size_bytes,
+            self.use_layerwise,
+            self.use_gva_layerwise,
+            self.load_async,
+        )
         backend = backend_map.get(self.backend_name)
         if backend is None:
             raise ValueError(f"Unsupported KV pool backend: {backend_name}")
@@ -373,7 +381,11 @@ class KVPoolScheduler:
             key_infos = self.store_scheduler.batch_get_key_info(all_keys)
             if len(key_infos) != len(all_keys):
                 logger.error(
-                    "KV pool batch_get_key_info returned unexpected number of results: expected=%d, actual=%d",
+                    "event=kv pool lookup result invalid backend=%s "
+                    "operation=batch_get_key_info expected_count=%d "
+                    "actual_count=%d reason=result_count_mismatch "
+                    "next_action=check_backend_response_and_key_alignment",
+                    self.backend_name,
                     len(all_keys),
                     len(key_infos),
                 )
@@ -592,9 +604,9 @@ class KVPoolScheduler:
         else:
             need_to_allocate = num_external_hit_tokens - num_computed_tokens
 
-        logger.debug(
-            "Reqid: %s, Total tokens %d, kvpool hit tokens: %d, need to load: %d",
-            request.request_id,
+        logger.info(
+            "event=kv pool lookup completed total_tokens=%d "
+            "kvpool_hit_tokens=%d load_tokens=%d",
             request.num_tokens,
             num_external_hit_tokens,
             need_to_allocate,
@@ -613,10 +625,10 @@ class KVPoolScheduler:
             can_load=force_layerwise_load,
             kvpool_store_skip_tokens=store_skip_tokens,
         )
-        logger.debug(
-            "KV pool load spec created req=%s vllm_cached=%d kvpool_cached=%d "
-            "need_to_allocate=%d load_async=%s use_layerwise=%s",
-            request.request_id,
+        logger.info(
+            "event=kv pool load spec created vllm_cached_tokens=%d "
+            "kvpool_cached_tokens=%d load_tokens=%d "
+            "load_async=%s use_layerwise=%s",
             num_computed_tokens,
             num_external_hit_tokens,
             need_to_allocate,
@@ -1071,7 +1083,13 @@ class KVPoolScheduler:
             logger.debug("event %s update with %s", event_id, count)
             total = self.sending_events.get(event_id, -1)
             if total == -1:
-                logger.warning("worker reports an invalid event: %s, count %s", event_id, count)
+                logger.warning(
+                    "event=kv pool worker event invalid event_id=%s count=%s "
+                    "reason=unknown_event "
+                    "next_action=check_worker_scheduler_event_lifecycle",
+                    event_id,
+                    count,
+                )
                 continue
             total = total + count
             if total >= self._expected_worker_count:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1712,7 +1712,10 @@ class KVPoolWorker:
             return
         while not self.layer_load_finished_events[self.current_layer].wait(timeout=10):
             self.kv_recv_thread.raise_if_failed()
-            logger.info("Layerwise %d load not done, keep waiting", self.current_layer)
+            logger.info(
+                "event=kv pool layer load waiting layer_id=%d",
+                self.current_layer,
+            )
         self.layer_load_finished_events[self.current_layer].clear()
 
     def get_block_ids_with_load_errors(self) -> set[int]:
@@ -1740,7 +1743,10 @@ class KVPoolWorker:
         if self.current_layer == self.num_layers - 1:
             while not self.layer_save_finished_events[self.num_layers - 1].wait(timeout=10):
                 send_thread.raise_if_failed()
-                logger.info("Layerwise %d save not done, keep waiting", self.current_layer)
+                logger.info(
+                    "event=kv pool layer save waiting layer_id=%d",
+                    self.current_layer,
+                )
             reuse_source_layers = set(self.prefetch_layer_map.values())
             for layer_id in range(self.num_layers):
                 if layer_id in reuse_source_layers:
@@ -2193,9 +2199,10 @@ class KVPoolWorker:
                             break
                 hits.append(hit_end)
         except Exception as e:
-            logger.error(
-                "Remote connection failed in get_common_prefix_length. type=%s, error=%s. "
-                "Check network and remote store.",
+            logger.exception(
+                "event=kv pool exists failed operation=exists "
+                "reason=backend_exists_exception error_type=%s error=%s "
+                "next_action=check_backend_exists_implementation",
                 type(e).__name__,
                 e,
             )
@@ -2412,8 +2419,10 @@ class KVPoolWorker:
                     token_len,
                 )
         except Exception as e:
-            logger.error(
-                "Remote connection failed in lookup. type=%s, error=%s. Check network and remote store.",
+            logger.exception(
+                "event=kv pool exists failed operation=exists "
+                "reason=backend_exists_exception error_type=%s error=%s "
+                "next_action=check_backend_exists_implementation",
                 type(e).__name__,
                 e,
             )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR improves AscendStoreConnector KV pool diagnostics following the structured logging guidance in [RFC #11229](https://github.com/vllm-project/vllm-ascend/issues/11229).

- Adds consistent `event=kv pool ...` descriptions and actionable context to backend, scheduler, worker, and transfer failures.
- Records bounded key samples at DEBUG level while keeping failure summaries concise.
- Adds Memcache initialization lifecycle logs with CPU-side duration.
- Restores the request-level KV pool hit and load-spec decisions to INFO with explicit token counts.
- Describes backend `exists()` exceptions accurately without assuming a network failure, and preserves tracebacks where the exception is converted to a cache miss.
- Keeps existing control flow and avoids metrics, device synchronization, and per-layer/block/key instrumentation.

### Does this PR introduce _any_ user-facing change?

Yes. AscendStoreConnector log messages use consistent KV pool event descriptions and more actionable diagnostic fields. There is no API or runtime behavior change.

### How was this patch tested?

- Added and updated unit-test assertions under `tests/ut/distributed/ascend_store/` for backend failures, scheduler configuration and lookup decisions, invalid backend results, and `exists()` exceptions.
- `python -m compileall -q vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store tests/ut/distributed/ascend_store`
- `git diff --check`
- Full pytest execution and Ruff checks were not available in the current Windows environment because those tools are not installed.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
