### PR TITLE
[Ops][Bugfix] Fix triton stub on x86 machines

### DIFF
--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -21,12 +21,31 @@ from types import ModuleType
 
 _triton_available = importlib.util.find_spec("triton") is not None
 
-for _gluon_stub in (
-    "triton.experimental.gluon",
-    "triton.experimental.gluon.language",
-):
-    if _gluon_stub not in sys.modules:
-        sys.modules[_gluon_stub] = ModuleType(_gluon_stub)
+# main2main compatibility: stub triton.experimental.gluon modules that
+# vllm main requires but triton-ascend 3.2.x does not provide. Runs at
+# module-import time (vllm.platforms plugin discovery resolves the
+# plugin's `register()` before any `from triton.experimental import gluon`
+# import, including in `python -m vllm.model_executor.models.registry`).
+# Only stub when gluon is genuinely absent; on aarch64 triton-ascend's
+# triton==3.5.0 dep leaves a real experimental/ on disk that we must not
+# shadow. find_spec must probe the parent `triton.experimental`, not the
+# leaf: a dotted name whose parent is missing raises ModuleNotFoundError
+# instead of returning None.
+if importlib.util.find_spec("triton.experimental") is None:
+    # `from triton.experimental import gluon` resolves the parent package
+    # before the leaf, so the parent must exist in sys.modules (with
+    # __path__ so it is treated as a package) or the import raises
+    # ModuleNotFoundError: No module named 'triton.experimental' (#13508).
+    if "triton.experimental" not in sys.modules:
+        _experimental = ModuleType("triton.experimental")
+        _experimental.__path__ = []
+        sys.modules["triton.experimental"] = _experimental
+    for _gluon_stub in (
+        "triton.experimental.gluon",
+        "triton.experimental.gluon.language",
+    ):
+        if _gluon_stub not in sys.modules:
+            sys.modules[_gluon_stub] = ModuleType(_gluon_stub)
 
 # main2main compat: `_aggregate` was added to triton.language.core in
 # vllm main post-0.26.0. Stub it here so vllm.triton_utils can import it

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -26,26 +26,29 @@ _triton_available = importlib.util.find_spec("triton") is not None
 # module-import time (vllm.platforms plugin discovery resolves the
 # plugin's `register()` before any `from triton.experimental import gluon`
 # import, including in `python -m vllm.model_executor.models.registry`).
-# Only stub when gluon is genuinely absent; on aarch64 triton-ascend's
-# triton==3.5.0 dep leaves a real experimental/ on disk that we must not
-# shadow. find_spec must probe the parent `triton.experimental`, not the
-# leaf: a dotted name whose parent is missing raises ModuleNotFoundError
-# instead of returning None.
-if importlib.util.find_spec("triton.experimental") is None:
-    # `from triton.experimental import gluon` resolves the parent package
-    # before the leaf, so the parent must exist in sys.modules (with
-    # __path__ so it is treated as a package) or the import raises
-    # ModuleNotFoundError: No module named 'triton.experimental' (#13508).
-    if "triton.experimental" not in sys.modules:
-        _experimental = ModuleType("triton.experimental")
-        _experimental.__path__ = []
-        sys.modules["triton.experimental"] = _experimental
-    for _gluon_stub in (
-        "triton.experimental.gluon",
-        "triton.experimental.gluon.language",
-    ):
-        if _gluon_stub not in sys.modules:
-            sys.modules[_gluon_stub] = ModuleType(_gluon_stub)
+#
+# The empty stubs must shadow gluon on BOTH architectures:
+# - x86_64: triton-ascend pins triton==3.2.0, which ships no `experimental/`
+#   at all; the parent package must exist in sys.modules (with __path__ so it
+#   is treated as a package) or `from triton.experimental import gluon` raises
+#   ModuleNotFoundError: No module named 'triton.experimental' (#13508).
+# - aarch64: triton-ascend pins triton==3.5.0, whose leftover `experimental/`
+#   ships a *real* gluon — but its `language/_layouts.py` imports
+#   `constexpr_type` from triton.language.core, a symbol added in triton 3.4.0
+#   that triton-ascend's 3.2.0-based core lacks. Loading the real gluon raises
+#   ImportError, so it must be shadowed, not used. Pre-registering the leaves
+#   in sys.modules short-circuits the disk load (importlib `_find_and_load`:
+#   `if name in sys.modules: return`) without executing the real __init__.py.
+if "triton.experimental" not in sys.modules:
+    _experimental = ModuleType("triton.experimental")
+    _experimental.__path__ = []
+    sys.modules["triton.experimental"] = _experimental
+for _gluon_stub in (
+    "triton.experimental.gluon",
+    "triton.experimental.gluon.language",
+):
+    if _gluon_stub not in sys.modules:
+        sys.modules[_gluon_stub] = ModuleType(_gluon_stub)
 
 # main2main compat: `_aggregate` was added to triton.language.core in
 # vllm main post-0.26.0. Stub it here so vllm.triton_utils can import it

