### PR TITLE
[v0.26.0rc][BugFix][Kimi K3] Unwrap StageMissingLayer before deleting unused Kimi K3 rot_proj

### DIFF
--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import torch
 from torch import nn
+from vllm.model_executor.models.utils import StageMissingLayer
 
 from vllm_ascend.models import kimi_k3
 from vllm_ascend.models.kimi_k3 import (
@@ -148,6 +149,41 @@ def test_kimi_k3_enables_projector_rotation_only_when_weight_is_loaded(
     assert actual == loaded_weights
     assert hasattr(wrapper.mm_projector, "rot_proj") is has_rot_proj
     assert ("mm_projector.rot_proj.weight" in dict(wrapper.named_parameters())) is has_rot_proj
+
+
+def test_kimi_k3_deletes_unused_rot_proj_when_projector_is_placeholder(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Text-only serving (--language-model-only, or --limit-mm-per-prompt at 0
+    # for all tower modalities) wraps tower components in StageMissingLayer.
+    # Its __getattr__ delegates to the wrapped projector, but del acts on the
+    # placeholder's own registries (empty by design), so deleting
+    # mm_projector.rot_proj directly raises AttributeError. The deletion must
+    # target the wrapped module instead.
+    class StubLoader:
+        def __init__(self, model, *, skip_prefixes):
+            assert model is wrapper
+            assert skip_prefixes == []
+
+        def load_weights(self, weights, *, mapper):
+            assert list(weights) == []
+            assert mapper is wrapper.hf_to_vllm_mapper
+            return {"mm_projector.linear_1.weight"}
+
+    monkeypatch.setattr(kimi_k3, "AutoWeightsLoader", StubLoader)
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(AscendKimiK3ForConditionalGeneration)
+    nn.Module.__init__(wrapper)
+    projector = nn.Module()
+    projector.rot_proj = nn.Linear(1, 1, bias=False)
+    wrapper.mm_projector = StageMissingLayer("vision_tower", projector)
+
+    actual = wrapper.load_weights(iter(()))
+
+    assert actual == {"mm_projector.linear_1.weight"}
+    # The unused rotation was released from the wrapped projector...
+    assert hasattr(projector, "rot_proj") is False
+    # ...and lookups through the placeholder no longer find it either.
+    assert hasattr(wrapper.mm_projector, "rot_proj") is False
 
 
 def test_kimi_k3_projector_applies_rotation_only_after_weight_load():

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -616,7 +616,15 @@ class AscendKimiK3ForConditionalGeneration(
         )
         loaded_weights = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
         if rot_proj is not None and rot_proj_weight_names.isdisjoint(loaded_weights):
-            del self.mm_projector.rot_proj
+            # StageMissingLayer.__getattr__ delegates to the wrapped module, so
+            # rot_proj above is the real one, but del must act on the module
+            # that actually holds the registration. Unwrap the placeholder
+            # (language-model-only / zero mm limit deployments) before deleting.
+            # cast: the runtime value is the projector or its StageMissingLayer
+            # wrapper, both nn.Module; the getattr default form confuses mypy.
+            target = cast(nn.Module, getattr(self.mm_projector, "module", self.mm_projector))
+            if "rot_proj" in target._modules:
+                del target.rot_proj
         return loaded_weights
 
 


### PR DESCRIPTION
### What this PR does / why we need it?

Serving Kimi K3 **text-only** (`--language-model-only`, or `--limit-mm-per-prompt` set to 0 for all tower modalities) with a checkpoint that does **not** carry projector rotation weights crashes deterministically during weight loading:

```python
AttributeError: 'StageMissingLayer' object has no attribute 'rot_proj'
  File ".../vllm_ascend/models/kimi_k3.py", line 619, in load_weights
    del self.mm_projector.rot_proj
```

**Root cause**: #14231 releases the unused (default-initialized) `rot_proj` when the checkpoint has no projector rotation weights — the cleanup requested in review. In text-only serving, vLLM core wraps tower components in `StageMissingLayer`, whose `__getattr__` delegates to the wrapped projector:

- `getattr(self.mm_projector, "rot_proj", None)` sees **through** the placeholder and finds the real `rot_proj` (not `None`), so the deletion branch is entered;
- `del self.mm_projector.rot_proj` acts on the placeholder's **own** registries (`_parameters` / `_modules` / `_buffers`), which are intentionally empty (the wrapped module is deliberately not registered to avoid missing-key errors during weight loading) → `AttributeError`.

The probe is deep but the deletion is shallow — same object, same attribute name, contradictory answers.

**Fix**: unwrap the placeholder before deleting, so the review-intended cleanup works for both the plain projector and the wrapped form. The projector forward already guards with `getattr(self, "rot_proj", None)`, so post-deletion behavior is unchanged.

### Does this PR introduce _any_ user-facing change?

Text-only Kimi K3 serving with checkpoints lacking projector rotation weights no longer crashes at startup. No behavior change otherwise.

### How was this patch tested?

- **Unit tests added**: `tests/ut/models/test_kimi_k3.py::test_kimi_k3_deletes_unused_rot_proj_when_projector_is_placeholder` — covers the `StageMissingLayer`-wrapped form (raises `AttributeError` before the fix, passes after). Existing rotation tests (plain-projector form) are unchanged and still pass.
- **Manual testing**: 8×Ascend 910B, TP8×EP, `releases/v0.26.0rc` @ `47660ebfa`, K3 w4a8 checkpoint (no projector rotation weights), `--language-model-only` + `--limit-mm-per-prompt '{"vision_chunk":0}'` — deterministic `AttributeError` at ~94% of checkpoint loading before the fix; clean startup after applying it.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
