### PR TITLE
[Ops][310P] Enable MTP speculative decoding with ACL graph mode

### DIFF
--- a/vllm_ascend/_310p/attention/attention_v1.py
+++ b/vllm_ascend/_310p/attention/attention_v1.py
@@ -219,7 +219,15 @@ class AscendAttentionBackendImpl310(AscendAttentionBackendImpl):
         Returns:
             The output tensor after flash attention.
         """
-        real_tokens = int(attn_metadata.seq_lens.sum().item())
+        # seq_lens.sum().item() is a synchronous D2H copy, which ACL
+        # forbids inside a graph capture (the drafter is captured whole under FULL).
+        # num_actual_tokens is the same quantity already available on the host -- the
+        # sibling splitfuse path below reads it the same way.
+        _nat = getattr(attn_metadata, "num_actual_tokens", None)
+        if _nat is not None:
+            real_tokens = int(_nat)
+        else:
+            real_tokens = int(attn_metadata.seq_lens.sum().item())
         seq_len = attn_metadata.seq_lens
         aligned_tokens = int(query.shape[0])
         delta = aligned_tokens - real_tokens

--- a/vllm_ascend/_310p/model_runner_310p.py
+++ b/vllm_ascend/_310p/model_runner_310p.py
@@ -65,6 +65,22 @@ _NGRAM_GRAPH_UNIFORM_DECODE_QUERY_LEN = 1
 _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
 
 
+def _is_stream_capturing() -> bool:
+    # Runtime truth first: the context flags are not set during the drafter's
+    # capture, so they cannot be relied on here.
+    try:
+        if torch.npu.is_current_stream_capturing():
+            return True
+    except Exception:
+        pass
+    try:
+        from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+
+        return bool(getattr(_EXTRA_CTX, "capturing", False))
+    except Exception:
+        return False
+
+
 class NPUModelRunner310(NPUModelRunner):
     """
     310P model runner with a distinct ACL graph capture/replay contract from 910B:
@@ -642,6 +658,12 @@ class NPUModelRunner310(NPUModelRunner):
             and not self.enable_enpu
             and forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL
             and not forward_context.capturing
