### PR TITLE
fix(tool-parser): handle DeepSeek V4 DSML streams

### DIFF
--- a/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
+++ b/tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py
@@ -4,6 +4,7 @@ import json
 from unittest.mock import MagicMock
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.parser.abstract_parser import DelegatingParser
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
 
 from vllm_ascend.patch.platform import patch_deepseek_v4_tool_call_parser
@@ -343,9 +344,443 @@ def test_composed_schema_conversion_in_streaming():
     }
 
 
+def test_non_streaming_incomplete_dsml_does_not_leak_into_content():
+    parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+    model_output = (
+        "hello\n"
+        f"{TC_START}\n"
+        f'{INV_START}plan_trip">\n'
+        f'{PARAM_START}notes" string="true">unfinished'
+    )
+
+    result = parser.extract_tool_calls(
+        model_output,
+        ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+        ),
+    )
+
+    assert not result.tools_called
+    assert result.tool_calls == []
+    assert result.content == "hello\n"
+    assert "<｜DSML｜" not in result.content
+
+
+def test_non_streaming_keeps_complete_invoke_without_outer_end():
+    parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+    model_output = (
+        "hello\n"
+        f"{TC_START}\n"
+        f'{INV_START}plan_trip">\n'
+        f'{PARAM_START}days" string="false">3{PARAM_END}\n'
+        f"{INV_END}"
+    )
+
+    result = parser.extract_tool_calls(
+        model_output,
+        ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+        ),
+    )
+
+    assert result.tools_called
+    assert result.content == "hello\n"
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "plan_trip"
+    assert json.loads(result.tool_calls[0].function.arguments) == {"days": 3}
+
+
+def test_terminal_parse_flushes_plain_text_and_resets_parser():
+    parser = DelegatingParser(MOCK_TOKENIZER)
+    tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+    parser.tool_parser = tool_parser
+
+    delta = parser.parse_delta(
+        "hello world",
+        [1],
+        ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+        ),
+        prompt_token_ids=[],
+        finished=True,
+    )
+
+    assert delta is not None
+    assert delta.content == "hello world"
+    assert tool_parser._buffer == ""
+    assert not tool_parser._in_tool_calls
+
+
+def test_terminal_parse_keeps_complete_invoke_without_outer_end():
+    parser = DelegatingParser(MOCK_TOKENIZER)
+    tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+    parser.tool_parser = tool_parser
+    model_output = (
+        f"{TC_START}\n"
+        f'{INV_START}plan_trip">\n'
+        f'{PARAM_START}days" string="false">3{PARAM_END}\n'
+        f"{INV_END}"
+    )
+
+    delta = parser.parse_delta(
+        model_output,
+        [1],
+        ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+        ),
+        prompt_token_ids=[],
+        finished=True,
+    )
+
+    assert delta is not None
+    assert delta.content is None
+    assert delta.tool_calls
+    assert json.loads(delta.tool_calls[0].function.arguments) == {"days": 3}
+    assert tool_parser._buffer == ""
+    assert not tool_parser._in_tool_calls
+
+
+def test_terminal_parse_discards_incomplete_dsml_residue_without_force_close():
+    parser = DelegatingParser(MOCK_TOKENIZER)
+    tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+    parser.tool_parser = tool_parser
+    model_output = (
+        "hello\n"
+        f"{TC_START}\n"
+        f'{INV_START}plan_trip">\n'
+        f'{PARAM_START}notes" string="true">unfinished'
+    )
+
+    delta = parser.parse_delta(
+        model_output,
+        [1],
+        ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+        ),
+        prompt_token_ids=[],
+        finished=True,
+    )
+
+    assert delta is not None
+    assert delta.content == "hello\n"
+    assert "<｜DSML｜" not in delta.content
+    arguments = "".join(
+        tool_call.function.arguments or ""
+        for tool_call in delta.tool_calls or []
+        if tool_call.function
+    )
+    assert arguments == '{"notes":"unfinished'
+    assert tool_parser._buffer == ""
+    assert not tool_parser._in_tool_calls
+    assert tool_parser._active_tool_index is None
+
+
+def test_terminal_parse_with_dsml_only_never_returns_raw_content():
+    parser = DelegatingParser(MOCK_TOKENIZER)
+    tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+    parser.tool_parser = tool_parser
+    model_output = f"{TC_START}\n{INV_START}plan_trip\">"
+
+    delta = parser.parse_delta(
+        model_output,
+        [1],
+        ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+        ),
+        prompt_token_ids=[],
+        finished=True,
+    )
+
+    assert delta is not None
+    assert delta.content in (None, "")
+    assert not delta.content or "<｜DSML｜" not in delta.content
+    assert tool_parser._buffer == ""
+    assert not tool_parser._in_tool_calls
+
+
+def test_streaming_without_reasoning_or_prompt_ids_never_returns_raw_dsml_content():
+    for tool_choice in (None, "auto"):
+        parser = DelegatingParser(MOCK_TOKENIZER)
+        tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+        parser.tool_parser = tool_parser
+        request = ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+            tool_choice=tool_choice,
+        )
+        model_output = (
+            f"{TC_START}\n"
+            f'{INV_START}plan_trip">\n'
+            f'{PARAM_START}notes" string="true">unfinished'
+        )
+
+        first_delta = parser.parse_delta(
+            model_output,
+            [1],
+            request,
+            prompt_token_ids=None,
+            finished=False,
+        )
+        terminal_delta = parser.parse_delta(
+            "",
+            [],
+            request,
+            prompt_token_ids=None,
+            finished=True,
+        )
+
+        content = "".join(
+            delta.content or ""
+            for delta in (first_delta, terminal_delta)
+            if delta is not None
+        )
+        arguments = "".join(
+            tool_call.function.arguments or ""
+            for delta in (first_delta, terminal_delta)
+            if delta is not None
+            for tool_call in delta.tool_calls or []
+            if tool_call.function
+        )
+        assert content == ""
+        assert "<｜DSML｜" not in content
+        assert arguments == '{"notes":"unfinished'
+        assert tool_parser._buffer == ""
+        assert not tool_parser._in_tool_calls
+
+
+def test_configured_reasoning_parser_does_not_receive_split_dsml():
+    for tool_choice in (None, "auto"):
+        parser = DelegatingParser(MOCK_TOKENIZER)
+        reasoning_parser = MagicMock()
+        tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+        parser.reasoning_parser = reasoning_parser
+        parser.tool_parser = tool_parser
+        # Mirror the real combined parser: the DeepSeek V4 tool parser is not
+        # engine-based, so DelegatingParser retains text history across chunks.
+        parser._engine_based = False
+        parser._stream_state.engine_based = False
+        request = ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tools=[_tools()],
+            tool_choice=tool_choice,
+        )
+        model_output = (
+            f"{TC_START}\n"
+            f'{INV_START}plan_trip">\n'
+            f'{PARAM_START}notes" string="true">unfinished'
+        )
+
+        deltas = []
+        for char in model_output:
+            delta = parser.parse_delta(
+                char,
+                [1],
+                request,
+                prompt_token_ids=None,
+                finished=False,
+            )
+            if delta is not None:
+                deltas.append(delta)
+        terminal_delta = parser.parse_delta(
+            "",
+            [],
+            request,
+            prompt_token_ids=None,
+            finished=True,
+        )
+        if terminal_delta is not None:
+            deltas.append(terminal_delta)
+
+        content = "".join(delta.content or "" for delta in deltas)
+        arguments = "".join(
+            tool_call.function.arguments or ""
+            for delta in deltas
+            for tool_call in delta.tool_calls or []
+            if tool_call.function
+        )
+        assert content == ""
+        assert "<｜DSML｜" not in content
+        assert arguments == '{"notes":"unfinished'
+        reasoning_parser.extract_reasoning_streaming.assert_not_called()
+        assert tool_parser._buffer == ""
+        assert not tool_parser._in_tool_calls
+
+
+def test_unrequested_tool_calls_discard_dsml_without_content_leak():
+    request_cases = (
+        (None, "none"),
+        ([_tools()], "none"),
+        (None, "auto"),
+    )
+    model_outputs = (
+        (
+            f"{TC_START}\n"
+            f'{INV_START}read">\n'
+            f'{PARAM_START}filepath" string="true">unfinished'
+        ),
+        (
+            f"{TC_START}\n"
+            f'{INV_START}read">\n'
+            f'{PARAM_START}filepath" string="true">complete{PARAM_END}\n'
+            f"{INV_END}\n{TC_END}"
+        ),
+    )
+
+    for tools, tool_choice in request_cases:
+        for model_output in model_outputs:
+            chunk_sizes = (1, 7, len(model_output))
+            cases = (
+                (chunk_size, reasoning_ended)
+                for chunk_size in chunk_sizes
+                for reasoning_ended in (False, True)
+            )
+            for chunk_size, reasoning_ended in cases:
+                parser = DelegatingParser(MOCK_TOKENIZER)
+                reasoning_parser = MagicMock()
+                parser.reasoning_parser = reasoning_parser
+                tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+                parser.tool_parser = tool_parser
+                parser._engine_based = False
+                parser._stream_state.engine_based = False
+                parser._stream_state.reasoning_ended = reasoning_ended
+                request = ChatCompletionRequest(
+                    model="deepseek-ai/DeepSeek-V2-Chat",
+                    messages=[],
+                    tools=tools,
+                    tool_choice=tool_choice,
+                )
+
+                deltas = []
+                for start in range(0, len(model_output), chunk_size):
+                    delta = parser.parse_delta(
+                        model_output[start : start + chunk_size],
+                        [1],
+                        request,
+                        prompt_token_ids=None,
+                        finished=False,
+                    )
+                    if delta is not None:
+                        deltas.append(delta)
+                terminal_delta = parser.parse_delta(
+                    "",
+                    [],
+                    request,
+                    prompt_token_ids=None,
+                    finished=True,
+                )
+                if terminal_delta is not None:
+                    deltas.append(terminal_delta)
+
+                content = "".join(delta.content or "" for delta in deltas)
+                tool_calls = [
+                    tool_call
+                    for delta in deltas
+                    for tool_call in delta.tool_calls or []
+                ]
+                assert content == ""
+                assert "<｜DSML｜" not in content
+                assert tool_calls == []
+                assert request.tool_choice == tool_choice
+                reasoning_parser.extract_reasoning_streaming.assert_not_called()
+                assert tool_parser._buffer == ""
+                assert not tool_parser._in_tool_calls
+
+
+def test_tool_choice_none_without_tools_preserves_plain_content():
+    parser = DelegatingParser(MOCK_TOKENIZER)
+    tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+    parser.tool_parser = tool_parser
+    request = ChatCompletionRequest(
+        model="deepseek-ai/DeepSeek-V2-Chat",
+        messages=[],
+        tool_choice="none",
+    )
+    model_output = "ordinary answer containing DSML <"
+    deltas = []
+
+    for char in model_output:
+        delta = parser.parse_delta(
+            char,
+            [1],
+            request,
+            prompt_token_ids=None,
+            finished=False,
+        )
+        if delta is not None:
+            deltas.append(delta)
+    terminal_delta = parser.parse_delta(
+        "",
+        [],
+        request,
+        prompt_token_ids=None,
+        finished=True,
+    )
+    if terminal_delta is not None:
+        deltas.append(terminal_delta)
+
+    assert "".join(delta.content or "" for delta in deltas) == model_output
+    assert not any(delta.tool_calls for delta in deltas)
+
+
+def test_terminal_partial_outer_dsml_start_is_discarded():
+    for prefix_len in range(2, len(TC_START)):
+        parser = DelegatingParser(MOCK_TOKENIZER)
+        tool_parser = DeepSeekV4ToolParser(MOCK_TOKENIZER)
+        parser.tool_parser = tool_parser
+        request = ChatCompletionRequest(
+            model="deepseek-ai/DeepSeek-V2-Chat",
+            messages=[],
+            tool_choice="none",
+        )
+        deltas = []
+
+        for char in TC_START[:prefix_len]:
+            delta = parser.parse_delta(
+                char,
+                [1],
+                request,
+                prompt_token_ids=None,
+                finished=False,
+            )
+            if delta is not None:
+                deltas.append(delta)
+        terminal_delta = parser.parse_delta(
+            "",
+            [],
+            request,
+            prompt_token_ids=None,
+            finished=True,
+        )
+        if terminal_delta is not None:
+            deltas.append(terminal_delta)
+
+        content = "".join(delta.content or "" for delta in deltas)
+        assert content == ""
+        assert not any(delta.tool_calls for delta in deltas)
+        assert tool_parser._buffer == ""
+
+
 def test_registered_parser_is_patch_loaded():
     # Regression check that Ascend patch applies at import-time.
     assert (
         DeepSeekV4ToolParser.extract_tool_calls_streaming
         is patch_deepseek_v4_tool_call_parser._patched_extract_tool_calls_streaming
+    )
+    assert (
+        DelegatingParser.parse_delta
+        is patch_deepseek_v4_tool_call_parser._patched_delegating_parse_delta
     )

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_tool_call_parser.py
@@ -35,6 +35,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     FunctionCall,
     ToolCall,
 )
