### PR TITLE
[Bugfix][PD] Support P-side pipeline parallelism in MooncakeHybridConnector

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -667,6 +667,41 @@ class KVCacheRecvingThread(threading.Thread):
             remote_transfer_port = self.remote_te_port[remote_engine_id][remote_handshake_port]
         session_id = f"{remote_host}:{remote_transfer_port}"
 
+        # With P-side PP the remote worker only owns its stage's
+        # kv_cache_tensors. Offset the local (D) group-major flat addr list to
+        # the remote stage's global group range before zipping, so stage-1
+        # data lands in D's groups 8-15 instead of overwriting groups 0-7.
+        local_addrs = local_kv_caches_base_addrs
+        block_len_arr = self.block_len_per_addr
+        block_stride_arr = self.block_stride_per_addr
+        addr_group_arr = self.addr_group_idx
+        if self._prefill_pp_size > 1:
+            tp_num_need_pulls = req_meta["tp_num_need_pulls"]
+            remote_pp_rank = req_meta["offset"] // tp_num_need_pulls
+            num_groups = len(self.kv_cache_config.kv_cache_tensors)
+            groups_per_stage = num_groups // self._prefill_pp_size
+            addrs_per_group, rem = divmod(len(local_addrs), num_groups)
+            if rem != 0:
+                raise ValueError("non-uniform per-group address counts unsupported")
+            if num_groups % self._prefill_pp_size != 0:
+                raise ValueError("pp split not group-aligned")
+            start = remote_pp_rank * groups_per_stage * addrs_per_group
+            end = (remote_pp_rank + 1) * groups_per_stage * addrs_per_group
+            local_addrs = local_addrs[start:end]
+            block_len_arr = self.block_len_per_addr[start:end]
+            block_stride_arr = self.block_stride_per_addr[start:end]
+            if addr_group_arr:
+                addr_group_arr = self.addr_group_idx[start:end]
+            logger.debug(
+                "Cross-PP pull alignment: remote_port=%d -> pp_rank=%d local_addrs[%d:%d]=%d remote=%d",
+                remote_handshake_port,
+                remote_pp_rank,
+                start,
+                end,
+                len(local_addrs),
+                len(remote_kv_caches_base_addrs),
+            )
+
         req_start_time = time.perf_counter()
         src_list, dst_list, length_list = [], [], []
         for i in range(self.hma_group_size):
@@ -682,12 +717,12 @@ class KVCacheRecvingThread(threading.Thread):
                 cur_remote_block_ids, cur_local_block_ids
             )
             for k, (src_layer_base_addr, dst_layer_base_addr) in enumerate(
-                zip(local_kv_caches_base_addrs, remote_kv_caches_base_addrs)
+                zip(local_addrs, remote_kv_caches_base_addrs)
             ):
-                if self.addr_group_idx and i not in self.addr_group_idx[k]:  # type: ignore[operator]
+                if addr_group_arr and i not in addr_group_arr[k]:  # type: ignore[operator]
                     continue
-                block_len = self.block_len_per_addr[k]
-                block_stride = self.block_stride_per_addr[k]
+                block_len = block_len_arr[k]
+                block_stride = block_stride_arr[k]
                 for remote_block_id, local_block_id in zip(grouped_remote_block_ids, grouped_local_block_ids):
                     src = src_layer_base_addr + local_block_id[0] * block_stride
                     dst = dst_layer_base_addr + remote_block_id[0] * block_stride
@@ -1177,6 +1212,10 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_scheduler is not None
         self.connector_scheduler.set_xfer_handshake_metadata(metadata)
 
+    def set_xfer_handshake_metadata_pp_aware(self, metadata) -> None:
+        assert self.connector_scheduler is not None
+        self.connector_scheduler.set_xfer_handshake_metadata_from_workers(metadata)
+
 
 class MooncakeConnectorScheduler:
     """Implementation of Scheduler side methods"""