--- a/vllm_ascend/__init__.py
+++ b/vllm_ascend/__init__.py
@@ -21,24 +21,6 @@ from types import ModuleType
 
 _triton_available = importlib.util.find_spec("triton") is not None
 
-# main2main compatibility: stub triton.experimental.gluon modules that
-# vllm main requires but triton-ascend 3.2.x does not provide. Runs at
-# module-import time (vllm.platforms plugin discovery resolves the
-# plugin's `register()` before any `from triton.experimental import gluon`
-# import, including in `python -m vllm.model_executor.models.registry`).
-#
-# The empty stubs must shadow gluon on BOTH architectures:
-# - x86_64: triton-ascend pins triton==3.2.0, which ships no `experimental/`
-#   at all; the parent package must exist in sys.modules (with __path__ so it
-#   is treated as a package) or `from triton.experimental import gluon` raises
-#   ModuleNotFoundError: No module named 'triton.experimental' (#13508).
-# - aarch64: triton-ascend pins triton==3.5.0, whose leftover `experimental/`
-#   ships a *real* gluon — but its `language/_layouts.py` imports
-#   `constexpr_type` from triton.language.core, a symbol added in triton 3.4.0
-#   that triton-ascend's 3.2.0-based core lacks. Loading the real gluon raises
-#   ImportError, so it must be shadowed, not used. Pre-registering the leaves
-#   in sys.modules short-circuits the disk load (importlib `_find_and_load`:
-#   `if name in sys.modules: return`) without executing the real __init__.py.
 if "triton.experimental" not in sys.modules:
     _experimental = ModuleType("triton.experimental")
     _experimental.__path__ = []


### PR DESCRIPTION
### What this PR does / why we need it?