+from vllm.parser.abstract_parser import DelegatingParser
 from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
 
 ESCAPED_ARGUMENTS_PARAM_NAME = "__vllm_param_arguments__"
@@ -350,11 +351,22 @@ def _patched_extract_tool_calls(
     if self.tool_call_start_token not in model_output:
         return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=model_output)
 
+    first_tool_idx = model_output.find(self.tool_call_start_token)
+    content = model_output[:first_tool_idx] if first_tool_idx > 0 else None
+
     try:
         _ensure_parser_regexes(self)
         tool_calls = []
-        for tool_call_match in self.tool_call_complete_regex.findall(model_output):
-            for invoke_name, invoke_content in self.invoke_complete_regex.findall(tool_call_match):
+        block_start = first_tool_idx
+        while block_start != -1:
+            payload_start = block_start + len(self.tool_call_start_token)
+            block_end = model_output.find(self.tool_call_end_token, payload_start)
+            if block_end == -1:
+                tool_call_payload = model_output[payload_start:]
+            else:
+                tool_call_payload = model_output[payload_start:block_end]
+
+            for invoke_name, invoke_content in self.invoke_complete_regex.findall(tool_call_payload):
                 params = _parse_invoke_params(self, invoke_content, request, invoke_name)
                 tool_calls.append(
                     ToolCall(
@@ -366,18 +378,23 @@ def _patched_extract_tool_calls(
                     )
                 )
 
-        if not tool_calls:
-            return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=model_output)
+            if block_end == -1:
+                break
+            block_start = model_output.find(
+                self.tool_call_start_token,
+                block_end + len(self.tool_call_end_token),
+            )
 
