### PR TITLE
[BugFix][Performance] Avoid dtype-converting valid token count copies

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -882,6 +882,45 @@ class TestNPUModelRunnerDebugger(unittest.TestCase):
         self.assertFalse(hasattr(runner, "_execution_start_time"))
 
 
+class TestCopyValidSampledTokenCount(unittest.TestCase):
+    class _HostBufferSpy:
+        def __init__(self, host_tensor):
+            self.dtype = host_tensor.dtype
+            self.received_tensor = None
+
+        def __getitem__(self, _key):
+            return self
+
+        def copy_(self, device_tensor, non_blocking=False):
+            self.received_tensor = device_tensor
+
+    @patch("torch.npu.stream", new=MagicMock())
+    @patch("torch.npu.current_stream", new=MagicMock())
+    def test_normalizes_device_counts_to_host_buffer_dtype(self):
+        dtype_cases = (
+            (torch.int32, torch.int64),
+            (torch.int64, torch.int32),
+        )
+        for device_dtype, host_dtype in dtype_cases:
+            with self.subTest(device_dtype=device_dtype, host_dtype=host_dtype):
+                runner = NPUModelRunner.__new__(NPUModelRunner)
+                runner.valid_sampled_token_count_event = MagicMock()
+                runner.valid_sampled_token_count_copy_stream = MagicMock()
+                host_buffer = self._HostBufferSpy(torch.empty(2, dtype=host_dtype))
+                runner.valid_sampled_token_count_cpu = host_buffer
+                runner.use_async_spec_decode = False
+                runner.input_batch = SimpleNamespace(prev_sampled_token_ids=None)
+
+                device_counts = torch.tensor([1, 3], dtype=device_dtype)
+                next_token_ids = torch.tensor([11, 22], dtype=torch.int64)
+                runner._copy_valid_sampled_token_count(next_token_ids, device_counts)
+
+                received_counts = host_buffer.received_tensor
+                assert received_counts is not None
+                # D2H copy must receive the target dtype to avoid an implicit cast.
+                self.assertEqual(received_counts.dtype, host_buffer.dtype)
+
+
 class TestCorrectOptimisticSeqLensCpu(unittest.TestCase):
     """Regression tests for async spec-decode seq_lens correction.
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1434,11 +1434,13 @@ class NPUModelRunner(GPUModelRunner):
         # Initialize a new stream to overlap the copy operation with
         # prepare_input of draft model.
         default_stream = torch.npu.current_stream()
-        with torch.npu.stream(self.valid_sampled_token_count_copy_stream): 
+        with torch.npu.stream(self.valid_sampled_token_count_copy_stream):
             self.valid_sampled_token_count_copy_stream.wait_stream(default_stream)
-            counts = valid_sampled_tokens_count
             counts_cpu = self.valid_sampled_token_count_cpu
             assert counts_cpu is not None
+            # Proposers may return different integer dtypes. Normalize on device
+            # because a dtype-converting D2H copy_ forces a host sync.
+            counts = valid_sampled_tokens_count.to(dtype=counts_cpu.dtype)
             counts_cpu[: counts.shape[0]].copy_(counts, non_blocking=True)
             self.valid_sampled_token_count_event.record()
 


### PR DESCRIPTION
### What this PR does / why we need it?

This is a follow-up to #10205.

#10205 changed `self.valid_sampled_token_count_cpu` to `torch.int64` to avoid an implicit dtype conversion during the asynchronous D2H copy for the MTP path. However, the shared copy helper also receives `torch.int32` ‎`valid_sampled_tokens_count` from other proposers:

- [triton_ngram_spec_decode](https://github.com/vllm-project/vllm-ascend/blob/9c3cf949db9dd352d21c9d4d31468d2958e0a953/vllm_ascend/ops/triton/spec_decode/ngram.py#L228-L259) returns `valid_sampled_tokens_count` as a view of the `torch.int32` output workspace:
    ```python
  base = torch.empty(..., dtype=torch.int32, device=device)
  valid_sampled_tokens_count = base[2 * batch_size : 3 * batch_size]
  ```
- [AscendExtractHiddenStatesProposer.prepare_next_token_ids_padded](https://github.com/vllm-project/vllm-ascend/blob/9c3cf949db9dd352d21c9d4d31468d2958e0a953/vllm_ascend/spec_decode/extract_hidden_states_proposer.py#L193-L198) explicitly converts the count to `torch.int32`:
   ```python
   valid_sampled_tokens_count = is_valid.to(torch.int32)
   ```
- These two return values are passed directly to `_copy_valid_sampled_token_count` at the [N-gram call site](https://github.com/vllm-project/vllm-ascend/blob/9c3cf949db9dd352d21c9d4d31468d2958e0a953/vllm_ascend/worker/model_runner_v1.py#L1744-L1760) and the [ExtractHiddenStates call site](https://github.com/vllm-project/vllm-ascend/blob/9c3cf949db9dd352d21c9d4d31468d2958e0a953/vllm_ascend/worker/model_runner_v1.py#L1805-L1814), respectively.

Those paths can therefore still trigger a dtype-converting D2H copy, which forces a host synchronization and defeats the side-stream overlap.

This PR normalizes the count tensor to the host buffer dtype on the NPU copy stream before calling `copy_(..., non_blocking=True)`. The original device tensor is retained for GPU-side async-spec-decode correction.

A regression test covers both `int32 -> int64` and `int64 -> int32` source/target dtype combinations and verifies that the tensor passed to the D2H copy matches the host buffer dtype.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added `TestCopyValidSampledTokenCount::test_normalizes_device_counts_to_host_buffer_dtype` covering both `int32 -> int64` and `int64 -> int32` source/target combinations.
- Relevant speculative-decoding E2E coverage is selected by CI.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
