### PR TITLE
[Test] Reduce A3 nightly single node test max parallelism from 9 to 8

### DIFF
--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -262,7 +262,7 @@ jobs:
       (needs.build-image.result == 'success' || needs.build-image.result == 'skipped')
     strategy:
       fail-fast: false
-      max-parallel: 9
+      max-parallel: 8
       matrix:
         vllm_ascend_branch: ${{ fromJSON(needs.setup-vars.outputs.vllm_ascend_branches) }}
         test_config: ${{ fromJson(needs.setup-vars.outputs.single_node) }}


### PR DESCRIPTION
### What this PR does / why we need it?
Reduce the max-parallel value of the A3 nightly test workflow from 9 to 8.
### Does this PR introduce _any_ user-facing change?
No.
### How was this patch tested?
This change only adjusts the GitHub Actions workflow concurrency configuration. It will be validated by the A3 nightly test workflow.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
