### PR TITLE
fix(csrc): avoid monolithic opapi link on A5

### DIFF
--- a/csrc/CMakeLists.txt
+++ b/csrc/CMakeLists.txt
@@ -97,8 +97,8 @@ if (BUILD_OPEN_PROJECT)
             -Wl,--whole-archive
             ops_aclnn
             -Wl,--no-whole-archive
-            -lopapi
             nnopbase
+            -Wl,-Bsymbolic
             profapi
             ge_common_base
             ascend_dump


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the legacy custom ACLNN link configuration on `releases/v0.18.0` for A5 builds:

- removes the direct dependency on the monolithic `libopapi.so`
- adds `-Wl,-Bsymbolic` so references inside `libcust_opapi.so` bind to the custom implementation

The monolithic opapi library also exports built-in ACLNN symbols. On A5, pulling it into a custom operator library can allow those symbols to shadow the custom definitions. The split CANN packaging used on A5 does not require this dependency for the tested operator.

The change is intentionally limited to the `csrc` link list.

### Does this PR introduce _any_ user-facing change?

Yes. A5 custom operator packages built through the v0.18 `csrc` framework no longer have a `DT_NEEDED` dependency on `libopapi.so`, avoiding the symbol interposition issue. There is no Python or ACLNN API change.

### How was this patch tested?

Validated on an Ascend950 A5 build host with CANN 9.1.0, using the `quant_lightning_indexer` and its `lightning_indexer` dependency from `cann/ops-transformer` as an external validation fixture.

Command under test:

```bash
bash csrc/build_aclnn.sh <vllm-ascend-source> ascend950
```

Results:

- baseline v0.18 package built successfully and `readelf -d libcust_opapi.so` showed `NEEDED libopapi.so`
- patched package built and installed successfully, including all four Ascend950 kernel variants
- the patched `libcust_opapi.so` has no `libopapi.so` dependency and has the ELF `SYMBOLIC` flag
- `aclnnQuantLightningIndexer`, `aclnnQuantLightningIndexerGetWorkspaceSize`, `aclnnLightningIndexer`, and `aclnnLightningIndexerGetWorkspaceSize` are exported
- `ldd` reported all dependencies resolved
- after sourcing the generated `set_env.bash`, `ctypes.CDLL("libcust_opapi.so")` loaded the installed library by name and resolved it from the custom OPP install directory

The external operator sources and their v0.18 compatibility adapter were used only for validation and are not included in this PR.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
