### PR TITLE
[v0.23.0][Performance] Batch KV Pool transfer value preparation

### DIFF
--- a/tests/ut/distributed/ascend_store/test_config_data.py
+++ b/tests/ut/distributed/ascend_store/test_config_data.py
@@ -285,6 +285,27 @@ class TestChunkedTokenDatabase(unittest.TestCase):
         self.assertEqual(size[0], 160)
         self.assertEqual(size[1], 320)
 
+    def test_prepare_values_matches_scalar_results(self):
+        starts = [0, 16]
+        ends = [16, 24]
+        block_ids = [5, 9]
+
+        addrs, sizes = self.db.prepare_values(starts, ends, block_ids)
+        expected = [
+            self.db.prepare_value(start, end, [], block_id=block_id)[:2]
+            for start, end, block_id in zip(starts, ends, block_ids)
+        ]
+
+        self.assertEqual(addrs, [addr for addr, _ in expected])
+        self.assertEqual(sizes, [size for _, size in expected])
+
+    def test_prepare_values_empty(self):
+        self.assertEqual(self.db.prepare_values([], [], []), ([], []))
+
+    def test_prepare_values_rejects_mismatched_inputs(self):
+        with self.assertRaisesRegex(ValueError, "must have the same length"):
+            self.db.prepare_values([0], [16], [])
+
     def test_prepare_value_layer(self):
         addr, size, block_id = self.db.prepare_value_layer(0, 16, [5, 6], layer_id=0)
         self.assertEqual(block_id, 5)

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -183,6 +183,7 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
     def test_handle_request_puts_missing_keys(self):
         t, store = self._make_thread([1, 0, 1, 0])
+        t.token_database.prepare_values = MagicMock(wraps=t.token_database.prepare_values)
         req = ReqMeta(
             req_id="r1",
             token_len_chunk=64,
@@ -194,8 +195,16 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t.request_queue.put(req)
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 1)
-        keys, _, _ = store.put_calls[0]
+        keys, addrs, sizes = store.put_calls[0]
         self.assertEqual(len(keys), 2)
+        self.assertEqual(addrs, [[1001], [1003]])
+        self.assertEqual(sizes, [[16], [16]])
+        t.token_database.prepare_values.assert_called_once_with(
+            [16, 48],
+            [32, 64],
+            [1, 3],
+            kv_cache_group_id=0,
+        )
 
     def test_handle_request_all_exist_no_put(self):
         t, store = self._make_thread([1, 1])
@@ -478,6 +487,54 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         t._handle_request(req)
         keys, _, _ = store.get_calls[0]
         self.assertEqual(len(keys), 1)
+
+    def test_handle_request_batches_values_per_group_in_order(self):
+        store = FakeStore()
+        db = ChunkedTokenDatabase(
+            [KeyMetadata("m", 0, 0, 0, 0), KeyMetadata("m", 0, 0, 0, 0, kv_cache_group_id=1)],
+            [16, 32],
+            None,
+            hash_block_size=16,
+        )
+        db.set_group_buffers(
+            {0: [1000], 1: [2000]},
+            {0: [16], 1: [32]},
+            {0: [16], 1: [32]},
+            group_num_layers={0: 1, 1: 1},
+        )
+        db.prepare_values = MagicMock(wraps=db.prepare_values)
+        t = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=db,
+            block_size=[16, 32],
+            tp_rank=0,
+            dcp_size=1,
+            ready_event=threading.Event(),
+            invalid_block_ids=set(),
+            invalid_block_ids_lock=threading.Lock(),
+        )
+        load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=32, can_load=True, token_len=32)
+        req = ReqMeta(
+            req_id="r1",
+            token_len_chunk=32,
+            block_ids_by_group=[[1, 2], [3]],
+            block_hashes=[b"h0", b"h1"],  # type: ignore[arg-type]
+            load_spec=load_spec,
+            kv_cache_group_ids=[0, 1],
+        )
+
+        t.request_queue.put(req)
+        t._handle_request(req)
+
+        keys, addrs, sizes = store.get_calls[0]
+        self.assertEqual(len(keys), 3)
+        self.assertEqual(addrs, [[1016], [1032], [2096]])
+        self.assertEqual(sizes, [[16], [16], [32]])
+        self.assertEqual(db.prepare_values.call_count, 2)
+        self.assertEqual(
+            [call.kwargs["kv_cache_group_id"] for call in db.prepare_values.call_args_list],
+            [0, 1],
+        )
 
 
 @unittest.skip("LayerMultiBlockReqMeta API is deprecated, tests need update for LayerTransferTask")

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -652,6 +652,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         worker.m_store.get = MagicMock()
         # Setup token database
         worker.token_database.set_group_buffers({0: [1000, 2000]}, {0: [160]})
