### PR TITLE
[Feature] add TP+SP hybrid sequence parallelism for Qwen3-VL VIT

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -251,6 +251,8 @@ class AscendConfig:
     )
     dump_config_path: str | None = None
     c8_enable_reshape_optim: bool = False
+    enable_vision_sp: bool = False
+    enable_vision_sp_fused: bool = False
 
     # ---- A-family (envs fallback): default = envs module value, before-validator injects ----
     enable_fused_mc2: int = 0

--- a/vllm_ascend/ops/vision_sp_strategy.py
+++ b/vllm_ascend/ops/vision_sp_strategy.py
@@ -1,0 +1,190 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""VIT Sequence Parallelism (TP+SP hybrid) strategy interface.
+
+Defines ``VisionSPStrategy`` — an abstract interface with 2 methods that the
+Forward patches call. Phase 1 implements ``NaiveVisionSPStrategy`` (sequential
+comm + matmul using existing primitives). Phase 2 will implement
+``FusedVisionSPStrategy`` (fused comm+matmul ops for 通算掩盖). The Forward
+code is identical for both phases — only the strategy implementation changes.
+
+``matmul_and_reducescatter`` is a standalone function (not part of the
+strategy interface) because no fused version is planned for ReduceScatter.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import torch
+from vllm.distributed import (
+    get_tp_group,
+    tensor_model_parallel_all_gather,
+    tensor_model_parallel_reduce_scatter,
+)
+
+
+class VisionSPStrategy(ABC):
+    """Abstract interface for VIT SP communication strategy.
+
+    Forward patches call these 2 methods for the attention path (AllGather+
+    matmul and AllToAll+matmul). The MLP path uses
+    ``vision_matmul_and_reducescatter`` directly (no strategy, no fused plan).
+    """
+
+    @abstractmethod
+    def allgather_and_matmul(self, input_: torch.Tensor, layer) -> torch.Tensor:
+        """AllGather(seq dim=0) + column-parallel matmul.
+
+        Used for qkv_proj and FFN UP (linear_fc1).
+        Args:
+            input_: [local_seq, ..., in_features]  (SP sharded on dim=0)
+            layer:  ColumnParallelLinear / QKVParallelLinear
+        Returns:
+            [full_seq, ..., out_features_per_partition]
+
+        Note: assumes ``layer.quant_method.apply`` returns a single tensor
+        (not a tuple). This holds when ``return_bias=False`` and
+        ``skip_bias_add=False``, which is the case for all current Qwen3-VL
+        vision layers. If a future layer uses ``skip_bias_add=True`` with a
+        real bias, this method would need to unpack the tuple and add bias.
+        """
+
+    @abstractmethod
+    def alltoall_matmul(self, input_: torch.Tensor, layer) -> torch.Tensor:
+        """AllToAll(seq->head) + full matmul with ReplicatedLinear weight.
+
+        Used for o_proj (proj). After AllToAll each rank holds all heads
+        for its local_seq. The o_proj is a ReplicatedLinear (full weight
+        [H, all_h*head_dim] on every rank), so each rank can compute the
+        full output without AllReduce.
+
+        Args:
+            input_: [full_seq, ..., local_h*head_dim]  (FA output)
+            layer:  ReplicatedLinear (full weight on every rank)
+        Returns:
+            [local_seq, ..., hidden]
+        """
+
+
+def vision_matmul_and_reducescatter(input_: torch.Tensor, layer) -> torch.Tensor:
+    """Row-parallel matmul + ReduceScatter(seq dim=0).
+
+    Standalone function — not part of VisionSPStrategy because no fused
+    version is planned for ReduceScatter. Uses existing primitives directly.
+
+    Used for FFN Down (linear_fc2).
+    Args:
+        input_: [full_seq, ..., local_ffn_dim]
+        layer:  RowParallelLinear
+    Returns:
+        [local_seq, ..., hidden]
+    """
+    tp_rank = get_tp_group().rank_in_group
+    # Row-parallel matmul: bias only on rank 0 to avoid double-add after
+    # ReduceScatter (ReduceScatter sums across ranks).
+    bias_ = None if (tp_rank > 0 or getattr(layer, "skip_bias_add", False)) else layer.bias
+    output_parallel = layer.quant_method.apply(layer, input_, bias_)
+    # ReduceScatter on seq dim: [full_seq, ...] -> [local_seq, ...]
+    output = tensor_model_parallel_reduce_scatter(output_parallel, dim=0)
+    return output
+
+
+class NaiveVisionSPStrategy(VisionSPStrategy):
+    """Phase 1: sequential comm + matmul using existing primitives.
+
+    No fused ops. All communication is done first, then matmul (or vice
+    versa). This is the simplest correct implementation to validate the
+    SP data flow before Phase 2 fusion.
+    """
+
+    def allgather_and_matmul(self, input_, layer):
+        # 1. AllGather on seq dim: [local_seq, ...] -> [full_seq, ...]
+        full_input = tensor_model_parallel_all_gather(input_, dim=0)
+        # 2. Column-parallel matmul (bias added on all ranks since each
+        #    rank holds a different output shard)
+        bias = layer.bias if not getattr(layer, "skip_bias_add", False) else None
+        output = layer.quant_method.apply(layer, full_input, bias)
+        return output
+
+    def alltoall_matmul(self, input_, layer):
+        tp_group = get_tp_group()
+        # 1. AllToAll: scatter seq (dim=0), gather head (dim=-1)
+        #    [full_seq, ..., local_h*head_dim] -> [local_seq, ..., all_h*head_dim]
+        gathered = tp_group.all_to_all(input_, scatter_dim=0, gather_dim=-1)
+        # 2. Full matmul with ReplicatedLinear weight [H, all_h*head_dim].
+        #    No AllReduce needed — each rank already has all heads for its
+        #    local_seq after AllToAll, and the weight is replicated.
+        bias = layer.bias if not getattr(layer, "skip_bias_add", False) else None
+        output = layer.quant_method.apply(layer, gathered, bias)
+        return output
+
+
+_strategy_instance: VisionSPStrategy | None = None
+
+
+def get_vision_sp_strategy() -> VisionSPStrategy:
+    """Factory: returns Naive (Phase 1) or Fused (Phase 2) strategy.
+
+    The choice is controlled by ``enable_vision_sp_fused()``. Forward code
+    calls this to get the strategy instance and is identical for both phases.
+    """
+    global _strategy_instance
+    if _strategy_instance is None:
+        from vllm_ascend.utils import enable_vision_sp_fused
+
+        if enable_vision_sp_fused():
+            _strategy_instance = FusedVisionSPStrategy()
+        else:
+            _strategy_instance = NaiveVisionSPStrategy()
+    return _strategy_instance
+
+
+def clear_vision_sp_strategy():
+    """Reset the strategy singleton. Called from clear_enable_sp()."""
+    global _strategy_instance
+    _strategy_instance = None
+
+
+class FusedVisionSPStrategy(VisionSPStrategy):
+    """Phase 2: fused comm+matmul (通算掩盖). Interface is identical to Naive.
+
+    Each method replaces sequential comm+matmul with a single fused op that
+    overlaps communication and computation. Requires Phase 2 fused ops to be
+    available (developed by other team members).
+
+    Reference implementations:
+    - allgather_and_matmul: see SequenceColumnParallelOp (linear_op.py:288)
+    - alltoall_matmul: see OProjRowParallelOp (linear_op.py:239)
+
+    Note: matmul_and_reducescatter is NOT part of this strategy — it uses
+    existing ReduceScatter directly (no fused version planned).
+    """
+
+    def allgather_and_matmul(self, input_, layer):
+        raise NotImplementedError(
+            "FusedVisionSPStrategy is Phase 2. Set additional_config."
+            "enable_vision_sp_fused to False to use NaiveVisionSPStrategy "
+            "(Phase 1)."
+        )
+
+    def alltoall_matmul(self, input_, layer):
+        raise NotImplementedError(
+            "FusedVisionSPStrategy is Phase 2. Set additional_config."
+            "enable_vision_sp_fused to False to use NaiveVisionSPStrategy "
+            "(Phase 1)."
+        )