+            # the capture flag is set on _EXTRA_CTX in the v2 aclgraph
+            # path (worker/v2/aclgraph_utils.py:171). If only that one is set this
+            # guard passes and we call stream.synchronize() inside an ACL capture ->
+            # "Not allow to synchronize captured-stream" (plog 107027), which surfaces
+            # later as the 107030 memcpy failure. Check both flags.
+            and not _is_stream_capturing()
             and hasattr(self, "update_stream")
         )
 

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -33,6 +33,13 @@ _STREAM_RESOURCE_ERROR_MARKERS = (
 _OLD_HDK_CAPTURE_ERROR_MARKERS = ("alloc sq cq fail",)
 
 
+def _is_stream_capturing() -> bool:
+    try:
+        return bool(torch.npu.is_current_stream_capturing())
+    except Exception:
+        return False
+
+
 def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
     message = str(exc)
     lowered_message = message.lower()
@@ -261,7 +268,13 @@ class ACLGraphWrapper:
         # When FULL + EAGLE draft (merge path), replay does not need this barrier.
         is_draft_eagle = _EXTRA_CTX.is_draft_model and self.use_eagle
         need_sync = self.runtime_mode == CUDAGraphMode.FULL and not is_draft_eagle
-        if not self.enable_enpu and need_sync:
+        # never synchronize a stream that is being captured -- ACL
+        # rejects it ("Not allow to synchronize captured-stream", plog 107027) and
+        # it surfaces later as a 107030 memcpy failure. This replay-ordering
+        # barrier is only meaningful outside capture anyway. The existing
+        # `is_draft_eagle` exemption does not cover MTP, whose drafter replays
+        # from inside the target's capture region.
+        if not self.enable_enpu and need_sync and not _is_stream_capturing():
             torch.npu.current_stream().synchronize()
         entry.aclgraph.replay()
         return entry.output

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3270,10 +3270,15 @@ class NPUModelRunner(GPUModelRunner):
                 self.dcp_manager.query_lens_full.copy_to_gpu()
         if cudagraph_runtime_mode is None:
             cudagraph_runtime_mode = _cudagraph_mode
-        else:
-            assert cudagraph_runtime_mode == _cudagraph_mode, (
-                f"Cudagraph runtime mode mismatch in dummy_run. "
-                f"Expected {_cudagraph_mode}, but got {cudagraph_runtime_mode}."
+        elif cudagraph_runtime_mode != _cudagraph_mode:
+            # with spec decode the batch descriptor carries draft-token
+            # slots, so the dispatcher does not recognise the padded size and returns
+            # NONE while capture_model is deliberately capturing PIECEWISE. The caller
+            # is the authority during capture -- honour it instead of asserting.
+            logger.warning(
+                "dummy_run cudagraph mode: dispatcher=%s caller=%s; using caller",
+                _cudagraph_mode,
+                cudagraph_runtime_mode,
             )
         num_tokens_padded = batch_desc.num_tokens
         num_reqs_padded = batch_desc.num_reqs if batch_desc.num_reqs is not None else num_reqs


### PR DESCRIPTION
### What this PR does / why we need it?

MTP speculative decoding on Ascend 310P only starts with `--enforce-eager`. With ACL graph
mode enabled — the default — engine init fails during graph capture:

```
RuntimeError: NPUModelRunner init failed, error is ACL stream synchronize failed, error code:507014
```

The reported error is a downstream symptom. plog shows the first failure:

```
StreamSynchronize: Not allow to synchronize captured-stream, stream_id=12
rtStreamSynchronize: ErrCode=107027, desc=[stream is captured]
...then
rtMemcpy: ErrCode=107030 [the current capture mode does not support this operation]
```

so this is a **synchronize issued inside an ACL graph capture**, not a memcpy problem.

Three defects, each reproduced and fixed here:

1. **`_dummy_run` asserts the caller's cudagraph mode equals the dispatcher's.**
   With spec decode the batch descriptor carries draft-token slots, so the padded size is not
   in the dispatcher's capture set and it returns `NONE`, while `capture_model` deliberately
   passes `PIECEWISE`. The caller is the authority during capture, so this now warns instead of
   asserting.

2. **`model_runner_310p`'s pre-replay barrier is gated on `forward_context.capturing`.**
   The v2 aclgraph path sets the flag on `_EXTRA_CTX` instead
   (`worker/v2/aclgraph_utils.py`), so when only that one is set the guard passes and
   `stream.synchronize()` runs inside a capture.

3. **`ACLGraphWrapper`'s replay-ordering sync exempts only `is_draft_model and use_eagle`.**
   MTP does not satisfy that, and its drafter replays from inside the target's capture region.

Guards now consult `torch.npu.is_current_stream_capturing()` — runtime truth, which cannot go
stale the way the context flags do.

A separate commit removes a synchronous D2H copy from the 310P attention forward:
`int(attn_metadata.seq_lens.sum().item())` is a device-to-host copy on every attention call.
`num_actual_tokens` already carries the same quantity on the host — the splitfuse path a few
lines below reads it exactly that way.

### Does this PR introduce _any_ user-facing change?

No new flags or API changes. MTP + ACL graph mode previously failed to start; it now runs.

### How was this patch tested?

Qwen3.5-9B on one Ascend 310P3, TP=1, fp16, real text prompts (synthetic/random-token prompts
are unusable here — draft acceptance collapses on them, since acceptance is a model-quality
metric). 4 prompts x 128 tokens, greedy, one warmup discarded.

Served with:
```
--speculative-config '{"method":"mtp","num_speculative_tokens":1}' \
--compilation-config '{"cudagraph_mode":"PIECEWISE"}'
```

| | ms/token |
|---|---|
| no MTP, PIECEWISE graph | 102.36 |
| MTP k=1, PIECEWISE graph | **80.70** |
| | **1.27x** |

Draft acceptance 81.8–95.5%. Before this PR the same configuration does not start at all;
with `--enforce-eager` it gives 90.10 ms/token, so graph mode is worth a further 1.12x on top.

### Known limitations

- **`FULL` / `FULL_DECODE_ONLY` still fail.** Those additionally capture the drafter
  (wrapped when `cudagraph_mode.has_full_cudagraphs()`), and the remaining synchronize
  in that path is inside torch_npu's own graph machinery rather than vllm-ascend. `PIECEWISE`
  captures the 32-layer target and leaves the 1-layer drafter eager, which is where the gain
  above comes from.
- Consequently the drafter still runs eager, ~50 ms/token. That is fine when verify is
  expensive (fp16, 1.27x) but not when it is cheap: on W8A8 the same setup measures 63.62 vs
  63.80 ms/token, i.e. a wash, because an uncaptured draft costs nearly as much as the whole
  decode step. Capturing the drafter is what would make MTP worthwhile at W8A8.

### Unrelated bug noticed while debugging

`vllm/config/speculative.py`'s `qwen3_5` branch reads `mtp_num_hidden_layers` from the
top-level config, but Qwen3.5 checkpoints nest it under `text_config`, so `n_predict` is
`None`. The `intern_s2_preview` branch immediately below reads it from `text_config` correctly.
Harmless here because `Qwen3_5MTP` re-reads it from `hf_text_config` with a default of 1, but
it should be fixed upstream.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
