### PR TITLE
[BugFix][Compilation] Scope fusion patterns per model shape to fix multi-model FULL-mode crash

### DIFF
--- a/tests/ut/compilation/test_base_pattern_shape_scoping.py
+++ b/tests/ut/compilation/test_base_pattern_shape_scoping.py
@@ -1,0 +1,232 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for per-model-shape scoping of fusion patterns (BasePattern).
+
+Regression tests for the FULL-mode (npugraph_ex) crash where a target-sized
+fusion pattern was applied to the spec-decode draft model's graph:
+"ValueError: Split sizes add up to 6144 but got the tensor's size of 4096".
+
+The tests mirror that failure mode with a toy ``cat(split(...))`` pattern
+(whose split sizes are baked from the example-input width, exactly like the
+qkv split in QKNormRope) and drive it through the real torch
+``PatternMatcherPass`` path:
+
+- a width-mismatched graph must be gracefully rejected (applied == 0, no
+  exception escaping ``PatternMatcherPass.apply``), which only works when
+  the search_fn guard raises ``RuntimeError`` (the exception type that
+  torch's check_fn catches);
+- a width-matched graph must still fuse (applied == 1);
+- target- and draft-sized variants of the same pattern class must coexist
+  in one process-global pass.
+
+The npugraph_ex/torchair registration is mocked out to keep the test
+hermetic (the process-global nge registry must not accumulate toy
+patterns) and to let the test run on machines without the NPU backend.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from collections.abc import Callable
+from unittest import mock
+
+import pytest
+import torch
+import torch._inductor.pattern_matcher as pm
+from torch.fx.experimental.proxy_tensor import make_fx
+
+
+def _import_base_pattern():
+    """Import base_pattern, stubbing the nge backend when unavailable.
+
+    On CI the npugraph_ex (or torchair) backend is importable; on machines
+    without it the stub keeps these logic tests runnable. The real nge
+    registration is mocked in every test below regardless.
+    """
+    try:
+        import vllm_ascend.compilation.passes.base_pattern as bp  # noqa: F401
+
+        return bp
+    except ImportError:
+        stub = types.ModuleType("npugraph_ex")
+        stub.register_replacement = lambda **kwargs: None
+        sys.modules.setdefault("npugraph_ex", stub)
+        import vllm_ascend.compilation.passes.base_pattern as bp
+
+        return bp
+
+
+base_pattern = _import_base_pattern()
+BasePattern = base_pattern.BasePattern
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_pattern_registry():
+    # The dedup registry is process-global by design (that is exactly what
+    # used to drop the draft model's registration); snapshot/restore it so
+    # tests stay independent.
+    saved = set(base_pattern._registered_patterns)
+    yield
+    base_pattern._registered_patterns.clear()
+    base_pattern._registered_patterns.update(saved)
+
+
+def _fake_vllm_config(dtype=torch.float32):
+    return types.SimpleNamespace(model_config=types.SimpleNamespace(dtype=dtype))
+
+
+class ToySplitCatPattern(BasePattern):
+    """cat(split(x, [w/2, w/2])) with sizes baked from the input width.
+
+    Structurally matches graphs of any width (torch's initial match ignores
+    int constants), but the re-trace verification in check_fn executes the
+    split with the real tensor width -- narrower inputs raise ValueError,
+    mirroring the QKNormRope qkv-split crash.
+    """
+
+    def __init__(self, vllm_config, width: int, num_tokens: int = 4):
+        super().__init__(vllm_config)
+        self.width = width
+        self.num_tokens = num_tokens
+
+    def get_inputs(self):
+        return [torch.randn(self.num_tokens, self.width, dtype=self.dtype)]
+
+    def get_pattern(self) -> Callable:
+        width = self.width
+
+        def pattern(x):
+            parts = torch.split(x, [width // 2, width - width // 2], dim=-1)
+            return torch.cat(parts, dim=-1)
+
+        return pattern
+
+    def get_replacement(self) -> Callable:
+        def replacement(x):
+            return x * 1.0
+
+        return replacement
+
+
+def _build_graph(width: int, num_tokens: int = 4) -> torch.fx.GraphModule:
+    def fn(x):
+        parts = torch.split(x, [width // 2, width - width // 2], dim=-1)
+        return torch.cat(parts, dim=-1)
+
+    x = torch.randn(num_tokens, width)
+    return make_fx(fn, tracing_mode="real")(x)
+
+
+def _register(pattern: ToySplitCatPattern, pm_pass: pm.PatternMatcherPass) -> None:
+    # Mock the nge registration: the toy pattern must not leak into the
+    # process-global npugraph_ex/torchair registry on NPU runners.
+    with mock.patch.object(base_pattern.nge, "register_replacement"):
+        pattern.register(pm_pass)
+
+
+def _apply(pm_pass: pm.PatternMatcherPass, graph: torch.fx.GraphModule) -> int:
+    applied = pm_pass.apply(graph)
+    graph.recompile()
+    return applied
+
+
+def test_width_mismatch_is_gracefully_rejected():
+    # Target-sized variant (width 64) applied to a draft-sized graph
+    # (width 40): the old code let ValueError escape from check_fn's
+    # re-trace and crash the whole compilation.
+    pm_pass = pm.PatternMatcherPass()
+    _register(ToySplitCatPattern(_fake_vllm_config(), width=64), pm_pass)
+
+    graph = _build_graph(width=40)
+    try:
+        applied = _apply(pm_pass, graph)
+    except ValueError as e:
+        pytest.fail(f"ValueError escaped the graceful rejection path: {e}")
+    assert applied == 0
+
+
+def test_width_match_still_fuses():
+    pm_pass = pm.PatternMatcherPass()
+    _register(ToySplitCatPattern(_fake_vllm_config(), width=64), pm_pass)
+
+    graph = _build_graph(width=64)
+    assert _apply(pm_pass, graph) == 1
+    # The split is gone; only the replacement op remains.
+    target_ops = {n.target.__name__ if callable(n.target) else str(n.target) for n in graph.graph.nodes}
+    assert not any("split" in op for op in target_ops), target_ops
+
+
+def test_target_and_draft_variants_coexist_in_one_global_pass():
+    # FULL mode compiles both models through one process-global pass; both
+    # width variants must be registered (the class+eps-only dedup key used
+    # to silently drop the draft-sized registration) and both graphs fuse.
+    pm_pass = pm.PatternMatcherPass()
+    _register(ToySplitCatPattern(_fake_vllm_config(), width=64), pm_pass)
+    _register(ToySplitCatPattern(_fake_vllm_config(), width=40), pm_pass)
+
+    target_graph = _build_graph(width=64)
+    draft_graph = _build_graph(width=40)
+    assert _apply(pm_pass, target_graph) == 1
+    assert _apply(pm_pass, draft_graph) == 1
+
+
+def test_same_shape_reregistration_is_deduplicated():
+    pm_pass = pm.PatternMatcherPass()
+    _register(ToySplitCatPattern(_fake_vllm_config(), width=64), pm_pass)
+    with mock.patch.object(pm, "register_replacement") as torch_register:
+        _register(ToySplitCatPattern(_fake_vllm_config(), width=64), pm_pass)
+    torch_register.assert_not_called()
+
+
+def test_unguarded_pattern_crashes_on_mismatch_anchors_the_regression():
+    # Anchor: with a plain (unguarded) search_fn, the very same setup lets
+    # ValueError escape PatternMatcherPass.apply -- this is the original
+    # "Split sizes add up to 6144 but got the tensor's size of 4096"
+    # crash. It proves the mismatched graph does structurally match, so the
+    # graceful rejection above is the guard working, not a missed match.
+    pm_pass = pm.PatternMatcherPass()
+    unguarded = ToySplitCatPattern(_fake_vllm_config(), width=64)
+    with (
+        mock.patch.object(base_pattern.nge, "register_replacement"),
+        mock.patch.object(base_pattern, "_wrap_search_fn_with_width_guard", side_effect=lambda f, *a, **k: f),
+    ):
+        unguarded.register(pm_pass)
+
+    graph = _build_graph(width=40)
+    with pytest.raises(ValueError, match="[Ss]plit sizes"):
+        pm_pass.apply(graph)
+
+
+def test_search_fn_wrapper_preserves_signature():
+    def search_fn(x, bias):
+        return x
+
+    wrapped = base_pattern._wrap_search_fn_with_width_guard(search_fn, "x", 64, "Toy")
+    import inspect
+
+    assert list(inspect.signature(wrapped).parameters) == ["x", "bias"]
+
+
+def test_search_fn_guard_raises_runtime_error_on_provable_mismatch():
+    def search_fn(x):
+        return x
+
+    wrapped = base_pattern._wrap_search_fn_with_width_guard(search_fn, "x", 64, "Toy")
+    with pytest.raises(RuntimeError, match="declining to apply"):
+        wrapped(torch.randn(2, 40))
+    # Width match and non-tensor args fall through to the original fn.
+    assert wrapped(torch.randn(2, 64)).shape == (2, 64)

--- a/tests/ut/compilation/test_base_pattern_shape_scoping.py
+++ b/tests/ut/compilation/test_base_pattern_shape_scoping.py
@@ -63,7 +63,7 @@ def _import_base_pattern():
         return bp
     except ImportError:
         stub = types.ModuleType("npugraph_ex")
-        stub.register_replacement = lambda **kwargs: None
+        stub.register_replacement = lambda **kwargs: None  # type: ignore[attr-defined]
         sys.modules.setdefault("npugraph_ex", stub)
         import vllm_ascend.compilation.passes.base_pattern as bp
 
@@ -89,7 +89,9 @@ def _fake_vllm_config(dtype=torch.float32):
     return types.SimpleNamespace(model_config=types.SimpleNamespace(dtype=dtype))
 
 
-class ToySplitCatPattern(BasePattern):
+class ToySplitCatPattern(BasePattern):  # type: ignore[misc, valid-type]
+    # (mypy cannot statically resolve BasePattern, which is imported from a
+    # function-returned module to stub the NPU backend when absent)
     """cat(split(x, [w/2, w/2])) with sizes baked from the input width.
 
     Structurally matches graphs of any width (torch's initial match ignores
@@ -232,7 +234,7 @@ def test_matched_width_unresolvable_symbolic_returns_none():
     # as unverifiable (None -> reject-on-unknown) instead of letting bool()
     # raise inside the caller's conditional and crash the compilation.
     sym_width = mock.MagicMock()
-    sym_width.__eq__.return_value = _UnresolvableBool()
+    sym_width.__eq__.return_value = _UnresolvableBool()  # type: ignore[attr-defined]
 
     fake_val = mock.MagicMock(spec=torch.Tensor)  # passes isinstance check
     fake_val.dim.return_value = 2

--- a/tests/ut/compilation/test_base_pattern_shape_scoping.py
+++ b/tests/ut/compilation/test_base_pattern_shape_scoping.py
@@ -221,6 +221,31 @@ def test_search_fn_wrapper_preserves_signature():
     assert list(inspect.signature(wrapped).parameters) == ["x", "bias"]
 
 
+class _UnresolvableBool:
+    def __bool__(self):
+        raise RuntimeError("GuardOnDataDependentSymNode: data-dependent symbol")
+
+
+def test_matched_width_unresolvable_symbolic_returns_none():
+    # Symbolic shapes: val.shape[-1] is a SymInt whose comparison yields a
+    # SymBool that cannot be statically resolved. The guard must treat that
+    # as unverifiable (None -> reject-on-unknown) instead of letting bool()
+    # raise inside the caller's conditional and crash the compilation.
+    sym_width = mock.MagicMock()
+    sym_width.__eq__.return_value = _UnresolvableBool()
+
+    fake_val = mock.MagicMock(spec=torch.Tensor)  # passes isinstance check
+    fake_val.dim.return_value = 2
+    fake_val.shape.__getitem__.return_value = sym_width
+
+    fake_node = mock.MagicMock()
+    fake_node.meta = {"val": fake_val}
+    fake_match = mock.MagicMock()
+    fake_match.kwargs = {"x": fake_node}
+
+    assert base_pattern._matched_main_input_has_expected_width(fake_match, "x", 64) is None
+
+
 def test_search_fn_guard_raises_runtime_error_on_provable_mismatch():
     def search_fn(x):
         return x

--- a/vllm_ascend/compilation/passes/base_pattern.py
+++ b/vllm_ascend/compilation/passes/base_pattern.py
@@ -63,7 +63,15 @@ def _matched_main_input_has_expected_width(match: Match, main_argname: str, expe
     val = main_node.meta.get("val")
     if not isinstance(val, torch.Tensor) or val.dim() < 2:
         return None
-    return val.shape[-1] == expected_width
+    try:
+        return bool(val.shape[-1] == expected_width)
+    except Exception:
+        # Symbolic widths (SymInt) compare to a SymBool that may not be
+        # statically resolvable (e.g. GuardOnDataDependentSymNode); bool()
+        # would raise inside the caller's conditional and crash the
+        # compilation. Treat as unverifiable and reject the match
+        # (reject-on-unknown), mirroring _wrap_search_fn_with_width_guard.
+        return None
 
 
 def _wrap_search_fn_with_width_guard(

--- a/vllm_ascend/compilation/passes/base_pattern.py
+++ b/vllm_ascend/compilation/passes/base_pattern.py
@@ -1,10 +1,31 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import functools
+import hashlib
+import inspect
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 
 import torch
 import torch._inductor.pattern_matcher as pm
-from torch._inductor.pattern_matcher import PatternMatcherPass
+from torch._inductor.pattern_matcher import Match, PatternMatcherPass
 from vllm.config import VllmConfig
+from vllm.logger import logger
 
 try:
     import npugraph_ex as nge
@@ -15,6 +36,85 @@ from vllm_ascend.compilation.passes.utils.npugraph_ex_utils_check import extra_s
 
 # Global set to track registered patterns and prevent duplicates
 _registered_patterns: set[str] = set()
+
+
+def _example_inputs_signature(example_inputs: list) -> str:
+    parts = []
+    for inp in example_inputs:
+        if isinstance(inp, torch.Tensor):
+            parts.append(f"{tuple(inp.shape)}:{inp.dtype}")
+        else:
+            parts.append(type(inp).__name__)
+    return ",".join(parts)
+
+
+def _matched_main_input_has_expected_width(match: Match, main_argname: str, expected_width: int) -> bool | None:
+    """Shape guard against cross-model pattern application.
+
+    Returns True/False when the matched main input's last-dim width is
+    verifiable from the match, and None when it is not (in which case the
+    caller rejects the match to stay on the safe side).
+    """
+    if not hasattr(match, "kwargs"):
+        return None
+    main_node = match.kwargs.get(main_argname)
+    if main_node is None or not hasattr(main_node, "meta"):
+        return None
+    val = main_node.meta.get("val")
+    if not isinstance(val, torch.Tensor) or val.dim() < 2:
+        return None
+    return val.shape[-1] == expected_width
+
+
+def _wrap_search_fn_with_width_guard(
+    search_fn: Callable,
+    main_argname: str,
+    expected_width: int,
+    pattern_name: str,
+) -> Callable:
+    """Guard a pattern search function against cross-model application.
+
+    torch's pattern_matcher verifies a structurally matched pattern by
+    re-tracing search_fn with the real shapes from the matched graph (the
+    check_fn wrapper created by register_replacement). Shape mismatches
+    surface during that re-trace as tensor-op errors; e.g. split_with_sizes
+    raises "Split sizes add up to X but got the tensor's size of Y" as a
+    ValueError, which check_fn does NOT catch (it only catches RuntimeError),
+    so the error escapes and kills the whole compilation. This is exactly how
+    a target-sized fusion pattern crashes the spec-decode draft model's graph
+    in FULL (npugraph_ex) mode, where the pattern registry is process-global.
+
+    Raising RuntimeError ourselves when the main input's width provably
+    differs turns the crash into torch's designed graceful rejection path
+    (check_fn -> log_trace_failure -> return False): the pattern is skipped
+    for that graph and compilation proceeds. The guard only fires when the
+    width is a concrete int that definitely mismatches; symbolic or unknown
+    widths fall through to the original re-trace verification.
+    """
+    params = list(inspect.signature(search_fn).parameters)
+    if main_argname not in params:
+        return search_fn
+    main_idx = params.index(main_argname)
+
+    @functools.wraps(search_fn)
+    def guarded(*args, **kwargs):
+        if main_idx < len(args):
+            tensor = args[main_idx]
+            shape = getattr(tensor, "shape", None)
+            if shape is not None and len(shape) > 0:
+                try:
+                    width_matches = bool(shape[-1] == expected_width)
+                except Exception:
+                    width_matches = None
+                if width_matches is False:
+                    raise RuntimeError(
+                        f"{pattern_name}: main input '{main_argname}' has width {shape[-1]}, "
+                        f"but this pattern instance was registered for width {expected_width} "
+                        "(another model configuration); declining to apply"
+                    )
+        return search_fn(*args, **kwargs)
+
+    return guarded
 
 
 class BasePattern(ABC):
@@ -38,26 +138,111 @@ class BasePattern(ABC):
     def get_extra_stream_scope_check(self):
         return extra_stream_scope_check
 
+    def _get_main_input_info(self, example_inputs: list[torch.Tensor]) -> tuple[str | None, int | None]:
+        """Find (argname, last-dim width) of the widest >=2-D example input.
+
+        The widest input is the main activation of the pattern (e.g. the fused
+        qkv tensor for QKNormRope patterns). Its width is the shape identity
+        used by the registration guard: the target model and the spec-decode
+        draft model differ exactly in this width.
+        """
+        argnames = list(inspect.signature(self.get_pattern()).parameters.keys())
+        main_argname: str | None = None
+        main_width: int | None = None
+        for argname, inp in zip(argnames, example_inputs):
+            if isinstance(inp, torch.Tensor) and inp.dim() >= 2:
+                if main_width is None or inp.shape[-1] > main_width:
+                    main_argname = argname
+                    main_width = inp.shape[-1]
+        return main_argname, main_width
+
+    def get_extra_check(self, main_argname: str | None = None, expected_width: int | None = None) -> Callable:
+        stream_scope_check = self.get_extra_stream_scope_check()
+        if main_argname is None or expected_width is None:
+            return stream_scope_check
+
+        pattern_name = self.__class__.__name__
+
+        def check_with_shape_guard(match: Match) -> bool:
+            if not stream_scope_check(match):
+                return False
+            width_matches = _matched_main_input_has_expected_width(match, main_argname, expected_width)
+            if width_matches is None:
+                # Cannot verify the input width from this match (unexpected
+                # Match flavor). Reject rather than risk applying a pattern
+                # baked with another model's shapes: a wrong fusion here
+                # crashes compilation, while skipping it only loses fusion.
+                logger.debug(
+                    "Rejecting %s pattern: main input width not verifiable from match",
+                    pattern_name,
+                )
+                return False
+            if not width_matches:
+                logger.debug(
+                    "Rejecting %s pattern: main input width != %d (pattern registered for another model)",
+                    pattern_name,
+                    expected_width,
+                )
+                return False
+            return True
+
+        return check_with_shape_guard
+
     def register(self, pm_pass: PatternMatcherPass) -> None:
-        # Create a unique identifier for this pattern based on class name and eps
-        pattern_id = f"{self.__class__.__name__}_{self.eps}"
+        pattern_fn = self.get_pattern()
+        replacement_fn = self.get_replacement()
+        example_inputs = self.get_inputs()
+
+        # The pattern id must include the example-input shapes. The target
+        # model and the spec-decode draft model instantiate the same pattern
+        # classes with different head configurations, and a class+eps-only id
+        # silently drops the second model's registration. Since the
+        # npugraph_ex/torchair replacement registry is process-global, the
+        # first-registered (target-sized) pattern then gets applied to the
+        # draft graph and crashes with e.g. "Split sizes add up to 6144 but
+        # got the tensor's size of 4096".
+        signature = _example_inputs_signature(example_inputs)
+        pattern_id = f"{self.__class__.__name__}_{self.eps}_{signature}"
 
         # Skip registration if this pattern has already been registered globally
         if pattern_id in _registered_patterns:
             return
 
-        pattern_fn = self.get_pattern()
-        replacement_fn = self.get_replacement()
-        example_inputs = self.get_inputs()
+        main_argname, main_width = self._get_main_input_info(example_inputs)
+
+        # Wrap the search function with a width guard BEFORE registration so
+        # that re-trace verification of a cross-model match raises RuntimeError
+        # (caught by pattern_matcher's check_fn) instead of letting tensor ops
+        # fail with e.g. ValueError, which escapes and crashes compilation.
+        if main_argname is not None and main_width is not None:
+            pattern_fn = _wrap_search_fn_with_width_guard(pattern_fn, main_argname, main_width, self.__class__.__name__)
+
+        # Unique closure names per shape keep the target and draft variants
+        # distinct in registries that key patterns by function name.
+        shape_tag = hashlib.md5(signature.encode(), usedforsecurity=False).hexdigest()[:8]
+        pattern_fn.__name__ = f"{pattern_fn.__name__}_{shape_tag}"
+        replacement_fn.__name__ = f"{replacement_fn.__name__}_{shape_tag}"
 
         pm.register_replacement(pattern_fn, replacement_fn, example_inputs, pm.fwd_only, pm_pass)
 
-        nge.register_replacement(
-            search_fn=pattern_fn,
-            replace_fn=replacement_fn,
-            example_inputs=example_inputs,
-            extra_check=self.get_extra_stream_scope_check(),
-        )
+        try:
+            nge.register_replacement(
+                search_fn=pattern_fn,
+                replace_fn=replacement_fn,
+                example_inputs=example_inputs,
+                extra_check=self.get_extra_check(main_argname, main_width),
+            )
+        except RuntimeError as e:
+            if "Duplicate pattern" in str(e):
+                logger.warning(
+                    "Pattern %s (eps=%s, inputs=%s) was rejected by the npugraph_ex/torchair "
+                    "registry as a duplicate; matching graphs will run unfused.",
+                    self.__class__.__name__,
+                    self.eps,
+                    signature,
+                )
+            else:
+                raise
 
         # Mark this pattern as registered
         _registered_patterns.add(pattern_id)


### PR DESCRIPTION
### What this PR does / why we need it?
With two models compiled in the same process (spec decode target + draft model) under `cudagraph_mode=FULL`, deployment crashed with:

```
ValueError: Split sizes add up to 6144 but got the tensor's size of 4096
```

(6144 = target qkv width; 4096 = draft qkv width.) Three contributing causes, all fixed in `BasePattern.register` so every fusion pass (qknorm_rope, norm_quant, allreduce_rmsnorm, muls_add, sequence_parallelism) benefits:

1. **Registration dedup key lacked model shape identity.** The npugraph_ex replacement registry is process-global, but the dedup key was `class-name + eps`. The target model registered its width-6144 variant first and the draft model's registration was silently dropped; the target-sized pattern then applied to the draft graph. The dedup key now includes an example-inputs shape signature so each model registers its own variant.
2. **Shape mismatch escaped torch's graceful rejection path.** `pattern_matcher`'s `check_fn` verifies a structurally matched pattern by re-tracing `search_fn` with real shapes, but only catches `RuntimeError`; `split` raises `ValueError`, which escaped and killed the whole compilation. The search_fn is now wrapped with a width guard that raises `RuntimeError` on a provable main-input width mismatch, landing in torch's designed graceful rejection path (pattern skipped, compilation proceeds). Symbolic/unknown widths fall through to the original re-trace verification; `functools.wraps` keeps the signature intact for `argnames_static`.
3. **nge duplicate-registration tolerance.** `nge.register_replacement` "Duplicate pattern" failures are downgraded to a warning, and pattern/replacement closures get a shape-hash name suffix so shape-keyed registries keep both variants.

Result: target and draft variants coexist in the process-global registry; each graph fuses with its own variant and the wrong one is gracefully declined — both models keep their fusions (a disable-registration workaround would lose both).
### Does this PR introduce _any_ user-facing change?
No. Internal compilation robustness fix; default behavior for single-model compilation is unchanged.
### How was this patch tested?
- Unit tests added: `tests/ut/compilation/test_base_pattern_shape_scoping.py` — replicates the crash and the fix on CPU through the real torch `PatternMatcherPass` path using a toy `cat(split(...))` pattern whose split sizes are baked from the example-input width (mirroring the QKNormRope qkv split):
  - the unguarded anchor test still raises the original `ValueError` (proving the mismatched graph does structurally match);
  - the guarded variant is declined with `applied == 0` and no exception;
  - width-matched graphs still fuse (`applied == 1`, split eliminated);
  - two width variants coexist in one process-global pass and both graphs fuse;
  - same-shape re-registration is deduplicated; wrapper signature is preserved.
- Verified on Ascend 910B3 (v0.22.1rc1 baseline) end to end: draft_model + FULL deploys and serves with both models fused (debug logs show the wrong variant being declined, the right one applied).
- Reproduced on the official v0.23.0 tag (Qwen3-8B + Qwen3-0.6B, FULL): traceback frame-identical to the above (`nge pattern_pass_manager.apply_pass` → `pattern_matcher check_fn` re-trace → `qknorm_rope_fusion_pass` split → `ValueError` escapes). With this patch applied on the v0.23.0 tag, compilation passes the crash point and proceeds to graph capture, unblocking the next failure (the `update_stream` AttributeError fixed by the companion PR).

> Note: developed with AI assistance (GLM-5.3); human-reviewed, human-validated on hardware.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