--- a/vllm_ascend/patch/worker/patch_qwen3vl.py
+++ b/vllm_ascend/patch/worker/patch_qwen3vl.py
@@ -1,15 +1,22 @@
 import torch
-from vllm.distributed import get_tensor_model_parallel_rank, get_tensor_model_parallel_world_size
+from vllm.distributed import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+    tensor_model_parallel_all_gather,
+)
+from vllm.model_executor.layers.linear import ReplicatedLinear, UnquantizedLinearMethod
+from vllm.model_executor.models.qwen2_5_vl import Qwen2_5_VisionAttention
 from vllm.model_executor.models.qwen3 import Qwen3Attention
 from vllm.model_executor.models.qwen3_moe import Qwen3MoeAttention
 from vllm.model_executor.models.qwen3_vl import (
+    Qwen3_VisionMLP,
     Qwen3_VisionTransformer,
     Qwen3VLForConditionalGeneration,
     pos_embed_interpolate_native,
 )
 
 from vllm_ascend.ops.rotary_embedding import AscendMRotaryEmbedding
-from vllm_ascend.utils import enable_sp
+from vllm_ascend.utils import enable_sp, enable_vision_sp
 
 
 def tensor_parallel_wrap(func):
@@ -103,3 +110,292 @@ def patch_qwen3_vl_moe_pp_layer_range():
 
 
 patch_qwen3_vl_moe_pp_layer_range()
