### PR TITLE
[v0.26.0rc][BugFix][MoE] Restore FlashComm1 shared expert DP default

### DIFF
--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy.py
@@ -68,8 +68,8 @@ DEEPSEEK_V4_PROMPTS = [
     "What is the meaning of life?",
 ]
 
-# The routed-expert SwiGLU clamp changes the second continuation (#14397).
-DEEPSEEK_V4_GOLDEN = ["Hello, my name is {name} and I", "What is the meaning of life?', 'What is the"]
+# FlashComm1 defaults shared experts to DP; this continuation matches that path.
+DEEPSEEK_V4_GOLDEN = ["Hello, my name is {name} and I", 'What is the meaning of life?",\n    "What is']
 
 
 @dataclass(frozen=True)

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -413,7 +413,22 @@ class TestAscendConfig(TestBase):
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_flashcomm1_does_not_enable_shared_expert_dp(self, mock_check_and_update_config):
+    def test_flashcomm1_defaults_to_shared_expert_dp(self, mock_check_and_update_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.parallel_config.tensor_parallel_size = 2
+        test_vllm_config.parallel_config.enable_expert_parallel = True
+        test_vllm_config.additional_config = {
+            "enable_flashcomm1": True,
+        }
+
+        ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertTrue(ascend_config.enable_flashcomm1)
+        self.assertTrue(ascend_config.enable_shared_expert_dp)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_explicit_shared_expert_tp_overrides_flashcomm_default(self, mock_check_and_update_config):
         test_vllm_config = VllmConfig()
         test_vllm_config.parallel_config.tensor_parallel_size = 2
         test_vllm_config.parallel_config.enable_expert_parallel = True

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -98,8 +98,9 @@ class AscendConfig:
             os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend"),
         )
 
+        enable_shared_expert_dp = additional_config.get("enable_shared_expert_dp", self.enable_flashcomm1)
         self.enable_shared_expert_dp = (
-            additional_config.get("enable_shared_expert_dp", False)
+            enable_shared_expert_dp
             and vllm_config.parallel_config.enable_expert_parallel
             and vllm_config.parallel_config.tensor_parallel_size > 1
         )


### PR DESCRIPTION
## What changed

- Restore the historical behavior that FlashComm1 defaults shared experts to data parallelism when `enable_shared_expert_dp` is not set.
- Preserve the explicit override: users can set `enable_shared_expert_dp: false` to use shared-expert TP.

## Why

#12950 decoupled the two options and changed the implicit default to `false`. Existing FlashComm1 deployments that relied on the previous default therefore silently switched their shared experts from DP to TP.

This PR only restores the compatibility default. It does not change the shared-expert execution or stream ordering paths.

## Validation

- `python -m pytest -q tests/ut/test_ascend_config.py`: 41 passed
- Added coverage for the FlashComm1 default and the explicit `false` override.
- A5 8-card startup and 2k/1k serving validation completed with shared-expert DP enabled.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
