### PR TITLE
[v0.26.0rc][Ops][Misc] Optimize speculative decoding drafting metadata preparation

### DIFF
--- a/tests/ut/worker/test_dcp_manager.py
+++ b/tests/ut/worker/test_dcp_manager.py
@@ -207,9 +207,9 @@ def test_prepare_spec_decode_drafting_metadata_transitions_to_decode() -> None:
         torch.tensor([1, 1], dtype=torch.int32),
     )
     assert draft_dcp_metadata.max_query_len == 1
-    assert torch.equal(
+    np.testing.assert_array_equal(
         draft_dcp_metadata.num_computed_tokens_of_dcp,
-        local_seq_lens,
+        local_seq_lens.numpy(),
     )
     assert torch.equal(
         draft_dcp_metadata.draft_cp_seq_len,
@@ -275,5 +275,5 @@ def test_update_spec_decode_drafting_metadata_prioritizes_sfa_dcp() -> None:
     manager._get_dcp_local_seq_lens.assert_called_once()
     assert torch.equal(
         manager._get_dcp_local_seq_lens.call_args.args[0],
-        torch.tensor([8, 12], dtype=torch.int32),
+        torch.tensor([9, 13], dtype=torch.int32),
     )

--- a/vllm_ascend/worker/dcp_utils.py
+++ b/vllm_ascend/worker/dcp_utils.py
@@ -514,18 +514,15 @@ class DCPManager:
         is_mla = self._is_mla_kv_cache_spec(kv_cache_spec)
         if is_mla:
             if dcp_metadata.draft_base_seq_lens is None:
-                local_seq_lens = torch.as_tensor(
-                    dcp_metadata.num_computed_tokens_of_dcp,
-                    device=seq_lens.device,
-                )
+                # MLA draft history is consumed on the host to build the DCP
+                # MTP attention mask below. Keep it on CPU instead of moving the
+                # per-rank DCP lengths to NPU and copying the summed result back.
+                local_seq_lens = torch.as_tensor(dcp_metadata.num_computed_tokens_of_dcp)
                 draft_base_seq_lens = local_seq_lens.sum(dim=-1)
                 if original_is_prefilling is not None:
-                    is_prefilling = original_is_prefilling[: draft_base_seq_lens.shape[0]].to(
-                        device=draft_base_seq_lens.device
-                    )
+                    is_prefilling = original_is_prefilling[: draft_base_seq_lens.shape[0]]
                     prefill_query_lens = original_query_lens_cpu[: draft_base_seq_lens.shape[0]].to(
-                        device=draft_base_seq_lens.device,
-                        dtype=draft_base_seq_lens.dtype,
+                        dtype=draft_base_seq_lens.dtype
                     )
                     draft_base_seq_lens = draft_base_seq_lens + torch.where(
                         is_prefilling,
@@ -537,11 +534,14 @@ class DCPManager:
         else:
             seq_lens_for_dcp = seq_lens_cpu if seq_lens_cpu is not None else seq_lens
         local_seq_lens = self._get_dcp_local_seq_lens(seq_lens_for_dcp + draft_index + 1)
-        dcp_metadata.num_computed_tokens_of_dcp = local_seq_lens
+        if is_mla:
+            dcp_metadata.num_computed_tokens_of_dcp = local_seq_lens.numpy()
+        else:
+            dcp_metadata.num_computed_tokens_of_dcp = local_seq_lens
         dcp_metadata.draft_cp_seq_len = local_seq_lens[:, self.dcp_world_rank]
         if is_mla and getattr(self, "speculative_config", None) is not None:
             num_draft_reqs = query_lens_cpu.shape[0]
-            draft_histories = (dcp_metadata.draft_base_seq_lens[:num_draft_reqs] + draft_index).to("cpu")
+            draft_histories = dcp_metadata.draft_base_seq_lens[:num_draft_reqs] + draft_index
             mask = self.generate_mtp_attention_mask_for_decode(
                 draft_histories.tolist(),
                 query_lens_cpu[:num_draft_reqs].numpy(),
@@ -575,7 +575,9 @@ class DCPManager:
             return
 
         seq_lens_for_dcp = seq_lens
-        if seq_lens_cpu is not None:
+        # SFA DCP writes rank_seq_lens into a device buffer below, so compute it
+        # from the device seq_lens to avoid a CPU->NPU copy on the drafting path.
+        if not is_sfa_dcp and seq_lens_cpu is not None:
             seq_lens_for_dcp = seq_lens_cpu
         local_seq_lens = self._get_dcp_local_seq_lens(seq_lens_for_dcp + draft_index + 1)
         rank_seq_lens = local_seq_lens[:, self.dcp_world_rank]


### PR DESCRIPTION
## Summary

  This PR reduces host-device synchronization overhead in DCP speculative decoding metadata preparation.
<img width="1181" height="410" alt="image" src="https://github.com/user-attachments/assets/61259e25-bbfd-4096-be38-0796dee7bc6b" />

<img width="869" height="401" alt="image" src="https://github.com/user-attachments/assets/82a2067b-e18c-4cfc-b867-be8980484847" />

  Profiling GLM5.2 MTP + DCP showed long `aten::to/_to_copy/copy_` host-side stalls caused by unnecessary CPU/NPU transfers in drafting metadata paths.

  Fix issue #14448 

  ## Changes

  - Keep MLA draft base sequence lengths on CPU in `prepare_spec_decode_drafting_cp_metadata`, since they are consumed on host to build the DCP MTP attention mask.
  - Preserve non-MLA behavior by only converting `num_computed_tokens_of_dcp` to numpy for MLA.
  - For SFA DCP update, compute local sequence lengths from device-side `seq_lens`, avoiding CPU→NPU copy before writing
 `dcp_context.seq_lens`.
  - Update related unit test expectations for MLA CPU/numpy metadata and SFA device `seq_lens` preference.

  ## Why

  The old path moved DCP token lengths to NPU, computed local lengths, then copied results back or copied CPU results to NPU again.

  In MTP eager drafting this created large sync points visible as long `aten::to/_to_copy/copy_` events.

  ## Testing
 
<img width="1044" height="401" alt="image" src="https://github.com/user-attachments/assets/7d9ab59a-cdb9-4347-9c42-07ca5bcb068b" />

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