@@ -1459,6 +1498,32 @@ class MooncakeConnectorScheduler:
             remote_multi_nodes_meta_mapping=self.multi_nodes_meta_mapping,
             num_prompt_blocks=num_prompt_blocks,
         )
+
+    def _port_offset_from_handshake_metadata(self, rank_metadata: KVConnectorHandshakeMetadata, metadata_key) -> int:
+        handshake_port = getattr(rank_metadata, "handshake_port", 0)
+        if handshake_port > 0:
+            return handshake_port - self.vllm_config.kv_transfer_config.kv_port
+        if isinstance(metadata_key, int):
+            return metadata_key
+        if len(metadata_key) == 2:
+            pp_rank, tp_rank = metadata_key
+            return pp_rank * self.tp_size + tp_rank
+        pp_rank, pcp_rank, tp_rank = metadata_key
+        return (pp_rank * 1 + pcp_rank) * self.tp_size + tp_rank
+
+    def set_xfer_handshake_metadata_from_workers(
+        self,
+        metadata,
+    ) -> None:
+        """Store worker metadata keyed by handshake port offset
+        (pp_rank * tp_size + tp_rank), matching how the recv thread resolves
+        peers in _get_remote_host_info_by_port."""
+        for metadata_key, rank_metadata in metadata.items():
+            offset = self._port_offset_from_handshake_metadata(rank_metadata, metadata_key)
+            self.multi_nodes_meta_mapping[str(offset)] = {
+                "host": rank_metadata.local_ip,
+                "engine_id": rank_metadata.engine_id,
+            }
 
     def set_xfer_handshake_metadata(self, metadata: dict[int, KVConnectorHandshakeMetadata]) -> None:
         """
@@ -1784,25 +1849,38 @@ class MooncakeConnectorWorker:
                 assert self.kv_recv_thread is not None
                 chosen_rank_list = self._get_remote_rank(remote_req_id, prefill_tp_size)
                 remote_handshake_port_list = [[x + meta.remote_port] for x in chosen_rank_list]
-                remote_host, remote_engine_id = self._get_remote_host_info_by_port(
-                    meta.remote_port,
-                    remote_handshake_port_list[0][0],
-                    meta.remote_host,
-                    meta.remote_engine_id,
-                    meta.remote_multi_nodes_meta_mapping,
-                )
-                self.kv_recv_thread.add_request(
-                    request_id=req_id,
-                    remote_request_id=remote_req_id,
-                    local_block_ids=meta.local_block_ids,
-                    remote_block_ids=meta.remote_block_ids,
-                    remote_engine_id=remote_engine_id,
-                    remote_host=remote_host,
-                    remote_handshake_port=remote_handshake_port_list[0][0],
-                    offset=0,
-                    tp_num_need_pulls=tp_num_need_pulls,
-                    all_task_done=True,
-                )
+                # Iterate all remote peers like the non-mamba branch; the old
+                # code only pulled from the first peer, so with P-side PP>1
+                # the later stages never transferred their KV.
+                # _get_remote_ranks_for_req yields exactly one
+                # peer per PP stage for equal-TP GQA; derive per-stage pull
+                # count from the list itself (upstream tp_num_need_pulls=tp
+                # mismatches this array for mamba).
+                num_stages = max(self._prefill_pp_size, 1)
+                pulls_per_stage = max(1, len(remote_handshake_port_list) // num_stages)
+                num_pulls = pulls_per_stage * num_stages
+                if len(remote_handshake_port_list) < num_pulls:
+                    raise ValueError(f"chosen ranks {chosen_rank_list} too few for {num_pulls} pulls")
+                for i in range(num_pulls):
+                    remote_host, remote_engine_id = self._get_remote_host_info_by_port(
+                        meta.remote_port,
+                        remote_handshake_port_list[i][0],
+                        meta.remote_host,
+                        meta.remote_engine_id,
+                        meta.remote_multi_nodes_meta_mapping,
+                    )
+                    self.kv_recv_thread.add_request(
+                        request_id=req_id,
+                        remote_request_id=remote_req_id,
+                        local_block_ids=meta.local_block_ids,
+                        remote_block_ids=meta.remote_block_ids,
+                        remote_engine_id=remote_engine_id,
+                        remote_host=remote_host,
+                        remote_handshake_port=remote_handshake_port_list[i][0],
+                        offset=i,
+                        tp_num_need_pulls=pulls_per_stage,
+                        all_task_done=(i == num_pulls - 1),
+                    )
             else:  # TODO: support prefill context parallel and pipeline parallel open at the same time
                 chosen_rank_list = self._get_remote_rank(remote_req_id, prefill_tp_size)
                 remote_handshake_port_list = [[x + meta.remote_port] for x in chosen_rank_list]


### PR DESCRIPTION
## Description

MooncakeHybridConnector (the HMA path for hybrid SSM/attention models, e.g. Qwen3.5) could not serve as the PD prefill instance with `pipeline-parallel-size > 1`. This PR fixes three stacked bugs; the second commit is an independent MRV2 crash fix found while testing the same configuration.

### Commit 1: hybrid connector PP fixes (`mooncake_hybrid_connector.py`)

1. **Startup crash** — the connector lacks `set_xfer_handshake_metadata_pp_aware`; with PP>1 the engine core passes `(pp_rank, tp_rank)`-keyed handshake metadata and the upstream base class raises `does not support PP-disaggregated KV transfer`. Fixed by storing worker metadata keyed by handshake port offset (`pp_rank * tp_size + tp_rank`), matching how the recv thread resolves peers in `_get_remote_host_info_by_port`.
2. **Missing transfers** — the `use_mamba` branch of `start_load_kv` issued a single pull (first peer only), so PP stages > 0 never transferred their KV and decode read stale memory. Now iterates all peers like the non-mamba branch; per-stage pull count is derived from `_get_remote_ranks_for_req` (one peer per stage for equal-TP GQA) rather than the mamba `tp_num_need_pulls = tp_size` convention, which mismatches that rank array.
3. **Wrong destination groups** — `_transfer_kv_cache_all_groups` zipped D's full group-major address list against the remote stage worker's shorter list, so pulls from stage 1 landed in D's groups 0..N/2-1, overwriting stage-0 data at wrong layer positions → garbage output. Now the local address list (plus aligned `block_len`/`block_stride`/`addr_group_idx` arrays) is offset to the remote stage's global group range before zipping.

### Commit 2: duplicate `is_prefilling` kwarg (`attn_utils.py`)

`build_attn_metadata` passes `is_prefilling` explicitly and also forwards `model_specific_attn_metadata.get_extra_common_attn_kwargs()`, which for `MambaHybridAttnMetadata` (vllm `58d3918e3`, the current verified commit) already returns `is_prefilling` → `TypeError` on the first forward of a mamba-hybrid model under MRV2. Can be split into a separate PR if maintainers prefer.

## Test Plan

- [x] Ascend 910, vllm @ verified commit `58d3918e3`, Qwen3.5-27B (hybrid GatedDeltaNet + attention, 64 layers, 4-layer HMA cache groups)
- [x] Topology: P = PP2 × TP2 (`kv_producer`) + D = TP2 (`kv_consumer`), `MooncakeHybridConnector`, MRV2 on both sides, single-node proxy
- [x] Before: startup ValueError (bug 1); after bypassing it: decode outputs garbage (bugs 2+3)
- [x] After: 3 distinct prompts decode correctly, matching the `MooncakeConnectorV1` baseline on the same topology; per-request logs show 4 cross-stage pulls (2 stages × 2 TP ranks) with 24↔24 address pairs each
- [ ] CI

## Notes

- Decode side still must be PP=1 (pre-existing hard constraint, unchanged).
- Non-uniform `prefill.pp_layer_partition` that does not align with HMA group boundaries is rejected with an assert.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