-        first_tool_idx = model_output.find(self.tool_call_start_token)
-        content = model_output[:first_tool_idx] if first_tool_idx > 0 else None
+        if not tool_calls:
+            return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=content)
+
         return ExtractedToolCallInformation(
             tools_called=True,
             tool_calls=tool_calls,
             content=content,
         )
     except Exception:
-        return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=model_output)
+        return ExtractedToolCallInformation(tools_called=False, tool_calls=[], content=content)
 
 
 def _reset_streaming_state(self: DeepSeekV4ToolParser) -> None:
@@ -446,6 +463,62 @@ def _pop_pending_delta_message(self: DeepSeekV4ToolParser) -> DeltaMessage | Non
 
     content = "".join(content_parts) or None
     return DeltaMessage(content=content, tool_calls=list(merged_tool_calls.values()))
+
+
+def _merge_delta_messages(
+    first: DeltaMessage | None,
+    second: DeltaMessage | None,
+) -> DeltaMessage | None:
+    if first is None:
+        return second
+    if second is None:
+        return first
+
+    content = None
+    if first.content is not None or second.content is not None:
+        content = (first.content or "") + (second.content or "")
+
+    reasoning = None
+    if first.reasoning is not None or second.reasoning is not None:
+        reasoning = (first.reasoning or "") + (second.reasoning or "")
+
+    merged_tool_calls: dict[int, DeltaToolCall] = {}
+    for message in (first, second):
+        for tool_call in message.tool_calls or []:
+            index = tool_call.index
+            function = tool_call.function
+            if index not in merged_tool_calls:
+                merged_tool_calls[index] = DeltaToolCall(
+                    index=index,
+                    id=tool_call.id,
+                    type=tool_call.type,
+                    function=DeltaFunctionCall(
+                        name=function.name if function else None,
+                        arguments=function.arguments if function else None,
+                    ),
+                )
+                continue
+
+            merged = merged_tool_calls[index]
+            if tool_call.id is not None:
+                merged.id = tool_call.id
+            if tool_call.type is not None:
+                merged.type = tool_call.type
+            if function is None:
+                continue
+            if merged.function is None:
+                merged.function = DeltaFunctionCall()
+            if function.name is not None:
+                merged.function.name = function.name
+            if function.arguments is not None:
+                merged.function.arguments = (merged.function.arguments or "") + function.arguments
+
+    return DeltaMessage(
+        role=second.role or first.role,
+        content=content,
+        reasoning=reasoning,
+        tool_calls=list(merged_tool_calls.values()),
+    )
 
 
 def _queue_delta_message(self: DeepSeekV4ToolParser, message: DeltaMessage | None) -> None:
