### PR TITLE
[Feature]minimax-m3: integrate AscendC MSA index score

### DIFF
--- a/csrc/attention/msa_index_score/CMakeLists.txt
+++ b/csrc/attention/msa_index_score/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/msa_index_score/README.md
+++ b/csrc/attention/msa_index_score/README.md
@@ -1,0 +1,100 @@
+# MsaIndexScore
+
+## 产品支持情况
+
+| 产品                                                      | 是否支持 |
+| --------------------------------------------------------- | :------: |
+| <term>Atlas A2 训练系列产品/Atlas 800I A2 推理产品</term> |    √     |
+| <term>Atlas A3 训练系列产品/Atlas A3 推理系列产品</term>  |    √     |
+| <term>Ascend 950PR/Ascend 950DT</term>                    |    ×     |
+
+## 功能说明
+
+- **算子功能**：计算 MSA（MiniMax Sparse Attention）模块 Index Branch 中的 block score。对每个 query token 与每个 KV sparse block，取该 block 内所有因果可见 token 的 $Q_{idx}$ 和 $K_{idx}$（可选 int8 反量化）的"matmul+maxpool"运算，得到逐 block 的重要性分数 `score`，用作 Index Branch 中后续 TopK 的输入。Prefill 与 Decode 由同一接口承载。
+
+- **计算公式**：
+
+    - 非量化场景：
+
+    $$
+    score = Maxpool[ Q_{idx}@K_{idx}^{T} ]
+    $$
+
+    - int8 量化场景：
+
+    $$
+    score = Maxpool[ scale \cdot Q_{idx}@K_{idx}^{T} ]
+    $$
+
+    完整公式：
+
+    $$
+    score = Maxpool[(scale \cdot) Q_{idx}@K_{idx}^{T} + atten\_mask] + local\_mask
+    $$
+
+    其中 Maxpool 按 sparse block（长度为 $block\_size$）在 KV token 维上取最大值。`start_loc`、`init_blocks`、`local_blocks` 共同生成 $local\_mask$，对序列头部 / 当前 query 附近若干强制保留的 block 写入高分，保证后续 TopK 一定选中它们。与 Triton raw score kernel 对齐时可将 `init_blocks`、`local_blocks` 置 0，关闭 $local\_mask$。
+
+## 参数说明
+
+> **说明：**
+>
+> - B（Batch Size）表示输入样本批量大小
+> - S（Sequence Length）表示序列长度，$S1$ 为 query 侧、$S2$ 为 key 侧
+> - T 表示所有 Batch 序列长度累加和，$T1$ 为 query 侧、$T2$ 为 key 侧
+> - N（Head Num）表示头数，$N1$ 为 query 侧、$N2$ 为 key 侧
+> - D（Head Dim）表示单个注意力头维度
+> - PageAttention 场景下 $block\_num$ 为物理 block 总数、$block\_size$ 为每个 block 的 token 数，$maxBlockNumPerSeq$ 为每个 batch 最大逻辑 block 数（通常 $\ge\lceil S2/block\_size\rceil$），$M_b=\lceil S2/block\_size\rceil$ 为逻辑 block 总数
+
+| 参数名                   | 输入/输出/属性 | 描述                                                         | 数据类型                     | 数据格式 |
+| ------------------------ | -------------- | ------------------------------------------------------------ | ---------------------------- | -------- |
+| query                    | 输入           | 公式中的 $Q_{idx}$。当前仅支持 TND，shape 为 $[T1, N1, D]$   | BFLOAT16, FLOAT16            | ND       |
+| key                      | 输入           | 公式中的 $K_{idx}$。支持 TND（$[T2, N2, D]$）、BNBD（$[block\_num, N2, block\_size, D]$）、BBND（$[block\_num, block\_size, N2, D]$） | BFLOAT16, FLOAT16, INT8      | ND, NZ   |
+| block_table              | 可选输入       | PageAttention 的逻辑 block → 物理 page 映射表。PA 场景必须传入，二维，第二维长度不能小于 $maxBlockNumPerSeq$；shape 为 $[B, S2/block\_size]$ | INT32                        | ND       |
+| scale                    | 可选输入       | 公式中的 $scale$，反量化系数。非量化必须为空；量化场景必选。PA 为 $[block\_num, N2, block\_size]$ 或 $[block\_num, block\_size, N2]$；TND 为 $[T2, N2]$ | FLOAT                        | ND, NZ   |
+| atten_mask               | 可选输入       | 控制因果可见的 mask。仅在 `sparse_mode=3` 时使用；取值为 1 表示该位不参与计算，为 0 表示参与计算；shape 为 $[2048, 2048]$ | INT8                         | ND       |
+| actual_seq_qlen | 可选输入       | 每个 Batch 中 Query 的有效 token 数。query 为 TND 时必须传入，单调不减（前缀和），shape 为 $[B+1]$ | INT32                        | ND       |
+| actual_seq_klen   | 可选输入       | 每个 Batch 中 Key 的有效 token 数。key 为 TND 时必须传入（前缀和）；PageAttention 场景下为各请求可见 $S2$，shape 为 $[B]$ | INT32                        | ND       |
+| start_loc                | 输入           | 当前 query 所在逻辑 block 索引（非 token 前缀），用于生成 $local\_mask$；shape 为 $[B]$ | INT32                        | ND       |
+| layout_key               | 属性           | key 布局。`"TND"` / `"BBND"` / `"BNBD"`。aclnn 参数名为 `layoutKeyOptional`，不传时默认 `"BBND"` | STRING                       | -        |
+| sparse_mode              | 属性           | sparse 模式。0：defaultMask（`atten_mask` 传空）；3：rightDownCausal（须传入 $[2048, 2048]$ 的 `atten_mask`） | INT64                        | -        |
+| init_blocks              | 属性           | $local\_mask$ 强制选中的头部 block 数。对逻辑 block $[0, init\_blocks)$ 写入高分 $1\mathrm{e}30$。可选，默认 $0$ | INT64                        | -        |
+| local_blocks             | 属性           | $local\_mask$ 强制选中的局部窗口长度。窗口为 $[max(0, start\_loc+1-local\_blocks), start\_loc]$，写入高分 $1\mathrm{e}29$（覆盖同位置的 `init_blocks`）。可选，默认 $1$（对齐 MiniMax HF）；与 Triton raw score 对齐时置 $0$ | INT64                        | -        |
+| score                    | 输出           | 公式中的 $score$，逐 block 重要性分数；shape 为 $[N1, T1, RoundUp(maxBlockNumPerSeq, 16)]$ | FLOAT                        | ND       |
+
+## 约束说明
+
+- 当前 $block\_size$ 仅支持 128。
+- `layout_key` 必须显式指定：`"BBND"` / `"BNBD"` / `"TND"`，与 `key` 实际 shape 一致。
+- PageAttention（`layout_key` 为 `"BBND"` / `"BNBD"`）场景下，`block_table` 必须传入；TND key 场景不得传入 `block_table`，`actual_seq_klen` 为 `[B+1]` 前缀和。
+- 非量化场景下，`key` dtype 与 `query` 相同（当前为 BFLOAT16 / FLOAT16），`scale` 必须为空；量化场景下仅支持 INT8，`scale` 必选：PA 为 $[block\_num, N2, block\_size]$ 或 $[block\_num, block\_size, N2]$，TND 为 $[T2, N2]$，dtype 为 FLOAT。当前不支持 FP8 与 <term>Ascend 950PR/Ascend 950DT</term>。
+- `sparse_mode` 当前仅支持 0、3：
+    - 为 0 时，代表 defaultMask 模式，`atten_mask` 传入空；
+    - 为 3 时，代表 rightDownCausal 模式，`atten_mask` 必须传入，shape 为 $[2048, 2048]$，取值为 1 代表该位不参与计算，为 0 代表该位参与计算。
+- `init_blocks`、`local_blocks` 必须 $\ge 0$ 且不超过逻辑 block 数（PA 为 `block_table` 第二维；TND 为 score 末维对齐宽度）。两者均为 0 时跳过 $local\_mask$。
+- 本算子输出止于 block score，**不包含** TopK。
+
+## 调用示例
+
+| 调用方式 | 样例代码 | 说明 |
+|----------|----------|------|
+| aclnn 单算子调用 | [test_aclnn_msa_index_score.cpp](./examples/test_aclnn_msa_index_score.cpp) | 内置 CPU golden 的端到端精度自验证 |
+| 接口文档 | [aclnnMsaIndexScore.md](./docs/aclnnMsaIndexScore.md) | 两段式接口说明 |
+| 测试说明 | [tests/README.md](./tests/README.md) | 用例矩阵与运行方式 |
+
+编译与运行：
+
+```bash
+bash build.sh --pkg --soc=ascend910b --ops=msa_index_score -j32
+./build_out/cann-ops-transformer-custom_linux-aarch64.run --quiet --install-path=/tmp/msa_opp
+export ASCEND_CUSTOM_OPP_PATH=/tmp/msa_opp/vendors/custom_transformer
+bash build.sh --run_example msa_index_score eager cust --vendor_name=custom
+```
+
+> **实现备注（A2/A3）**
+>
+> - key 布局由属性 `layout_key`（aclnn：`layoutKeyOptional`）指定，支持 PageAttention **BBND** / **BNBD**，以及 packed **TND**（无 `block_table`，`actual_seq_klen` 为 `[B+1]` 前缀和）。默认 `"BBND"`。
+> - `sparse_mode=3` 的 `atten_mask[2048,2048]` 在 host 校验必选；device 侧按 rightDownCausal
+>   解析可见窗口（与 LightningIndexer 一致），不逐元素加载模板。
+> - `start_loc` 为逻辑 block 索引，与属性 `init_blocks`（默认 0）、`local_blocks`（默认 1）
+>   一起在 Maxpool 之后施加 `local_mask`。
+> - 完整公式：`score = Maxpool[(scale·)Q@Kᵀ + atten_mask] + local_mask`。

--- a/csrc/attention/msa_index_score/README.md
+++ b/csrc/attention/msa_index_score/README.md
@@ -1,87 +1,87 @@
 # MsaIndexScore
 
-## 产品支持情况
+## Product Support
 
-| 产品                                                      | 是否支持 |
-| --------------------------------------------------------- | :------: |
-| <term>Atlas A2 训练系列产品/Atlas 800I A2 推理产品</term> |    √     |
-| <term>Atlas A3 训练系列产品/Atlas A3 推理系列产品</term>  |    √     |
-| <term>Ascend 950PR/Ascend 950DT</term>                    |    ×     |
+| Product                                                               | Supported |
+| --------------------------------------------------------------------- | :-------: |
+| <term>Atlas A2 Training Series/Atlas 800I A2 Inference Product</term> |     √     |
+| <term>Atlas A3 Training Series/Atlas A3 Inference Series</term>       |     √     |
+| <term>Ascend 950PR/Ascend 950DT</term>                                |     ×     |
 
-## 功能说明
+## Function Description
 
-- **算子功能**：计算 MSA（MiniMax Sparse Attention）模块 Index Branch 中的 block score。对每个 query token 与每个 KV sparse block，取该 block 内所有因果可见 token 的 $Q_{idx}$ 和 $K_{idx}$（可选 int8 反量化）的"matmul+maxpool"运算，得到逐 block 的重要性分数 `score`，用作 Index Branch 中后续 TopK 的输入。Prefill 与 Decode 由同一接口承载。
+- **Operator function**: Computes block scores for the Index Branch of the MSA (MiniMax Sparse Attention) module. For each query token and each sparse KV block, the operator applies a "matmul + max-pool" operation to $Q_{idx}$ and $K_{idx}$ (with optional int8 dequantization) over all causally visible tokens in that block. The resulting per-block importance score, `score`, is used as the input to the subsequent TopK operation in the Index Branch. Prefill and decode share the same interface.
 
-- **计算公式**：
+- **Formulas**:
 
-    - 非量化场景：
+    - Non-quantized case:
 
     $$
     score = Maxpool[ Q_{idx}@K_{idx}^{T} ]
     $$
 
-    - int8 量化场景：
+    - Int8-quantized case:
 
     $$
     score = Maxpool[ scale \cdot Q_{idx}@K_{idx}^{T} ]
     $$
 
-    完整公式：
+    Complete formula:
 
     $$
     score = Maxpool[(scale \cdot) Q_{idx}@K_{idx}^{T} + atten\_mask] + local\_mask
     $$
 
-    其中 Maxpool 按 sparse block（长度为 $block\_size$）在 KV token 维上取最大值。`start_loc`、`init_blocks`、`local_blocks` 共同生成 $local\_mask$，对序列头部 / 当前 query 附近若干强制保留的 block 写入高分，保证后续 TopK 一定选中它们。与 Triton raw score kernel 对齐时可将 `init_blocks`、`local_blocks` 置 0，关闭 $local\_mask$。
+    Maxpool takes the maximum along the KV-token dimension within each sparse block of length $block\_size$. `start_loc`, `init_blocks`, and `local_blocks` jointly generate $local\_mask$. High scores are written to the leading blocks and to blocks near the current query so that they are always selected by the subsequent TopK operation. Set `init_blocks` and `local_blocks` to 0 to disable $local\_mask$ and match the Triton raw-score kernel.
 
-## 参数说明
+## Parameters
 
-> **说明：**
+> **Notes:**
 >
-> - B（Batch Size）表示输入样本批量大小
-> - S（Sequence Length）表示序列长度，$S1$ 为 query 侧、$S2$ 为 key 侧
-> - T 表示所有 Batch 序列长度累加和，$T1$ 为 query 侧、$T2$ 为 key 侧
-> - N（Head Num）表示头数，$N1$ 为 query 侧、$N2$ 为 key 侧
-> - D（Head Dim）表示单个注意力头维度
-> - PageAttention 场景下 $block\_num$ 为物理 block 总数、$block\_size$ 为每个 block 的 token 数，$maxBlockNumPerSeq$ 为每个 batch 最大逻辑 block 数（通常 $\ge\lceil S2/block\_size\rceil$），$M_b=\lceil S2/block\_size\rceil$ 为逻辑 block 总数
+> - B (Batch Size) is the number of input samples.
+> - S (Sequence Length) is the sequence length; $S1$ is for the query side and $S2$ is for the key side.
+> - T is the sum of sequence lengths across the batch; $T1$ is for the query side and $T2$ is for the key side.
+> - N (Head Num) is the number of heads; $N1$ is for the query side and $N2$ is for the key side.
+> - D (Head Dim) is the dimension of one attention head.
+> - In PageAttention, $block\_num$ is the total number of physical blocks, $block\_size$ is the number of tokens per block, $maxBlockNumPerSeq$ is the maximum number of logical blocks per batch entry (typically $\ge\lceil S2/block\_size\rceil$), and $M_b=\lceil S2/block\_size\rceil$ is the total number of logical blocks.
 
-| 参数名                   | 输入/输出/属性 | 描述                                                         | 数据类型                     | 数据格式 |
-| ------------------------ | -------------- | ------------------------------------------------------------ | ---------------------------- | -------- |
-| query                    | 输入           | 公式中的 $Q_{idx}$。当前仅支持 TND，shape 为 $[T1, N1, D]$   | BFLOAT16, FLOAT16            | ND       |
-| key                      | 输入           | 公式中的 $K_{idx}$。支持 TND（$[T2, N2, D]$）、BNBD（$[block\_num, N2, block\_size, D]$）、BBND（$[block\_num, block\_size, N2, D]$） | BFLOAT16, FLOAT16, INT8      | ND, NZ   |
-| block_table              | 可选输入       | PageAttention 的逻辑 block → 物理 page 映射表。PA 场景必须传入，二维，第二维长度不能小于 $maxBlockNumPerSeq$；shape 为 $[B, S2/block\_size]$ | INT32                        | ND       |
-| scale                    | 可选输入       | 公式中的 $scale$，反量化系数。非量化必须为空；量化场景必选。PA 为 $[block\_num, N2, block\_size]$ 或 $[block\_num, block\_size, N2]$；TND 为 $[T2, N2]$ | FLOAT                        | ND, NZ   |
-| atten_mask               | 可选输入       | 控制因果可见的 mask。仅在 `sparse_mode=3` 时使用；取值为 1 表示该位不参与计算，为 0 表示参与计算；shape 为 $[2048, 2048]$ | INT8                         | ND       |
-| actual_seq_qlen | 可选输入       | 每个 Batch 中 Query 的有效 token 数。query 为 TND 时必须传入，单调不减（前缀和），shape 为 $[B+1]$ | INT32                        | ND       |
-| actual_seq_klen   | 可选输入       | 每个 Batch 中 Key 的有效 token 数。key 为 TND 时必须传入（前缀和）；PageAttention 场景下为各请求可见 $S2$，shape 为 $[B]$ | INT32                        | ND       |
-| start_loc                | 输入           | 当前 query 所在逻辑 block 索引（非 token 前缀），用于生成 $local\_mask$；shape 为 $[B]$ | INT32                        | ND       |
-| layout_key               | 属性           | key 布局。`"TND"` / `"BBND"` / `"BNBD"`。aclnn 参数名为 `layoutKeyOptional`，不传时默认 `"BBND"` | STRING                       | -        |
-| sparse_mode              | 属性           | sparse 模式。0：defaultMask（`atten_mask` 传空）；3：rightDownCausal（须传入 $[2048, 2048]$ 的 `atten_mask`） | INT64                        | -        |
-| init_blocks              | 属性           | $local\_mask$ 强制选中的头部 block 数。对逻辑 block $[0, init\_blocks)$ 写入高分 $1\mathrm{e}30$。可选，默认 $0$ | INT64                        | -        |
-| local_blocks             | 属性           | $local\_mask$ 强制选中的局部窗口长度。窗口为 $[max(0, start\_loc+1-local\_blocks), start\_loc]$，写入高分 $1\mathrm{e}29$（覆盖同位置的 `init_blocks`）。可选，默认 $1$（对齐 MiniMax HF）；与 Triton raw score 对齐时置 $0$ | INT64                        | -        |
-| score                    | 输出           | 公式中的 $score$，逐 block 重要性分数；shape 为 $[N1, T1, RoundUp(maxBlockNumPerSeq, 16)]$ | FLOAT                        | ND       |
+| Parameter | Input/Output/Attribute | Description | Data Type | Format |
+| --------- | ---------------------- | ----------- | --------- | ------ |
+| query | Input | $Q_{idx}$ in the formula. Only TND is currently supported, with shape $[T1, N1, D]$. | BFLOAT16, FLOAT16 | ND |
+| key | Input | $K_{idx}$ in the formula. Supports TND (`[T2, N2, D]`), BNBD (`[block_num, N2, block_size, D]`), and BBND (`[block_num, block_size, N2, D]`). | BFLOAT16, FLOAT16, INT8 | ND, NZ |
+| block_table | Optional input | PageAttention logical-block-to-physical-page mapping. Required for PageAttention. It must be two-dimensional, and its second dimension must be at least $maxBlockNumPerSeq$; shape: $[B, S2/block\_size]$. | INT32 | ND |
+| scale | Optional input | Dequantization coefficient $scale$ in the formula. It must be empty for non-quantized inputs and is required for quantized inputs. Shape for PageAttention: $[block\_num, N2, block\_size]$ or $[block\_num, block\_size, N2]$; shape for TND: $[T2, N2]$. | FLOAT | ND, NZ |
+| atten_mask | Optional input | Mask controlling causal visibility. Used only when `sparse_mode=3`. A value of 1 excludes a position from computation, while 0 includes it; shape: $[2048, 2048]$. | INT8 | ND |
+| actual_seq_qlen | Optional input | Number of valid query tokens in each batch entry. Required when query uses TND. It is a non-decreasing prefix sum with shape $[B+1]$. | INT32 | ND |
+| actual_seq_klen | Optional input | Number of valid key tokens in each batch entry. For a TND key, it is a required prefix sum. For PageAttention, it contains the visible $S2$ of each request; shape: $[B]$. | INT32 | ND |
+| start_loc | Input | Logical-block index containing the current query, rather than a token prefix. Used to generate $local\_mask$; shape: $[B]$. | INT32 | ND |
+| layout_key | Attribute | Key layout: `"TND"`, `"BBND"`, or `"BNBD"`. The aclnn parameter is named `layoutKeyOptional` and defaults to `"BBND"` when omitted. | STRING | - |
+| sparse_mode | Attribute | Sparse mode. 0: defaultMask (`atten_mask` is empty); 3: rightDownCausal (requires an `atten_mask` of shape $[2048, 2048]$). | INT64 | - |
+| init_blocks | Attribute | Number of leading blocks forced by $local\_mask$. Logical blocks in $[0, init\_blocks)$ receive the high score $1\mathrm{e}30$. Optional; default: $0$. | INT64 | - |
+| local_blocks | Attribute | Length of the local window forced by $local\_mask$. The window is $[max(0, start\_loc+1-local\_blocks), start\_loc]$ and receives the high score $1\mathrm{e}29$, overriding `init_blocks` at overlapping positions. Optional; default: $1$ to match MiniMax HF. Set it to $0$ to match the Triton raw score. | INT64 | - |
+| score | Output | Per-block importance score $score$ in the formula; shape: $[N1, T1, RoundUp(maxBlockNumPerSeq, 16)]$. | FLOAT | ND |
 
-## 约束说明
+## Constraints
 
-- 当前 $block\_size$ 仅支持 128。
-- `layout_key` 必须显式指定：`"BBND"` / `"BNBD"` / `"TND"`，与 `key` 实际 shape 一致。
-- PageAttention（`layout_key` 为 `"BBND"` / `"BNBD"`）场景下，`block_table` 必须传入；TND key 场景不得传入 `block_table`，`actual_seq_klen` 为 `[B+1]` 前缀和。
-- 非量化场景下，`key` dtype 与 `query` 相同（当前为 BFLOAT16 / FLOAT16），`scale` 必须为空；量化场景下仅支持 INT8，`scale` 必选：PA 为 $[block\_num, N2, block\_size]$ 或 $[block\_num, block\_size, N2]$，TND 为 $[T2, N2]$，dtype 为 FLOAT。当前不支持 FP8 与 <term>Ascend 950PR/Ascend 950DT</term>。
-- `sparse_mode` 当前仅支持 0、3：
-    - 为 0 时，代表 defaultMask 模式，`atten_mask` 传入空；
-    - 为 3 时，代表 rightDownCausal 模式，`atten_mask` 必须传入，shape 为 $[2048, 2048]$，取值为 1 代表该位不参与计算，为 0 代表该位参与计算。
-- `init_blocks`、`local_blocks` 必须 $\ge 0$ 且不超过逻辑 block 数（PA 为 `block_table` 第二维；TND 为 score 末维对齐宽度）。两者均为 0 时跳过 $local\_mask$。
-- 本算子输出止于 block score，**不包含** TopK。
+- Only a $block\_size$ of 128 is currently supported.
+- `layout_key` must be explicitly set to `"BBND"`, `"BNBD"`, or `"TND"` and must match the actual shape of `key`.
+- In PageAttention (`layout_key` is `"BBND"` or `"BNBD"`), `block_table` is required. For a TND key, `block_table` must be omitted and `actual_seq_klen` must be a `[B+1]` prefix sum.
+- In the non-quantized case, `key` must have the same dtype as `query` (currently BFLOAT16 or FLOAT16), and `scale` must be empty. Only INT8 quantization is supported. For quantized inputs, `scale` is required: its PageAttention shape is $[block\_num, N2, block\_size]$ or $[block\_num, block\_size, N2]$, and its TND shape is $[T2, N2]$ with dtype FLOAT. FP8 and <term>Ascend 950PR/Ascend 950DT</term> are not currently supported.
+- `sparse_mode` currently supports only 0 and 3:
+    - 0 selects defaultMask mode, and `atten_mask` must be empty.
+    - 3 selects rightDownCausal mode. `atten_mask` is required with shape $[2048, 2048]$; 1 excludes a position from computation, while 0 includes it.
+- `init_blocks` and `local_blocks` must be $\ge 0$ and must not exceed the number of logical blocks (the second dimension of `block_table` for PageAttention, or the aligned final score dimension for TND). When both are 0, $local\_mask$ is skipped.
+- The operator outputs block scores only; it does **not** perform TopK.
 
-## 调用示例
+## Examples
 
-| 调用方式 | 样例代码 | 说明 |
-|----------|----------|------|
-| aclnn 单算子调用 | [test_aclnn_msa_index_score.cpp](./examples/test_aclnn_msa_index_score.cpp) | 内置 CPU golden 的端到端精度自验证 |
-| 接口文档 | [aclnnMsaIndexScore.md](./docs/aclnnMsaIndexScore.md) | 两段式接口说明 |
-| 测试说明 | [tests/README.md](./tests/README.md) | 用例矩阵与运行方式 |
+| Invocation | Example | Description |
+| ---------- | ------- | ----------- |
+| Standalone aclnn operator | [test_aclnn_msa_index_score.cpp](./examples/test_aclnn_msa_index_score.cpp) | End-to-end accuracy self-check with a built-in CPU golden implementation |
+| Interface documentation | [aclnnMsaIndexScore.md](./docs/aclnnMsaIndexScore.md) | Two-stage interface documentation |
+| Test documentation | [tests/README.md](./tests/README.md) | Test matrix and execution instructions |
 
-编译与运行：
+Build and run:
 
 ```bash
 bash build.sh --pkg --soc=ascend910b --ops=msa_index_score -j32
@@ -90,11 +90,9 @@ export ASCEND_CUSTOM_OPP_PATH=/tmp/msa_opp/vendors/custom_transformer
 bash build.sh --run_example msa_index_score eager cust --vendor_name=custom
 ```
 
-> **实现备注（A2/A3）**
+> **Implementation Notes (A2/A3)**
 >
-> - key 布局由属性 `layout_key`（aclnn：`layoutKeyOptional`）指定，支持 PageAttention **BBND** / **BNBD**，以及 packed **TND**（无 `block_table`，`actual_seq_klen` 为 `[B+1]` 前缀和）。默认 `"BBND"`。
-> - `sparse_mode=3` 的 `atten_mask[2048,2048]` 在 host 校验必选；device 侧按 rightDownCausal
->   解析可见窗口（与 LightningIndexer 一致），不逐元素加载模板。
-> - `start_loc` 为逻辑 block 索引，与属性 `init_blocks`（默认 0）、`local_blocks`（默认 1）
->   一起在 Maxpool 之后施加 `local_mask`。
-> - 完整公式：`score = Maxpool[(scale·)Q@Kᵀ + atten_mask] + local_mask`。
+> - The key layout is selected by the `layout_key` attribute (`layoutKeyOptional` in aclnn). PageAttention **BBND** and **BNBD**, as well as packed **TND**, are supported. TND does not use `block_table`, and `actual_seq_klen` is a `[B+1]` prefix sum. The default layout is `"BBND"`.
+> - For `sparse_mode=3`, the host requires `atten_mask[2048,2048]`. The device interprets the visible window according to rightDownCausal semantics, consistent with LightningIndexer, without loading the mask template element by element.
+> - `start_loc` is a logical-block index. Together with the `init_blocks` attribute (default: 0) and `local_blocks` attribute (default: 1), it applies `local_mask` after Maxpool.
+> - Complete formula: `score = Maxpool[(scale·)Q@Kᵀ + atten_mask] + local_mask`.

--- a/csrc/attention/msa_index_score/docs/aclnnMsaIndexScore.md
+++ b/csrc/attention/msa_index_score/docs/aclnnMsaIndexScore.md
@@ -1,0 +1,495 @@
+# aclnnMsaIndexScore
+
+[📄 查看源码](https://gitcode.com/cann/ops-transformer/tree/master/attention/msa_index_score)
+
+## 产品支持情况
+
+| 产品                                                      | 是否支持 |
+| --------------------------------------------------------- | :------: |
+| <term>Atlas A2 训练系列产品/Atlas 800I A2 推理产品</term> |    √     |
+| <term>Atlas A3 训练系列产品/Atlas A3 推理系列产品</term>  |    √     |
+| <term>Ascend 950PR/Ascend 950DT</term>                    |    ×     |
+
+## 功能说明
+
+- **算子功能**：计算 MSA（MiniMax Sparse Attention）模块 Index Branch 中的 block score。对每个 query token 与每个 KV sparse block，取该 block 内所有因果可见 token 的 $Q_{idx}$ 和 $K_{idx}$（可选 int8 反量化）的"matmul+maxpool"运算获得逐block的重要性分数score，用作 Index Branch 中后续的 TopK 输入。Prefill 与 Decode 由同一接口承载。
+
+- **计算公式**：
+
+    - 非量化场景：
+
+    $$
+    score = Maxpool[ Q_{idx}@K_{idx}^{T} ]
+    $$
+
+    - int8量化场景：
+
+    $$
+    score = Maxpool[ scale \cdot Q_{idx}@K_{idx}^{T}  ]
+    $$
+
+    完整公式（含因果 mask 与 local_mask）：
+
+    $$
+    score = Maxpool[(scale \cdot) Q_{idx}@K_{idx}^{T} + atten\_mask] + local\_mask
+    $$
+
+    $local\_mask$ 由 `startLoc`、`initBlocks`、`localBlocks` 生成：逻辑 block $[0, initBlocks)$ 写入 $1\mathrm{e}30$；窗口 $[max(0, startLoc+1-localBlocks), startLoc]$ 写入 $1\mathrm{e}29$（覆盖同位置的 init）。两者均为 0 时关闭 $local\_mask$。
+
+- **参数介绍**：
+
+    > - B（Batch Size）表示输入样本批量大小
+    > - S（Sequence Length）表示序列长度，$S1$ 为 query 侧、$S2$ 为 key 侧
+    > - T 表示所有 Batch 序列长度累加和，$T1$ 为 query 侧、$T2$ 为 key 侧
+    > - N（Head Num）表示头数，$N1$ 为 query 侧、$N2$ 为 key 侧
+    > - D（Head Dim）表示单个注意力头维度；
+    > - PageAttention 场景下 $block\_num$ 为物理 block 总数、$block\_size$ 为每个 block 的 token 数，$maxBlockNumPerSeq$ 为每个 batch 最大逻辑 block 数（通常 $\ge\lceil S2/block\_size\rceil$），$M_b=\lceil S2/block\_size\rceil$为逻辑 block 总数
+
+## 函数原型
+
+每个算子分为[两段式接口](https://gitcode.com/cann/ops-transformer/blob/master/docs/zh/context/two_phase_api.md)，必须先调用 `aclnnMsaIndexScoreGetWorkspaceSize` 接口获取入参并计算所需 workspace 大小，再调用 `aclnnMsaIndexScore` 接口执行计算。
+
+```cpp
+aclnnStatus aclnnMsaIndexScoreGetWorkspaceSize(
+    const aclTensor *query,
+    const aclTensor *key,
+    const aclTensor *blockTableOptional,
+    const aclTensor *scaleOptional,
+    const aclTensor *attenMaskOptional,
+    const aclTensor *actualSeqQlenOptional,
+    const aclTensor *actualSeqKlenOptional,
+    const aclTensor *startLoc,
+    char            *layoutKeyOptional,
+    int64_t          sparseMode,
+    int64_t          initBlocks,
+    int64_t          localBlocks,
+    const aclTensor *score,
+    uint64_t        *workspaceSize,
+    aclOpExecutor  **executor);
+aclnnStatus aclnnMsaIndexScore(
+    void           *workspace,
+    uint64_t        workspaceSize,
+    aclOpExecutor  *executor,
+    aclrtStream     stream);
+```
+
+## aclnnMsaIndexScoreGetWorkspaceSize
+
+### 参数说明
+
+| 参数名                        | 输入/输出 | 描述                                              | 使用说明                                                     | 数据类型                     | 数据格式 | 维度                                                         |
+| ----------------------------- | --------- | ------------------------------------------------- | ------------------------------------------------------------ | ---------------------------- | -------- | ------------------------------------------------------------ |
+| query                         | 输入      | 公式中的$Q_{idx}$                                 | 支持的shape为：TND                                           | BFLOAT16, FLOAT16            | ND       | 3（$[T1, N1, D]$）                                           |
+| key                           | 输入      | 公式中的$K_{idx}$                                 | 支持的shape为：TND、BNBD、BBND                               | BFLOAT16, FLOAT16, INT8      | ND, NZ   | 3（$[T2, N2, D]$）或 4（$[block\_num, N2, block\_size, D]$、$[block\_num, block\_size, N2, D]$） |
+| blockTableOptional            | 输入      | 表示当前传入的使用PageAttention存储的block映射表  | PageAttention场景下，blockTableOptional需为2维；第二维长度不能小于 $maxBlockNumPerSeq$ | INT32                        | ND       | 2（$[B, S2/block\_size]$）                                   |
+| scaleOptional                 | 输入      | 公式中的$scale$，反量化系数                       | 非量化场景传入`nullptr`；量化场景时必选。PA 为 BNB/BBN；TND 为 $[T2, N2]$（N2=1 时可 $[T2]$） | FLOAT                        | ND, NZ   | 3（$[block\_num, N2, block\_size]$、$[block\_num, block\_size, N2]$）或 2（$[T2, N2]$） |
+| attenMaskOptional             | 输入      | 控制因果可见的mask掩码。                          | 仅在sparseMode=3时使用，作为base mask控制causal可见；取值为1代表该位不参与计算，为0代表该位参与计算 | INT8                         | ND       | 2（$[2048, 2048]$）                                          |
+| actualSeqQlenOptional | 输入      | 每个Batch中，Query的有效token数                   | 当传入TND时，该入参必须传入，单调不减（前缀和）              | INT32                        | ND       | 1（$[B+1]$）                                                 |
+| actualSeqKlenOptional   | 输入      | 每个Batch中，Key的有效token数                     | key 为 TND 时必须传入，单调不减（前缀和，$[B+1]$）；PageAttention 场景下为各请求可见 $S2$（$[B]$） | INT32                        | ND       | 1（$[B]$ 或 $[B+1]$）                                        |
+| startLoc                      | 输入      | 当前 query 所在逻辑 block 索引（非 token 前缀） | 与 `initBlocks` / `localBlocks` 一起生成 $local\_mask$ | INT32                        | ND       | 1（$[B]$）                                                   |
+| layoutKeyOptional             | 输入      | key 的数据排布                                | 取值 `"TND"` / `"BBND"` / `"BNBD"`。不传或空串时默认 `"BBND"`。必须与 `key` 实际 shape 一致，不可仅凭维度推断 | CHAR*                        | -        | -                                                            |
+| sparseMode                    | 输入      | 表示sparse的模式                                  | 为0时，代表defaultMask模式；为3时，代表rightDownCausal模式的mask，对应以右顶点为划分的下三角场景。 | INT64                        | -        | -                                                            |
+| initBlocks                    | 输入      | $local\_mask$ 强制选中的头部 block 数             | 对逻辑 block $[0, initBlocks)$ 写入高分 $1\mathrm{e}30$。可选，默认 $0$；须 $\ge 0$ 且 $\le maxBlockNumPerSeq$ | INT64                        | -        | -                                                            |
+| localBlocks                   | 输入      | $local\_mask$ 强制选中的局部窗口长度              | 窗口为 $[max(0, startLoc+1-localBlocks), startLoc]$，写入高分 $1\mathrm{e}29$（覆盖同位置 init）。可选，默认 $1$（对齐 MiniMax HF）；与 Triton raw score 对齐时置 $0$ | INT64                        | -        | -                                                            |
+| score                         | 输出      | 公式中的$score$                                   | 逐block的重要性分数；末维为对齐后的逻辑 block 数             | FLOAT                        | ND       | 3（$[N1, T1, RoundUp(maxBlockNumPerSeq, 16)]$）              |
+| workspaceSize                 | 输出      | 所需 workspace 字节数                             | -                                                            | uint64_t                     | -        | -                                                            |
+| executor                      | 输出      | 算子执行器                                        | -                                                            | aclOpExecutor**              | -        | -                                                            |
+
+### 返回值
+
+| 返回码                  | 错误码 | 说明                                     |
+| ----------------------- | ------ | ---------------------------------------- |
+| ACLNN_SUCCESS           | 0      | 执行成功                                 |
+| ACLNN_ERR_PARAM_NULLPTR | 161001 | 必选入参或出参为空指针                   |
+| ACLNN_ERR_PARAM_INVALID | 161002 | 数据类型、数据格式、维度或取值不满足约束 |
+
+## aclnnMsaIndexScore
+
+### 参数说明
+
+| 参数名        | 输入/输出 | 描述                               |
+| ------------- | --------- | ---------------------------------- |
+| workspace     | 输入      | device 侧 workspace 地址           |
+| workspaceSize | 输入      | workspace 字节数，由第一段接口返回 |
+| executor      | 输入      | 算子执行器，由第一段接口返回       |
+| stream        | 输入      | acl stream                         |
+
+### 返回值
+
+| 返回码                  | 错误码 | 说明       |
+| ----------------------- | ------ | ---------- |
+| ACLNN_SUCCESS           | 0      | 执行成功   |
+| ACLNN_ERR_PARAM_INVALID | 161002 | 参数不合法 |
+
+## 约束说明
+
+- 当前 $block\_size$ 值使用128。
+- `layoutKeyOptional` 必须显式指定 key 布局：`"BBND"`（$[block\_num, block\_size, N2, D]$）、`"BNBD"`（$[block\_num, N2, block\_size, D]$）或 `"TND"`（$[T2, N2, D]$）。不传时默认 `"BBND"`。
+- PageAttention（`layoutKey` 为 `"BBND"` / `"BNBD"`）场景下，`blockTableOptional` 必须传入；TND key 场景不得传入 `blockTableOptional`，`actualSeqKlenOptional` 为 $[B+1]$ 前缀和。
+- 非量化场景下，`key` dtype 与 `query` 相同（当前为 BFLOAT16 / FLOAT16），`scaleOptional` 必须为 `nullptr`；量化场景下仅支持 INT8，`scaleOptional` 必选，dtype 为 FLOAT：PA 为 $[block\_num, N2, block\_size]$ 或 $[block\_num, block\_size, N2]$，TND 为 $[T2, N2]$。当前不支持 FP8 与 <term>Ascend 950PR/Ascend 950DT</term>。
+- `sparseMode` 当前仅支持 0、3：
+    - 为 0 时，代表 defaultMask 模式，`attenMaskOptional` 传入 `nullptr`；
+    - 为 3 时，代表 rightDownCausal 模式，`attenMaskOptional` 必须传入，shape 为 $[2048, 2048]$，取值为 1 代表该位不参与计算，为 0 代表该位参与计算。
+- `initBlocks`、`localBlocks` 必须 $\ge 0$ 且不超过逻辑 block 数（PA 为 `blockTableOptional` 第二维；TND 为 score 末维对齐宽度）。两者均为 0 时跳过 $local\_mask$。
+
+
+## 调用示例
+
+示例代码如下（BBND PageAttention）。TND：`layoutKeyOptional="TND"`，`key` 为 $[T2, N2, D]$，`blockTableOptional` 传 `nullptr`，`actualSeqKlenOptional` 为 $[B+1]$ 前缀和。BNBD：`layoutKeyOptional="BNBD"`，`key` 为 $[block\_num, N2, block\_size, D]$。含 TND/BNBD 的精度自验证见 [test_aclnn_msa_index_score.cpp](../examples/test_aclnn_msa_index_score.cpp)。
+
+```Cpp
+#include <iostream>
+#include <vector>
+#include <cstdint>
+#include "acl/acl.h"
+#include "aclnnop/aclnn_msa_index_score.h"
+
+using namespace std;
+
+namespace {
+
+#define CHECK_RET(cond) ((cond) ? true : (false))
+
+#define LOG_PRINT(message, ...)         \
+  do {                                  \
+    (void)printf(message, ##__VA_ARGS__); \
+  } while (0)
+
+int64_t GetShapeSize(const std::vector<int64_t>& shape) {
+  int64_t shapeSize = 1;
+  for (auto i : shape) {
+    shapeSize *= i;
+  }
+  return shapeSize;
+}
+
+int64_t RoundUp(int64_t value, int64_t align) {
+  return (value + align - 1) / align * align;
+}
+
+int Init(int32_t deviceId, aclrtStream* stream) {
+  auto ret = aclInit(nullptr);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclInit failed. ERROR: %d\n", ret);
+    return ret;
+  }
+  ret = aclrtSetDevice(deviceId);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclrtSetDevice failed. ERROR: %d\n", ret);
+    return ret;
+  }
+  ret = aclrtCreateStream(stream);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclrtCreateStream failed. ERROR: %d\n", ret);
+    return ret;
+  }
+  return 0;
+}
+
+template <typename T>
+int CreateAclTensor(const std::vector<T>& hostData, const std::vector<int64_t>& shape, void** deviceAddr,
+                    aclDataType dataType, aclTensor** tensor) {
+  auto size = GetShapeSize(shape) * sizeof(T);
+  auto ret = aclrtMalloc(deviceAddr, size, ACL_MEM_MALLOC_HUGE_FIRST);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclrtMalloc failed. ERROR: %d\n", ret);
+    return ret;
+  }
+
+  ret = aclrtMemcpy(*deviceAddr, size, hostData.data(), size, ACL_MEMCPY_HOST_TO_DEVICE);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclrtMemcpy failed. ERROR: %d\n", ret);
+    return ret;
+  }
+
+  std::vector<int64_t> strides(shape.size(), 1);
+  for (int64_t i = static_cast<int64_t>(shape.size()) - 2; i >= 0; i--) {
+    strides[i] = shape[i + 1] * strides[i + 1];
+  }
+
+  *tensor = aclCreateTensor(shape.data(), shape.size(), dataType, strides.data(), 0, aclFormat::ACL_FORMAT_ND,
+                            shape.data(), shape.size(), *deviceAddr);
+  return 0;
+}
+
+struct TensorResources {
+  void* queryDeviceAddr = nullptr;
+  void* keyDeviceAddr = nullptr;
+  void* blockTableDeviceAddr = nullptr;
+  void* attenMaskDeviceAddr = nullptr;
+  void* actualSeqQlenDeviceAddr = nullptr;
+  void* actualSeqKlenDeviceAddr = nullptr;
+  void* startLocDeviceAddr = nullptr;
+  void* scoreDeviceAddr = nullptr;
+
+  aclTensor* queryTensor = nullptr;
+  aclTensor* keyTensor = nullptr;
+  aclTensor* blockTableTensor = nullptr;
+  aclTensor* attenMaskTensor = nullptr;
+  aclTensor* actualSeqQlenTensor = nullptr;
+  aclTensor* actualSeqKlenTensor = nullptr;
+  aclTensor* startLocTensor = nullptr;
+  aclTensor* scoreTensor = nullptr;
+};
+
+int InitializeTensors(TensorResources& resources) {
+  // TND query + PA_BBND key，sparseMode=3
+  constexpr int64_t B = 1;
+  constexpr int64_t T1 = 2;
+  constexpr int64_t N1 = 2;
+  constexpr int64_t N2 = 1;
+  constexpr int64_t D = 128;
+  constexpr int64_t S2 = 256;
+  constexpr int64_t blockSize = 128;
+  constexpr int64_t blockNum = 2;
+  constexpr int64_t maxBlockNumPerSeq = S2 / blockSize;  // 2
+  const int64_t scoreStride = RoundUp(maxBlockNumPerSeq, 16);
+
+  std::vector<int64_t> queryShape = {T1, N1, D};
+  std::vector<int64_t> keyShape = {blockNum, blockSize, N2, D};           // BBND
+  std::vector<int64_t> blockTableShape = {B, maxBlockNumPerSeq};
+  std::vector<int64_t> attenMaskShape = {2048, 2048};
+  std::vector<int64_t> actualSeqQlenShape = {B + 1};
+  std::vector<int64_t> actualSeqKlenShape = {B};
+  std::vector<int64_t> startLocShape = {B};
+  std::vector<int64_t> scoreShape = {N1, T1, scoreStride};
+
+  std::vector<uint16_t> queryHostData(GetShapeSize(queryShape), 0x3C00);  // fp16 1.0
+  std::vector<uint16_t> keyHostData(GetShapeSize(keyShape), 0x3C00);
+  std::vector<int32_t> blockTableHostData = {0, 1};
+  std::vector<int8_t> attenMaskHostData(GetShapeSize(attenMaskShape), 0);  // 0: 参与计算
+  std::vector<int32_t> actualSeqQlenHostData = {0, static_cast<int32_t>(T1)};
+  std::vector<int32_t> actualSeqKlenHostData = {static_cast<int32_t>(S2)};
+  std::vector<int32_t> startLocHostData = {1};  // 当前 query 所在逻辑 block 索引
+  std::vector<float> scoreHostData(GetShapeSize(scoreShape), 0.0f);
+
+  int ret = CreateAclTensor(queryHostData, queryShape, &resources.queryDeviceAddr,
+                            aclDataType::ACL_FLOAT16, &resources.queryTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  ret = CreateAclTensor(keyHostData, keyShape, &resources.keyDeviceAddr,
+                        aclDataType::ACL_FLOAT16, &resources.keyTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  ret = CreateAclTensor(blockTableHostData, blockTableShape, &resources.blockTableDeviceAddr,
+                        aclDataType::ACL_INT32, &resources.blockTableTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  ret = CreateAclTensor(attenMaskHostData, attenMaskShape, &resources.attenMaskDeviceAddr,
+                        aclDataType::ACL_INT8, &resources.attenMaskTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  ret = CreateAclTensor(actualSeqQlenHostData, actualSeqQlenShape,
+                        &resources.actualSeqQlenDeviceAddr, aclDataType::ACL_INT32,
+                        &resources.actualSeqQlenTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  ret = CreateAclTensor(actualSeqKlenHostData, actualSeqKlenShape,
+                        &resources.actualSeqKlenDeviceAddr, aclDataType::ACL_INT32,
+                        &resources.actualSeqKlenTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  ret = CreateAclTensor(startLocHostData, startLocShape, &resources.startLocDeviceAddr,
+                        aclDataType::ACL_INT32, &resources.startLocTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  ret = CreateAclTensor(scoreHostData, scoreShape, &resources.scoreDeviceAddr,
+                        aclDataType::ACL_FLOAT, &resources.scoreTensor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    return ret;
+  }
+  return ACL_SUCCESS;
+}
+
+int ExecuteMsaIndexScore(TensorResources& resources, aclrtStream stream,
+                         void** workspaceAddr, uint64_t* workspaceSize) {
+  int64_t sparseMode = 3;
+  int64_t initBlocks = 0;
+  int64_t localBlocks = 1;
+  char layoutKey[] = "BBND";
+  aclOpExecutor* executor = nullptr;
+
+  // 非量化：scaleOptional 传 nullptr
+  int ret = aclnnMsaIndexScoreGetWorkspaceSize(
+      resources.queryTensor,
+      resources.keyTensor,
+      resources.blockTableTensor,
+      nullptr,  // scaleOptional
+      resources.attenMaskTensor,
+      resources.actualSeqQlenTensor,
+      resources.actualSeqKlenTensor,
+      resources.startLocTensor,
+      layoutKey,
+      sparseMode,
+      initBlocks,
+      localBlocks,
+      resources.scoreTensor,
+      workspaceSize,
+      &executor);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclnnMsaIndexScoreGetWorkspaceSize failed. ERROR: %d\n", ret);
+    return ret;
+  }
+
+  if (*workspaceSize > 0ULL) {
+    ret = aclrtMalloc(workspaceAddr, *workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    if (!CHECK_RET(ret == ACL_SUCCESS)) {
+      LOG_PRINT("allocate workspace failed. ERROR: %d\n", ret);
+      return ret;
+    }
+  }
+
+  ret = aclnnMsaIndexScore(*workspaceAddr, *workspaceSize, executor, stream);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclnnMsaIndexScore failed. ERROR: %d\n", ret);
+    return ret;
+  }
+  return ACL_SUCCESS;
+}
+
+int PrintScoreOutResult(const std::vector<int64_t>& shape, void** deviceAddr) {
+  auto size = GetShapeSize(shape);
+  std::vector<float> resultData(size, 0.0f);
+  auto ret = aclrtMemcpy(resultData.data(), resultData.size() * sizeof(resultData[0]),
+                         *deviceAddr, size * sizeof(resultData[0]), ACL_MEMCPY_DEVICE_TO_HOST);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("copy result from device to host failed. ERROR: %d\n", ret);
+    return ret;
+  }
+  for (int64_t i = 0; i < size; i++) {
+    LOG_PRINT("score result[%ld] is: %f\n", i, resultData[i]);
+  }
+  return ACL_SUCCESS;
+}
+
+void CleanupResources(TensorResources& resources, void* workspaceAddr,
+                      aclrtStream stream, int32_t deviceId) {
+  if (resources.queryTensor) {
+    aclDestroyTensor(resources.queryTensor);
+  }
+  if (resources.keyTensor) {
+    aclDestroyTensor(resources.keyTensor);
+  }
+  if (resources.blockTableTensor) {
+    aclDestroyTensor(resources.blockTableTensor);
+  }
+  if (resources.attenMaskTensor) {
+    aclDestroyTensor(resources.attenMaskTensor);
+  }
+  if (resources.actualSeqQlenTensor) {
+    aclDestroyTensor(resources.actualSeqQlenTensor);
+  }
+  if (resources.actualSeqKlenTensor) {
+    aclDestroyTensor(resources.actualSeqKlenTensor);
+  }
+  if (resources.startLocTensor) {
+    aclDestroyTensor(resources.startLocTensor);
+  }
+  if (resources.scoreTensor) {
+    aclDestroyTensor(resources.scoreTensor);
+  }
+
+  if (resources.queryDeviceAddr) {
+    aclrtFree(resources.queryDeviceAddr);
+  }
+  if (resources.keyDeviceAddr) {
+    aclrtFree(resources.keyDeviceAddr);
+  }
+  if (resources.blockTableDeviceAddr) {
+    aclrtFree(resources.blockTableDeviceAddr);
+  }
+  if (resources.attenMaskDeviceAddr) {
+    aclrtFree(resources.attenMaskDeviceAddr);
+  }
+  if (resources.actualSeqQlenDeviceAddr) {
+    aclrtFree(resources.actualSeqQlenDeviceAddr);
+  }
+  if (resources.actualSeqKlenDeviceAddr) {
+    aclrtFree(resources.actualSeqKlenDeviceAddr);
+  }
+  if (resources.startLocDeviceAddr) {
+    aclrtFree(resources.startLocDeviceAddr);
+  }
+  if (resources.scoreDeviceAddr) {
+    aclrtFree(resources.scoreDeviceAddr);
+  }
+
+  if (workspaceAddr) {
+    aclrtFree(workspaceAddr);
+  }
+  if (stream) {
+    aclrtDestroyStream(stream);
+  }
+  aclrtResetDevice(deviceId);
+  aclFinalize();
+}
+
+}  // namespace
+
+int main() {
+  int32_t deviceId = 0;
+  aclrtStream stream = nullptr;
+  TensorResources resources = {};
+  void* workspaceAddr = nullptr;
+  uint64_t workspaceSize = 0;
+  constexpr int64_t T1 = 2;
+  constexpr int64_t N1 = 2;
+  constexpr int64_t maxBlockNumPerSeq = 2;
+  std::vector<int64_t> scoreShape = {N1, T1, RoundUp(maxBlockNumPerSeq, 16)};
+  int ret = ACL_SUCCESS;
+
+  ret = Init(deviceId, &stream);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("Init acl failed. ERROR: %d\n", ret);
+    return ret;
+  }
+
+  ret = InitializeTensors(resources);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("InitializeTensors failed. ERROR: %d\n", ret);
+    CleanupResources(resources, workspaceAddr, stream, deviceId);
+    return ret;
+  }
+
+  ret = ExecuteMsaIndexScore(resources, stream, &workspaceAddr, &workspaceSize);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("ExecuteMsaIndexScore failed. ERROR: %d\n", ret);
+    CleanupResources(resources, workspaceAddr, stream, deviceId);
+    return ret;
+  }
+
+  ret = aclrtSynchronizeStream(stream);
+  if (!CHECK_RET(ret == ACL_SUCCESS)) {
+    LOG_PRINT("aclrtSynchronizeStream failed. ERROR: %d\n", ret);
+    CleanupResources(resources, workspaceAddr, stream, deviceId);
+    return ret;
+  }
+
+  PrintScoreOutResult(scoreShape, &resources.scoreDeviceAddr);
+
+  CleanupResources(resources, workspaceAddr, stream, deviceId);
+  return 0;
+}
+```
+
+TND / BNBD 与上面 BBND 示例的差异如下（完整精度用例见 [test_aclnn_msa_index_score.cpp](../examples/test_aclnn_msa_index_score.cpp) 中的 `L1-bnbd*`、`L1-tnd*`、`L0-tnd-tiny`）。
+
+```Cpp
+// BNBD PageAttention：layoutKey="BNBD"，key 为 [block_num, N2, block_size, D]
+char layoutKeyBnbd[] = "BNBD";
+std::vector<int64_t> keyShapeBnbd = {blockNum, N2, blockSize, D};
+
+// TND packed key：layoutKey="TND"，不传 blockTableOptional，actualSeqKlenOptional 为 [B+1] 前缀和
+char layoutKeyTnd[] = "TND";
+constexpr int64_t T2 = 256;
+std::vector<int64_t> keyShapeTnd = {T2, N2, D};
+std::vector<int64_t> actualSeqKlenShapeTnd = {B + 1};  // 例如 {0, T2}
+aclTensor* blockTableTnd = nullptr;
+```

--- a/csrc/attention/msa_index_score/docs/aclnnMsaIndexScore.md
+++ b/csrc/attention/msa_index_score/docs/aclnnMsaIndexScore.md
@@ -1,53 +1,52 @@
 # aclnnMsaIndexScore
 
-[📄 查看源码](https://gitcode.com/cann/ops-transformer/tree/master/attention/msa_index_score)
+[📄 View Source](https://gitcode.com/cann/ops-transformer/tree/master/attention/msa_index_score)
 
-## 产品支持情况
+## Product Support
 
-| 产品                                                      | 是否支持 |
-| --------------------------------------------------------- | :------: |
-| <term>Atlas A2 训练系列产品/Atlas 800I A2 推理产品</term> |    √     |
-| <term>Atlas A3 训练系列产品/Atlas A3 推理系列产品</term>  |    √     |
-| <term>Ascend 950PR/Ascend 950DT</term>                    |    ×     |
+| Product                                                               | Supported |
+| --------------------------------------------------------------------- | :-------: |
+| <term>Atlas A2 Training Series/Atlas 800I A2 Inference Product</term> |     √     |
+| <term>Atlas A3 Training Series/Atlas A3 Inference Series</term>       |     √     |
+| <term>Ascend 950PR/Ascend 950DT</term>                                |     ×     |
 
-## 功能说明
+## Function Description
 
-- **算子功能**：计算 MSA（MiniMax Sparse Attention）模块 Index Branch 中的 block score。对每个 query token 与每个 KV sparse block，取该 block 内所有因果可见 token 的 $Q_{idx}$ 和 $K_{idx}$（可选 int8 反量化）的"matmul+maxpool"运算获得逐block的重要性分数score，用作 Index Branch 中后续的 TopK 输入。Prefill 与 Decode 由同一接口承载。
+- **Operator behavior**: Computes block scores for the Index Branch of the MSA (MiniMax Sparse Attention) module. For every query token and KV sparse block, it applies matmul and max-pooling to $Q_{idx}$ and $K_{idx}$ over all causally visible tokens in the block, with optional INT8 dequantization. The resulting per-block importance scores are used as the input to the subsequent TopK stage. Prefill and decode share the same interface.
 
-- **计算公式**：
+- **Formulas**:
 
-    - 非量化场景：
+    - Non-quantized:
 
-    $$
-    score = Maxpool[ Q_{idx}@K_{idx}^{T} ]
-    $$
+  $$
+  score = Maxpool[ Q_{idx}@K_{idx}^{T} ]
+  $$
+    - INT8-quantized:
 
-    - int8量化场景：
+  $$
+  score = Maxpool[ scale \cdot Q_{idx}@K_{idx}^{T}  ]
+  $$
 
-    $$
-    score = Maxpool[ scale \cdot Q_{idx}@K_{idx}^{T}  ]
-    $$
+  Complete formula, including the causal mask and $local\_mask$:
 
-    完整公式（含因果 mask 与 local_mask）：
+  $$
+  score = Maxpool[(scale \cdot) Q_{idx}@K_{idx}^{T} + atten\_mask] + local\_mask
+  $$
 
-    $$
-    score = Maxpool[(scale \cdot) Q_{idx}@K_{idx}^{T} + atten\_mask] + local\_mask
-    $$
+  $local\_mask$ is generated from `startLoc`, `initBlocks`, and `localBlocks`. Logical blocks in $[0, initBlocks)$ are assigned $1\mathrm{e}30$. Blocks in the window $[max(0, startLoc+1-localBlocks), startLoc]$ are assigned $1\mathrm{e}29$, overriding an init-block score at the same position. Setting both block counts to 0 disables $local\_mask$.
 
-    $local\_mask$ 由 `startLoc`、`initBlocks`、`localBlocks` 生成：逻辑 block $[0, initBlocks)$ 写入 $1\mathrm{e}30$；窗口 $[max(0, startLoc+1-localBlocks), startLoc]$ 写入 $1\mathrm{e}29$（覆盖同位置的 init）。两者均为 0 时关闭 $local\_mask$。
+- **Notation**:
 
-- **参数介绍**：
+  > - B (Batch Size) is the number of input samples.
+  > - S (Sequence Length) is the sequence length. $S1$ is the query length and $S2$ is the key length.
+  > - T is the sum of sequence lengths across the batch. $T1$ is for queries and $T2$ is for keys.
+  > - N (Head Num) is the number of heads. $N1$ is the number of query heads and $N2$ is the number of key heads.
+  > - D (Head Dim) is the dimension of each attention head.
+  > - For PageAttention, $block\_num$ is the total number of physical blocks, $block\_size$ is the number of tokens per block, and $maxBlockNumPerSeq$ is the maximum number of logical blocks per batch item, typically $\ge\lceil S2/block\_size\rceil$. $M_b=\lceil S2/block\_size\rceil$ is the total number of logical blocks.
 
-    > - B（Batch Size）表示输入样本批量大小
-    > - S（Sequence Length）表示序列长度，$S1$ 为 query 侧、$S2$ 为 key 侧
-    > - T 表示所有 Batch 序列长度累加和，$T1$ 为 query 侧、$T2$ 为 key 侧
-    > - N（Head Num）表示头数，$N1$ 为 query 侧、$N2$ 为 key 侧
-    > - D（Head Dim）表示单个注意力头维度；
-    > - PageAttention 场景下 $block\_num$ 为物理 block 总数、$block\_size$ 为每个 block 的 token 数，$maxBlockNumPerSeq$ 为每个 batch 最大逻辑 block 数（通常 $\ge\lceil S2/block\_size\rceil$），$M_b=\lceil S2/block\_size\rceil$为逻辑 block 总数
+## Function Prototypes
 
-## 函数原型
-
-每个算子分为[两段式接口](https://gitcode.com/cann/ops-transformer/blob/master/docs/zh/context/two_phase_api.md)，必须先调用 `aclnnMsaIndexScoreGetWorkspaceSize` 接口获取入参并计算所需 workspace 大小，再调用 `aclnnMsaIndexScore` 接口执行计算。
+This operator uses a [two-stage interface](https://gitcode.com/cann/ops-transformer/blob/master/docs/zh/context/two_phase_api.md). Call `aclnnMsaIndexScoreGetWorkspaceSize` first to validate the inputs and obtain the required workspace size, then call `aclnnMsaIndexScore` to execute the computation.
 
 ```cpp
 aclnnStatus aclnnMsaIndexScoreGetWorkspaceSize(
@@ -75,67 +74,66 @@ aclnnStatus aclnnMsaIndexScore(
 
 ## aclnnMsaIndexScoreGetWorkspaceSize
 
-### 参数说明
+### Parameters
 
-| 参数名                        | 输入/输出 | 描述                                              | 使用说明                                                     | 数据类型                     | 数据格式 | 维度                                                         |
-| ----------------------------- | --------- | ------------------------------------------------- | ------------------------------------------------------------ | ---------------------------- | -------- | ------------------------------------------------------------ |
-| query                         | 输入      | 公式中的$Q_{idx}$                                 | 支持的shape为：TND                                           | BFLOAT16, FLOAT16            | ND       | 3（$[T1, N1, D]$）                                           |
-| key                           | 输入      | 公式中的$K_{idx}$                                 | 支持的shape为：TND、BNBD、BBND                               | BFLOAT16, FLOAT16, INT8      | ND, NZ   | 3（$[T2, N2, D]$）或 4（$[block\_num, N2, block\_size, D]$、$[block\_num, block\_size, N2, D]$） |
-| blockTableOptional            | 输入      | 表示当前传入的使用PageAttention存储的block映射表  | PageAttention场景下，blockTableOptional需为2维；第二维长度不能小于 $maxBlockNumPerSeq$ | INT32                        | ND       | 2（$[B, S2/block\_size]$）                                   |
-| scaleOptional                 | 输入      | 公式中的$scale$，反量化系数                       | 非量化场景传入`nullptr`；量化场景时必选。PA 为 BNB/BBN；TND 为 $[T2, N2]$（N2=1 时可 $[T2]$） | FLOAT                        | ND, NZ   | 3（$[block\_num, N2, block\_size]$、$[block\_num, block\_size, N2]$）或 2（$[T2, N2]$） |
-| attenMaskOptional             | 输入      | 控制因果可见的mask掩码。                          | 仅在sparseMode=3时使用，作为base mask控制causal可见；取值为1代表该位不参与计算，为0代表该位参与计算 | INT8                         | ND       | 2（$[2048, 2048]$）                                          |
-| actualSeqQlenOptional | 输入      | 每个Batch中，Query的有效token数                   | 当传入TND时，该入参必须传入，单调不减（前缀和）              | INT32                        | ND       | 1（$[B+1]$）                                                 |
-| actualSeqKlenOptional   | 输入      | 每个Batch中，Key的有效token数                     | key 为 TND 时必须传入，单调不减（前缀和，$[B+1]$）；PageAttention 场景下为各请求可见 $S2$（$[B]$） | INT32                        | ND       | 1（$[B]$ 或 $[B+1]$）                                        |
-| startLoc                      | 输入      | 当前 query 所在逻辑 block 索引（非 token 前缀） | 与 `initBlocks` / `localBlocks` 一起生成 $local\_mask$ | INT32                        | ND       | 1（$[B]$）                                                   |
-| layoutKeyOptional             | 输入      | key 的数据排布                                | 取值 `"TND"` / `"BBND"` / `"BNBD"`。不传或空串时默认 `"BBND"`。必须与 `key` 实际 shape 一致，不可仅凭维度推断 | CHAR*                        | -        | -                                                            |
-| sparseMode                    | 输入      | 表示sparse的模式                                  | 为0时，代表defaultMask模式；为3时，代表rightDownCausal模式的mask，对应以右顶点为划分的下三角场景。 | INT64                        | -        | -                                                            |
-| initBlocks                    | 输入      | $local\_mask$ 强制选中的头部 block 数             | 对逻辑 block $[0, initBlocks)$ 写入高分 $1\mathrm{e}30$。可选，默认 $0$；须 $\ge 0$ 且 $\le maxBlockNumPerSeq$ | INT64                        | -        | -                                                            |
-| localBlocks                   | 输入      | $local\_mask$ 强制选中的局部窗口长度              | 窗口为 $[max(0, startLoc+1-localBlocks), startLoc]$，写入高分 $1\mathrm{e}29$（覆盖同位置 init）。可选，默认 $1$（对齐 MiniMax HF）；与 Triton raw score 对齐时置 $0$ | INT64                        | -        | -                                                            |
-| score                         | 输出      | 公式中的$score$                                   | 逐block的重要性分数；末维为对齐后的逻辑 block 数             | FLOAT                        | ND       | 3（$[N1, T1, RoundUp(maxBlockNumPerSeq, 16)]$）              |
-| workspaceSize                 | 输出      | 所需 workspace 字节数                             | -                                                            | uint64_t                     | -        | -                                                            |
-| executor                      | 输出      | 算子执行器                                        | -                                                            | aclOpExecutor**              | -        | -                                                            |
+| Parameter             | Input/Output | Description                                        | Usage                                                                                                                                                                                                                  | Data Type               | Format | Dimensions                                                                                      |
+| --------------------- | ------------ | -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| query                 | Input        | $Q_{idx}$ in the formula                           | The supported layout is TND.                                                                                                                                                                                           | BFLOAT16, FLOAT16       | ND     | 3 ($[T1, N1, D]$)                                                                               |
+| key                   | Input        | $K_{idx}$ in the formula                           | The supported layouts are TND, BNBD, and BBND.                                                                                                                                                                         | BFLOAT16, FLOAT16, INT8 | ND, NZ | 3 ($[T2, N2, D]$) or 4 ($[block\_num, N2, block\_size, D]$, $[block\_num, block\_size, N2, D]$) |
+| blockTableOptional    | Input        | PageAttention logical-to-physical block mapping    | Required for PageAttention. It must be 2D, and its second dimension must be at least $maxBlockNumPerSeq$.                                                                                                              | INT32                   | ND     | 2 ($[B, S2/block\_size]$)                                                                       |
+| scaleOptional         | Input        | Dequantization coefficient $scale$ in the formula  | Pass `nullptr` for non-quantized input. This parameter is required for quantized input. Its layout is BNB/BBN for PageAttention or $[T2, N2]$ for TND; $[T2]$ is also accepted when N2=1.                              | FLOAT                   | ND, NZ | 3 ($[block\_num, N2, block\_size]$, $[block\_num, block\_size, N2]$) or 2 ($[T2, N2]$)          |
+| attenMaskOptional     | Input        | Mask controlling causal visibility                 | Used only when `sparseMode=3` as the base causal mask. A value of 1 excludes the position from computation, while 0 includes it.                                                                                       | INT8                    | ND     | 2 ($[2048, 2048]$)                                                                              |
+| actualSeqQlenOptional | Input        | Valid query-token counts for each batch item       | Required for TND input. Values must be non-decreasing prefix sums.                                                                                                                                                     | INT32                   | ND     | 1 ($[B+1]$)                                                                                     |
+| actualSeqKlenOptional | Input        | Valid key-token counts for each batch item         | For a TND key, this parameter is required and contains non-decreasing prefix sums with shape $[B+1]$. For PageAttention, it contains the visible $S2$ for each request with shape $[B]$.                               | INT32                   | ND     | 1 ($[B]$ or $[B+1]$)                                                                            |
+| startLoc              | Input        | Logical block index containing the current query   | Used with `initBlocks` and `localBlocks` to generate $local\_mask$. It is a block index, not a token prefix.                                                                                                           | INT32                   | ND     | 1 ($[B]$)                                                                                       |
+| layoutKeyOptional     | Input        | Key layout                                         | Supported values are `"TND"`, `"BBND"`, and `"BNBD"`. An omitted or empty value defaults to `"BBND"`. It must match the actual `key` shape and must not be inferred from the number of dimensions alone.               | CHAR*                   | -      | -                                                                                               |
+| sparseMode            | Input        | Sparse-mask mode                                   | 0 selects `defaultMask`; 3 selects the `rightDownCausal` mask, a lower-triangular region aligned to the upper-right vertex.                                                                                            | INT64                   | -      | -                                                                                               |
+| initBlocks            | Input        | Number of leading blocks forced by $local\_mask$   | Assigns $1\mathrm{e}30$ to logical blocks in $[0, initBlocks)$. Optional; defaults to 0. The value must be $\ge 0$ and $\le maxBlockNumPerSeq$.                                                                        | INT64                   | -      | -                                                                                               |
+| localBlocks           | Input        | Length of the local window forced by $local\_mask$ | Assigns $1\mathrm{e}29$ to $[max(0, startLoc+1-localBlocks), startLoc]$, overriding init-block scores at the same positions. Optional; defaults to 1 to match MiniMax HF. Set it to 0 when matching Triton raw scores. | INT64                   | -      | -                                                                                               |
+| score                 | Output       | $score$ in the formula                             | Per-block importance scores. The final dimension is the aligned number of logical blocks.                                                                                                                              | FLOAT                   | ND     | 3 ($[N1, T1, RoundUp(maxBlockNumPerSeq, 16)]$)                                                  |
+| workspaceSize         | Output       | Required workspace size in bytes                   | -                                                                                                                                                                                                                      | uint64_t                | -      | -                                                                                               |
+| executor              | Output       | Operator executor                                  | -                                                                                                                                                                                                                      | aclOpExecutor**         | -      | -                                                                                               |
 
-### 返回值
+### Return Values
 
-| 返回码                  | 错误码 | 说明                                     |
-| ----------------------- | ------ | ---------------------------------------- |
-| ACLNN_SUCCESS           | 0      | 执行成功                                 |
-| ACLNN_ERR_PARAM_NULLPTR | 161001 | 必选入参或出参为空指针                   |
-| ACLNN_ERR_PARAM_INVALID | 161002 | 数据类型、数据格式、维度或取值不满足约束 |
+| Return Code             | Error Code | Description                                                     |
+| ----------------------- | ---------- | --------------------------------------------------------------- |
+| ACLNN_SUCCESS           | 0          | Execution succeeded.                                            |
+| ACLNN_ERR_PARAM_NULLPTR | 161001     | A required input or output is a null pointer.                   |
+| ACLNN_ERR_PARAM_INVALID | 161002     | A data type, format, dimension, or value violates a constraint. |
 
 ## aclnnMsaIndexScore
 
-### 参数说明
+### Parameters
 
-| 参数名        | 输入/输出 | 描述                               |
-| ------------- | --------- | ---------------------------------- |
-| workspace     | 输入      | device 侧 workspace 地址           |
-| workspaceSize | 输入      | workspace 字节数，由第一段接口返回 |
-| executor      | 输入      | 算子执行器，由第一段接口返回       |
-| stream        | 输入      | acl stream                         |
+| Parameter     | Input/Output | Description                                                    |
+| ------------- | ------------ | -------------------------------------------------------------- |
+| workspace     | Input        | Device-side workspace address.                                 |
+| workspaceSize | Input        | Workspace size in bytes returned by the first-stage interface. |
+| executor      | Input        | Operator executor returned by the first-stage interface.       |
+| stream        | Input        | ACL stream.                                                    |
 
-### 返回值
+### Return Values
 
-| 返回码                  | 错误码 | 说明       |
-| ----------------------- | ------ | ---------- |
-| ACLNN_SUCCESS           | 0      | 执行成功   |
-| ACLNN_ERR_PARAM_INVALID | 161002 | 参数不合法 |
+| Return Code             | Error Code | Description          |
+| ----------------------- | ---------- | -------------------- |
+| ACLNN_SUCCESS           | 0          | Execution succeeded. |
+| ACLNN_ERR_PARAM_INVALID | 161002     | Invalid parameter.   |
 
-## 约束说明
+## Constraints
 
-- 当前 $block\_size$ 值使用128。
-- `layoutKeyOptional` 必须显式指定 key 布局：`"BBND"`（$[block\_num, block\_size, N2, D]$）、`"BNBD"`（$[block\_num, N2, block\_size, D]$）或 `"TND"`（$[T2, N2, D]$）。不传时默认 `"BBND"`。
-- PageAttention（`layoutKey` 为 `"BBND"` / `"BNBD"`）场景下，`blockTableOptional` 必须传入；TND key 场景不得传入 `blockTableOptional`，`actualSeqKlenOptional` 为 $[B+1]$ 前缀和。
-- 非量化场景下，`key` dtype 与 `query` 相同（当前为 BFLOAT16 / FLOAT16），`scaleOptional` 必须为 `nullptr`；量化场景下仅支持 INT8，`scaleOptional` 必选，dtype 为 FLOAT：PA 为 $[block\_num, N2, block\_size]$ 或 $[block\_num, block\_size, N2]$，TND 为 $[T2, N2]$。当前不支持 FP8 与 <term>Ascend 950PR/Ascend 950DT</term>。
-- `sparseMode` 当前仅支持 0、3：
-    - 为 0 时，代表 defaultMask 模式，`attenMaskOptional` 传入 `nullptr`；
-    - 为 3 时，代表 rightDownCausal 模式，`attenMaskOptional` 必须传入，shape 为 $[2048, 2048]$，取值为 1 代表该位不参与计算，为 0 代表该位参与计算。
-- `initBlocks`、`localBlocks` 必须 $\ge 0$ 且不超过逻辑 block 数（PA 为 `blockTableOptional` 第二维；TND 为 score 末维对齐宽度）。两者均为 0 时跳过 $local\_mask$。
+- The current $block\_size$ is 128.
+- `layoutKeyOptional` must explicitly identify the key layout: `"BBND"` for $[block\_num, block\_size, N2, D]$, `"BNBD"` for $[block\_num, N2, block\_size, D]$, or `"TND"` for $[T2, N2, D]$. If omitted, it defaults to `"BBND"`.
+- For PageAttention (`layoutKey` is `"BBND"` or `"BNBD"`), `blockTableOptional` is required. For a TND key, `blockTableOptional` must be omitted and `actualSeqKlenOptional` must contain $[B+1]$ prefix sums.
+- For non-quantized input, `key` must have the same data type as `query`, currently BFLOAT16 or FLOAT16, and `scaleOptional` must be `nullptr`. Quantized input supports INT8 only and requires a FLOAT `scaleOptional`: $[block\_num, N2, block\_size]$ or $[block\_num, block\_size, N2]$ for PageAttention, and $[T2, N2]$ for TND. FP8 and <term>Ascend 950PR/Ascend 950DT</term> are not currently supported.
+- `sparseMode` currently supports only 0 and 3:
+    - 0 selects `defaultMask`, and `attenMaskOptional` must be `nullptr`.
+    - 3 selects `rightDownCausal`, and `attenMaskOptional` is required with shape $[2048, 2048]$. A value of 1 excludes the position from computation, while 0 includes it.
+- `initBlocks` and `localBlocks` must be $\ge 0$ and must not exceed the number of logical blocks: the second dimension of `blockTableOptional` for PageAttention, or the aligned final score dimension for TND. Setting both to 0 skips $local\_mask$.
 
+## Example
 
-## 调用示例
-
-示例代码如下（BBND PageAttention）。TND：`layoutKeyOptional="TND"`，`key` 为 $[T2, N2, D]$，`blockTableOptional` 传 `nullptr`，`actualSeqKlenOptional` 为 $[B+1]$ 前缀和。BNBD：`layoutKeyOptional="BNBD"`，`key` 为 $[block\_num, N2, block\_size, D]$。含 TND/BNBD 的精度自验证见 [test_aclnn_msa_index_score.cpp](../examples/test_aclnn_msa_index_score.cpp)。
+The following example uses BBND PageAttention. For TND, set `layoutKeyOptional="TND"`, use a $[T2, N2, D]$ `key`, pass `nullptr` for `blockTableOptional`, and provide $[B+1]$ prefix sums in `actualSeqKlenOptional`. For BNBD, set `layoutKeyOptional="BNBD"` and use a $[block\_num, N2, block\_size, D]$ `key`. See [test_aclnn_msa_index_score.cpp](../examples/test_aclnn_msa_index_score.cpp) for TND and BNBD accuracy self-checks.
 
 ```Cpp
 #include <iostream>
@@ -257,10 +255,10 @@ int InitializeTensors(TensorResources& resources) {
   std::vector<uint16_t> queryHostData(GetShapeSize(queryShape), 0x3C00);  // fp16 1.0
   std::vector<uint16_t> keyHostData(GetShapeSize(keyShape), 0x3C00);
   std::vector<int32_t> blockTableHostData = {0, 1};
-  std::vector<int8_t> attenMaskHostData(GetShapeSize(attenMaskShape), 0);  // 0: 参与计算
+  std::vector<int8_t> attenMaskHostData(GetShapeSize(attenMaskShape), 0);  // 0: included in computation
   std::vector<int32_t> actualSeqQlenHostData = {0, static_cast<int32_t>(T1)};
   std::vector<int32_t> actualSeqKlenHostData = {static_cast<int32_t>(S2)};
-  std::vector<int32_t> startLocHostData = {1};  // 当前 query 所在逻辑 block 索引
+  std::vector<int32_t> startLocHostData = {1};  // Logical block index containing the current query
   std::vector<float> scoreHostData(GetShapeSize(scoreShape), 0.0f);
 
   int ret = CreateAclTensor(queryHostData, queryShape, &resources.queryDeviceAddr,
@@ -316,7 +314,7 @@ int ExecuteMsaIndexScore(TensorResources& resources, aclrtStream stream,
   char layoutKey[] = "BBND";
   aclOpExecutor* executor = nullptr;
 
-  // 非量化：scaleOptional 传 nullptr
+  // Non-quantized input: pass nullptr for scaleOptional
   int ret = aclnnMsaIndexScoreGetWorkspaceSize(
       resources.queryTensor,
       resources.keyTensor,
@@ -479,17 +477,17 @@ int main() {
 }
 ```
 
-TND / BNBD 与上面 BBND 示例的差异如下（完整精度用例见 [test_aclnn_msa_index_score.cpp](../examples/test_aclnn_msa_index_score.cpp) 中的 `L1-bnbd*`、`L1-tnd*`、`L0-tnd-tiny`）。
+The TND and BNBD cases differ from the BBND example above as shown below. See the `L1-bnbd*`, `L1-tnd*`, and `L0-tnd-tiny` cases in [test_aclnn_msa_index_score.cpp](../examples/test_aclnn_msa_index_score.cpp) for complete accuracy tests.
 
 ```Cpp
-// BNBD PageAttention：layoutKey="BNBD"，key 为 [block_num, N2, block_size, D]
+// BNBD PageAttention: layoutKey="BNBD"; key is [block_num, N2, block_size, D]
 char layoutKeyBnbd[] = "BNBD";
 std::vector<int64_t> keyShapeBnbd = {blockNum, N2, blockSize, D};
 
-// TND packed key：layoutKey="TND"，不传 blockTableOptional，actualSeqKlenOptional 为 [B+1] 前缀和
+// Packed TND key: layoutKey="TND"; omit blockTableOptional; actualSeqKlenOptional is a [B+1] prefix sum
 char layoutKeyTnd[] = "TND";
 constexpr int64_t T2 = 256;
 std::vector<int64_t> keyShapeTnd = {T2, N2, D};
-std::vector<int64_t> actualSeqKlenShapeTnd = {B + 1};  // 例如 {0, T2}
+std::vector<int64_t> actualSeqKlenShapeTnd = {B + 1};  // For example, {0, T2}
 aclTensor* blockTableTnd = nullptr;
 ```

--- a/csrc/attention/msa_index_score/examples/test_aclnn_msa_index_score.cpp
+++ b/csrc/attention/msa_index_score/examples/test_aclnn_msa_index_score.cpp
@@ -1,0 +1,595 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file test_aclnn_msa_index_score.cpp
+ * \brief aclnnMsaIndexScore 调用示例，内置 CPU golden 做端到端精度自验证。
+ *
+ * 用例矩阵覆盖：Prefill 多 M-tile、prefix 非 128 对齐的边界 block、varlen 多 batch、
+ * Decode(q_len=1)、投机解码(q_len>1)、长序列多 S-tile 轮转、block_table 乱序、
+ * 无效尾填充、bf16 / fp16 双 dtype、int8 key 前融合反量化、PA BNBD、TND packed key。
+ */
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "acl/acl.h"
+#include "aclnnop/aclnn_msa_index_score.h"
+
+namespace {
+
+constexpr int64_t BLOCK_SIZE = 128;
+constexpr int64_t NUM_KV_HEADS = 1; // MSA index cache 为单头共享，P0 仅支持 1
+constexpr int64_t SCORE_STRIDE_ALIGN = 16;
+constexpr float kNegInf = -3.4028234663852886e+38F;
+constexpr float kAtol = 1e-3F;
+constexpr float kRtol = 1e-3F;
+
+enum class KeyLayout {
+    BBND = 0,
+    BNBD = 1,
+    TND = 2,
+};
+
+const char *LayoutKeyName(KeyLayout layout)
+{
+    switch (layout) {
+        case KeyLayout::TND:
+            return "TND";
+        case KeyLayout::BNBD:
+            return "BNBD";
+        case KeyLayout::BBND:
+        default:
+            return "BBND";
+    }
+}
+
+struct TestCase {
+    const char *name;
+    int64_t numQHeads;
+    int64_t headDim;
+    int64_t numPages;
+    std::vector<int32_t> qLen;     // 每个请求的 query 长度
+    std::vector<int32_t> kvLen;    // 每个请求可见的 kv 长度
+    std::vector<int32_t> startLoc; // 当前 query 所在逻辑 block 索引（local_mask）
+    bool useBf16;
+    bool useInt8Key;        // true: key=int8，scale=[NP,N_kv,P] 或 TND [T2,N2]
+    int64_t sparseMode = 3; // 0 / 3
+    KeyLayout keyLayout = KeyLayout::BBND;
+};
+
+constexpr float kLocalScoreInit = 1.0e30F;
+constexpr float kLocalScoreLocal = 1.0e29F;
+constexpr int64_t kInitBlocks = 0;
+constexpr int64_t kLocalBlocks = 1;
+constexpr int64_t kAttenMaskSize = 2048;
+
+int64_t CeilDivI64(int64_t a, int64_t b) { return (a + b - 1) / b; }
+
+int64_t RoundUpI64(int64_t a, int64_t b) { return CeilDivI64(a, b) * b; }
+
+// 简单可复现的伪随机源，取值落在 [-1, 1)。
+float PseudoRandom(uint32_t seed)
+{
+    seed = seed * 1664525U + 1013904223U;
+    seed ^= seed >> 16;
+    seed = seed * 2246822519U;
+    seed ^= seed >> 13;
+    return static_cast<float>(seed % 20000U) / 10000.0F - 1.0F;
+}
+
+// bf16 <-> fp32：截断低 16 位尾数（round-to-nearest-even 对本用例不必要）。
+uint16_t FloatToBf16(float v)
+{
+    uint32_t bits = 0;
+    (void)memcpy(&bits, &v, sizeof(bits));
+    return static_cast<uint16_t>(bits >> 16);
+}
+
+float Bf16ToFloat(uint16_t v)
+{
+    const uint32_t bits = static_cast<uint32_t>(v) << 16;
+    float out = 0.0F;
+    (void)memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+class DeviceBuffer {
+public:
+    ~DeviceBuffer()
+    {
+        for (auto *t : tensors_) {
+            if (t != nullptr) {
+                (void)aclDestroyTensor(t);
+            }
+        }
+        for (auto *p : addrs_) {
+            if (p != nullptr) {
+                (void)aclrtFree(p);
+            }
+        }
+    }
+
+    template <typename T>
+    aclTensor *Create(const std::vector<T> &host, const std::vector<int64_t> &shape, aclDataType dtype,
+                      void **addrOut = nullptr)
+    {
+        void *devAddr = nullptr;
+        const size_t bytes = host.size() * sizeof(T);
+        if (aclrtMalloc(&devAddr, bytes, ACL_MEM_MALLOC_HUGE_FIRST) != ACL_SUCCESS) {
+            return nullptr;
+        }
+        addrs_.push_back(devAddr);
+        if (aclrtMemcpy(devAddr, bytes, host.data(), bytes, ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+            return nullptr;
+        }
+        std::vector<int64_t> strides(shape.size(), 1);
+        for (int64_t i = static_cast<int64_t>(shape.size()) - 2; i >= 0; i--) {
+            strides[i] = shape[i + 1] * strides[i + 1];
+        }
+        aclTensor *t = aclCreateTensor(shape.data(), shape.size(), dtype, strides.data(), 0, ACL_FORMAT_ND,
+                                       shape.data(), shape.size(), devAddr);
+        tensors_.push_back(t);
+        if (addrOut != nullptr) {
+            *addrOut = devAddr;
+        }
+        return t;
+    }
+
+private:
+    std::vector<void *> addrs_;
+    std::vector<aclTensor *> tensors_;
+};
+
+/// CPU 参考：score = Maxpool[(scale·)Q@Kᵀ + atten_mask] + local_mask
+void ComputeGolden(const TestCase &tc, const std::vector<int32_t> &actualSeqQlen,
+                   const std::vector<int32_t> &actualSeqKlen, const std::vector<int32_t> &blockTable, int64_t maxBlocks,
+                   int64_t scoreStride, int64_t totalQ, const std::vector<float> &queryF,
+                   const std::vector<float> &keyF, const std::vector<float> &deqScale, std::vector<float> &golden)
+{
+    const int64_t batch = static_cast<int64_t>(tc.qLen.size());
+    golden.assign(static_cast<size_t>(tc.numQHeads * totalQ * scoreStride), kNegInf);
+
+    auto keyAt = [&](int64_t pageOrTok, int64_t n, int64_t d) -> float {
+        if (tc.keyLayout == KeyLayout::TND) {
+            return keyF[static_cast<size_t>(((pageOrTok + n) * NUM_KV_HEADS) * tc.headDim + d)];
+        }
+        // BBND [NP,P,1,D] 与 BNBD [NP,1,P,D] 在 N2=1 时同址
+        return keyF[static_cast<size_t>(((pageOrTok * BLOCK_SIZE) + n) * tc.headDim + d)];
+    };
+    auto scaleAt = [&](int64_t pageOrTok, int64_t n) -> float {
+        if (!tc.useInt8Key) {
+            return 1.0F;
+        }
+        if (tc.keyLayout == KeyLayout::TND) {
+            return deqScale[static_cast<size_t>(pageOrTok + n)];
+        }
+        return deqScale[static_cast<size_t>(pageOrTok * BLOCK_SIZE + n)];
+    };
+
+    for (int64_t b = 0; b < batch; ++b) {
+        const int32_t qBegin = actualSeqQlen[b];
+        const int32_t qEnd = actualSeqQlen[b + 1];
+        const int32_t qLen = qEnd - qBegin;
+        const int32_t kvLen = tc.kvLen[b];
+        const int64_t numBlocks = CeilDivI64(kvLen, BLOCK_SIZE);
+        const int32_t qBlock = tc.startLoc[b];
+        const int32_t localStart =
+            (qBlock + 1 > static_cast<int32_t>(kLocalBlocks)) ? (qBlock + 1 - static_cast<int32_t>(kLocalBlocks)) : 0;
+        const int32_t cuK = (tc.keyLayout == KeyLayout::TND) ? actualSeqKlen[b] : 0;
+
+        for (int32_t t = qBegin; t < qEnd; ++t) {
+            const int32_t tOff = t - qBegin;
+            int32_t visibleKeyEnd = kvLen;
+            if (tc.sparseMode == 3) {
+                visibleKeyEnd = kvLen - qLen + tOff + 1;
+                if (visibleKeyEnd < 0) {
+                    visibleKeyEnd = 0;
+                }
+                if (visibleKeyEnd > kvLen) {
+                    visibleKeyEnd = kvLen;
+                }
+            }
+            for (int64_t h = 0; h < tc.numQHeads; ++h) {
+                for (int64_t blk = 0; blk < numBlocks; ++blk) {
+                    const int32_t pageOrTok = (tc.keyLayout == KeyLayout::TND) ?
+                                                  (cuK + static_cast<int32_t>(blk * BLOCK_SIZE)) :
+                                                  blockTable[b * maxBlocks + blk];
+                    float best = 0.0F;
+                    bool any = false;
+                    for (int64_t n = 0; n < BLOCK_SIZE; ++n) {
+                        if (blk * BLOCK_SIZE + n >= visibleKeyEnd) {
+                            break;
+                        }
+                        float acc = 0.0F;
+                        const float s = scaleAt(pageOrTok, n);
+                        for (int64_t d = 0; d < tc.headDim; ++d) {
+                            acc += queryF[((t * tc.numQHeads) + h) * tc.headDim + d] * (keyAt(pageOrTok, n, d) * s);
+                        }
+                        if (!any || acc > best) {
+                            best = acc;
+                            any = true;
+                        }
+                    }
+                    if (!any) {
+                        continue;
+                    }
+                    golden[(h * totalQ + t) * scoreStride + blk] = best;
+                }
+                for (int64_t blk = 0; blk < numBlocks; ++blk) {
+                    float boost = 0.0F;
+                    if (blk < kInitBlocks) {
+                        boost = kLocalScoreInit;
+                    }
+                    if (blk >= localStart && blk <= qBlock) {
+                        boost = kLocalScoreLocal;
+                    }
+                    if (boost != 0.0F) {
+                        golden[(h * totalQ + t) * scoreStride + blk] = boost;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void PrintVec(const char *tag, const float *data, int64_t n)
+{
+    (void)printf("  %s[", tag);
+    for (int64_t i = 0; i < n; ++i) {
+        (void)printf("%s%.6g", i == 0 ? "" : ", ", static_cast<double>(data[i]));
+    }
+    (void)printf("]\n");
+}
+
+/// 小尺寸用例的 host 侧逐步拆解：Q/K -> DOT/DEQUANT -> MASK -> MAX。
+void PrintTracePipeline(const TestCase &tc, const std::vector<int32_t> &actualSeqQlen,
+                        const std::vector<int32_t> &blockTable, int64_t maxBlocks, int64_t scoreStride, int64_t totalQ,
+                        const std::vector<float> &queryF, const std::vector<float> &keyF,
+                        const std::vector<float> &deqScale, const std::vector<float> &actual)
+{
+    (void)printf("\n======== HOST TRACE: %s (int8=%d) ========\n", tc.name, tc.useInt8Key ? 1 : 0);
+    (void)printf("shape: Hq=%ld D=%ld qLen=%d kvLen=%d startLoc=%d blockSize=%ld maxBlocks=%ld scoreStride=%ld\n",
+                 tc.numQHeads, tc.headDim, tc.qLen[0], tc.kvLen[0], tc.startLoc[0], BLOCK_SIZE, maxBlocks, scoreStride);
+    const int32_t page = blockTable[0];
+    for (int64_t t = 0; t < tc.qLen[0]; ++t) {
+        for (int64_t h = 0; h < tc.numQHeads; ++h) {
+            const int64_t flat = t * tc.numQHeads + h;
+            const float *q = &queryF[static_cast<size_t>(flat * tc.headDim)];
+            (void)printf("\n-- row flat=%ld (token=%ld head=%ld) --\n", flat, t, h);
+            PrintVec("Q", q, tc.headDim);
+            const int32_t tOff = static_cast<int32_t>(t);
+            int32_t visibleKeyEnd = tc.kvLen[0];
+            if (tc.sparseMode == 3) {
+                visibleKeyEnd = tc.kvLen[0] - tc.qLen[0] + tOff + 1;
+                if (visibleKeyEnd < 0) {
+                    visibleKeyEnd = 0;
+                }
+                if (visibleKeyEnd > tc.kvLen[0]) {
+                    visibleKeyEnd = tc.kvLen[0];
+                }
+            }
+            float best = kNegInf;
+            bool any = false;
+            for (int64_t n = 0; n < visibleKeyEnd + 2 && n < BLOCK_SIZE; ++n) {
+                const float *k = &keyF[static_cast<size_t>((page * BLOCK_SIZE + n) * tc.headDim)];
+                const float ds = tc.useInt8Key ? deqScale[static_cast<size_t>(page) * BLOCK_SIZE + n] : 1.0F;
+                float acc = 0.0F;
+                for (int64_t d = 0; d < tc.headDim; ++d) {
+                    acc += q[d] * (k[d] * ds);
+                }
+                const bool visible = (n < visibleKeyEnd);
+                (void)printf("    S[%ld]=%.6g deqScale=%.6g %s\n", n, static_cast<double>(acc), static_cast<double>(ds),
+                             visible ? "KEEP" : "MASK");
+                if (visible && (!any || acc > best)) {
+                    best = acc;
+                    any = true;
+                }
+            }
+            const float deviceOut = actual[static_cast<size_t>((h * totalQ + (actualSeqQlen[0] + t)) * scoreStride)];
+            (void)printf("  [MAX]=%.6g [OUT]=%.6g\n", static_cast<double>(any ? best : kNegInf),
+                         static_cast<double>(deviceOut));
+        }
+    }
+    (void)printf("======== END HOST TRACE ========\n\n");
+    (void)maxBlocks;
+}
+
+bool Compare(const std::string &name, const std::vector<float> &actual, const std::vector<float> &golden)
+{
+    size_t badCount = 0;
+    size_t infBad = 0;
+    size_t total = 0;
+    float maxAbsDiff = 0.0F;
+    size_t firstBad = 0;
+    bool hasBad = false;
+
+    for (size_t i = 0; i < golden.size(); ++i) {
+        const float g = golden[i];
+        const float a = actual[i];
+        if (g <= kNegInf * 0.5F) { // 填充位：要求实测同样是极小值
+            if (!(a <= kNegInf * 0.5F)) {
+                if (!hasBad) {
+                    firstBad = i;
+                    hasBad = true;
+                }
+                ++infBad;
+            }
+            continue;
+        }
+        if (g >= 1.0e28F) { // local_mask 强制高分
+            if (!(a >= 1.0e28F)) {
+                if (!hasBad) {
+                    firstBad = i;
+                    hasBad = true;
+                }
+                ++badCount;
+            }
+            continue;
+        }
+        ++total;
+        const float diff = std::fabs(a - g);
+        maxAbsDiff = diff > maxAbsDiff ? diff : maxAbsDiff;
+        if (diff > kAtol + kRtol * std::fabs(g)) {
+            if (!hasBad) {
+                firstBad = i;
+                hasBad = true;
+            }
+            ++badCount;
+        }
+    }
+
+    const bool pass = (badCount == 0) && (infBad == 0);
+    (void)printf("  [%s] valid=%zu mismatch=%zu fill_mismatch=%zu max_abs_diff=%.6g -> %s\n", name.c_str(), total,
+                 badCount, infBad, static_cast<double>(maxAbsDiff), pass ? "PASS" : "FAIL");
+    if (!pass) {
+        (void)printf("    first mismatch at %zu: actual=%g golden=%g\n", firstBad,
+                     static_cast<double>(actual[firstBad]), static_cast<double>(golden[firstBad]));
+    }
+    return pass;
+}
+
+bool RunCase(const TestCase &tc, aclrtStream stream)
+{
+    const int64_t batch = static_cast<int64_t>(tc.qLen.size());
+    std::vector<int32_t> actualSeqQlen(batch + 1, 0);
+    for (int64_t b = 0; b < batch; ++b) {
+        actualSeqQlen[b + 1] = actualSeqQlen[b] + tc.qLen[b];
+    }
+    const int64_t totalQ = actualSeqQlen[batch];
+
+    int64_t maxBlocks = 1;
+    for (int64_t b = 0; b < batch; ++b) {
+        maxBlocks = std::max<int64_t>(maxBlocks, CeilDivI64(tc.kvLen[b], BLOCK_SIZE));
+    }
+    const int64_t scoreStride = RoundUpI64(maxBlocks, SCORE_STRIDE_ALIGN);
+
+    // block_table 故意打乱，验证 paged 间接寻址。
+    std::vector<int32_t> blockTable(static_cast<size_t>(batch * maxBlocks), 0);
+    for (int64_t b = 0; b < batch; ++b) {
+        for (int64_t k = 0; k < maxBlocks; ++k) {
+            blockTable[b * maxBlocks + k] = static_cast<int32_t>((b * 7 + k * 3 + 1) % tc.numPages);
+        }
+    }
+
+    // fp32 参考数据；再按 dtype 转成低精度输入，golden 用转换后的值以对齐数值路径。
+    const bool isTnd = (tc.keyLayout == KeyLayout::TND);
+    int64_t totalK = 0;
+    std::vector<int32_t> actualSeqKlenPrefix(static_cast<size_t>(batch + 1), 0);
+    if (isTnd) {
+        for (int64_t b = 0; b < batch; ++b) {
+            actualSeqKlenPrefix[b + 1] = actualSeqKlenPrefix[b] + tc.kvLen[b];
+        }
+        totalK = actualSeqKlenPrefix[batch];
+    }
+    const int64_t keyTokens = isTnd ? totalK : (tc.numPages * BLOCK_SIZE);
+    std::vector<float> queryF(static_cast<size_t>(totalQ * tc.numQHeads * tc.headDim));
+    std::vector<float> keyF(static_cast<size_t>(keyTokens * tc.headDim));
+    std::vector<uint16_t> queryBf(queryF.size());
+    std::vector<uint16_t> keyBf(keyF.size());
+    std::vector<aclFloat16> queryHf(queryF.size());
+    std::vector<aclFloat16> keyHf(keyF.size());
+
+    for (size_t i = 0; i < queryF.size(); ++i) {
+        const float v = PseudoRandom(static_cast<uint32_t>(i) + 1U) * 0.5F;
+        if (tc.useBf16) {
+            queryBf[i] = FloatToBf16(v);
+            queryF[i] = Bf16ToFloat(queryBf[i]);
+        } else {
+            queryHf[i] = aclFloatToFloat16(v);
+            queryF[i] = aclFloat16ToFloat(queryHf[i]);
+        }
+    }
+    for (size_t i = 0; i < keyF.size(); ++i) {
+        if (tc.useInt8Key) {
+            // int8 量化值：落在 [-64, 63]，golden 用同一整数值的 fp32。
+            const int8_t qv =
+                static_cast<int8_t>(static_cast<int>(PseudoRandom(static_cast<uint32_t>(i) + 999983U) * 64.0F));
+            keyF[i] = static_cast<float>(qv);
+        } else {
+            const float v = PseudoRandom(static_cast<uint32_t>(i) + 999983U) * 0.5F;
+            if (tc.useBf16) {
+                keyBf[i] = FloatToBf16(v);
+                keyF[i] = Bf16ToFloat(keyBf[i]);
+            } else {
+                keyHf[i] = aclFloatToFloat16(v);
+                keyF[i] = aclFloat16ToFloat(keyHf[i]);
+            }
+        }
+    }
+    // 反量化 scale：PA [NP, N_kv=1, P]；TND [T2, N2=1]。
+    std::vector<float> deqScale(static_cast<size_t>(keyTokens), 1.0F);
+    std::vector<int8_t> keyI8;
+    if (tc.useInt8Key) {
+        keyI8.resize(keyF.size());
+        for (size_t i = 0; i < keyF.size(); ++i) {
+            keyI8[i] = static_cast<int8_t>(keyF[i]);
+        }
+        for (size_t i = 0; i < deqScale.size(); ++i) {
+            deqScale[i] = 0.01F + 0.02F * (PseudoRandom(static_cast<uint32_t>(i) + 424242U) + 1.0F);
+        }
+    }
+
+    DeviceBuffer buf;
+    const std::vector<int64_t> queryShape = {totalQ, tc.numQHeads, tc.headDim};
+    std::vector<int64_t> keyShape;
+    if (isTnd) {
+        keyShape = {totalK, NUM_KV_HEADS, tc.headDim};
+    } else if (tc.keyLayout == KeyLayout::BNBD) {
+        keyShape = {tc.numPages, NUM_KV_HEADS, BLOCK_SIZE, tc.headDim};
+    } else {
+        keyShape = {tc.numPages, BLOCK_SIZE, NUM_KV_HEADS, tc.headDim};
+    }
+    const std::vector<int64_t> scoreShape = {tc.numQHeads, totalQ, scoreStride};
+
+    aclTensor *queryT =
+        tc.useBf16 ? buf.Create(queryBf, queryShape, ACL_BF16) : buf.Create(queryHf, queryShape, ACL_FLOAT16);
+    aclTensor *keyT = nullptr;
+    if (tc.useInt8Key) {
+        keyT = buf.Create(keyI8, keyShape, ACL_INT8);
+    } else {
+        keyT = tc.useBf16 ? buf.Create(keyBf, keyShape, ACL_BF16) : buf.Create(keyHf, keyShape, ACL_FLOAT16);
+    }
+    aclTensor *blockTableT = nullptr;
+    if (!isTnd) {
+        blockTableT = buf.Create(blockTable, {batch, maxBlocks}, ACL_INT32);
+    }
+    aclTensor *scaleT = nullptr;
+    if (tc.useInt8Key) {
+        if (isTnd) {
+            scaleT = buf.Create(deqScale, {totalK, NUM_KV_HEADS}, ACL_FLOAT);
+        } else {
+            scaleT = buf.Create(deqScale, {tc.numPages, NUM_KV_HEADS, BLOCK_SIZE}, ACL_FLOAT);
+        }
+    }
+    aclTensor *actualSeqQlenT = buf.Create(actualSeqQlen, {batch + 1}, ACL_INT32);
+    aclTensor *actualSeqKlenT =
+        isTnd ? buf.Create(actualSeqKlenPrefix, {batch + 1}, ACL_INT32) : buf.Create(tc.kvLen, {batch}, ACL_INT32);
+    aclTensor *startLocT = buf.Create(tc.startLoc, {batch}, ACL_INT32);
+    std::vector<int8_t> attenMaskHost(static_cast<size_t>(kAttenMaskSize * kAttenMaskSize), 0);
+    aclTensor *attenMaskT = nullptr;
+    if (tc.sparseMode == 3) {
+        attenMaskT = buf.Create(attenMaskHost, {kAttenMaskSize, kAttenMaskSize}, ACL_INT8);
+    }
+
+    std::vector<float> scoreInit(static_cast<size_t>(tc.numQHeads * totalQ * scoreStride), 0.0F);
+    void *scoreDev = nullptr;
+    aclTensor *scoreT = buf.Create(scoreInit, scoreShape, ACL_FLOAT, &scoreDev);
+
+    if (queryT == nullptr || keyT == nullptr || actualSeqQlenT == nullptr || actualSeqKlenT == nullptr ||
+        startLocT == nullptr || scoreT == nullptr || (!isTnd && blockTableT == nullptr) ||
+        (tc.sparseMode == 3 && attenMaskT == nullptr)) {
+        (void)printf("  [%s] create tensor failed -> FAIL\n", tc.name);
+        return false;
+    }
+
+    uint64_t workspaceSize = 0;
+    aclOpExecutor *executor = nullptr;
+    void *workspaceAddr = nullptr;
+    int ret =
+        aclnnMsaIndexScoreGetWorkspaceSize(queryT, keyT, blockTableT, scaleT, attenMaskT, actualSeqQlenT,
+                                           actualSeqKlenT, startLocT, const_cast<char *>(LayoutKeyName(tc.keyLayout)),
+                                           tc.sparseMode, kInitBlocks, kLocalBlocks, scoreT, &workspaceSize, &executor);
+    if (ret != ACL_SUCCESS) {
+        (void)printf("  [%s] GetWorkspaceSize failed, ERROR %d -> FAIL\n", tc.name, ret);
+        return false;
+    }
+    if (workspaceSize > 0ULL && aclrtMalloc(&workspaceAddr, workspaceSize, ACL_MEM_MALLOC_HUGE_FIRST) != ACL_SUCCESS) {
+        (void)printf("  [%s] malloc workspace failed -> FAIL\n", tc.name);
+        return false;
+    }
+    ret = aclnnMsaIndexScore(workspaceAddr, workspaceSize, executor, stream);
+    if (ret != ACL_SUCCESS) {
+        (void)printf("  [%s] aclnnMsaIndexScore failed, ERROR %d -> FAIL\n", tc.name, ret);
+        (void)aclrtFree(workspaceAddr);
+        return false;
+    }
+    (void)aclrtSynchronizeStream(stream);
+
+    std::vector<float> actual(scoreInit.size(), 0.0F);
+    (void)aclrtMemcpy(actual.data(), actual.size() * sizeof(float), scoreDev, actual.size() * sizeof(float),
+                      ACL_MEMCPY_DEVICE_TO_HOST);
+    if (workspaceAddr != nullptr) {
+        (void)aclrtFree(workspaceAddr);
+    }
+
+    std::vector<float> golden;
+    ComputeGolden(tc, actualSeqQlen, isTnd ? actualSeqKlenPrefix : tc.kvLen, blockTable, maxBlocks, scoreStride, totalQ,
+                  queryF, keyF, deqScale, golden);
+    if (std::strstr(tc.name, "debug-trace") != nullptr) {
+        PrintTracePipeline(tc, actualSeqQlen, blockTable, maxBlocks, scoreStride, totalQ, queryF, keyF, deqScale,
+                           actual);
+    }
+    return Compare(tc.name, actual, golden);
+}
+
+} // namespace
+
+int main()
+{
+    const int32_t deviceId = 0;
+    aclrtStream stream = nullptr;
+    if (aclInit(nullptr) != ACL_SUCCESS || aclrtSetDevice(deviceId) != ACL_SUCCESS ||
+        aclrtCreateStream(&stream) != ACL_SUCCESS) {
+        (void)printf("[FAIL] init acl failed\n");
+        return -1;
+    }
+
+    // startLoc 为逻辑 block 索引；因果由 sparseMode=3（rightDownCausal）承担。
+    const std::vector<TestCase> cases = {
+        // name                       Hq   D    pages  qLen           kvLen         startLoc(block) bf16  int8
+        {"L0-debug-trace", 2, 16, 2, {2}, {5}, {16}, false, false},
+        {"L0-int8-dequant-trace", 2, 16, 2, {2}, {5}, {16}, false, true},
+        {"L0-prefill-aligned", 8, 128, 8, {32}, {256}, {1}, false, false},
+        {"L1-prefill-unaligned", 8, 128, 8, {32, 17}, {300, 130}, {2, 0}, false, false},
+        {"L1-prefill-multi-mtile", 8, 128, 16, {64, 48}, {700, 520}, {4, 3}, false, false},
+        {"L1-decode-lq1",
+         8,
+         128,
+         16,
+         {1, 1, 1, 1, 1, 1},
+         {900, 512, 128, 129, 1, 4096},
+         {7, 3, 0, 1, 0, 31},
+         false,
+         false},
+        {"L1-decode-speculative", 8, 128, 16, {4, 2}, {1024, 260}, {7, 2}, false, false},
+        {"L1-long-seq-multi-stile", 8, 128, 40, {8}, {4096}, {31}, false, false},
+        {"L1-bf16", 8, 128, 8, {32, 17}, {300, 130}, {2, 0}, true, false},
+        {"L1-head-dim-64", 8, 64, 8, {32, 17}, {300, 130}, {2, 0}, false, false},
+        {"L1-heads-16", 16, 128, 8, {13}, {300}, {2}, false, false},
+        {"L1-int8-dequant", 8, 128, 8, {32, 17}, {300, 130}, {2, 0}, false, true},
+        {"L2-tiny-kv", 8, 128, 4, {1, 1}, {1, 3}, {0, 0}, false, false},
+        {"L1-bnbd", 8, 128, 8, {32, 17}, {300, 130}, {2, 0}, false, false, 3, KeyLayout::BNBD},
+        {"L1-bnbd-int8", 8, 128, 8, {32, 17}, {300, 130}, {2, 0}, false, true, 3, KeyLayout::BNBD},
+        {"L1-tnd-unaligned", 8, 128, 0, {32, 17}, {300, 130}, {2, 0}, false, false, 3, KeyLayout::TND},
+        {"L1-tnd-int8", 8, 128, 0, {32, 17}, {300, 130}, {2, 0}, false, true, 3, KeyLayout::TND},
+        {"L0-tnd-tiny", 2, 16, 0, {2}, {5}, {16}, false, false, 3, KeyLayout::TND},
+    };
+
+    size_t passed = 0;
+    (void)printf("running %zu MsaIndexScore cases\n", cases.size());
+    for (const auto &tc : cases) {
+        if (RunCase(tc, stream)) {
+            ++passed;
+        }
+    }
+    (void)printf("%s: %zu/%zu cases passed\n", passed == cases.size() ? "[PASS]" : "[FAIL]", passed, cases.size());
+
+    (void)aclrtDestroyStream(stream);
+    (void)aclrtResetDevice(deviceId);
+    (void)aclFinalize();
+    return passed == cases.size() ? 0 : -1;
+}

--- a/csrc/attention/msa_index_score/msa_index_score_torch_adpt.h
+++ b/csrc/attention/msa_index_score/msa_index_score_torch_adpt.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MSA_INDEX_SCORE_TORCH_ADPT_H
+#define MSA_INDEX_SCORE_TORCH_ADPT_H
+
+namespace vllm_ascend {
+namespace msa_index_score_detail {
+
+constexpr int64_t QUERY_DIM_NUM = 3;
+constexpr int64_t KEY_CACHE_DIM_NUM = 3;
+constexpr int64_t KEY_CACHE_WITH_HEAD_DIM_NUM = 4;
+constexpr int64_t BLOCK_TABLE_DIM_NUM = 2;
+constexpr int64_t SEQ_LEN_DIM_NUM = 1;
+constexpr int64_t BLOCK_SIZE = 128;
+constexpr int64_t SCORE_ALIGNMENT = 16;
+
+void CheckMsaIndexScoreParams(
+    const at::Tensor& query, const at::Tensor& key,
+    const at::Tensor& blockTable, const at::Tensor& startLoc,
+    const c10::optional<at::Tensor>& scale,
+    const c10::optional<at::Tensor>& attenMask,
+    const c10::optional<at::Tensor>& actualSeqQlen,
+    const c10::optional<at::Tensor>& actualSeqKlen,
+    const std::string& layoutKey, int64_t sparseMode,
+    int64_t initBlocks, int64_t localBlocks)
+{
+    TORCH_CHECK(query.dim() == QUERY_DIM_NUM,
+                "query must use TND layout [T,N,D]");
+    TORCH_CHECK(query.scalar_type() == at::kHalf ||
+                    query.scalar_type() == at::kBFloat16,
+                "query dtype must be float16 or bfloat16");
+    TORCH_CHECK(key.dim() == KEY_CACHE_DIM_NUM ||
+                    key.dim() == KEY_CACHE_WITH_HEAD_DIM_NUM,
+                "key must be [block_num,128,D] or [block_num,128,1,D]");
+    TORCH_CHECK(key.scalar_type() == query.scalar_type(),
+                "non-quantized key dtype must match query dtype");
+    TORCH_CHECK(layoutKey == "BBND", "only BBND key layout is supported");
+    TORCH_CHECK(blockTable.dim() == BLOCK_TABLE_DIM_NUM &&
+                    blockTable.scalar_type() == at::kInt,
+                "block_table must be a 2D int32 tensor");
+    TORCH_CHECK(startLoc.dim() == SEQ_LEN_DIM_NUM &&
+                    startLoc.scalar_type() == at::kInt,
+                "start_loc must be a 1D int32 tensor");
+    TORCH_CHECK(actualSeqQlen.has_value() &&
+                    actualSeqQlen.value().defined() &&
+                    actualSeqQlen.value().dim() == SEQ_LEN_DIM_NUM &&
+                    actualSeqQlen.value().scalar_type() == at::kInt,
+                "actual_seq_qlen must be a 1D int32 tensor");
+    TORCH_CHECK(actualSeqKlen.has_value() &&
+                    actualSeqKlen.value().defined() &&
+                    actualSeqKlen.value().dim() == SEQ_LEN_DIM_NUM &&
+                    actualSeqKlen.value().scalar_type() == at::kInt,
+                "actual_seq_klen must be a 1D int32 tensor");
+    TORCH_CHECK(actualSeqQlen.value().size(0) ==
+                    actualSeqKlen.value().size(0) + 1,
+                "actual_seq_qlen size must equal batch_size + 1");
+    TORCH_CHECK(blockTable.size(0) == actualSeqKlen.value().size(0) &&
+                    startLoc.size(0) == actualSeqKlen.value().size(0),
+                "block_table/start_loc batch size mismatch");
+    TORCH_CHECK(key.size(1) == BLOCK_SIZE,
+                "MSA index score requires block size 128");
+    TORCH_CHECK(sparseMode == 0 || sparseMode == 3,
+                "sparse_mode must be 0 or 3");
+    if (sparseMode == 3) {
+        TORCH_CHECK(attenMask.has_value() && attenMask.value().defined(),
+                    "sparse_mode=3 requires atten_mask");
+        TORCH_CHECK(attenMask.value().sizes() == at::IntArrayRef({2048, 2048}) &&
+                        attenMask.value().scalar_type() == at::kChar,
+                    "atten_mask must be int8 with shape [2048,2048]");
+    } else {
+        TORCH_CHECK(!attenMask.has_value() || !attenMask.value().defined(),
+                    "sparse_mode=0 does not accept atten_mask");
+    }
+    TORCH_CHECK(!scale.has_value() || !scale.value().defined(),
+                "scale is only valid for an int8 key cache");
+    TORCH_CHECK(initBlocks >= 0 && localBlocks >= 0,
+                "init_blocks and local_blocks must be non-negative");
+}
+
+}  // namespace msa_index_score_detail
+
+at::Tensor npu_msa_index_score(
+    const at::Tensor& query, const at::Tensor& key,
+    const at::Tensor& blockTable, const at::Tensor& startLoc,
+    const c10::optional<at::Tensor>& scale,
+    const c10::optional<at::Tensor>& attenMask,
+    const c10::optional<at::Tensor>& actualSeqQlen,
+    const c10::optional<at::Tensor>& actualSeqKlen,
+    c10::string_view layoutKey, int64_t sparseMode,
+    int64_t initBlocks, int64_t localBlocks)
+{
+    std::string layoutKeyStr(layoutKey);
+    msa_index_score_detail::CheckMsaIndexScoreParams(
+        query, key, blockTable, startLoc, scale, attenMask,
+        actualSeqQlen, actualSeqKlen, layoutKeyStr, sparseMode,
+        initBlocks, localBlocks);
+
+    at::Tensor normalizedKey = key.dim() ==
+            msa_index_score_detail::KEY_CACHE_DIM_NUM
+        ? key.unsqueeze(2)
+        : key;
+    const int64_t scoreStride =
+        ((blockTable.size(1) + msa_index_score_detail::SCORE_ALIGNMENT - 1) /
+         msa_index_score_detail::SCORE_ALIGNMENT) *
+        msa_index_score_detail::SCORE_ALIGNMENT;
+    at::Tensor score = at::empty(
+        {query.size(1), query.size(0), scoreStride},
+        query.options().dtype(at::kFloat));
+
+    // The aclnn executor can retain attribute pointers until ACL graph capture
+    // is finalized.  A pointer into the stack-local std::string becomes
+    // dangling after this adapter returns and crashes in
+    // NnopbaseExecutorArgsGetDfxInfo during FULL_DECODE_ONLY capture.  This
+    // adapter only supports BBND, so give the executor process-lifetime
+    // storage, matching the capture-safe behavior of built-in ACLNN ops.
+    static char layoutKeyBBND[] = "BBND";
+    EXEC_NPU_CMD(aclnnMsaIndexScore, query, normalizedKey, blockTable,
+                 scale, attenMask, actualSeqQlen, actualSeqKlen, startLoc,
+                 layoutKeyBBND, sparseMode, initBlocks, localBlocks, score);
+    return score;
+}
+
+}  // namespace vllm_ascend
+
+#endif  // MSA_INDEX_SCORE_TORCH_ADPT_H

--- a/csrc/attention/msa_index_score/op_host/CMakeLists.txt
+++ b/csrc/attention/msa_index_score/op_host/CMakeLists.txt
@@ -1,0 +1,39 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+    msa_index_score_def.cpp
+    )
+endif()
+
+# MsaIndexScore 的 device 侧实现直接依赖 3rdparty/catlass 的头文件模板库。
+# Catlass 为 header-only，只需把 include 根目录注入 kernel 编译选项即可。
+# CATLASS >= 1.5.0 按架构拆分 TileCopy/CopyGmToL1 等实现：A2/A3 必须定义 CATLASS_ARCH=2201，
+# 否则旧 notla API（TileCopy<ArchTag,A,B,C,Bias>）不会被实例化。
+# v1.3.1-notla 头文件不读取该宏（仅 include guard 含 CATLASS_ARCH_ 前缀），定义后为 no-op。
+#
+# MSA_INDEX_SCORE_DEBUG=1 打开 device 侧 printf/DumpTensor。
+# 大 shape 对齐测试必须关闭：DumpTensor/printf 会导致 device 子进程超时（E39007）。
+add_ops_compile_options(
+    OP_NAME MsaIndexScore
+    OPTIONS --cce-auto-sync=off
+            -Wno-deprecated-declarations
+            -fpermissive
+    OPTIONS -I${CMAKE_SOURCE_DIR}/third_party/catlass/include
+    OPTIONS -DCATLASS_ARCH=2201
+    OPTIONS -DMSA_INDEX_SCORE_DEBUG=0
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    add_modules_sources(OPTYPE msa_index_score ACLNNTYPE aclnn)
+endif()

--- a/csrc/attention/msa_index_score/op_host/msa_index_score_def.cpp
+++ b/csrc/attention/msa_index_score/op_host/msa_index_score_def.cpp
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_def.cpp
+ * \brief MsaIndexScore 算子原型注册（对齐 docs/aclnnMsaIndexScore.md）。
+ *
+ * dtype 组合（按列表下标对齐）：
+ *   0: query=bf16, key=bf16  （非量化）
+ *   1: query=fp16, key=fp16  （非量化）
+ *   2: query=fp16, key=int8  （前融合 int8，scale 为反量化系数）
+ *
+ * A2/A3：PageAttention BBND/BNBD key 与 TND packed key；sparse_mode∈{0,3}。不支持 FP8 / Ascend 950。
+ */
+
+#include <cstdint>
+#include "register/op_def_registry.h"
+
+namespace ops {
+class MsaIndexScore : public OpDef {
+public:
+    explicit MsaIndexScore(const char *name)
+        : OpDef(name)
+    {
+        // Q_idx, TND: [T1, N1, D]
+        this->Input("query")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT16})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // K_idx：BBND [block_num, block_size, N2, D]、BNBD [block_num, N2, block_size, D]、TND [T2, N2, D]
+        this->Input("key")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_INT8})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // PA 逻辑 block → 物理 page；PA 场景必须传入
+        this->Input("block_table")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // 非量化：必须为空。int8：反量化系数 [block_num, N2, block_size]
+        this->Input("scale")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // sparse_mode=3 时必选，压缩下三角模板 [2048, 2048]；内核按 rightDownCausal 解析，不逐元素加载
+        this->Input("atten_mask")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT8, ge::DT_INT8, ge::DT_INT8})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // query 长度前缀和 (cumsum), [B+1]；TND 必选
+        this->Input("actual_seq_qlen")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // PA：各请求可见 S2，[B]
+        this->Input("actual_seq_klen")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // 当前 query 所在逻辑 block 索引，用于生成 local_mask，[B]
+        this->Input("start_loc")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_INT32, ge::DT_INT32, ge::DT_INT32})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
+        // [N1, T1, RoundUp(maxBlockNumPerSeq, 16)]
+        this->Output("score")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_FLOAT, ge::DT_FLOAT, ge::DT_FLOAT})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND, ge::FORMAT_ND});
+
+        // key 布局：TND / BBND / BNBD。aclnn 参数名为 layoutKeyOptional。
+        this->Attr("layout_key").AttrType(OPTIONAL).String("BBND");
+        // 0: defaultMask；3: rightDownCausal
+        this->Attr("sparse_mode").AttrType(OPTIONAL).Int(3);
+        // local_mask：强制选中 block 数（对齐 Triton prepare / HF；对比 raw score 时可置 0）
+        this->Attr("init_blocks").AttrType(OPTIONAL).Int(0);
+        this->Attr("local_blocks").AttrType(OPTIONAL).Int(1);
+
+        OpAICoreConfig aicoreConfig;
+        aicoreConfig.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true);
+        // Atlas A2（ascend910b）/ A3（ascend910_93）；不注册 Ascend 950。
+        this->AICore().AddConfig("ascend910b", aicoreConfig);
+        this->AICore().AddConfig("ascend910_93", aicoreConfig);
+    }
+};
+OP_ADD(MsaIndexScore);
+} // namespace ops

--- a/csrc/attention/msa_index_score/op_host/msa_index_score_infershape.cpp
+++ b/csrc/attention/msa_index_score/op_host/msa_index_score_infershape.cpp
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_infershape.cpp
+ * \brief MsaIndexScore InferShape / InferDataType。
+ */
+
+#include <graph/utils/type_utils.h>
+#include <register/op_impl_registry.h>
+#include "err/ops_err.h"
+
+#include <cstring>
+
+using namespace ge;
+
+namespace ops {
+namespace {
+constexpr uint32_t MSA_QUERY_INDEX = 0;
+constexpr uint32_t MSA_KEY_INDEX = 1;
+constexpr uint32_t MSA_BLOCK_TABLE_INDEX = 2;
+constexpr uint32_t MSA_ACTUAL_SEQ_KLEN_INDEX = 6;
+constexpr uint32_t MSA_QUERY_DIM_NUM = 3;
+constexpr uint32_t MSA_KEY_TND_DIM_NUM = 3;
+constexpr uint32_t MSA_BLOCK_TABLE_DIM_NUM = 2;
+constexpr uint32_t MSA_ATTR_LAYOUT_KEY = 0;
+constexpr int64_t MSA_SCORE_STRIDE_ALIGN = 16;
+constexpr int64_t MSA_BLOCK_SIZE = 128;
+
+inline int64_t RoundUpTo(int64_t value, int64_t align) { return (value + align - 1) / align * align; }
+} // namespace
+
+static ge::graphStatus InferShapeMsaIndexScore(gert::InferShapeContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OP_LOGE("MsaIndexScore", "InferShapeContext is nullptr!"), return ge::GRAPH_FAILED);
+    OP_LOGI(context->GetNodeName(), "Enter MsaIndexScore InferShape impl.");
+
+    const gert::Shape *queryShape = context->GetInputShape(MSA_QUERY_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, queryShape);
+    const gert::Shape *keyShape = context->GetInputShape(MSA_KEY_INDEX);
+    OP_CHECK_NULL_WITH_CONTEXT(context, keyShape);
+    const gert::Shape *blockTableShape = context->GetOptionalInputShape(MSA_BLOCK_TABLE_INDEX);
+    gert::Shape *scoreShape = context->GetOutputShape(0);
+    OP_CHECK_NULL_WITH_CONTEXT(context, scoreShape);
+
+    OP_CHECK_IF(queryShape->GetDimNum() != MSA_QUERY_DIM_NUM,
+                OP_LOGE(context, "query must be TND with 3 dims, but got %zu.", queryShape->GetDimNum()),
+                return ge::GRAPH_FAILED);
+
+    auto attrs = context->GetAttrs();
+    const char *layoutKeyPtr = (attrs != nullptr) ? attrs->GetStr(MSA_ATTR_LAYOUT_KEY) : nullptr;
+    const char *layoutKey = (layoutKeyPtr == nullptr || layoutKeyPtr[0] == '\0') ? "BBND" : layoutKeyPtr;
+    OP_CHECK_IF(std::strcmp(layoutKey, "TND") != 0 && std::strcmp(layoutKey, "BBND") != 0 &&
+                    std::strcmp(layoutKey, "BNBD") != 0,
+                OP_LOGE(context, "layout_key must be TND, BBND or BNBD, got %s.", layoutKey), return ge::GRAPH_FAILED);
+    const bool isTnd = (std::strcmp(layoutKey, "TND") == 0);
+
+    const int64_t totalQ = queryShape->GetDim(0);
+    const int64_t numQHeads = queryShape->GetDim(1);
+    int64_t maxBlocks = 0;
+    if (!isTnd) {
+        OP_CHECK_IF(blockTableShape == nullptr, OP_LOGE(context, "layout_key=BBND/BNBD requires block_table."),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(blockTableShape->GetDimNum() != MSA_BLOCK_TABLE_DIM_NUM,
+                    OP_LOGE(context, "block_table must have 2 dims, but got %zu.", blockTableShape->GetDimNum()),
+                    return ge::GRAPH_FAILED);
+        maxBlocks = blockTableShape->GetDim(1);
+    } else {
+        OP_CHECK_IF(keyShape->GetDimNum() != MSA_KEY_TND_DIM_NUM,
+                    OP_LOGE(context, "layout_key=TND requires key rank 3."), return ge::GRAPH_FAILED);
+        const gert::Shape *klenShape = context->GetOptionalInputShape(MSA_ACTUAL_SEQ_KLEN_INDEX);
+        const gert::Tensor *klenTensor = context->GetOptionalInputTensor(MSA_ACTUAL_SEQ_KLEN_INDEX);
+        const int32_t *klenData = (klenTensor != nullptr) ? klenTensor->GetData<int32_t>() : nullptr;
+        if (klenData != nullptr && klenShape != nullptr && klenShape->GetDimNum() == 1 && klenShape->GetDim(0) >= 2) {
+            const int64_t prefixN = klenShape->GetDim(0);
+            for (int64_t i = 0; i + 1 < prefixN; ++i) {
+                const int64_t kv = static_cast<int64_t>(klenData[i + 1]) - static_cast<int64_t>(klenData[i]);
+                const int64_t blocks = (kv <= 0) ? 0 : ((kv + MSA_BLOCK_SIZE - 1) / MSA_BLOCK_SIZE);
+                if (blocks > maxBlocks) {
+                    maxBlocks = blocks;
+                }
+            }
+        } else {
+            const int64_t totalK = keyShape->GetDim(0);
+            maxBlocks = (totalK + MSA_BLOCK_SIZE - 1) / MSA_BLOCK_SIZE;
+        }
+    }
+    OP_CHECK_IF(maxBlocks <= 0, OP_LOGE(context, "maxBlocksPerSeq must be positive."), return ge::GRAPH_FAILED);
+
+    // maxpool 已经把一个 block 内的 blockSize 个 token 归约成 1 个分数，
+    // 因此输出末维是 block 数（16 对齐）而不是 kv token 数。
+    scoreShape->SetDimNum(MSA_QUERY_DIM_NUM);
+    scoreShape->SetDim(0, numQHeads);                                    // 0: numQHeads
+    scoreShape->SetDim(1, totalQ);                                       // 1: totalQ
+    scoreShape->SetDim(2, RoundUpTo(maxBlocks, MSA_SCORE_STRIDE_ALIGN)); // 2: scoreBlockStride
+
+    OP_LOGI(context->GetNodeName(), "MsaIndexScore InferShape end.");
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus InferDataTypeMsaIndexScore(gert::InferDataTypeContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OP_LOGE("MsaIndexScore", "InferDataTypeContext is nullptr!"),
+                return ge::GRAPH_FAILED);
+    // score 恒为 fp32：Cube 以 fp32 累加，下游 topk 直接消费 fp32。
+    context->SetOutputDataType(0, ge::DT_FLOAT);
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(MsaIndexScore).InferShape(InferShapeMsaIndexScore).InferDataType(InferDataTypeMsaIndexScore);
+} // namespace ops

--- a/csrc/attention/msa_index_score/op_host/msa_index_score_tiling.cpp
+++ b/csrc/attention/msa_index_score/op_host/msa_index_score_tiling.cpp
@@ -1,0 +1,364 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_tiling.cpp
+ * \brief MsaIndexScore Tiling 实现（A2/A3：PA BBND/BNBD + TND packed key；sparse_mode 0/3）。
+ */
+
+#include "msa_index_score_tiling.h"
+#include "../op_kernel/msa_index_score_common.h"
+
+#include <cstring>
+
+using namespace ge;
+using namespace MsaIndexScoreNs;
+
+namespace optiling {
+namespace {
+constexpr uint32_t MSA_QUERY_DIM_NUM = 3;
+constexpr uint32_t MSA_KEY_TND_DIM_NUM = 3;
+constexpr uint32_t MSA_KEY_PA_DIM_NUM = 4;
+constexpr uint32_t MSA_BLOCK_TABLE_DIM_NUM = 2;
+constexpr uint32_t MSA_SCALE_PA_DIM_NUM = 3;
+constexpr uint32_t MSA_SCALE_TND_DIM_NUM = 2;
+constexpr uint32_t MSA_ATTEN_MASK_DIM_NUM = 2;
+
+inline uint32_t RoundUpU32(uint32_t value, uint32_t align) { return (value + align - 1) / align * align; }
+
+ge::graphStatus ParseLayoutKeyAttr(gert::TilingContext *context, const char *layoutKey, uint32_t &keyLayout)
+{
+    const char *s = (layoutKey == nullptr || layoutKey[0] == '\0') ? "BBND" : layoutKey;
+    if (std::strcmp(s, "TND") == 0) {
+        keyLayout = MSA_KEY_LAYOUT_TND;
+    } else if (std::strcmp(s, "BBND") == 0) {
+        keyLayout = MSA_KEY_LAYOUT_BBND;
+    } else if (std::strcmp(s, "BNBD") == 0) {
+        keyLayout = MSA_KEY_LAYOUT_BNBD;
+    } else {
+        OP_LOGE(context, "layout_key must be TND, BBND or BNBD, got %s.", s);
+        return ge::GRAPH_FAILED;
+    }
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus ParseAndCheck(gert::TilingContext *context, MsaIndexScoreInfo &info)
+{
+    info.platformInfo = context->GetPlatformInfo();
+    OP_CHECK_IF(info.platformInfo == nullptr, OP_LOGE(context, "GetPlatformInfo is nullptr."), return ge::GRAPH_FAILED);
+
+    const gert::StorageShape *queryShape = context->GetInputShape(MSA_IDX_QUERY);
+    OP_CHECK_NULL_WITH_CONTEXT(context, queryShape);
+    const gert::StorageShape *keyShape = context->GetInputShape(MSA_IDX_KEY);
+    OP_CHECK_NULL_WITH_CONTEXT(context, keyShape);
+    const gert::StorageShape *blockTableShape = context->GetOptionalInputShape(MSA_IDX_BLOCK_TABLE);
+    const gert::StorageShape *actualSeqQlenShape = context->GetOptionalInputShape(MSA_IDX_ACTUAL_SEQ_QLEN);
+    OP_CHECK_IF(actualSeqQlenShape == nullptr, OP_LOGE(context, "TND query requires actual_seq_qlen."),
+                return ge::GRAPH_FAILED);
+    const gert::StorageShape *actualSeqKlenShape = context->GetOptionalInputShape(MSA_IDX_ACTUAL_SEQ_KLEN);
+    OP_CHECK_IF(actualSeqKlenShape == nullptr, OP_LOGE(context, "actual_seq_klen is required."),
+                return ge::GRAPH_FAILED);
+    const gert::StorageShape *startLocShape = context->GetInputShape(MSA_IDX_START_LOC);
+    OP_CHECK_NULL_WITH_CONTEXT(context, startLocShape);
+
+    const gert::Shape &q = queryShape->GetStorageShape();
+    const gert::Shape &kc = keyShape->GetStorageShape();
+    const gert::Shape &qlen = actualSeqQlenShape->GetStorageShape();
+    const gert::Shape &klen = actualSeqKlenShape->GetStorageShape();
+
+    OP_CHECK_IF(q.GetDimNum() != MSA_QUERY_DIM_NUM,
+                OP_LOGE(context, "query must be TND(3 dims), got %zu.", q.GetDimNum()), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(qlen.GetDimNum() != 1 || qlen.GetDim(0) < 2, OP_LOGE(context, "actual_seq_qlen must be 1D [B+1]."),
+                return ge::GRAPH_FAILED);
+
+    info.totalQ = static_cast<uint32_t>(q.GetDim(0));
+    info.numQHeads = static_cast<uint32_t>(q.GetDim(1));
+    info.headDim = static_cast<uint32_t>(q.GetDim(2));
+    info.batch = static_cast<uint32_t>(qlen.GetDim(0) - 1);
+
+    const auto *attrs = context->GetAttrs();
+    OP_CHECK_NULL_WITH_CONTEXT(context, attrs);
+    if (ParseLayoutKeyAttr(context, attrs->GetStr(MSA_ATTR_LAYOUT_KEY), info.keyLayout) != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+
+    if (info.keyLayout == MSA_KEY_LAYOUT_TND) {
+        info.totalK = static_cast<uint32_t>(kc.GetDim(0));
+        info.numKvHeads = static_cast<uint32_t>(kc.GetDim(1));
+        info.blockSize = MSA_BLOCK_SIZE;
+        info.numPages = 0;
+        OP_CHECK_IF(kc.GetDimNum() != MSA_KEY_TND_DIM_NUM,
+                    OP_LOGE(context, "layout_key=TND requires key rank 3 [T2,N2,D], got %zu.", kc.GetDimNum()),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(static_cast<uint32_t>(kc.GetDim(2)) != info.headDim,
+                    OP_LOGE(context, "TND key headDim(%ld) must equal query headDim(%u).", kc.GetDim(2), info.headDim),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(blockTableShape != nullptr, OP_LOGE(context, "layout_key=TND must not pass block_table."),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(klen.GetDimNum() != 1 || static_cast<uint32_t>(klen.GetDim(0)) != info.batch + 1,
+                    OP_LOGE(context, "TND actual_seq_klen must be [B+1] prefix-sum."), return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(kc.GetDimNum() != MSA_KEY_PA_DIM_NUM,
+                    OP_LOGE(context, "layout_key=%s requires key rank 4, got %zu.",
+                            info.keyLayout == MSA_KEY_LAYOUT_BNBD ? "BNBD" : "BBND", kc.GetDimNum()),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(blockTableShape == nullptr, OP_LOGE(context, "PageAttention (BBND/BNBD) requires block_table."),
+                    return ge::GRAPH_FAILED);
+        const gert::Shape &bt = blockTableShape->GetStorageShape();
+        OP_CHECK_IF(bt.GetDimNum() != MSA_BLOCK_TABLE_DIM_NUM,
+                    OP_LOGE(context, "block_table must have 2 dims, got %zu.", bt.GetDimNum()),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF(
+            static_cast<uint32_t>(bt.GetDim(0)) != info.batch,
+            OP_LOGE(context, "block_table batch(%ld) must equal actual_seq_qlen batch(%u).", bt.GetDim(0), info.batch),
+            return ge::GRAPH_FAILED);
+        info.maxBlocksPerBatch = static_cast<uint32_t>(bt.GetDim(1));
+        info.numPages = static_cast<uint32_t>(kc.GetDim(0));
+        if (info.keyLayout == MSA_KEY_LAYOUT_BBND) {
+            info.blockSize = static_cast<uint32_t>(kc.GetDim(1));
+            info.numKvHeads = static_cast<uint32_t>(kc.GetDim(2));
+            OP_CHECK_IF(
+                static_cast<uint32_t>(kc.GetDim(3)) != info.headDim,
+                OP_LOGE(context, "BBND key headDim(%ld) must equal query headDim(%u).", kc.GetDim(3), info.headDim),
+                return ge::GRAPH_FAILED);
+        } else {
+            info.numKvHeads = static_cast<uint32_t>(kc.GetDim(1));
+            info.blockSize = static_cast<uint32_t>(kc.GetDim(2));
+            OP_CHECK_IF(
+                static_cast<uint32_t>(kc.GetDim(3)) != info.headDim,
+                OP_LOGE(context, "BNBD key headDim(%ld) must equal query headDim(%u).", kc.GetDim(3), info.headDim),
+                return ge::GRAPH_FAILED);
+        }
+        OP_CHECK_IF(klen.GetDimNum() != 1 || static_cast<uint32_t>(klen.GetDim(0)) != info.batch,
+                    OP_LOGE(context, "PA actual_seq_klen must be [B] visible S2."), return ge::GRAPH_FAILED);
+    }
+
+    if (info.keyLayout == MSA_KEY_LAYOUT_TND) {
+        const gert::StorageShape *scoreShape = context->GetOutputShape(0);
+        OP_CHECK_NULL_WITH_CONTEXT(context, scoreShape);
+        const gert::Shape &scOut = scoreShape->GetStorageShape();
+        OP_CHECK_IF(scOut.GetDimNum() != MSA_QUERY_DIM_NUM, OP_LOGE(context, "score must be 3D [N1,T1,stride]."),
+                    return ge::GRAPH_FAILED);
+        info.maxBlocksPerBatch = static_cast<uint32_t>(scOut.GetDim(2));
+        OP_CHECK_IF(info.maxBlocksPerBatch == 0, OP_LOGE(context, "TND score last dim must be positive."),
+                    return ge::GRAPH_FAILED);
+        OP_CHECK_IF((info.maxBlocksPerBatch % MSA_SCORE_STRIDE_ALIGN) != 0,
+                    OP_LOGE(context, "TND score last dim(%u) must be a multiple of %u.", info.maxBlocksPerBatch,
+                            MSA_SCORE_STRIDE_ALIGN),
+                    return ge::GRAPH_FAILED);
+    }
+    OP_CHECK_IF(info.blockSize != MSA_BLOCK_SIZE,
+                OP_LOGE(context, "only blockSize == %u is supported, got %u.", MSA_BLOCK_SIZE, info.blockSize),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(
+        info.headDim == 0 || (info.headDim % MSA_SCORE_STRIDE_ALIGN) != 0,
+        OP_LOGE(context, "headDim(%u) must be a positive multiple of %u.", info.headDim, MSA_SCORE_STRIDE_ALIGN),
+        return ge::GRAPH_FAILED);
+    OP_CHECK_IF(info.headDim > MSA_K_TILE,
+                OP_LOGE(context, "headDim(%u) larger than %u is not supported yet.", info.headDim, MSA_K_TILE),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(info.numKvHeads == 0 || (info.numQHeads % info.numKvHeads) != 0,
+                OP_LOGE(context, "numQHeads(%u) must be divisible by numKvHeads(%u).", info.numQHeads, info.numKvHeads),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(info.batch == 0 || info.totalQ == 0 || info.maxBlocksPerBatch == 0,
+                OP_LOGE(context, "batch/totalQ/maxBlocksPerBatch must be positive."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(info.keyLayout != MSA_KEY_LAYOUT_TND && info.numPages == 0,
+                OP_LOGE(context, "PA numPages must be positive."), return ge::GRAPH_FAILED);
+    OP_CHECK_IF(static_cast<uint32_t>(startLocShape->GetStorageShape().GetDim(0)) != info.batch,
+                OP_LOGE(context, "start_loc size must equal batch."), return ge::GRAPH_FAILED);
+
+    const auto *queryDesc = context->GetInputDesc(MSA_IDX_QUERY);
+    OP_CHECK_NULL_WITH_CONTEXT(context, queryDesc);
+    info.queryDtype = queryDesc->GetDataType();
+    OP_CHECK_IF(info.queryDtype != ge::DT_BF16 && info.queryDtype != ge::DT_FLOAT16,
+                OP_LOGE(context, "query dtype must be bf16 or fp16 on A2/A3."), return ge::GRAPH_FAILED);
+
+    const auto *keyDesc = context->GetInputDesc(MSA_IDX_KEY);
+    OP_CHECK_NULL_WITH_CONTEXT(context, keyDesc);
+    info.keyDtype = keyDesc->GetDataType();
+    info.isQuant = (info.keyDtype == ge::DT_INT8);
+    if (info.isQuant) {
+        OP_CHECK_IF(info.queryDtype != ge::DT_FLOAT16, OP_LOGE(context, "int8 key currently requires fp16 query."),
+                    return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(info.keyDtype != info.queryDtype, OP_LOGE(context, "non-quant key dtype must match query dtype."),
+                    return ge::GRAPH_FAILED);
+    }
+
+    const gert::StorageShape *scaleShape = context->GetOptionalInputShape(MSA_IDX_SCALE);
+    if (info.isQuant) {
+        OP_CHECK_IF(scaleShape == nullptr, OP_LOGE(context, "int8 key requires dequant scale."),
+                    return ge::GRAPH_FAILED);
+        const gert::Shape &sc = scaleShape->GetStorageShape();
+        if (info.keyLayout == MSA_KEY_LAYOUT_TND) {
+            const bool ok2d =
+                (sc.GetDimNum() == MSA_SCALE_TND_DIM_NUM && static_cast<uint32_t>(sc.GetDim(0)) == info.totalK &&
+                 static_cast<uint32_t>(sc.GetDim(1)) == info.numKvHeads);
+            const bool ok1d =
+                (sc.GetDimNum() == 1 && info.numKvHeads == 1 && static_cast<uint32_t>(sc.GetDim(0)) == info.totalK);
+            OP_CHECK_IF(!ok2d && !ok1d,
+                        OP_LOGE(context, "TND dequant scale must be [%u, %u] or [%u] (N2=1).", info.totalK,
+                                info.numKvHeads, info.totalK),
+                        return ge::GRAPH_FAILED);
+        } else {
+            OP_CHECK_IF(sc.GetDimNum() != MSA_SCALE_PA_DIM_NUM,
+                        OP_LOGE(context, "PA dequant scale must be 3D [NP, N_kv, P], got rank %zu.", sc.GetDimNum()),
+                        return ge::GRAPH_FAILED);
+            OP_CHECK_IF(
+                static_cast<uint32_t>(sc.GetDim(0)) != info.numPages ||
+                    static_cast<uint32_t>(sc.GetDim(1)) != info.numKvHeads ||
+                    static_cast<uint32_t>(sc.GetDim(2)) != info.blockSize,
+                OP_LOGE(context, "dequant scale shape must be [%u, %u, %u], got [%ld, %ld, %ld].", info.numPages,
+                        info.numKvHeads, info.blockSize, sc.GetDim(0), sc.GetDim(1), sc.GetDim(2)),
+                return ge::GRAPH_FAILED);
+        }
+        const auto *scaleDesc = context->GetOptionalInputDesc(MSA_IDX_SCALE);
+        OP_CHECK_NULL_WITH_CONTEXT(context, scaleDesc);
+        OP_CHECK_IF(scaleDesc->GetDataType() != ge::DT_FLOAT, OP_LOGE(context, "dequant scale dtype must be float32."),
+                    return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(scaleShape != nullptr, OP_LOGE(context, "non-quant path must not pass scale."),
+                    return ge::GRAPH_FAILED);
+    }
+
+    const int64_t *sparseModeAttr = attrs->GetInt(MSA_ATTR_SPARSE_MODE);
+    info.sparseMode = (sparseModeAttr == nullptr) ? MSA_SPARSE_MODE_RIGHT_DOWN : static_cast<uint32_t>(*sparseModeAttr);
+    OP_CHECK_IF(info.sparseMode != MSA_SPARSE_MODE_DEFAULT && info.sparseMode != MSA_SPARSE_MODE_RIGHT_DOWN,
+                OP_LOGE(context, "sparse_mode must be 0 or 3, got %u.", info.sparseMode), return ge::GRAPH_FAILED);
+
+    const gert::StorageShape *attenMaskShape = context->GetOptionalInputShape(MSA_IDX_ATTEN_MASK);
+    if (info.sparseMode == MSA_SPARSE_MODE_RIGHT_DOWN) {
+        OP_CHECK_IF(attenMaskShape == nullptr,
+                    OP_LOGE(context, "sparse_mode=3 requires atten_mask of shape [2048, 2048]."),
+                    return ge::GRAPH_FAILED);
+        const gert::Shape &am = attenMaskShape->GetStorageShape();
+        OP_CHECK_IF(am.GetDimNum() != MSA_ATTEN_MASK_DIM_NUM ||
+                        static_cast<uint32_t>(am.GetDim(0)) != MSA_ATTEN_MASK_SIZE ||
+                        static_cast<uint32_t>(am.GetDim(1)) != MSA_ATTEN_MASK_SIZE,
+                    OP_LOGE(context, "atten_mask must be [2048, 2048], got rank=%zu dims=[%ld,%ld].", am.GetDimNum(),
+                            am.GetDimNum() > 0 ? am.GetDim(0) : -1, am.GetDimNum() > 1 ? am.GetDim(1) : -1),
+                    return ge::GRAPH_FAILED);
+    } else {
+        OP_CHECK_IF(attenMaskShape != nullptr, OP_LOGE(context, "sparse_mode=0 must not pass atten_mask."),
+                    return ge::GRAPH_FAILED);
+    }
+
+    const int64_t *initBlocksAttr = attrs->GetInt(MSA_ATTR_INIT_BLOCKS);
+    const int64_t *localBlocksAttr = attrs->GetInt(MSA_ATTR_LOCAL_BLOCKS);
+    info.initBlocks = (initBlocksAttr == nullptr) ? MSA_DEFAULT_INIT_BLOCKS : static_cast<uint32_t>(*initBlocksAttr);
+    info.localBlocks =
+        (localBlocksAttr == nullptr) ? MSA_DEFAULT_LOCAL_BLOCKS : static_cast<uint32_t>(*localBlocksAttr);
+    OP_CHECK_IF(info.initBlocks > info.maxBlocksPerBatch || info.localBlocks > info.maxBlocksPerBatch,
+                OP_LOGE(context, "init_blocks/local_blocks must be <= maxBlocksPerBatch."), return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus DoTiling(gert::TilingContext *context, const MsaIndexScoreInfo &info)
+{
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(info.platformInfo);
+    const uint32_t aicNum = ascendcPlatform.GetCoreNumAic();
+    const uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
+    OP_CHECK_IF(aicNum == 0, OP_LOGE(context, "aic core num is 0."), return ge::GRAPH_FAILED);
+
+    const uint32_t scoreBlockStride = RoundUpU32(info.maxBlocksPerBatch, MSA_SCORE_STRIDE_ALIGN);
+    // S workspace：非量化路径元素为 fp16（AIC fixpipe F322F16 直接写出），int8 路径 fp32。
+    const uint32_t sWsBytes =
+        aicNum * MSA_WORKSPACE_STAGES * MSA_STILE_ELEM_NUM * (info.isQuant ? sizeof(float) : sizeof(uint16_t));
+    const bool useKScratch = info.isQuant || (info.keyLayout == MSA_KEY_LAYOUT_TND);
+    const uint32_t kScratchBytes = useKScratch ? (aicNum * MSA_K_SCRATCH_ELEM_NUM * sizeof(uint16_t)) : 0U;
+    // K scratch 基址以 4B 为单位表达（kernel 内按 float* 折算），S 变 fp16 后偏移减半。
+    const uint32_t kScratchOffsetElems = sWsBytes / sizeof(float);
+
+    MsaIndexScoreTilingData tilingData;
+    tilingData.set_batch(info.batch);
+    tilingData.set_totalQ(info.totalQ);
+    tilingData.set_numQHeads(info.numQHeads);
+    tilingData.set_numKvHeads(info.numKvHeads);
+    tilingData.set_gqaGroup(info.numQHeads / info.numKvHeads);
+    tilingData.set_headDim(info.headDim);
+    tilingData.set_blockSize(info.blockSize);
+    tilingData.set_maxBlocksPerBatch(info.maxBlocksPerBatch);
+    tilingData.set_scoreBlockStride(scoreBlockStride);
+    tilingData.set_usedCoreNum(aicNum);
+    tilingData.set_isQuant(info.isQuant ? 1U : 0U);
+    tilingData.set_sparseMode(info.sparseMode);
+    tilingData.set_initBlocks(info.initBlocks);
+    tilingData.set_localBlocks(info.localBlocks);
+    tilingData.set_numPages(info.numPages);
+    tilingData.set_keyLayout(info.keyLayout);
+    tilingData.set_totalK(info.totalK);
+
+    tilingData.set_strideQt(info.numQHeads * info.headDim);
+    tilingData.set_strideQn(info.headDim);
+    if (info.keyLayout == MSA_KEY_LAYOUT_TND) {
+        tilingData.set_strideKvBlock(0);
+        tilingData.set_strideKvToken(info.numKvHeads * info.headDim);
+        tilingData.set_strideScalePage(info.numKvHeads);
+        tilingData.set_strideScaleHead(1);
+    } else if (info.keyLayout == MSA_KEY_LAYOUT_BNBD) {
+        tilingData.set_strideKvBlock(info.numKvHeads * info.blockSize * info.headDim);
+        tilingData.set_strideKvToken(info.headDim);
+        tilingData.set_strideScalePage(info.numKvHeads * info.blockSize);
+        tilingData.set_strideScaleHead(info.blockSize);
+    } else {
+        tilingData.set_strideKvBlock(info.blockSize * info.numKvHeads * info.headDim);
+        tilingData.set_strideKvToken(info.numKvHeads * info.headDim);
+        tilingData.set_strideScalePage(info.numKvHeads * info.blockSize);
+        tilingData.set_strideScaleHead(info.blockSize);
+    }
+    tilingData.set_strideOutHead(info.totalQ * scoreBlockStride);
+    tilingData.set_strideOutToken(scoreBlockStride);
+    tilingData.set_kScratchOffsetElems(kScratchOffsetElems);
+
+    tilingData.SaveToBuffer(context->GetRawTilingData()->GetData(), context->GetRawTilingData()->GetCapacity());
+    context->GetRawTilingData()->SetDataSize(tilingData.GetDataSize());
+
+    // MIX 1AIC:2AIV：CalcTschBlockDim 的 sliceNum 按 AIV 计数，内部再 / (aiv/aic)。
+    // 传入 aicNum 会再除一次得到 blockDim=aic/2（910B3: 20→10），只能打一半 Cube。
+    // 与 LightningIndexer 等 MIX 算子一致：sliceNum = aivNum → 910B3 blockDim=20。
+    context->SetBlockDim(ascendcPlatform.CalcTschBlockDim(aivNum, aicNum, aivNum));
+
+    size_t *workspaces = context->GetWorkspaceSizes(1);
+    OP_CHECK_NULL_WITH_CONTEXT(context, workspaces);
+    workspaces[0] =
+        ascendcPlatform.GetLibApiWorkSpaceSize() + static_cast<size_t>(sWsBytes) + static_cast<size_t>(kScratchBytes);
+
+    uint64_t tilingKey = MSA_TILING_KEY_FP16;
+    if (info.isQuant) {
+        tilingKey = MSA_TILING_KEY_FP16_INT8;
+    } else {
+        tilingKey = (info.queryDtype == ge::DT_BF16) ? MSA_TILING_KEY_BF16 : MSA_TILING_KEY_FP16;
+    }
+    context->SetTilingKey(tilingKey);
+    return ge::GRAPH_SUCCESS;
+}
+} // namespace
+
+static ge::graphStatus TilingPrepareForMsaIndexScore(gert::TilingParseContext * /* context */)
+{
+    return ge::GRAPH_SUCCESS;
+}
+
+static ge::graphStatus TilingForMsaIndexScore(gert::TilingContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_VECTOR_INNER_ERR("MsaIndexScore", "Tiling context is null."),
+                return ge::GRAPH_FAILED);
+    MsaIndexScoreInfo info;
+    if (ParseAndCheck(context, info) != ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+    return DoTiling(context, info);
+}
+
+IMPL_OP_OPTILING(MsaIndexScore)
+    .Tiling(TilingForMsaIndexScore)
+    .TilingParse<MsaIndexScoreCompileInfo>(TilingPrepareForMsaIndexScore);
+
+} // namespace optiling

--- a/csrc/attention/msa_index_score/op_host/msa_index_score_tiling.h
+++ b/csrc/attention/msa_index_score/op_host/msa_index_score_tiling.h
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_tiling.h
+ * \brief MsaIndexScore TilingData 定义与 host 侧解析类声明。
+ */
+
+#ifndef MSA_INDEX_SCORE_TILING_H
+#define MSA_INDEX_SCORE_TILING_H
+
+#include "exe_graph/runtime/tiling_context.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "register/op_def_registry.h"
+#include "register/tilingdata_base.h"
+#include "err/ops_err.h"
+
+namespace optiling {
+
+// 与 op_def 入参顺序一致
+constexpr uint32_t MSA_IDX_QUERY = 0;
+constexpr uint32_t MSA_IDX_KEY = 1;
+constexpr uint32_t MSA_IDX_BLOCK_TABLE = 2;
+constexpr uint32_t MSA_IDX_SCALE = 3;
+constexpr uint32_t MSA_IDX_ATTEN_MASK = 4;
+constexpr uint32_t MSA_IDX_ACTUAL_SEQ_QLEN = 5;
+constexpr uint32_t MSA_IDX_ACTUAL_SEQ_KLEN = 6;
+constexpr uint32_t MSA_IDX_START_LOC = 7;
+
+constexpr uint32_t MSA_ATTR_LAYOUT_KEY = 0;
+constexpr uint32_t MSA_ATTR_SPARSE_MODE = 1;
+constexpr uint32_t MSA_ATTR_INIT_BLOCKS = 2;
+constexpr uint32_t MSA_ATTR_LOCAL_BLOCKS = 3;
+
+BEGIN_TILING_DATA_DEF(MsaIndexScoreTilingData)
+TILING_DATA_FIELD_DEF(uint32_t, batch)
+TILING_DATA_FIELD_DEF(uint32_t, totalQ)
+TILING_DATA_FIELD_DEF(uint32_t, numQHeads)
+TILING_DATA_FIELD_DEF(uint32_t, numKvHeads)
+TILING_DATA_FIELD_DEF(uint32_t, gqaGroup)
+TILING_DATA_FIELD_DEF(uint32_t, headDim)
+TILING_DATA_FIELD_DEF(uint32_t, blockSize)
+TILING_DATA_FIELD_DEF(uint32_t, maxBlocksPerBatch)
+TILING_DATA_FIELD_DEF(uint32_t, scoreBlockStride)
+TILING_DATA_FIELD_DEF(uint32_t, usedCoreNum)
+TILING_DATA_FIELD_DEF(uint32_t, isQuant)    // 1: key 为 int8
+TILING_DATA_FIELD_DEF(uint32_t, sparseMode) // 0 / 3
+TILING_DATA_FIELD_DEF(uint32_t, initBlocks)
+TILING_DATA_FIELD_DEF(uint32_t, localBlocks)
+TILING_DATA_FIELD_DEF(uint32_t, numPages)
+TILING_DATA_FIELD_DEF(uint32_t, strideQt)
+TILING_DATA_FIELD_DEF(uint32_t, strideQn)
+TILING_DATA_FIELD_DEF(uint32_t, strideKvBlock)
+TILING_DATA_FIELD_DEF(uint32_t, strideKvToken)
+TILING_DATA_FIELD_DEF(uint32_t, strideScalePage)
+TILING_DATA_FIELD_DEF(uint32_t, strideScaleHead)
+TILING_DATA_FIELD_DEF(uint32_t, strideOutHead)
+TILING_DATA_FIELD_DEF(uint32_t, strideOutToken)
+TILING_DATA_FIELD_DEF(uint32_t, kScratchOffsetElems)
+TILING_DATA_FIELD_DEF(uint32_t, keyLayout) // MSA_KEY_LAYOUT_BBND / BNBD / TND
+TILING_DATA_FIELD_DEF(uint32_t, totalK)    // TND：key 第 0 维 T2；PA：0
+END_TILING_DATA_DEF
+REGISTER_TILING_DATA_CLASS(MsaIndexScore, MsaIndexScoreTilingData)
+
+struct MsaIndexScoreCompileInfo {};
+
+struct MsaIndexScoreInfo {
+    fe::PlatFormInfos *platformInfo = nullptr;
+    uint32_t batch = 0;
+    uint32_t totalQ = 0;
+    uint32_t numQHeads = 0;
+    uint32_t numKvHeads = 0;
+    uint32_t headDim = 0;
+    uint32_t blockSize = 0;
+    uint32_t maxBlocksPerBatch = 0;
+    uint32_t numPages = 0;
+    uint32_t sparseMode = 3;
+    uint32_t initBlocks = 0;
+    uint32_t localBlocks = 1;
+    uint32_t keyLayout = 0;
+    uint32_t totalK = 0;
+    bool isQuant = false;
+    ge::DataType queryDtype = ge::DT_BF16;
+    ge::DataType keyDtype = ge::DT_BF16;
+};
+
+} // namespace optiling
+
+#endif // MSA_INDEX_SCORE_TILING_H

--- a/csrc/attention/msa_index_score/op_kernel/arch22/msa_block_mmad.h
+++ b/csrc/attention/msa_index_score/op_kernel/arch22/msa_block_mmad.h
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_block_mmad.h
+ * \brief Q 驻留 L1 + K L1 pingpong + L0C 双缓冲的 BlockMmad。
+ *
+ * 基于 Catlass FullLoadA：同一 M-tile 只搬一次 Q；相邻 K page 的 FIXPIPE 与 Cube 重叠。
+ * Atlas A2 L0C=128KB，两块 128x128 fp32 C 各 64KB。ENABLE_UNIT_FLAG 保持 false。
+ */
+
+#ifndef MSA_BLOCK_MMAD_H
+#define MSA_BLOCK_MMAD_H
+
+#include "catlass/catlass.hpp"
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm/helper.hpp"
+#include "catlass/gemm/tile/tile_copy.hpp"
+#include "catlass/gemm/tile/tile_mmad.hpp"
+
+#include "../msa_index_score_common.h"
+
+namespace MsaIndexScoreNs {
+
+template <class AType_, class BType_, class CType_, uint32_t STAGES_IN = 3, bool USE_UNIT_FLAG_ = false>
+class MsaBlockMmad {
+public:
+    using ArchTag = Catlass::Arch::AtlasA2;
+    using ElementA = typename AType_::Element;
+    using LayoutA = typename AType_::Layout;
+    using ElementB = typename BType_::Element;
+    using LayoutB = typename BType_::Layout;
+    using ElementC = typename CType_::Element;
+    using LayoutC = typename CType_::Layout;
+    using BiasType = void;
+    using TileCopy = Catlass::Gemm::Tile::TileCopy<ArchTag, AType_, BType_, CType_, BiasType>;
+    using TileMmad = Catlass::Gemm::Tile::TileMmad<ArchTag, AType_, BType_, BiasType>;
+    using CopyGmToL1A = typename TileCopy::CopyGmToL1A;
+    using CopyGmToL1B = typename TileCopy::CopyGmToL1B;
+    using CopyL1ToL0A = typename TileCopy::CopyL1ToL0A;
+    using CopyL1ToL0B = typename TileCopy::CopyL1ToL0B;
+    using CopyL0CToGm = typename TileCopy::CopyL0CToGm;
+    using ElementAccumulator =
+        typename Catlass::Gemm::helper::ElementAccumulatorSelector<ElementA, ElementB>::ElementAccumulator;
+    using LayoutAInL1 = typename CopyL1ToL0A::LayoutSrc;
+    using LayoutBInL1 = typename CopyL1ToL0B::LayoutSrc;
+    using LayoutAInL0 = typename CopyL1ToL0A::LayoutDst;
+    using LayoutBInL0 = typename CopyL1ToL0B::LayoutDst;
+    using LayoutCInL0 = Catlass::layout::zN;
+    using L1AAlignHelper = Catlass::Gemm::helper::L1AlignHelper<ElementA, LayoutA>;
+    using L1BAlignHelper = Catlass::Gemm::helper::L1AlignHelper<ElementB, LayoutB>;
+
+    // K (B) 的 L1 流水级数。非量化 3 级：fixpipe 减半（fp16 S）后 MTE2 的逐页延迟
+    // （~390ns，L2 命中）会成为新的关键路径，加深一级让 MTE2 提前两页预取。
+    // int8 保持 2 级：K 源是每 stile 复用的 per-core scratch，AIV 下一 stile 的 cast
+    // 会重写该区，更深的预取与 cast 重写产生竞态（实测 STAGES=3 下 int8 崩溃）。
+    // L1 占用：A 32KB + 3×32KB B = 128KB / 512KB。
+    static constexpr uint32_t STAGES = STAGES_IN;
+    // 非量化路径开 unit flag：mmad 与 fixpipe 的依赖交给硬件互锁，省掉每页
+    // M_FIX/FIX_M 四次标量 set/wait。标量因此能在 cube 完成前就发出下一页的
+    // MTE2/MTE1，把 GM→L1 的搬运藏到 cube/fixpipe 后面。
+    static constexpr bool USE_UNIT_FLAG = USE_UNIT_FLAG_;
+    static constexpr uint32_t L0C_STAGES = 2;
+    static constexpr uint32_t L1_M = MSA_ROW_TILE_M;
+    static constexpr uint32_t L1_N = MSA_BLOCK_SIZE;
+    static constexpr uint32_t L1_K = MSA_K_TILE;
+    static constexpr uint32_t L1A_SIZE = L1_M * L1_K * sizeof(ElementA);
+    static constexpr uint32_t L1B_SIZE = L1_N * L1_K * sizeof(ElementB);
+    // L0A/L0B 各仅 64KB，B tile 32KB → 乒乓固定 2 级（32KB/级）；与 L1B STAGES 解耦。
+    static constexpr uint32_t L0A_STAGES = 2;
+    static constexpr uint32_t L0A_RESIDENT_ID = 0;
+    static constexpr uint32_t L0A_FALLBACK_ID = 1;
+    static constexpr uint32_t L0B_STAGES = 2;
+    static constexpr uint32_t L0A_PINGPONG_BUF_SIZE = ArchTag::L0A_SIZE / L0A_STAGES;
+    static constexpr uint32_t L0B_PINGPONG_BUF_SIZE = ArchTag::L0B_SIZE / L0B_STAGES;
+    static constexpr uint32_t L0C_TILE_SIZE = L1_M * L1_N * sizeof(ElementAccumulator);
+
+    static_assert(std::is_same_v<LayoutC, Catlass::layout::RowMajor>, "LayoutC must be RowMajor (fixpipe nz2nd)");
+    // A2 的 L0A/L0B 各仅 64KB：A/B tile 32KB，乒乓最多 2 级（32KB/级）。
+    static_assert(L0A_PINGPONG_BUF_SIZE >= L1A_SIZE, "L0A pingpong buf smaller than A tile");
+    static_assert(L0B_PINGPONG_BUF_SIZE >= L1B_SIZE, "L0B pingpong buf smaller than B tile");
+    static_assert(L0C_TILE_SIZE * L0C_STAGES <= ArchTag::L0C_SIZE, "L0C pingpong exceeds L0C");
+    static_assert(L1A_SIZE + L1B_SIZE * STAGES <= ArchTag::L1_SIZE, "L1 A+B exceeds L1");
+
+    __aicore__ inline MsaBlockMmad(Catlass::Arch::Resource<ArchTag> &resource)
+    {
+        l1ATensor_ = resource.l1Buf.template GetBufferByByte<ElementA>(0);
+        const uint32_t l1BOffset = L1A_SIZE;
+        for (uint32_t i = 0; i < STAGES; ++i) {
+            l1BTensorList_[i] = resource.l1Buf.template GetBufferByByte<ElementB>(l1BOffset + L1B_SIZE * i);
+            l1BEventList_[i] = static_cast<int32_t>(i + STAGES);
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList_[i]);
+        }
+        // L0A 槽 0 专供常驻 Q：不预置 M_MTE1，改用 LoadA 内「Set+Wait 成对」自平衡，
+        // 避免计数型 flag 让 MTE1 用构造时的余额提前放行、覆盖仍被 mmad 读取的 Q。
+        // 槽 1 供 kTileCount>1 的回退路径（每 k-tile 重搬 A），沿用预置 + 析构等待。
+        for (uint32_t i = 0; i < L0A_STAGES; ++i) {
+            l0ATensorList_[i] = resource.l0ABuf.template GetBufferByByte<ElementA>(L0A_PINGPONG_BUF_SIZE * i);
+            l0AEventList_[i] = static_cast<int32_t>(i);
+        }
+        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList_[L0A_FALLBACK_ID]);
+        for (uint32_t i = 0; i < L0B_STAGES; ++i) {
+            l0BTensorList_[i] = resource.l0BBuf.template GetBufferByByte<ElementB>(L0B_PINGPONG_BUF_SIZE * i);
+            l0BEventList_[i] = static_cast<int32_t>(i + STAGES + L0A_STAGES);
+            AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList_[i]);
+        }
+        for (uint32_t i = 0; i < L0C_STAGES; ++i) {
+            l0CTensorList_[i] = resource.l0CBuf.template GetBufferByByte<ElementAccumulator>(L0C_TILE_SIZE * i);
+            l0CEventList_[i] = static_cast<int32_t>(i);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList_[i]);
+        }
+    }
+
+    __aicore__ inline ~MsaBlockMmad()
+    {
+        for (uint32_t i = 0; i < STAGES; ++i) {
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList_[i]);
+        }
+        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList_[L0A_FALLBACK_ID]);
+        for (uint32_t i = 0; i < L0B_STAGES; ++i) {
+            AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList_[i]);
+        }
+        for (uint32_t i = 0; i < L0C_STAGES; ++i) {
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList_[i]);
+        }
+    }
+
+    __aicore__ inline void operator()(const AscendC::GlobalTensor<ElementA> &gmA, const LayoutA &layoutA,
+                                      const AscendC::GlobalTensor<ElementB> &gmB, const LayoutB &layoutB,
+                                      const AscendC::GlobalTensor<ElementC> &gmC, const LayoutC &layoutC,
+                                      const Catlass::GemmCoord &actualShape, bool needLoadL1)
+    {
+        const uint32_t mRound = RoundUp<L1AAlignHelper::M_ALIGNED>(actualShape.m());
+        const uint32_t nRound = RoundUp<L1BAlignHelper::N_ALIGNED>(actualShape.n());
+        auto layoutAInL1 = LayoutAInL1::template MakeLayout<ElementA>(L1_M, actualShape.k());
+        auto layoutBInL1 = LayoutBInL1::template MakeLayout<ElementB>(L1_K, L1_N);
+        auto layoutInL0C = LayoutCInL0::MakeLayoutInL0C(Catlass::MakeCoord(mRound, nRound));
+        uint32_t kActual = Min(actualShape.k(), L1_K);
+
+        const uint32_t kTileCount = CeilDiv<L1_K>(actualShape.k());
+        const uint32_t mPartLoop = CeilDiv<L1_M>(mRound);
+        const uint32_t nPartLoop = CeilDiv<L1_N>(nRound);
+        // headDim <= L1_K（实际场景恒成立）时整块 Q 一次进 L0A，可跨 page 复用；
+        // 否则退回逐 page 重搬 A 的通用路径。
+        const bool qResident = (kTileCount == 1U) && (mPartLoop == 1U) && (CeilDiv<L1_K>(kActual) == 1U);
+
+        if (needLoadL1) {
+            auto layoutTileA = layoutA.GetTileLayout(Catlass::MakeCoord(actualShape.m(), actualShape.k()));
+            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEvent_);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1AEvent_);
+            copyGmToL1A_(l1ATensor_, gmA, layoutAInL1, layoutTileA);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEvent_);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1AEvent_);
+            if (qResident) {
+                // 本 M-tile 的 Q 一次搬进 L0A 并驻留：省掉每页 32KB 的 L1→L0A
+                // 搬运与两次标量同步。先让 MTE1 等上一 M-tile 的 mmad 读完。
+                AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList_[L0A_RESIDENT_ID]);
+                AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList_[L0A_RESIDENT_ID]);
+                LayoutAInL0 layoutAInL0 = LayoutAInL0::template MakeLayout<ElementA>(mRound, kActual);
+                copyL1ToL0A_(l0ATensorList_[L0A_RESIDENT_ID], l1ATensor_, layoutAInL0, layoutAInL1);
+                AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(l0AEventList_[L0A_RESIDENT_ID]);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(l0AEventList_[L0A_RESIDENT_ID]);
+            }
+        }
+
+        AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList_[l1ListId_]);
+        auto layoutTileB = layoutB.GetTileLayout(Catlass::MakeCoord(kActual, actualShape.n()));
+        copyGmToL1B_(l1BTensorList_[l1ListId_], gmB, layoutBInL1, layoutTileB);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList_[l1ListId_]);
+
+        // 等本槽位上一轮 FIXPIPE 完成后再写 L0C，从而与另一槽位的 FIXPIPE 重叠。
+        // unit flag 下该依赖由硬件维护，省掉这次标量等待。
+        if constexpr (!USE_UNIT_FLAG) {
+            AscendC::WaitFlag<AscendC::HardEvent::FIX_M>(l0CEventList_[l0CListId_]);
+        }
+
+        for (uint32_t kLoopIdx = 0; kLoopIdx < kTileCount; ++kLoopIdx) {
+            const uint32_t l1ListIdNext = (l1ListId_ + 1 < STAGES) ? (l1ListId_ + 1) : 0;
+            uint32_t kActualNext = 0;
+            if (kLoopIdx < kTileCount - 1) {
+                const uint32_t kLoopIdxNext = kLoopIdx + 1;
+                kActualNext = (kLoopIdxNext < kTileCount - 1) ? L1_K : (actualShape.k() - kLoopIdxNext * L1_K);
+                Catlass::MatrixCoord gmTileBOffset{kLoopIdxNext * L1_K, 0};
+                auto gmTileB = gmB[layoutB.GetOffset(gmTileBOffset)];
+                AscendC::WaitFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList_[l1ListIdNext]);
+                layoutTileB = layoutB.GetTileLayout(Catlass::MakeCoord(kActualNext, actualShape.n()));
+                copyGmToL1B_(l1BTensorList_[l1ListIdNext], gmTileB, layoutBInL1, layoutTileB);
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList_[l1ListIdNext]);
+            }
+
+            auto l1ATensor = l1ATensor_;
+            auto l1BTensor = l1BTensorList_[l1ListId_];
+            const uint32_t kPartLoop = CeilDiv<L1_K>(kActual);
+
+            for (uint32_t mPartIdx = 0; mPartIdx < mPartLoop; ++mPartIdx) {
+                const uint32_t mPartActual = (mPartIdx < mPartLoop - 1) ? L1_M : (mRound - mPartIdx * L1_M);
+                for (uint32_t kPartIdx = 0; kPartIdx < kPartLoop; ++kPartIdx) {
+                    const uint32_t kPartActual = (kPartIdx < kPartLoop - 1) ? L1_K : (kActual - kPartIdx * L1_K);
+                    auto l0ATile = l0ATensorList_[qResident ? L0A_RESIDENT_ID : L0A_FALLBACK_ID];
+                    if (!qResident) {
+                        LayoutAInL0 layoutAInL0 = LayoutAInL0::template MakeLayout<ElementA>(mPartActual, kPartActual);
+                        Catlass::MatrixCoord l1AOffset{mPartIdx * L1_M, kPartIdx * L1_K + kLoopIdx * L1_K};
+                        auto l1ATile = l1ATensor[layoutAInL1.GetOffset(l1AOffset)];
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0AEventList_[L0A_FALLBACK_ID]);
+                        copyL1ToL0A_(l0ATile, l1ATile, layoutAInL0, layoutAInL1);
+                    }
+
+                    for (uint32_t nPartIdx = 0; nPartIdx < nPartLoop; ++nPartIdx) {
+                        const uint32_t nPartActual = (nPartIdx < nPartLoop - 1) ? L1_N : (nRound - nPartIdx * L1_N);
+                        auto l0BTile = l0BTensorList_[l0BListId_];
+                        LayoutBInL0 layoutBInL0 = LayoutBInL0::template MakeLayout<ElementB>(kPartActual, nPartActual);
+                        Catlass::MatrixCoord l1BOffset{kPartIdx * L1_K, nPartIdx * L1_N};
+                        auto l1BTile = l1BTensor[layoutBInL1.GetOffset(l1BOffset)];
+                        AscendC::WaitFlag<AscendC::HardEvent::M_MTE1>(l0BEventList_[l0BListId_]);
+                        if ((kPartIdx == 0) && (nPartIdx == 0)) {
+                            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE1>(l1BEventList_[l1ListId_]);
+                        }
+                        copyL1ToL0B_(l0BTile, l1BTile, layoutBInL0, layoutBInL1);
+                        if ((kPartIdx == kPartLoop - 1) && (nPartIdx == nPartLoop - 1)) {
+                            AscendC::SetFlag<AscendC::HardEvent::MTE1_MTE2>(l1BEventList_[l1ListId_]);
+                        }
+                        AscendC::SetFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                        Catlass::MatrixCoord l0COffset{mPartIdx * L1_M, nPartIdx * L1_N};
+                        auto l0CTile = l0CTensorList_[l0CListId_][layoutInL0C.GetOffset(l0COffset)];
+                        AscendC::WaitFlag<AscendC::HardEvent::MTE1_M>(EVENT_ID0);
+                        const bool initC = ((kLoopIdx == 0) && (kPartIdx == 0));
+                        uint8_t unitFlag = 0b00;
+                        if constexpr (USE_UNIT_FLAG) {
+                            const bool last = (kLoopIdx == kTileCount - 1) && (mPartIdx == mPartLoop - 1) &&
+                                              (kPartIdx == kPartLoop - 1) && (nPartIdx == nPartLoop - 1);
+                            unitFlag = last ? 0b11 : 0b10;
+                        }
+                        tileMmad_(l0CTile, l0ATile, l0BTile, mPartActual, nPartActual, kPartActual, initC, unitFlag);
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0BEventList_[l0BListId_]);
+                        l0BListId_ = (l0BListId_ + 1 < L0B_STAGES) ? (l0BListId_ + 1) : 0;
+                    }
+                    if (!qResident) {
+                        AscendC::SetFlag<AscendC::HardEvent::M_MTE1>(l0AEventList_[L0A_FALLBACK_ID]);
+                    }
+                }
+            }
+            l1ListId_ = l1ListIdNext;
+            kActual = kActualNext;
+        }
+
+        LayoutC layoutBlock = layoutC.GetTileLayout(actualShape.GetCoordMN());
+        if constexpr (USE_UNIT_FLAG) {
+            copyL0CToGm_(gmC, l0CTensorList_[l0CListId_], layoutBlock, layoutInL0C, 0b11);
+        } else {
+            AscendC::SetFlag<AscendC::HardEvent::M_FIX>(l0CEventList_[l0CListId_]);
+            AscendC::WaitFlag<AscendC::HardEvent::M_FIX>(l0CEventList_[l0CListId_]);
+            copyL0CToGm_(gmC, l0CTensorList_[l0CListId_], layoutBlock, layoutInL0C);
+            AscendC::SetFlag<AscendC::HardEvent::FIX_M>(l0CEventList_[l0CListId_]);
+        }
+        l0CListId_ = (l0CListId_ + 1 < L0C_STAGES) ? (l0CListId_ + 1) : 0;
+    }
+
+private:
+    AscendC::LocalTensor<ElementA> l1ATensor_;
+    AscendC::LocalTensor<ElementB> l1BTensorList_[STAGES];
+    AscendC::LocalTensor<ElementA> l0ATensorList_[STAGES];
+    AscendC::LocalTensor<ElementB> l0BTensorList_[STAGES];
+    AscendC::LocalTensor<ElementAccumulator> l0CTensorList_[L0C_STAGES];
+    int32_t l1AEvent_{0};
+    int32_t l1BEventList_[STAGES]{};
+    int32_t l0AEventList_[STAGES]{};
+    int32_t l0BEventList_[STAGES]{};
+    int32_t l0CEventList_[L0C_STAGES]{};
+    uint32_t l1ListId_{0};
+    uint32_t l0BListId_{0};
+    uint32_t l0CListId_{0};
+    TileMmad tileMmad_;
+    CopyGmToL1A copyGmToL1A_;
+    CopyGmToL1B copyGmToL1B_;
+    CopyL1ToL0A copyL1ToL0A_;
+    CopyL1ToL0B copyL1ToL0B_;
+    CopyL0CToGm copyL0CToGm_;
+};
+
+} // namespace MsaIndexScoreNs
+
+#endif // MSA_BLOCK_MMAD_H

--- a/csrc/attention/msa_index_score/op_kernel/arch22/msa_index_score_epilogue.h
+++ b/csrc/attention/msa_index_score/op_kernel/arch22/msa_index_score_epilogue.h
@@ -1,0 +1,785 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_epilogue.h
+ * \brief AIV 侧 Epilogue：可选反量化列乘 -> atten_mask -> 分段 RowMax -> local_mask -> 写回。
+ *
+ * 数值路径：
+ *   score = Maxpool[ (scale·) Q@Kᵀ + atten_mask ] + local_mask
+ * atten_mask（sparse_mode=3）按 rightDownCausal 解析，不加载 [2048,2048] 模板。
+ * local_mask 由 start_loc（query 所在逻辑 block）+ init/local_blocks 生成强制 +∞。
+ */
+
+#ifndef MSA_INDEX_SCORE_EPILOGUE_H
+#define MSA_INDEX_SCORE_EPILOGUE_H
+
+#include "kernel_operator.h"
+
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/resource.hpp"
+
+#include "../msa_index_score_common.h"
+#include "../msa_index_score_debug.h"
+#include "msa_index_score_task.h"
+
+namespace MsaIndexScoreNs {
+
+template <bool IS_QUANT>
+class MsaSegRowMaxEpilogue {
+public:
+    using ArchTag = Catlass::Arch::AtlasA2;
+    // S workspace 元素类型：非量化 fp16，int8 fp32。
+    using ElementS = std::conditional_t<IS_QUANT, float, half>;
+
+    // score 暂存容量：1 AIC : 2 AIV 下每个 subcore 最多拿到半个 M-tile 的行；
+    // 一次 flush 覆盖 MSA_STAGE_BLOCKS 个 block（= 每行 1KB 连续写回）。
+    static constexpr uint32_t MSA_STAGE_ROWS = MSA_ROW_TILE_M / 2;
+    static constexpr uint32_t MSA_STAGE_BLOCKS = 256;
+    static_assert(MSA_STAGE_BLOCKS % MSA_BLOCKS_PER_STILE == 0, "stage window must hold whole S-tiles");
+
+    // UB 手工布局（字节偏移），catlass 不提供 UB allocator。
+    static constexpr uint32_t UB_OFF_S = 0;
+    static constexpr uint32_t UB_SIZE_S = MSA_ROWS_PER_PASS * MSA_BLOCKS_PER_STILE * MSA_BLOCK_SIZE * sizeof(float);
+    static constexpr uint32_t UB_OFF_T64 = UB_OFF_S + UB_SIZE_S;
+    static constexpr uint32_t UB_SIZE_T64 = MSA_REDUCE_ROWS * (MSA_BLOCK_SIZE / 2) * sizeof(float);
+    static constexpr uint32_t UB_OFF_T8 = UB_OFF_T64 + UB_SIZE_T64;
+    static constexpr uint32_t UB_SIZE_T8 = MSA_REDUCE_ROWS * MSA_FP32_PER_BLOCK * sizeof(float);
+    static constexpr uint32_t UB_OFF_ROWMAX = UB_OFF_T8 + UB_SIZE_T8;
+    static constexpr uint32_t UB_SIZE_ROWMAX = 512;
+    // 反量化 scale 一页：block_size 个 fp32 = 512B。
+    static constexpr uint32_t UB_OFF_DEQ = UB_OFF_ROWMAX + UB_SIZE_ROWMAX;
+    static constexpr uint32_t UB_SIZE_DEQ = MSA_BLOCK_SIZE * sizeof(float);
+    // 非量化：WholeReduceMax 的 fp16 输出（每 pass MSA_REDUCE_ROWS 个 half）。
+    static constexpr uint32_t UB_OFF_RED16 = UB_OFF_DEQ + UB_SIZE_DEQ;
+    static constexpr uint32_t UB_SIZE_RED16 = MSA_REDUCE_ROWS * sizeof(half);
+    // score 暂存：本 subcore 的行 × 一次 flush 覆盖的 block 数。逐 pass 只写 32B 到 GM
+    // 会把 MTE3 压到 ~9GB/s；改为在 UB 内按行累积、整行（≥1KB）一次写回。
+    static constexpr uint32_t UB_OFF_STAGE = ((UB_OFF_RED16 + UB_SIZE_RED16 + 511U) / 512U) * 512U;
+    static constexpr uint32_t UB_SIZE_STAGE = MSA_STAGE_ROWS * MSA_STAGE_BLOCKS * sizeof(float);
+    // 非量化：S16（fp16 载入缓冲）复用量化路径的 fp32 S 区（64KB = 两级 32KB 乒乓）。
+    // v0.7 PipeUtilization：aiv_mte2_wait_ratio≈0.84、aiv_mte2_ratio≈0.33、aiv_vec_ratio≈0.57，
+    // 说明 GM→UB 与归约串行；两级缓冲让下一 pass 的 MTE2 叠在当前 pass 的 V 上。
+    static constexpr uint32_t UB_OFF_S16 = UB_OFF_S;
+    static constexpr uint32_t UB_SIZE_S16 = MSA_ROWS_PER_PASS * MSA_BLOCKS_PER_STILE * MSA_BLOCK_SIZE * sizeof(half);
+    static constexpr uint32_t S16_STAGES = 2;
+    static constexpr uint32_t UB_TOTAL = UB_OFF_STAGE + UB_SIZE_STAGE;
+    static_assert(UB_TOTAL <= ArchTag::UB_SIZE, "MsaSegRowMaxEpilogue UB out of bounds");
+    static_assert(UB_OFF_S16 + S16_STAGES * UB_SIZE_S16 <= UB_OFF_T64, "S16 ping-pong overlaps T64");
+
+    static constexpr uint32_t STILE_WIDTH = MSA_BLOCKS_PER_STILE * MSA_BLOCK_SIZE;
+    // fp16：一个 32B datablock 16 个元素，一个 repeat 128 个元素（掩码 128 位）。
+    static constexpr uint32_t MSA_HALF_PER_BLOCK = 16;
+    static constexpr uint32_t MSA_HALF_PER_MASK_WORD = 64;
+
+    // -3.4e38 越界，float→half 按 IEEE 就近舍入得 -inf；归约后由 Maxs 抬回 MSA_FILL_VALUE。
+    static constexpr half FILL_VALUE_H = static_cast<half>(MSA_FILL_VALUE);
+
+    __aicore__ inline MsaSegRowMaxEpilogue() {}
+
+    __aicore__ inline void Init(Catlass::Arch::Resource<ArchTag> &resource, uint32_t numQHeads, uint32_t strideOutHead,
+                                uint32_t strideOutToken, uint32_t maxBlocksPerBatch, uint32_t strideScalePage,
+                                uint32_t strideScaleHead, bool isQuant, uint32_t keyLayout, uint32_t totalK,
+                                const AscendC::GlobalTensor<float> &gScore, const AscendC::GlobalTensor<float> &gScale,
+                                const AscendC::GlobalTensor<int32_t> &gBlockTable)
+    {
+        numQHeads_ = numQHeads;
+        strideOutHead_ = strideOutHead;
+        strideOutToken_ = strideOutToken;
+        maxBlocksPerBatch_ = maxBlocksPerBatch;
+        strideScalePage_ = strideScalePage;
+        strideScaleHead_ = strideScaleHead;
+        isQuant_ = isQuant;
+        keyLayout_ = keyLayout;
+        totalK_ = totalK;
+        if (keyLayout_ == MSA_KEY_LAYOUT_TND) {
+            // N2=1 packed [T2] / [T2,1]：token 步长为 1，避免误用 PA page 步长。
+            strideScalePage_ = 1;
+            strideScaleHead_ = 1;
+        }
+        gScore_ = gScore;
+        gScale_ = gScale;
+        gBlockTable_ = gBlockTable;
+
+        ubS_ = resource.ubBuf.template GetBufferByByte<float>(UB_OFF_S);
+        ubS16Ping_[0] = resource.ubBuf.template GetBufferByByte<half>(UB_OFF_S16);
+        ubS16Ping_[1] = resource.ubBuf.template GetBufferByByte<half>(UB_OFF_S16 + UB_SIZE_S16);
+        ubS16_ = ubS16Ping_[0];
+        ubT64_ = resource.ubBuf.template GetBufferByByte<float>(UB_OFF_T64);
+        ubT8_ = resource.ubBuf.template GetBufferByByte<float>(UB_OFF_T8);
+        ubRowMax_ = resource.ubBuf.template GetBufferByByte<float>(UB_OFF_ROWMAX);
+        ubDeqScale_ = resource.ubBuf.template GetBufferByByte<float>(UB_OFF_DEQ);
+        ubRed16_ = resource.ubBuf.template GetBufferByByte<half>(UB_OFF_RED16);
+        ubStage_ = resource.ubBuf.template GetBufferByByte<float>(UB_OFF_STAGE);
+    }
+
+    /// 进入一个新任务（M-tile）：确定本 subcore 负责的行区间并复位 score 暂存窗口。
+    __aicore__ inline void BeginTask(const MsaTask &task, uint32_t subIdx, uint32_t subBlockNum)
+    {
+        const uint32_t subM = MsaCeilDiv(task.mActual, subBlockNum);
+        mOff_ = subIdx * subM;
+        mSub_ = (mOff_ >= task.mActual) ? 0U : MsaMinU32(subM, task.mActual - mOff_);
+        // 暂存区按半个 M-tile 静态分配；若 subcore 数变化导致行数超出则退回逐 pass 直写。
+        stageOn_ = (mSub_ > 0U) && (mSub_ <= MSA_STAGE_ROWS);
+        stageBlkBase_ = 0;
+        stageBlkEnd_ = 0;
+        rowInReqBase_ = task.mStart + mOff_;
+        tokenBase0_ = task.cuQStart;
+        if constexpr (!IS_QUANT) {
+            // 本任务两级 S16 的 V_MTE2 余额；EndTask 对称 Wait，避免跨任务/跨启动泄漏。
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+        }
+    }
+
+    /// 任务结束：把暂存窗口里剩余的 score 写回 GM。
+    __aicore__ inline void EndTask()
+    {
+        FlushStage();
+        if constexpr (!IS_QUANT) {
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+        }
+    }
+
+    /// 处理一个 S tile（MSA_BLOCKS_PER_STILE 个 sparse block）中属于本 subcore 的行。
+    __aicore__ inline void ProcessSTile(const AscendC::GlobalTensor<ElementS> &gS, const MsaTask &task,
+                                        uint32_t blkBase, uint32_t subIdx, uint32_t subBlockNum, bool dumpDebug = false)
+    {
+        if (mSub_ == 0U) {
+            return;
+        }
+        const uint32_t mOff = mOff_;
+        const uint32_t mSub = mSub_;
+        if (stageOn_ && (blkBase >= stageBlkBase_ + MSA_STAGE_BLOCKS)) {
+            FlushStage();
+            stageBlkBase_ = blkBase;
+            stageBlkEnd_ = blkBase;
+        }
+
+#if MSA_INDEX_SCORE_DEBUG
+        if (dumpDebug) {
+            AscendC::printf("[MSA_DBG][AIV] ProcessSTile blkBase=%u subIdx=%u mOff=%u mSub=%u "
+                            "fullEndBlk=%u visibleEndBlk=%u isQuant=%u\n",
+                            blkBase, subIdx, mOff, mSub, task.fullEndBlk, task.visibleEndBlk,
+                            static_cast<uint32_t>(isQuant_));
+        }
+#endif
+
+        if constexpr (IS_QUANT) {
+            for (uint32_t p0 = 0; p0 < mSub; p0 += MSA_ROWS_PER_PASS) {
+                const uint32_t rows = MsaMinU32(MSA_ROWS_PER_PASS, mSub - p0);
+                ProcessPass(gS, task, blkBase, mOff + p0, rows, dumpDebug && (p0 == 0));
+            }
+        } else if (blkBase >= task.visibleEndBlk) {
+            for (uint32_t p0 = 0; p0 < mSub; p0 += MSA_ROWS_PER_PASS) {
+                const uint32_t rows = MsaMinU32(MSA_ROWS_PER_PASS, mSub - p0);
+                ProcessPass(gS, task, blkBase, mOff + p0, rows, false);
+            }
+        } else {
+            // 非量化可见 tile：pass i 的 MTE2 与 pass i-1 的 mask/reduce/stage 重叠。
+            uint32_t stage = 0;
+            bool hasPrev = false;
+            uint32_t prevRowOff = 0;
+            uint32_t prevRows = 0;
+            uint32_t prevStage = 0;
+            for (uint32_t p0 = 0; p0 < mSub; p0 += MSA_ROWS_PER_PASS) {
+                const uint32_t rows = MsaMinU32(MSA_ROWS_PER_PASS, mSub - p0);
+                const uint32_t rowOff = mOff + p0;
+                IssueS16(gS, rowOff, rows, stage);
+                if (hasPrev) {
+                    WaitS16(prevStage);
+                    ProcessPass(gS, task, blkBase, prevRowOff, prevRows, dumpDebug && (prevRowOff == mOff), true);
+                    ReleaseS16(prevStage);
+                }
+                hasPrev = true;
+                prevRowOff = rowOff;
+                prevRows = rows;
+                prevStage = stage;
+                stage ^= 1U;
+            }
+            if (hasPrev) {
+                WaitS16(prevStage);
+                ProcessPass(gS, task, blkBase, prevRowOff, prevRows, false, true);
+                ReleaseS16(prevStage);
+            }
+        }
+        stageBlkEnd_ = blkBase + MSA_BLOCKS_PER_STILE;
+    }
+
+private:
+    /// 非量化乒乓：把本 pass 的 S 搬进 ubS16Ping_[stage]，不阻塞 Vector。
+    __aicore__ inline void IssueS16(const AscendC::GlobalTensor<ElementS> &gS, uint32_t rowOff, uint32_t rows,
+                                    uint32_t stage)
+    {
+        if constexpr (IS_QUANT) {
+            return;
+        } else {
+            const int32_t evt = static_cast<int32_t>(stage);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(evt);
+            auto dst = ubS16Ping_[stage];
+            if (rows < MSA_ROWS_PER_PASS) {
+                AscendC::Duplicate(dst, static_cast<half>(MSA_FILL_VALUE), MSA_ROWS_PER_PASS * STILE_WIDTH);
+                AscendC::PipeBarrier<PIPE_V>();
+            }
+            AscendC::DataCopy(dst, gS[static_cast<uint64_t>(rowOff) * STILE_WIDTH], rows * STILE_WIDTH);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(evt);
+        }
+    }
+
+    __aicore__ inline void WaitS16(uint32_t stage)
+    {
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(static_cast<int32_t>(stage));
+        ubS16_ = ubS16Ping_[stage];
+    }
+
+    __aicore__ inline void ReleaseS16(uint32_t stage)
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(static_cast<int32_t>(stage));
+    }
+
+    /// 处理一个 pass（最多 MSA_ROWS_PER_PASS 行 × MSA_BLOCKS_PER_STILE 个 block）。
+    /// sLoaded：非量化乒乓路径已把 S 搬进 ubS16_，跳过本函数内的 GM→UB。
+    __aicore__ inline void ProcessPass(const AscendC::GlobalTensor<ElementS> &gS, const MsaTask &task, uint32_t blkBase,
+                                       uint32_t rowOff, uint32_t rows, bool dumpDebug, bool sLoaded = false)
+    {
+        const bool allInvalid = (blkBase >= task.visibleEndBlk);
+
+#if MSA_INDEX_SCORE_DEBUG
+        if (dumpDebug) {
+            AscendC::printf("[MSA_DBG][AIV] ProcessPass rowOff=%u rows=%u allInvalid=%u STILE_WIDTH=%u\n", rowOff, rows,
+                            static_cast<uint32_t>(allInvalid), STILE_WIDTH);
+        }
+#endif
+
+#if MSA_INDEX_SCORE_DEBUG
+        uint32_t sDumpN = MSA_DEBUG_DUMP_ELEMS;
+        if (task.kvLen > 0 && task.kvLen <= 8) {
+            sDumpN = static_cast<uint32_t>(task.kvLen) + 3U;
+        }
+#endif
+        if (!allInvalid) {
+            if (!sLoaded) {
+                // 短 pass 只拷了部分行；SegRowMax 固定按 16 行归约，未写入区域必须是 -inf。
+                // 满 16 行时 DataCopy 覆盖整块 ubS_，可跳过 Duplicate。
+                if (rows < MSA_ROWS_PER_PASS) {
+                    if constexpr (IS_QUANT) {
+                        AscendC::Duplicate(ubS_, MSA_FILL_VALUE, MSA_ROWS_PER_PASS * STILE_WIDTH);
+                    } else {
+                        AscendC::Duplicate(ubS16_, static_cast<half>(MSA_FILL_VALUE), MSA_ROWS_PER_PASS * STILE_WIDTH);
+                    }
+                    AscendC::PipeBarrier<PIPE_V>();
+                }
+                // 上一 pass 的归约还在读 ubS_/ubS16_（score 已改为暂存在 UB，不再有
+                // 逐 pass 的 MTE3 顺带排空 V），MTE2 覆盖该缓冲前必须显式等 V。
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+                if constexpr (IS_QUANT) {
+                    AscendC::DataCopy(ubS_, gS[static_cast<uint64_t>(rowOff) * STILE_WIDTH], rows * STILE_WIDTH);
+                } else {
+                    AscendC::DataCopy(ubS16_, gS[static_cast<uint64_t>(rowOff) * STILE_WIDTH], rows * STILE_WIDTH);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+            }
+
+#if MSA_INDEX_SCORE_DEBUG
+            if (dumpDebug) {
+                AscendC::printf("[MSA_DBG][AIV] after DOT load S ub (row0, blk0 first %u fp32):\n", sDumpN);
+                MsaDumpUbSample(ubS_, MSA_DUMP_DESC_S_DOT, sDumpN);
+                AscendC::printf("[MSA_DBG][AIV] S_after_dot:");
+                MsaPrintUbFloats(ubS_, sDumpN);
+            }
+#endif
+
+            if (isQuant_) {
+                ApplyDequantScale(task, blkBase, MSA_ROWS_PER_PASS);
+#if MSA_INDEX_SCORE_DEBUG
+                if (dumpDebug) {
+                    AscendC::printf("[MSA_DBG][AIV] S_after_dequant:");
+                    MsaPrintUbFloats(ubS_, sDumpN);
+                }
+#endif
+            }
+
+            ApplyMask(task, blkBase, rowOff, rows);
+
+#if MSA_INDEX_SCORE_DEBUG
+            if (dumpDebug) {
+                AscendC::printf("[MSA_DBG][AIV] after MASK S ub (row0, blk0 first %u fp32), "
+                                "maskRange=[fullEndBlk,visibleEndBlk)=[%u,%u):\n",
+                                sDumpN, task.fullEndBlk, task.visibleEndBlk);
+                MsaDumpUbSample(ubS_, MSA_DUMP_DESC_S_MASK, sDumpN);
+                AscendC::printf("[MSA_DBG][AIV] S_after_mask:");
+                MsaPrintUbFloats(ubS_, sDumpN);
+
+                // 逐行打印本 pass 的 validCount，核对 MASK 切分点。
+                for (uint32_t r = 0; r < rows && r < 8U; ++r) {
+                    const uint32_t rowInReq = task.mStart + rowOff + r;
+                    const uint32_t tOff = rowInReq / numQHeads_;
+                    const int32_t visibleKeyEnd = VisibleKeyEnd(task, static_cast<int32_t>(tOff));
+                    const uint32_t blk = blkBase; // 小用例通常只有 blk0
+                    int32_t validCount = visibleKeyEnd - static_cast<int32_t>(blk * MSA_BLOCK_SIZE);
+                    if (validCount < 0) {
+                        validCount = 0;
+                    }
+                    if (validCount > static_cast<int32_t>(MSA_BLOCK_SIZE)) {
+                        validCount = static_cast<int32_t>(MSA_BLOCK_SIZE);
+                    }
+                    AscendC::printf("[MSA_DBG][AIV] row r=%u flat=%u tokenOff=%u visibleEnd=%d validCount=%d\n", r,
+                                    rowInReq, tOff, visibleKeyEnd, validCount);
+                    if (validCount < static_cast<int32_t>(MSA_BLOCK_SIZE) && validCount >= 0) {
+                        const uint32_t base = (r * MSA_BLOCKS_PER_STILE) * MSA_BLOCK_SIZE;
+                        const uint32_t lo = (validCount >= 2) ? static_cast<uint32_t>(validCount - 2) : 0U;
+                        const uint32_t hi = static_cast<uint32_t>(validCount) + 3U;
+                        AscendC::printf("[MSA_DBG][AIV]   S_after_mask[%u:%u]:", lo, hi);
+                        AscendC::PipeBarrier<PIPE_ALL>();
+                        for (uint32_t i = lo; i < hi && i < MSA_BLOCK_SIZE; ++i) {
+                            AscendC::printf(" %f", ubS_.GetValue(base + i));
+                        }
+                        AscendC::printf("\n");
+                    }
+                }
+            }
+#endif
+
+            if constexpr (IS_QUANT) {
+                SegRowMax();
+            } else {
+                SegRowMaxWhole();
+            }
+
+#if MSA_INDEX_SCORE_DEBUG
+            if (dumpDebug) {
+                AscendC::printf("[MSA_DBG][AIV] after MAX rowmax (rows[0:%u) x %u blocks):\n", rows,
+                                MSA_BLOCKS_PER_STILE);
+                MsaDumpUbSample(ubRowMax_, MSA_DUMP_DESC_SCORE_MAX, rows * MSA_BLOCKS_PER_STILE);
+                for (uint32_t r = 0; r < rows && r < 8U; ++r) {
+                    AscendC::printf("[MSA_DBG][AIV] score_after_max[r=%u]:", r);
+                    AscendC::PipeBarrier<PIPE_ALL>();
+                    for (uint32_t j = 0; j < MSA_BLOCKS_PER_STILE; ++j) {
+                        AscendC::printf(" %f", ubRowMax_.GetValue(r * MSA_BLOCKS_PER_STILE + j));
+                    }
+                    AscendC::printf("\n");
+                }
+            }
+#endif
+        } else {
+            AscendC::Duplicate(ubRowMax_, MSA_FILL_VALUE, MSA_REDUCE_ROWS);
+            AscendC::PipeBarrier<PIPE_V>();
+#if MSA_INDEX_SCORE_DEBUG
+            if (dumpDebug) {
+                AscendC::printf("[MSA_DBG][AIV] allInvalid stile -> fill score with -inf\n");
+            }
+#endif
+        }
+
+        FillInvalidBlocks(task, blkBase);
+        ApplyLocalMaskUb(task, blkBase, rows);
+
+#if MSA_INDEX_SCORE_DEBUG
+        if (dumpDebug) {
+            AscendC::printf("[MSA_DBG][AIV] final score before store (after fillInvalid+localMask), "
+                            "rows[0:%u) x %u blocks:\n",
+                            rows, MSA_BLOCKS_PER_STILE);
+            MsaDumpUbSample(ubRowMax_, MSA_DUMP_DESC_SCORE_FINAL, rows * MSA_BLOCKS_PER_STILE);
+            for (uint32_t r = 0; r < rows && r < 8U; ++r) {
+                AscendC::printf("[MSA_DBG][AIV] score_final[r=%u]:", r);
+                AscendC::PipeBarrier<PIPE_ALL>();
+                for (uint32_t j = 0; j < MSA_BLOCKS_PER_STILE; ++j) {
+                    AscendC::printf(" %f", ubRowMax_.GetValue(r * MSA_BLOCKS_PER_STILE + j));
+                }
+                AscendC::printf("\n");
+            }
+        }
+#endif
+
+        if (stageOn_) {
+            StageScore(blkBase, rowOff - mOff_, rows);
+        } else {
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+            StoreScore(task, blkBase, rowOff, rows);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+        }
+    }
+
+    /// 把本 pass 的 [rows, MSA_BLOCKS_PER_STILE] 归约结果搬到 score 暂存区对应的
+    /// 行 × block 窗口（行内 stride 为 MSA_STAGE_BLOCKS），供整行 flush。
+    __aicore__ inline void StageScore(uint32_t blkBase, uint32_t stageRow, uint32_t rows)
+    {
+        const uint32_t colOff = blkBase - stageBlkBase_;
+        AscendC::Adds<float>(ubStage_[stageRow * MSA_STAGE_BLOCKS + colOff], ubRowMax_, 0.0F,
+                             static_cast<int32_t>(MSA_BLOCKS_PER_STILE), static_cast<uint8_t>(rows),
+                             AscendC::UnaryRepeatParams(1, 1, MSA_STAGE_BLOCKS / MSA_FP32_PER_BLOCK,
+                                                        MSA_BLOCKS_PER_STILE / MSA_FP32_PER_BLOCK));
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    /// 把 score 暂存窗口按行写回 GM：每行一次 ≥1KB 的连续 DataCopy。
+    __aicore__ inline void FlushStage()
+    {
+        if (!stageOn_ || stageBlkEnd_ <= stageBlkBase_) {
+            return;
+        }
+        const uint32_t count = stageBlkEnd_ - stageBlkBase_;
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+        uint32_t tOff = rowInReqBase_ / numQHeads_;
+        uint32_t h = rowInReqBase_ - tOff * numQHeads_;
+        uint64_t tokenBase = static_cast<uint64_t>(tokenBase0_ + tOff) * strideOutToken_ + stageBlkBase_;
+        for (uint32_t r = 0; r < mSub_; ++r) {
+            AscendC::DataCopy(gScore_[tokenBase + static_cast<uint64_t>(h) * strideOutHead_],
+                              ubStage_[r * MSA_STAGE_BLOCKS], count);
+            if (++h == numQHeads_) {
+                h = 0;
+                tokenBase += strideOutToken_;
+            }
+        }
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_V>(EVENT_ID0);
+    }
+
+    /// sparse_mode=3：rightDownCausal；否则仅 kv_len 截断。
+    __aicore__ inline int32_t VisibleKeyEnd(const MsaTask &task, int32_t tOff) const
+    {
+        if (task.sparseMode == MSA_SPARSE_MODE_RIGHT_DOWN) {
+            return MsaClampI32(task.kvLen - task.qLen + tOff + 1, 0, task.kvLen < 0 ? 0 : task.kvLen);
+        }
+        return task.kvLen < 0 ? 0 : task.kvLen;
+    }
+
+    /// 只对 [fullEndBlk, visibleEndBlk) 的边界 block 逐行置 -inf。
+    /// 全可见 block 走无 mask 快通道；全不可见 block 的结果在 FillInvalidBlocks 中整体覆盖。
+    __aicore__ inline void ApplyMask(const MsaTask &task, uint32_t blkBase, uint32_t rowOff, uint32_t rows)
+    {
+        if (task.fullEndBlk >= task.visibleEndBlk) {
+            return;
+        }
+        const uint32_t jLo = (task.fullEndBlk > blkBase) ? (task.fullEndBlk - blkBase) : 0;
+        if (jLo >= MSA_BLOCKS_PER_STILE) {
+            return;
+        }
+        const uint32_t jHi =
+            MsaMinU32(MSA_BLOCKS_PER_STILE, (task.visibleEndBlk > blkBase) ? (task.visibleEndBlk - blkBase) : 0);
+
+        bool touched = false;
+        for (uint32_t r = 0; r < rows; ++r) {
+            const uint32_t rowInReq = task.mStart + rowOff + r;
+            const uint32_t tOff = rowInReq / numQHeads_;
+            const int32_t visibleKeyEnd = VisibleKeyEnd(task, static_cast<int32_t>(tOff));
+            for (uint32_t j = jLo; j < jHi; ++j) {
+                const uint32_t blk = blkBase + j;
+                int32_t validCount = visibleKeyEnd - static_cast<int32_t>(blk * MSA_BLOCK_SIZE);
+                if (validCount < 0) {
+                    validCount = 0;
+                }
+                if (validCount >= static_cast<int32_t>(MSA_BLOCK_SIZE)) {
+                    continue;
+                }
+                if constexpr (IS_QUANT) {
+                    FillBlockTail((r * MSA_BLOCKS_PER_STILE + j) * MSA_BLOCK_SIZE, static_cast<uint32_t>(validCount));
+                } else {
+                    // 非量化归约在 fp16 域起步，mask 必须先落在 ubS16_ 上。
+                    FillBlockTailFp16((r * MSA_BLOCKS_PER_STILE + j) * MSA_BLOCK_SIZE,
+                                      static_cast<uint32_t>(validCount));
+                }
+                touched = true;
+            }
+        }
+        if (touched) {
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+    }
+
+    /// Maxpool 之后、Store 之前施加 local_mask。
+    /// 用与 FillInvalidBlocks 相同的位掩码 Duplicate，保证 32B 对齐访问。
+    __aicore__ inline void ApplyLocalMaskUb(const MsaTask &task, uint32_t blkBase, uint32_t rows)
+    {
+        if (task.initBlocks == 0 && task.localBlocks == 0) {
+            return;
+        }
+        const int32_t qBlock = task.startLoc;
+        const int32_t localStart = (qBlock + 1 > static_cast<int32_t>(task.localBlocks)) ?
+                                       (qBlock + 1 - static_cast<int32_t>(task.localBlocks)) :
+                                       0;
+
+        uint64_t initBits = 0;
+        uint64_t localBits = 0;
+        for (uint32_t j = 0; j < MSA_BLOCKS_PER_STILE; ++j) {
+            const int32_t blk = static_cast<int32_t>(blkBase + j);
+            if (blk < 0 || blk >= static_cast<int32_t>(task.visibleEndBlk)) {
+                continue;
+            }
+            if (static_cast<uint32_t>(blk) < task.initBlocks) {
+                initBits |= (1ULL << j);
+            }
+            if (blk >= localStart && blk <= qBlock) {
+                localBits |= (1ULL << j);
+            }
+        }
+        initBits &= ~localBits; // local 覆盖 init
+
+        const uint8_t repeats =
+            static_cast<uint8_t>((rows * MSA_BLOCKS_PER_STILE + MSA_FP32_PER_REPEAT - 1) / MSA_FP32_PER_REPEAT);
+        if (initBits != 0) {
+            uint64_t bits = 0;
+            for (uint32_t g = 0; g < MSA_FP32_PER_REPEAT / MSA_BLOCKS_PER_STILE; ++g) {
+                bits |= (initBits << (g * MSA_BLOCKS_PER_STILE));
+            }
+            uint64_t mask[2] = {bits, 0};
+            AscendC::Duplicate<float>(ubRowMax_, MSA_LOCAL_SCORE_INIT, mask, repeats, 1,
+                                      MSA_FP32_PER_REPEAT / MSA_FP32_PER_BLOCK);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        if (localBits != 0) {
+            uint64_t bits = 0;
+            for (uint32_t g = 0; g < MSA_FP32_PER_REPEAT / MSA_BLOCKS_PER_STILE; ++g) {
+                bits |= (localBits << (g * MSA_BLOCKS_PER_STILE));
+            }
+            uint64_t mask[2] = {bits, 0};
+            AscendC::Duplicate<float>(ubRowMax_, MSA_LOCAL_SCORE_LOCAL, mask, repeats, 1,
+                                      MSA_FP32_PER_REPEAT / MSA_FP32_PER_BLOCK);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+    }
+
+    /// 把 ubS_[base + validCount, base + MSA_BLOCK_SIZE) 置为 -inf。
+    /// 拆成「整 64-fp32 repeat 尾段」+「单 repeat 内的位掩码」两步，保证每次 Duplicate 都是 256B 对齐。
+    __aicore__ inline void FillBlockTail(uint32_t base, uint32_t validCount)
+    {
+        if (validCount >= MSA_BLOCK_SIZE) {
+            return;
+        }
+        const uint32_t alignedStart = MsaCeilDiv(validCount, MSA_FP32_PER_REPEAT) * MSA_FP32_PER_REPEAT;
+        if (alignedStart < MSA_BLOCK_SIZE) {
+            AscendC::Duplicate(ubS_[base + alignedStart], MSA_FILL_VALUE, MSA_BLOCK_SIZE - alignedStart);
+        }
+        if (validCount < alignedStart) {
+            const uint32_t repeatBase = base + (validCount / MSA_FP32_PER_REPEAT) * MSA_FP32_PER_REPEAT;
+            const uint32_t lane = validCount % MSA_FP32_PER_REPEAT;
+            uint64_t bits = (lane == 0) ? ~0ULL : (~0ULL << lane);
+            uint64_t mask[2] = {bits, 0};
+            AscendC::Duplicate<float>(ubS_[repeatBase], MSA_FILL_VALUE, mask, 1, 1,
+                                      MSA_FP32_PER_REPEAT / MSA_FP32_PER_BLOCK);
+        }
+    }
+
+    /// 把某一行在某个 block 内 [validCount, MSA_BLOCK_SIZE) 的列置为 -inf。
+    /// fp16 下一个 repeat 恰好 128 lane = 一个 block 的 8 个 datablock，
+    /// 故一条带 128 位掩码的 Duplicate 即可。
+    __aicore__ inline void FillBlockTailFp16(uint32_t base, uint32_t validCount)
+    {
+        if (validCount >= MSA_BLOCK_SIZE) {
+            return;
+        }
+        uint64_t lo = 0;
+        uint64_t hi = 0;
+        if (validCount < MSA_HALF_PER_MASK_WORD) {
+            lo = ~0ULL << validCount;
+            hi = ~0ULL;
+        } else {
+            hi = ~0ULL << (validCount - MSA_HALF_PER_MASK_WORD);
+        }
+        uint64_t mask[2] = {lo, hi};
+        AscendC::Duplicate<half>(ubS16_[base], FILL_VALUE_H, mask, 1, 1, MSA_BLOCK_SIZE / MSA_HALF_PER_BLOCK);
+    }
+
+    /// int8 路径：S 已是 Q · cast(K_int8)，再按列乘 scale[page,0,n] 完成反量化。
+    /// 数学上 Q·(K_int8*s) = (Q·cast(K_int8))*s（int8→fp 对整数精确）。
+    __aicore__ inline void ApplyDequantScale(const MsaTask &task, uint32_t blkBase, uint32_t rows)
+    {
+        for (uint32_t j = 0; j < MSA_BLOCKS_PER_STILE; ++j) {
+            const uint32_t blk = blkBase + j;
+            if (blk >= task.visibleEndBlk) {
+                break;
+            }
+            uint64_t scaleOff = 0;
+            uint32_t nValidScale = MSA_BLOCK_SIZE;
+            if (keyLayout_ == MSA_KEY_LAYOUT_TND) {
+                const uint32_t tokenStart = task.cuKStart + blk * MSA_BLOCK_SIZE;
+                // TND scale 为 packed [T2, N2]，N2=1 时按 token 连续存放，不能用 PA 的 page 步长。
+                scaleOff = static_cast<uint64_t>(tokenStart);
+                const uint32_t seqTok = blk * MSA_BLOCK_SIZE;
+                nValidScale = 0;
+                if (task.kvLen > 0 && seqTok < static_cast<uint32_t>(task.kvLen)) {
+                    nValidScale = static_cast<uint32_t>(task.kvLen) - seqTok;
+                    if (nValidScale > MSA_BLOCK_SIZE) {
+                        nValidScale = MSA_BLOCK_SIZE;
+                    }
+                }
+            } else {
+                const int32_t page = gBlockTable_.GetValue(task.batchIdx * maxBlocksPerBatch_ + blk);
+                scaleOff = static_cast<uint64_t>(page) * strideScalePage_;
+            }
+            // 上一轮 Mul 占用 ubDeqScale_，必须等 V 完成后再 MTE2 覆盖。
+            AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+            if (nValidScale < MSA_BLOCK_SIZE) {
+                AscendC::Duplicate(ubDeqScale_, 0.0f, MSA_BLOCK_SIZE);
+                AscendC::PipeBarrier<PIPE_V>();
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID1);
+            }
+            if (nValidScale > 0) {
+                const uint32_t bytes = nValidScale * static_cast<uint32_t>(sizeof(float));
+                if ((bytes % 32U) == 0U) {
+                    AscendC::DataCopy(ubDeqScale_, gScale_[scaleOff], nValidScale);
+                } else {
+                    AscendC::DataCopyExtParams params;
+                    params.blockCount = 1;
+                    params.blockLen = bytes;
+                    params.srcStride = 0;
+                    params.dstStride = 0;
+                    AscendC::DataCopyPadExtParams<float> pad;
+                    pad.isPad = false;
+                    pad.leftPadding = 0;
+                    pad.rightPadding = 0;
+                    pad.paddingValue = 0;
+                    AscendC::DataCopyPad(ubDeqScale_, gScale_[scaleOff], params, pad);
+                }
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID1);
+
+            for (uint32_t r = 0; r < rows; ++r) {
+                const uint32_t base = r * STILE_WIDTH + j * MSA_BLOCK_SIZE;
+                AscendC::Mul(ubS_[base], ubS_[base], ubDeqScale_, static_cast<int32_t>(MSA_BLOCK_SIZE));
+            }
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+    }
+
+    /// 把 ubS_ 视作 [MSA_REDUCE_ROWS, MSA_BLOCK_SIZE] 做行归约，结果落在 ubRowMax_[MSA_REDUCE_ROWS]，
+    /// 其排布恰为 [MSA_ROWS_PER_PASS][MSA_BLOCKS_PER_STILE] 行主序。
+    __aicore__ inline void SegRowMax()
+    {
+        constexpr uint32_t HALF_BLOCK = MSA_BLOCK_SIZE / 2;
+        constexpr uint8_t SRC_REP_BLK = MSA_BLOCK_SIZE / MSA_FP32_PER_BLOCK; // 16
+        constexpr uint8_t DST_REP_BLK = HALF_BLOCK / MSA_FP32_PER_BLOCK;     // 8
+
+        AscendC::Max<float>(ubT64_, ubS_, ubS_[HALF_BLOCK], static_cast<int32_t>(MSA_FP32_PER_REPEAT),
+                            static_cast<uint8_t>(MSA_REDUCE_ROWS),
+                            AscendC::BinaryRepeatParams(1, 1, 1, DST_REP_BLK, SRC_REP_BLK, SRC_REP_BLK));
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::BlockReduceMax<float, true>(ubT8_, ubT64_, static_cast<uint8_t>(MSA_REDUCE_ROWS),
+                                             static_cast<int32_t>(MSA_FP32_PER_REPEAT), 1, 1, DST_REP_BLK);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::BlockReduceMax<float, true>(ubRowMax_, ubT8_,
+                                             static_cast<uint8_t>(MSA_REDUCE_ROWS / MSA_FP32_PER_BLOCK),
+                                             static_cast<int32_t>(MSA_FP32_PER_REPEAT), 1, 1, DST_REP_BLK);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    /// 非量化路径：一个 sparse block（128 个 fp16）恰好等于向量单元一个满 repeat，
+    /// 故整个 pass 的分段 RowMax 可由单条 WholeReduceMax 完成——每 repeat 归约一个
+    /// block，128 次迭代按 [row][block] 行主序密集写出，与 ubRowMax_ 的排布一致。
+    /// 相比「配对 Max + Cast + 两级 BlockReduceMax」省掉 3 条全宽向量指令和 3 次 barrier。
+    /// max 在 fp16 上无舍入、Cast fp16→fp32 精确且保序，结果与 fp32 归约逐 bit 一致。
+    __aicore__ inline void SegRowMaxWhole()
+    {
+        constexpr uint8_t SRC_REP_BLK = MSA_BLOCK_SIZE / MSA_HALF_PER_BLOCK; // 8
+        AscendC::WholeReduceMax<half>(ubRed16_, ubS16_, static_cast<int32_t>(MSA_BLOCK_SIZE),
+                                      static_cast<int32_t>(MSA_REDUCE_ROWS), 1, 1, SRC_REP_BLK,
+                                      AscendC::ReduceOrder::ORDER_ONLY_VALUE);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Cast(ubRowMax_, ubRed16_, AscendC::RoundMode::CAST_NONE, MSA_REDUCE_ROWS);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // mask/短 pass 填充在 fp16 域是 -inf，归约后抬回 fp32 的 MSA_FILL_VALUE，
+        // 与 int8 路径及原实现的填充值保持一致（真实分值远大于 -3.4e38，不受影响）。
+        AscendC::Maxs<float>(ubRowMax_, ubRowMax_, MSA_FILL_VALUE, MSA_REDUCE_ROWS);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    /// blk >= visibleEndBlk 的位置整体置为 -inf。
+    __aicore__ inline void FillInvalidBlocks(const MsaTask &task, uint32_t blkBase)
+    {
+        const uint32_t invStart = (task.visibleEndBlk > blkBase) ? (task.visibleEndBlk - blkBase) : 0;
+        if (invStart >= MSA_BLOCKS_PER_STILE) {
+            return;
+        }
+        if (invStart == 0) {
+            AscendC::Duplicate(ubRowMax_, MSA_FILL_VALUE, MSA_REDUCE_ROWS);
+            AscendC::PipeBarrier<PIPE_V>();
+            return;
+        }
+        uint64_t groupBits = 0;
+        for (uint32_t k = invStart; k < MSA_BLOCKS_PER_STILE; ++k) {
+            groupBits |= (1ULL << k);
+        }
+        uint64_t bits = 0;
+        for (uint32_t g = 0; g < MSA_FP32_PER_REPEAT / MSA_BLOCKS_PER_STILE; ++g) {
+            bits |= (groupBits << (g * MSA_BLOCKS_PER_STILE));
+        }
+        uint64_t mask[2] = {bits, 0};
+        AscendC::Duplicate<float>(ubRowMax_, MSA_FILL_VALUE, mask,
+                                  static_cast<uint8_t>(MSA_REDUCE_ROWS / MSA_FP32_PER_REPEAT), 1,
+                                  MSA_FP32_PER_REPEAT / MSA_FP32_PER_BLOCK);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void StoreScore(const MsaTask &task, uint32_t blkBase, uint32_t rowOff, uint32_t rows)
+    {
+        // 行 = (token, head) 扁平索引、head 为低位，故 pass 内逐行递推即可，
+        // 无需每行一次标量整除（整除在 AIV 上是数十 cycle 的长指令）。
+        uint32_t tOff = (task.mStart + rowOff) / numQHeads_;
+        uint32_t h = (task.mStart + rowOff) - tOff * numQHeads_;
+        uint64_t tokenBase = static_cast<uint64_t>(task.cuQStart + tOff) * strideOutToken_ + blkBase;
+        for (uint32_t r = 0; r < rows; ++r) {
+            AscendC::DataCopy(gScore_[tokenBase + static_cast<uint64_t>(h) * strideOutHead_],
+                              ubRowMax_[r * MSA_BLOCKS_PER_STILE], MSA_BLOCKS_PER_STILE);
+            if (++h == numQHeads_) {
+                h = 0;
+                tokenBase += strideOutToken_;
+            }
+        }
+    }
+
+    AscendC::GlobalTensor<float> gScore_;
+    AscendC::GlobalTensor<float> gScale_;
+    AscendC::GlobalTensor<int32_t> gBlockTable_;
+    AscendC::LocalTensor<float> ubS_;
+    AscendC::LocalTensor<half> ubS16_;
+    AscendC::LocalTensor<half> ubS16Ping_[S16_STAGES];
+    AscendC::LocalTensor<float> ubT64_;
+    AscendC::LocalTensor<float> ubT8_;
+    AscendC::LocalTensor<float> ubRowMax_;
+    AscendC::LocalTensor<float> ubDeqScale_;
+    AscendC::LocalTensor<half> ubRed16_;
+    AscendC::LocalTensor<float> ubStage_;
+
+    // 当前任务内本 subcore 的行区间与 score 暂存窗口。
+    uint32_t mOff_ = 0;
+    uint32_t mSub_ = 0;
+    uint32_t rowInReqBase_ = 0;
+    uint32_t tokenBase0_ = 0;
+    uint32_t stageBlkBase_ = 0;
+    uint32_t stageBlkEnd_ = 0;
+    bool stageOn_ = false;
+
+    uint32_t numQHeads_ = 1;
+    uint32_t strideOutHead_ = 0;
+    uint32_t strideOutToken_ = 0;
+    uint32_t maxBlocksPerBatch_ = 0;
+    uint32_t strideScalePage_ = 0;
+    uint32_t strideScaleHead_ = 1;
+    uint32_t keyLayout_ = MSA_KEY_LAYOUT_BBND;
+    uint32_t totalK_ = 0;
+    bool isQuant_ = false;
+};
+
+} // namespace MsaIndexScoreNs
+
+#endif // MSA_INDEX_SCORE_EPILOGUE_H

--- a/csrc/attention/msa_index_score/op_kernel/arch22/msa_index_score_kernel.h
+++ b/csrc/attention/msa_index_score/op_kernel/arch22/msa_index_score_kernel.h
@@ -1,0 +1,443 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_kernel.h
+ * \brief MsaIndexScore Atlas A2/A3 核函数：AIC 做 paged QKᵀ，AIV 做（可选反量化）+ mask + 分段 RowMax。
+ *        不支持 Ascend 950 / FP8。
+ *
+ * 非量化：query/key 同为 bf16|fp16，score 侧不乘 scale。
+ * int8 量化：key 为 int8；AIV 将 page DataCopy+Cast 到 fp 暂存后通知 AIC 做 Mmad；
+ * AIV 在 mask 前按 scale[NP,N_kv,P] 对 S 做列乘完成 per-token 反量化。
+ */
+
+#ifndef MSA_INDEX_SCORE_KERNEL_H
+#define MSA_INDEX_SCORE_KERNEL_H
+
+#include "kernel_operator.h"
+
+#include "catlass/catlass.hpp"
+#include "catlass/arch/arch.hpp"
+#include "catlass/arch/resource.hpp"
+#include "catlass/arch/cross_core_sync.hpp"
+#include "catlass/coord.hpp"
+#include "catlass/gemm_coord.hpp"
+#include "catlass/matrix_coord.hpp"
+#include "catlass/layout/layout.hpp"
+#include "catlass/gemm/gemm_type.hpp"
+
+#include "../msa_index_score_common.h"
+#include "../msa_index_score_debug.h"
+#include "msa_block_mmad.h"
+#include "msa_index_score_task.h"
+#include "msa_index_score_epilogue.h"
+
+namespace MsaIndexScoreNs {
+
+template <class ElementQ_, bool IS_QUANT>
+class MsaIndexScoreKernel {
+public:
+    using ElementQ = ElementQ_;
+    using ArchTag = Catlass::Arch::AtlasA2;
+
+    using LayoutQ = Catlass::layout::RowMajor;
+    using LayoutK = Catlass::layout::ColumnMajor;
+    using LayoutS = Catlass::layout::RowMajor;
+
+    using QType = Catlass::Gemm::GemmType<ElementQ, LayoutQ>;
+    using KType = Catlass::Gemm::GemmType<ElementQ, LayoutK>;
+    // S workspace 元素：非量化 fp16（fixpipe F322F16 直接写，写读流量减半），int8 fp32
+    // （S 幅值大、1e-3 容差下 fp16 精度余量不足 15%，保持 fp32 反量化）。
+    using ElementS = std::conditional_t<IS_QUANT, float, half>;
+    using SType = Catlass::Gemm::GemmType<ElementS, LayoutS>;
+
+    // int8 的 K 源是每 stile 复用的 per-core scratch，保持 2 级 L1B 流水（3 级实测竞态崩溃）；
+    // 同样出于该 scratch 的时序保守性，unit flag 只在非量化路径开启。
+    using BlockMmad = MsaBlockMmad<QType, KType, SType, IS_QUANT ? 2U : 3U, !IS_QUANT>;
+
+    static constexpr uint32_t REVERSE_DEPTH = MSA_WORKSPACE_STAGES - 1;
+    static constexpr uint32_t STILE_WIDTH = MSA_BLOCKS_PER_STILE * MSA_BLOCK_SIZE;
+    static constexpr bool IS_QUANT_V = IS_QUANT;
+    // 单 page cast 暂存：int8 + half 共用 epilogue 前半段 UB（S 尚未载入）。
+    static constexpr uint32_t UB_OFF_CAST_I8 = 0;
+    static constexpr uint32_t UB_SIZE_CAST_I8 = MSA_BLOCK_SIZE * MSA_K_TILE * sizeof(int8_t);
+    static constexpr uint32_t UB_OFF_CAST_FP = UB_OFF_CAST_I8 + UB_SIZE_CAST_I8;
+    static constexpr uint32_t UB_SIZE_CAST_FP = MSA_BLOCK_SIZE * MSA_K_TILE * sizeof(half);
+    static_assert(UB_OFF_CAST_FP + UB_SIZE_CAST_FP <= ArchTag::UB_SIZE, "cast UB out of bounds");
+
+    __aicore__ inline MsaIndexScoreKernel() {}
+
+    __aicore__ inline void Init(GM_ADDR query, GM_ADDR key, GM_ADDR blockTable, GM_ADDR scale, GM_ADDR actualSeqQlen,
+                                GM_ADDR actualSeqKlen, GM_ADDR startLoc, GM_ADDR score, GM_ADDR workspace,
+                                const MsaIndexScoreTilingData *__restrict tiling)
+    {
+        tiling_ = tiling;
+        gQuery_.SetGlobalBuffer(reinterpret_cast<__gm__ ElementQ *>(query));
+        if constexpr (IS_QUANT_V) {
+            gKeyInt8_.SetGlobalBuffer(reinterpret_cast<__gm__ int8_t *>(key));
+        } else {
+            gKeyFp_.SetGlobalBuffer(reinterpret_cast<__gm__ ElementQ *>(key));
+        }
+        if (IS_QUANT_V || tiling_->keyLayout == MSA_KEY_LAYOUT_TND) {
+            gKeyScratch_.SetGlobalBuffer(reinterpret_cast<__gm__ ElementQ *>(
+                reinterpret_cast<__gm__ float *>(workspace) + tiling_->kScratchOffsetElems));
+        }
+        if (tiling_->keyLayout != MSA_KEY_LAYOUT_TND) {
+            gBlockTable_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(blockTable));
+        }
+        gScale_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(scale));
+        gActualSeqQlen_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(actualSeqQlen));
+        gActualSeqKlen_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(actualSeqKlen));
+        gStartLoc_.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(startLoc));
+        gScore_.SetGlobalBuffer(reinterpret_cast<__gm__ float *>(score));
+        gWorkspace_.SetGlobalBuffer(reinterpret_cast<__gm__ ElementS *>(workspace));
+
+        scheduler_.Init(tiling_->batch, tiling_->numQHeads, tiling_->maxBlocksPerBatch, tiling_->scoreBlockStride,
+                        tiling_->sparseMode, tiling_->initBlocks, tiling_->localBlocks, tiling_->keyLayout,
+                        gActualSeqQlen_, gActualSeqKlen_, gStartLoc_);
+    }
+
+    __aicore__ inline void Process()
+    {
+        if ASCEND_IS_AIC {
+            ProcessCube();
+        }
+        if ASCEND_IS_AIV {
+            ProcessVector();
+        }
+    }
+
+private:
+    __aicore__ inline void ProcessCube()
+    {
+        Catlass::Arch::Resource<ArchTag> resource;
+        BlockMmad blockMmad(resource);
+        Catlass::Arch::CrossCoreFlagWithReverse<REVERSE_DEPTH> flagSReady{MSA_FLAG_S_READY, MSA_FLAG_S_READY_REVERSE};
+        Catlass::Arch::CrossCoreFlag flagKReady{MSA_FLAG_K_READY};
+
+        const uint32_t coreIdx = AscendC::GetBlockIdx();
+        const uint32_t coreNum = AscendC::GetBlockNum();
+        const uint64_t coreWsBase = static_cast<uint64_t>(coreIdx) * MSA_WORKSPACE_STAGES * MSA_STILE_ELEM_NUM;
+        const uint64_t coreKScratch = static_cast<uint64_t>(coreIdx) * MSA_K_SCRATCH_ELEM_NUM;
+        const uint32_t totalTasks = scheduler_.TotalTasks();
+
+#if MSA_INDEX_SCORE_DEBUG
+        if (MsaDebugPrimaryCore()) {
+            AscendC::printf("[MSA_DBG][AIC] tiling batch=%u totalQ=%u Hq=%u D=%u isQuant=%u numPages=%u "
+                            "totalTasks=%u\n",
+                            tiling_->batch, tiling_->totalQ, tiling_->numQHeads, tiling_->headDim, tiling_->isQuant,
+                            tiling_->numPages, totalTasks);
+        }
+#endif
+
+        uint32_t tileSeq = 0;
+        MsaTask task;
+        for (uint32_t taskIdx = coreIdx; taskIdx < totalTasks; taskIdx += coreNum) {
+            scheduler_.Decode(taskIdx, task);
+#if MSA_INDEX_SCORE_DEBUG
+            const bool dbgTask = MsaDebugPrimaryCore() && (taskIdx == coreIdx);
+#else
+            constexpr bool dbgTask = false;
+#endif
+            // 只对可见 S-tile 做 QKᵀ + 握手；因果不可见尾由 AIV 直接写 -inf，避免空转同步。
+            bool needLoadQ = true;
+            for (uint32_t st = 0; st < task.numComputeSTiles; ++st) {
+                const bool needKScratch = StileNeedsKScratch(task, st * MSA_BLOCKS_PER_STILE);
+                if (needKScratch) {
+                    // MIX 1AIC:2AIV：AIV→AIC 的 0x2 flag 需两个 AIV 都 Set 后才放行。
+                    Catlass::Arch::CrossCoreWaitFlag(flagKReady);
+                    AscendC::PipeBarrier<PIPE_ALL>();
+                }
+                const uint64_t sBase =
+                    coreWsBase + static_cast<uint64_t>(tileSeq % MSA_WORKSPACE_STAGES) * MSA_STILE_ELEM_NUM;
+                ComputeSTile(blockMmad, task, st * MSA_BLOCKS_PER_STILE, sBase, coreKScratch, needLoadQ,
+                             dbgTask && (st == 0));
+                needLoadQ = false;
+                Catlass::Arch::CrossCoreSetFlagWithReverse<0x2, PIPE_FIX>(flagSReady);
+                ++tileSeq;
+            }
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline bool KeyBlockNeedsScratch(const MsaTask &task, uint32_t blk) const
+    {
+        if constexpr (IS_QUANT_V) {
+            return true;
+        }
+        if (tiling_->keyLayout != MSA_KEY_LAYOUT_TND) {
+            return false;
+        }
+        // TND fp16：完整 128-token 页与 BBND 一样直接从 packed GM mmad。
+        // 仅最后一条请求的尾页可能越过 T2，需要 AIV 填零后再走 scratch。
+        const uint32_t nValidTok = KeyBlockValidTokens(task, blk);
+        return (nValidTok > 0) && (nValidTok < MSA_BLOCK_SIZE) && (task.batchIdx + 1U == tiling_->batch);
+    }
+
+    __aicore__ inline bool StileNeedsKScratch(const MsaTask &task, uint32_t blkBase) const
+    {
+        for (uint32_t j = 0; j < MSA_BLOCKS_PER_STILE; ++j) {
+            const uint32_t blk = blkBase + j;
+            if (blk >= task.visibleEndBlk) {
+                break;
+            }
+            if (KeyBlockNeedsScratch(task, blk)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    __aicore__ inline uint32_t KeyBlockValidTokens(const MsaTask &task, uint32_t blk) const
+    {
+        if (tiling_->keyLayout != MSA_KEY_LAYOUT_TND) {
+            return MSA_BLOCK_SIZE;
+        }
+        const uint32_t seqTok = blk * tiling_->blockSize;
+        if (task.kvLen <= 0 || seqTok >= static_cast<uint32_t>(task.kvLen)) {
+            return 0;
+        }
+        const uint32_t seqRemain = static_cast<uint32_t>(task.kvLen) - seqTok;
+        return seqRemain < MSA_BLOCK_SIZE ? seqRemain : MSA_BLOCK_SIZE;
+    }
+
+    __aicore__ inline uint64_t KeyBlockGmOffset(const MsaTask &task, uint32_t blk) const
+    {
+        if (tiling_->keyLayout == MSA_KEY_LAYOUT_TND) {
+            const uint32_t tokenStart = task.cuKStart + blk * tiling_->blockSize;
+            const uint32_t tokStride = tiling_->numKvHeads * tiling_->headDim;
+            return static_cast<uint64_t>(tokenStart) * tokStride;
+        }
+        const int32_t page = gBlockTable_.GetValue(task.batchIdx * tiling_->maxBlocksPerBatch + blk);
+        return static_cast<uint64_t>(page) * tiling_->strideKvBlock;
+    }
+
+    template <typename T>
+    __aicore__ inline void CopyGmToUbPartial(const AscendC::LocalTensor<T> &ub, const AscendC::GlobalTensor<T> &gm,
+                                             uint32_t nElem)
+    {
+        if (nElem == 0) {
+            return;
+        }
+        const uint32_t bytes = nElem * static_cast<uint32_t>(sizeof(T));
+        if ((bytes % 32U) == 0U) {
+            AscendC::DataCopy(ub, gm, nElem);
+            return;
+        }
+        AscendC::DataCopyExtParams params;
+        params.blockCount = 1;
+        params.blockLen = bytes;
+        params.srcStride = 0;
+        params.dstStride = 0;
+        AscendC::DataCopyPadExtParams<T> pad;
+        pad.isPad = false;
+        pad.leftPadding = 0;
+        pad.rightPadding = 0;
+        pad.paddingValue = 0;
+        AscendC::DataCopyPad(ub, gm, params, pad);
+    }
+
+    /// AIV：把本 S-tile 可见 block 的 K 收进 per-core scratch（int8 cast 或 TND fp copy+尾填充）。
+    __aicore__ inline void GatherKeySTileToScratch(Catlass::Arch::Resource<ArchTag> &resource, const MsaTask &task,
+                                                   uint32_t blkBase, uint64_t kScratchBase)
+    {
+        AscendC::LocalTensor<int8_t> ubI8 = resource.ubBuf.template GetBufferByByte<int8_t>(UB_OFF_CAST_I8);
+        AscendC::LocalTensor<half> ubHalf = resource.ubBuf.template GetBufferByByte<half>(UB_OFF_CAST_FP);
+        const uint32_t headDim = tiling_->headDim;
+        const uint32_t nElem = MSA_BLOCK_SIZE * headDim;
+        const uint32_t pageStride = MSA_BLOCK_SIZE * MSA_K_TILE;
+
+        for (uint32_t j = 0; j < MSA_BLOCKS_PER_STILE; ++j) {
+            const uint32_t blk = blkBase + j;
+            if (blk >= task.visibleEndBlk) {
+                break;
+            }
+            if (!KeyBlockNeedsScratch(task, blk)) {
+                continue;
+            }
+            const uint64_t kOffset = KeyBlockGmOffset(task, blk);
+            const uint64_t scratchOff = kScratchBase + static_cast<uint64_t>(j) * pageStride;
+            const uint32_t nValidTok = KeyBlockValidTokens(task, blk);
+            const uint32_t nValid = nValidTok * headDim;
+
+            if constexpr (IS_QUANT_V) {
+                // 与已通过的 PA int8 路径对齐：整页 DataCopy+Cast（nElem），EVENT_ID0。
+                // TND 仅在尾页会越过 T2 时改为部分拷贝；中间整页禁止走 CopyGmToUbPartial。
+                uint32_t copyN = nElem;
+                if (tiling_->keyLayout == MSA_KEY_LAYOUT_TND) {
+                    const uint32_t tokenStart = task.cuKStart + blk * tiling_->blockSize;
+                    const uint32_t packedEnd = tokenStart + MSA_BLOCK_SIZE;
+                    if (tiling_->totalK > 0 && packedEnd > tiling_->totalK) {
+                        copyN = nValid;
+                    }
+                }
+                if (copyN < nElem) {
+                    AscendC::Duplicate(ubHalf, static_cast<half>(0), nElem);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID0);
+                }
+                if (copyN > 0) {
+                    if (copyN == nElem) {
+                        AscendC::DataCopy(ubI8, gKeyInt8_[kOffset], nElem);
+                    } else {
+                        CopyGmToUbPartial(ubI8, gKeyInt8_[kOffset], copyN);
+                    }
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID0);
+                    AscendC::Cast(ubHalf, ubI8, AscendC::RoundMode::CAST_NONE, copyN);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID0);
+                AscendC::DataCopy(gKeyScratch_[scratchOff], ubHalf, nElem);
+            } else {
+                AscendC::LocalTensor<ElementQ> ubK = resource.ubBuf.template GetBufferByByte<ElementQ>(UB_OFF_CAST_FP);
+                if (nValid < nElem) {
+                    AscendC::Duplicate(ubK, static_cast<ElementQ>(0), nElem);
+                    AscendC::PipeBarrier<PIPE_V>();
+                    AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+                    AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(EVENT_ID2);
+                }
+                if (nValid > 0) {
+                    CopyGmToUbPartial(ubK, gKeyFp_[kOffset], nValid);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(EVENT_ID2);
+                }
+                AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2);
+                AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(EVENT_ID2);
+                AscendC::DataCopy(gKeyScratch_[scratchOff], ubK, nElem);
+            }
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID0);
+            AscendC::PipeBarrier<PIPE_ALL>();
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    __aicore__ inline void ComputeSTile(BlockMmad &blockMmad, const MsaTask &task, uint32_t blkBase, uint64_t sBase,
+                                        uint64_t kScratchBase, bool needLoadL1, bool dumpDebug)
+    {
+        const uint32_t mActual = task.mActual;
+        const uint32_t headDim = tiling_->headDim;
+        const LayoutQ layoutQ(mActual, headDim, tiling_->strideQn);
+        const LayoutK layoutKScratch(headDim, MSA_BLOCK_SIZE, headDim);
+        const LayoutK layoutKGm(headDim, MSA_BLOCK_SIZE, tiling_->strideKvToken);
+        const LayoutS layoutS(mActual, MSA_BLOCK_SIZE, STILE_WIDTH);
+        const Catlass::GemmCoord shape{mActual, MSA_BLOCK_SIZE, headDim};
+        const uint64_t qOffset = static_cast<uint64_t>(task.globalRowBase) * tiling_->strideQn;
+        const uint32_t pageStride = MSA_BLOCK_SIZE * MSA_K_TILE;
+
+#if MSA_INDEX_SCORE_DEBUG
+        if (dumpDebug) {
+            const uint32_t qDumpN = headDim < MSA_DEBUG_DUMP_ELEMS ? headDim : MSA_DEBUG_DUMP_ELEMS;
+            AscendC::printf("[MSA_DBG][AIC] ComputeSTile blkBase=%u mActual=%u headDim=%u isQuant=%u\n", blkBase,
+                            mActual, headDim, static_cast<uint32_t>(IS_QUANT_V));
+            MsaDumpGmSample(gQuery_[qOffset], MSA_DUMP_DESC_Q, qDumpN);
+        }
+#endif
+
+        for (uint32_t j = 0; j < MSA_BLOCKS_PER_STILE; ++j) {
+            const uint32_t blk = blkBase + j;
+            if (blk >= task.visibleEndBlk) {
+                break;
+            }
+            if (KeyBlockNeedsScratch(task, blk)) {
+                const uint64_t scratchOff = kScratchBase + static_cast<uint64_t>(j) * pageStride;
+                blockMmad(gQuery_[qOffset], layoutQ, gKeyScratch_[scratchOff], layoutKScratch,
+                          gWorkspace_[sBase + static_cast<uint64_t>(j) * MSA_BLOCK_SIZE], layoutS, shape, needLoadL1);
+            } else if constexpr (!IS_QUANT_V) {
+                const uint64_t kOffset = KeyBlockGmOffset(task, blk);
+                blockMmad(gQuery_[qOffset], layoutQ, gKeyFp_[kOffset], layoutKGm,
+                          gWorkspace_[sBase + static_cast<uint64_t>(j) * MSA_BLOCK_SIZE], layoutS, shape, needLoadL1);
+            }
+            needLoadL1 = false;
+        }
+
+#if MSA_INDEX_SCORE_DEBUG
+        if (dumpDebug) {
+            AscendC::PipeBarrier<PIPE_ALL>();
+            AscendC::printf("[MSA_DBG][AIC] after DOT S row0 blk0:");
+            MsaPrintGmFloats(gWorkspace_[sBase], MSA_DEBUG_DUMP_ELEMS);
+        }
+#endif
+    }
+
+    __aicore__ inline void ProcessVector()
+    {
+        Catlass::Arch::Resource<ArchTag> resource;
+        MsaSegRowMaxEpilogue<IS_QUANT_V> epilogue;
+        epilogue.Init(resource, tiling_->numQHeads, tiling_->strideOutHead, tiling_->strideOutToken,
+                      tiling_->maxBlocksPerBatch, tiling_->strideScalePage, tiling_->strideScaleHead, IS_QUANT_V,
+                      tiling_->keyLayout, tiling_->totalK, gScore_, gScale_, gBlockTable_);
+        Catlass::Arch::CrossCoreFlagWithReverse<REVERSE_DEPTH> flagSReady{MSA_FLAG_S_READY, MSA_FLAG_S_READY_REVERSE};
+        Catlass::Arch::CrossCoreFlag flagKReady{MSA_FLAG_K_READY};
+
+        const uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        const uint32_t subIdx = AscendC::GetSubBlockIdx();
+        const uint32_t coreIdx = AscendC::GetBlockIdx() / subBlockNum;
+        const uint32_t coreNum = AscendC::GetBlockNum();
+        const uint64_t coreWsBase = static_cast<uint64_t>(coreIdx) * MSA_WORKSPACE_STAGES * MSA_STILE_ELEM_NUM;
+        const uint64_t coreKScratch = static_cast<uint64_t>(coreIdx) * MSA_K_SCRATCH_ELEM_NUM;
+        const uint32_t totalTasks = scheduler_.TotalTasks();
+
+        uint32_t tileSeq = 0;
+        MsaTask task;
+        for (uint32_t taskIdx = coreIdx; taskIdx < totalTasks; taskIdx += coreNum) {
+            scheduler_.Decode(taskIdx, task);
+#if MSA_INDEX_SCORE_DEBUG
+            const bool dbgTask = MsaDebugPrimaryCore() && (taskIdx == coreIdx) && (subIdx == 0);
+#else
+            constexpr bool dbgTask = false;
+#endif
+            epilogue.BeginTask(task, subIdx, subBlockNum);
+            for (uint32_t st = 0; st < task.numComputeSTiles; ++st) {
+                if (StileNeedsKScratch(task, st * MSA_BLOCKS_PER_STILE)) {
+                    // AIV0 写 scratch；AIV0/AIV1 barrier 后双方都 Set，满足 1:2 MIX 握手。
+                    if (subIdx == 0) {
+                        GatherKeySTileToScratch(resource, task, st * MSA_BLOCKS_PER_STILE, coreKScratch);
+                    }
+                    Catlass::Arch::CrossCoreBarrier<0x1, PIPE_MTE3>();
+                    Catlass::Arch::CrossCoreSetFlag<0x2, PIPE_MTE3>(flagKReady);
+                }
+                Catlass::Arch::CrossCoreWaitFlagWithReverse<0x2, PIPE_MTE3>(flagSReady);
+                const uint64_t sBase =
+                    coreWsBase + static_cast<uint64_t>(tileSeq % MSA_WORKSPACE_STAGES) * MSA_STILE_ELEM_NUM;
+                epilogue.ProcessSTile(gWorkspace_[sBase], task, st * MSA_BLOCKS_PER_STILE, subIdx, subBlockNum,
+                                      dbgTask && (st == 0));
+                ++tileSeq;
+            }
+            // 因果不可见尾：不握手，直接写 -inf（与 AIC 跳过这些 tile 对齐）。
+            for (uint32_t st = task.numComputeSTiles; st < task.numSTiles; ++st) {
+                epilogue.ProcessSTile(gWorkspace_[0], task, st * MSA_BLOCKS_PER_STILE, subIdx, subBlockNum, false);
+            }
+            epilogue.EndTask();
+        }
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+    const MsaIndexScoreTilingData *__restrict tiling_ = nullptr;
+    MsaTaskScheduler scheduler_;
+
+    AscendC::GlobalTensor<ElementQ> gQuery_;
+    AscendC::GlobalTensor<ElementQ> gKeyFp_;
+    AscendC::GlobalTensor<int8_t> gKeyInt8_;
+    AscendC::GlobalTensor<ElementQ> gKeyScratch_;
+    AscendC::GlobalTensor<int32_t> gBlockTable_;
+    AscendC::GlobalTensor<float> gScale_;
+    AscendC::GlobalTensor<int32_t> gActualSeqQlen_;
+    AscendC::GlobalTensor<int32_t> gActualSeqKlen_;
+    AscendC::GlobalTensor<int32_t> gStartLoc_;
+    AscendC::GlobalTensor<float> gScore_;
+    AscendC::GlobalTensor<ElementS> gWorkspace_;
+};
+
+} // namespace MsaIndexScoreNs
+
+#endif // MSA_INDEX_SCORE_KERNEL_H

--- a/csrc/attention/msa_index_score/op_kernel/arch22/msa_index_score_task.h
+++ b/csrc/attention/msa_index_score/op_kernel/arch22/msa_index_score_task.h
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_task.h
+ * \brief varlen + sparse_mode 因果裁剪的任务枚举器。
+ *
+ * atten_mask（sparse_mode=3）采用与 LightningIndexer 相同的 rightDownCausal 解析：
+ *   visible_key_end(q) = kv_len - q_len + t_off + 1
+ * 不物化 / 不加载 [2048,2048] 模板。
+ *
+ * start_loc[b] 为当前 query 所在逻辑 block 索引，仅用于 local_mask（强制高分），
+ * 不再作为 token 级 prefix 偏移。
+ */
+
+#ifndef MSA_INDEX_SCORE_TASK_H
+#define MSA_INDEX_SCORE_TASK_H
+
+#include "kernel_operator.h"
+#include "../msa_index_score_common.h"
+
+namespace MsaIndexScoreNs {
+
+__aicore__ inline uint32_t MsaCeilDiv(uint32_t a, uint32_t b) { return (a + b - 1) / b; }
+
+__aicore__ inline uint32_t MsaMinU32(uint32_t a, uint32_t b) { return a < b ? a : b; }
+
+__aicore__ inline int32_t MsaClampI32(int32_t v, int32_t lo, int32_t hi)
+{
+    if (v < lo) {
+        return lo;
+    }
+    if (v > hi) {
+        return hi;
+    }
+    return v;
+}
+
+/// 一个任务 = 一个请求内的一个 M-tile。
+/// M 维 = 请求内 (token, head) 扁平行索引，head 为低位。
+struct MsaTask {
+    uint32_t batchIdx;
+    uint32_t cuQStart;
+    uint32_t mStart;
+    uint32_t mActual;
+    uint32_t globalRowBase;
+    int32_t startLoc; // 当前 query 所在逻辑 block 索引（local_mask）
+    int32_t kvLen;
+    int32_t qLen;
+    uint32_t cuKStart; // TND：本请求在 packed key 中的 token 起点；PA：0
+    uint32_t sparseMode;
+    uint32_t initBlocks;
+    uint32_t localBlocks;
+    uint32_t fullEndBlk;
+    uint32_t visibleEndBlk;
+    uint32_t numSTiles;        // 含不可见尾，必须写 -inf 的 S-tile 数
+    uint32_t numComputeSTiles; // AIC 真正做 QKᵀ 的 S-tile 数（<= numSTiles）
+};
+
+class MsaTaskScheduler {
+public:
+    __aicore__ inline MsaTaskScheduler() {}
+
+    __aicore__ inline void Init(uint32_t batch, uint32_t numQHeads, uint32_t maxBlocksPerBatch,
+                                uint32_t scoreBlockStride, uint32_t sparseMode, uint32_t initBlocks,
+                                uint32_t localBlocks, uint32_t keyLayout,
+                                const AscendC::GlobalTensor<int32_t> &actualSeqQlen,
+                                const AscendC::GlobalTensor<int32_t> &actualSeqKlen,
+                                const AscendC::GlobalTensor<int32_t> &startLoc)
+    {
+        batch_ = batch;
+        numQHeads_ = numQHeads;
+        maxBlocksPerBatch_ = maxBlocksPerBatch;
+        scoreBlockStride_ = scoreBlockStride;
+        sparseMode_ = sparseMode;
+        initBlocks_ = initBlocks;
+        localBlocks_ = localBlocks;
+        keyLayout_ = keyLayout;
+        gActualSeqQlen_ = actualSeqQlen;
+        gActualSeqKlen_ = actualSeqKlen;
+        gStartLoc_ = startLoc;
+
+        totalTasks_ = 0;
+        for (uint32_t b = 0; b < batch_; ++b) {
+            const uint32_t qLen = static_cast<uint32_t>(gActualSeqQlen_.GetValue(b + 1) - gActualSeqQlen_.GetValue(b));
+            totalTasks_ += MsaCeilDiv(qLen * numQHeads_, MSA_ROW_TILE_M);
+        }
+        Reset();
+    }
+
+    __aicore__ inline uint32_t TotalTasks() const { return totalTasks_; }
+
+    __aicore__ inline void Reset()
+    {
+        curBatch_ = 0;
+        taskBase_ = 0;
+        LoadBatch(0);
+    }
+
+    /// 按 sparse_mode 计算某 query token 的可见 key 上界（半开区间右端）。
+    __aicore__ inline int32_t VisibleKeyEndOf(int32_t tOff) const
+    {
+        if (sparseMode_ == MSA_SPARSE_MODE_RIGHT_DOWN) {
+            // rightDownCausal：j <= kvLen - qLen + tOff  <=>  end = kvLen - qLen + tOff + 1
+            return MsaClampI32(kvLen_ - qLen_ + tOff + 1, 0, kvLen_ < 0 ? 0 : kvLen_);
+        }
+        // defaultMask：仅受 kv_len 截断
+        return kvLen_ < 0 ? 0 : kvLen_;
+    }
+
+    __aicore__ inline void Decode(uint32_t taskIdx, MsaTask &task)
+    {
+        while (taskIdx >= taskBase_ + curTasks_) {
+            taskBase_ += curTasks_;
+            ++curBatch_;
+            LoadBatch(curBatch_);
+        }
+
+        task.batchIdx = curBatch_;
+        task.cuQStart = cuQStart_;
+        task.startLoc = startLoc_;
+        task.kvLen = kvLen_;
+        task.qLen = qLen_;
+        task.cuKStart = cuKStart_;
+        task.sparseMode = sparseMode_;
+        task.initBlocks = initBlocks_;
+        task.localBlocks = localBlocks_;
+        task.mStart = (taskIdx - taskBase_) * MSA_ROW_TILE_M;
+        task.mActual = MsaMinU32(MSA_ROW_TILE_M, curRows_ - task.mStart);
+        // Cube L0A fractal 为 MSA_M_ALIGN 行。整请求不足对齐宽度时保持原样（L0 已覆盖）；
+        // 否则把末尾短 tile 向前重叠到 MSA_M_ALIGN 行，避免 mActual∈(0,16) 的 int8 路径出错。
+        if (task.mActual > 0U && task.mActual < MSA_M_ALIGN && task.mStart >= MSA_M_ALIGN) {
+            task.mStart -= (MSA_M_ALIGN - task.mActual);
+            task.mActual = MSA_M_ALIGN;
+        }
+        task.globalRowBase = cuQStart_ * numQHeads_ + task.mStart;
+
+        const uint32_t tokenLo = task.mStart / numQHeads_;
+        const uint32_t tokenHi = (task.mStart + task.mActual - 1) / numQHeads_;
+        const int32_t visibleKeyEndHi = VisibleKeyEndOf(static_cast<int32_t>(tokenHi));
+        const int32_t visibleKeyEndLo = VisibleKeyEndOf(static_cast<int32_t>(tokenLo));
+
+        uint32_t visibleEndBlk = MsaCeilDiv(static_cast<uint32_t>(visibleKeyEndHi), MSA_BLOCK_SIZE);
+        visibleEndBlk = MsaMinU32(visibleEndBlk, maxBlocksPerBatch_);
+
+        const uint32_t causalFull = static_cast<uint32_t>(visibleKeyEndLo) / MSA_BLOCK_SIZE;
+        const uint32_t seqFull = (kvLen_ < 0 ? 0U : static_cast<uint32_t>(kvLen_)) / MSA_BLOCK_SIZE;
+        uint32_t fullEndBlk = MsaMinU32(causalFull, seqFull);
+
+        task.visibleEndBlk = visibleEndBlk;
+        task.fullEndBlk = MsaMinU32(fullEndBlk, visibleEndBlk);
+
+        // 不可见尾一律写 -inf，末维对齐到 scoreBlockStride
+        task.numSTiles = MsaCeilDiv(scoreBlockStride_, MSA_BLOCKS_PER_STILE);
+        task.numComputeSTiles = MsaCeilDiv(task.visibleEndBlk, MSA_BLOCKS_PER_STILE);
+        if (task.numComputeSTiles > task.numSTiles) {
+            task.numComputeSTiles = task.numSTiles;
+        }
+    }
+
+private:
+    __aicore__ inline void LoadBatch(uint32_t b)
+    {
+        if (b >= batch_) {
+            curTasks_ = 0;
+            curRows_ = 0;
+            cuQStart_ = 0;
+            kvLen_ = 0;
+            qLen_ = 0;
+            startLoc_ = 0;
+            cuKStart_ = 0;
+            return;
+        }
+        cuQStart_ = static_cast<uint32_t>(gActualSeqQlen_.GetValue(b));
+        qLen_ = static_cast<int32_t>(gActualSeqQlen_.GetValue(b + 1)) - static_cast<int32_t>(cuQStart_);
+        if (qLen_ < 0) {
+            qLen_ = 0;
+        }
+        curRows_ = static_cast<uint32_t>(qLen_) * numQHeads_;
+        curTasks_ = MsaCeilDiv(curRows_, MSA_ROW_TILE_M);
+        if (keyLayout_ == MSA_KEY_LAYOUT_TND) {
+            cuKStart_ = static_cast<uint32_t>(gActualSeqKlen_.GetValue(b));
+            kvLen_ = static_cast<int32_t>(gActualSeqKlen_.GetValue(b + 1)) - static_cast<int32_t>(cuKStart_);
+            if (kvLen_ < 0) {
+                kvLen_ = 0;
+            }
+        } else {
+            cuKStart_ = 0;
+            kvLen_ = gActualSeqKlen_.GetValue(b);
+        }
+        startLoc_ = gStartLoc_.GetValue(b);
+    }
+
+    AscendC::GlobalTensor<int32_t> gActualSeqQlen_;
+    AscendC::GlobalTensor<int32_t> gActualSeqKlen_;
+    AscendC::GlobalTensor<int32_t> gStartLoc_;
+
+    uint32_t batch_ = 0;
+    uint32_t numQHeads_ = 1;
+    uint32_t maxBlocksPerBatch_ = 0;
+    uint32_t scoreBlockStride_ = 0;
+    uint32_t sparseMode_ = MSA_SPARSE_MODE_RIGHT_DOWN;
+    uint32_t initBlocks_ = MSA_DEFAULT_INIT_BLOCKS;
+    uint32_t localBlocks_ = MSA_DEFAULT_LOCAL_BLOCKS;
+    uint32_t keyLayout_ = MSA_KEY_LAYOUT_BBND;
+
+    uint32_t totalTasks_ = 0;
+    uint32_t curBatch_ = 0;
+    uint32_t taskBase_ = 0;
+    uint32_t curTasks_ = 0;
+    uint32_t curRows_ = 0;
+    uint32_t cuQStart_ = 0;
+    int32_t kvLen_ = 0;
+    int32_t qLen_ = 0;
+    int32_t startLoc_ = 0;
+    uint32_t cuKStart_ = 0;
+};
+
+} // namespace MsaIndexScoreNs
+
+#endif // MSA_INDEX_SCORE_TASK_H

--- a/csrc/attention/msa_index_score/op_kernel/msa_index_score.cpp
+++ b/csrc/attention/msa_index_score/op_kernel/msa_index_score.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score.cpp
+ * \brief MsaIndexScore kernel 入口。
+ *
+ * 入参顺序与 op_def / aclnn 对齐：
+ *   query, key, block_table, scale, atten_mask, actual_seq_qlen, actual_seq_klen, start_loc, score
+ * atten_mask 仅做 host 校验；device 侧按 sparse_mode 解析因果，不消费该 GM。
+ */
+
+#include "kernel_operator.h"
+#include "lib/matmul_intf.h"
+#include "msa_index_score_common.h"
+#include "arch22/msa_index_score_kernel.h"
+
+using namespace MsaIndexScoreNs;
+
+#define MSA_INVOKE_KERNEL(ElementQ, IsQuant) \
+    do { \
+        MsaIndexScoreKernel<ElementQ, IsQuant> op; \
+        op.Init(query, key, blockTable, scale, actualSeqQlen, actualSeqKlen, startLoc, score, userWs, tilingData); \
+        op.Process(); \
+    } while (0)
+
+extern "C" __global__ __aicore__ void msa_index_score(GM_ADDR query, GM_ADDR key, GM_ADDR blockTable, GM_ADDR scale,
+                                                      GM_ADDR attenMask, GM_ADDR actualSeqQlen, GM_ADDR actualSeqKlen,
+                                                      GM_ADDR startLoc, GM_ADDR score, GM_ADDR workspace,
+                                                      GM_ADDR tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIC_1_2);
+    (void)attenMask; // host 校验；device 按 sparse_mode 解析 rightDownCausal
+    GM_ADDR userWs = AscendC::GetUserWorkspace(workspace);
+    if (userWs == nullptr) {
+        return;
+    }
+    GET_TILING_DATA_WITH_STRUCT(MsaIndexScoreTilingData, tilingDataIn, tiling);
+    const MsaIndexScoreTilingData *__restrict tilingData = &tilingDataIn;
+
+    if (TILING_KEY_IS(MSA_TILING_KEY_BF16)) {
+        MSA_INVOKE_KERNEL(bfloat16_t, false);
+    } else if (TILING_KEY_IS(MSA_TILING_KEY_FP16)) {
+        MSA_INVOKE_KERNEL(half, false);
+    } else if (TILING_KEY_IS(MSA_TILING_KEY_FP16_INT8)) {
+        MSA_INVOKE_KERNEL(half, true);
+    }
+}

--- a/csrc/attention/msa_index_score/op_kernel/msa_index_score_common.h
+++ b/csrc/attention/msa_index_score/op_kernel/msa_index_score_common.h
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_common.h
+ * \brief host / device 共用的编译期常量与 TilingKey 定义。
+ *
+ * 该头文件不依赖 AscendC，可被 op_host 的 tiling 直接 include。
+ */
+
+#ifndef MSA_INDEX_SCORE_COMMON_H
+#define MSA_INDEX_SCORE_COMMON_H
+
+#include <cstdint>
+
+namespace MsaIndexScoreNs {
+
+// 一个 sparse block（同时也是一个 paged-cache page）的 token 数。
+// 该值同时是 BlockMmad 的 L1TileShape::N，必须是编译期常量。
+constexpr uint32_t MSA_BLOCK_SIZE = 128;
+
+// 一个 M-tile 的行数。行 = 请求内 (token, head) 扁平索引，head 为低位。
+constexpr uint32_t MSA_ROW_TILE_M = 128;
+
+// Cube L0A fractal / 向量归约对齐行数。末尾短 tile 不足该值时向前重叠。
+constexpr uint32_t MSA_M_ALIGN = 16;
+
+// BlockMmad 的 L1TileShape::K。headDim <= 该值时 kLoop = 1，
+// headDim 更大时 BlockMmad 内部自动多轮 K 迭代。
+constexpr uint32_t MSA_K_TILE = 128;
+
+// 一个 S workspace tile 覆盖的 sparse block 数（AIC 每产出这么多 block 同步一次 AIV）。
+// 取 8 使得每行的归约结果恰为 8 个 fp32 = 32B，输出可以按 32B 对齐整块写回。
+constexpr uint32_t MSA_BLOCKS_PER_STILE = 8;
+
+// S workspace 轮转级数。AIC 领先 AIV 的未消费 tile 数 <= MSA_WORKSPACE_STAGES - 1。
+// 5 -> 8：AIV 乒乓化后服务速度提升，加深缓冲让 AIC 几乎不因 AIV 停顿（wait_id2→0）。
+// 非量化路径 S 为 fp16，8 级 × 256KB × 20 核 = 40MB，仍可整体驻留 L2。
+constexpr uint32_t MSA_WORKSPACE_STAGES = 8;
+
+// 一个 S workspace tile 的元素数：[MSA_ROW_TILE_M, MSA_BLOCKS_PER_STILE * MSA_BLOCK_SIZE]
+// 非量化路径元素为 fp16（fixpipe F322F16 直接写），int8 路径为 fp32。
+constexpr uint32_t MSA_STILE_ELEM_NUM = MSA_ROW_TILE_M * MSA_BLOCKS_PER_STILE * MSA_BLOCK_SIZE;
+// 非量化 S tile 的字节数（fp16）。
+constexpr uint32_t MSA_STILE_BYTES_FP16 = MSA_STILE_ELEM_NUM * sizeof(uint16_t);
+// int8 路径 S tile 的字节数（fp32）。
+constexpr uint32_t MSA_STILE_BYTES_FP32 = MSA_STILE_ELEM_NUM * sizeof(float);
+
+// int8 路径：每个 AIC 私有一块 K cast 暂存，容纳一个 S-tile 内全部 page
+// （AIV 先 cast，AIC 再 Mmad，避免逐 page 细粒度同步）。
+// 单页布局 [blockSize, headDim] 行主序，按 j*P*D 排列。
+constexpr uint32_t MSA_K_SCRATCH_ELEM_NUM = MSA_BLOCKS_PER_STILE * MSA_BLOCK_SIZE * MSA_K_TILE;
+
+// AIV 单次归约处理的行数。受 level-0 向量 API repeatTimes(uint8_t) 上限约束：
+// MSA_ROWS_PER_PASS * MSA_BLOCKS_PER_STILE <= 255，且乘积需为 8 的倍数。
+constexpr uint32_t MSA_ROWS_PER_PASS = 16;
+
+// 归约展开后的逻辑行数：把 [rows, BLOCKS, BLOCK_SIZE] 视作 [rows*BLOCKS, BLOCK_SIZE]。
+constexpr uint32_t MSA_REDUCE_ROWS = MSA_ROWS_PER_PASS * MSA_BLOCKS_PER_STILE;
+
+// 向量单元一个 repeat 处理的 fp32 数 / 一个 32B datablock 的 fp32 数。
+constexpr uint32_t MSA_FP32_PER_REPEAT = 64;
+constexpr uint32_t MSA_FP32_PER_BLOCK = 8;
+
+// score 输出末维的对齐粒度。
+constexpr uint32_t MSA_SCORE_STRIDE_ALIGN = 16;
+
+// 不可见 block 的填充值（-inf），使其在下游 topk 中必然落选。
+constexpr float MSA_FILL_VALUE = -3.4028234663852886e+38F;
+
+// local_mask 强制高分（对齐 Triton decode：init=1e30，local=1e29；local 覆盖 init）。
+constexpr float MSA_LOCAL_SCORE_INIT = 1.0e30F;
+constexpr float MSA_LOCAL_SCORE_LOCAL = 1.0e29F;
+
+// sparse_mode：0=defaultMask（无因果截断）；3=rightDownCausal（与 LightningIndexer 一致）。
+constexpr uint32_t MSA_SPARSE_MODE_DEFAULT = 0;
+constexpr uint32_t MSA_SPARSE_MODE_RIGHT_DOWN = 3;
+
+// MiniMax 默认强制选块数（接口文档未暴露 attr；P0 以常量对齐 HF/Triton 常见配置）。
+constexpr uint32_t MSA_DEFAULT_INIT_BLOCKS = 0;
+constexpr uint32_t MSA_DEFAULT_LOCAL_BLOCKS = 1;
+
+// key 数据排布。BBND / BNBD 为 PageAttention；TND 为 packed varlen，无 block_table。
+constexpr uint32_t MSA_KEY_LAYOUT_BBND = 0; // [block_num, block_size, N2, D]
+constexpr uint32_t MSA_KEY_LAYOUT_BNBD = 1; // [block_num, N2, block_size, D]
+constexpr uint32_t MSA_KEY_LAYOUT_TND = 2;  // [T2, N2, D]
+
+// atten_mask 压缩下三角模板边长（sparse_mode=3 时校验）。
+constexpr uint32_t MSA_ATTEN_MASK_SIZE = 2048;
+
+// FFTS cross-core flag id，合法范围 0~7（8/9/10 为保留 barrier）。
+constexpr uint16_t MSA_FLAG_S_READY = 1;
+constexpr uint16_t MSA_FLAG_S_READY_REVERSE = 2;
+// int8 路径：AIV cast K→scratch 完成后通知 AIC。
+constexpr uint16_t MSA_FLAG_K_READY = 3;
+constexpr uint16_t MSA_FLAG_K_READY_REVERSE = 4;
+
+} // namespace MsaIndexScoreNs
+
+// TilingKey：按 query dtype × key 是否 int8 分支。
+// 必须是宏而非 constexpr —— TILING_KEY_IS() 在算子预编译阶段按文本解析，只接受数值常量或宏。
+#define MSA_TILING_KEY_BF16 0
+#define MSA_TILING_KEY_FP16 1
+#define MSA_TILING_KEY_BF16_INT8 2
+#define MSA_TILING_KEY_FP16_INT8 3
+
+#endif // MSA_INDEX_SCORE_COMMON_H

--- a/csrc/attention/msa_index_score/op_kernel/msa_index_score_debug.h
+++ b/csrc/attention/msa_index_score/op_kernel/msa_index_score_debug.h
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file msa_index_score_debug.h
+ * \brief Device-side debug helpers for MsaIndexScore (printf / DumpTensor).
+ *
+ * Enable by compiling with -DMSA_INDEX_SCORE_DEBUG=1 (and AscendC dump macros).
+ * Dumps are limited to AIC/AIV block 0 and the first S-tile / first pass to
+ * keep logs readable.
+ */
+
+#ifndef MSA_INDEX_SCORE_DEBUG_H
+#define MSA_INDEX_SCORE_DEBUG_H
+
+#include "kernel_operator.h"
+
+#ifndef MSA_INDEX_SCORE_DEBUG
+#define MSA_INDEX_SCORE_DEBUG 0
+#endif
+
+namespace MsaIndexScoreNs {
+
+// DumpTensor 描述符：便于在日志中区分阶段。
+constexpr uint32_t MSA_DUMP_DESC_Q = 1001;
+constexpr uint32_t MSA_DUMP_DESC_K = 1002;
+constexpr uint32_t MSA_DUMP_DESC_S_DOT = 2001;
+constexpr uint32_t MSA_DUMP_DESC_S_MASK = 2002;
+constexpr uint32_t MSA_DUMP_DESC_SCORE_MAX = 3001;
+constexpr uint32_t MSA_DUMP_DESC_SCORE_FINAL = 3002;
+
+// 常规采样长度；小尺寸用例 (D=16 / kvLen<=8) 时 DumpTensor 可覆盖完整向量。
+constexpr uint32_t MSA_DEBUG_DUMP_ELEMS = 16;
+// 边界 mask 窗口：打印 valid 尾部与紧随其后的 -inf，便于肉眼核对。
+constexpr uint32_t MSA_DEBUG_MASK_WINDOW = 8;
+
+#if MSA_INDEX_SCORE_DEBUG
+
+__aicore__ inline bool MsaDebugPrimaryCore()
+{
+    // AIC: blockIdx == cube core；AIV: blockIdx == aivIdx（core0/sub0 -> 0）。
+    return AscendC::GetBlockIdx() == 0;
+}
+
+template <typename T>
+__aicore__ inline void MsaDumpGmSample(const AscendC::GlobalTensor<T> &g, uint32_t desc, uint32_t n)
+{
+    AscendC::DumpTensor(g, desc, n);
+}
+
+__aicore__ inline void MsaDumpUbSample(const AscendC::LocalTensor<float> &ub, uint32_t desc, uint32_t n)
+{
+    AscendC::PipeBarrier<PIPE_ALL>();
+    AscendC::DumpTensor(ub, desc, n);
+}
+
+__aicore__ inline void MsaPrintUbFloats(const AscendC::LocalTensor<float> &ub, uint32_t n)
+{
+    AscendC::PipeBarrier<PIPE_ALL>();
+    const uint32_t lim = n < MSA_DEBUG_DUMP_ELEMS ? n : MSA_DEBUG_DUMP_ELEMS;
+    for (uint32_t i = 0; i < lim; ++i) {
+        AscendC::printf(" %f", ub.GetValue(i));
+    }
+    AscendC::printf("\n");
+}
+
+template <typename T>
+__aicore__ inline void MsaPrintGmFloats(const AscendC::GlobalTensor<T> &g, uint32_t n)
+{
+    const uint32_t lim = n < MSA_DEBUG_DUMP_ELEMS ? n : MSA_DEBUG_DUMP_ELEMS;
+    for (uint32_t i = 0; i < lim; ++i) {
+        AscendC::printf(" %f", static_cast<float>(g.GetValue(i)));
+    }
+    AscendC::printf("\n");
+}
+
+#else // !MSA_INDEX_SCORE_DEBUG
+
+__aicore__ inline bool MsaDebugPrimaryCore() { return false; }
+
+template <typename T>
+__aicore__ inline void MsaDumpGmSample(const AscendC::GlobalTensor<T> &, uint32_t, uint32_t)
+{}
+
+__aicore__ inline void MsaDumpUbSample(const AscendC::LocalTensor<float> &, uint32_t, uint32_t) {}
+
+__aicore__ inline void MsaPrintUbFloats(const AscendC::LocalTensor<float> &, uint32_t) {}
+
+template <typename T>
+__aicore__ inline void MsaPrintGmFloats(const AscendC::GlobalTensor<T> &, uint32_t)
+{}
+
+#endif // MSA_INDEX_SCORE_DEBUG
+
+} // namespace MsaIndexScoreNs
+
+#endif // MSA_INDEX_SCORE_DEBUG_H

--- a/csrc/attention/msa_index_score/tests/CMakeLists.txt
+++ b/csrc/attention/msa_index_score/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/msa_index_score/tests/README.md
+++ b/csrc/attention/msa_index_score/tests/README.md
@@ -1,8 +1,8 @@
-# MsaIndexScore 测试说明
+# MsaIndexScore Test Guide
 
-## 1. 端到端精度自验证（当前主用例）
+## 1. End-to-End Accuracy Self-Check (Primary Test)
 
-`examples/test_aclnn_msa_index_score.cpp` 自包含 aclnn 调用 + CPU golden。
+`examples/test_aclnn_msa_index_score.cpp` contains both the aclnn invocation and a CPU golden implementation.
 
 ```bash
 bash build.sh --pkg --soc=ascend910b --ops=msa_index_score -j32
@@ -11,30 +11,30 @@ export ASCEND_CUSTOM_OPP_PATH=/tmp/msa_opp/vendors/custom_transformer
 bash build.sh --run_example msa_index_score eager cust --vendor_name=custom
 ```
 
-## 2. 用例矩阵
+## 2. Test Matrix
 
-对齐设计文档黄金用例；`start_loc` 为**逻辑 block 索引**，因果由 `sparse_mode=3` 承担。
+The matrix follows the golden cases in the design document. `start_loc` is a **logical-block index**, and `sparse_mode=3` provides causal masking.
 
-| 用例 | 场景 | 覆盖点 |
-|------|------|--------|
-| `L0-debug-trace` | 极小尺寸 | 主路径 / TRACE |
-| `L0-int8-dequant-trace` | int8 + scale | 前融合反量化 |
-| `L0-prefill-aligned` | chunked prefill 对齐 | rightDownCausal + local_mask |
-| `L1-prefill-unaligned` | 多 batch varlen | 边界 block mask |
-| `L1-prefill-multi-mtile` | 行数 > M-tile | M-tile 切分 |
-| `L1-decode-lq1` | decode q_len=1 | 多长度 |
-| `L1-decode-speculative` | q_len>1 | 投机解码 |
-| `L1-long-seq-multi-stile` | kv=4096 | 多 S-tile |
-| `L1-bf16` / `L1-int8-dequant` | dtype | 非量化 / 量化 |
-| `L2-tiny-kv` | 极小 kv | 尾填充 |
-| `L1-bnbd` / `L1-bnbd-int8` | PA BNBD | `[NP, N2, P, D]` |
-| `L1-tnd-unaligned` / `L1-tnd-int8` / `L0-tnd-tiny` | TND packed | 无 block_table，klen 前缀和 |
+| Test Case | Scenario | Coverage |
+| --------- | -------- | -------- |
+| `L0-debug-trace` | Minimal dimensions | Main path/TRACE |
+| `L0-int8-dequant-trace` | int8 + scale | Prefused dequantization |
+| `L0-prefill-aligned` | Aligned chunked prefill | rightDownCausal + local_mask |
+| `L1-prefill-unaligned` | Multi-batch variable length | Boundary-block mask |
+| `L1-prefill-multi-mtile` | Row count > M-tile | M-tile partitioning |
+| `L1-decode-lq1` | Decode with q_len=1 | Multiple sequence lengths |
+| `L1-decode-speculative` | q_len>1 | Speculative decoding |
+| `L1-long-seq-multi-stile` | kv=4096 | Multiple S-tiles |
+| `L1-bf16` / `L1-int8-dequant` | dtype | Non-quantized/quantized |
+| `L2-tiny-kv` | Minimal KV length | Tail padding |
+| `L1-bnbd` / `L1-bnbd-int8` | PageAttention BNBD | `[NP, N2, P, D]` |
+| `L1-tnd-unaligned` / `L1-tnd-int8` / `L0-tnd-tiny` | Packed TND | No block_table; klen prefix sum |
 
-默认跑完整用例矩阵（含 TND / BNBD）。key 布局由 `layout_key`（aclnn：`layoutKeyOptional`）指定，不再从 shape 推断。
+The complete test matrix, including TND and BNBD, runs by default. The key layout is specified by `layout_key` (`layoutKeyOptional` in aclnn) and is no longer inferred from the shape.
 
-## 3. Python 参考
+## 3. Python Reference
 
-`tests/golden/msa_index_score_golden.py`：
+`tests/golden/msa_index_score_golden.py`:
 
 ```python
 golden = msa_index_score_golden(
@@ -42,8 +42,8 @@ golden = msa_index_score_golden(
     sparse_mode=3, scale=None)
 ```
 
-## 4. 判定标准
+## 4. Acceptance Criteria
 
-- 填充位（不可见 block）两侧同为 `-inf`
-- `local_mask` 强制高分两侧同为 `≥1e28`
-- 有效位 `atol/rtol=1e-3`，`error_ratio≤1e-3`
+- Padded positions (invisible blocks) are `-inf` on both sides.
+- Blocks forced to high scores by `local_mask` are `≥1e28` on both sides.
+- Valid positions use `atol/rtol=1e-3` and `error_ratio≤1e-3`.

--- a/csrc/attention/msa_index_score/tests/README.md
+++ b/csrc/attention/msa_index_score/tests/README.md
@@ -1,0 +1,49 @@
+# MsaIndexScore 测试说明
+
+## 1. 端到端精度自验证（当前主用例）
+
+`examples/test_aclnn_msa_index_score.cpp` 自包含 aclnn 调用 + CPU golden。
+
+```bash
+bash build.sh --pkg --soc=ascend910b --ops=msa_index_score -j32
+./build_out/cann-ops-transformer-custom_linux-aarch64.run --quiet --install-path=/tmp/msa_opp
+export ASCEND_CUSTOM_OPP_PATH=/tmp/msa_opp/vendors/custom_transformer
+bash build.sh --run_example msa_index_score eager cust --vendor_name=custom
+```
+
+## 2. 用例矩阵
+
+对齐设计文档黄金用例；`start_loc` 为**逻辑 block 索引**，因果由 `sparse_mode=3` 承担。
+
+| 用例 | 场景 | 覆盖点 |
+|------|------|--------|
+| `L0-debug-trace` | 极小尺寸 | 主路径 / TRACE |
+| `L0-int8-dequant-trace` | int8 + scale | 前融合反量化 |
+| `L0-prefill-aligned` | chunked prefill 对齐 | rightDownCausal + local_mask |
+| `L1-prefill-unaligned` | 多 batch varlen | 边界 block mask |
+| `L1-prefill-multi-mtile` | 行数 > M-tile | M-tile 切分 |
+| `L1-decode-lq1` | decode q_len=1 | 多长度 |
+| `L1-decode-speculative` | q_len>1 | 投机解码 |
+| `L1-long-seq-multi-stile` | kv=4096 | 多 S-tile |
+| `L1-bf16` / `L1-int8-dequant` | dtype | 非量化 / 量化 |
+| `L2-tiny-kv` | 极小 kv | 尾填充 |
+| `L1-bnbd` / `L1-bnbd-int8` | PA BNBD | `[NP, N2, P, D]` |
+| `L1-tnd-unaligned` / `L1-tnd-int8` / `L0-tnd-tiny` | TND packed | 无 block_table，klen 前缀和 |
+
+默认跑完整用例矩阵（含 TND / BNBD）。key 布局由 `layout_key`（aclnn：`layoutKeyOptional`）指定，不再从 shape 推断。
+
+## 3. Python 参考
+
+`tests/golden/msa_index_score_golden.py`：
+
+```python
+golden = msa_index_score_golden(
+    query, key, block_table, actual_seq_qlen, actual_seq_klen, start_loc,
+    sparse_mode=3, scale=None)
+```
+
+## 4. 判定标准
+
+- 填充位（不可见 block）两侧同为 `-inf`
+- `local_mask` 强制高分两侧同为 `≥1e28`
+- 有效位 `atol/rtol=1e-3`，`error_ratio≤1e-3`

--- a/csrc/attention/msa_index_score/tests/golden/msa_index_score_golden.py
+++ b/csrc/attention/msa_index_score/tests/golden/msa_index_score_golden.py
@@ -75,13 +75,11 @@ def msa_index_score_golden(
             blocks = (kv + block_size - 1) // block_size
             if blocks > max_blocks:
                 max_blocks = blocks
-        num_kv_heads = key.shape[1]
         k = key.astype(np.float32)[:, 0, :]
     else:
         batch = len(actual_seq_klen)
         max_blocks = block_table.shape[1]
         is_bnbd = key.shape[2] == block_size and key.shape[1] != block_size
-        num_kv_heads = key.shape[1] if is_bnbd else key.shape[2]
         if is_bnbd:
             k = key.astype(np.float32)[:, 0, :, :]
         else:

--- a/csrc/attention/msa_index_score/tests/golden/msa_index_score_golden.py
+++ b/csrc/attention/msa_index_score/tests/golden/msa_index_score_golden.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""MsaIndexScore CPU 参考实现。
+
+数值路径（与 kernel 对齐）：
+  score = Maxpool[ (scale ·) Q @ Kᵀ + atten_mask ] + local_mask
+
+- sparse_mode=0：无因果，仅 actual_seq_klen 截断
+- sparse_mode=3：rightDownCausal，visible_end = actual_seq_klen - q_len + t_off + 1
+- local_mask：由 start_loc（query 所在逻辑 block）+ init/local_blocks 强制高分
+"""
+
+import numpy as np
+
+NEG_INF = np.float32(-3.4028234663852886e38)
+LOCAL_SCORE_INIT = np.float32(1.0e30)
+LOCAL_SCORE_LOCAL = np.float32(1.0e29)
+SCORE_STRIDE_ALIGN = 16
+SPARSE_MODE_DEFAULT = 0
+SPARSE_MODE_RIGHT_DOWN = 3
+DEFAULT_INIT_BLOCKS = 0
+DEFAULT_LOCAL_BLOCKS = 1
+
+
+def round_up(value, align):
+    return (value + align - 1) // align * align
+
+
+def _visible_key_end(sparse_mode, actual_seq_klen, q_len, t_off):
+    if sparse_mode == SPARSE_MODE_RIGHT_DOWN:
+        return int(np.clip(actual_seq_klen - q_len + t_off + 1, 0, actual_seq_klen))
+    return int(actual_seq_klen)
+
+
+def msa_index_score_golden(
+    query,
+    key,
+    block_table,
+    actual_seq_qlen,
+    actual_seq_klen,
+    start_loc,
+    sparse_mode=SPARSE_MODE_RIGHT_DOWN,
+    block_size=128,
+    scale=None,
+    init_blocks=DEFAULT_INIT_BLOCKS,
+    local_blocks=DEFAULT_LOCAL_BLOCKS,
+):
+    """计算 MSA index block score。
+
+    Args:
+        query:       [T1, N1, D]
+        key:         PA BBND [NP, P, N2, D]、BNBD [NP, N2, P, D]，或 TND [T2, N2, D]
+        block_table: PA [B, MB]；TND 为 None
+        actual_seq_qlen:    [B+1]
+        actual_seq_klen:    PA [B]；TND 前缀和 [B+1]
+        start_loc:   [B]，当前 query 所在逻辑 block 索引（local_mask）
+        sparse_mode: 0 或 3
+        scale:       int8 时 PA [NP, N2, P] 或 TND [T2, N2]；非量化为 None
+    """
+    total_q, num_q_heads, head_dim = query.shape
+    is_tnd = key.ndim == 3
+    if is_tnd:
+        batch = len(actual_seq_klen) - 1
+        max_blocks = 0
+        for b in range(batch):
+            kv = int(actual_seq_klen[b + 1]) - int(actual_seq_klen[b])
+            blocks = (kv + block_size - 1) // block_size
+            if blocks > max_blocks:
+                max_blocks = blocks
+        num_kv_heads = key.shape[1]
+        k = key.astype(np.float32)[:, 0, :]
+    else:
+        batch = len(actual_seq_klen)
+        max_blocks = block_table.shape[1]
+        is_bnbd = key.shape[2] == block_size and key.shape[1] != block_size
+        num_kv_heads = key.shape[1] if is_bnbd else key.shape[2]
+        if is_bnbd:
+            k = key.astype(np.float32)[:, 0, :, :]
+        else:
+            k = key.astype(np.float32)[:, :, 0, :]
+    score_stride = round_up(max_blocks, SCORE_STRIDE_ALIGN)
+    is_quant = np.issubdtype(key.dtype, np.integer)
+
+    if is_quant:
+        if scale is None:
+            raise ValueError("int8 key requires dequant scale")
+    elif scale is not None:
+        raise ValueError("non-quant path must not pass scale")
+
+    q = query.astype(np.float32)
+    deq = None
+    if is_quant:
+        deq = scale.astype(np.float32)
+        if is_tnd:
+            deq = deq.reshape(-1) if deq.ndim == 1 else deq[:, 0]
+        else:
+            deq = deq[:, 0, :]
+
+    out = np.full((num_q_heads, total_q, score_stride), NEG_INF, dtype=np.float32)
+
+    for b in range(batch):
+        q_begin, q_end = int(actual_seq_qlen[b]), int(actual_seq_qlen[b + 1])
+        q_len = q_end - q_begin
+        if is_tnd:
+            cu_k = int(actual_seq_klen[b])
+            kv = int(actual_seq_klen[b + 1]) - cu_k
+        else:
+            cu_k = 0
+            kv = int(actual_seq_klen[b])
+        num_blocks = (kv + block_size - 1) // block_size
+        q_block = int(start_loc[b])
+        local_start = max(0, q_block + 1 - int(local_blocks))
+
+        for t in range(q_begin, q_end):
+            t_off = t - q_begin
+            visible_key_end = _visible_key_end(sparse_mode, kv, q_len, t_off)
+            for blk in range(num_blocks):
+                key_lo = blk * block_size
+                valid = min(visible_key_end - key_lo, block_size)
+                if valid <= 0:
+                    continue
+                if is_tnd:
+                    tok = cu_k + key_lo
+                    k_page = k[tok : tok + valid, :]
+                    if deq is not None:
+                        k_page = k_page * deq[tok : tok + valid, None]
+                else:
+                    page = int(block_table[b, blk])
+                    k_page = k[page, :valid, :]
+                    if deq is not None:
+                        k_page = k_page * deq[page, :valid, None]
+                s = q[t] @ k_page.T
+                out[:, t, blk] = s.max(axis=1)
+
+            for blk in range(num_blocks):
+                boost = None
+                if blk < int(init_blocks):
+                    boost = LOCAL_SCORE_INIT
+                if local_start <= blk <= q_block:
+                    boost = LOCAL_SCORE_LOCAL
+                if boost is not None:
+                    out[:, t, blk] = boost
+
+    return out
+
+
+def compare(actual, golden, atol=1e-3, rtol=1e-3, error_ratio_threshold=1e-3):
+    """比对 actual 与 golden。填充位必须同为 -inf；强制高分位允许同为 +inf/1e29/1e30。"""
+    actual = np.asarray(actual, dtype=np.float32)
+    golden = np.asarray(golden, dtype=np.float32)
+    if actual.shape != golden.shape:
+        return False, f"shape mismatch: actual={actual.shape} golden={golden.shape}"
+
+    fill_a = np.isneginf(actual)
+    fill_g = np.isneginf(golden)
+    if not np.array_equal(fill_a, fill_g):
+        return False, "fill(-inf) mask mismatch"
+
+    # 强制高分：两侧都极大即可
+    boost_g = golden >= 1.0e28
+    boost_a = actual >= 1.0e28
+    if not np.array_equal(boost_a, boost_g):
+        return False, "local_mask boost mask mismatch"
+
+    valid = (~fill_g) & (~boost_g)
+    if not np.any(valid):
+        return True, "ok (all fill/boost)"
+
+    diff = np.abs(actual[valid] - golden[valid])
+    denom = np.maximum(np.abs(golden[valid]), 1.0)
+    bad = diff > (atol + rtol * denom)
+    ratio = float(np.mean(bad)) if bad.size else 0.0
+    if ratio > error_ratio_threshold:
+        max_diff = float(np.max(diff)) if diff.size else 0.0
+        return False, f"error_ratio={ratio:.6f} max_abs_diff={max_diff}"
+    return True, "ok"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -129,6 +129,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "store_kv_block_metadata"
         "sparse_attention_score"
         "k2q_csr"
+        "msa_index_score"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
@@ -176,6 +177,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "store_kv_block_metadata"
         "sparse_attention_score"
         "k2q_csr"
+        "msa_index_score"
     )
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")
     SOC_ARG="ascend910_93"

--- a/csrc/cmake/custom_build.cmake
+++ b/csrc/cmake/custom_build.cmake
@@ -188,6 +188,7 @@ if (BUILD_OPEN_PROJECT)
             error_manager
             ascendalog
             unified_dlog
+            ascendcl
             -Wl,--as-needed
             -Wl,--whole-archive
             tiling_api

--- a/csrc/cmake/func.cmake
+++ b/csrc/cmake/func.cmake
@@ -642,12 +642,10 @@ function(add_bin_compile_target)
         set(BINARY_INFO_CONFIG_FILE ${BIN_OUT_DIR}/binary_info_config.json)
         set(RELOCATABLE_KERNEL_INFO_CONFIG_FILE ${BIN_OUT_DIR}/relocatable_kernel_info_config.json)
 
-        add_custom_command(OUTPUT ${BINARY_INFO_CONFIG_FILE}
-                COMMAND ${HI_PYTHON} ${ASCENDC_CMAKE_UTIL_DIR}/ascendc_ops_config.py -p ${BIN_OUT_DIR} -s ${BINARY_COMPUTE_UNIT}
-        )
-
         add_custom_target(${OPS_CONFIG_TARGET}
-                DEPENDS ${BINARY_INFO_CONFIG_FILE}
+                COMMAND ${HI_PYTHON} ${ASCENDC_CMAKE_UTIL_DIR}/ascendc_ops_config.py
+                        -p ${BIN_OUT_DIR} -s ${BINARY_COMPUTE_UNIT}
+                BYPRODUCTS ${BINARY_INFO_CONFIG_FILE} ${RELOCATABLE_KERNEL_INFO_CONFIG_FILE}
         )
 
         add_dependencies(ops_transformer_config ${OPS_CONFIG_TARGET})

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -46,6 +46,7 @@
 #include "attention/recurrent_gated_delta_rule/recurrent_gated_delta_rule_torch_adpt.h"
 #include "attention/recurrent_gated_delta_rule_v310/recurrent_gated_delta_rule_310_torch_adpt.h"
 #include "attention/k2q_csr/k2q_csr_torch_adpt.h"
+#include "attention/msa_index_score/msa_index_score_torch_adpt.h"
 #include "attention/sparse_attention_score/sparse_attention_score_torch_adpt.h"
 #include "attention/sparse_attention_score_prefill/sparse_attention_score_prefill_torch_adpt.h"
 #include "attention/store_kv_block/store_kv_block_torch_adpt.h"
@@ -2566,5 +2567,16 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     );
     ops.impl("npu_sparse_attention_score", torch::kPrivateUse1,
              &vllm_ascend::npu_sparse_attention_score);
+
+    ops.def(
+        "npu_msa_index_score("
+        "Tensor query, Tensor key, Tensor block_table, Tensor start_loc, *, "
+        "Tensor? scale=None, Tensor? atten_mask=None, "
+        "Tensor? actual_seq_qlen=None, Tensor? actual_seq_klen=None, "
+        "str layout_key=\"BBND\", int sparse_mode=3, "
+        "int init_blocks=0, int local_blocks=0) -> Tensor"
+    );
+    ops.impl("npu_msa_index_score", torch::kPrivateUse1,
+             &vllm_ascend::npu_msa_index_score);
 }
 #endif

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -328,6 +328,23 @@ at::Tensor npu_sparse_attention_score_meta(
                             query.options().dtype(out_dtype).device(c10::kMeta));
 }
 
+at::Tensor npu_msa_index_score_meta(
+    const at::Tensor &query, const at::Tensor &,
+    const at::Tensor &block_table, const at::Tensor &,
+    const c10::optional<at::Tensor> &,
+    const c10::optional<at::Tensor> &,
+    const c10::optional<at::Tensor> &,
+    const c10::optional<at::Tensor> &,
+    c10::string_view, int64_t, int64_t, int64_t)
+{
+    const c10::SymInt score_stride =
+        ceil_div(block_table.sym_size(1), 16) * c10::SymInt(16);
+    const std::vector<c10::SymInt> output_size = {
+        query.sym_size(1), query.sym_size(0), score_stride};
+    return at::empty_symint(
+        output_size, query.options().dtype(at::kFloat).device(c10::kMeta));
+}
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor> npu_kv_quant_sparse_flash_attention_meta(
     const at::Tensor &query,
     const at::Tensor &key,
@@ -1527,6 +1544,7 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("npu_k2q_csr", &vllm_ascend::meta::npu_k2q_csr_meta);
     ops.impl("npu_sparse_attention_score_prefill",
              &vllm_ascend::meta::npu_sparse_attention_score_prefill_meta);
+    ops.impl("npu_msa_index_score", &vllm_ascend::meta::npu_msa_index_score_meta);
     ops.impl("npu_kv_quant_sparse_flash_attention",
              &vllm_ascend::meta::npu_kv_quant_sparse_flash_attention_meta);
     // MoE dispatch-ffn-combine

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -21,7 +21,10 @@ from vllm_ascend.models.minimax_m3.minimax_m3 import _scatter_index_cache
 from vllm_ascend.models.minimax_m3.msa_m3 import (
     AscendMiniMaxM3IndexerBackend,
     AscendMiniMaxM3IndexerCache,
+    AscendMiniMaxM3IndexerDecodeMetadata,
+    AscendMiniMaxM3IndexerImpl,
     AscendMiniMaxM3IndexerLinear,
+    AscendMiniMaxM3IndexerMetadata,
     AscendMiniMaxM3IndexerMetadataBuilder,
     AscendMiniMaxM3SparseBackend,
     AscendMiniMaxM3SparseDecodeMetadata,
@@ -34,6 +37,9 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
     _sparse_proj_quant_type,
     _use_fused_qkv_indexer,
     minimax_m3_sparse_forward,
+)
+from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
+    _index_score_topk_candidates,
 )
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     minimax_m3_sparse_attn_decode as minimax_m3_sparse_attn_decode_npu,
@@ -565,6 +571,110 @@ def test_indexer_linear_weight_loader_uses_first_index_k_shard_for_all_ranks() -
     layer.weight_loader(param, loaded_weight, "index_k")
 
     assert torch.equal(param.data[2:3], loaded_weight[:1])
+
+
+@patch("vllm_ascend.models.minimax_m3.msa_m3.get_tp_group")
+@patch("vllm_ascend.models.minimax_m3.msa_m3.get_forward_context")
+def test_indexer_speculative_decode_uses_ascendc_tp_sharded_path(
+    mock_get_forward_context: MagicMock,
+    mock_get_tp_group: MagicMock,
+) -> None:
+    impl = object.__new__(AscendMiniMaxM3IndexerImpl)
+    torch.nn.Module.__init__(impl)
+    impl.num_index_heads = 1
+    impl.index_head_dim = 4
+    impl.index_cache = SimpleNamespace(
+        prefix="layer.attn.index_cache",
+        kv_cache=torch.zeros(4, 128, 4),
+    )
+
+    decode = AscendMiniMaxM3IndexerDecodeMetadata(
+        cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([258], dtype=torch.int32),
+        context_lens=torch.tensor([256], dtype=torch.int32),
+        block_table=torch.tensor([[0, 1, 2]], dtype=torch.int32),
+        max_seq_len=258,
+        decode_query_len=2,
+    )
+    metadata = AscendMiniMaxM3IndexerMetadata(
+        seq_lens=decode.seq_lens,
+        max_seq_len=decode.max_seq_len,
+        slot_mapping=torch.arange(2, dtype=torch.int64),
+        num_actual_tokens=2,
+        num_decodes=1,
+        num_decode_tokens=2,
+        num_prefills=0,
+        num_prefill_tokens=0,
+        decode=decode,
+    )
+    mock_get_forward_context.return_value = SimpleNamespace(
+        attn_metadata={impl.index_cache.prefix: metadata},
+    )
+    mock_get_tp_group.return_value = SimpleNamespace(
+        world_size=4,
+        rank_in_group=0,
+    )
+    expected = torch.zeros((1, 2, 2), dtype=torch.int32)
+
+    with patch.object(
+        impl,
+        "_decode_topk_tp_sharded",
+        return_value=expected,
+    ) as mock_tp_sharded:
+        actual, prefill = impl.forward(torch.zeros(2, 4))
+
+    assert actual is expected
+    assert prefill is None
+    mock_tp_sharded.assert_called_once()
+    assert mock_tp_sharded.call_args.args[7] == 2
+
+
+def test_speculative_decode_candidates_use_per_token_visibility() -> None:
+    score = torch.tensor([[[5.0], [7.0]]])
+
+    indices, scores = _index_score_topk_candidates(
+        score,
+        context_lens=torch.tensor([-1], dtype=torch.int32),
+        decode_query_len=2,
+        topk=2,
+        block_offset=1,
+    )
+
+    assert torch.equal(indices, torch.tensor([[[-1, -1], [1, -1]]], dtype=torch.int32))
+    assert torch.isneginf(scores[0, 0]).all()
+    assert scores[0, 1, 0] == 7.0
+    assert torch.isneginf(scores[0, 1, 1])
+
+
+def test_speculative_decode_candidates_move_local_mask_per_token() -> None:
+    score = torch.tensor([[[9.0, 1.0], [9.0, 1.0]]])
+
+    indices, scores = _index_score_topk_candidates(
+        score,
+        context_lens=torch.tensor([127], dtype=torch.int32),
+        decode_query_len=2,
+        topk=1,
+        local_blocks=1,
+    )
+
+    assert torch.equal(indices, torch.tensor([[[0], [1]]], dtype=torch.int32))
+    assert torch.equal(scores, torch.full((1, 2, 1), 1.0e29))
+
+
+def test_speculative_decode_candidates_do_not_overforce_earlier_tp_shard() -> None:
+    score = torch.tensor([[[9.0, 8.0], [9.0, 8.0]]])
+
+    indices, scores = _index_score_topk_candidates(
+        score,
+        context_lens=torch.tensor([510], dtype=torch.int32),
+        decode_query_len=2,
+        topk=1,
+        block_offset=0,
+        local_blocks=2,
+    )
+
+    assert torch.equal(indices, torch.tensor([[[0], [0]]], dtype=torch.int32))
+    assert torch.equal(scores, torch.tensor([[[9.0], [9.0]]]))
 
 
 @patch("vllm_ascend.models.minimax_m3.msa_m3.minimax_m3_sparse_attn")

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -26,6 +26,7 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
     AscendMiniMaxM3IndexerLinear,
     AscendMiniMaxM3IndexerMetadata,
     AscendMiniMaxM3IndexerMetadataBuilder,
+    AscendMiniMaxM3IndexerPrefillMetadata,
     AscendMiniMaxM3SparseBackend,
     AscendMiniMaxM3SparseDecodeMetadata,
     AscendMiniMaxM3SparseImpl,
@@ -39,8 +40,10 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
     minimax_m3_sparse_forward,
 )
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
+    MiniMaxM3TPDecodeScoreMetadata,
     _as_ascendc_index_kv_cache,
     _index_score_topk_candidates,
+    _minimax_m3_index_decode,
     _minimax_m3_index_score,
     minimax_m3_index_decode,
     minimax_m3_index_prefill,
@@ -143,8 +146,13 @@ def _make_sparse_builder(device: torch.device) -> AscendMiniMaxM3SparseMetadataB
     )
 
 
-def _make_indexer_builder(device: torch.device) -> AscendMiniMaxM3IndexerMetadataBuilder:
+def _make_indexer_builder(
+    device: torch.device,
+    *,
+    tp_size: int = 1,
+) -> AscendMiniMaxM3IndexerMetadataBuilder:
     vllm_config = _make_vllm_config()
+    vllm_config.parallel_config.tensor_parallel_size = tp_size
     spec = FullAttentionSpec(
         block_size=128,
         num_kv_heads=1,
@@ -407,12 +415,14 @@ def test_sparse_prepare_bypasses_fused_qkv_norm_rope_on_a5() -> None:
 
 def test_a5_index_decode_uses_a5_triton_without_tp_block_sharding() -> None:
     module_source = inspect.getsource(msa_m3_module)
-    a5_branch_start = module_source.index("if get_ascend_device_type() == AscendDeviceType.A5:")
+    a5_branch_start = module_source.index("if not _USE_ASCENDC_INDEX_SCORE:")
     a5_branch_end = module_source.index("\n\ndef _should_use_tp_sharded_index_decode", a5_branch_start)
     import_branches = module_source[a5_branch_start:a5_branch_end]
 
-    assert import_branches.count("minimax_m3_index_decode") == 2
+    assert import_branches.count("minimax_m3_index_decode") == 1
     assert "msa_m3_triton_a5" in import_branches
+    assert "msa_m3_triton" not in import_branches.replace("msa_m3_triton_a5", "")
+    assert "get_ascend_device_type() != AscendDeviceType.A5" in module_source
     with patch(
         "vllm_ascend.models.minimax_m3.msa_m3.get_ascend_device_type",
         return_value=AscendDeviceType.A5,
@@ -428,6 +438,170 @@ def test_non_a5_decode_keeps_tp_block_sharding() -> None:
         assert _should_use_tp_sharded_index_decode(tp_size=4, num_prefills=0)
         assert not _should_use_tp_sharded_index_decode(tp_size=1, num_prefills=0)
         assert not _should_use_tp_sharded_index_decode(tp_size=4, num_prefills=1)
+
+
+def test_a5_indexer_forward_keeps_original_decode_path() -> None:
+    impl = object.__new__(AscendMiniMaxM3IndexerImpl)
+    torch.nn.Module.__init__(impl)
+    impl.num_index_heads = 1
+    impl.num_kv_heads = 1
+    impl.index_head_dim = 4
+    impl.topk_blocks = 2
+    impl.init_blocks = 1
+    impl.local_blocks = 1
+    impl.scale = 0.5
+    impl.index_cache = SimpleNamespace(
+        prefix="layer.attn.index_cache",
+        kv_cache=torch.zeros(4, 128, 4),
+    )
+    decode = AscendMiniMaxM3IndexerDecodeMetadata(
+        seq_lens=torch.tensor([129], dtype=torch.int32),
+        block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+        max_seq_len=129,
+        decode_query_len=1,
+    )
+    metadata = AscendMiniMaxM3IndexerMetadata(
+        seq_lens=decode.seq_lens,
+        max_seq_len=decode.max_seq_len,
+        slot_mapping=torch.zeros(1, dtype=torch.int64),
+        num_actual_tokens=1,
+        num_decodes=1,
+        num_decode_tokens=1,
+        num_prefills=0,
+        num_prefill_tokens=0,
+        decode=decode,
+    )
+    expected = torch.zeros(1, 1, 2, dtype=torch.int32)
+    tp_group = SimpleNamespace(world_size=4, rank_in_group=0)
+
+    with (
+        patch.object(msa_m3_module, "_USE_ASCENDC_INDEX_SCORE", False),
+        patch.object(
+            msa_m3_module,
+            "get_forward_context",
+            return_value=SimpleNamespace(
+                attn_metadata={impl.index_cache.prefix: metadata},
+            ),
+        ),
+        patch.object(msa_m3_module, "get_tp_group", return_value=tp_group),
+        patch.object(
+            msa_m3_module,
+            "_should_use_tp_sharded_index_decode",
+            return_value=False,
+        ),
+        patch.object(
+            msa_m3_module,
+            "minimax_m3_index_decode",
+            return_value=expected,
+            create=True,
+        ) as mock_decode,
+    ):
+        actual, prefill = impl.forward(torch.zeros(1, 4))
+
+    assert actual is expected
+    assert prefill is None
+    mock_decode.assert_called_once()
+    decode_args = mock_decode.call_args.args
+    assert torch.equal(decode_args[0], torch.zeros(1, 1, 4))
+    assert decode_args[1] is impl.index_cache.kv_cache
+    assert decode_args[2] is decode.block_table
+    assert decode_args[3] is decode.seq_lens
+    assert decode_args[4:] == (
+        decode.max_seq_len,
+        impl.topk_blocks,
+        impl.init_blocks,
+        impl.local_blocks,
+        impl.num_kv_heads,
+        decode.decode_query_len,
+    )
+    assert mock_decode.call_args.kwargs == {"sm_scale": impl.scale}
+
+
+def test_a5_indexer_forward_keeps_original_prefill_path() -> None:
+    impl = object.__new__(AscendMiniMaxM3IndexerImpl)
+    torch.nn.Module.__init__(impl)
+    impl.num_index_heads = 1
+    impl.num_kv_heads = 1
+    impl.index_head_dim = 4
+    impl.topk_blocks = 2
+    impl.init_blocks = 1
+    impl.local_blocks = 1
+    impl.scale = 0.5
+    impl.index_cache = SimpleNamespace(
+        prefix="layer.attn.index_cache",
+        kv_cache=torch.zeros(4, 128, 4),
+    )
+    prefill_metadata = AscendMiniMaxM3IndexerPrefillMetadata(
+        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([129], dtype=torch.int32),
+        context_lens=torch.tensor([128], dtype=torch.int32),
+        block_table=torch.tensor([[0, 1]], dtype=torch.int32),
+        max_query_len=1,
+        max_seq_len=129,
+    )
+    metadata = AscendMiniMaxM3IndexerMetadata(
+        seq_lens=prefill_metadata.seq_lens,
+        max_seq_len=prefill_metadata.max_seq_len,
+        slot_mapping=torch.zeros(1, dtype=torch.int64),
+        num_actual_tokens=1,
+        num_decodes=0,
+        num_decode_tokens=0,
+        num_prefills=1,
+        num_prefill_tokens=1,
+        prefill=prefill_metadata,
+    )
+    score = torch.zeros(1, 1, 2)
+    expected = torch.zeros(1, 1, 2, dtype=torch.int32)
+
+    with (
+        patch.object(msa_m3_module, "_USE_ASCENDC_INDEX_SCORE", False),
+        patch.object(
+            msa_m3_module,
+            "get_forward_context",
+            return_value=SimpleNamespace(
+                attn_metadata={impl.index_cache.prefix: metadata},
+            ),
+        ),
+        patch.object(
+            msa_m3_module,
+            "minimax_m3_index_score",
+            return_value=score,
+            create=True,
+        ) as mock_score,
+        patch.object(
+            msa_m3_module,
+            "minimax_m3_index_topk",
+            return_value=expected,
+            create=True,
+        ) as mock_topk,
+    ):
+        decode, actual = impl.forward(torch.zeros(1, 4))
+
+    assert decode is None
+    assert actual is expected
+    mock_score.assert_called_once()
+    score_args = mock_score.call_args.args
+    assert torch.equal(score_args[0], torch.zeros(1, 1, 4))
+    assert score_args[1] is impl.index_cache.kv_cache
+    assert score_args[2] is prefill_metadata.block_table
+    assert score_args[3] is prefill_metadata.cu_seqlens_q
+    assert score_args[4] is prefill_metadata.seq_lens
+    assert score_args[5] is prefill_metadata.context_lens
+    assert score_args[6:] == (
+        prefill_metadata.max_query_len,
+        prefill_metadata.max_seq_len,
+        impl.num_kv_heads,
+        impl.scale,
+    )
+    mock_topk.assert_called_once_with(
+        score,
+        prefill_metadata.cu_seqlens_q,
+        prefill_metadata.context_lens,
+        prefill_metadata.max_query_len,
+        impl.topk_blocks,
+        impl.init_blocks,
+        impl.local_blocks,
+    )
 
 
 @patch(
@@ -590,7 +764,7 @@ def test_indexer_linear_weight_loader_uses_first_index_k_shard_for_all_ranks() -
 def test_ascendc_index_cache_converts_runtime_shape_to_bbnd() -> None:
     index_key_cache = torch.zeros(4, 128, 128)
 
-    actual = _as_ascendc_index_kv_cache((index_key_cache,))
+    actual = _as_ascendc_index_kv_cache(index_key_cache)
 
     assert actual.shape == (4, 128, 1, 128)
     assert actual.data_ptr() == index_key_cache.data_ptr()
@@ -600,7 +774,7 @@ def test_ascendc_index_cache_rejects_non_runtime_shape() -> None:
     index_key_cache = torch.zeros(4, 128, 1, 128)
 
     with pytest.raises(ValueError, match=r"\[num_blocks, 128, head_dim\]"):
-        _as_ascendc_index_kv_cache((index_key_cache,))
+        _as_ascendc_index_kv_cache(index_key_cache)
 
 
 def test_ascendc_index_score_forwards_metadata_operands() -> None:
@@ -620,7 +794,7 @@ def test_ascendc_index_score_forwards_metadata_operands() -> None:
     ) as mock_index_score:
         actual = _minimax_m3_index_score(
             idx_q,
-            (index_key_cache,),
+            index_key_cache,
             block_table,
             cu_seqlens_q,
             seq_lens,
@@ -633,6 +807,8 @@ def test_ascendc_index_score_forwards_metadata_operands() -> None:
     assert args[1].shape == (4, 128, 1, 128)
     assert args[3] is start_loc
     assert kwargs["atten_mask"] is causal_mask
+    assert kwargs["init_blocks"] == 0
+    assert kwargs["local_blocks"] == 0
 
 
 def test_ascendc_index_score_uses_dense_mode_without_mask() -> None:
@@ -650,7 +826,7 @@ def test_ascendc_index_score_uses_dense_mode_without_mask() -> None:
     ) as mock_index_score:
         _minimax_m3_index_score(
             idx_q,
-            (index_key_cache,),
+            index_key_cache,
             block_table,
             cu_seqlens_q,
             seq_lens,
@@ -687,7 +863,7 @@ def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
     ):
         actual = minimax_m3_index_prefill(
             idx_q,
-            (index_key_cache,),
+            index_key_cache,
             block_table,
             cu_seqlens_q,
             seq_lens,
@@ -703,7 +879,7 @@ def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
     assert actual is expected
     mock_score.assert_called_once_with(
         idx_q,
-        (index_key_cache,),
+        index_key_cache,
         block_table,
         cu_seqlens_q,
         seq_lens,
@@ -739,7 +915,7 @@ def test_ascendc_index_decode_wraps_score_candidates() -> None:
     ) as mock_decode:
         actual = minimax_m3_index_decode(
             idx_q,
-            (index_key_cache,),
+            index_key_cache,
             block_table,
             cu_seqlens_q,
             seq_lens,
@@ -755,7 +931,7 @@ def test_ascendc_index_decode_wraps_score_candidates() -> None:
     assert actual is expected
     mock_decode.assert_called_once_with(
         idx_q,
-        (index_key_cache,),
+        index_key_cache,
         block_table,
         cu_seqlens_q,
         seq_lens,
@@ -769,13 +945,60 @@ def test_ascendc_index_decode_wraps_score_candidates() -> None:
     )
 
 
+@pytest.mark.parametrize("decode_query_len", [1, 2])
+def test_decode_applies_forced_blocks_only_in_topk(decode_query_len: int) -> None:
+    idx_q = torch.zeros(decode_query_len, 2, 128)
+    index_key_cache = torch.zeros(4, 128, 128)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, decode_query_len], dtype=torch.int32)
+    seq_lens = torch.tensor([128 + decode_query_len], dtype=torch.int32)
+    context_lens = torch.tensor([128], dtype=torch.int32)
+    start_loc = torch.tensor([1], dtype=torch.int32)
+    causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
+    score = torch.zeros(2, decode_query_len, 4)
+    expected_indices = torch.zeros(2, decode_query_len, 2, dtype=torch.int32)
+    expected_scores = torch.zeros(2, decode_query_len, 2)
+
+    with (
+        patch(
+            "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_score",
+            return_value=score,
+        ) as mock_score,
+        patch(
+            "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._index_score_topk_candidates",
+            return_value=(expected_indices, expected_scores),
+        ) as mock_topk,
+    ):
+        actual_indices, actual_scores = _minimax_m3_index_decode(
+            idx_q,
+            index_key_cache,
+            block_table,
+            cu_seqlens_q,
+            seq_lens,
+            context_lens,
+            start_loc,
+            causal_mask,
+            topk=2,
+            init_blocks=1,
+            local_blocks=1,
+            decode_query_len=decode_query_len,
+        )
+
+    assert actual_indices is expected_indices
+    assert actual_scores is expected_scores
+    assert mock_score.call_args.kwargs.get("init_blocks", 0) == 0
+    assert mock_score.call_args.kwargs.get("local_blocks", 0) == 0
+    assert mock_topk.call_args.kwargs["init_blocks"] == 1
+    assert mock_topk.call_args.kwargs["local_blocks"] == 1
+
+
 @pytest.mark.parametrize(
-    ("tp_rank", "expects_causal_mask"),
-    [(0, False), (1, True)],
+    ("tp_rank", "expected_blocks"),
+    [(0, [0, 1]), (1, [2, 3])],
 )
-def test_tp_block_parallel_decode_only_masks_last_chunk(
+def test_tp_single_token_decode_uses_dense_mode(
     tp_rank: int,
-    expects_causal_mask: bool,
+    expected_blocks: list[int],
 ) -> None:
     class FakeTPGroup:
         world_size = 2
@@ -788,13 +1011,22 @@ def test_tp_block_parallel_decode_only_masks_last_chunk(
     idx_q = torch.zeros(1, 1, 128)
     index_key_cache = torch.zeros(4, 128, 128)
     block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
-    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
-    seq_lens = torch.tensor([512], dtype=torch.int32)
     context_lens = torch.tensor([511], dtype=torch.int32)
-    start_loc = torch.tensor([3], dtype=torch.int32)
     causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
     local_topk = torch.zeros(2, 1, 1, dtype=torch.int32)
     local_scores = torch.ones(2, 1, 1)
+    builder = _make_indexer_builder(torch.device("cpu"), tp_size=2)
+    with patch(
+        "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
+        return_value=FakeTPGroup(),
+    ):
+        tp_score = builder._build_tp_score_metadata(
+            block_table,
+            torch.tensor([0, 1], dtype=torch.int32),
+            context_lens,
+            max_seq_len=512,
+            decode_query_len=1,
+        )
 
     with patch(
         "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_decode",
@@ -802,26 +1034,202 @@ def test_tp_block_parallel_decode_only_masks_last_chunk(
     ) as mock_decode:
         minimax_m3_index_tp_block_parallel_decode(
             idx_q,
-            (index_key_cache,),
-            block_table,
-            cu_seqlens_q,
-            seq_lens,
-            context_lens,
-            start_loc,
+            index_key_cache,
+            tp_score,
             causal_mask,
-            max_seq_len=512,
             topk=1,
             init_blocks=0,
             local_blocks=0,
-            decode_query_len=1,
             tp_group=FakeTPGroup(),
         )
 
-    passed_mask = mock_decode.call_args.args[7]
-    if expects_causal_mask:
-        assert passed_mask is causal_mask
-    else:
-        assert passed_mask is None
+    decode_args = mock_decode.call_args.args
+    assert decode_args[7] is None
+    assert torch.equal(
+        decode_args[2],
+        torch.tensor([expected_blocks], dtype=torch.int32),
+    )
+    assert torch.equal(decode_args[3], torch.tensor([0, 1], dtype=torch.int32))
+    assert torch.equal(decode_args[4], torch.tensor([256], dtype=torch.int32))
+
+
+@pytest.mark.parametrize(
+    ("tp_rank", "expected_block_table", "expected_k_lens"),
+    [
+        (0, [[0, 1], [2, 3], [4, 5]], [129, 13, 130]),
+        (1, [[1], [3], [5]], [1, 0, 75]),
+    ],
+)
+def test_tp_speculative_decode_uses_packed_causal_halo(
+    tp_rank: int,
+    expected_block_table: list[list[int]],
+    expected_k_lens: list[int],
+) -> None:
+    class FakeTPGroup:
+        world_size = 2
+        rank_in_group = tp_rank
+
+        @staticmethod
+        def all_gather(tensor: torch.Tensor, dim: int) -> torch.Tensor:
+            return torch.cat((tensor, tensor), dim=dim)
+
+    # Request 0's query positions 126, 127 and 128 straddle the TP chunks
+    # [0, 128) and [128, 256). Rank 0 includes rank 1's block as a score-only
+    # halo, so packed right-down causal visibility is [127, 128, 129]. Its
+    # halo score is discarded before TopK, leaving [127, 128, 128] for chunk0.
+    # Request 2 starts at 200, so rank 0 uses klen=130: right-down visibility
+    # begins at 128 and the entire owned block remains visible for every query.
+    idx_q = torch.arange(9, dtype=torch.float32).view(9, 1, 1).expand(-1, -1, 128)
+    causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
+    score_width = len(expected_block_table[0])
+    causal_score = torch.zeros(2, 9, score_width)
+    local_topk = torch.zeros(2, 9, 1, dtype=torch.int32)
+    local_scores = torch.ones(2, 9, 1)
+    builder = _make_indexer_builder(torch.device("cpu"), tp_size=2)
+    common = _create_common_attn_metadata(
+        BatchSpec(seq_lens=[129, 13, 203], query_lens=[3, 3, 3]),
+        block_size=128,
+        device=torch.device("cpu"),
+    )
+    with (
+        patch(
+            "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
+            return_value=FakeTPGroup(),
+        ),
+        patch(
+            "vllm_ascend.models.minimax_m3.msa_m3.split_decodes_and_prefills",
+            return_value=(3, 0, 9, 0),
+        ),
+        patch.object(
+            builder,
+            "_build_tp_score_metadata",
+            wraps=builder._build_tp_score_metadata,
+        ) as mock_build_tp_score,
+    ):
+        metadata = builder.build(0, common)
+    assert mock_build_tp_score.call_count == 1
+    assert metadata.decode is not None
+    assert metadata.decode.tp_score is not None
+    tp_score = metadata.decode.tp_score
+
+    with (
+        patch(
+            "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_score",
+            return_value=causal_score,
+        ) as mock_score,
+        patch(
+            "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._index_score_topk_candidates",
+            return_value=(local_topk, local_scores),
+        ) as mock_topk,
+    ):
+        minimax_m3_index_tp_block_parallel_decode(
+            idx_q,
+            torch.zeros(2, 128, 128),
+            tp_score,
+            causal_mask,
+            topk=1,
+            init_blocks=0,
+            local_blocks=0,
+            tp_group=FakeTPGroup(),
+        )
+
+    mock_score.assert_called_once()
+    score_args = mock_score.call_args.args
+    assert score_args[6] is causal_mask
+    assert torch.equal(
+        score_args[2],
+        torch.tensor(expected_block_table, dtype=torch.int32),
+    )
+    assert torch.equal(score_args[3], torch.tensor([0, 3, 6, 9], dtype=torch.int32))
+    assert torch.equal(
+        score_args[4],
+        torch.tensor(expected_k_lens, dtype=torch.int32),
+    )
+    assert torch.equal(mock_topk.call_args.args[0], causal_score[..., :1])
+
+
+def test_tp_block_parallel_forwards_global_forced_block_counts() -> None:
+    class FakeTPGroup:
+        world_size = 2
+        rank_in_group = 1
+
+        @staticmethod
+        def all_gather(tensor: torch.Tensor, dim: int) -> torch.Tensor:
+            return torch.cat((tensor, tensor), dim=dim)
+
+    idx_q = torch.zeros(1, 1, 128)
+    causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
+    local_topk = torch.zeros(2, 1, 1, dtype=torch.int32)
+    local_scores = torch.ones(2, 1, 1)
+    tp_score = MiniMaxM3TPDecodeScoreMetadata(
+        block_table=torch.tensor([[4, 5, 6, 7]], dtype=torch.int32),
+        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+        seq_lens=torch.tensor([512], dtype=torch.int32),
+        context_lens=torch.tensor([511], dtype=torch.int32),
+        start_loc=torch.tensor([3], dtype=torch.int32),
+        block_offset=4,
+        block_count=4,
+        decode_query_len=1,
+    )
+
+    with patch(
+        "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_decode",
+        return_value=(local_topk, local_scores),
+    ) as mock_decode:
+        minimax_m3_index_tp_block_parallel_decode(
+            idx_q,
+            torch.zeros(8, 128, 128),
+            tp_score,
+            causal_mask,
+            topk=1,
+            init_blocks=5,
+            local_blocks=6,
+            tp_group=FakeTPGroup(),
+        )
+
+    assert mock_decode.call_args.kwargs["init_blocks"] == 5
+    assert mock_decode.call_args.kwargs["local_blocks"] == 6
+    assert mock_decode.call_args.kwargs["block_offset"] == 4
+
+
+def test_tp_topk_applies_init_blocks_by_global_block_id() -> None:
+    score = torch.tensor([[[1.0, 2.0]]])
+
+    indices, scores = _index_score_topk_candidates(
+        score,
+        context_lens=torch.tensor([256], dtype=torch.int32),
+        decode_query_len=1,
+        topk=2,
+        block_offset=4,
+        init_blocks=5,
+    )
+
+    assert torch.equal(indices, torch.tensor([[[4, 5]]], dtype=torch.int32))
+    assert scores[0, 0, 0] == 1.0e30
+    assert scores[0, 0, 1] == 2.0
+
+
+def test_speculative_topk_masks_future_blocks_before_selection() -> None:
+    score = torch.tensor(
+        [
+            [
+                [9.0, 8.0, 7.0, 1.0e20],
+                [9.0, 8.0, 7.0, 6.0],
+            ]
+        ]
+    )
+
+    indices, scores = _index_score_topk_candidates(
+        score,
+        context_lens=torch.tensor([383], dtype=torch.int32),
+        decode_query_len=2,
+        topk=3,
+        local_blocks=1,
+    )
+
+    assert set(indices[0, 0].tolist()) == {0, 1, 2}
+    assert torch.isfinite(scores[0, 0]).all()
+    assert set(indices[0, 1].tolist()) == {0, 1, 3}
 
 
 @patch("vllm_ascend.models.minimax_m3.msa_m3.get_tp_group")
@@ -850,6 +1258,16 @@ def test_indexer_speculative_decode_uses_tp_block_parallel_path(
         start_loc=torch.tensor([2], dtype=torch.int32),
         max_seq_len=258,
         decode_query_len=2,
+        tp_score=MiniMaxM3TPDecodeScoreMetadata(
+            block_table=torch.tensor([[0, 1, 2]], dtype=torch.int32),
+            cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32),
+            seq_lens=torch.tensor([258], dtype=torch.int32),
+            context_lens=torch.tensor([256], dtype=torch.int32),
+            start_loc=torch.tensor([2], dtype=torch.int32),
+            block_offset=0,
+            block_count=3,
+            decode_query_len=2,
+        ),
     )
     metadata = AscendMiniMaxM3IndexerMetadata(
         seq_lens=decode.seq_lens,
@@ -881,11 +1299,9 @@ def test_indexer_speculative_decode_uses_tp_block_parallel_path(
     assert actual is expected
     assert prefill is None
     mock_tp_block_parallel.assert_called_once()
-    call_args = mock_tp_block_parallel.call_args.args
     call_kwargs = mock_tp_block_parallel.call_args.kwargs
-    assert call_args[6] is decode.start_loc
-    assert call_args[7] is metadata.causal_mask
-    assert call_kwargs["decode_query_len"] == 2
+    assert mock_tp_block_parallel.call_args.args[2] is decode.tp_score
+    assert mock_tp_block_parallel.call_args.args[3] is metadata.causal_mask
     assert call_kwargs["tp_group"] is mock_get_tp_group.return_value
 
 

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -1098,6 +1098,7 @@ def test_tp_single_token_decode_uses_dense_mode(
     )
     assert torch.equal(decode_args[3], torch.tensor([0, 1], dtype=torch.int32))
     assert torch.equal(decode_args[4], torch.tensor([256], dtype=torch.int32))
+    assert decode_args[6].dtype == torch.int32
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -369,9 +369,15 @@ def test_indexer_metadata_builder_trims_graph_padded_spec_decode() -> None:
     common.num_actual_tokens = 60
     builder = _make_indexer_builder(device, tp_size=4)
 
-    with patch(
-        "vllm_ascend.models.minimax_m3.msa_m3.split_decodes_and_prefills",
-        return_value=(16, 0, 60, 0),
+    with (
+        patch(
+            "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
+            return_value=SimpleNamespace(rank_in_group=0),
+        ),
+        patch(
+            "vllm_ascend.models.minimax_m3.msa_m3.split_decodes_and_prefills",
+            return_value=(16, 0, 60, 0),
+        ),
     ):
         first = builder.build(0, common)
         second = builder.build(0, common)
@@ -1197,25 +1203,33 @@ def test_tp_score_metadata_reuses_graph_input_storage() -> None:
     cu_seqlens_q = torch.tensor([0, 4], dtype=torch.int32)
     context_lens = torch.tensor([125], dtype=torch.int32)
 
-    first = builder._build_tp_score_metadata(
-        block_table,
-        cu_seqlens_q,
-        context_lens,
-        max_seq_len=256,
-        decode_query_len=4,
-    )
-    context_lens.copy_(torch.tensor([129], dtype=torch.int32))
-    second = builder._build_tp_score_metadata(
-        block_table,
-        cu_seqlens_q,
-        context_lens,
-        max_seq_len=256,
-        decode_query_len=4,
-    )
+    tp_group = SimpleNamespace(rank_in_group=1)
+    with patch(
+        "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
+        return_value=tp_group,
+    ):
+        first = builder._build_tp_score_metadata(
+            block_table,
+            cu_seqlens_q,
+            context_lens,
+            max_seq_len=256,
+            decode_query_len=4,
+        )
+        context_lens.copy_(torch.tensor([129], dtype=torch.int32))
+        second = builder._build_tp_score_metadata(
+            block_table,
+            cu_seqlens_q,
+            context_lens,
+            max_seq_len=256,
+            decode_query_len=4,
+        )
 
     assert first.block_table is second.block_table is block_table
     assert first.context_lens is second.context_lens is context_lens
     assert first.cu_seqlens_q is second.cu_seqlens_q is cu_seqlens_q
+    assert first.max_block_count == second.max_block_count == 2
+    assert first.block_offset == second.block_offset == 1
+    assert first.block_count == second.block_count == 1
 
 
 def test_tp_block_parallel_forwards_global_forced_block_counts() -> None:
@@ -1235,8 +1249,10 @@ def test_tp_block_parallel_forwards_global_forced_block_counts() -> None:
         block_table=torch.tensor([[4, 5, 6, 7]], dtype=torch.int32),
         cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
         context_lens=torch.tensor([511], dtype=torch.int32),
-        max_seq_len=1024,
+        max_block_count=8,
         block_size=128,
+        block_offset=4,
+        block_count=4,
         decode_query_len=1,
     )
 
@@ -1330,8 +1346,10 @@ def test_indexer_speculative_decode_uses_tp_block_parallel_path(
             block_table=torch.tensor([[0, 1, 2]], dtype=torch.int32),
             cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32),
             context_lens=torch.tensor([256], dtype=torch.int32),
-            max_seq_len=258,
+            max_block_count=3,
             block_size=128,
+            block_offset=0,
+            block_count=2,
             decode_query_len=2,
         ),
     )

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -770,6 +770,15 @@ def test_ascendc_index_cache_converts_runtime_shape_to_bbnd() -> None:
     assert actual.data_ptr() == index_key_cache.data_ptr()
 
 
+def test_ascendc_index_cache_unwraps_runtime_tuple() -> None:
+    index_key_cache = torch.zeros(4, 128, 128)
+
+    actual = _as_ascendc_index_kv_cache((index_key_cache,))
+
+    assert actual.shape == (4, 128, 1, 128)
+    assert actual.data_ptr() == index_key_cache.data_ptr()
+
+
 def test_ascendc_index_cache_rejects_non_runtime_shape() -> None:
     index_key_cache = torch.zeros(4, 128, 1, 128)
 

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -297,10 +297,7 @@ def test_indexer_metadata_builder(batch_spec: BatchSpec) -> None:
         assert metadata.num_decodes == batch_spec.batch_size
         assert metadata.prefill is None
         assert metadata.decode is not None
-        assert torch.equal(
-            metadata.decode.start_loc,
-            metadata.decode.context_lens // 128,
-        )
+        assert metadata.decode.start_loc is None
     else:
         assert metadata.num_prefills == batch_spec.batch_size
         assert metadata.decode is None
@@ -356,6 +353,48 @@ def test_sparse_metadata_builder_fia_padded_dummy_request() -> None:
     assert indexer_metadata.num_prefills == batch_size
     assert indexer_metadata.prefill is not None
     assert indexer_metadata.prefill.context_lens.shape[0] == batch_size
+
+
+def test_indexer_metadata_builder_trims_graph_padded_spec_decode() -> None:
+    device = torch.device("cpu")
+    common = _create_common_attn_metadata(
+        BatchSpec(
+            seq_lens=[132] * 16,
+            query_lens=[4] * 16,
+            name="padded_spec_decode",
+        ),
+        block_size=128,
+        device=device,
+    )
+    common.num_actual_tokens = 60
+    builder = _make_indexer_builder(device, tp_size=4)
+
+    with (
+        patch(
+            "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
+            return_value=SimpleNamespace(rank_in_group=0),
+        ),
+        patch(
+            "vllm_ascend.models.minimax_m3.msa_m3.split_decodes_and_prefills",
+            return_value=(16, 0, 60, 0),
+        ),
+    ):
+        first = builder.build(0, common)
+        second = builder.build(0, common)
+
+    assert first.num_decodes == 15
+    assert first.num_decode_tokens == 60
+    assert first.decode is not None
+    assert first.decode.tp_score is not None
+    assert first.decode.cu_seqlens_q.shape == (16,)
+    assert first.decode.cu_seqlens_q[-1] == 60
+    assert first.decode.block_table.shape[0] == 15
+    assert first.decode.tp_score.context_lens.shape == (15,)
+    assert second.decode is not None
+    assert second.decode.tp_score is not None
+    assert first.decode.tp_score.block_table.data_ptr() == second.decode.tp_score.block_table.data_ptr()
+    assert first.decode.tp_score.context_lens.data_ptr() == second.decode.tp_score.context_lens.data_ptr()
+    assert first.decode.tp_score.cu_seqlens_q.data_ptr() == second.decode.tp_score.cu_seqlens_q.data_ptr()
 
 
 def test_sparse_proj_quant_type_falls_back_to_language_model_prefix() -> None:
@@ -802,6 +841,8 @@ def test_ascendc_index_score_forwards_metadata_operands() -> None:
             seq_lens,
             start_loc,
             causal_mask,
+            init_blocks=2,
+            local_blocks=3,
         )
 
     assert actual is expected
@@ -887,6 +928,8 @@ def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
         seq_lens,
         start_loc,
         causal_mask,
+        init_blocks=1,
+        local_blocks=1,
     )
     mock_topk.assert_called_once_with(
         score,
@@ -988,7 +1031,10 @@ def test_decode_applies_forced_blocks_only_in_topk(decode_query_len: int) -> Non
 
     assert actual_indices is expected_indices
     assert actual_scores is expected_scores
-    assert mock_score.call_args.kwargs == {}
+    assert mock_score.call_args.kwargs == {
+        "init_blocks": 1,
+        "local_blocks": 1,
+    }
     assert mock_topk.call_args.kwargs["init_blocks"] == 1
     assert mock_topk.call_args.kwargs["local_blocks"] == 1
 
@@ -1052,6 +1098,7 @@ def test_tp_single_token_decode_uses_dense_mode(
     )
     assert torch.equal(decode_args[3], torch.tensor([0, 1], dtype=torch.int32))
     assert torch.equal(decode_args[4], torch.tensor([256], dtype=torch.int32))
+    assert decode_args[6].dtype == torch.int32
 
 
 @pytest.mark.parametrize(
@@ -1149,6 +1196,43 @@ def test_tp_speculative_decode_uses_packed_causal_halo(
     assert torch.equal(mock_topk.call_args.args[0], causal_score[..., :1])
 
 
+def test_tp_score_metadata_reuses_graph_input_storage() -> None:
+    """TP metadata consumed by ACLGraph must not point at per-build tensors."""
+
+    builder = _make_indexer_builder(torch.device("cpu"), tp_size=2)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, 4], dtype=torch.int32)
+    context_lens = torch.tensor([125], dtype=torch.int32)
+
+    tp_group = SimpleNamespace(rank_in_group=1)
+    with patch(
+        "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
+        return_value=tp_group,
+    ):
+        first = builder._build_tp_score_metadata(
+            block_table,
+            cu_seqlens_q,
+            context_lens,
+            max_seq_len=256,
+            decode_query_len=4,
+        )
+        context_lens.copy_(torch.tensor([129], dtype=torch.int32))
+        second = builder._build_tp_score_metadata(
+            block_table,
+            cu_seqlens_q,
+            context_lens,
+            max_seq_len=256,
+            decode_query_len=4,
+        )
+
+    assert first.block_table is second.block_table is block_table
+    assert first.context_lens is second.context_lens is context_lens
+    assert first.cu_seqlens_q is second.cu_seqlens_q is cu_seqlens_q
+    assert first.max_block_count == second.max_block_count == 2
+    assert first.block_offset == second.block_offset == 1
+    assert first.block_count == second.block_count == 1
+
+
 def test_tp_block_parallel_forwards_global_forced_block_counts() -> None:
     class FakeTPGroup:
         world_size = 2
@@ -1165,9 +1249,9 @@ def test_tp_block_parallel_forwards_global_forced_block_counts() -> None:
     tp_score = MiniMaxM3TPDecodeScoreMetadata(
         block_table=torch.tensor([[4, 5, 6, 7]], dtype=torch.int32),
         cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
-        seq_lens=torch.tensor([512], dtype=torch.int32),
         context_lens=torch.tensor([511], dtype=torch.int32),
-        start_loc=torch.tensor([3], dtype=torch.int32),
+        max_block_count=8,
+        block_size=128,
         block_offset=4,
         block_count=4,
         decode_query_len=1,
@@ -1262,11 +1346,11 @@ def test_indexer_speculative_decode_uses_tp_block_parallel_path(
         tp_score=MiniMaxM3TPDecodeScoreMetadata(
             block_table=torch.tensor([[0, 1, 2]], dtype=torch.int32),
             cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32),
-            seq_lens=torch.tensor([258], dtype=torch.int32),
             context_lens=torch.tensor([256], dtype=torch.int32),
-            start_loc=torch.tensor([2], dtype=torch.int32),
+            max_block_count=3,
+            block_size=128,
             block_offset=0,
-            block_count=3,
+            block_count=2,
             decode_query_len=2,
         ),
     )

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -369,15 +369,9 @@ def test_indexer_metadata_builder_trims_graph_padded_spec_decode() -> None:
     common.num_actual_tokens = 60
     builder = _make_indexer_builder(device, tp_size=4)
 
-    with (
-        patch(
-            "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
-            return_value=SimpleNamespace(rank_in_group=0),
-        ),
-        patch(
-            "vllm_ascend.models.minimax_m3.msa_m3.split_decodes_and_prefills",
-            return_value=(16, 0, 60, 0),
-        ),
+    with patch(
+        "vllm_ascend.models.minimax_m3.msa_m3.split_decodes_and_prefills",
+        return_value=(16, 0, 60, 0),
     ):
         first = builder.build(0, common)
         second = builder.build(0, common)
@@ -841,8 +835,6 @@ def test_ascendc_index_score_forwards_metadata_operands() -> None:
             seq_lens,
             start_loc,
             causal_mask,
-            init_blocks=2,
-            local_blocks=3,
         )
 
     assert actual is expected
@@ -928,8 +920,6 @@ def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
         seq_lens,
         start_loc,
         causal_mask,
-        init_blocks=1,
-        local_blocks=1,
     )
     mock_topk.assert_called_once_with(
         score,
@@ -1031,10 +1021,7 @@ def test_decode_applies_forced_blocks_only_in_topk(decode_query_len: int) -> Non
 
     assert actual_indices is expected_indices
     assert actual_scores is expected_scores
-    assert mock_score.call_args.kwargs == {
-        "init_blocks": 1,
-        "local_blocks": 1,
-    }
+    assert mock_score.call_args.kwargs == {}
     assert mock_topk.call_args.kwargs["init_blocks"] == 1
     assert mock_topk.call_args.kwargs["local_blocks"] == 1
 
@@ -1098,7 +1085,6 @@ def test_tp_single_token_decode_uses_dense_mode(
     )
     assert torch.equal(decode_args[3], torch.tensor([0, 1], dtype=torch.int32))
     assert torch.equal(decode_args[4], torch.tensor([256], dtype=torch.int32))
-    assert decode_args[6].dtype == torch.int32
 
 
 @pytest.mark.parametrize(
@@ -1204,33 +1190,25 @@ def test_tp_score_metadata_reuses_graph_input_storage() -> None:
     cu_seqlens_q = torch.tensor([0, 4], dtype=torch.int32)
     context_lens = torch.tensor([125], dtype=torch.int32)
 
-    tp_group = SimpleNamespace(rank_in_group=1)
-    with patch(
-        "vllm_ascend.models.minimax_m3.msa_m3.get_tp_group",
-        return_value=tp_group,
-    ):
-        first = builder._build_tp_score_metadata(
-            block_table,
-            cu_seqlens_q,
-            context_lens,
-            max_seq_len=256,
-            decode_query_len=4,
-        )
-        context_lens.copy_(torch.tensor([129], dtype=torch.int32))
-        second = builder._build_tp_score_metadata(
-            block_table,
-            cu_seqlens_q,
-            context_lens,
-            max_seq_len=256,
-            decode_query_len=4,
-        )
+    first = builder._build_tp_score_metadata(
+        block_table,
+        cu_seqlens_q,
+        context_lens,
+        max_seq_len=256,
+        decode_query_len=4,
+    )
+    context_lens.copy_(torch.tensor([129], dtype=torch.int32))
+    second = builder._build_tp_score_metadata(
+        block_table,
+        cu_seqlens_q,
+        context_lens,
+        max_seq_len=256,
+        decode_query_len=4,
+    )
 
     assert first.block_table is second.block_table is block_table
     assert first.context_lens is second.context_lens is context_lens
     assert first.cu_seqlens_q is second.cu_seqlens_q is cu_seqlens_q
-    assert first.max_block_count == second.max_block_count == 2
-    assert first.block_offset == second.block_offset == 1
-    assert first.block_count == second.block_count == 1
 
 
 def test_tp_block_parallel_forwards_global_forced_block_counts() -> None:
@@ -1250,10 +1228,8 @@ def test_tp_block_parallel_forwards_global_forced_block_counts() -> None:
         block_table=torch.tensor([[4, 5, 6, 7]], dtype=torch.int32),
         cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
         context_lens=torch.tensor([511], dtype=torch.int32),
-        max_block_count=8,
+        max_seq_len=1024,
         block_size=128,
-        block_offset=4,
-        block_count=4,
         decode_query_len=1,
     )
 
@@ -1347,10 +1323,8 @@ def test_indexer_speculative_decode_uses_tp_block_parallel_path(
             block_table=torch.tensor([[0, 1, 2]], dtype=torch.int32),
             cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32),
             context_lens=torch.tensor([256], dtype=torch.int32),
-            max_block_count=3,
+            max_seq_len=258,
             block_size=128,
-            block_offset=0,
-            block_count=2,
             decode_query_len=2,
         ),
     )

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -39,6 +39,7 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
     minimax_m3_sparse_forward,
 )
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
+    _as_ascendc_index_kv_cache,
     _index_score_topk_candidates,
 )
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
@@ -571,6 +572,22 @@ def test_indexer_linear_weight_loader_uses_first_index_k_shard_for_all_ranks() -
     layer.weight_loader(param, loaded_weight, "index_k")
 
     assert torch.equal(param.data[2:3], loaded_weight[:1])
+
+
+def test_ascendc_index_cache_converts_runtime_shape_to_bbnd() -> None:
+    index_key_cache = torch.zeros(4, 128, 128)
+
+    actual = _as_ascendc_index_kv_cache((index_key_cache,))
+
+    assert actual.shape == (4, 128, 1, 128)
+    assert actual.data_ptr() == index_key_cache.data_ptr()
+
+
+def test_ascendc_index_cache_rejects_non_runtime_shape() -> None:
+    index_key_cache = torch.zeros(4, 128, 1, 128)
+
+    with pytest.raises(ValueError, match=r"\[num_blocks, 128, head_dim\]"):
+        _as_ascendc_index_kv_cache((index_key_cache,))
 
 
 @patch("vllm_ascend.models.minimax_m3.msa_m3.get_tp_group")

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -779,13 +779,6 @@ def test_ascendc_index_cache_unwraps_runtime_tuple() -> None:
     assert actual.data_ptr() == index_key_cache.data_ptr()
 
 
-def test_ascendc_index_cache_rejects_non_runtime_shape() -> None:
-    index_key_cache = torch.zeros(4, 128, 1, 128)
-
-    with pytest.raises(ValueError, match=r"\[num_blocks, 128, head_dim\]"):
-        _as_ascendc_index_kv_cache(index_key_cache)
-
-
 def test_ascendc_index_score_forwards_metadata_operands() -> None:
     idx_q = torch.zeros(1, 2, 128)
     index_key_cache = torch.zeros(4, 128, 128)
@@ -816,8 +809,8 @@ def test_ascendc_index_score_forwards_metadata_operands() -> None:
     assert args[1].shape == (4, 128, 1, 128)
     assert args[3] is start_loc
     assert kwargs["atten_mask"] is causal_mask
-    assert kwargs["init_blocks"] == 0
-    assert kwargs["local_blocks"] == 0
+    assert "init_blocks" not in kwargs
+    assert "local_blocks" not in kwargs
 
 
 def test_ascendc_index_score_uses_dense_mode_without_mask() -> None:
@@ -995,8 +988,7 @@ def test_decode_applies_forced_blocks_only_in_topk(decode_query_len: int) -> Non
 
     assert actual_indices is expected_indices
     assert actual_scores is expected_scores
-    assert mock_score.call_args.kwargs.get("init_blocks", 0) == 0
-    assert mock_score.call_args.kwargs.get("local_blocks", 0) == 0
+    assert mock_score.call_args.kwargs == {}
     assert mock_topk.call_args.kwargs["init_blocks"] == 1
     assert mock_topk.call_args.kwargs["local_blocks"] == 1
 

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -835,6 +835,8 @@ def test_ascendc_index_score_forwards_metadata_operands() -> None:
             seq_lens,
             start_loc,
             causal_mask,
+            init_blocks=2,
+            local_blocks=3,
         )
 
     assert actual is expected
@@ -920,6 +922,8 @@ def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
         seq_lens,
         start_loc,
         causal_mask,
+        init_blocks=1,
+        local_blocks=1,
     )
     mock_topk.assert_called_once_with(
         score,
@@ -1021,7 +1025,10 @@ def test_decode_applies_forced_blocks_only_in_topk(decode_query_len: int) -> Non
 
     assert actual_indices is expected_indices
     assert actual_scores is expected_scores
-    assert mock_score.call_args.kwargs == {}
+    assert mock_score.call_args.kwargs == {
+        "init_blocks": 1,
+        "local_blocks": 1,
+    }
     assert mock_topk.call_args.kwargs["init_blocks"] == 1
     assert mock_topk.call_args.kwargs["local_blocks"] == 1
 

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -41,6 +41,10 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     _as_ascendc_index_kv_cache,
     _index_score_topk_candidates,
+    _minimax_m3_index_score,
+    minimax_m3_index_decode,
+    minimax_m3_index_prefill,
+    minimax_m3_index_tp_block_parallel_decode,
 )
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     minimax_m3_sparse_attn_decode as minimax_m3_sparse_attn_decode_npu,
@@ -280,14 +284,23 @@ def test_indexer_metadata_builder(batch_spec: BatchSpec) -> None:
 
     assert metadata.num_actual_tokens == sum(batch_spec.query_lens)
     assert metadata.num_decodes + metadata.num_prefills == batch_spec.batch_size
+    assert metadata.causal_mask.shape == (2048, 2048)
     if batch_spec.name == "decode_only":
         assert metadata.num_decodes == batch_spec.batch_size
         assert metadata.prefill is None
         assert metadata.decode is not None
+        assert torch.equal(
+            metadata.decode.start_loc,
+            metadata.decode.context_lens // 128,
+        )
     else:
         assert metadata.num_prefills == batch_spec.batch_size
         assert metadata.decode is None
         assert metadata.prefill is not None
+        assert torch.equal(
+            metadata.prefill.start_loc,
+            metadata.prefill.context_lens // 128,
+        )
 
 
 def test_sparse_metadata_builder_fia_padded_dummy_request() -> None:
@@ -590,9 +603,230 @@ def test_ascendc_index_cache_rejects_non_runtime_shape() -> None:
         _as_ascendc_index_kv_cache((index_key_cache,))
 
 
+def test_ascendc_index_score_forwards_metadata_operands() -> None:
+    idx_q = torch.zeros(1, 2, 128)
+    index_key_cache = torch.zeros(4, 128, 128)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.tensor([129], dtype=torch.int32)
+    start_loc = torch.tensor([1], dtype=torch.int32)
+    causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
+    expected = torch.zeros(2, 1, 4)
+
+    with patch(
+        "vllm_ascend.models.minimax_m3.ops.msa_m3_npu.torch.ops._C_ascend.npu_msa_index_score",
+        return_value=expected,
+        create=True,
+    ) as mock_index_score:
+        actual = _minimax_m3_index_score(
+            idx_q,
+            (index_key_cache,),
+            block_table,
+            cu_seqlens_q,
+            seq_lens,
+            start_loc,
+            causal_mask,
+        )
+
+    assert actual is expected
+    args, kwargs = mock_index_score.call_args
+    assert args[1].shape == (4, 128, 1, 128)
+    assert args[3] is start_loc
+    assert kwargs["atten_mask"] is causal_mask
+
+
+def test_ascendc_index_score_uses_dense_mode_without_mask() -> None:
+    idx_q = torch.zeros(1, 2, 128)
+    index_key_cache = torch.zeros(4, 128, 128)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.tensor([128], dtype=torch.int32)
+    start_loc = torch.tensor([1], dtype=torch.int32)
+
+    with patch(
+        "vllm_ascend.models.minimax_m3.ops.msa_m3_npu.torch.ops._C_ascend.npu_msa_index_score",
+        return_value=torch.zeros(2, 1, 4),
+        create=True,
+    ) as mock_index_score:
+        _minimax_m3_index_score(
+            idx_q,
+            (index_key_cache,),
+            block_table,
+            cu_seqlens_q,
+            seq_lens,
+            start_loc,
+            None,
+        )
+
+    kwargs = mock_index_score.call_args.kwargs
+    assert kwargs["atten_mask"] is None
+    assert kwargs["sparse_mode"] == 0
+
+
+def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
+    idx_q = torch.zeros(1, 2, 128)
+    index_key_cache = torch.zeros(4, 128, 128)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.tensor([129], dtype=torch.int32)
+    context_lens = torch.tensor([128], dtype=torch.int32)
+    start_loc = torch.tensor([1], dtype=torch.int32)
+    causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
+    score = torch.zeros(2, 1, 4)
+    expected = torch.zeros(2, 1, 2, dtype=torch.int32)
+
+    with (
+        patch(
+            "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_score",
+            return_value=score,
+        ) as mock_score,
+        patch(
+            "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_prefill_topk",
+            return_value=expected,
+        ) as mock_topk,
+    ):
+        actual = minimax_m3_index_prefill(
+            idx_q,
+            (index_key_cache,),
+            block_table,
+            cu_seqlens_q,
+            seq_lens,
+            context_lens,
+            start_loc,
+            causal_mask,
+            max_query_len=1,
+            topk=2,
+            init_blocks=1,
+            local_blocks=1,
+        )
+
+    assert actual is expected
+    mock_score.assert_called_once_with(
+        idx_q,
+        (index_key_cache,),
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        start_loc,
+        causal_mask,
+    )
+    mock_topk.assert_called_once_with(
+        score,
+        cu_seqlens_q,
+        context_lens,
+        1,
+        2,
+        1,
+        1,
+    )
+
+
+def test_ascendc_index_decode_wraps_score_candidates() -> None:
+    idx_q = torch.zeros(1, 2, 128)
+    index_key_cache = torch.zeros(4, 128, 128)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.tensor([129], dtype=torch.int32)
+    context_lens = torch.tensor([128], dtype=torch.int32)
+    start_loc = torch.tensor([1], dtype=torch.int32)
+    causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
+    expected = torch.zeros(2, 1, 2, dtype=torch.int32)
+    scores = torch.zeros(2, 1, 2)
+
+    with patch(
+        "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_decode",
+        return_value=(expected, scores),
+    ) as mock_decode:
+        actual = minimax_m3_index_decode(
+            idx_q,
+            (index_key_cache,),
+            block_table,
+            cu_seqlens_q,
+            seq_lens,
+            context_lens,
+            start_loc,
+            causal_mask,
+            topk=2,
+            init_blocks=1,
+            local_blocks=1,
+            decode_query_len=1,
+        )
+
+    assert actual is expected
+    mock_decode.assert_called_once_with(
+        idx_q,
+        (index_key_cache,),
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        context_lens,
+        start_loc,
+        causal_mask,
+        topk=2,
+        init_blocks=1,
+        local_blocks=1,
+        decode_query_len=1,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tp_rank", "expects_causal_mask"),
+    [(0, False), (1, True)],
+)
+def test_tp_block_parallel_decode_only_masks_last_chunk(
+    tp_rank: int,
+    expects_causal_mask: bool,
+) -> None:
+    class FakeTPGroup:
+        world_size = 2
+        rank_in_group = tp_rank
+
+        @staticmethod
+        def all_gather(tensor: torch.Tensor, dim: int) -> torch.Tensor:
+            return torch.cat((tensor, tensor), dim=dim)
+
+    idx_q = torch.zeros(1, 1, 128)
+    index_key_cache = torch.zeros(4, 128, 128)
+    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
+    seq_lens = torch.tensor([512], dtype=torch.int32)
+    context_lens = torch.tensor([511], dtype=torch.int32)
+    start_loc = torch.tensor([3], dtype=torch.int32)
+    causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
+    local_topk = torch.zeros(2, 1, 1, dtype=torch.int32)
+    local_scores = torch.ones(2, 1, 1)
+
+    with patch(
+        "vllm_ascend.models.minimax_m3.ops.msa_m3_npu._minimax_m3_index_decode",
+        return_value=(local_topk, local_scores),
+    ) as mock_decode:
+        minimax_m3_index_tp_block_parallel_decode(
+            idx_q,
+            (index_key_cache,),
+            block_table,
+            cu_seqlens_q,
+            seq_lens,
+            context_lens,
+            start_loc,
+            causal_mask,
+            max_seq_len=512,
+            topk=1,
+            init_blocks=0,
+            local_blocks=0,
+            decode_query_len=1,
+            tp_group=FakeTPGroup(),
+        )
+
+    passed_mask = mock_decode.call_args.args[7]
+    if expects_causal_mask:
+        assert passed_mask is causal_mask
+    else:
+        assert passed_mask is None
+
+
 @patch("vllm_ascend.models.minimax_m3.msa_m3.get_tp_group")
 @patch("vllm_ascend.models.minimax_m3.msa_m3.get_forward_context")
-def test_indexer_speculative_decode_uses_ascendc_tp_sharded_path(
+def test_indexer_speculative_decode_uses_tp_block_parallel_path(
     mock_get_forward_context: MagicMock,
     mock_get_tp_group: MagicMock,
 ) -> None:
@@ -600,6 +834,9 @@ def test_indexer_speculative_decode_uses_ascendc_tp_sharded_path(
     torch.nn.Module.__init__(impl)
     impl.num_index_heads = 1
     impl.index_head_dim = 4
+    impl.topk_blocks = 2
+    impl.init_blocks = 1
+    impl.local_blocks = 1
     impl.index_cache = SimpleNamespace(
         prefix="layer.attn.index_cache",
         kv_cache=torch.zeros(4, 128, 4),
@@ -610,6 +847,7 @@ def test_indexer_speculative_decode_uses_ascendc_tp_sharded_path(
         seq_lens=torch.tensor([258], dtype=torch.int32),
         context_lens=torch.tensor([256], dtype=torch.int32),
         block_table=torch.tensor([[0, 1, 2]], dtype=torch.int32),
+        start_loc=torch.tensor([2], dtype=torch.int32),
         max_seq_len=258,
         decode_query_len=2,
     )
@@ -617,6 +855,7 @@ def test_indexer_speculative_decode_uses_ascendc_tp_sharded_path(
         seq_lens=decode.seq_lens,
         max_seq_len=decode.max_seq_len,
         slot_mapping=torch.arange(2, dtype=torch.int64),
+        causal_mask=torch.zeros(2048, 2048, dtype=torch.int8),
         num_actual_tokens=2,
         num_decodes=1,
         num_decode_tokens=2,
@@ -633,17 +872,21 @@ def test_indexer_speculative_decode_uses_ascendc_tp_sharded_path(
     )
     expected = torch.zeros((1, 2, 2), dtype=torch.int32)
 
-    with patch.object(
-        impl,
-        "_decode_topk_tp_sharded",
+    with patch(
+        "vllm_ascend.models.minimax_m3.msa_m3.minimax_m3_index_tp_block_parallel_decode",
         return_value=expected,
-    ) as mock_tp_sharded:
+    ) as mock_tp_block_parallel:
         actual, prefill = impl.forward(torch.zeros(2, 4))
 
     assert actual is expected
     assert prefill is None
-    mock_tp_sharded.assert_called_once()
-    assert mock_tp_sharded.call_args.args[7] == 2
+    mock_tp_block_parallel.assert_called_once()
+    call_args = mock_tp_block_parallel.call_args.args
+    call_kwargs = mock_tp_block_parallel.call_args.kwargs
+    assert call_args[6] is decode.start_loc
+    assert call_args[7] is metadata.causal_mask
+    assert call_kwargs["decode_query_len"] == 2
+    assert call_kwargs["tp_group"] is mock_get_tp_group.return_value
 
 
 def test_speculative_decode_candidates_use_per_token_visibility() -> None:

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -882,16 +882,30 @@ def test_ascendc_index_score_uses_dense_mode_without_mask() -> None:
     assert kwargs["sparse_mode"] == 0
 
 
-def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
+@pytest.mark.parametrize(
+    ("max_seq_len", "expected_score_width"),
+    [
+        (1, 16),
+        (128, 16),
+        (129, 16),
+        (2048, 16),
+        (2049, 32),
+        (133000, 1040),
+    ],
+)
+def test_ascendc_index_prefill_limits_score_width_for_topk(
+    max_seq_len: int,
+    expected_score_width: int,
+) -> None:
     idx_q = torch.zeros(1, 2, 128)
     index_key_cache = torch.zeros(4, 128, 128)
-    block_table = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    block_table = torch.arange(1040, dtype=torch.int32).view(1, 1040)
     cu_seqlens_q = torch.tensor([0, 1], dtype=torch.int32)
     seq_lens = torch.tensor([129], dtype=torch.int32)
     context_lens = torch.tensor([128], dtype=torch.int32)
     start_loc = torch.tensor([1], dtype=torch.int32)
     causal_mask = torch.zeros(2048, 2048, dtype=torch.int8)
-    score = torch.zeros(2, 1, 4)
+    score = torch.zeros(2, 1, 1040)
     expected = torch.zeros(2, 1, 2, dtype=torch.int32)
 
     with (
@@ -914,6 +928,7 @@ def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
             start_loc,
             causal_mask,
             max_query_len=1,
+            max_seq_len=max_seq_len,
             topk=2,
             init_blocks=1,
             local_blocks=1,
@@ -931,15 +946,14 @@ def test_ascendc_index_prefill_wraps_score_and_topk() -> None:
         init_blocks=1,
         local_blocks=1,
     )
-    mock_topk.assert_called_once_with(
-        score,
-        cu_seqlens_q,
-        context_lens,
-        1,
-        2,
-        1,
-        1,
-    )
+    mock_topk.assert_called_once()
+    topk_args = mock_topk.call_args.args
+    limited_score = topk_args[0]
+    assert limited_score.shape == (2, 1, expected_score_width)
+    assert limited_score.data_ptr() == score.data_ptr()
+    assert topk_args[1] is cu_seqlens_q
+    assert topk_args[2] is context_lens
+    assert topk_args[3:] == (1, 2, 1, 1)
 
 
 def test_ascendc_index_decode_wraps_score_candidates() -> None:

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -264,60 +264,18 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
         max_seq_len: int,
         decode_query_len: int,
     ) -> MiniMaxM3TPDecodeScoreMetadata:
-        """Build the TP halo metadata once for all indexer layers."""
+        """Package graph-stable inputs; derive TP tensors in model forward."""
         tp_rank = get_tp_group().rank_in_group
         max_block_count = (max_seq_len + self.block_size - 1) // self.block_size
         blocks_per_tp = (max_block_count + self.tp_size - 1) // self.tp_size
         block_offset = tp_rank * blocks_per_tp
         block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
-        local_context_lens = context_lens - block_offset * self.block_size
-
-        if block_count == 0:
-            return MiniMaxM3TPDecodeScoreMetadata(
-                block_table=block_table[:, :0],
-                cu_seqlens_q=cu_seqlens_q,
-                seq_lens=torch.zeros_like(context_lens),
-                context_lens=local_context_lens,
-                start_loc=torch.zeros_like(context_lens),
-                block_offset=block_offset,
-                block_count=0,
-                decode_query_len=decode_query_len,
-            )
-
-        halo_blocks = (decode_query_len - 1 + self.block_size - 1) // self.block_size
-        score_block_end = min(
-            block_offset + block_count + halo_blocks,
-            max_block_count,
-        )
-        score_block_table = block_table[:, block_offset:score_block_end].contiguous()
-        chunk_capacity = block_count * self.block_size
-        score_capacity = score_block_table.shape[-1] * self.block_size
-        max_score_k_len = min(
-            chunk_capacity + decode_query_len - 1,
-            score_capacity,
-        )
-        score_k_lens = torch.clamp(
-            context_lens + decode_query_len - block_offset * self.block_size,
-            min=0,
-            max=max_score_k_len,
-        )
-        score_start_loc = (
-            torch.div(
-                context_lens,
-                self.block_size,
-                rounding_mode="floor",
-            )
-            - block_offset
-        ).clamp(
-            min=0,
-            max=score_block_table.shape[-1] - 1,
-        )
         return MiniMaxM3TPDecodeScoreMetadata(
-            block_table=score_block_table,
+            block_table=block_table,
             cu_seqlens_q=cu_seqlens_q,
-            seq_lens=score_k_lens,
-            context_lens=local_context_lens,
-            start_loc=score_start_loc.to(dtype=torch.int32),
+            context_lens=context_lens,
+            max_block_count=max_block_count,
+            block_size=self.block_size,
             block_offset=block_offset,
             block_count=block_count,
             decode_query_len=decode_query_len,
@@ -384,7 +342,6 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
             active_decodes = _active_decode_num_reqs(num_decodes, num_decode_tokens, decode_query_len)
             decode_context_lens = None
             decode_cu_seqlens_q = None
-            decode_start_loc = None
             if _USE_ASCENDC_INDEX_SCORE:
                 decode_context_lens = self.context_len_buffer[:active_decodes]
                 decode_context_lens.copy_(
@@ -392,11 +349,6 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
                     non_blocking=True,
                 )
                 decode_cu_seqlens_q = query_start_loc[: active_decodes + 1].to(torch.int32)
-                decode_start_loc = torch.div(
-                    decode_context_lens,
-                    self.block_size,
-                    rounding_mode="floor",
-                ).to(dtype=torch.int32)
             decode_metadata = AscendMiniMaxM3IndexerDecodeMetadata(
                 seq_lens=seq_lens[:active_decodes],
                 block_table=block_table[:active_decodes],
@@ -404,7 +356,6 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
                 decode_query_len=decode_query_len,
                 cu_seqlens_q=decode_cu_seqlens_q,
                 context_lens=decode_context_lens,
-                start_loc=decode_start_loc,
             )
             if _USE_ASCENDC_INDEX_SCORE and self.tp_size > 1 and active_prefills == 0:
                 decode_metadata.tp_score = self._build_tp_score_metadata(
@@ -552,6 +503,11 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
                         tp_group=tp_group,
                     )
                 else:
+                    decode_start_loc = torch.div(
+                        d.context_lens,
+                        self.block_size,
+                        rounding_mode="floor",
+                    ).to(dtype=torch.int32)
                     decode_topk = minimax_m3_index_decode_ascendc(
                         decode_iq,
                         kv,
@@ -559,7 +515,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
                         d.cu_seqlens_q,
                         d.seq_lens,
                         d.context_lens,
-                        d.start_loc,
+                        decode_start_loc,
                         index_md.causal_mask,
                         topk=self.topk_blocks,
                         init_blocks=self.init_blocks,

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -265,12 +265,19 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
         decode_query_len: int,
     ) -> MiniMaxM3TPDecodeScoreMetadata:
         """Package graph-stable inputs; derive TP tensors in model forward."""
+        tp_rank = get_tp_group().rank_in_group
+        max_block_count = (max_seq_len + self.block_size - 1) // self.block_size
+        blocks_per_tp = (max_block_count + self.tp_size - 1) // self.tp_size
+        block_offset = tp_rank * blocks_per_tp
+        block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
         return MiniMaxM3TPDecodeScoreMetadata(
             block_table=block_table,
             cu_seqlens_q=cu_seqlens_q,
             context_lens=context_lens,
-            max_seq_len=max_seq_len,
+            max_block_count=max_block_count,
             block_size=self.block_size,
+            block_offset=block_offset,
+            block_count=block_count,
             decode_query_len=decode_query_len,
         )
 

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -565,6 +565,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
                     p.start_loc,
                     index_md.causal_mask,
                     max_query_len=p.max_query_len,
+                    max_seq_len=p.max_seq_len,
                     topk=self.topk_blocks,
                     init_blocks=self.init_blocks,
                     local_blocks=self.local_blocks,

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -37,23 +37,28 @@ from vllm.v1.kv_cache_interface import (
     KVCacheSpec,
 )
 
+from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
+    MiniMaxM3TPDecodeScoreMetadata,
+    minimax_m3_index_tp_block_parallel_decode,
     minimax_m3_sparse_attn,
     minimax_m3_sparse_attn_decode,
+)
+from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
+    minimax_m3_index_decode as minimax_m3_index_decode_ascendc,
+)
+from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
+    minimax_m3_index_prefill as minimax_m3_index_prefill_ascendc,
 )
 from vllm_ascend.ops.linear import AscendColumnParallelLinear
 from vllm_ascend.ops.linear_op import get_parallel_op
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
-if get_ascend_device_type() == AscendDeviceType.A5:
+_USE_ASCENDC_INDEX_SCORE = get_ascend_device_type() != AscendDeviceType.A5
+
+if not _USE_ASCENDC_INDEX_SCORE:
     from vllm_ascend.models.minimax_m3.ops.msa_m3_triton_a5 import (
-        minimax_m3_index_decode,
-        minimax_m3_index_score,
-        minimax_m3_index_topk,
-    )
-else:
-    from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
         minimax_m3_index_decode,
         minimax_m3_index_score,
         minimax_m3_index_topk,
@@ -166,7 +171,7 @@ class AscendMiniMaxM3IndexerCache(nn.Module, AttentionLayerBase):
         cache_config: CacheConfig | None = None,
     ) -> None:
         super().__init__()
-        self.kv_cache: tuple[torch.Tensor] = (torch.tensor([]),)
+        self.kv_cache = torch.tensor([])
         self.head_dim = head_dim
         self.dtype = torch.bfloat16
         self.prefix = prefix
@@ -198,6 +203,7 @@ class AscendMiniMaxM3IndexerPrefillMetadata:
     block_table: torch.Tensor
     max_query_len: int
     max_seq_len: int
+    start_loc: torch.Tensor | None = None
 
 
 @dataclass
@@ -206,6 +212,10 @@ class AscendMiniMaxM3IndexerDecodeMetadata:
     block_table: torch.Tensor
     max_seq_len: int
     decode_query_len: int
+    cu_seqlens_q: torch.Tensor | None = None
+    context_lens: torch.Tensor | None = None
+    start_loc: torch.Tensor | None = None
+    tp_score: MiniMaxM3TPDecodeScoreMetadata | None = None
 
 
 @dataclass
@@ -218,6 +228,7 @@ class AscendMiniMaxM3IndexerMetadata(AttentionMetadata):
     num_decode_tokens: int
     num_prefills: int
     num_prefill_tokens: int
+    causal_mask: torch.Tensor | None = None
     prefill: AscendMiniMaxM3IndexerPrefillMetadata | None = None
     decode: AscendMiniMaxM3IndexerDecodeMetadata | None = None
 
@@ -239,6 +250,77 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
             vllm_config.scheduler_config.max_num_batched_tokens,
             dtype=torch.int32,
             device=device,
+        )
+        self.block_size = kv_cache_spec.block_size
+        self.tp_size = vllm_config.parallel_config.tensor_parallel_size
+        self.attn_mask_builder = AttentionMaskBuilder(device) if _USE_ASCENDC_INDEX_SCORE else None
+
+    def _build_tp_score_metadata(
+        self,
+        block_table: torch.Tensor,
+        cu_seqlens_q: torch.Tensor,
+        context_lens: torch.Tensor,
+        *,
+        max_seq_len: int,
+        decode_query_len: int,
+    ) -> MiniMaxM3TPDecodeScoreMetadata:
+        """Build the TP halo metadata once for all indexer layers."""
+        tp_rank = get_tp_group().rank_in_group
+        max_block_count = (max_seq_len + self.block_size - 1) // self.block_size
+        blocks_per_tp = (max_block_count + self.tp_size - 1) // self.tp_size
+        block_offset = tp_rank * blocks_per_tp
+        block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
+        local_context_lens = context_lens - block_offset * self.block_size
+
+        if block_count == 0:
+            return MiniMaxM3TPDecodeScoreMetadata(
+                block_table=block_table[:, :0],
+                cu_seqlens_q=cu_seqlens_q,
+                seq_lens=torch.zeros_like(context_lens),
+                context_lens=local_context_lens,
+                start_loc=torch.zeros_like(context_lens),
+                block_offset=block_offset,
+                block_count=0,
+                decode_query_len=decode_query_len,
+            )
+
+        halo_blocks = (decode_query_len - 1 + self.block_size - 1) // self.block_size
+        score_block_end = min(
+            block_offset + block_count + halo_blocks,
+            max_block_count,
+        )
+        score_block_table = block_table[:, block_offset:score_block_end].contiguous()
+        chunk_capacity = block_count * self.block_size
+        score_capacity = score_block_table.shape[-1] * self.block_size
+        max_score_k_len = min(
+            chunk_capacity + decode_query_len - 1,
+            score_capacity,
+        )
+        score_k_lens = torch.clamp(
+            context_lens + decode_query_len - block_offset * self.block_size,
+            min=0,
+            max=max_score_k_len,
+        )
+        score_start_loc = (
+            torch.div(
+                context_lens,
+                self.block_size,
+                rounding_mode="floor",
+            )
+            - block_offset
+        ).clamp(
+            min=0,
+            max=score_block_table.shape[-1] - 1,
+        )
+        return MiniMaxM3TPDecodeScoreMetadata(
+            block_table=score_block_table,
+            cu_seqlens_q=cu_seqlens_q,
+            seq_lens=score_k_lens,
+            context_lens=local_context_lens,
+            start_loc=score_start_loc.to(dtype=torch.int32),
+            block_offset=block_offset,
+            block_count=block_count,
+            decode_query_len=decode_query_len,
         )
 
     def build(
@@ -282,6 +364,15 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
                 block_table=block_table[num_decodes:prefill_end],
                 max_query_len=common_attn_metadata.max_query_len,
                 max_seq_len=common_attn_metadata.max_seq_len,
+                start_loc=(
+                    torch.div(
+                        prefill_context_lens,
+                        self.block_size,
+                        rounding_mode="floor",
+                    ).to(dtype=torch.int32)
+                    if _USE_ASCENDC_INDEX_SCORE
+                    else None
+                ),
             )
 
         decode_metadata: AscendMiniMaxM3IndexerDecodeMetadata | None = None
@@ -291,12 +382,40 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
             query_lens_cpu = qsl_cpu[1 : num_decodes + 1] - qsl_cpu[:num_decodes]
             decode_query_len = int(query_lens_cpu[0].item())
             active_decodes = _active_decode_num_reqs(num_decodes, num_decode_tokens, decode_query_len)
+            decode_context_lens = None
+            decode_cu_seqlens_q = None
+            decode_start_loc = None
+            if _USE_ASCENDC_INDEX_SCORE:
+                decode_context_lens = self.context_len_buffer[:active_decodes]
+                decode_context_lens.copy_(
+                    seq_lens[:active_decodes] - decode_query_len,
+                    non_blocking=True,
+                )
+                decode_cu_seqlens_q = query_start_loc[: active_decodes + 1].to(torch.int32)
+                decode_start_loc = torch.div(
+                    decode_context_lens,
+                    self.block_size,
+                    rounding_mode="floor",
+                ).to(dtype=torch.int32)
             decode_metadata = AscendMiniMaxM3IndexerDecodeMetadata(
                 seq_lens=seq_lens[:active_decodes],
                 block_table=block_table[:active_decodes],
                 max_seq_len=common_attn_metadata.max_seq_len,
                 decode_query_len=decode_query_len,
+                cu_seqlens_q=decode_cu_seqlens_q,
+                context_lens=decode_context_lens,
+                start_loc=decode_start_loc,
             )
+            if _USE_ASCENDC_INDEX_SCORE and self.tp_size > 1 and active_prefills == 0:
+                assert decode_cu_seqlens_q is not None
+                assert decode_context_lens is not None
+                decode_metadata.tp_score = self._build_tp_score_metadata(
+                    decode_metadata.block_table,
+                    decode_cu_seqlens_q,
+                    decode_context_lens,
+                    max_seq_len=decode_metadata.max_seq_len,
+                    decode_query_len=decode_query_len,
+                )
 
         return AscendMiniMaxM3IndexerMetadata(
             seq_lens=seq_lens,
@@ -307,6 +426,9 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
             num_decode_tokens=num_decode_tokens,
             num_prefills=active_prefills,
             num_prefill_tokens=num_prefill_tokens,
+            causal_mask=(
+                self.attn_mask_builder.get_splitfuse_attn_mask() if self.attn_mask_builder is not None else None
+            ),
             prefill=prefill_metadata,
             decode=decode_metadata,
         )
@@ -345,7 +467,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
     def _decode_topk_tp_sharded(
         self,
         idx_q: torch.Tensor,
-        index_kv_cache: tuple[torch.Tensor],
+        index_kv_cache: torch.Tensor,
         block_table: torch.Tensor,
         seq_lens: torch.Tensor,
         max_seq_len: int,
@@ -420,59 +542,110 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
             d = index_md.decode
             assert d is not None
             tp_group = get_tp_group()
-            tp_size = tp_group.world_size
-            tp_rank = tp_group.rank_in_group
             decode_iq = iq[:num_decode_tokens]
-            if _should_use_tp_sharded_index_decode(tp_size, index_md.num_prefills):
-                decode_topk = self._decode_topk_tp_sharded(
-                    decode_iq,
-                    kv,
-                    d.block_table,
-                    d.seq_lens,
-                    d.max_seq_len,
-                    d.decode_query_len,
-                    tp_group,
-                    tp_size,
-                    tp_rank,
-                )
+            if _USE_ASCENDC_INDEX_SCORE:
+                assert d.cu_seqlens_q is not None
+                assert d.context_lens is not None
+                assert d.start_loc is not None
+                assert index_md.causal_mask is not None
+                if tp_group is not None and tp_group.world_size > 1 and index_md.num_prefills == 0:
+                    assert d.tp_score is not None
+                    decode_topk = minimax_m3_index_tp_block_parallel_decode(
+                        decode_iq,
+                        kv,
+                        d.tp_score,
+                        index_md.causal_mask,
+                        topk=self.topk_blocks,
+                        init_blocks=self.init_blocks,
+                        local_blocks=self.local_blocks,
+                        tp_group=tp_group,
+                    )
+                else:
+                    decode_topk = minimax_m3_index_decode_ascendc(
+                        decode_iq,
+                        kv,
+                        d.block_table,
+                        d.cu_seqlens_q,
+                        d.seq_lens,
+                        d.context_lens,
+                        d.start_loc,
+                        index_md.causal_mask,
+                        topk=self.topk_blocks,
+                        init_blocks=self.init_blocks,
+                        local_blocks=self.local_blocks,
+                        decode_query_len=d.decode_query_len,
+                    )
             else:
-                decode_topk = minimax_m3_index_decode(
-                    decode_iq,
-                    kv,
-                    d.block_table,
-                    d.seq_lens,
-                    d.max_seq_len,
-                    self.topk_blocks,
-                    self.init_blocks,
-                    self.local_blocks,
-                    self.num_kv_heads,
-                    d.decode_query_len,
-                    sm_scale=self.scale,
-                )
+                tp_size = tp_group.world_size
+                tp_rank = tp_group.rank_in_group
+                if _should_use_tp_sharded_index_decode(tp_size, index_md.num_prefills):
+                    decode_topk = self._decode_topk_tp_sharded(
+                        decode_iq,
+                        kv,
+                        d.block_table,
+                        d.seq_lens,
+                        d.max_seq_len,
+                        d.decode_query_len,
+                        tp_group,
+                        tp_size,
+                        tp_rank,
+                    )
+                else:
+                    decode_topk = minimax_m3_index_decode(
+                        decode_iq,
+                        kv,
+                        d.block_table,
+                        d.seq_lens,
+                        d.max_seq_len,
+                        self.topk_blocks,
+                        self.init_blocks,
+                        self.local_blocks,
+                        self.num_kv_heads,
+                        d.decode_query_len,
+                        sm_scale=self.scale,
+                    )
         if index_md.num_prefills > 0:
             p = index_md.prefill
             assert p is not None
-            score = minimax_m3_index_score(
-                iq[num_decode_tokens:],
-                kv,
-                p.block_table,
-                p.cu_seqlens_q,
-                p.seq_lens,
-                p.context_lens,
-                p.max_query_len,
-                p.max_seq_len,
-                self.num_kv_heads,
-                self.scale,
-            )
-            prefill_topk = minimax_m3_index_topk(
-                score,
-                p.cu_seqlens_q,
-                p.context_lens,
-                p.max_query_len,
-                self.topk_blocks,
-                self.init_blocks,
-                self.local_blocks,
-            )
+            if _USE_ASCENDC_INDEX_SCORE:
+                assert p.start_loc is not None
+                assert index_md.causal_mask is not None
+                prefill_topk = minimax_m3_index_prefill_ascendc(
+                    iq[num_decode_tokens:],
+                    kv,
+                    p.block_table,
+                    p.cu_seqlens_q,
+                    p.seq_lens,
+                    p.context_lens,
+                    p.start_loc,
+                    index_md.causal_mask,
+                    max_query_len=p.max_query_len,
+                    topk=self.topk_blocks,
+                    init_blocks=self.init_blocks,
+                    local_blocks=self.local_blocks,
+                )
+            else:
+                score = minimax_m3_index_score(
+                    iq[num_decode_tokens:],
+                    kv,
+                    p.block_table,
+                    p.cu_seqlens_q,
+                    p.seq_lens,
+                    p.context_lens,
+                    p.max_query_len,
+                    p.max_seq_len,
+                    self.num_kv_heads,
+                    self.scale,
+                )
+                prefill_topk = minimax_m3_index_topk(
+                    score,
+                    p.cu_seqlens_q,
+                    p.context_lens,
+                    p.max_query_len,
+                    self.topk_blocks,
+                    self.init_blocks,
+                    self.local_blocks,
+                )
         return decode_topk, prefill_topk
 
 

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -166,7 +166,7 @@ class AscendMiniMaxM3IndexerCache(nn.Module, AttentionLayerBase):
         cache_config: CacheConfig | None = None,
     ) -> None:
         super().__init__()
-        self.kv_cache = torch.tensor([])
+        self.kv_cache: tuple[torch.Tensor] = (torch.tensor([]),)
         self.head_dim = head_dim
         self.dtype = torch.bfloat16
         self.prefix = prefix
@@ -345,7 +345,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
     def _decode_topk_tp_sharded(
         self,
         idx_q: torch.Tensor,
-        index_kv_cache: torch.Tensor,
+        index_kv_cache: tuple[torch.Tensor],
         block_table: torch.Tensor,
         seq_lens: torch.Tensor,
         max_seq_len: int,

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -265,19 +265,12 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
         decode_query_len: int,
     ) -> MiniMaxM3TPDecodeScoreMetadata:
         """Package graph-stable inputs; derive TP tensors in model forward."""
-        tp_rank = get_tp_group().rank_in_group
-        max_block_count = (max_seq_len + self.block_size - 1) // self.block_size
-        blocks_per_tp = (max_block_count + self.tp_size - 1) // self.tp_size
-        block_offset = tp_rank * blocks_per_tp
-        block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
         return MiniMaxM3TPDecodeScoreMetadata(
             block_table=block_table,
             cu_seqlens_q=cu_seqlens_q,
             context_lens=context_lens,
-            max_block_count=max_block_count,
+            max_seq_len=max_seq_len,
             block_size=self.block_size,
-            block_offset=block_offset,
-            block_count=block_count,
             decode_query_len=decode_query_len,
         )
 

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -407,8 +407,6 @@ class AscendMiniMaxM3IndexerMetadataBuilder(AttentionMetadataBuilder[AscendMiniM
                 start_loc=decode_start_loc,
             )
             if _USE_ASCENDC_INDEX_SCORE and self.tp_size > 1 and active_prefills == 0:
-                assert decode_cu_seqlens_q is not None
-                assert decode_context_lens is not None
                 decode_metadata.tp_score = self._build_tp_score_metadata(
                     decode_metadata.block_table,
                     decode_cu_seqlens_q,
@@ -518,9 +516,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
             dim=-1,
         )
         local_gathered_topk = gathered_topk.narrow(0, local_head_start, local_head_count)
-        merged_topk = torch.gather(local_gathered_topk, dim=-1, index=merged_pos)
-
-        return merged_topk
+        return torch.gather(local_gathered_topk, dim=-1, index=merged_pos)
 
     def forward(
         self,
@@ -544,12 +540,7 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
             tp_group = get_tp_group()
             decode_iq = iq[:num_decode_tokens]
             if _USE_ASCENDC_INDEX_SCORE:
-                assert d.cu_seqlens_q is not None
-                assert d.context_lens is not None
-                assert d.start_loc is not None
-                assert index_md.causal_mask is not None
-                if tp_group is not None and tp_group.world_size > 1 and index_md.num_prefills == 0:
-                    assert d.tp_score is not None
+                if tp_group.world_size > 1 and index_md.num_prefills == 0:
                     decode_topk = minimax_m3_index_tp_block_parallel_decode(
                         decode_iq,
                         kv,
@@ -608,8 +599,6 @@ class AscendMiniMaxM3IndexerImpl(nn.Module):
             p = index_md.prefill
             assert p is not None
             if _USE_ASCENDC_INDEX_SCORE:
-                assert p.start_loc is not None
-                assert index_md.causal_mask is not None
                 prefill_topk = minimax_m3_index_prefill_ascendc(
                     iq[num_decode_tokens:],
                     kv,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -151,6 +151,9 @@ def _minimax_m3_index_score(
     seq_lens: torch.Tensor,
     start_loc: torch.Tensor,
     causal_mask: torch.Tensor | None,
+    *,
+    init_blocks: int = 0,
+    local_blocks: int = 0,
 ) -> torch.Tensor:
     """Compute MSA index scores with the bundled AscendC operator.
 
@@ -160,6 +163,8 @@ def _minimax_m3_index_score(
 
     A causal mask selects sparse mode 3. Passing no mask selects dense mode 0
     for a TP chunk that is entirely before the current query positions.
+    ``init_blocks`` and ``local_blocks`` are kept for parity with the index
+    scoring interface; candidate forcing is applied by the TopK stage.
     """
     index_kv_cache = _as_ascendc_index_kv_cache(index_kv_cache)
     return torch.ops._C_ascend.npu_msa_index_score(
@@ -200,6 +205,8 @@ def minimax_m3_index_prefill(
         seq_lens,
         start_loc,
         causal_mask,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
     )
     return _minimax_m3_index_prefill_topk(
         score,
@@ -318,6 +325,8 @@ def _minimax_m3_index_decode(
         seq_lens,
         start_loc,
         causal_mask,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
     )
     if block_count is None:
         block_count = block_table.shape[-1]

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -64,26 +64,23 @@ def _npu_k2q_csr(
 
 
 def _as_ascendc_index_kv_cache(
-    index_kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
+    index_kv_cache: tuple[torch.Tensor],
 ) -> torch.Tensor:
-    """Normalize the index-key cache to the AscendC BBND input layout.
+    """Convert the runtime index K cache to the AscendC BBND layout.
 
-    Ascend's cache allocator may expose an index cache as a split K/V tuple,
-    even though the indexer only consumes the key tensor.  Keep this identical
-    to the normalization used by the Triton implementation, then restore the
-    singleton head dimension required by the BBND AscendC operator.
+    The model runner binds this K-only cache as a one-element tuple containing
+    a tensor shaped ``[num_blocks, 128, head_dim]``.  MsaIndexScore expects the
+    BBND shape ``[num_blocks, 128, 1, head_dim]`` instead.
     """
-    if isinstance(index_kv_cache, (tuple, list)):
-        if not index_kv_cache:
-            raise ValueError("Index KV cache tuple must contain a key tensor")
-        index_kv_cache = index_kv_cache[0]
-    if index_kv_cache.ndim == 5 and index_kv_cache.shape[0] == 2:
-        index_kv_cache = index_kv_cache[0]
-    if index_kv_cache.ndim == 3:
-        index_kv_cache = index_kv_cache.unsqueeze(2)
-    if index_kv_cache.ndim != 4 or index_kv_cache.shape[2] != 1:
-        raise ValueError(f"Unexpected index KV cache shape: {tuple(index_kv_cache.shape)}")
-    return index_kv_cache
+    if not isinstance(index_kv_cache, tuple) or len(index_kv_cache) != 1:
+        raise ValueError("M3 index cache must be a one-tensor tuple containing K")
+    (index_key_cache,) = index_kv_cache
+    if index_key_cache.ndim != 3 or index_key_cache.shape[1] != _MSA_INDEX_BLOCK_SIZE:
+        raise ValueError(
+            "M3 index K cache must have shape "
+            f"[num_blocks, {_MSA_INDEX_BLOCK_SIZE}, head_dim], got {tuple(index_key_cache.shape)}"
+        )
+    return index_key_cache.unsqueeze(2)
 
 
 def _split_main_kv_cache(
@@ -134,7 +131,7 @@ def _build_cu_block_lens(
 @torch.no_grad()
 def minimax_m3_index_score(
     idx_q: torch.Tensor,
-    index_kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
+    index_kv_cache: tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -275,7 +272,7 @@ def _index_score_topk_candidates(
 @torch.no_grad()
 def minimax_m3_index_decode(
     idx_q: torch.Tensor,
-    index_kv_cache: torch.Tensor,
+    index_kv_cache: tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import torch
 
+from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.utils import (
     AscendDeviceType,
     enable_custom_op,
@@ -12,6 +13,7 @@ from vllm_ascend.utils import (
 )
 
 _SPARSE_ATTN_INNER_PRECISE = 4
+_MSA_INDEX_BLOCK_SIZE = 128
 _ASCEND_DEVICE_TYPE = get_ascend_device_type()
 
 
@@ -61,6 +63,29 @@ def _npu_k2q_csr(
     )
 
 
+def _as_ascendc_index_kv_cache(
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
+) -> torch.Tensor:
+    """Normalize the index-key cache to the AscendC BBND input layout.
+
+    Ascend's cache allocator may expose an index cache as a split K/V tuple,
+    even though the indexer only consumes the key tensor.  Keep this identical
+    to the normalization used by the Triton implementation, then restore the
+    singleton head dimension required by the BBND AscendC operator.
+    """
+    if isinstance(index_kv_cache, (tuple, list)):
+        if not index_kv_cache:
+            raise ValueError("Index KV cache tuple must contain a key tensor")
+        index_kv_cache = index_kv_cache[0]
+    if index_kv_cache.ndim == 5 and index_kv_cache.shape[0] == 2:
+        index_kv_cache = index_kv_cache[0]
+    if index_kv_cache.ndim == 3:
+        index_kv_cache = index_kv_cache.unsqueeze(2)
+    if index_kv_cache.ndim != 4 or index_kv_cache.shape[2] != 1:
+        raise ValueError(f"Unexpected index KV cache shape: {tuple(index_kv_cache.shape)}")
+    return index_kv_cache
+
+
 def _split_main_kv_cache(
     kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
 ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -106,6 +131,202 @@ def _build_cu_block_lens(
     return cu_block_lens
 
 
+@torch.no_grad()
+def minimax_m3_index_score(
+    idx_q: torch.Tensor,
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seq_lens: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    max_query_len: int,
+    max_seq_len: int,
+    num_kv_heads: int,
+    sm_scale: float | None = None,
+    *,
+    start_loc: torch.Tensor | None = None,
+    init_blocks: int = 0,
+    local_blocks: int = 0,
+) -> torch.Tensor:
+    """Compute causal MSA index scores with the bundled AscendC operator.
+
+    ``start_loc`` is the current query block in the *passed block table*.  For
+    a TP-sharded table this is a per-request local block index, not the scalar
+    global ``block_offset`` used by the Triton decode kernel.
+    """
+    del max_query_len, max_seq_len, sm_scale
+    if idx_q.ndim != 3:
+        raise ValueError(f"Unexpected index query shape: {tuple(idx_q.shape)}")
+    index_kv_cache = _as_ascendc_index_kv_cache(index_kv_cache)
+    if idx_q.shape[1] != num_kv_heads:
+        raise ValueError("M3 requires num_idx_heads == num_kv_heads")
+
+    if start_loc is None:
+        start_loc = torch.div(
+            prefix_lens,
+            _MSA_INDEX_BLOCK_SIZE,
+            rounding_mode="floor",
+        ).to(dtype=torch.int32)
+    elif start_loc.ndim != 1 or start_loc.shape != prefix_lens.shape:
+        raise ValueError("start_loc must be a 1D tensor matching prefix_lens")
+    else:
+        start_loc = start_loc.to(dtype=torch.int32)
+    causal_mask = AttentionMaskBuilder(idx_q.device).get_splitfuse_attn_mask()
+    return torch.ops._C_ascend.npu_msa_index_score(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        start_loc,
+        atten_mask=causal_mask,
+        actual_seq_qlen=cu_seqlens_q,
+        actual_seq_klen=seq_lens,
+        layout_key="BBND",
+        sparse_mode=3,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
+    )
+
+
+def _index_score_topk_candidates(
+    score: torch.Tensor,
+    context_lens: torch.Tensor,
+    decode_query_len: int,
+    topk: int,
+    block_offset: int = 0,
+    init_blocks: int = 0,
+    local_blocks: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return global block IDs and scores after exactly one local TopK."""
+    block_count = score.shape[-1]
+    query_offsets = torch.arange(
+        decode_query_len,
+        dtype=context_lens.dtype,
+        device=context_lens.device,
+    ).repeat(context_lens.shape[0])
+    visible_tokens = context_lens.repeat_interleave(decode_query_len) + query_offsets + 1
+    valid_block_count = torch.div(
+        visible_tokens + _MSA_INDEX_BLOCK_SIZE - 1,
+        _MSA_INDEX_BLOCK_SIZE,
+        rounding_mode="floor",
+    ).clamp(min=0, max=block_count)
+
+    if init_blocks > 0 or local_blocks > 0:
+        # start_loc is one value per request, so the AscendC local mask cannot
+        # move when speculative tokens cross a block boundary.  Apply the
+        # forced-block scores here per token, before the one and only TopK.
+        global_valid_block_count = torch.div(
+            visible_tokens + block_offset * _MSA_INDEX_BLOCK_SIZE + _MSA_INDEX_BLOCK_SIZE - 1,
+            _MSA_INDEX_BLOCK_SIZE,
+            rounding_mode="floor",
+        ).clamp(min=0)
+        local_block_ids = torch.arange(block_count, device=score.device)
+        global_block_ids = local_block_ids + block_offset
+        valid_blocks = global_block_ids[None, :] < global_valid_block_count[:, None]
+        if init_blocks > 0:
+            # TP callers pass the number of initial blocks that overlap this
+            # local shard, matching the AscendC attribute's local-table
+            # semantics.
+            init_mask = valid_blocks & (local_block_ids[None, :] < init_blocks)
+            score = torch.where(init_mask[None, :, :], 1.0e30, score)
+        if local_blocks > 0:
+            local_start = (global_valid_block_count - local_blocks).clamp(min=0)
+            local_mask = valid_blocks & (global_block_ids[None, :] >= local_start[:, None])
+            score = torch.where(local_mask[None, :, :], 1.0e29, score)
+
+    selected_count = min(topk, block_count)
+    raw_scores, raw_topk = torch.topk(
+        score,
+        k=selected_count,
+        dim=-1,
+    )
+    if selected_count == topk:
+        topk_indices = raw_topk.to(dtype=torch.int32)
+        topk_scores = raw_scores
+    else:
+        topk_indices = torch.full(
+            (*raw_topk.shape[:-1], topk),
+            -1,
+            dtype=torch.int32,
+            device=raw_topk.device,
+        )
+        topk_scores = torch.full(
+            (*raw_scores.shape[:-1], topk),
+            float("-inf"),
+            dtype=raw_scores.dtype,
+            device=raw_scores.device,
+        )
+        topk_indices[..., :selected_count].copy_(raw_topk)
+        topk_scores[..., :selected_count].copy_(raw_scores)
+
+    valid_candidate = (topk_indices >= 0) & (topk_indices < valid_block_count[None, :, None])
+    topk_indices = torch.where(
+        valid_candidate,
+        topk_indices + block_offset,
+        -1,
+    )
+    topk_scores = torch.where(
+        valid_candidate,
+        topk_scores,
+        float("-inf"),
+    )
+    return topk_indices, topk_scores
+
+
+@torch.no_grad()
+def minimax_m3_index_decode(
+    idx_q: torch.Tensor,
+    index_kv_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seq_lens: torch.Tensor,
+    context_lens: torch.Tensor,
+    max_seq_len: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    num_kv_heads: int,
+    decode_query_len: int,
+    sm_scale: float | None = None,
+    *,
+    start_loc: torch.Tensor | None = None,
+    block_offset: int = 0,
+    return_scores: bool = False,
+) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+    """Run AscendC decode score followed by one non-fused local TopK."""
+    # AscendC start_loc is per request.  For q>1, disable its fixed local mask
+    # and apply the equivalent moving mask per speculative token below.
+    ascendc_init_blocks = init_blocks if decode_query_len == 1 else 0
+    ascendc_local_blocks = local_blocks if decode_query_len == 1 else 0
+    score = minimax_m3_index_score(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        context_lens,
+        decode_query_len,
+        max_seq_len,
+        num_kv_heads,
+        sm_scale,
+        start_loc=start_loc,
+        init_blocks=ascendc_init_blocks,
+        local_blocks=ascendc_local_blocks,
+    )
+    topk_indices, topk_scores = _index_score_topk_candidates(
+        score[..., : block_table.shape[-1]],
+        context_lens,
+        decode_query_len,
+        topk,
+        block_offset,
+        init_blocks=init_blocks if decode_query_len > 1 else 0,
+        local_blocks=local_blocks if decode_query_len > 1 else 0,
+    )
+    if return_scores:
+        return topk_indices, topk_scores
+    return topk_indices
+
+
+@torch.no_grad()
 def _minimax_m3_sparse_attn_a3(
     q: torch.Tensor,
     kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -77,10 +77,8 @@ class MiniMaxM3TPDecodeScoreMetadata:
     block_table: torch.Tensor
     cu_seqlens_q: torch.Tensor
     context_lens: torch.Tensor
-    max_block_count: int
+    max_seq_len: int
     block_size: int
-    block_offset: int
-    block_count: int
     decode_query_len: int
 
 
@@ -153,9 +151,6 @@ def _minimax_m3_index_score(
     seq_lens: torch.Tensor,
     start_loc: torch.Tensor,
     causal_mask: torch.Tensor | None,
-    *,
-    init_blocks: int = 0,
-    local_blocks: int = 0,
 ) -> torch.Tensor:
     """Compute MSA index scores with the bundled AscendC operator.
 
@@ -165,8 +160,6 @@ def _minimax_m3_index_score(
 
     A causal mask selects sparse mode 3. Passing no mask selects dense mode 0
     for a TP chunk that is entirely before the current query positions.
-    ``init_blocks`` and ``local_blocks`` are kept for parity with the index
-    scoring interface; candidate forcing is applied by the TopK stage.
     """
     index_kv_cache = _as_ascendc_index_kv_cache(index_kv_cache)
     return torch.ops._C_ascend.npu_msa_index_score(
@@ -207,8 +200,6 @@ def minimax_m3_index_prefill(
         seq_lens,
         start_loc,
         causal_mask,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
     )
     return _minimax_m3_index_prefill_topk(
         score,
@@ -327,8 +318,6 @@ def _minimax_m3_index_decode(
         seq_lens,
         start_loc,
         causal_mask,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
     )
     if block_count is None:
         block_count = block_table.shape[-1]
@@ -391,9 +380,13 @@ def minimax_m3_index_tp_block_parallel_decode(
 ) -> torch.Tensor:
     """Run packed-query scoring and TopK over TP-sharded KV blocks."""
     full_idx_q = tp_group.all_gather(idx_q.contiguous(), dim=1).contiguous()
+    tp_size = tp_group.world_size
     tp_rank = tp_group.rank_in_group
-    block_offset = metadata.block_offset
-    block_count = metadata.block_count
+
+    max_block_count = (metadata.max_seq_len + metadata.block_size - 1) // metadata.block_size
+    blocks_per_tp = (max_block_count + tp_size - 1) // tp_size
+    block_offset = tp_rank * blocks_per_tp
+    block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
     if block_count == 0:
         # MsaIndexScore requires a non-empty block-table width. Ranks without
         # logical blocks contribute neutral candidates to the collectives.
@@ -421,7 +414,7 @@ def minimax_m3_index_tp_block_parallel_decode(
         halo_blocks = (metadata.decode_query_len - 1 + metadata.block_size - 1) // metadata.block_size
         score_block_end = min(
             block_offset + block_count + halo_blocks,
-            metadata.max_block_count,
+            max_block_count,
         )
         score_block_table = metadata.block_table[:, block_offset:score_block_end].contiguous()
         local_context_lens = metadata.context_lens - block_offset * metadata.block_size
@@ -442,11 +435,10 @@ def minimax_m3_index_tp_block_parallel_decode(
                 metadata.block_size,
                 rounding_mode="floor",
             )
-            .sub(block_offset)
-            .clamp(
-                min=0,
-                max=score_block_table.shape[-1] - 1,
-            )
+            - block_offset
+        ).clamp(
+            min=0,
+            max=score_block_table.shape[-1] - 1,
         )
         local_topk, local_scores = _minimax_m3_index_decode(
             full_idx_q,
@@ -455,7 +447,7 @@ def minimax_m3_index_tp_block_parallel_decode(
             metadata.cu_seqlens_q,
             score_k_lens,
             local_context_lens,
-            score_start_loc,
+            score_start_loc.to(dtype=torch.int32),
             None if metadata.decode_query_len == 1 else causal_mask,
             topk=topk,
             init_blocks=init_blocks,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -442,10 +442,11 @@ def minimax_m3_index_tp_block_parallel_decode(
                 metadata.block_size,
                 rounding_mode="floor",
             )
-            - block_offset
-        ).clamp(
-            min=0,
-            max=score_block_table.shape[-1] - 1,
+            .sub(block_offset)
+            .clamp(
+                min=0,
+                max=score_block_table.shape[-1] - 1,
+            )
         )
         local_topk, local_scores = _minimax_m3_index_decode(
             full_idx_q,
@@ -454,7 +455,7 @@ def minimax_m3_index_tp_block_parallel_decode(
             metadata.cu_seqlens_q,
             score_k_lens,
             local_context_lens,
-            score_start_loc.to(dtype=torch.int32),
+            score_start_loc,
             None if metadata.decode_query_len == 1 else causal_mask,
             topk=topk,
             init_blocks=init_blocks,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -95,14 +95,7 @@ def _as_ascendc_index_kv_cache(
     ``[num_blocks, 128, 1, head_dim]`` instead.
     """
     if isinstance(index_kv_cache, tuple):
-        if len(index_kv_cache) != 1:
-            raise ValueError("M3 index cache tuple must contain only the K tensor")
-        (index_kv_cache,) = index_kv_cache
-    if index_kv_cache.ndim != 3 or index_kv_cache.shape[1] != _MSA_INDEX_BLOCK_SIZE:
-        raise ValueError(
-            "M3 index K cache must have shape "
-            f"[num_blocks, {_MSA_INDEX_BLOCK_SIZE}, head_dim], got {tuple(index_kv_cache.shape)}"
-        )
+        index_kv_cache = index_kv_cache[0]
     return index_kv_cache.unsqueeze(2)
 
 
@@ -243,17 +236,12 @@ def _index_score_topk_candidates(
         device=context_lens.device,
     ).repeat(context_lens.shape[0])
     visible_tokens = context_lens.repeat_interleave(decode_query_len) + query_offsets + 1
-    valid_block_count = torch.div(
-        visible_tokens + _MSA_INDEX_BLOCK_SIZE - 1,
-        _MSA_INDEX_BLOCK_SIZE,
-        rounding_mode="floor",
-    ).clamp(min=0, max=block_count)
-
     global_valid_block_count = torch.div(
         visible_tokens + block_offset * _MSA_INDEX_BLOCK_SIZE + _MSA_INDEX_BLOCK_SIZE - 1,
         _MSA_INDEX_BLOCK_SIZE,
         rounding_mode="floor",
     ).clamp(min=0)
+    valid_block_count = (global_valid_block_count - block_offset).clamp(min=0, max=block_count)
     local_block_ids = torch.arange(block_count, device=score.device)
     global_block_ids = local_block_ids + block_offset
     valid_blocks = global_block_ids[None, :] < global_valid_block_count[:, None]
@@ -262,24 +250,22 @@ def _index_score_topk_candidates(
     # valid candidate and only then be discarded by output validation.
     score = torch.where(valid_blocks[None, :, :], score, float("-inf"))
 
-    if init_blocks > 0 or local_blocks > 0:
-        # Apply forced-block scores here per token, before the one and only
-        # TopK. This is shared by single-token and speculative decode.
-        if init_blocks > 0:
-            init_mask = valid_blocks & (global_block_ids[None, :] < init_blocks)
-            score = torch.where(init_mask[None, :, :], 1.0e30, score)
-        if local_blocks > 0:
-            local_start = (global_valid_block_count - local_blocks).clamp(min=0)
-            local_mask = valid_blocks & (global_block_ids[None, :] >= local_start[:, None])
-            score = torch.where(local_mask[None, :, :], 1.0e29, score)
+    # Apply forced-block scores per token before the one and only TopK.
+    if init_blocks > 0:
+        init_mask = valid_blocks & (global_block_ids[None, :] < init_blocks)
+        score = torch.where(init_mask[None, :, :], 1.0e30, score)
+    if local_blocks > 0:
+        local_start = (global_valid_block_count - local_blocks).clamp(min=0)
+        local_mask = valid_blocks & (global_block_ids[None, :] >= local_start[:, None])
+        score = torch.where(local_mask[None, :, :], 1.0e29, score)
 
-    selected_count = min(topk, block_count)
+    actual_topk_count = min(topk, block_count)
     raw_scores, raw_topk = torch.topk(
         score,
-        k=selected_count,
+        k=actual_topk_count,
         dim=-1,
     )
-    if selected_count == topk:
+    if actual_topk_count == topk:
         topk_indices = raw_topk.to(dtype=torch.int32)
         topk_scores = raw_scores
     else:
@@ -295,8 +281,8 @@ def _index_score_topk_candidates(
             dtype=raw_scores.dtype,
             device=raw_scores.device,
         )
-        topk_indices[..., :selected_count].copy_(raw_topk)
-        topk_scores[..., :selected_count].copy_(raw_scores)
+        topk_indices[..., :actual_topk_count].copy_(raw_topk)
+        topk_scores[..., :actual_topk_count].copy_(raw_scores)
 
     valid_candidate = (topk_indices >= 0) & (topk_indices < valid_block_count[None, :, None])
     topk_indices = torch.where(
@@ -342,7 +328,7 @@ def _minimax_m3_index_decode(
     )
     if block_count is None:
         block_count = block_table.shape[-1]
-    topk_indices, topk_scores = _index_score_topk_candidates(
+    return _index_score_topk_candidates(
         score[..., :block_count],
         context_lens,
         decode_query_len,
@@ -351,7 +337,6 @@ def _minimax_m3_index_decode(
         init_blocks=init_blocks,
         local_blocks=local_blocks,
     )
-    return topk_indices, topk_scores
 
 
 @torch.no_grad()

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -212,12 +212,12 @@ def minimax_m3_index_prefill(
         init_blocks=init_blocks,
         local_blocks=local_blocks,
     )
-    logical_block_count = (
-        max_seq_len + _MSA_INDEX_BLOCK_SIZE - 1
-    ) // _MSA_INDEX_BLOCK_SIZE
+    logical_block_count = (max_seq_len + _MSA_INDEX_BLOCK_SIZE - 1) // _MSA_INDEX_BLOCK_SIZE
     logical_score_width = (
-        logical_block_count + _MSA_SCORE_BLOCK_ALIGNMENT - 1
-    ) // _MSA_SCORE_BLOCK_ALIGNMENT * _MSA_SCORE_BLOCK_ALIGNMENT
+        (logical_block_count + _MSA_SCORE_BLOCK_ALIGNMENT - 1)
+        // _MSA_SCORE_BLOCK_ALIGNMENT
+        * _MSA_SCORE_BLOCK_ALIGNMENT
+    )
     score = score[..., :logical_score_width]
     return _minimax_m3_index_prefill_topk(
         score,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -3,23 +3,25 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 import torch
 
-from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
 from vllm_ascend.utils import (
     AscendDeviceType,
     enable_custom_op,
     get_ascend_device_type,
 )
-from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
-    minimax_m3_index_topk as _minimax_m3_index_prefill_topk,
-)
 
 _SPARSE_ATTN_INNER_PRECISE = 4
 _MSA_INDEX_BLOCK_SIZE = 128
 _ASCEND_DEVICE_TYPE = get_ascend_device_type()
+
+if _ASCEND_DEVICE_TYPE != AscendDeviceType.A5:
+    from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
+        minimax_m3_index_topk as _minimax_m3_index_prefill_topk,
+    )
 
 
 def _k2q_csr_block_stats(cu_block_lens: torch.Tensor) -> tuple[int, int]:
@@ -68,24 +70,35 @@ def _npu_k2q_csr(
     )
 
 
+@dataclass
+class MiniMaxM3TPDecodeScoreMetadata:
+    """Per-forward metadata for packed TP decode scoring."""
+
+    block_table: torch.Tensor
+    cu_seqlens_q: torch.Tensor
+    seq_lens: torch.Tensor
+    context_lens: torch.Tensor
+    start_loc: torch.Tensor
+    block_offset: int
+    block_count: int
+    decode_query_len: int
+
+
 def _as_ascendc_index_kv_cache(
-    index_kv_cache: tuple[torch.Tensor],
+    index_kv_cache: torch.Tensor,
 ) -> torch.Tensor:
     """Convert the runtime index K cache to the AscendC BBND layout.
 
-    The model runner binds this K-only cache as a one-element tuple containing
-    a tensor shaped ``[num_blocks, 128, head_dim]``.  MsaIndexScore expects the
-    BBND shape ``[num_blocks, 128, 1, head_dim]`` instead.
+    The model runner binds this K-only cache as a tensor shaped
+    ``[num_blocks, 128, head_dim]``. MsaIndexScore expects the BBND shape
+    ``[num_blocks, 128, 1, head_dim]`` instead.
     """
-    if not isinstance(index_kv_cache, tuple) or len(index_kv_cache) != 1:
-        raise ValueError("M3 index cache must be a one-tensor tuple containing K")
-    (index_key_cache,) = index_kv_cache
-    if index_key_cache.ndim != 3 or index_key_cache.shape[1] != _MSA_INDEX_BLOCK_SIZE:
+    if index_kv_cache.ndim != 3 or index_kv_cache.shape[1] != _MSA_INDEX_BLOCK_SIZE:
         raise ValueError(
             "M3 index K cache must have shape "
-            f"[num_blocks, {_MSA_INDEX_BLOCK_SIZE}, head_dim], got {tuple(index_key_cache.shape)}"
+            f"[num_blocks, {_MSA_INDEX_BLOCK_SIZE}, head_dim], got {tuple(index_kv_cache.shape)}"
         )
-    return index_key_cache.unsqueeze(2)
+    return index_kv_cache.unsqueeze(2)
 
 
 def _split_main_kv_cache(
@@ -136,7 +149,7 @@ def _build_cu_block_lens(
 @torch.no_grad()
 def _minimax_m3_index_score(
     idx_q: torch.Tensor,
-    index_kv_cache: tuple[torch.Tensor],
+    index_kv_cache: torch.Tensor,
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -174,7 +187,7 @@ def _minimax_m3_index_score(
 @torch.no_grad()
 def minimax_m3_index_prefill(
     idx_q: torch.Tensor,
-    index_kv_cache: tuple[torch.Tensor],
+    index_kv_cache: torch.Tensor,
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -231,23 +244,24 @@ def _index_score_topk_candidates(
         rounding_mode="floor",
     ).clamp(min=0, max=block_count)
 
+    global_valid_block_count = torch.div(
+        visible_tokens + block_offset * _MSA_INDEX_BLOCK_SIZE + _MSA_INDEX_BLOCK_SIZE - 1,
+        _MSA_INDEX_BLOCK_SIZE,
+        rounding_mode="floor",
+    ).clamp(min=0)
+    local_block_ids = torch.arange(block_count, device=score.device)
+    global_block_ids = local_block_ids + block_offset
+    valid_blocks = global_block_ids[None, :] < global_valid_block_count[:, None]
+    # A dense raw-score TP chunk can contain whole future speculative blocks
+    # for a shorter request. Remove them before TopK so they cannot displace a
+    # valid candidate and only then be discarded by output validation.
+    score = torch.where(valid_blocks[None, :, :], score, float("-inf"))
+
     if init_blocks > 0 or local_blocks > 0:
-        # start_loc is one value per request, so the AscendC local mask cannot
-        # move when speculative tokens cross a block boundary.  Apply the
-        # forced-block scores here per token, before the one and only TopK.
-        global_valid_block_count = torch.div(
-            visible_tokens + block_offset * _MSA_INDEX_BLOCK_SIZE + _MSA_INDEX_BLOCK_SIZE - 1,
-            _MSA_INDEX_BLOCK_SIZE,
-            rounding_mode="floor",
-        ).clamp(min=0)
-        local_block_ids = torch.arange(block_count, device=score.device)
-        global_block_ids = local_block_ids + block_offset
-        valid_blocks = global_block_ids[None, :] < global_valid_block_count[:, None]
+        # Apply forced-block scores here per token, before the one and only
+        # TopK. This is shared by single-token and speculative decode.
         if init_blocks > 0:
-            # TP callers pass the number of initial blocks that overlap this
-            # local shard, matching the AscendC attribute's local-table
-            # semantics.
-            init_mask = valid_blocks & (local_block_ids[None, :] < init_blocks)
+            init_mask = valid_blocks & (global_block_ids[None, :] < init_blocks)
             score = torch.where(init_mask[None, :, :], 1.0e30, score)
         if local_blocks > 0:
             local_start = (global_valid_block_count - local_blocks).clamp(min=0)
@@ -296,7 +310,7 @@ def _index_score_topk_candidates(
 @torch.no_grad()
 def _minimax_m3_index_decode(
     idx_q: torch.Tensor,
-    index_kv_cache: tuple[torch.Tensor],
+    index_kv_cache: torch.Tensor,
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -309,12 +323,9 @@ def _minimax_m3_index_decode(
     local_blocks: int,
     decode_query_len: int,
     block_offset: int = 0,
+    block_count: int | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Run AscendC decode score followed by one non-fused local TopK."""
-    # AscendC start_loc is per request.  For q>1, disable its fixed local mask
-    # and apply the equivalent moving mask per speculative token below.
-    ascendc_init_blocks = init_blocks if decode_query_len == 1 else 0
-    ascendc_local_blocks = local_blocks if decode_query_len == 1 else 0
     score = _minimax_m3_index_score(
         idx_q,
         index_kv_cache,
@@ -323,17 +334,17 @@ def _minimax_m3_index_decode(
         seq_lens,
         start_loc,
         causal_mask,
-        init_blocks=ascendc_init_blocks,
-        local_blocks=ascendc_local_blocks,
     )
+    if block_count is None:
+        block_count = block_table.shape[-1]
     topk_indices, topk_scores = _index_score_topk_candidates(
-        score[..., : block_table.shape[-1]],
+        score[..., :block_count],
         context_lens,
         decode_query_len,
         topk,
         block_offset,
-        init_blocks=init_blocks if decode_query_len > 1 else 0,
-        local_blocks=local_blocks if decode_query_len > 1 else 0,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
     )
     return topk_indices, topk_scores
 
@@ -341,7 +352,7 @@ def _minimax_m3_index_decode(
 @torch.no_grad()
 def minimax_m3_index_decode(
     idx_q: torch.Tensor,
-    index_kv_cache: tuple[torch.Tensor],
+    index_kv_cache: torch.Tensor,
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -375,30 +386,19 @@ def minimax_m3_index_decode(
 @torch.no_grad()
 def minimax_m3_index_tp_block_parallel_decode(
     idx_q: torch.Tensor,
-    index_kv_cache: tuple[torch.Tensor],
-    block_table: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    seq_lens: torch.Tensor,
-    context_lens: torch.Tensor,
-    start_loc: torch.Tensor,
+    index_kv_cache: torch.Tensor,
+    metadata: MiniMaxM3TPDecodeScoreMetadata,
     causal_mask: torch.Tensor,
     *,
-    max_seq_len: int,
     topk: int,
     init_blocks: int,
     local_blocks: int,
-    decode_query_len: int,
     tp_group: Any,
 ) -> torch.Tensor:
-    """Run decode with KV blocks sharded across tensor-parallel ranks."""
+    """Run packed-query scoring and TopK over TP-sharded KV blocks."""
     full_idx_q = tp_group.all_gather(idx_q.contiguous(), dim=1)
-    tp_size = tp_group.world_size
     tp_rank = tp_group.rank_in_group
-
-    max_block_count = (max_seq_len + _MSA_INDEX_BLOCK_SIZE - 1) // _MSA_INDEX_BLOCK_SIZE
-    blocks_per_tp = (max_block_count + tp_size - 1) // tp_size
-    block_offset = tp_rank * blocks_per_tp
-    block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
+    block_count = metadata.block_count
     if block_count == 0:
         # MsaIndexScore requires a non-empty block-table width. Ranks without
         # logical blocks contribute neutral candidates to the collectives.
@@ -420,35 +420,21 @@ def minimax_m3_index_tp_block_parallel_decode(
             device=full_idx_q.device,
         )
     else:
-        local_block_table = block_table[:, block_offset : block_offset + block_count].contiguous()
-        local_seq_lens = torch.clamp(
-            seq_lens - block_offset * _MSA_INDEX_BLOCK_SIZE,
-            min=0,
-            max=block_count * _MSA_INDEX_BLOCK_SIZE,
-        )
-        local_context_lens = context_lens - block_offset * _MSA_INDEX_BLOCK_SIZE
-        local_start_loc = start_loc - block_offset
-        local_init_blocks = max(
-            0,
-            min(init_blocks - block_offset, block_count),
-        )
-        local_local_blocks = min(local_blocks, block_count)
-        is_last_chunk = block_offset + block_count == max_block_count
-        local_causal_mask = causal_mask if is_last_chunk else None
         local_topk, local_scores = _minimax_m3_index_decode(
             full_idx_q,
             index_kv_cache,
-            local_block_table,
-            cu_seqlens_q,
-            local_seq_lens,
-            local_context_lens,
-            local_start_loc,
-            local_causal_mask,
+            metadata.block_table,
+            metadata.cu_seqlens_q,
+            metadata.seq_lens,
+            metadata.context_lens,
+            metadata.start_loc,
+            None if metadata.decode_query_len == 1 else causal_mask,
             topk=topk,
-            init_blocks=local_init_blocks,
-            local_blocks=local_local_blocks,
-            decode_query_len=decode_query_len,
-            block_offset=block_offset,
+            init_blocks=init_blocks,
+            local_blocks=local_blocks,
+            decode_query_len=metadata.decode_query_len,
+            block_offset=metadata.block_offset,
+            block_count=block_count,
         )
 
     gathered_scores = tp_group.all_gather(local_scores.contiguous(), dim=-1)

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -85,14 +85,19 @@ class MiniMaxM3TPDecodeScoreMetadata:
 
 
 def _as_ascendc_index_kv_cache(
-    index_kv_cache: torch.Tensor,
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor],
 ) -> torch.Tensor:
     """Convert the runtime index K cache to the AscendC BBND layout.
 
-    The model runner binds this K-only cache as a tensor shaped
-    ``[num_blocks, 128, head_dim]``. MsaIndexScore expects the BBND shape
+    The model runner binds this K-only cache as a one-element tuple whose
+    tensor is shaped ``[num_blocks, 128, head_dim]``. Direct calls may pass
+    that tensor without the tuple. MsaIndexScore expects the BBND shape
     ``[num_blocks, 128, 1, head_dim]`` instead.
     """
+    if isinstance(index_kv_cache, tuple):
+        if len(index_kv_cache) != 1:
+            raise ValueError("M3 index cache tuple must contain only the K tensor")
+        (index_kv_cache,) = index_kv_cache
     if index_kv_cache.ndim != 3 or index_kv_cache.shape[1] != _MSA_INDEX_BLOCK_SIZE:
         raise ValueError(
             "M3 index K cache must have shape "
@@ -149,7 +154,7 @@ def _build_cu_block_lens(
 @torch.no_grad()
 def _minimax_m3_index_score(
     idx_q: torch.Tensor,
-    index_kv_cache: torch.Tensor,
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -187,7 +192,7 @@ def _minimax_m3_index_score(
 @torch.no_grad()
 def minimax_m3_index_prefill(
     idx_q: torch.Tensor,
-    index_kv_cache: torch.Tensor,
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -310,7 +315,7 @@ def _index_score_topk_candidates(
 @torch.no_grad()
 def _minimax_m3_index_decode(
     idx_q: torch.Tensor,
-    index_kv_cache: torch.Tensor,
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -352,7 +357,7 @@ def _minimax_m3_index_decode(
 @torch.no_grad()
 def minimax_m3_index_decode(
     idx_q: torch.Tensor,
-    index_kv_cache: torch.Tensor,
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -386,7 +391,7 @@ def minimax_m3_index_decode(
 @torch.no_grad()
 def minimax_m3_index_tp_block_parallel_decode(
     idx_q: torch.Tensor,
-    index_kv_cache: torch.Tensor,
+    index_kv_cache: torch.Tensor | tuple[torch.Tensor],
     metadata: MiniMaxM3TPDecodeScoreMetadata,
     causal_mask: torch.Tensor,
     *,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -16,6 +16,7 @@ from vllm_ascend.utils import (
 
 _SPARSE_ATTN_INNER_PRECISE = 4
 _MSA_INDEX_BLOCK_SIZE = 128
+_MSA_SCORE_BLOCK_ALIGNMENT = 16
 _ASCEND_DEVICE_TYPE = get_ascend_device_type()
 
 if _ASCEND_DEVICE_TYPE != AscendDeviceType.A5:
@@ -194,6 +195,7 @@ def minimax_m3_index_prefill(
     causal_mask: torch.Tensor,
     *,
     max_query_len: int,
+    max_seq_len: int,
     topk: int,
     init_blocks: int,
     local_blocks: int,
@@ -210,6 +212,13 @@ def minimax_m3_index_prefill(
         init_blocks=init_blocks,
         local_blocks=local_blocks,
     )
+    logical_block_count = (
+        max_seq_len + _MSA_INDEX_BLOCK_SIZE - 1
+    ) // _MSA_INDEX_BLOCK_SIZE
+    logical_score_width = (
+        logical_block_count + _MSA_SCORE_BLOCK_ALIGNMENT - 1
+    ) // _MSA_SCORE_BLOCK_ALIGNMENT * _MSA_SCORE_BLOCK_ALIGNMENT
+    score = score[..., :logical_score_width]
     return _minimax_m3_index_prefill_topk(
         score,
         cu_seqlens_q,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -72,13 +72,13 @@ def _npu_k2q_csr(
 
 @dataclass
 class MiniMaxM3TPDecodeScoreMetadata:
-    """Per-forward metadata for packed TP decode scoring."""
+    """Graph-stable inputs for packed TP decode scoring."""
 
     block_table: torch.Tensor
     cu_seqlens_q: torch.Tensor
-    seq_lens: torch.Tensor
     context_lens: torch.Tensor
-    start_loc: torch.Tensor
+    max_block_count: int
+    block_size: int
     block_offset: int
     block_count: int
     decode_query_len: int
@@ -165,6 +165,8 @@ def _minimax_m3_index_score(
 
     A causal mask selects sparse mode 3. Passing no mask selects dense mode 0
     for a TP chunk that is entirely before the current query positions.
+    ``init_blocks`` and ``local_blocks`` are kept for parity with the index
+    scoring interface; candidate forcing is applied by the TopK stage.
     """
     index_kv_cache = _as_ascendc_index_kv_cache(index_kv_cache)
     return torch.ops._C_ascend.npu_msa_index_score(
@@ -177,8 +179,6 @@ def _minimax_m3_index_score(
         actual_seq_klen=seq_lens,
         layout_key="BBND",
         sparse_mode=3 if causal_mask is not None else 0,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
     )
 
 
@@ -207,6 +207,8 @@ def minimax_m3_index_prefill(
         seq_lens,
         start_loc,
         causal_mask,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
     )
     return _minimax_m3_index_prefill_topk(
         score,
@@ -325,6 +327,8 @@ def _minimax_m3_index_decode(
         seq_lens,
         start_loc,
         causal_mask,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
     )
     if block_count is None:
         block_count = block_table.shape[-1]
@@ -386,8 +390,9 @@ def minimax_m3_index_tp_block_parallel_decode(
     tp_group: Any,
 ) -> torch.Tensor:
     """Run packed-query scoring and TopK over TP-sharded KV blocks."""
-    full_idx_q = tp_group.all_gather(idx_q.contiguous(), dim=1)
+    full_idx_q = tp_group.all_gather(idx_q.contiguous(), dim=1).contiguous()
     tp_rank = tp_group.rank_in_group
+    block_offset = metadata.block_offset
     block_count = metadata.block_count
     if block_count == 0:
         # MsaIndexScore requires a non-empty block-table width. Ranks without
@@ -410,20 +415,53 @@ def minimax_m3_index_tp_block_parallel_decode(
             device=full_idx_q.device,
         )
     else:
+        # Keep all derived tensors in the model forward. FULL_DECODE_ONLY
+        # captures and replays this work, whereas tensors allocated by the
+        # metadata builder would leave the graph holding stale device pointers.
+        halo_blocks = (metadata.decode_query_len - 1 + metadata.block_size - 1) // metadata.block_size
+        score_block_end = min(
+            block_offset + block_count + halo_blocks,
+            metadata.max_block_count,
+        )
+        score_block_table = metadata.block_table[:, block_offset:score_block_end].contiguous()
+        local_context_lens = metadata.context_lens - block_offset * metadata.block_size
+        chunk_capacity = block_count * metadata.block_size
+        score_capacity = score_block_table.shape[-1] * metadata.block_size
+        max_score_k_len = min(
+            chunk_capacity + metadata.decode_query_len - 1,
+            score_capacity,
+        )
+        score_k_lens = torch.clamp(
+            metadata.context_lens + metadata.decode_query_len - block_offset * metadata.block_size,
+            min=0,
+            max=max_score_k_len,
+        )
+        score_start_loc = (
+            torch.div(
+                metadata.context_lens,
+                metadata.block_size,
+                rounding_mode="floor",
+            )
+            .sub(block_offset)
+            .clamp(
+                min=0,
+                max=score_block_table.shape[-1] - 1,
+            )
+        )
         local_topk, local_scores = _minimax_m3_index_decode(
             full_idx_q,
             index_kv_cache,
-            metadata.block_table,
+            score_block_table,
             metadata.cu_seqlens_q,
-            metadata.seq_lens,
-            metadata.context_lens,
-            metadata.start_loc,
+            score_k_lens,
+            local_context_lens,
+            score_start_loc,
             None if metadata.decode_query_len == 1 else causal_mask,
             topk=topk,
             init_blocks=init_blocks,
             local_blocks=local_blocks,
             decode_query_len=metadata.decode_query_len,
-            block_offset=metadata.block_offset,
+            block_offset=block_offset,
             block_count=block_count,
         )
 

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 
 from vllm_ascend.attention.attention_mask import AttentionMaskBuilder
@@ -10,6 +12,9 @@ from vllm_ascend.utils import (
     AscendDeviceType,
     enable_custom_op,
     get_ascend_device_type,
+)
+from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
+    minimax_m3_index_topk as _minimax_m3_index_prefill_topk,
 )
 
 _SPARSE_ATTN_INNER_PRECISE = 4
@@ -129,46 +134,28 @@ def _build_cu_block_lens(
 
 
 @torch.no_grad()
-def minimax_m3_index_score(
+def _minimax_m3_index_score(
     idx_q: torch.Tensor,
     index_kv_cache: tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
-    prefix_lens: torch.Tensor,
-    max_query_len: int,
-    max_seq_len: int,
-    num_kv_heads: int,
-    sm_scale: float | None = None,
+    start_loc: torch.Tensor,
+    causal_mask: torch.Tensor | None,
     *,
-    start_loc: torch.Tensor | None = None,
     init_blocks: int = 0,
     local_blocks: int = 0,
 ) -> torch.Tensor:
-    """Compute causal MSA index scores with the bundled AscendC operator.
+    """Compute MSA index scores with the bundled AscendC operator.
 
     ``start_loc`` is the current query block in the *passed block table*.  For
     a TP-sharded table this is a per-request local block index, not the scalar
     global ``block_offset`` used by the Triton decode kernel.
-    """
-    del max_query_len, max_seq_len, sm_scale
-    if idx_q.ndim != 3:
-        raise ValueError(f"Unexpected index query shape: {tuple(idx_q.shape)}")
-    index_kv_cache = _as_ascendc_index_kv_cache(index_kv_cache)
-    if idx_q.shape[1] != num_kv_heads:
-        raise ValueError("M3 requires num_idx_heads == num_kv_heads")
 
-    if start_loc is None:
-        start_loc = torch.div(
-            prefix_lens,
-            _MSA_INDEX_BLOCK_SIZE,
-            rounding_mode="floor",
-        ).to(dtype=torch.int32)
-    elif start_loc.ndim != 1 or start_loc.shape != prefix_lens.shape:
-        raise ValueError("start_loc must be a 1D tensor matching prefix_lens")
-    else:
-        start_loc = start_loc.to(dtype=torch.int32)
-    causal_mask = AttentionMaskBuilder(idx_q.device).get_splitfuse_attn_mask()
+    A causal mask selects sparse mode 3. Passing no mask selects dense mode 0
+    for a TP chunk that is entirely before the current query positions.
+    """
+    index_kv_cache = _as_ascendc_index_kv_cache(index_kv_cache)
     return torch.ops._C_ascend.npu_msa_index_score(
         idx_q,
         index_kv_cache,
@@ -178,9 +165,46 @@ def minimax_m3_index_score(
         actual_seq_qlen=cu_seqlens_q,
         actual_seq_klen=seq_lens,
         layout_key="BBND",
-        sparse_mode=3,
+        sparse_mode=3 if causal_mask is not None else 0,
         init_blocks=init_blocks,
         local_blocks=local_blocks,
+    )
+
+
+@torch.no_grad()
+def minimax_m3_index_prefill(
+    idx_q: torch.Tensor,
+    index_kv_cache: tuple[torch.Tensor],
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seq_lens: torch.Tensor,
+    context_lens: torch.Tensor,
+    start_loc: torch.Tensor,
+    causal_mask: torch.Tensor,
+    *,
+    max_query_len: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+) -> torch.Tensor:
+    """Compute AscendC prefill scores and finalize their block TopK."""
+    score = _minimax_m3_index_score(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        start_loc,
+        causal_mask,
+    )
+    return _minimax_m3_index_prefill_topk(
+        score,
+        cu_seqlens_q,
+        context_lens,
+        max_query_len,
+        topk,
+        init_blocks,
+        local_blocks,
     )
 
 
@@ -270,42 +294,35 @@ def _index_score_topk_candidates(
 
 
 @torch.no_grad()
-def minimax_m3_index_decode(
+def _minimax_m3_index_decode(
     idx_q: torch.Tensor,
     index_kv_cache: tuple[torch.Tensor],
     block_table: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
     seq_lens: torch.Tensor,
     context_lens: torch.Tensor,
-    max_seq_len: int,
+    start_loc: torch.Tensor,
+    causal_mask: torch.Tensor | None,
+    *,
     topk: int,
     init_blocks: int,
     local_blocks: int,
-    num_kv_heads: int,
     decode_query_len: int,
-    sm_scale: float | None = None,
-    *,
-    start_loc: torch.Tensor | None = None,
     block_offset: int = 0,
-    return_scores: bool = False,
-) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Run AscendC decode score followed by one non-fused local TopK."""
     # AscendC start_loc is per request.  For q>1, disable its fixed local mask
     # and apply the equivalent moving mask per speculative token below.
     ascendc_init_blocks = init_blocks if decode_query_len == 1 else 0
     ascendc_local_blocks = local_blocks if decode_query_len == 1 else 0
-    score = minimax_m3_index_score(
+    score = _minimax_m3_index_score(
         idx_q,
         index_kv_cache,
         block_table,
         cu_seqlens_q,
         seq_lens,
-        context_lens,
-        decode_query_len,
-        max_seq_len,
-        num_kv_heads,
-        sm_scale,
-        start_loc=start_loc,
+        start_loc,
+        causal_mask,
         init_blocks=ascendc_init_blocks,
         local_blocks=ascendc_local_blocks,
     )
@@ -318,9 +335,135 @@ def minimax_m3_index_decode(
         init_blocks=init_blocks if decode_query_len > 1 else 0,
         local_blocks=local_blocks if decode_query_len > 1 else 0,
     )
-    if return_scores:
-        return topk_indices, topk_scores
+    return topk_indices, topk_scores
+
+
+@torch.no_grad()
+def minimax_m3_index_decode(
+    idx_q: torch.Tensor,
+    index_kv_cache: tuple[torch.Tensor],
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seq_lens: torch.Tensor,
+    context_lens: torch.Tensor,
+    start_loc: torch.Tensor,
+    causal_mask: torch.Tensor,
+    *,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    decode_query_len: int,
+) -> torch.Tensor:
+    """Compute AscendC decode scores and return their block TopK."""
+    topk_indices, _ = _minimax_m3_index_decode(
+        idx_q,
+        index_kv_cache,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        context_lens,
+        start_loc,
+        causal_mask,
+        topk=topk,
+        init_blocks=init_blocks,
+        local_blocks=local_blocks,
+        decode_query_len=decode_query_len,
+    )
     return topk_indices
+
+
+@torch.no_grad()
+def minimax_m3_index_tp_block_parallel_decode(
+    idx_q: torch.Tensor,
+    index_kv_cache: tuple[torch.Tensor],
+    block_table: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    seq_lens: torch.Tensor,
+    context_lens: torch.Tensor,
+    start_loc: torch.Tensor,
+    causal_mask: torch.Tensor,
+    *,
+    max_seq_len: int,
+    topk: int,
+    init_blocks: int,
+    local_blocks: int,
+    decode_query_len: int,
+    tp_group: Any,
+) -> torch.Tensor:
+    """Run decode with KV blocks sharded across tensor-parallel ranks."""
+    full_idx_q = tp_group.all_gather(idx_q.contiguous(), dim=1)
+    tp_size = tp_group.world_size
+    tp_rank = tp_group.rank_in_group
+
+    max_block_count = (max_seq_len + _MSA_INDEX_BLOCK_SIZE - 1) // _MSA_INDEX_BLOCK_SIZE
+    blocks_per_tp = (max_block_count + tp_size - 1) // tp_size
+    block_offset = tp_rank * blocks_per_tp
+    block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
+    if block_count == 0:
+        # MsaIndexScore requires a non-empty block-table width. Ranks without
+        # logical blocks contribute neutral candidates to the collectives.
+        candidate_shape = (
+            full_idx_q.shape[1],
+            full_idx_q.shape[0],
+            topk,
+        )
+        local_topk = torch.full(
+            candidate_shape,
+            -1,
+            dtype=torch.int32,
+            device=full_idx_q.device,
+        )
+        local_scores = torch.full(
+            candidate_shape,
+            float("-inf"),
+            dtype=torch.float32,
+            device=full_idx_q.device,
+        )
+    else:
+        local_block_table = block_table[:, block_offset : block_offset + block_count].contiguous()
+        local_seq_lens = torch.clamp(
+            seq_lens - block_offset * _MSA_INDEX_BLOCK_SIZE,
+            min=0,
+            max=block_count * _MSA_INDEX_BLOCK_SIZE,
+        )
+        local_context_lens = context_lens - block_offset * _MSA_INDEX_BLOCK_SIZE
+        local_start_loc = start_loc - block_offset
+        local_init_blocks = max(
+            0,
+            min(init_blocks - block_offset, block_count),
+        )
+        local_local_blocks = min(local_blocks, block_count)
+        is_last_chunk = block_offset + block_count == max_block_count
+        local_causal_mask = causal_mask if is_last_chunk else None
+        local_topk, local_scores = _minimax_m3_index_decode(
+            full_idx_q,
+            index_kv_cache,
+            local_block_table,
+            cu_seqlens_q,
+            local_seq_lens,
+            local_context_lens,
+            local_start_loc,
+            local_causal_mask,
+            topk=topk,
+            init_blocks=local_init_blocks,
+            local_blocks=local_local_blocks,
+            decode_query_len=decode_query_len,
+            block_offset=block_offset,
+        )
+
+    gathered_scores = tp_group.all_gather(local_scores.contiguous(), dim=-1)
+    gathered_topk = tp_group.all_gather(local_topk.contiguous(), dim=-1)
+
+    local_head_count = idx_q.shape[1]
+    local_head_start = tp_rank * local_head_count
+    local_gathered_scores = gathered_scores.narrow(0, local_head_start, local_head_count)
+    _, merged_pos = torch.topk(
+        local_gathered_scores,
+        k=topk,
+        dim=-1,
+    )
+    local_gathered_topk = gathered_topk.narrow(0, local_head_start, local_head_count)
+    return torch.gather(local_gathered_topk, dim=-1, index=merged_pos)
 
 
 @torch.no_grad()

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -77,8 +77,10 @@ class MiniMaxM3TPDecodeScoreMetadata:
     block_table: torch.Tensor
     cu_seqlens_q: torch.Tensor
     context_lens: torch.Tensor
-    max_seq_len: int
+    max_block_count: int
     block_size: int
+    block_offset: int
+    block_count: int
     decode_query_len: int
 
 
@@ -389,13 +391,9 @@ def minimax_m3_index_tp_block_parallel_decode(
 ) -> torch.Tensor:
     """Run packed-query scoring and TopK over TP-sharded KV blocks."""
     full_idx_q = tp_group.all_gather(idx_q.contiguous(), dim=1).contiguous()
-    tp_size = tp_group.world_size
     tp_rank = tp_group.rank_in_group
-
-    max_block_count = (metadata.max_seq_len + metadata.block_size - 1) // metadata.block_size
-    blocks_per_tp = (max_block_count + tp_size - 1) // tp_size
-    block_offset = tp_rank * blocks_per_tp
-    block_count = max(0, min(blocks_per_tp, max_block_count - block_offset))
+    block_offset = metadata.block_offset
+    block_count = metadata.block_count
     if block_count == 0:
         # MsaIndexScore requires a non-empty block-table width. Ranks without
         # logical blocks contribute neutral candidates to the collectives.
@@ -423,7 +421,7 @@ def minimax_m3_index_tp_block_parallel_decode(
         halo_blocks = (metadata.decode_query_len - 1 + metadata.block_size - 1) // metadata.block_size
         score_block_end = min(
             block_offset + block_count + halo_blocks,
-            max_block_count,
+            metadata.max_block_count,
         )
         score_block_table = metadata.block_table[:, block_offset:score_block_end].contiguous()
         local_context_lens = metadata.context_lens - block_offset * metadata.block_size


### PR DESCRIPTION
### What this PR does / why we need it?
- AscendC Operator Integration: Integrated the bundled MsaIndexScore custom operator for MiniMax-M3, routing prefill, decode, and speculative decode paths through AscendC.
- Speculative Decode Support: Enabled speculative decoding by handling per-token visibility and applying local masks dynamically, while preserving tensor-parallel decode sharding.
- TopK Logic: Maintained TopK operations in Python to allow for flexible handling of speculative candidates while offloading the heavy score computation to the optimized AscendC kernel.

### Does this PR introduce _any_ user-facing change?
NA

### How was this patch tested?
- Precision：GPQA achieves 93.xx
- Performance：Prefill and decode performance improved by 8% and 20% respectively under a 64k input / 1k output workload.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
