### PR TITLE
[Doc][MRV2] Add prefill context parallelism guide

### DIFF
--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -2,35 +2,74 @@
 
 ## Overview
 
-The context parallel features include Decode Context Parallel (DCP) and DSA-CP.
+Context Parallel (CP) serves long-context requests by splitting work or KV-cache storage along the sequence dimension:
 
-Decode Context Parallel (DCP) shards the KV cache along the sequence dimension across devices in a Tensor Parallel (TP) group. It removes redundant KV-cache copies and can increase the batch size available for long-context decoding.
+- Prefill Context Parallel (PCP) splits the prefill tokens of a long prefill request across additional ranks. Each rank computes a different part of the sequence, reducing time to first token (TTFT).
+- Decode Context Parallel (DCP) shards the KV cache across ranks in a DCP group, which may reuse ranks from the PCP group, the Tensor Parallel (TP) group, or both, depending on the parallel configuration. It reduces duplicated KV-cache storage and can increase decode throughput.
 
-Prefill Context Parallel is not supported by vLLM Ascend. The upstream `prefill_context_parallel_size` option must remain at its default value of `1`.
+For a general introduction to these two strategies, see the upstream [vLLM Context Parallel Deployment](https://docs.vllm.ai/en/latest/serving/context_parallel_deployment/) guide.
 
-DSA-CP is a separate sparse-attention optimization controlled by `additional_config.enable_dsa_cp`. See [Additional Configuration](../configuration/additional_config.md) for its configuration and model requirements.
+DSA-CP is a separate sparse-attention optimization controlled by `additional_config.enable_dsa_cp`. It will be removed once PCP support is stable. See [Additional Configuration](../configuration/additional_config.md) for its configuration and model requirements.
 
 ## Supported Scenarios
+
+### Prefill Context Parallel
+
+PCP support is experimental and available only with ModelRunner V2. The following table shows the basic backend support and whether each feature can be combined with PCP:
+
+| Attention Backend | Basic PCP | Prefix Caching + PCP | Chunked Prefill + PCP | MLAPO + PCP | Speculative Decoding + PCP | P/D Disaggregation + PCP | Sequence Parallelism (SP) + PCP |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| MLA | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| GQA | 🟠 Partial compatibility (eager) | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| SFA | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| DSA | 🟠 Partial compatibility (eager) | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+
+- ✅ **Full compatibility**: The basic path or feature combination is supported.
+- 🟠 **Partial compatibility**: The basic path or feature combination is supported with the stated limitations.
+- ❌ **No compatibility**: The backend or feature combination is not supported by the initial MRV2 PCP implementation.
+- **Not applicable**: The feature does not apply to the attention backend.
+
+### Decode Context Parallel
 
 DCP supports eager and graph execution, prefix caching, chunked prefill, speculative decoding, P/D disaggregation, and MLAPO on the model and hardware combinations documented by vLLM Ascend. The following table shows whether each feature can be combined with DCP across devices and attention backends:
 
 | Device | Attention Backend | Chunked Prefill + DCP | Prefix Caching + DCP | Graph Mode + DCP | P/D Disaggregation + DCP | MLAPO + DCP | Speculative Decoding + DCP |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Ascend A2/A3 | MLA/GQA | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported (MLA)<br>— Not applicable (GQA) | 🟢 P/D disaggregation<br>🔴 PD-mixed deployment |
-| Ascend A2/A3 | SFA | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported | 🟢 Supported |
-| Ascend 950 | MLA/GQA | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental | 🔵 Experimental (MLA)<br>— Not applicable (GQA) | 🔵 P/D disaggregation<br>🔴 PD-mixed deployment |
-| Ascend 950 | SFA | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported | 🔴 Not supported |
+| Ascend A2/A3 | MLA/GQA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility (MLA)<br>— Not applicable (GQA) | ✅ P/D disaggregation<br>❌ PD-mixed deployment |
+| Ascend A2/A3 | SFA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility |
+| Ascend 950 | MLA/GQA | 🟠 Partial compatibility | 🟠 Partial compatibility | 🟠 Partial compatibility | 🟠 Partial compatibility | 🟠 Partial compatibility (MLA)<br>— Not applicable (GQA) | 🟠 P/D disaggregation<br>❌ PD-mixed deployment |
+| Ascend 950 | SFA | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
 
-- 🟢 **Supported**: Combining the feature with DCP is supported.
-- 🔵 **Experimental**: Combining the feature with DCP is experimentally supported; interfaces and functionality may change.
-- 🔴 **Not supported**: Combining the feature with DCP is not supported.
+- ✅ **Full compatibility**: Combining the feature with DCP is supported.
+- 🟠 **Partial compatibility**: Combining the feature with DCP is experimentally supported; interfaces and functionality may change.
+- ❌ **No compatibility**: Combining the feature with DCP is not supported.
 - **Not applicable**: The feature does not apply to this attention backend.
 
 DSA-CP supports prefix caching, chunked prefill, speculative decoding, P/D disaggregation on the model and hardware combinations documented by vLLM Ascend.
 
 ## Usage
 
-### DCP
+### Prefill Context Parallel
+
+Enable ModelRunner V2 and set `prefill_context_parallel_size` to the number of PCP ranks:
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+
+vllm serve <supported-model> \
+    --tensor-parallel-size <tp-size> \
+    --prefill-context-parallel-size <pcp-size> \
+    --enforce-eager
+```
+
+Unlike DCP, PCP adds extra ranks: `world_size_with_pcp = prefill_context_parallel_size * original_world_size`.
+
+#### Constraints
+
+- PCP is supported only with ModelRunner V2.
+- PCP and [DSA-CP](#dsa-cp) cannot be enabled simultaneously with the DSA backend.
+
+### Decode Context Parallel
 
 ```bash
 vllm serve <glm-5.2-model> \
@@ -38,21 +77,12 @@ vllm serve <glm-5.2-model> \
   --prefill-context-parallel-size 1 \
   --decode-context-parallel-size <N> \
   --block-size <B> \
-  --cp-kv-cache-interleave-size <B> \
+  --cp-kv-cache-interleave-size <B>
 ```
 
 DCP reuses the TP devices and does not increase the world size.
 
-### DSA-CP
-
-```bash
-vllm serve <glm-5.2-model> \
-  --tensor-parallel-size <N> \
-  --block-size <B> \
-  --additional-config '{"enable_flashcomm1": true, "enable_dsa_cp": true}'
-```
-
-## Constraints
+#### Constraints
 
 - For an MLA model such as DeepSeek-R1:
     - `tensor_parallel_size >= decode_context_parallel_size`
@@ -69,5 +99,14 @@ vllm serve <glm-5.2-model> \
         --cp-kv-cache-interleave-size 128 \
         --kv-transfer-config '{...}'
     ```
+
+### DSA-CP
+
+```bash
+vllm serve <glm-5.2-model> \
+  --tensor-parallel-size <N> \
+  --block-size <B> \
+  --additional-config '{"enable_dsa_cp": true}'
+```
 
 For implementation details, see the [Context Parallel design document](../../developer_guide/Design_Documents/context_parallel.md).


### PR DESCRIPTION
### What this PR does / why we need it?

Updates the Context Parallel documentation with MRV2 PCP support status, usage, world-size behavior, and constraints while retaining the existing DCP and DSA-CP guidance.

### Does this PR introduce _any_ user-facing change?

No. This is a documentation-only change.

### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
