### PR TITLE
[bugfix][v0.26.0]Fix weight loading for modelslim FAQuant model

### DIFF
--- a/vllm_ascend/patch/worker/patch_deepseek_mtp.py
+++ b/vllm_ascend/patch/worker/patch_deepseek_mtp.py
@@ -66,6 +66,12 @@ class AscendDeepSeekMTP(DeepSeekMTP):
         else:
             return f"model.layers.{spec_layer}.rot.weight"
 
+    def load_weights(self, weights):
+        # Fix Deepseek MTP layer FAQuant weight loading issue, upstream DeepseekMTP not using AutoWeightsLoader.
+        if self.quant_config is not None and (cache_scale_mapper := self.quant_config.get_cache_scale_mapper()):
+            weights = cache_scale_mapper.apply(weights)
+        return super().load_weights(weights)
+
 
 class AscendGlmMoeDsaForCausalLM(GlmMoeDsaForCausalLM):
     def load_weights(self, weights):

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -586,6 +586,7 @@ class AscendModelSlimConfig(QuantizationConfig):
     def get_cache_scale_mapper(self) -> "WeightsMapper":
         """Upstream use staticmethod, but we need to use instance attribute"""
         suffix_map = {}
+        regex_map = {}
         if self.enable_c8_quant:
             suffix_map.update(
                 {
@@ -596,26 +597,28 @@ class AscendModelSlimConfig(QuantizationConfig):
                 }
             )
         if self.enable_fa_quant:
-            suffix_map.update(
+            # Some models (e.g., Kimi-K2.6) have a nested module and call AutoWeightsLoader twice, to avoid double
+            # mapping, we use regex mapping.
+            regex_map.update(
                 {
-                    ".fa_q.scale": ".mla_attn.mla_attn.fa_q.scale",
-                    ".fa_k.scale": ".mla_attn.mla_attn.fa_k.scale",
-                    ".fa_v.scale": ".mla_attn.mla_attn.fa_v.scale",
-                    ".fa_q.offset": ".mla_attn.mla_attn.fa_q.offset",
-                    ".fa_k.offset": ".mla_attn.mla_attn.fa_k.offset",
-                    ".fa_v.offset": ".mla_attn.mla_attn.fa_v.offset",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.fa_q\.scale$"): ".mla_attn.mla_attn.fa_q.scale",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.fa_k\.scale$"): ".mla_attn.mla_attn.fa_k.scale",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.fa_v\.scale$"): ".mla_attn.mla_attn.fa_v.scale",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.fa_q\.offset$"): ".mla_attn.mla_attn.fa_q.offset",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.fa_k\.offset$"): ".mla_attn.mla_attn.fa_k.offset",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.fa_v\.offset$"): ".mla_attn.mla_attn.fa_v.offset",
                 }
             )
         if self.enable_indexer_quant:
-            suffix_map.update(
+            regex_map.update(
                 {
-                    ".indexer.q_rot": ".mla_attn.mla_attn.indexer.q_rot",
-                    ".indexer.k_rot": ".mla_attn.mla_attn.indexer.k_rot",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.indexer\.q_rot$"): ".mla_attn.mla_attn.indexer.q_rot",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.indexer\.k_rot$"): ".mla_attn.mla_attn.indexer.k_rot",
                 }
             )
-        if not suffix_map:
+        if not suffix_map and not regex_map:
             return QuantizationConfig.get_cache_scale_mapper()
-        cache_scale_mapper = WeightsMapper(orig_to_new_suffix=suffix_map)
+        cache_scale_mapper = WeightsMapper(orig_to_new_suffix=suffix_map, orig_to_new_regex=regex_map)
         return cache_scale_mapper | QuantizationConfig.get_cache_scale_mapper()
 
     def _has_quant_weight(self, prefix: str, packed_modules_mapping: Mapping[str, list[str]]) -> bool:


### PR DESCRIPTION

### What this PR does / why we need it?

Fix weight loading for some modelslim FAQuant model.
There are two issues about it.
- For `DeepSeek-V3.1-W8A8C8` which has a `FAQuant` MTP layer, there is KeyError: 'model.layers.61.mtp_block.self_attn.fa_k.offset'. Because the upstream vllm `DeepSeekMTP` not using the `AutoWeightLoader`, we patch `DeepseekMTP` to fix it. Related main branch PR: #13684 , and for main branch, this patch has already been deleted in #10896, and vllm-ascend will keep the `deepseek_mtp` modeling file.
- For `Kimi-K2.6-W4A4C8` which has `FAQuant`, there is KeyError: 'layers.0.self_attn.mla_attn.mla_attn.mla_attn.mla_attn.fa_k.offset'
. `KimiK25ForConditionalGeneration.load_weights` will call `AutoWeightsLoader` and the inner `language_model` (actually `DeepseekV2ForCausalLM`) will also call `AutoWeightsLoader`, our suffix mapper will run twice, and make a wrong key `'layers.0.self_attn.mla_attn.mla_attn.mla_attn.mla_attn.fa_k.offset'` instead of `'layers.0.self_attn.mla_attn.mla_attn.fa_k.offset'`. We use a regex mapper to avoid this situation.



### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

Test on  DeepSeek-V3.1-W8A8C8 and Kimi-K2.6-W4A4C8

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
