### PR TITLE
[v0.25.1rc][BugFix][MoE] Keep fused MC2 on legacy dispatch path

### DIFF
--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -170,6 +170,7 @@ def test_select_moe_comm_method_a2_uses_mc2_within_capacity(monkeypatch, num_tok
     ("num_tokens", "ep_world_size", "expected"),
     [
         (128, 8, MoECommType.FUSED_MC2),
+        (4097, 64, MoECommType.ALLTOALL),
         (128, 128, MoECommType.MC2),
         (4097, 8, MoECommType.FUSED_MC2),
         (4097, 128, MoECommType.ALLTOALL),

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -1,4 +1,3 @@
-import importlib.util
 import math
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -40,7 +39,9 @@ _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES = {
     "quanttype.w4a8",
 }
 
-_MEGA_MOE_SUPPORTED = importlib.util.find_spec("cann_ops_transformer") is not None
+# Keep v0.25 on the legacy dispatch_ffn_combine path. Installing CANN 9.1
+# must not implicitly enable MegaMoe on this release branch.
+_MEGA_MOE_SUPPORTED = False
 _MEGA_MOE_TOKENS_PER_RANK_LIMIT = 4096
 _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT = 512
 _MC2_TOKENS_PER_RANK_LIMIT = 512


### PR DESCRIPTION
### What this PR does / why we need it?

CANN 9.1 installs `cann_ops_transformer`, so the v0.25 fused-MC2 path automatically switches from the legacy `dispatch_ffn_combine` implementation to CANN MegaMoe. That changes the runtime implementation solely because the image was upgraded and exposes the buffer-capacity failure described in #14273.

For the v0.25 release branch, enabling MegaMoe implicitly is too risky. This PR keeps the release on its previously validated behavior:

- Treat MegaMoe as unsupported on v0.25 regardless of whether `cann_ops_transformer` is installed.
- Preserve `enable_fused_mc2=1` on the legacy `dispatch_ffn_combine` path for EP sizes up to 32.
- Preserve the existing MC2/ALLTOALL fallback for larger EP sizes instead of applying the legacy fused operator outside its supported range.
- Remove the now-unused runtime module probe and add an EP64 selector regression case.

This is a v0.25 release-policy decision, not a claim that MegaMoe is generally unsupported. Main and v0.26 can retain the MegaMoe fixes in #14439 and #14358.

Refs #14273.

Supersedes #14519.

### Does this PR introduce _any_ user-facing change?

Yes. Installing CANN 9.1 no longer implicitly enables MegaMoe on v0.25. Configurations with `enable_fused_mc2=1` and EP <= 32 continue to use the legacy `dispatch_ffn_combine` implementation, matching the CANN 9.0.1-era path. Larger EP configurations keep their existing MC2/ALLTOALL fallback.

### How was this patch tested?

- `pytest -q tests/ut/test_ascend_forward_context.py` (`26 passed`)
- `ruff check vllm_ascend/ascend_forward_context.py tests/ut/test_ascend_forward_context.py`
- `python3 -m py_compile vllm_ascend/ascend_forward_context.py tests/ut/test_ascend_forward_context.py`
- `git diff --check upstream/releases/v0.25.1rc...HEAD`

The exact runtime policy (`_MEGA_MOE_SUPPORTED = False`) was also validated on CANN 9.1 with a two-node DeepSeek V4 Flash W8A8 PD deployment. The short request and 477-token request passed, followed by three concurrency-16 rounds with 48/48 HTTP 200 responses. The request windows had no NaN, token-0, all-`-1`, `507035`, traceback, or EngineDead failure signature. A separate 32-rank HCCL all-reduce returned the expected value on every rank.

That runtime run used the same one-line policy change plus diagnostic-only logging. The final commit adds the release-policy comment, removes the unused import, and adds the focused unit test; the full two-node deployment was not repeated after packaging this commit.

- vLLM version: v0.25.1
- vLLM main: https://github.com/vllm-project/vllm/commit/fe784ff22e630a31fd798f392b01e0a75c18f047
