### PR TITLE
[CI][v0.26] test selection, ci-gate, and workflow cancellation improvements

### DIFF
--- a/.github/workflows/_analyze_failure.yaml
+++ b/.github/workflows/_analyze_failure.yaml
@@ -114,7 +114,7 @@ jobs:
 
       # ---- Step 4: Upload report ----
       - name: Upload failure analysis report
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: failure-analysis-report

--- a/.github/workflows/_manual-hitest.yaml
+++ b/.github/workflows/_manual-hitest.yaml
@@ -67,7 +67,7 @@ jobs:
           python3 .github/workflows/scripts/run_hitest.py
 
       - name: Upload recommended pytest paths artifact
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: recommended-pytest-paths
@@ -77,7 +77,7 @@ jobs:
 
       - name: Export hitest_paths output
         id: export-paths
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           FILE=".github/workflows/scripts/recommended_pytest_paths.txt"
           if [ -f "$FILE" ]; then

--- a/.github/workflows/_selected_tests.yaml
+++ b/.github/workflows/_selected_tests.yaml
@@ -318,7 +318,7 @@ jobs:
           retention-days: 7
 
       - name: Upload coverage data
-        if: ${{ always() && inputs.enable-coverage }}
+        if: ${{ !cancelled() && inputs.enable-coverage }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -329,7 +329,7 @@ jobs:
           compression-level: 0
 
       - name: Upload selected test logs
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -340,7 +340,7 @@ jobs:
           compression-level: 0
 
   upload-coverage-to-obs:
-      if: ${{ always() && inputs.enable-coverage }}
+      if: ${{ !cancelled() && inputs.enable-coverage }}
       needs: selected-tests
       runs-on: ubuntu-latest
       continue-on-error: true

--- a/.github/workflows/pr_e2e_command.yml
+++ b/.github/workflows/pr_e2e_command.yml
@@ -215,7 +215,7 @@ jobs:
   report:
     name: Report result
     needs: [e2e-test, trigger-selected-tests]
-    if: always() && needs.e2e-test.result == 'success' && needs.e2e-test.outputs.notify_comment_id != ''
+    if: ${{ !cancelled() && needs.e2e-test.result == 'success' && needs.e2e-test.outputs.notify_comment_id != '' }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Update comment with result

--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -231,7 +231,7 @@ jobs:
             .github/workflows/_build_csrc_cache.yaml \
             .github/workflows/scripts/csrc_cache_targets.json \
             .github/workflows/scripts/resolve_csrc_cache_targets.py; then
-            echo "::error::CSRC build workflows changed on $BASE_REF after this run was created."
+            echo "::error::CSRC build workflows changed on $BASE_REF, please rebase the code."
             echo "::error::Trigger a new PR workflow run."
             exit 1
           fi
@@ -242,6 +242,7 @@ jobs:
       - uses: dorny/paths-filter@v4
         id: filter
         with:
+          list-files: json
           filters: |
             src:
               - 'vllm_ascend/**'
@@ -262,7 +263,10 @@ jobs:
               - '.github/workflows/scripts/run_selected_tests.sh'
               - '.github/workflows/scripts/test_config.yaml'
               - '.github/workflows/scripts/runner_label.json'
-              - 'tests/**'
+              - 'tests/ut/**'
+              - 'tests/e2e/pull_request/**'
+              - 'tests/e2e/*.py'
+              - 'tests/e2e/*.sh'
               - 'tools/**'
               - 'CMakeLists.txt'
 
@@ -278,7 +282,8 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install regex
           python3 .github/workflows/scripts/select_tests.py \
-            --diff-base ${{ steps.source-snapshot.outputs.base_sha }}
+            --diff-base ${{ steps.source-snapshot.outputs.base_sha }} \
+            --filtered-changed-files-json '${{ steps.filter.outputs.src_files }}'
 
       - name: Set no-tests output when source paths unchanged
         id: noop
@@ -327,7 +332,6 @@ jobs:
       - ensure-csrc-cache
     if: >-
       ${{
-        always() &&
         needs.pre-commit.result == 'success' &&
         needs.select-tests.result == 'success' &&
         needs.select-tests.outputs.has_tests == 'true' &&
@@ -353,7 +357,6 @@ jobs:
       - ensure-csrc-cache
     if: >-
       ${{
-        always() &&
         needs.pre-commit.result == 'success' &&
         needs.select-tests.result == 'success' &&
         contains(github.event.pull_request.labels.*.name, 'ready') &&
@@ -447,7 +450,7 @@ jobs:
 
       - name: Export coverage paths output
         id: export-paths
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           FILE="recommended_pytest_paths.txt"
           if [ -f "$FILE" ]; then
@@ -466,10 +469,12 @@ jobs:
   # in GitHub branch protection rules instead of tracking individual matrix job names.
   ci-gate:
     needs: [pre-commit, select-tests, run-selected-tests]
-    if: ${{ always() && contains(github.event.pull_request.labels.*.name, 'ready') }}
+    if: ${{ !cancelled() }}
     runs-on: linux-amd64-cpu-2-hk
     steps:
       - name: Check all required jobs
+        env:
+          HAS_READY_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ready') }}
         run: |
           set -euo pipefail
 
@@ -482,17 +487,29 @@ jobs:
           echo "select-tests: ${SELECT_TESTS_RESULT}"
           echo "has_tests: ${HAS_TESTS}"
 
-          if [ "${PRE_COMMIT_RESULT}" != "success" ] && [ "${PRE_COMMIT_RESULT}" != "skipped" ]; then
+          if [ "${PRE_COMMIT_RESULT}" != "success" ]; then
             echo "::error::pre-commit did not succeed (result: ${PRE_COMMIT_RESULT})"
             exit 1
           fi
 
-          if [ "${SELECT_TESTS_RESULT}" != "success" ] && [ "${SELECT_TESTS_RESULT}" != "skipped" ]; then
+          if [ "${SELECT_TESTS_RESULT}" != "success" ]; then
             echo "::error::select-tests did not succeed (result: ${SELECT_TESTS_RESULT})"
             exit 1
           fi
 
+          # Even after successful test selection, only explicit true/false
+          # values are valid. A missing output must not mean no tests.
+          if [ "${HAS_TESTS}" != "true" ] && [ "${HAS_TESTS}" != "false" ]; then
+            echo "::error::Invalid or missing has_tests output: '${HAS_TESTS}'"
+            exit 1
+          fi
+
           if [ "${HAS_TESTS}" = "true" ]; then
+            if [ "${HAS_READY_LABEL}" != "true" ]; then
+              echo "::error::Selected tests are required; add the ready label"
+              exit 1
+            fi
+
             TESTS_RESULT="${{ needs.run-selected-tests.result }}"
             echo "run-selected-tests: ${TESTS_RESULT}"
             if [ "${TESTS_RESULT}" != "success" ]; then
@@ -509,7 +526,7 @@ jobs:
   analyze-failure-report:
     name: Analyze failure report
     needs: [run-selected-tests, recommend-tests-from-coverage]
-    if: always()
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/_analyze_failure.yaml
     with:
       log_artifact_pattern: selected-test-logs-*

--- a/.github/workflows/push_build_precommit_cache.yaml
+++ b/.github/workflows/push_build_precommit_cache.yaml
@@ -88,7 +88,7 @@ jobs:
           pre-commit run --all-files --hook-stage manual --show-diff-on-failure
 
       - name: Save pre-commit cache
-        if: always() && steps.check-cache.outputs.cache-hit != 'true'
+        if: ${{ !cancelled() && steps.check-cache.outputs.cache-hit != 'true' }}
         uses: runs-on/cache/save@v5
         with:
           path: /tmp/pre-commit-cache

--- a/.github/workflows/schedule_main2main.yaml
+++ b/.github/workflows/schedule_main2main.yaml
@@ -250,7 +250,6 @@ jobs:
           pip install uv pytest
 
       - name: Configure git identity
-        if: always()
         working-directory: ${{ github.workspace }}
         run: |
           set -eu
@@ -259,7 +258,7 @@ jobs:
           gh --version
 
       - name: Check npu and CANN info
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           npu-smi info || true
           if [ -d /usr/local/Ascend/ascend-toolkit/latest ]; then
@@ -509,7 +508,7 @@ jobs:
           fi
 
       - name: Upload workspace
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
@@ -520,7 +519,7 @@ jobs:
       - name: Summarize final status
         id: final-status
         working-directory: ${{ github.workspace }}
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           set -eu
           eval "${MAIN2MAIN_LOG_HELPERS}"

--- a/.github/workflows/schedule_update_estimated_times.yaml
+++ b/.github/workflows/schedule_update_estimated_times.yaml
@@ -153,7 +153,7 @@ jobs:
 
   update-estimated-times:
     needs: [run-tests-main, run-tests-release]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/scripts/select_tests.py
+++ b/.github/workflows/scripts/select_tests.py
@@ -36,12 +36,13 @@ Pipeline (PR-driven mode):
   5. Partition  -- split test groups across parallel runners by estimated time.
   6. Output     -- write test_groups / has_tests / matched_modules.
 
-Test-only optimization:
-  If a PR changes only files under ``tests/`` (no source code touched), the
-  module-matching step is bypassed. Only the ``default_cpu_ut`` module (which
-  is always-on) and the changed test files themselves are run. This avoids
-  the broad regression triggered by ``optional: false`` modules when the
-  intent of the PR is purely to add or adjust tests.
+Test/tool-scoped optimization:
+  In PR-driven mode, the workflow passes both the full diff and the changed
+  files matched by the PR test path filter. If the filtered files contain only
+  test paths and/or non-bisect ``tools`` paths, normal module matching is
+  bypassed. The selector runs ``default_cpu_ut`` and directly changed test
+  files. Files outside the PR test filter, such as nightly-only files and docs,
+  do not widen the test scope. Bisect changes retain their dedicated policy.
 
 Bisect-tool optimization:
   If a PR is scoped to ``tools/bisect`` and its paired UT/config/format files,
@@ -357,14 +358,17 @@ def _is_test_path(path: str) -> bool:
     return _is_ut_path(path) or _is_e2e_path(path)
 
 
-def _is_test_only_change(changed_files: list[str]) -> bool:
-    """Return True if *changed_files* contains only files under ``tests/``.
+def _is_cpu_ut_scoped_change(changed_files: list[str]) -> bool:
+    """Return True when PR-filtered changes only require CPU UT.
 
-    When a PR touches nothing but test files, there is no source change
-    requiring broad regression; only the changed tests (and the always-on
-    ``default_cpu_ut`` module) need to run.
+    The workflow removes files outside its source-path filter before passing
+    this list. Ordinary tools and test-only changes share the same broad CPU
+    UT coverage; bisect paths retain their dedicated selection policy.
     """
-    return bool(changed_files) and all(_is_test_path(f) for f in changed_files)
+    return bool(changed_files) and all(
+        _is_test_path(f) or (_matches_path_dependency(f, "tools") and not _is_bisect_tool_scoped_path(f))
+        for f in changed_files
+    )
 
 
 def _is_bisect_tool_scoped_path(file_path: str) -> bool:
@@ -733,6 +737,13 @@ def main():
         "to run a single test method.",
     )
     parser.add_argument(
+        "--filtered-changed-files-json",
+        type=str,
+        default=None,
+        help="JSON array containing changed files matched by the PR workflow path filter. "
+        "Used only for test-scoped detection and changed-test collection.",
+    )
+    parser.add_argument(
         "--config",
         type=Path,
         default=_CONFIG_PATH,
@@ -768,16 +779,26 @@ def main():
             _scan_e2e_test_dir(path, all_groups)
     else:
         changed_files = _get_changed_files(args.diff_base) if args.diff_base else args.changed_files
+        filtered_changed_files = changed_files
+        if args.filtered_changed_files_json is not None:
+            try:
+                filtered_changed_files = json.loads(args.filtered_changed_files_json)
+            except json.JSONDecodeError as exc:
+                parser.error(f"Invalid --filtered-changed-files-json: {exc}")
+            if not isinstance(filtered_changed_files, list) or not all(
+                isinstance(file_path, str) for file_path in filtered_changed_files
+            ):
+                parser.error("--filtered-changed-files-json must be a JSON array of strings")
         bisect_tool_scoped_change = _is_bisect_tool_scoped_change(changed_files)
-        test_only_change = _is_test_only_change(changed_files)
+        cpu_ut_scoped_change = _is_cpu_ut_scoped_change(filtered_changed_files)
         if bisect_tool_scoped_change:
             print(
                 "Detected bisect tool-scoped change: running only matching tool modules (skipping always-on modules).",
                 file=sys.stderr,
             )
-        elif test_only_change:
+        elif cpu_ut_scoped_change:
             print(
-                "Detected test-only change: running only default_cpu_ut"
+                "Detected CPU-UT-scoped change: running only default_cpu_ut"
                 " and the changed test files (skipping source-driven modules).",
                 file=sys.stderr,
             )
@@ -785,14 +806,14 @@ def main():
             matched_modules = [module["name"] for module in config]
         elif bisect_tool_scoped_change:
             matched_modules = _match_modules(changed_files, config, include_always=False)
-        elif test_only_change:
+        elif cpu_ut_scoped_change:
             matched_modules = [m["name"] for m in config if m["name"] == DEFAULT_CPU_UT_MODULE]
         else:
             matched_modules = _match_modules(changed_files, config)
         test_dirs, cpu_only_dirs = _collect_test_dirs(matched_modules, config)
 
         changed_test_files = []
-        for f in changed_files:
+        for f in filtered_changed_files:
             if not _is_test_path(f):
                 continue
             target = Path(_pytest_node_file_path(f))

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -706,7 +706,7 @@
     - tests/ut/tools/bisect
 
 - name: _tools
-  optional: false
+  optional: true
   source_file_dependencies:
     - tools/
   tests:

--- a/.github/workflows/scripts/test_select_tests.py
+++ b/.github/workflows/scripts/test_select_tests.py
@@ -119,6 +119,25 @@ def test_collect_paths_and_basic_path_helpers():
     assert select_tests._is_ut_path("tests/ut/a.py")
     assert select_tests._is_e2e_path("tests/e2e")
     assert select_tests._is_e2e_path("tests/e2e/a.py")
+    assert select_tests._is_cpu_ut_scoped_change(["tests/ut/test_x.py"])
+    assert not select_tests._is_cpu_ut_scoped_change(
+        [
+            "tests/e2e/pull_request/one_card/test_x.py",
+            ".github/workflows/schedule_nightly_test_a5.yaml",
+        ]
+    )
+    assert not select_tests._is_cpu_ut_scoped_change(["docs/source/developer_guide/testing.md"])
+    assert not select_tests._is_cpu_ut_scoped_change(["tests/ut/test_x.py", "vllm_ascend/worker/model_runner_v1.py"])
+    assert not select_tests._is_cpu_ut_scoped_change(["tests/ut/test_x.py", "csrc/build.sh"])
+    assert not select_tests._is_cpu_ut_scoped_change(["tests/ut/test_x.py", ".github/workflows/pr_test.yaml"])
+    assert select_tests._is_cpu_ut_scoped_change(["tools/docs_codegen/scanner.py"])
+    assert select_tests._is_cpu_ut_scoped_change(
+        ["tools/docs_codegen/scanner.py", "tests/ut/_tools/test_docs_codegen.py"]
+    )
+    assert select_tests._is_cpu_ut_scoped_change(["tools/docs_codegen/scanner.py", "tests/ut/test_envs.py"])
+    assert not select_tests._is_cpu_ut_scoped_change(["tools/docs_codegen/scanner.py", "vllm_ascend/envs.py"])
+    assert not select_tests._is_cpu_ut_scoped_change(["tools/bisect/runner.py"])
+    assert not select_tests._is_cpu_ut_scoped_change(["tools/bisect/runner.py", "tools/docs_codegen/scanner.py"])
     assert select_tests._configured_nodeid_targets_for_file(
         "tests/e2e/pull_request/two_card/test_split.py",
         nodeid_config,
@@ -475,10 +494,15 @@ def test_main_end_to_end_changed_files_options_and_skip(tmp_path, monkeypatch, c
             str(config_path),
             "--changed-files",
             "tests/e2e/pull_request/two_card/test_two_card.py",
+            ".github/workflows/schedule_nightly_test_a5.yaml",
+            "--filtered-changed-files-json",
+            json.dumps(["tests/e2e/pull_request/two_card/test_two_card.py"]),
         ],
     )
     select_tests.main()
-    out = capsys.readouterr().out
+    captured = capsys.readouterr()
+    assert "Detected CPU-UT-scoped change" in captured.err
+    out = captured.out
     groups_line = next(line for line in out.splitlines() if line.startswith("test_groups="))
     test_groups = json.loads(groups_line.removeprefix("test_groups="))
     selected_tests = set(test_groups[0]["tests"].split())
@@ -522,7 +546,7 @@ def test_bisect_tool_scoped_change_skips_global_modules(tmp_path, monkeypatch, c
         },
         {
             "name": "_tools",
-            "optional": False,
+            "optional": True,
             "source_file_dependencies": ["tools/"],
             "tests": ["tests/ut/_tools"],
         },
@@ -576,6 +600,31 @@ def test_bisect_tool_scoped_change_skips_global_modules(tmp_path, monkeypatch, c
     }
     assert "tests/ut/default/test_default.py" not in selected_tests
     assert "tests/e2e/pull_request/one_card/test_model.py" not in selected_tests
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "select_tests.py",
+            "--config",
+            str(config_path),
+            "--changed-files",
+            "tools/docs_codegen/scanner.py",
+            "tests/ut/_tools/test_base_tool.py",
+        ],
+    )
+    select_tests.main()
+    captured = capsys.readouterr()
+    assert "Detected CPU-UT-scoped change" in captured.err
+    assert "matched_modules=default_cpu_ut" in captured.out
+    groups_line = next(line for line in captured.out.splitlines() if line.startswith("test_groups="))
+    test_groups = json.loads(groups_line.removeprefix("test_groups="))
+    selected_tests = {test for group in test_groups for test in group["tests"].split()}
+    assert selected_tests == {
+        "tests/ut/_tools/test_base_tool.py",
+        "tests/ut/default/test_default.py",
+        "tests/ut/tools/bisect/test_auto_bisect.py",
+    }
 
 
 def test_default_cpu_ut_always_runs(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
### What this PR does / why we need it?
Backports three CI workflow improvements from `main` to the `releases/v0.26.0rc` branch:

1. **Improve workflow cancellation behavior (#13949)** — replaces the necessary failure-handling `always()` conditions with `!cancelled()` so artifact uploads and failure reports still run after a failure but are skipped on cancellation, and removes redundant `always()` conditions that should only run after their dependencies succeed.

2. **Enforce ready labels for selected PR tests (#14204)** — makes `ci-gate` fail closed: it now runs for every non-cancelled run, requires `pre-commit` and `select-tests` to succeed (no more `skipped` fallback), validates that `has_tests` is an explicit `true`/`false` (a missing output no longer means "no tests"), and requires the `ready` label plus a successful `run-selected-tests` whenever tests are selected. Adapted for the release branch, which has no a5 hardware — `has_tests_a5` / `ready-a5` / `run-selected-tests-a5` are not present and were intentionally omitted.

3. **Optimize PR test selection (#14298)** — limits the PR path filter to relevant UT/E2E paths (`tests/ut/**`, `tests/e2e/pull_request/**`, `tests/e2e/*.py`, `tests/e2e/*.sh`), passes the filtered changed-file list to `select_tests.py`, and uses it for lightweight (test-only / ordinary-tool) scope detection so files outside the filter (nightly workflows, docs) no longer widen the selected test scope. `_tools` becomes `optional: true` while bisect-specific behavior is preserved.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
