### PR TITLE
[BugFix][KV Offload] Restrict layerwise and sparse KV offload o Ascend A3

### DIFF
--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -99,6 +99,68 @@ class TestAscendConfig(TestBase):
         config._sparse_li_c8_layer_filter_enabled = AscendConfig._has_sparse_li_c8_layer_config(quant_config)
         return config
 
+    @staticmethod
+    def _make_kv_offload_device_validation_config(
+        kv_transfer_config=None,
+        *,
+        sparse_offload_enabled: bool = False,
+    ):
+        config = AscendConfig.__new__(AscendConfig)
+        config.vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
+        config.sparse_kv_offload_config = SimpleNamespace(enabled=sparse_offload_enabled)
+        return config
+
+    def test_rejects_prefill_kv_offload_on_a2(self):
+        multi_connector = KVTransferConfig(
+            kv_connector="MultiConnector",
+            kv_role="kv_producer",
+            kv_connector_extra_config={
+                "connectors": [
+                    {
+                        "kv_connector": "SfaRemoteD2HConnector",
+                        "kv_role": "kv_producer",
+                    },
+                    {
+                        "kv_connector": "AscendStoreConnector",
+                        "kv_role": "kv_producer",
+                        "kv_connector_extra_config": {
+                            "backend": "memcache",
+                            "use_layerwise": True,
+                        },
+                    },
+                ]
+            },
+        )
+        config = self._make_kv_offload_device_validation_config(multi_connector)
+
+        with self.assertRaisesRegex(
+            NotImplementedError,
+            "Layerwise Prefill KV Cache Offload, SfaRemoteD2HConnector",
+        ):
+            config.validate_kv_offload_device_support(AscendDeviceType.A2)
+
+    def test_rejects_decode_kv_offload_on_non_a3(self):
+        connector = KVTransferConfig(
+            kv_connector="SfaRemoteD2HConnector",
+            kv_role="kv_consumer",
+        )
+        config = self._make_kv_offload_device_validation_config(
+            connector,
+            sparse_offload_enabled=True,
+        )
+
+        for device_type in (AscendDeviceType.A2, AscendDeviceType.A5, AscendDeviceType._310P):
+            with (
+                self.subTest(device_type=device_type),
+                self.assertRaisesRegex(
+                    NotImplementedError,
+                    "Sparse KV Cache Offload, SfaRemoteD2HConnector",
+                ),
+            ):
+                config.validate_kv_offload_device_support(device_type)
+
+        config.validate_kv_offload_device_support(AscendDeviceType.A3)
+
     def test_sparse_li_c8_layer_filter_uses_indexer_quant_type(self):
         config = self._make_sparse_li_c8_config(
             {

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -242,6 +242,7 @@ class TestNPUWorker(TestBase):
         mock_register_atb_extensions.assert_called_once()
         mock_register_ascend_customop.assert_called_once()
         mock_init_ascend_config.assert_called_once_with(self.vllm_config_mock)
+        mock_init_ascend_config.return_value.validate_kv_offload_device_support.assert_called_once()
         mock_check_ascend_device_type.assert_called_once()
 
         # Verify cache_dtype setting

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -354,6 +354,41 @@ class AscendConfig:
                 f"({num_logical_experts} logical experts + {num_redundant_experts} EPLB redundant experts)."
             )
 
+    def validate_kv_offload_device_support(self, device_type: Any) -> None:
+        """Reject KV offload features that are unavailable on the device."""
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
+            get_gva_layerwise_config,
+        )
+        from vllm_ascend.utils import AscendDeviceType
+
+        if device_type == AscendDeviceType.A3:
+            return
+
+        kv_transfer_config = self.vllm_config.kv_transfer_config
+        unsupported_features = []
+        if get_gva_layerwise_config(kv_transfer_config) is not None:
+            unsupported_features.append("Layerwise Prefill KV Cache Offload")
+        if self.sparse_kv_offload_config.enabled:
+            unsupported_features.append("Sparse KV Cache Offload")
+
+        connector_name = getattr(kv_transfer_config, "kv_connector", None)
+        connector_extra_config = getattr(kv_transfer_config, "kv_connector_extra_config", None) or {}
+        uses_sfa_remote_d2h = connector_name == "SfaRemoteD2HConnector"
+        if connector_name == "MultiConnector":
+            uses_sfa_remote_d2h = any(
+                isinstance(connector, dict) and connector.get("kv_connector") == "SfaRemoteD2HConnector"
+                for connector in connector_extra_config.get("connectors", []) or []
+            )
+        if uses_sfa_remote_d2h:
+            unsupported_features.append("SfaRemoteD2HConnector")
+
+        if unsupported_features:
+            raise NotImplementedError(
+                "The following KV offload features are supported only on Ascend A3: "
+                + ", ".join(unsupported_features)
+                + "."
+            )
+
     def _validate_sparse_c8_kv_offload_compatibility(self) -> None:
         if self.sparse_kv_offload_config.enabled and self.enable_sparse_sfa_c8:
             raise NotImplementedError(

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -122,11 +122,13 @@ class NPUWorker(WorkerBase):
         from vllm_ascend import ops
 
         ops.register_dummy_fusion_op()
-        if get_ascend_device_type() != AscendDeviceType.A5:
+        ascend_device_type = get_ascend_device_type()
+        if ascend_device_type != AscendDeviceType.A5:
             _register_atb_extensions()
         register_ascend_customop(vllm_config)
         # init ascend config and soc version
-        init_ascend_config(vllm_config)
+        ascend_config = init_ascend_config(vllm_config)
+        ascend_config.validate_kv_offload_device_support(ascend_device_type)
         from vllm_ascend.logger import configure_ascend_file_logging
 
         configure_ascend_file_logging()


### PR DESCRIPTION
Fail worker initialization when layerwise Prefill offload, sparse KV offload, or SfaRemoteD2HConnector is configured on Ascend A2. Cover nested MultiConnector configurations and document the limitation.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
