### PR TITLE
[BugFix][KV Pool] Accept lazy_init for Yuanrong backend

### DIFF
--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/base.py
@@ -10,7 +10,7 @@ class Backend(ABC):
     store: Any | None = None
 
     @abstractmethod
-    def __init__(self, parallel_config: ParallelConfig):
+    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
         pass
 
     @classmethod

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py
@@ -48,7 +48,9 @@ class YuanrongConfig:
 
 
 class YuanrongBackend(Backend):
-    def __init__(self, parallel_config: ParallelConfig):
+    def __init__(self, parallel_config: ParallelConfig, lazy_init: bool = False):
+        if lazy_init:
+            logger.warning("YuanrongBackend does not support lazy initialization; initializing eagerly.")
         try:
             from yr.datasystem.hetero_client import HeteroClient  # type: ignore[import-not-found]
             from yr.datasystem.kv_client import SetParam  # type: ignore[import-not-found]


### PR DESCRIPTION
### What this PR does / why we need it?

`KVPoolWorker` passes the common `lazy_init` keyword to every AscendStore backend. `YuanrongBackend` did not accept that keyword, so starting `AscendStoreConnector` with `backend: "yuanrong"` failed with:

```text
TypeError: YuanrongBackend.__init__() got an unexpected keyword argument 'lazy_init'
```

This PR makes `YuanrongBackend` accept the common argument. Yuanrong does not support lazy initialization, so it logs a warning when requested and continues to initialize eagerly.

A regression test verifies that `lazy_init=True` is accepted and `store.init()` is still called.

### Does this PR introduce _any_ user-facing change?

Yes. `AscendStoreConnector` can start with the Yuanrong backend when the worker supplies the common `lazy_init` argument. Yuanrong initialization behavior remains eager.

### How was this patch tested?

- Added `test_backend_accepts_lazy_init_and_initializes_eagerly` in `tests/ut/distributed/test_yuanrong_backend.py`.
- `python -m py_compile vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/yuanrong_backend.py tests/ut/distributed/test_yuanrong_backend.py`
- `git diff --check`

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
