### PR TITLE
feat(api): default dsv4 thinking settings

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -269,6 +269,9 @@ curl http://<node0_ip>:8900/v1/chat/completions \
     }'
 ```
 
+For requests with `"model": "dsv4"`, omitted `thinking` and `reasoning_effort` fields default to
+`{"type": "enabled"}` and `"high"`, respectively. Explicitly supplied values are preserved.
+
 Expected Result:
 
 The service returns HTTP 200 OK with a JSON response containing the `choices` field.

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -455,6 +455,9 @@ curl http://<node0_ip>:8900/v1/chat/completions \
     }'
 ```
 
+For requests with `"model": "dsv4"`, omitted `thinking` and `reasoning_effort` fields default to
+`{"type": "enabled"}` and `"high"`, respectively. Explicitly supplied values are preserved.
+
 Expected Result:
 
 The service returns HTTP 200 OK with a JSON response containing the `choices` field.

--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
+import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.tokenizers import deepseek_v4
 
@@ -12,6 +15,52 @@ class FakeTokenizer:
 
     def encode(self, text, add_special_tokens=False, **kwargs):
         return text
+
+
+def _parse_chat_request(model: str, **extra_fields):
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": "hi"}],
+        **extra_fields,
+    }
+    return ChatCompletionRequest.model_validate_json(json.dumps(payload))
+
+
+def test_dsv4_request_adds_thinking_defaults():
+    request = _parse_chat_request("dsv4")
+    params = request.build_chat_params(None, "auto")
+
+    assert request.thinking == {"type": "enabled"}
+    assert request.reasoning_effort == "high"
+    assert params.chat_template_kwargs["enable_thinking"] is True
+
+
+@pytest.mark.parametrize(
+    ("provided_fields", "expected_thinking", "expected_reasoning_effort"),
+    [
+        ({"thinking": {"type": "disabled"}}, {"type": "disabled"}, "high"),
+        ({"reasoning_effort": "low"}, {"type": "enabled"}, "low"),
+        (
+            {"thinking": None, "reasoning_effort": None},
+            None,
+            None,
+        ),
+    ],
+)
+def test_dsv4_request_preserves_provided_fields(
+    provided_fields, expected_thinking, expected_reasoning_effort
+):
+    request = _parse_chat_request("dsv4", **provided_fields)
+
+    assert request.thinking == expected_thinking
+    assert request.reasoning_effort == expected_reasoning_effort
+
+
+def test_request_defaults_only_apply_to_dsv4():
+    request = _parse_chat_request("another-model")
+
+    assert "thinking" not in request.model_dump()
+    assert request.reasoning_effort is None
 
 
 def test_deepseek_v4_reasoning_effort_accepts_latest_values():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -320,7 +320,23 @@
 #       Remove this patch if upstream streaming behavior is updated to satisfy the
 #       same DeepSeek DSML incrementality contract.
 #
-# ** 12a. File: platform/patch_minimax_m2_tool_call_parser.py**
+# ** 12a. File: platform/patch_deepseek_v4_request_defaults.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionRequest`
+#    Why:
+#       Requests for the served model name `dsv4` should use thinking mode by
+#       default when callers omit DeepSeek's thinking controls.
+#    How:
+#       Extend request pre-validation to fill a missing `thinking` object with
+#       `{"type": "enabled"}` and a missing `reasoning_effort` with `"high"`,
+#       without overriding caller-provided values.
+#    Related PR (if no, explain why):
+#       No, this is a deployment-specific default for the `dsv4` served name.
+#    Future Plan:
+#       Remove this patch when the default is configurable through a stable vLLM
+#       request-default hook.
+#
+# ** 12b. File: platform/patch_minimax_m2_tool_call_parser.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.tool_parsers.minimax_m2_tool_parser.MinimaxM2ToolParser`
 #    Why:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -16,14 +16,13 @@
 
 import os
 
-from vllm_ascend import envs
-
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_kv_cache_utils  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
+from vllm_ascend import envs
 from vllm_ascend.utils import is_310p, vllm_version_is
 
 if envs.VLLM_ASCEND_LOPT_ENABLE:
@@ -33,8 +32,9 @@ if not is_310p():
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa
 else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
-import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_request_defaults  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
+import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 
 if vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_request_defaults.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_request_defaults.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+
+DSV4_SERVED_MODEL_NAME = "dsv4"
+DSV4_DEFAULT_REASONING_EFFORT = "high"
+DSV4_DEFAULT_THINKING_TYPE = "enabled"
+
+
+_request_normalizer = ChatCompletionRequest.__pydantic_decorators__.model_validators[
+    "_normalize_messages_before"
+]
+_original_request_normalizer = _request_normalizer.func
+
+
+def _normalize_dsv4_request_before(data: Any) -> Any:
+    if isinstance(data, dict) and data.get("model") == DSV4_SERVED_MODEL_NAME:
+        data.setdefault("thinking", {"type": DSV4_DEFAULT_THINKING_TYPE})
+        data.setdefault("reasoning_effort", DSV4_DEFAULT_REASONING_EFFORT)
+    return _original_request_normalizer(data)
+
+
+_request_normalizer.func = _normalize_dsv4_request_before
+ChatCompletionRequest.model_rebuild(force=True)


### PR DESCRIPTION
## What this PR does / why we need it?

This PR defines the default thinking behavior for requests using the served model name `"dsv4"`.

A pre-validation patch is added to `ChatCompletionRequest`. When a request uses `"model": "dsv4"` and omits the DeepSeek thinking controls, the following defaults are applied:

- `thinking` defaults to `{"type": "enabled"}`.
- `reasoning_effort` defaults to `"high"`.

The patch uses `setdefault`, so explicitly provided values are preserved. This includes values such as:

- `thinking={"type": "disabled"}`
- `reasoning_effort="low"`
- Explicit `null` values

Requests using other model names are not modified.

The patch is registered during platform patch initialization, and the default behavior is documented in the DeepSeek V4 Flash and DeepSeek V4 Pro deployment guides.

This PR only changes the default DSV4 request settings. It does not include any DSML tool-parser changes.

## Does this PR introduce any user-facing change?

Yes.

For requests containing `"model": "dsv4"`, omitting `thinking` and `reasoning_effort` now enables thinking and selects `"high"` reasoning effort by default.

Explicitly supplied values continue to take precedence, and requests for other model names remain unchanged.

## How was this patch tested?

Unit coverage was added for:

- Applying both defaults when the fields are omitted.
- Preserving an explicitly disabled `thinking` value.
- Preserving an explicitly provided `reasoning_effort`.
- Preserving explicit `null` values.
- Ensuring the defaults only apply to `"dsv4"`.
- Verifying that the resulting chat parameters enable thinking.

Test file:

`tests/ut/patch/platform/test_deepseek_v4_thinking.py`

Static checks completed:

- `ruff check`
- `python -m compileall`
- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