@@ -742,6 +815,57 @@ def _process_streaming_buffer(self: DeepSeekV4ToolParser, request: ChatCompletio
         self._streaming_param_mode = "string" if is_string else "json"
 
 
+def _finish_streaming(
+    self: DeepSeekV4ToolParser,
+    request: ChatCompletionRequest | None = None,
+) -> DeltaMessage | None:
+    _ensure_streaming_attrs(self)
+    _process_streaming_buffer(self, request)
+    pending_delta = _pop_pending_delta_message(self)
+
+    if not self._in_tool_calls:
+        start_overlap = _partial_tag_overlap(self._buffer, self.tool_call_start_token)
+        if start_overlap == len(self._buffer) and start_overlap > 1:
+            # The model stopped after beginning the outer DSML marker but
+            # before completing ``<｜DSML｜tool_calls>``.  A lone ``<`` is still
+            # valid ordinary content and must be flushed; two or more exact
+            # marker-prefix characters are specific enough to discard safely.
+            self._buffer = ""
+        if self._buffer:
+            pending_delta = _merge_delta_messages(
+                pending_delta,
+                DeltaMessage(content=self._buffer),
+            )
+            self._buffer = ""
+        return pending_delta
+
+    # Anything left in the buffer belongs to an unfinished DSML structure.
+    # It must never be exposed as ordinary response content.
+    self._buffer = ""
+
+    active_index = self._active_tool_index
+    if active_index is not None:
+        # Do not force-close an incomplete invoke or parameter. Remove its
+        # bookkeeping so DelegatingParser cannot append a fabricated `{}`.
+        for values in (
+            self.prev_tool_call_arr,
+            self.streamed_args_for_tool,
+            self._args_started,
+        ):
+            if active_index < len(values):
+                del values[active_index:]
+        self.current_tool_index = active_index
+
+    self._streaming_param_mode = None
+    self._streaming_param_key = None
+    self._streaming_param_raw_parts.clear()
+    self._active_tool_index = None
+    self._active_tool_name = None
+    self._in_tool_calls = False
+
+    return pending_delta
+
+
 def _patched_extract_tool_calls_streaming(
     self: DeepSeekV4ToolParser,
     previous_text: str,
@@ -767,6 +891,182 @@ def _patched_extract_tool_calls_streaming(
         return DeltaMessage(content="")
 
     return None
+
+
+_original_delegating_parse_delta = DelegatingParser.parse_delta
+
+
+def _request_suppresses_tool_calls(request: Any) -> bool:
+    return getattr(request, "tool_choice", None) == "none" or not bool(
+        getattr(request, "tools", None)
+    )
+
+
+def _discard_unrequested_tool_call_deltas(
+    delta_message: DeltaMessage | None,
+    *,
+    suppress_tool_calls: bool,
+) -> DeltaMessage | None:
+    if delta_message is not None and suppress_tool_calls:
+        delta_message.tool_calls = []
+    return delta_message
+
+
+def _call_original_delegating_parse_delta(
+    self: DelegatingParser,
+    delta_text: str,
+    delta_token_ids: list[int],
+    request: Any,
+    prompt_token_ids: list[int] | None,
+    *,
+    finished: bool,
+    suppress_tool_calls: bool,
+) -> DeltaMessage | None:
+    # Upstream treats ``tool_choice='none'`` as an instruction to bypass the
+    # tool parser and return delta_text verbatim.  DeepSeek V4 can still emit
+    # DSML in this situation.  Route through the parser as if auto parsing was
+    # selected, then remove every structured tool delta before returning.
+    original_tool_choice = getattr(request, "tool_choice", None)
+    if suppress_tool_calls:
+        request.tool_choice = None
+    try:
+        delta_message = _original_delegating_parse_delta(
+            self,
+            delta_text,
+            delta_token_ids,
+            request,
+            prompt_token_ids,
+            finished=finished,
+        )
+    finally:
+        if suppress_tool_calls:
+            request.tool_choice = original_tool_choice
+
+    return _discard_unrequested_tool_call_deltas(
+        delta_message,
+        suppress_tool_calls=suppress_tool_calls,
+    )
+
+
+def _patched_delegating_parse_delta(
+    self: DelegatingParser,
+    delta_text: str,
+    delta_token_ids: list[int],
+    request: Any,
+    prompt_token_ids: list[int] | None = None,
+    *,
+    finished: bool,
+) -> DeltaMessage | None:
+    tool_parser = getattr(self, "_tool_parser", None)
+    prefix_delta = None
+    state = self._stream_state
+    suppress_tool_calls = isinstance(
+        tool_parser, DeepSeekV4ToolParser
+    ) and _request_suppresses_tool_calls(request)
+
+    if isinstance(tool_parser, DeepSeekV4ToolParser):
+        reasoning_parser = getattr(self, "_reasoning_parser", None)
+
+        # With no reasoning parser there is no reasoning phase to wait for.
+        if reasoning_parser is None:
+            state.reasoning_ended = True
+
+        # DeepSeek V4 servers normally configure both the reasoning parser and
+        # the tool parser.  A response may nevertheless start directly with a
+        # DSML tool call.  Hold back only a possible split start marker; once a
+        # complete marker is present, route it to the tool parser before the
+        # reasoning parser can expose it through ``delta.content``.
+        is_auto_tool_request = bool(getattr(request, "tools", None)) and getattr(
+            request, "tool_choice", None
+        ) in (None, "auto")
+        should_probe_for_dsml = is_auto_tool_request or suppress_tool_calls
+        if reasoning_parser is not None and not state.reasoning_ended and should_probe_for_dsml:
+            probe_text = getattr(self, "_deepseek_v4_dsml_probe_text", "") + delta_text
+            probe_token_ids = getattr(self, "_deepseek_v4_dsml_probe_token_ids", []) + list(
+                delta_token_ids
+            )
+            start_token = tool_parser.tool_call_start_token
+            start_idx = probe_text.find(start_token)
+
+            if start_idx == -1:
+                overlap = _partial_tag_overlap(probe_text, start_token)
+                if overlap and not finished:
+                    self._deepseek_v4_dsml_probe_text = probe_text
+                    self._deepseek_v4_dsml_probe_token_ids = probe_token_ids
+                    return None
+
+                # No DSML marker was found.  Flush ordinary text normally.  At
+                # EOS, discard only the suffix that is still an exact partial
+                # DSML marker, because it cannot be retracted after emission.
+                if overlap:
+                    probe_text = probe_text[:-overlap]
+                delta_text = probe_text
+                delta_token_ids = probe_token_ids
+            else:
+                text_before_dsml = probe_text[:start_idx]
+                if text_before_dsml:
+                    prefix_delta = _original_delegating_parse_delta(
+                        self,
+                        text_before_dsml,
+                        [],
+                        request,
+                        prompt_token_ids,
+                        finished=False,
+                    )
+
+                # The prefix has already gone through reasoning extraction.
+                # Start the tool phase with a clean text history so it receives
+                # the DSML marker exactly once.
+                state.previous_text = ""
+                state.previous_token_ids = []
+                state.reasoning_ended = True
+                state.prompt_reasoning_checked = True
+                state.tool_call_text_started = False
+                delta_text = probe_text[start_idx:]
+                delta_token_ids = probe_token_ids
+
+            self._deepseek_v4_dsml_probe_text = ""
+            self._deepseek_v4_dsml_probe_token_ids = []
+
+    if not finished or not isinstance(tool_parser, DeepSeekV4ToolParser):
+        delta_message = _merge_delta_messages(
+            prefix_delta,
+            _call_original_delegating_parse_delta(
+                self,
+                delta_text,
+                delta_token_ids,
+                request,
+                prompt_token_ids,
+                finished=finished,
+                suppress_tool_calls=suppress_tool_calls,
+            ),
+        )
+        return delta_message
+
+    delta_message = _call_original_delegating_parse_delta(
+        self,
+        delta_text,
+        delta_token_ids,
+        request,
+        prompt_token_ids,
+        finished=False,
+        suppress_tool_calls=suppress_tool_calls,
+    )
+    delta_message = _merge_delta_messages(prefix_delta, delta_message)
+    finish_delta = tool_parser.finish_streaming(request)
+    finish_delta = _discard_unrequested_tool_call_deltas(
+        finish_delta,
+        suppress_tool_calls=suppress_tool_calls,
+    )
+    delta_message = _merge_delta_messages(delta_message, finish_delta)
+
+    try:
+        self._append_unstreamed_tool_args(delta_message)
+        return delta_message
+    finally:
+        self._deepseek_v4_dsml_probe_text = ""
+        self._deepseek_v4_dsml_probe_token_ids = []
+        tool_parser._reset_streaming_state()
 
 
 # Backward-compatible monkey patches.
@@ -799,4 +1099,6 @@ DeepSeekV4ToolParser._finish_buffered_wrapper_param = _finish_buffered_wrapper_p
 DeepSeekV4ToolParser._close_streaming_tool_call = _close_streaming_tool_call
 DeepSeekV4ToolParser._safe_content_len_before_tag_end = _safe_content_len_before_tag_end
 DeepSeekV4ToolParser._process_streaming_buffer = _process_streaming_buffer
+DeepSeekV4ToolParser.finish_streaming = _finish_streaming
 DeepSeekV4ToolParser.extract_tool_calls_streaming = _patched_extract_tool_calls_streaming
+DelegatingParser.parse_delta = _patched_delegating_parse_delta


### PR DESCRIPTION
## What this PR does / why we need it?

DeepSeek V4 may emit a DSML tool-call block before the reasoning parser reaches the completed state. When DSML markers are split across streaming chunks, or generation ends with an incomplete DSML structure, the raw DSML content may be exposed as normal response content or the tool call may be parsed incorrectly.

This PR improves DeepSeek V4 DSML handling by:

- Routing complete DSML blocks to the tool parser before the reasoning parser exposes them as content.
- Supporting DSML markers and tool arguments split across streaming chunks.
- Correctly finalizing complete tool calls when the outer DSML end marker is missing.
- Discarding incomplete DSML residue at the end of generation instead of leaking it into response content.
- Avoiding fabricated empty arguments for incomplete tool calls.
- Suppressing DSML tool calls when tools are not requested or `tool_choice="none"`.
- Preserving ordinary text that appears before a DSML tool-call block.

This PR is limited to DSML parsing behavior. It does not change the default `reasoning_effort` value.

## Does this PR introduce any user-facing change?

Yes. DeepSeek V4 streaming and non-streaming responses no longer expose incomplete or unrequested DSML markup as normal content, and valid DSML tool calls are parsed more reliably.

## How was this patch tested?

Unit coverage was added for:

- Chunked tool names and arguments.
- DSML markers split across streaming chunks.
- Responses that enter the tool phase without reasoning content.
- Complete and incomplete DSML structures at the end of generation.
- Requests without tools and requests using `tool_choice="none"`.
- Streaming and non-streaming parsing behavior.

Test file:

`tests/ut/patch/platform/test_patch_deepseek_v4_tool_call_parser.py`

Static checks completed:

- `ruff check`
- `python -m compileall`
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
