### PR TITLE
[BugFix][Mamba] Derive attention block size from K+V page to fix mamba slot padding

### DIFF
--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -88,12 +88,15 @@ def verify_and_update_config(cls, vllm_config) -> None:
     else:
         attn_num_kv_heads = model_config.get_num_kv_heads(parallel_config)
         attn_head_size = model_config.get_head_size()
-        attn_single_token_k_page_size = attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
         attn_token_page_size = 2 * attn_head_size * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
 
-    attn_block_size = kernel_block_size * cdiv(ssm_block_page_size, kernel_block_size * attn_single_token_k_page_size)
-    assert attn_single_token_k_page_size * attn_block_size == ssm_block_page_size, (
-        "Cannot align ssm_page_size and attn_page_size."
+    # Derive from the K+V page size, the same base the downstream padding
+    # uses. Deriving from the K-only page size doubles the attention page
+    # and pads the mamba slot to ~2x what it actually needs.
+    attn_block_size = kernel_block_size * cdiv(ssm_block_page_size, kernel_block_size * attn_token_page_size)
+    assert attn_token_page_size * attn_block_size == ssm_block_page_size, (
+        f"Cannot align ssm_page_size and attn_page_size. ssm={ssm_block_page_size} "
+        f"k_and_v_page={attn_token_page_size} block={attn_block_size}"
     )
 
     # override attention block size if either (a) the


### PR DESCRIPTION
### What this PR does / why we need it?

The attention block size is derived from the K-only page size (`attn_single_token_k_page_size`) while the downstream 
padding uses the K+V page size (`attn_token_page_size`) — the two sides are inconsistent.

Historical context: the K-only derivation was deliberately introduced in #6887, where K and SSM shared one contiguous 
tensor (`[k, ssm]`), so aligning the K page with the SSM block was the right constraint for that layout. The three-tensor 
layout has since been superseded by the unified `page_size_padded` mechanism (the attention page is padded up to 
the mamba padded page), so the K-only derivation no longer matches the layout it was designed for. 

Note that the 310P path (`patch_mamba_config_310.py`) already derives from the K+V page via `FullAttentionSpec`.

For hybrid models (e.g. Qwen3.5-35B-A3B) the inconsistency:

- doubles the block size (2048 vs 1024), coarsening the prefix cache reuse granularity
- pads the mamba slot to ~2x what it actually needs, wasting KV cache

This PR derives the attention block size from the K+V page size, making the padding exactly ssm+conv (zero waste) with no precision impact.

### Does this PR introduce _any_ user-facing change?

No API or interface changes. The derived block size for hybrid models changes (2048 -> 1024 for Qwen3.5-35B-A3B), improving KV cache efficiency.

### How was this patch tested?

Verified on Ascend NPU with Qwen3.5-35B-A3B (bf16 / MXFP8, single NPU):

- block size 2048 -> 1024; `mamba_page_size_padded` 4,243,456 -> 2,146,304 (zero waste)
- KV cache capacity +7.3%
- prefix cache hit rates match the expected values for all input shapes


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