+
+
+# ---------------------------------------------------------------------------
+# VIT Sequence Parallelism (TP+SP hybrid) — Module E: registration
+# ---------------------------------------------------------------------------
+# Patches are applied at import time. Each wrapper checks enable_vision_sp()
+# at runtime: when SP is off, the original forward is called (zero overhead);
+# when SP is on, the SP forward (which calls VisionSPStrategy) is called.
+
+_orig_vision_attention_forward = Qwen2_5_VisionAttention.forward
+_orig_vision_mlp_forward = Qwen3_VisionMLP.forward
+_orig_vision_transformer_forward = Qwen3_VisionTransformer.forward
+
+
+def _sp_vision_transformer_forward(self, x, grid_thw, *, encoder_metadata=None):
+    """SP-mode VisionTransformer.forward.
+
+    Compared to the original forward (qwen3_vl.py:800), this version:
+    - Pads total_seq to be divisible by tp_size (padding is trimmed at exit)
+    - Splits the sequence across TP ranks before the blocks loop (SP entry)
+    - AllGathers before each deepstack merger and before the final merger (SP exit)
+    - Trims padding from the final output
+    """
+    hidden_states = x.to(device=self.device, dtype=self.dtype, non_blocking=True)
+    hidden_states = self.patch_embed(hidden_states)
+
+    if encoder_metadata is None:
+        if isinstance(grid_thw, list):
+            grid_thw_list = grid_thw
+        else:
+            grid_thw_list = grid_thw.tolist()
+        encoder_metadata = self.prepare_encoder_metadata(grid_thw_list)
+
+    pos_embeds = encoder_metadata["pos_embeds"]
+    hidden_states = hidden_states + pos_embeds
+    hidden_states = hidden_states.unsqueeze(1)  # [total_seq, 1, hidden]
+
+    tp_size = get_tensor_model_parallel_world_size()
+    tp_rank = get_tensor_model_parallel_rank()
+    total_seq = hidden_states.shape[0]
+
+    # --- SP entry padding ---
+    # total_seq may not be divisible by tp_size (e.g. tp_size >= 8).
+    # Pad with zeros so each rank gets an equal-sized shard.
+    # The padded tokens' outputs are discarded at SP exit.
+    padded_seq = ((total_seq + tp_size - 1) // tp_size) * tp_size
+    if padded_seq != total_seq:
+        # Shallow-copy metadata dict so we don't mutate the caller's copy
+        # (the same metadata may be reused across forward calls, e.g. cudagraph).
+        encoder_metadata = dict(encoder_metadata)
+        pad_len = padded_seq - total_seq
+        hidden_states = torch.nn.functional.pad(hidden_states, (0, 0, 0, 0, 0, pad_len))
+        # Pad rotary cos/sin to match the AllGathered full_seq inside blocks.
+        # Pad with the last valid entry so RoPE produces finite values for
+        # dummy tokens (their output is discarded at exit).
+        cos = encoder_metadata.get("rotary_pos_emb_cos")
+        sin = encoder_metadata.get("rotary_pos_emb_sin")
+        if cos is not None and cos.shape[0] == total_seq:
+            cos_pad = cos[-1:].expand(pad_len, -1)
+            encoder_metadata["rotary_pos_emb_cos"] = torch.cat([cos, cos_pad], dim=0)
+        if sin is not None and sin.shape[0] == total_seq:
+            sin_pad = sin[-1:].expand(pad_len, -1)
+            encoder_metadata["rotary_pos_emb_sin"] = torch.cat([sin, sin_pad], dim=0)
+        # Pad cu_seqlens by appending padded_seq as a dummy segment endpoint
+        # so FIA sees a token-count matching the padded input. The dummy
+        # segment isolates padded tokens' attention from real tokens.
+        cu_seqlens = encoder_metadata.get("cu_seqlens")
+        if cu_seqlens is not None and cu_seqlens[-1].item() == total_seq:
+            dummy = torch.tensor([padded_seq], dtype=cu_seqlens.dtype, device=cu_seqlens.device)
+            encoder_metadata["cu_seqlens"] = torch.cat([cu_seqlens, dummy])
+
+    # SP entry: split sequence evenly across TP ranks
+    local_seq = padded_seq // tp_size
+    hidden_states = hidden_states[tp_rank * local_seq : (tp_rank + 1) * local_seq]
+
+    deepstack_feature_lists = []
+    for layer_num, blk in enumerate(self.blocks):
+        # Block.forward is NOT patched — it calls self.attn() and self.mlp()
+        # which ARE patched. Residual Add and LayerNorm operate on local_seq
+        # (both are element-wise, so local_seq is correct).
+        hidden_states = blk(
+            hidden_states,
+            cu_seqlens=encoder_metadata["cu_seqlens"],
+            rotary_pos_emb_cos=encoder_metadata["rotary_pos_emb_cos"],
+            rotary_pos_emb_sin=encoder_metadata["rotary_pos_emb_sin"],
+            max_seqlen=encoder_metadata["max_seqlen"],
+            sequence_lengths=encoder_metadata.get("sequence_lengths"),
+        )
+        if layer_num in self.deepstack_visual_indexes:
+            # Deepstack mergers require full_seq (they reshape by
+            # spatial_merge_size). AllGather, TRIM padding to total_seq,
+            # then run merger. Trimming is critical: without it, the merger
+            # produces padded_seq/4 tokens while the final merger produces
+            # total_seq/4, causing torch.cat dim=0 mismatch.
+            full_hs = tensor_model_parallel_all_gather(hidden_states, dim=0)
+            if padded_seq != total_seq:
+                full_hs = full_hs[:total_seq]
+            deepstack_merger_idx = self.deepstack_visual_indexes.index(layer_num)
+            deepstack_feature = self.deepstack_merger_list[deepstack_merger_idx](full_hs)
+            deepstack_feature_lists.append(deepstack_feature)
+
+    # SP exit: AllGather to restore full (padded) seq for the final merger
+    hidden_states = tensor_model_parallel_all_gather(hidden_states, dim=0)
+    # Trim padding back to original total_seq
+    if padded_seq != total_seq:
+        hidden_states = hidden_states[:total_seq]
+    hidden_states = self.merger(hidden_states)
+    hidden_states = torch.cat([hidden_states] + deepstack_feature_lists, dim=1)
+    return hidden_states
+
+
+def _sp_vision_attention_forward(
+    self,
+    x,
+    cu_seqlens,
+    rotary_pos_emb_cos,
+    rotary_pos_emb_sin,
+    max_seqlen,
+    sequence_lengths,
+):
+    """SP-mode VisionAttention.forward (Ulysses-style SP for attention).
+
+    Original flow (TP-only, qwen2_5_vl.py:398-456):
+        x [full_seq] -> qkv -> RoPE -> FA -> o_proj(+AllReduce) -> [full_seq]
+
+    SP flow (TP+SP):
+        x [local_seq] -> AllGather+qkv -> RoPE -> FA -> AllToAll+o_proj(+AllReduce) -> [local_seq]
+    """
+    import einops
+
+    from vllm_ascend.ops.vision_sp_strategy import get_vision_sp_strategy
+
+    strategy = get_vision_sp_strategy()
+
+    # x: [local_seq, 1, hidden] (SP sharded on dim=0)
+    # Step 1: AllGather & Matmul (qkv)
+    #   strategy: all_gather(x, dim=0) -> [full_seq, 1, hidden]
+    #             then quant_method.apply(qkv_layer, full_x, bias)
+    #             -> [full_seq, 1, 3*local_h*head_dim]
+    x = strategy.allgather_and_matmul(x, self.qkv)
+
+    seq_len, batch_size, _ = x.shape
+    qkv = einops.rearrange(
+        x,
+        "s b (three head head_dim) -> b s three head head_dim",
+        three=3,
+        head=self.num_attention_heads_per_partition,
+    )
+
+    # Step 2: RoPE
+    #   cos/sin are the FULL versions (all ranks hold a copy, not SP-sharded).
+    #   x is already full_seq after Step 1's AllGather, so dimensions match.
+    if rotary_pos_emb_cos is not None and rotary_pos_emb_sin is not None:
+        qk, v = qkv[:, :, :2], qkv[:, :, 2]
+        qk_reshaped = einops.rearrange(qk, "b s two head head_dim -> (two b) s head head_dim", two=2)
+        qk_reshaped = qk_reshaped.contiguous()
+        qk_rotated = self.apply_rotary_emb(qk_reshaped, rotary_pos_emb_cos, rotary_pos_emb_sin)
+        qk_rotated = qk_rotated.view(
+            2,
+            batch_size,
+            seq_len,
+            self.num_attention_heads_per_partition,
+            self.hidden_size_per_attention_head,
+        )
+        q, k = qk_rotated.unbind(dim=0)
+    else:
+        q, k, v = qkv.unbind(dim=2)
+
+    # Step 3: FA (Flash Attention / FIA)
+    #   Each rank computes attention for its local_h heads over full_seq.
+    #   cu_seqlens and max_seqlen are the full versions — SP does not change
+    #   sequence boundaries, only which tokens each rank stores between layers.
+    context_layer = self.attn(
+        query=q,
+        key=k,
+        value=v,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen,
+        sequence_lengths=sequence_lengths,
+    )
+    context_layer = einops.rearrange(context_layer, "b s h d -> s b (h d)", b=batch_size).contiguous()
+    # [full_seq, 1, local_h*head_dim]
+
+    # Step 4: AllToAll & Matmul (o_proj)
+    #   strategy: all_to_all(context, scatter=seq, gather=head)
+    #             -> [local_seq, 1, all_h*head_dim]
+    #             then quant_method.apply(proj, gathered, bias)
+    #             -> [local_seq, 1, hidden] (full, no AllReduce needed)
+    #   o_proj is ReplicatedLinear when SP is enabled (full weight on every rank)
+    output = strategy.alltoall_matmul(context_layer, self.proj)
+    return output
+
+
+def _sp_vision_mlp_forward(self, x):
+    """SP-mode VisionMLP.forward (AllGather/ReduceScatter SP for MLP).
+
+    Original flow (TP-only, qwen3_vl.py:408-410):
+        x [full_seq] -> linear_fc1 -> act_fn -> linear_fc2(+AllReduce) -> [full_seq]
+
+    SP flow (TP+SP):
+        x [local_seq] -> AllGather+linear_fc1 -> act_fn -> linear_fc2+ReduceScatter -> [local_seq]
+    """
+    from vllm_ascend.ops.vision_sp_strategy import (
+        get_vision_sp_strategy,
+        vision_matmul_and_reducescatter,
+    )
+
+    strategy = get_vision_sp_strategy()
+    # x: [local_seq, 1, hidden]
+    # Step 1: AllGather & FFN UP
+    up_out = strategy.allgather_and_matmul(x, self.linear_fc1)
+    # [full_seq, 1, local_ffn_dim]
+    # Step 2: Gelu (element-wise, same as TP-only)
+    act_out = self.act_fn(up_out)
+    # [full_seq, 1, local_ffn_dim]
+    # Step 3: FFN Down & ReduceScatter
+    #   Standalone function (no fused version planned for ReduceScatter)
+    down_out = vision_matmul_and_reducescatter(act_out, self.linear_fc2)
+    # [local_seq, 1, hidden]
+    return down_out
+
+
+# --- Runtime dispatch wrappers ---
+
+
+def _vision_attention_forward_wrapper(self, *args, **kwargs):
+    if enable_vision_sp():
+        return _sp_vision_attention_forward(self, *args, **kwargs)
+    return _orig_vision_attention_forward(self, *args, **kwargs)
+
+
+def _vision_mlp_forward_wrapper(self, x):
+    if enable_vision_sp():
+        return _sp_vision_mlp_forward(self, x)
+    return _orig_vision_mlp_forward(self, x)
+
+
+def _vision_transformer_forward_wrapper(self, *args, **kwargs):
+    if enable_vision_sp():
+        return _sp_vision_transformer_forward(self, *args, **kwargs)
+    return _orig_vision_transformer_forward(self, *args, **kwargs)
+
+
+# --- Apply patches ---
+Qwen2_5_VisionAttention.forward = _vision_attention_forward_wrapper
+Qwen3_VisionMLP.forward = _vision_mlp_forward_wrapper
+Qwen3_VisionTransformer.forward = _vision_transformer_forward_wrapper
+
+
+# ---------------------------------------------------------------------------
+# Path A: Replace o_proj with ReplicatedLinear when SP is enabled
+# ---------------------------------------------------------------------------
+# When vision SP is enabled, o_proj must use a full (replicated) weight
+# [H, N*head_dim] on every rank so that after AllToAll each rank can compute
+# the complete output for its local_seq without AllReduce. ReplicatedLinear's
+# weight_loader loads the checkpoint weight without TP sharding, so every rank
+# naturally receives the full weight at load time -- no runtime AllGather
+# needed.
+#
+# When SP is NOT enabled, o_proj stays RowParallelLinear (original behavior).
+# enable_vision_sp() is determined by config and stable throughout inference;
+# it is only reset by clear_enable_sp() during startup reinit (before model
+# construction), so the layer type is always consistent with the runtime flag.
+# ---------------------------------------------------------------------------
+
+_orig_vision_attn_init = Qwen2_5_VisionAttention.__init__
+
+
+def _patched_vision_attn_init(self, *args, **kwargs):
+    _orig_vision_attn_init(self, *args, **kwargs)
+    if enable_vision_sp():
+        tp_size = get_tensor_model_parallel_world_size()
+        orig_proj = self.proj
+        output_size = orig_proj.weight.shape[0]
+        input_size = orig_proj.weight.shape[1] * tp_size
+        has_bias = orig_proj.bias is not None
+        if not isinstance(orig_proj.quant_method, UnquantizedLinearMethod):
+            raise NotImplementedError(
+                "ReplicatedLinear o_proj with quantized ViT is not yet "
+                "supported. Please disable vision SP or use unquantized ViT."
+            )
+        self.proj = ReplicatedLinear(
+            input_size=input_size,
+            output_size=output_size,
+            bias=has_bias,
+        )
+
+
+Qwen2_5_VisionAttention.__init__ = _patched_vision_attn_init

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -73,6 +73,8 @@ _DYNAMIC_EPLB_BUFFER_SIZE = 100
 _IS_MOE_MODEL = None
 _IS_DRAFTER_MOE_MODEL = None
 _IS_VL_MODEL = None
+_ENABLE_VISION_SP = None
+_ENABLE_VISION_SP_FUSED = None
 _HAS_LAYER_IDX = None
 _HAS_ROPE = None
 _ATNN_CALCULATION_STREAM = None
@@ -136,9 +138,19 @@ def enable_sfa_dcp_replicated_indexer(vllm_config: VllmConfig | None = None) -> 
 
 
 def clear_enable_sp():
+    global _ENABLE_VISION_SP, _ENABLE_VISION_SP_FUSED
+    _ENABLE_VISION_SP = None
+    _ENABLE_VISION_SP_FUSED = None
     enable_dsa_cp.cache_clear()
     enable_dsa_cp_with_o_proj_tp.cache_clear()
     _libc_getenv.cache_clear()
+    # Reset the vision SP strategy singleton so that flag changes take effect
+    try:
+        from vllm_ascend.ops.vision_sp_strategy import clear_vision_sp_strategy
+
+        clear_vision_sp_strategy()
+    except ImportError:
+        pass
 
 
 _IS_RC_DEVICE: bool | None = None
@@ -817,6 +829,70 @@ def enable_sp(vllm_config=None) -> bool:
         return False
 
     return bool(vllm_config.parallel_config.use_sequence_parallel_moe)
+
+
+def enable_vision_sp(vllm_config=None) -> bool:
+    """Check if VIT sequence parallelism (TP+SP hybrid) is enabled.
+
+    Reads from additional_config first, then falls back to env var.
+    Result is cached globally; pass vllm_config with refresh=True to re-read.
+    """
+    global _ENABLE_VISION_SP
+    if vllm_config is None:
+        try:
+            from vllm.config import get_current_vllm_config
+
+            vllm_config = get_current_vllm_config()
+        except AssertionError:
+            vllm_config = None
+
+    additional_config = getattr(vllm_config, "additional_config", None) if vllm_config is not None else None
+    refresh = additional_config.get("refresh", False) if additional_config else False
+
+    if _ENABLE_VISION_SP is None or refresh:
+        if additional_config is not None and "enable_vision_sp" in additional_config:
+            _ENABLE_VISION_SP = bool(additional_config["enable_vision_sp"])
+        else:
+            try:
+                _ENABLE_VISION_SP = get_ascend_config().enable_vision_sp
+            except RuntimeError:
+                _ENABLE_VISION_SP = False
+
+    if not bool(_ENABLE_VISION_SP):
+        return False
+
+    # SP requires tp_size > 1 (SP reuses the TP communication group)
+    from vllm.distributed import get_tensor_model_parallel_world_size
+
+    if get_tensor_model_parallel_world_size() <= 1:
+        return False
+
+    # SP is incompatible with VIT data-parallel mode (disable_tp=True means
+    # weights are not sharded, so AllGather/AllToAll on the TP group would
+    # produce garbage). Auto-disable in that case.
+    try:
+        from vllm.model_executor.models.vision import is_vit_use_data_parallel
+
+        if is_vit_use_data_parallel():
+            return False
+    except Exception:
+        pass
+
+    return True
+
+
+def enable_vision_sp_fused() -> bool:
+    """Check if fused comm ops (Phase 2) are enabled for VIT SP.
+
+    Only meaningful when enable_vision_sp() is also True.
+    """
+    global _ENABLE_VISION_SP_FUSED
+    if _ENABLE_VISION_SP_FUSED is None:
+        try:
+            _ENABLE_VISION_SP_FUSED = get_ascend_config().enable_vision_sp_fused
+        except RuntimeError:
+            _ENABLE_VISION_SP_FUSED = False
+    return bool(_ENABLE_VISION_SP_FUSED)
 
 
 # TODO remove it after vllm has this func


### PR DESCRIPTION
…coder

- add TP+SP hybrid sequence parallelism for Qwen3-VL VIT encoder
- fix padding, DP guard, metadata mutation, and ReduceScatter interface
- remove incorrect AllReduce in SP o_proj, use AllGathered full weight
- switch SP o_proj to ReplicatedLinear (Path A)

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
