### PR TITLE
feat(api): default DeepSeek V4 thinking settings

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -269,6 +269,9 @@ curl http://<node0_ip>:8900/v1/chat/completions \
     }'
 ```
 
+DeepSeek V4 defaults to `reasoning_effort="high"` with thinking enabled, regardless
+of the served model name. Explicit non-null controls take precedence.
+
 Expected Result:
 
 The service returns HTTP 200 OK with a JSON response containing the `choices` field.

--- a/docs/source/tutorials/models/DeepSeek-V4-Pro.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Pro.md
@@ -455,6 +455,9 @@ curl http://<node0_ip>:8900/v1/chat/completions \
     }'
 ```
 
+DeepSeek V4 defaults to `reasoning_effort="high"` with thinking enabled, regardless
+of the served model name. Explicit non-null controls take precedence.
+
 Expected Result:
 
 The service returns HTTP 200 OK with a JSON response containing the `choices` field.

--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
+import pytest
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
 from vllm.tokenizers import deepseek_v4
 
 from vllm_ascend.patch.platform import patch_deepseek_v4_thinking_defaults
@@ -16,33 +21,113 @@ class FakeTokenizer:
         return text
 
 
-def test_deepseek_v4_renderer_applies_thinking_defaults(monkeypatch):
-    captured_kwargs = []
+class ReasoningTokenizer(FakeTokenizer):
+    def get_vocab(self):
+        return {"<think>": 1, "</think>": 2}
+
+
+@pytest.mark.parametrize(
+    ("provided_kwargs", "expected_kwargs"),
+    [
+        ({}, {"enable_thinking": True, "reasoning_effort": "high"}),
+        (
+            {"reasoning_effort": "low"},
+            {"enable_thinking": True, "reasoning_effort": "low"},
+        ),
+        (
+            {"reasoning_effort": "none"},
+            {"enable_thinking": False, "reasoning_effort": "none"},
+        ),
+        (
+            {"enable_thinking": False},
+            {"enable_thinking": False, "reasoning_effort": "high"},
+        ),
+        (
+            {"thinking": False},
+            {"thinking": False, "reasoning_effort": "high"},
+        ),
+    ],
+)
+def test_deepseek_v4_thinking_defaults_preserve_explicit_controls(
+    provided_kwargs,
+    expected_kwargs,
+):
+    original_kwargs = dict(provided_kwargs)
+
+    assert patch_deepseek_v4_thinking_defaults._apply_deepseek_v4_thinking_defaults(provided_kwargs) == expected_kwargs
+    assert provided_kwargs == original_kwargs
+
+
+def test_renderer_and_reasoning_parser_receive_matching_defaults(monkeypatch):
+    class FakeDeepseekV4Renderer:
+        pass
+
+    captured_renderer_kwargs = []
 
     def fake_apply_chat_template(self, *args, **kwargs):
-        captured_kwargs.append(kwargs)
+        captured_renderer_kwargs.append(kwargs)
         return "prompt"
 
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking_defaults,
+        "DeepseekV4Renderer",
+        FakeDeepseekV4Renderer,
+    )
     monkeypatch.setattr(
         patch_deepseek_v4_thinking_defaults,
         "_original_apply_chat_template",
         fake_apply_chat_template,
     )
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking_defaults,
+        "_original_effective_chat_template_kwargs",
+        lambda self, request: {},
+    )
+    serving = SimpleNamespace(renderer=FakeDeepseekV4Renderer())
+    request = ChatCompletionRequest(
+        model="custom-served-alias",
+        messages=[{"role": "user", "content": "hi"}],
+    )
 
-    cases = [
-        ({}, {"enable_thinking": True, "reasoning_effort": "high"}),
-        ({"reasoning_effort": "low"}, {"enable_thinking": True, "reasoning_effort": "low"}),
-        ({"reasoning_effort": "none"}, {"enable_thinking": False, "reasoning_effort": "none"}),
-        ({"enable_thinking": False}, {"enable_thinking": False, "reasoning_effort": "high"}),
-        ({"thinking": False}, {"thinking": False, "reasoning_effort": "high"}),
-    ]
-    for provided_kwargs, expected_kwargs in cases:
-        result = patch_deepseek_v4_thinking_defaults._apply_chat_template(
-            object(), [{"role": "user", "content": "hi"}], **provided_kwargs
-        )
+    effective_kwargs = patch_deepseek_v4_thinking_defaults._effective_chat_template_kwargs(
+        serving,
+        request,
+    )
+    patch_deepseek_v4_thinking_defaults._apply_chat_template(
+        serving.renderer,
+        messages=request.messages,
+    )
 
