### PR TITLE
[BugFix][SFA] Use DCP-sharded slot mapping in prolog v3 KV write

### DIFF
--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1500,7 +1500,7 @@ class AscendSFAImpl(MLAAttentionImpl):
 
         cos = attn_metadata.cos
         sin = attn_metadata.sin
-        slot_mapping = attn_metadata.slot_mapping
+        slot_mapping_li = attn_metadata.slot_mapping
         slot_mapping_sfa = self._get_sfa_kv_slot_mapping(attn_metadata)
 
         # Inputs and outputs may be padded for CUDA graphs
@@ -1551,7 +1551,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     kv_cache=kv_cache,
                     cos=cos,
                     sin=sin,
-                    slot_mapping=slot_mapping,
+                    slot_mapping=slot_mapping_sfa,
                     num_input_tokens=num_input_tokens,
                 )
         # native
@@ -1642,7 +1642,7 @@ class AscendSFAImpl(MLAAttentionImpl):
             else:
                 torch_npu.npu_scatter_nd_update_(
                     kv_cache[dsa_k_cache_idx].view(-1, k_li.shape[-1]),
-                    slot_mapping.view(-1, 1),
+                    slot_mapping_li.view(-1, 1),
                     k_li.view(-1, k_li.shape[-1]),
                 )  # b, s, n, d
             if self.enable_sparse_li_c8:
@@ -1660,7 +1660,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                 else:
                     torch_npu.npu_scatter_nd_update_(
                         kv_cache[dsa_k_scale_cache_idx].view(-1, k_li_scale.shape[-1]),
-                        slot_mapping.view(-1, 1),
+                        slot_mapping_li.view(-1, 1),
                         k_li_scale.view(-1, k_li_scale.shape[-1]),
                     )
         # Notify for every layer that wrote the cache, not just indexer layers:

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -1527,9 +1527,9 @@ class AscendSFAImpl(MLAAttentionImpl):
                     hidden_states.contiguous(), need_gather_q_kv
                 )
             if fused_type == PreprocessType.PROLOG_V3:
-                assert slot_mapping.numel() == hidden_states.shape[0], (
+                assert slot_mapping_sfa.numel() == hidden_states.shape[0], (
                     "SFA Prolog V3 requires one cache index per input token, "
-                    f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping.numel()}."
+                    f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping_sfa.numel()}."
                 )
             if self.has_indexer:
                 k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
@@ -1543,7 +1543,7 @@ class AscendSFAImpl(MLAAttentionImpl):
                     kv_cache=kv_cache,
                     cos=cos,
                     sin=sin,
-                    slot_mapping=slot_mapping,
+                    slot_mapping=slot_mapping_sfa,
                 )
             else:
                 hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_mlapo(


### PR DESCRIPTION
### What this PR does / why we need it?
#### How it was found

Found while debugging garbled decode output on **GLM5.2** in a PD-disaggregated deployment with **w4a8** weights and `enable_sparse_sfa_c8` enabled. The prefill node was unaffected; only the decode node produced wrong results.

Four conditions must hold at once for the bug to trigger:

1. `enable_sfa_prolog_v3` requires `is_kv_consumer`, so only the **D node** of a PD-disaggregated deployment takes this path;
2. it also requires `enable_sparse_sfa_c8`;
3. `_get_sfa_prolog_v3_unsupported_reasons` requires w8a8-dynamic `fused_qkv_a_proj` and `q_proj`, which the w4a8 checkpoint satisfies;
4. the two slot mappings only diverge when `decode_context_parallel_size > 1` (see `enable_sfa_dcp_replicated_indexer` in `vllm_ascend/utils.py`).

#### Root cause

Under DCP, `AscendSFADCPMetadataBuilder` maintains two different slot mappings, as documented by the "SFA DCP replicated-indexer layout" comment in `vllm_ascend/attention/context_parallel/sfa_cp.py`:

- `attn_metadata.slot_mapping` is the **replicated** view. The LightningIndexer cache is replicated on every DCP rank so index selection runs against the full sequence and keeps the same sparse top-k semantics as non-DCP SFA.
- `attn_metadata.dcp_context.slot_mapping` is the **DCP-local** view. The SFA KV cache stays sharded across DCP ranks to preserve the KV memory saving.

`AscendSFAImpl.forward` already derives `slot_mapping_sfa` for exactly this purpose and uses it on the native path — `exec_kv`, the packed-C8 `npu_scatter_nd_update_`, and `reshape_and_cache`. The SFA Prolog V3 decode branch was the only KV-writing path still passing the replicated `attn_metadata.slot_mapping` into `_sfa_preprocess_with_prolog_v3`, which forwards it to `npu_mla_prolog_v3` as `cache_index`. The prolog therefore wrote SFA KV into indices belonging to the replicated layout, so subsequent decode steps read back KV from the wrong slots.

#### Changes

- Pass `slot_mapping_sfa` instead of `attn_metadata.slot_mapping` to `_sfa_preprocess_with_prolog_v3`.
- Update the assert above the call to validate the same tensor that is actually passed. Both tensors are sliced to `num_input_tokens`, so this does not change which batches pass the assert; it only keeps the check and its error message consistent with the value in use.

### Does this PR introduce _any_ user-facing change?
No API or configuration change. It is a correctness fix: with SFA Prolog V3 and DCP both enabled, decode output was previously incorrect due to mismatched KV cache indices, and is now correct.

### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
