### PR TITLE
[BugFix][SpecDecode] Restore MRO-shadowed ACL graph setup in draft_model proposer

### DIFF
--- a/tests/ut/spec_decode/test_draft_proposer_mro.py
+++ b/tests/ut/spec_decode/test_draft_proposer_mro.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for MRO resolution of ``_maybe_share_lm_head``.
+
+``AscendDraftModelProposer`` inherits from upstream ``DraftModelProposer``
+first and ``AscendSpecDecodeBaseProposer`` second. Upstream's
+``_maybe_share_lm_head`` is a deliberate no-op (independent draft models
+don't share lm_head), so when it wins MRO resolution it silently skips the
+Ascend implementation -- which, for the draft_model method, is the only
+place that arms ACL full-graph support (``self.update_stream`` and the
+``ACLGraphWrapper``-wrapped ``self._runnable``). The subclass therefore
+overrides the method and delegates explicitly to the Ascend base; these
+tests pin that contract.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from vllm.v1.spec_decode.draft_model import DraftModelProposer
+
+from vllm_ascend.spec_decode.draft_proposer import AscendDraftModelProposer
+from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+
+
+def test_maybe_share_lm_head_not_shadowed_by_upstream_no_op():
+    # The upstream no-op used to win MRO resolution, making the drafter
+    # crash with "AttributeError: ... no attribute 'update_stream'" in
+    # cudagraph mode (and silently skip draft graph capture).
+    resolved = AscendDraftModelProposer._maybe_share_lm_head
+    assert resolved is not DraftModelProposer._maybe_share_lm_head
+
+
+def test_maybe_share_lm_head_delegates_to_ascend_base():
+    fake_self = object()
+    fake_model = object()
+    with mock.patch.object(AscendSpecDecodeBaseProposer, "_maybe_share_lm_head", autospec=True) as base_impl:
+        # Unbound-method style call with a stand-in instance; mypy cannot
+        # see that autospec makes the receiver type irrelevant here.
+        AscendDraftModelProposer._maybe_share_lm_head(fake_self, fake_model)  # type: ignore[arg-type]
+    base_impl.assert_called_once_with(fake_self, fake_model)
+
+
+def test_mro_order_unchanged_by_the_fix():
+    # The fix must delegate only ``_maybe_share_lm_head``; the class MRO is
+    # unchanged, so unrelated methods still resolve upstream-first.
+    assert AscendDraftModelProposer.__mro__[:3] == (
+        AscendDraftModelProposer,
+        DraftModelProposer,
+        AscendSpecDecodeBaseProposer,
+    )

--- a/vllm_ascend/spec_decode/draft_proposer.py
+++ b/vllm_ascend/spec_decode/draft_proposer.py
@@ -1,4 +1,5 @@
 import torch
+from torch import nn
 from vllm.config import VllmConfig
 from vllm.v1.spec_decode.draft_model import DraftModelProposer
 
@@ -15,3 +16,16 @@ class AscendDraftModelProposer(DraftModelProposer, AscendSpecDecodeBaseProposer)
         AscendSpecDecodeBaseProposer.__init__(self, vllm_config, device, False, runner=runner)
         self._raise_if_vocab_size_mismatch()
         self._raise_if_draft_tp_mismatch()
+
+    def _maybe_share_lm_head(self, model: nn.Module) -> None:
+        # Upstream DraftModelProposer._maybe_share_lm_head is a no-op ("draft
+        # models don't share lm_head with the target model"). Because it comes
+        # first in the MRO, it shadows the Ascend implementation. The Ascend
+        # version is still required for the draft_model method: it leaves
+        # lm_head untouched (the eagle/dflash and mtp branches don't apply),
+        # but it sets up ACL full-graph support -- self.update_stream and the
+        # ACLGraphWrapper-wrapped self._runnable. Without this delegation,
+        # cudagraph mode crashes with "AttributeError: 'AscendDraftModelProposer'
+        # object has no attribute 'update_stream'" and the draft model
+        # silently runs in eager mode (no graph capture).
+        AscendSpecDecodeBaseProposer._maybe_share_lm_head(self, model)


### PR DESCRIPTION
### What this PR does / why we need it?
Speculative decoding with `method=draft_model` and cudagraph enabled crashed at deployment with:

```
AttributeError: 'AscendDraftModelProposer' object has no attribute 'update_stream'
```

Root cause is MRO shadowing. `AscendDraftModelProposer` inherits from upstream `DraftModelProposer` (first in MRO) and `AscendSpecDecodeBaseProposer` (second). Upstream's `_maybe_share_lm_head` is a deliberate no-op (independent draft models don't share lm_head), so it wins MRO resolution and silently skips the Ascend implementation — which, for the draft_model method, is the only place that arms ACL full-graph support (`self.update_stream` and the `ACLGraphWrapper`-wrapped `self._runnable` at the end of the method). The visible AttributeError is only the surface; the deeper effect is that draft-model graph capture never happened and the drafter silently ran eager.

EAGLE/MTP are not affected: `EagleProposer`/`MtpProposer` don't override `_maybe_share_lm_head`, so MRO resolves to the Ascend implementation normally.

The fix delegates explicitly from the subclass to `AscendSpecDecodeBaseProposer._maybe_share_lm_head`: no MRO change, no base-class change, zero impact on the eagle/mtp paths (lm_head semantics for draft_model are unchanged — the Ascend implementation leaves it untouched for this method).
### Does this PR introduce _any_ user-facing change?

No configuration or API changes. The behavior change is the fix itself: draft_model + cudagraph mode now deploys instead of crashing, and the drafter's graph setup actually runs.

### How was this patch tested?
- Unit test added: `tests/ut/spec_decode/test_draft_proposer_mro.py` — pins that the resolved `_maybe_share_lm_head` is not the upstream no-op, that it delegates to the Ascend base, and that the class MRO is otherwise unchanged.
- Verified on Ascend 910B3 (v0.22.1rc1 baseline) end to end: with this fix, `method=draft_model` + cudagraph deploys past the crash point and the draft model is wrapped with ACLGraphWrapper (log: `[spec_decode/base] Wrapping draft model with ACLGraphWrapper: runtime_mode=FULL...`).
- Reproduced on the official v0.23.0 tag as well (Qwen3-8B + Qwen3-0.6B, FULL + capture sizes [6,12]): during graph capture, `dummy_run → _update_full_graph_params → self.update_stream → AttributeError`. Note the trigger order differs across versions — on v0.23.0 the QKNormRope cross-model pattern crash (#PR2) fires first during compilation and masks this one until #PR2 is applied.

> Note: developed with AI assistance (GLM-5.3); human-reviewed, human-validated on hardware.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