-        assert result == "prompt"
-        assert captured_kwargs[-1] == expected_kwargs
+    assert effective_kwargs == {key: captured_renderer_kwargs[-1][key] for key in effective_kwargs}
+    reasoning_parser = DeepSeekV3ReasoningParser(
+        ReasoningTokenizer(),
+        chat_template_kwargs=effective_kwargs,
+    )
+    assert isinstance(reasoning_parser._parser, DeepSeekR1ReasoningParser)
+    reasoning, content = reasoning_parser.extract_reasoning(
+        "internal reasoning</think>final answer",
+        request,
+    )
+    assert reasoning == "internal reasoning"
+    assert content == "final answer"
+
+
+def test_effective_defaults_only_apply_to_deepseek_v4_renderer(monkeypatch):
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking_defaults,
+        "_original_effective_chat_template_kwargs",
+        lambda self, request: {"custom": "value"},
+    )
+
+    kwargs = patch_deepseek_v4_thinking_defaults._effective_chat_template_kwargs(
+        SimpleNamespace(renderer=object()),
+        ChatCompletionRequest(
+            model="deepseek-v4",
+            messages=[{"role": "user", "content": "hi"}],
+        ),
+    )
+
+    assert kwargs == {"custom": "value"}
 
 
 def test_deepseek_v4_reasoning_effort_accepts_latest_values():

--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -3,6 +3,8 @@
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.tokenizers import deepseek_v4
 
+from vllm_ascend.patch.platform import patch_deepseek_v4_thinking_defaults
+
 
 class FakeTokenizer:
     vocab_size = 1
@@ -12,6 +14,35 @@ class FakeTokenizer:
 
     def encode(self, text, add_special_tokens=False, **kwargs):
         return text
+
+
+def test_deepseek_v4_renderer_applies_thinking_defaults(monkeypatch):
+    captured_kwargs = []
+
+    def fake_apply_chat_template(self, *args, **kwargs):
+        captured_kwargs.append(kwargs)
+        return "prompt"
+
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking_defaults,
+        "_original_apply_chat_template",
+        fake_apply_chat_template,
+    )
+
+    cases = [
+        ({}, {"enable_thinking": True, "reasoning_effort": "high"}),
+        ({"reasoning_effort": "low"}, {"enable_thinking": True, "reasoning_effort": "low"}),
+        ({"reasoning_effort": "none"}, {"enable_thinking": False, "reasoning_effort": "none"}),
+        ({"enable_thinking": False}, {"enable_thinking": False, "reasoning_effort": "high"}),
+        ({"thinking": False}, {"thinking": False, "reasoning_effort": "high"}),
+    ]
+    for provided_kwargs, expected_kwargs in cases:
+        result = patch_deepseek_v4_thinking_defaults._apply_chat_template(
+            object(), [{"role": "user", "content": "hi"}], **provided_kwargs
+        )
+
+        assert result == "prompt"
+        assert captured_kwargs[-1] == expected_kwargs
 
 
 def test_deepseek_v4_reasoning_effort_accepts_latest_values():

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -341,14 +341,17 @@
 # ** 12b. File: platform/patch_deepseek_v4_thinking_defaults.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.renderers.deepseek_v4.DeepseekV4Renderer`
+#   2. `vllm.entrypoints.openai.chat_completion.serving.OpenAIServingChat`
 #    Why:
-#       Apply thinking defaults at the renderer level.
+#       Renderer-local defaults are applied after the response reasoning parser
+#       is created, so the parser cannot observe that thinking was enabled.
 #    How:
-#       Default missing `reasoning_effort` to `"high"` and enable thinking.
+#       Default missing `reasoning_effort` to `"high"` and enable thinking in
+#       the effective chat-template kwargs shared by rendering and parsing.
 #    Related PR (if no, explain why):
 #       No; this is a deployment-specific default.
 #    Future Plan:
-#       Remove when vLLM supports renderer defaults.
+#       Remove when vLLM supports renderer and parser defaults from one source.
 #
 # ** 13. File: platform/patch_camem_allocator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -338,6 +338,18 @@
 #       Remove this patch once the supported vLLM version contains the upstream
 #       MiniMax-M2 incremental tool-call streaming fix.
 #
+# ** 12b. File: platform/patch_deepseek_v4_thinking_defaults.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.renderers.deepseek_v4.DeepseekV4Renderer`
+#    Why:
+#       Apply thinking defaults at the renderer level.
+#    How:
+#       Default missing `reasoning_effort` to `"high"` and enable thinking.
+#    Related PR (if no, explain why):
+#       No; this is a deployment-specific default.
+#    Future Plan:
+#       Remove when vLLM supports renderer defaults.
+#
 # ** 13. File: platform/patch_camem_allocator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.model.is_cumem_allocator_available`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -37,6 +37,7 @@ import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_glm_tool_call_streaming  # noqa
 
 if vllm_version_is("0.23.0"):
+    import vllm_ascend.patch.platform.patch_deepseek_v4_thinking_defaults  # noqa
     import vllm_ascend.patch.platform.patch_glm47_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_m2_tool_call_parser  # noqa
     import vllm_ascend.patch.platform.patch_minimax_usage_accounting  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking_defaults.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking_defaults.py
@@ -1,8 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.renderers.deepseek_v4 import DeepseekV4Renderer
 
 DEFAULT_REASONING_EFFORT = "high"
