### PR TITLE
[CI] liqo-test offload probe workflow (retest 800i-4)

### DIFF
--- a/.github/workflows/test-liqo.yml
+++ b/.github/workflows/test-liqo.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   # 800i-4：liqo-test label → 远程 offload 到 aiframework / mind-third-ci，job 容器申请 4 卡 ascend-1980
+  # runner 已加 liqo.io/api-server-support: remote 注解（ascend-ci-deployment PR #1361），验证远端 API 访问与 NPU 分配
   test-800i-4-remote:
     runs-on: [liqo-test]
     container:

--- a/.github/workflows/test-liqo.yml
+++ b/.github/workflows/test-liqo.yml
@@ -1,0 +1,10 @@
+name: test-liqo
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: [liqo-test]
+    steps:
+      - run: echo "hello liqo-test"
+      - run: sleep 600

--- a/.github/workflows/test-liqo.yml
+++ b/.github/workflows/test-liqo.yml
@@ -3,8 +3,34 @@ on:
   pull_request:
 
 jobs:
-  test:
+  # 800i-4：liqo-test label → 远程 offload 到 aiframework / mind-third-ci，job 容器申请 4 卡 ascend-1980
+  test-800i-4-remote:
     runs-on: [liqo-test]
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-a3-ubuntu22.04-py3.12
     steps:
-      - run: echo "hello liqo-test"
+      - name: Show NPU allocation
+        run: |
+          echo "HOSTNAME=$(hostname)"
+          echo "nproc=$(nproc)"
+          npu-smi info || true
+          echo "--- davinci devices ---"
+          ls -l /dev/davinci* 2>/dev/null || true
+          echo "device count: $(ls /dev/davinci[0-9]* 2>/dev/null | wc -l)"
+      - run: sleep 600
+
+  # 800i-2：liqo-test-local label → 钉在 cn12-001 本地 arm64 节点，job 容器申请 2 卡 ascend-1980
+  test-800i-2-local:
+    runs-on: [liqo-test-local]
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-a3-ubuntu22.04-py3.12
+    steps:
+      - name: Show NPU allocation
+        run: |
+          echo "HOSTNAME=$(hostname)"
+          echo "nproc=$(nproc)"
+          npu-smi info || true
+          echo "--- davinci devices ---"
+          ls -l /dev/davinci* 2>/dev/null || true
+          echo "device count: $(ls /dev/davinci[0-9]* 2>/dev/null | wc -l)"
       - run: sleep 600


### PR DESCRIPTION
Retest 800i-4 remote NPU allocation via liqo-test scale set. Runner config (ascend-ci-deployment) updated: removed nodeAffinity to align with successful sglang/gy005 case, letting npu-scheduler auto-schedule. Triggering pull_request event to validate.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