+        worker.token_database.prepare_values = MagicMock(wraps=worker.token_database.prepare_values)
 
         load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=16, can_load=True, token_len=16)
         req = ReqMeta(
@@ -665,6 +666,7 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         meta.add_request(req)
         worker.start_load_kv(meta)
         worker.m_store.get.assert_called_once()
+        worker.token_database.prepare_values.assert_called_once_with([0], [16], [0], kv_cache_group_id=0)
 
     def test_start_load_kv_sync_uses_tail_block_id(self):
         worker = self._make_worker()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/config_data.py
@@ -386,6 +386,38 @@ class ChunkedTokenDatabase:
             size_list.append(size)
         return addr_list, size_list, block_id
 
+    def prepare_values(
+        self,
+        starts: Sequence[int],
+        ends: Sequence[int],
+        block_ids: Sequence[int],
+        kv_cache_group_id: int = 0,
+        cache_role: str = "kv",
+    ) -> tuple[list[list[int]], list[list[int]]]:
+        """Prepare transfer addresses and sizes for a batch of cache blocks."""
+        if not (len(starts) == len(ends) == len(block_ids)):
+            raise ValueError("starts, ends and block_ids must have the same length")
+        if len(block_ids) == 0:
+            return [], []
+
+        group_addrs, group_block_len, group_block_stride = self._get_group_buffers(kv_cache_group_id, cache_role)
+        if not group_block_len:
+            return ([[] for _ in block_ids], [[] for _ in block_ids])
+
+        entry_indices = np.arange(len(group_addrs)) % len(group_block_len)
+        base_addrs = np.asarray(group_addrs, dtype=np.int64)
+        block_lens = np.asarray(group_block_len, dtype=np.int64)[entry_indices]
+        block_strides = (
+            np.asarray(group_block_stride, dtype=np.int64)[entry_indices] if group_block_stride else block_lens
+        )
+        block_ids_array = np.asarray(block_ids, dtype=np.int64)
+        token_spans = np.asarray(ends, dtype=np.int64) - np.asarray(starts, dtype=np.int64)
+        group_block_size = self.get_block_size(kv_cache_group_id)
+
+        addrs = base_addrs[None, :] + block_ids_array[:, None] * block_strides[None, :]
+        sizes = token_spans[:, None] * block_lens[None, :] // group_block_size
+        return addrs.tolist(), sizes.tolist()
+
     def prepare_block_info(self, start: int, end: int, block_ids: list[int]) -> tuple[int, list[int]]:
         block_size = self.block_size[0]
         block_id = block_ids[start // block_size]

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -551,27 +551,6 @@ class KVTransferThread(threading.Thread):
         skip_flags = req_meta.skip_null_blocks_by_group
         return group_id < len(skip_flags) and skip_flags[group_id] if skip_flags else False
 
-    def _prepare_value(
-        self,
-        start: int,
-        end: int,
-        block_ids: list[int],
-        kv_cache_group_id: int = 0,
-        cache_role: str = "kv",
-        block_id: int | None = None,
-    ):
-        try:
-            return self.token_database.prepare_value(
-                start,
-                end,
-                block_ids,
-                kv_cache_group_id=kv_cache_group_id,
-                cache_role=cache_role,
-                block_id=block_id,
-            )
-        except TypeError:
-            return self.token_database.prepare_value(start, end, block_ids)
-
     def _decode_adaptor_prefill_pp(
         self,
         keys: list[str],
@@ -776,8 +755,12 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 keys[:3],
             )
 
-            addrs = []
-            sizes = []
+            addrs, sizes = self.token_database.prepare_values(
+                starts,
+                ends,
+                key_block_ids,
+                kv_cache_group_id=group_id,
+            )
             stored_events: list[BlockStored] = []
             all_hashes = (
                 [
@@ -793,15 +776,6 @@ class KVCacheStoreSendingThread(KVTransferThread):
                 else []
             )
             for index, start in enumerate(starts):
-                addr, size, _ = self._prepare_value(
-                    start,
-                    ends[index],
-                    block_ids,
-                    kv_cache_group_id=group_id,
-                    block_id=key_block_ids[index],
-                )
-                addrs.append(addr)
-                sizes.append(size)
                 if self.enable_kv_event:
                     token_ids = req_meta.token_ids[start : ends[index]] if req_meta.token_ids is not None else None
                     block_size = (
@@ -883,6 +857,10 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         )
         for group_id in group_ids:
             block_ids = req_meta.block_ids_by_group[group_id]
+            group_starts: list[int] = []
+            group_ends: list[int] = []
+            group_keys: list[str] = []
+            group_block_ids: list[int] = []
             group_block_size = self._get_block_size(group_id)
             mask_num = (
                 req_meta.load_spec.vllm_cached_tokens  # type: ignore[union-attr]
@@ -903,17 +881,21 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 chunk_filter=chunk_filter,
                 grouped_hash_cache=grouped_hash_cache,
             ):
-                addr, size, block_id = self._prepare_value(
-                    start,
-                    end,
-                    block_ids,
-                    kv_cache_group_id=group_id,
-                    block_id=block_id,
-                )
-                key_list.append(key)
-                addr_list.append(addr)
-                size_list.append(size)
-                block_id_list.append(block_id)
+                group_starts.append(start)
+                group_ends.append(end)
+                group_keys.append(key)
+                group_block_ids.append(block_id)
+
+            group_addrs, group_sizes = self.token_database.prepare_values(
+                group_starts,
+                group_ends,
+                group_block_ids,
+                kv_cache_group_id=group_id,
+            )
+            key_list.extend(group_keys)
+            addr_list.extend(group_addrs)
+            size_list.extend(group_sizes)
+            block_id_list.extend(group_block_ids)
         if not key_list:
             self.set_finished_request(req_id)
             self.request_queue.task_done()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -793,6 +793,10 @@ class KVPoolWorker:
                 if group_id >= len(request.block_ids_by_group):
                     continue
                 block_ids = request.block_ids_by_group[group_id]
+                group_starts: list[int] = []
+                group_ends: list[int] = []
+                group_keys: list[str] = []
+                group_block_ids: list[int] = []
                 group_block_size = self.grouped_block_size[group_id]
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
                 skip_null = group_id < len(self.group_uses_align_state) and self.group_uses_align_state[group_id]
@@ -816,17 +820,21 @@ class KVPoolWorker:
                     chunk_filter=chunk_filter,
                     grouped_hash_cache=grouped_hash_cache,
                 ):
-                    addr, size, block_id = self.token_database.prepare_value(
-                        start,
-                        end,
-                        block_ids,
-                        kv_cache_group_id=group_id,
-                        block_id=block_id,
-                    )
-                    key_list.append(key)
-                    addr_list.append(addr)
-                    size_list.append(size)
-                    block_id_list.append(block_id)
+                    group_starts.append(start)
+                    group_ends.append(end)
+                    group_keys.append(key)
+                    group_block_ids.append(block_id)
+
+                group_addrs, group_sizes = self.token_database.prepare_values(
+                    group_starts,
+                    group_ends,
+                    group_block_ids,
+                    kv_cache_group_id=group_id,
+                )
+                key_list.extend(group_keys)
+                addr_list.extend(group_addrs)
+                size_list.extend(group_sizes)
+                block_id_list.extend(group_block_ids)
             if not key_list:
                 continue
             key_list_c = _circular_shift(key_list, self.tp_rank % len(key_list))


### PR DESCRIPTION
### What this PR does / why we need it?

Non-layerwise KV Pool load and save paths prepared transfer addresses one cache block at a time. Each call looped over every local KV tensor in Python, leaving address preparation exposed even when asynchronous loading was enabled.

This change:

- adds a NumPy-vectorized batch preparation path for block addresses and transfer sizes;
- uses it for asynchronous load, synchronous load, and save after missing-key filtering;
- batches each hybrid KV cache group independently so group-specific block sizes and layouts remain intact;
- preserves the existing key, address, size, and physical block ordering.

A local CPU microbenchmark covering 128 blocks and 156 cache tensors reduced preparation time from 1.589 ms to 0.416 ms (3.82x). This is an algorithm-level microbenchmark and does not replace NPU profiling.

### Does this PR introduce _any_ user-facing change?

No functional or configuration change. It reduces CPU overhead in non-layerwise KV Pool transfer preparation.

### How was this patch tested?

- Updated unit tests for full and partial blocks, empty and invalid inputs, hybrid group ordering, synchronous load, asynchronous load, and save.
- Relevant unit tests: 144 passed, 10 skipped.
- All pre-commit hooks passed.
- NPU profiling was not run locally.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