+
+
+def _apply_deepseek_v4_thinking_defaults(
+    chat_template_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    effective_kwargs = dict(chat_template_kwargs)
+    reasoning_effort = effective_kwargs.get("reasoning_effort")
+    if reasoning_effort is None:
+        reasoning_effort = DEFAULT_REASONING_EFFORT
+        effective_kwargs["reasoning_effort"] = reasoning_effort
+    if effective_kwargs.get("thinking") is None and effective_kwargs.get("enable_thinking") is None:
+        effective_kwargs["enable_thinking"] = reasoning_effort != "none"
+    return effective_kwargs
 
 
 _original_apply_chat_template = DeepseekV4Renderer._apply_chat_template
@@ -10,17 +27,37 @@ _original_apply_chat_template = DeepseekV4Renderer._apply_chat_template
 
 # Patch reason: the request model field is a configurable served-model alias,
 # so it cannot reliably identify requests rendered by DeepSeek V4.
-# Patch functionality: apply DeepSeek V4 thinking defaults at its renderer,
-# while preserving explicitly supplied non-null template arguments.
+# Patch functionality: apply the shared DeepSeek V4 thinking defaults before
+# rendering while preserving explicitly supplied non-null template arguments.
 # Signature: matches the upstream method; no parameters are added.
 def _apply_chat_template(self, *args, **kwargs):
-    reasoning_effort = kwargs.get("reasoning_effort")
-    if reasoning_effort is None:
-        reasoning_effort = DEFAULT_REASONING_EFFORT
-        kwargs["reasoning_effort"] = reasoning_effort
-    if kwargs.get("thinking") is None and kwargs.get("enable_thinking") is None:
-        kwargs["enable_thinking"] = reasoning_effort != "none"
-    return _original_apply_chat_template(self, *args, **kwargs)
+    # ### PATCH START: DeepSeek V4 thinking defaults
+    effective_kwargs = _apply_deepseek_v4_thinking_defaults(kwargs)
+    # ### PATCH END: DeepSeek V4 thinking defaults
+    return _original_apply_chat_template(
+        self,
+        *args,
+        **effective_kwargs,
+    )
+
+
+_original_effective_chat_template_kwargs = OpenAIServingChat._effective_chat_template_kwargs
+
+
+# Patch reason: OpenAIServingChat creates the reasoning parser before invoking
+# the DeepSeek V4 renderer, so renderer-local defaults are otherwise invisible
+# to both streaming and non-streaming response parsing.
+# Patch functionality: return the same effective thinking kwargs used by the
+# DeepSeek V4 renderer while leaving every other renderer unchanged.
+# Signature: matches the upstream method; no parameters are added.
+def _effective_chat_template_kwargs(self, request: ChatCompletionRequest) -> dict[str, Any]:
+    chat_template_kwargs = _original_effective_chat_template_kwargs(self, request)
+    # ### PATCH START: Share DeepSeek V4 defaults with parser
+    if isinstance(self.renderer, DeepseekV4Renderer):
+        chat_template_kwargs = _apply_deepseek_v4_thinking_defaults(chat_template_kwargs)
+    # ### PATCH END: Share DeepSeek V4 defaults with parser
+    return chat_template_kwargs
 
 
 DeepseekV4Renderer._apply_chat_template = _apply_chat_template
+OpenAIServingChat._effective_chat_template_kwargs = _effective_chat_template_kwargs

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking_defaults.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking_defaults.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from vllm.renderers.deepseek_v4 import DeepseekV4Renderer
+
+DEFAULT_REASONING_EFFORT = "high"
+
+
+_original_apply_chat_template = DeepseekV4Renderer._apply_chat_template
+
+
+# Patch reason: the request model field is a configurable served-model alias,
+# so it cannot reliably identify requests rendered by DeepSeek V4.
+# Patch functionality: apply DeepSeek V4 thinking defaults at its renderer,
+# while preserving explicitly supplied non-null template arguments.
+# Signature: matches the upstream method; no parameters are added.
+def _apply_chat_template(self, *args, **kwargs):
+    reasoning_effort = kwargs.get("reasoning_effort")
+    if reasoning_effort is None:
+        reasoning_effort = DEFAULT_REASONING_EFFORT
+        kwargs["reasoning_effort"] = reasoning_effort
+    if kwargs.get("thinking") is None and kwargs.get("enable_thinking") is None:
+        kwargs["enable_thinking"] = reasoning_effort != "none"
+    return _original_apply_chat_template(self, *args, **kwargs)
+
+
+DeepseekV4Renderer._apply_chat_template = _apply_chat_template


### PR DESCRIPTION
## Summary

- Default missing `reasoning_effort` to `"high"` in `DeepseekV4Renderer`.
- Enable thinking by default while preserving explicitly provided settings.
- Treat `reasoning_effort="none"` as disabled thinking.
- Register the patch for vLLM 0.23.0 and document the default behavior.

## Tests

- Add unit tests covering defaults and explicit overrides.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