vLLM `main` (post-`v0.26.0`, PR vllm-project/vllm#48841) imports Gluon unconditionally when `HAS_TRITON` is true:

```python
# vllm/triton_utils/__init__.py
if TYPE_CHECKING or HAS_TRITON:
    from triton.experimental import gluon
    from triton.experimental.gluon import language as gl
    from triton.language.core import _aggregate as aggregate
```

On Ascend, `triton-ascend==3.2.x` installs as the `triton` package, so `HAS_TRITON` is `True` and these imports execute. vLLM-Ascend already stubs the gluon symbols in `vllm_ascend/__init__.py`, but the stub only registers the two **leaf** modules and is incomplete in two distinct, architecture-specific ways:

```python
for _gluon_stub in ("triton.experimental.gluon", "triton.experimental.gluon.language"):
    if _gluon_stub not in sys.modules:
        sys.modules[_gluon_stub] = ModuleType(_gluon_stub)
```

`triton-ascend 3.2.x` declares architecture-dependent triton dependencies (`triton-ascend/python/setup.py`, `ARCHITECTURE_DEPENDENCIES`): `triton==3.2.0` on x86_64, `triton==3.5.0` on aarch64. This makes the same stub fail on **both** architectures, for different reasons:

- **x86_64 — `ModuleNotFoundError: No module named 'triton.experimental'` (#13508).** triton 3.2.0 ships no `experimental/` directory at all. `from triton.experimental import gluon` resolves the **parent package** `triton.experimental` before the leaf (CPython `importlib._bootstrap._find_and_load_unlocked`: `if name in sys.modules: return`, then `_find_spec(name, parent.__path__)`). With only the leaves pre-stubbed, the parent resolves to neither `sys.modules` nor disk and the import raises. The pre-stubbed leaves are never consulted.

- **aarch64 — `ImportError: cannot import name 'constexpr_type' from 'triton.language.core'`.** triton 3.5.0 *does* ship a real `experimental/gluon/` (left on disk because triton-ascend's `get_packages()` does not include `triton/experimental`, so installing triton-ascend does not overwrite the 3.5.0 leftovers). But that real gluon's `language/_layouts.py` imports `constexpr_type` from `triton.language.core` — a symbol added in **triton 3.4.0** — while triton-ascend's `triton.language.core` is based on 3.2.0 and lacks it. So loading the real gluon raises `ImportError`. The pre-existing leaf-only stub happened to mask this on aarch64 (the empty `triton.experimental.gluon` in `sys.modules` short-circuits the disk load via `if name in sys.modules: return`, so the real `__init__.py` never executes) — but only by accident, and the stub still lacks the parent package the x86 path needs.

**This PR** makes the stub register the **complete** parent→leaf hierarchy with empty modules, unconditionally on both architectures:

```python
if "triton.experimental" not in sys.modules:
    _experimental = ModuleType("triton.experimental")
    _experimental.__path__ = []          # treated as a package -> _handle_fromlist runs
    sys.modules["triton.experimental"] = _experimental
for _gluon_stub in ("triton.experimental.gluon", "triton.experimental.gluon.language"):
    if _gluon_stub not in sys.modules:
        sys.modules[_gluon_stub] = ModuleType(_gluon_stub)
```

- On **x86_64**, registering the parent `triton.experimental` (with `__path__ = []`) lets `from triton.experimental import gluon` short-circuit on `if name in sys.modules` and skip the disk lookup that fails — fixing #13508.
- On **aarch64**, the empty leaves shadow the real (broken-against-3.2.0-core) gluon: `if name in sys.modules: return` returns the empty module without executing the real `__init__.py`, so the `constexpr_type` import is never reached. The empty parent is harmless (the real parent's `__init__.py` is also short-circuited).

The empty stubs are correct because vLLM only *imports* the gluon symbols for re-export (`__all__`); no current code path invokes them, so an empty `ModuleType` is sufficient. (If a future triton-ascend baselines on a triton that ships a gluon compatible with its own core, this stub should be revisited — same as the existing `VLLM_VERSION != "0.26.0"` gate is revisited each release.)

The `_aggregate` stub below is left unchanged (its `if _triton_available` + `try/except` + `hasattr` guard is already sound).

- Fixes #13508

### Does this PR introduce _any_ user-facing change?

No API or behavior change for end users. On x86_64 Ascend, vLLM startup that previously crashed with `ModuleNotFoundError: No module named 'triton.experimental'` now proceeds past the Gluon import. On aarch64, behavior is unchanged from the pre-stub working state (startup already succeeded there because the leaf-only stub masked the incompatible real gluon); this PR only makes the stub hierarchy complete and explicit so the same code is correct on both architectures rather than relying on per-arch accident.

### How was this patch tested?

**1. Isolated matrix — 2 scenarios × 4 stub variants (no NPU required):**

Reproduces both architecture-specific failures and confirms the fix on both. Scenarios are built by laying out a synthetic `triton/` package on disk: x86_64 shape = no `experimental/` dir; aarch64 shape = real `experimental/gluon/` tree whose `_layouts.py` does `from triton.language.core import ... constexpr_type` against a `core.py` that lacks it (mirroring triton-ascend 3.2.x).

| stub variant | x86_64 (no experimental/) | aarch64 (real gluon, core lacks constexpr_type) |
|---|---|---|
| no stub (baseline) | FAIL `No module named 'triton.experimental'` | FAIL `cannot import name 'constexpr_type'` |
| leaf-only (original upstream stub) | FAIL `No module named 'triton.experimental'` | OK (masks real gluon by accident) |
| `find_spec`-skip (first attempt) | OK | **FAIL `cannot import name 'constexpr_type'`** ← aarch64 regression |
| **this PR (full parent+leaf hierarchy)** | **OK** | **OK** |

The `find_spec`-skip variant (skip the stub when `triton.experimental` exists) was the first attempt — it fixed x86_64 but **regressed aarch64** by no longer masking the real gluon, which then crashed on `constexpr_type`. That variant is explicitly rejected by this matrix. (This also corrects the suggestion in #13508 to "prefer the real gluon when present" — on triton-ascend 3.2.x the real gluon cannot load against the 3.2.0-based core, so it must be shadowed, not used.)

**2. Confirming the shadow mechanism on the aarch64 shape:**

```python
import sys
# ... apply this PR's stub ...
from triton.experimental import gluon
from triton.experimental.gluon import language as gl
assert "triton.experimental.gluon.nvidia" not in sys.modules   # real gluon __init__ never executed
```

The real gluon's submodule `triton.experimental.gluon.nvidia` is absent from `sys.modules`, proving the empty stub short-circuited the disk load rather than loading-then-failing.

**3. End-to-end on x86_64 A2 pod (DeepSeek-V4-Flash, TP=8):**

With this stub applied, `vllm serve` startup that previously ended at `vllm/triton_utils/__init__.py:15` (`from triton.experimental import gluon`) now proceeds past `vllm.triton_utils` into `vllm.config` / `vllm.engine.arg_utils`, and the model serves successfully. (A separate, pre-existing deployment pitfall — running `vllm serve` from a cwd containing a `vllm/` subdir, which shadows the installed package with `(unknown location)` — was also resolved by changing the launch directory; that is a usage issue, not part of this code change.)

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
