### PR TITLE
[Spec Decode] [Doc] Support speculative decode KV slidng window for Dspark

### DIFF
--- a/docs/source/developer_guide/Design_Documents/speculative_kv_sliding_window.md
+++ b/docs/source/developer_guide/Design_Documents/speculative_kv_sliding_window.md
@@ -35,7 +35,7 @@ Let `W` be the window size, `b` the kernel block size, `K = future_offset`
 the number of draft query positions lying beyond the `seq_lens` value the
 adapter sees. The adapter computes, entirely on device:
 
-```
+```text
 start        = floor(clamp(seq_lens + K - W, min=0) / b) * b   # block-aligned window start
 windowed_len = seq_lens - start                                # <= W + b - 1
 start_block  = start // b

--- a/docs/source/developer_guide/Design_Documents/speculative_kv_sliding_window.md
+++ b/docs/source/developer_guide/Design_Documents/speculative_kv_sliding_window.md
@@ -1,0 +1,118 @@
+# Speculative Decoding KV Sliding Window
+
+Speculative decoding draft models are typically trained on short contexts
+(e.g. 4-8K tokens). At inference time, when the running context grows far
+beyond the training length, the draft's attention over the full KV cache goes
+out-of-distribution and acceptance collapses: on GLM-5.2 with an early DSpark
+draft, the mean acceptance length dropped from ~5 to ~1 at 32K context, making
+speculation a net loss.
+
+The KV sliding window caps the **draft model's attention** to the most recent
+`draft_window_size` tokens. The target model is untouched - it always attends
+to the full context, so generation quality is preserved; only the draft reads
+a shorter, in-distribution window. On acceptance-collapsed drafts this
+restores acceptance (the same GLM-5.2 draft recovered from ~1.0 to ~4.7-5.5
+at 32K, up to +381% end-to-end throughput in the original evaluation).
+
+## Configuration
+
+The window is enabled through `additional_config` and is available for the
+EAGLE3 / DFlash / DSpark draft paths on the default (MRV1) model runner:
+
+```json
+{"draft_window_size": 2048}
+```
+
+It is disabled by default (key absent). MTP force-disables it (MTP reuses the
+target's own layers, so windowing the draft would window the target); for a
+DSpark draft that was natively trained together with a DeepSeek-V4 target, a
+warning is logged because the draft is already long-context stable and
+windowing degrades acceptance.
+
+## Window math
+
+Let `W` be the window size, `b` the kernel block size, `K = future_offset`
+the number of draft query positions lying beyond the `seq_lens` value the
+adapter sees. The adapter computes, entirely on device:
+
+```
+start        = floor(clamp(seq_lens + K - W, min=0) / b) * b   # block-aligned window start
+windowed_len = seq_lens - start                                # <= W + b - 1
+start_block  = start // b
+needed       = ceil(windowed_len / b)  (capped at max_window_blocks = W//b + 1)
+```
+
+`future_offset` differs by draft family because their `seq_lens` semantics
+differ:
+
+| Method | future_offset | Why |
+| --- | --- | --- |
+| EAGLE3 | `num_speculative_tokens` | `seq_lens` is context-only; the K draft positions lie beyond it, so the window end must cover `seq_lens + K`. |
+| DFlash / DSpark | `0` | the input-preparation kernel already bakes the query stretch (bonus + mask tokens) into `seq_lens`, so `final = seq_lens`. |
+
+The block table is cropped by gathering columns
+`start_block[i] + [0, max_window_blocks)` from the full table into a
+zero-padded clone; columns past `needed` (and past the full-table width) are
+zeroed. Zeroed columns are never read because every FIA KV-length input is
+capped at the same `windowed_len`.
+
+Two invariants hold throughout:
+
+- **slot_mapping is never windowed.** Draft KV writes still go through the
+  full block table at absolute positions, so the cache stays coherent for the
+  target model and for window sizes changed between steps.
+- **Only what FIA reads is capped.** The FIA kernel's KV-length inputs are the
+  NPU `seq_lens` tensor plus CPU mirrors (`seq_lens_cpu`, `_seq_lens_cpu`,
+  `seq_lens_cpu_upper_bound`); all of them are windowed with the same
+  arithmetic so no path can read past the window.
+
+## MRV1 implementation
+
+`SlidingWindowAdapter` (`vllm_ascend/spec_decode/utils.py`) owns the math
+above and a persistent `[max_num_reqs, max_window_blocks]` clone buffer. It is
+constructed in `AscendSpecDecodeBaseProposer.__init__`
+(`vllm_ascend/spec_decode/llm_base_proposer.py`) when `draft_window_size` is
+set, then applied to the draft's `common_attn_metadata` **before** the
+per-layer metadata is built.
+
+There are two apply points because of how the drafts construct metadata:
+
+- EAGLE3 / DFlash: applied once in `_propose` on the shared
+  `common_attn_metadata` (`llm_base_proposer.py`).
+- DSpark: that path is bypassed - the dspark branch of
+  `build_draft_attn_metadata` overwrites
+  `common_attn_metadata.block_table_tensor` with a per-group full table before
+  building. The adapter is therefore applied **after** the per-group overwrite
+  and before `builder.build_for_drafting`, so FIA reads the windowed clone of
+  the per-group table instead of the full one.
+
+## MRV2 status
+
+Model Runner V2 is not yet covered by this feature. The MRV2 speculator
+system bakes `seq_lens` / block tables into the final per-layer metadata
+inside `build_attn_metadata` - there is no shared `common_attn_metadata` to
+mutate after the build, so porting the window requires applying it to the
+**builder inputs** (windowed `input_buffers.seq_lens`, gathered per-group
+block-table clones, capped `seq_lens_cpu_upper_bound`) around the
+`_build_draft_attn_metadata` call in
+`vllm_ascend/worker/v2/spec_decode/dspark/speculator.py`. The window math
+and the two invariants above carry over unchanged.
+
+## Expected behavior
+
+- Drafts trained on short contexts that collapse on long inputs (acceptance
+  dropping with context length): the window restores acceptance up to the
+  draft's short-context level. The gain grows with input length.
+- Drafts already stable at long context (recently trained drafts, or drafts
+  with their own SWA structure): the window provides no benefit and can hurt
+  if set **below** the draft's training window - the draft expects to see
+  more context than the window allows. Rule of thumb: keep
+  `draft_window_size` at or above the draft's training/native window, or
+  leave it off when acceptance is already flat across context lengths.
+- End-to-end effect combines the acceptance change with the draft's reduced
+  KV-read cost; with no acceptance gain the two roughly cancel.
+
+## Related Files
+
+- Shared window adapter: `vllm_ascend/spec_decode/utils.py`
+- MRV1 proposer (apply points, config validation): `vllm_ascend/spec_decode/llm_base_proposer.py`

--- a/docs/source/user_guide/feature_guide/speculative_decoding.md
+++ b/docs/source/user_guide/feature_guide/speculative_decoding.md
@@ -322,6 +322,72 @@ The following code configures vLLM Ascend to use speculative decoding where prop
       --speculative-config '{"method": "dspark", "model": "deepseek-ai/dspark_qwen3_8b_block7", "num_speculative_tokens": 7, "enforce_eager": true}'
     ```
 
+## Draft KV Sliding Window {: #draft-kv-sliding-window }
+
+Draft models are often trained on short contexts (e.g. 4-8K tokens). When the
+running context grows far beyond that, the draft's attention goes
+out-of-distribution and the acceptance rate collapses — speculation turns
+into overhead. The **draft KV sliding window** caps only the *draft model's*
+attention to the most recent `draft_window_size` tokens. The target model
+still attends to the full context, so output quality is unchanged.
+
+Enable it through `--additional-config` with any of the `eagle3`, `dflash`,
+and `dspark` methods:
+
+```shell
+vllm serve path/to/target/model \
+  --tensor-parallel-size 8 \
+  --speculative-config '{"method": "dspark", "model": "path/to/draft/model", "num_speculative_tokens": 7, "enforce_eager": true}' \
+  --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+  --additional-config '{"draft_window_size": 2048}'
+```
+
+For offline inference, pass the same key inside `additional_config`:
+
+```python
+llm = LLM(
+    model="path/to/target/model",
+    speculative_config={
+        "method": "dspark",
+        "model": "path/to/draft/model",
+        "num_speculative_tokens": 7,
+        "enforce_eager": True,
+    },
+    additional_config={"draft_window_size": 2048},
+)
+```
+
+`additional_config` is forwarded to `EngineArgs` like the other engine
+options.
+
+- **`draft_window_size`** (int, optional): the number of most recent tokens
+  the draft attention can read. Omit the key (or remove it) to disable the
+  window. Typical values are 512-4096; the window is block-aligned internally,
+  so any positive value works.
+- Works on the default model runner (MRV1). Not yet supported under
+  `VLLM_USE_V2_MODEL_RUNNER=1`.
+- For `mtp` the window is ignored (force-disabled): MTP reuses the target
+  model's own layers, so windowing it would change the target's computation.
+
+### When to enable it
+
+- **Enable** when the draft was trained on short contexts and acceptance
+  degrades as conversations grow: e.g. an early GLM-5.2 DSpark draft dropped
+  from mean acceptance ~5 (short context) to ~1 at 32K; a 512-1024 window
+  restored it to ~4.7-5.5, with end-to-end throughput up to +381% at 32K.
+- **Leave it off** when the draft is already stable at long context — the
+  window then only removes information the draft could have used. In
+  particular, if the draft itself was trained with sliding-window attention
+  (its config carries a native `sliding_window`), keep
+  `draft_window_size` at or above that training window, or disable the
+  feature; a window smaller than the training window measurably reduces
+  acceptance (observed -4.5% mean acceptance for a 1024 window against a
+  2048-native SWA DSpark draft at 32K input).
+
+Check the effect with the server log: `SpecDecoding metrics: Mean acceptance
+length: ...` lines report the acceptance per interval — compare runs with the
+window off and on under your real workload before settling on a value.
+
 ## Speculating using Suffix Decoding
 
 The following code configures vLLM to use speculative decoding where proposals are generated using Suffix Decoding [(SuffixDecoding: Extreme Speculative Decoding for Emerging AI Applications)](https://arxiv.org/abs/2411.04975).

--- a/tests/e2e/pull_request/one_card/spec_decode/test_dspark.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/test_dspark.py
@@ -75,3 +75,84 @@ def test_dspark_acceptance(
 
     match = all(abs(a - b) < 0.1 for a, b in zip(acceptance_per_pos, golden))
     assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"
+
+
+@pytest.mark.parametrize("method", DSPARK.keys())
+@pytest.mark.parametrize("num_speculative_tokens", [7])
+def test_dspark_kv_sliding_window(
+    method: str,
+    num_speculative_tokens: int,
+):
+    """DSpark draft attention with a KV sliding window.
+
+    Same serving setup and assertions as test_dspark_acceptance (greedy
+    acceptance per position against a golden baseline), but with
+    draft_window_size=512 and a prompt longer than the window, so the draft
+    attention runs on the windowed block table. The window only changes what
+    the draft reads, never the target model's verification, so acceptance
+    stays in the same range as the no-window run (slightly lower, since the
+    draft sees less context).
+    """
+    main_model_name = DSPARK[method]["main"]
+    spec_model_name = DSPARK[method]["spec"]
+
+    tokenizer = AutoTokenizer.from_pretrained(
+        main_model_name,
+        trust_remote_code=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    # Prompt longer than the 512-token window, so the draft attention reads
+    # the cropped block table from the first step on.
+    filler = " ".join(f"context paragraph {i} about speculative decoding." for i in range(220))
+    prompts = [{"role": "user", "content": f"{filler} Hello, your name is"}]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [prompt],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        for prompt in prompts
+    ]
+
+    speculative_config = {
+        "method": "dspark",
+        "model": spec_model_name,
+        "num_speculative_tokens": num_speculative_tokens,
+    }
+
+    compilation_config = CompilationConfig(cudagraph_mode="PIECEWISE", cudagraph_capture_sizes=[7, 8])
+
+    with VllmRunner(
+        main_model_name,
+        max_model_len=4096,
+        disable_log_stats=False,
+        tensor_parallel_size=1,
+        max_num_seqs=256,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.8,
+        speculative_config=speculative_config,
+        compilation_config=compilation_config,
+        enable_prefix_caching=False,
+        additional_config={"draft_window_size": 512},
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        output_tokens = output.outputs[0].token_ids
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        print(f"Output tokens: {output_tokens}")
+
+    acceptance_per_pos = calculate_acceptance_per_pos(metrics, num_speculative_tokens, Counter, Vector)
+    golden = BASELINES[f"{method}_sliding_window"]
+
+    match = all(abs(a - b) < 0.1 for a, b in zip(acceptance_per_pos, golden))
+    assert match, f"acceptance_per_pos {acceptance_per_pos} does not match golden {golden}"

--- a/tests/e2e/pull_request/one_card/spec_decode/utils.py
+++ b/tests/e2e/pull_request/one_card/spec_decode/utils.py
@@ -41,6 +41,12 @@ BASELINES = {
     "dflash_dynamic": [0.62, 0.40, 0.24, 0.16, 0.08, 0.08, 0.00, 0.00],
     "dspark": [1.0, 0.8, 0.6, 0.6, 0.6, 0.6, 0.6],
     "dspark_dynamic": [0.68, 0.54, 0.46, 0.38, 0.22, 0.11, 0.11],
+    # DSpark with draft_window_size=512 on a prompt longer than the window
+    # (test_dspark_kv_sliding_window in test_dspark.py). Measured on the
+    # deepseek-ai/dspark_qwen3_8b_block7 single-block draft in CI; positions
+    # 3-6 exceed the no-window "dspark" baseline because the single-block
+    # drafter relies on the most recent context, which the window keeps.
+    "dspark_sliding_window": [0.88, 0.88, 0.88, 0.88, 0.75, 0.75, 0.62],
 }
 
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -362,11 +362,32 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         self.draft_window_size = get_ascend_config().draft_window_size
         if self.draft_window_size is not None:
+            # Compatibility validation before enabling sliding-window draft attention.
+            _target_model_type = getattr(
+                getattr(self.vllm_config.model_config, "hf_config", None),
+                "model_type",
+                "",
+            )
+            _target_is_deepseek_v4 = _target_model_type.startswith("deepseek_v4")
+            if self.method == "mtp":
+                # MTP reuses the target's own layers; capping its attention to a
+                # window is not applicable -> force the window off.
+                logger.info(
+                    "[sliding-window] draft method is MTP, 与滑窗不适配, 已强制关闭 draft_window_size (forced OFF)."
+                )
+                self.draft_window_size = None
+            elif self.method == "dspark" and _target_is_deepseek_v4:
+                logger.info(
+                    "[sliding-window] DSpark 为和主模型 DeepseekV4 一起训练的原生草稿模型, 开启滑窗会导致接收长度劣化。"
+                )
+
+        if self.draft_window_size is not None:
             # EAGLE3: seq_lens is context-only, K draft positions lie beyond it
             #   -> future_offset = K.
-            # DFlash: set_inputs_first_pass bakes the query stretch into seq_lens
-            #   -> future_offset = 0.
-            future_offset = 0 if self.method == "dflash" else self.num_speculative_tokens
+            # DFlash / DSpark: set_inputs_first_pass bakes the query stretch into
+            #   seq_lens (dspark_proposer adds num_query_per_req at cad.seq_lens),
+            #   so the window end must not add K again -> future_offset = 0.
+            future_offset = 0 if self.method in ("dflash", "dspark") else self.num_speculative_tokens
             self.sliding_window = SlidingWindowAdapter(
                 self.draft_window_size,
                 self.kernel_block_size,
@@ -935,7 +956,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )
 
-        if self.draft_window_size is not None:
+        if self.draft_window_size is not None and self.method != "dspark":
+            # DSpark's draft attention reads the per-group block_table assembled
+            # in build_draft_attn_metadata (which overwrites this table), so the
+            # window is applied there instead. Applying here would window a table
+            # that gets discarded and leave seq_lens windowed against an unwindowed
+            # table -> FIA reads the oldest blocks. See sw-dspark-flow-analysis.md.
             self.sliding_window.apply(common_attn_metadata)
 
         if self.supports_mm_inputs:
@@ -2323,6 +2349,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 slot_mapping = self._per_group_query_slot_mapping_buffers[gid]
                 if slot_mapping is not None:
                     common_attn_metadata.slot_mapping = slot_mapping[:num_input_tokens]
+                # Apply the sliding window to the per-group block_table + seq_lens
+                # that DSpark's draft FIA actually reads. This branch overwrites
+                # common_attn_metadata.block_table_tensor with the full per-group
+                # table, so the window applied earlier (line 922) is bypassed; we
+                # skipped it there for dspark and re-apply here on the per-group
+                # table so FIA reads the recent-blocks clone instead of block 0.
+                if self.draft_window_size is not None:
+                    self.sliding_window.apply(common_attn_metadata)
                 attn_metadata = builder.build_for_drafting(
                     common_attn_metadata, draft_index=1, **extra_attn_metadata_args
                 )

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -362,31 +362,34 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
 
         self.draft_window_size = get_ascend_config().draft_window_size
         if self.draft_window_size is not None:
-            # Compatibility validation before enabling sliding-window draft attention.
-            _target_model_type = getattr(
-                getattr(self.vllm_config.model_config, "hf_config", None),
-                "model_type",
-                "",
-            )
+            # Compatibility validation before enabling sliding-window draft
+            # attention. model_config may be absent in unit-test harnesses,
+            # so look it up defensively.
+            _target_hf_config = getattr(getattr(self.vllm_config, "model_config", None), "hf_config", None)
+            _target_model_type = getattr(_target_hf_config, "model_type", "") or ""
             _target_is_deepseek_v4 = _target_model_type.startswith("deepseek_v4")
             if self.method == "mtp":
-                # MTP reuses the target's own layers; capping its attention to a
-                # window is not applicable -> force the window off.
-                logger.info(
-                    "[sliding-window] draft method is MTP, 与滑窗不适配, 已强制关闭 draft_window_size (forced OFF)."
+                # MTP reuses the target's own layers; capping its attention
+                # to a window would also window the target model.
+                logger.warning(
+                    "[sliding-window] draft method is MTP, which is not "
+                    "compatible with draft_window_size; the window is ignored."
                 )
-                self.draft_window_size = None
             elif self.method == "dspark" and _target_is_deepseek_v4:
-                logger.info(
-                    "[sliding-window] DSpark 为和主模型 DeepseekV4 一起训练的原生草稿模型, 开启滑窗会导致接收长度劣化。"
+                logger.warning(
+                    "[sliding-window] DSpark drafts trained natively with a "
+                    "DeepSeek-V4 target are long-context stable; enabling the "
+                    "sliding window degrades acceptance length."
                 )
 
-        if self.draft_window_size is not None:
+        if self.draft_window_size is not None and self.method != "mtp":
             # EAGLE3: seq_lens is context-only, K draft positions lie beyond it
             #   -> future_offset = K.
             # DFlash / DSpark: set_inputs_first_pass bakes the query stretch into
             #   seq_lens (dspark_proposer adds num_query_per_req at cad.seq_lens),
             #   so the window end must not add K again -> future_offset = 0.
+            # MTP is excluded: it reuses the target's own layers, so windowing
+            # it would also window the target model.
             future_offset = 0 if self.method in ("dflash", "dspark") else self.num_speculative_tokens
             self.sliding_window = SlidingWindowAdapter(
                 self.draft_window_size,
@@ -956,12 +959,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                     common_attn_metadata.block_table_tensor, num_reqs_padded
                 )
 
-        if self.draft_window_size is not None and self.method != "dspark":
+        if self.draft_window_size is not None and self.method not in ("dspark", "mtp"):
             # DSpark's draft attention reads the per-group block_table assembled
             # in build_draft_attn_metadata (which overwrites this table), so the
             # window is applied there instead. Applying here would window a table
             # that gets discarded and leave seq_lens windowed against an unwindowed
             # table -> FIA reads the oldest blocks. See sw-dspark-flow-analysis.md.
+            # MTP is excluded: it reuses the target's own layers, so windowing
+            # it would also window the target model.
             self.sliding_window.apply(common_attn_metadata)
 
         if self.supports_mm_inputs:
@@ -1863,8 +1868,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             # Compute the slot mapping.
             # When sliding window is enabled, block_table_tensor may be cropped
             # for attention, but slot mapping needs the full block table to
-            # address the absolute KV cache positions.
-            if self.draft_window_size is not None:
+            # address the absolute KV cache positions. (self.sliding_window is
+            # None for MTP - the adapter is not constructed for it.)
+            if self.sliding_window is not None:
                 block_table_for_slot = self.sliding_window.full_block_table
             else:
                 block_table_for_slot = old_common_metadata.block_table_tensor
@@ -2355,7 +2361,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 # table, so the window applied earlier (line 922) is bypassed; we
                 # skipped it there for dspark and re-apply here on the per-group
                 # table so FIA reads the recent-blocks clone instead of block 0.
-                if self.draft_window_size is not None:
+                # (dspark only - self.sliding_window is None for MTP.)
+                if self.sliding_window is not None:
                     self.sliding_window.apply(common_attn_metadata)
                 attn_metadata = builder.build_for_drafting(
                     common_attn_metadata, draft_index=1, **extra_attn_metadata_args

--- a/vllm_ascend/spec_decode/utils.py
+++ b/vllm_ascend/spec_decode/utils.py
@@ -82,20 +82,20 @@ def correct_optimistic_seq_lens_cpu(
 
 class SlidingWindowAdapter:
     """
-    Sliding-window draft attention for the draft model (EAGLE3 and DFlash).
+    Sliding-window draft attention for the draft model (EAGLE3 / DFlash / DSpark).
     Caps the draft model's attention to the most recent ``window_size`` (W) tokens
     by (a) cropping its block table to the window's blocks and (b) keeping every
     KV-length tensor the FIA kernel can read (notably ``_seq_lens_cpu`` for EAGLE3,
-    GPU ``seq_lens`` for DFlash's ``parallel_drafting``) capped at W. Slot-mapping
-    is untouched and still addresses the full, absolute KV cache via
+    GPU ``seq_lens`` for DFlash/DSpark ``parallel_drafting``) capped at W.
+    Slot-mapping is untouched and still addresses the full, absolute KV cache via
     :attr:`full_block_table`.
 
     ``future_offset`` is the number of tokens beyond ``seq_lens`` (at :meth:`apply`
     time) that the window end must cover:
       * EAGLE3 passes ``num_speculative_tokens`` — its ``seq_lens`` is context-only
         and the K draft positions lie beyond it, so ``final = seq_lens + K``.
-      * DFlash passes ``0`` — its ``set_inputs_first_pass`` already bakes the query
-        stretch (bonus + mask) into ``seq_lens``, so ``final = seq_lens``.
+      * DFlash / DSpark pass ``0`` — ``set_inputs_first_pass`` already bakes the
+        query stretch (bonus + mask) into ``seq_lens``, so ``final = seq_lens``.
     """
 
     def __init__(
@@ -126,14 +126,13 @@ class SlidingWindowAdapter:
         w = self.window_size
         b = self.block_size
         num_reqs = common_attn_metadata.seq_lens.shape[0]
+        full_cols = self.full_block_table.shape[1]
 
         # Window math on the (NPU) seq_lens. Pure arithmetic -> stays on NPU.
         self.start_tokens_in_window_rounding = ((common_attn_metadata.seq_lens + k_future - w).clamp(min=0) // b) * b
         self._windowed_seq_lens = common_attn_metadata.seq_lens - self.start_tokens_in_window_rounding
         start_block_indices = self.start_tokens_in_window_rounding // b
-        needed_blocks_per_req = (self._windowed_seq_lens + b - 1) // b
 
-        full_cols = self.full_block_table.shape[1]
         # column offset grid [1, max_window_blocks]
         cols = torch.arange(self.max_window_blocks, device=self.full_block_table.device).unsqueeze(0)
         # source column per (row, col): start_block_indices[:, None] + cols
@@ -142,8 +141,10 @@ class SlidingWindowAdapter:
         src_cols_clamped = src_cols.clamp(max=full_cols - 1)
 
         gathered = torch.gather(self.full_block_table, 1, src_cols_clamped)
-        needed = torch.clamp(needed_blocks_per_req, max=self.max_window_blocks).unsqueeze(1)
-        # keep only columns within `needed` and within the full table; zero the rest
+
+        needed = torch.clamp(
+            (self._windowed_seq_lens + b - 1) // b, max=self.max_window_blocks
+        ).unsqueeze(1)
         valid_mask = (cols < needed) & (src_cols < full_cols)
         out[:num_reqs].copy_(gathered * valid_mask.to(gathered.dtype))
 
@@ -157,19 +158,18 @@ class SlidingWindowAdapter:
         w = self.window_size
         b = self.block_size
 
+
         self.compute_sliding_window_block_table(common_attn_metadata, self._block_table_clone)
         common_attn_metadata.block_table_tensor = self._block_table_clone[:num_reqs]
 
         # update NPU seq_lens: reuse the value computed in compute().
         common_attn_metadata.seq_lens = self._windowed_seq_lens
 
-        # update CPU mirrors: recompute from each one's own CPU tensor -> stays on CPU,
-        # no D2H sync. numerically identical to the NPU
         for name in ("seq_lens_cpu", "_seq_lens_cpu", "seq_lens_cpu_upper_bound"):
             src = getattr(common_attn_metadata, name, None)
             if src is not None:
-                _windowed_cpu = src - ((src + k_future - w).clamp(min=0) // b) * b
-                setattr(common_attn_metadata, name, _windowed_cpu)
+                _windowed = src - ((src + k_future - w).clamp(min=0) // b) * b
+                setattr(common_attn_metadata, name, _windowed)
 
 
 @contextmanager

--- a/vllm_ascend/spec_decode/utils.py
+++ b/vllm_ascend/spec_decode/utils.py
@@ -142,9 +142,7 @@ class SlidingWindowAdapter:
 
         gathered = torch.gather(self.full_block_table, 1, src_cols_clamped)
 
-        needed = torch.clamp(
-            (self._windowed_seq_lens + b - 1) // b, max=self.max_window_blocks
-        ).unsqueeze(1)
+        needed = torch.clamp((self._windowed_seq_lens + b - 1) // b, max=self.max_window_blocks).unsqueeze(1)
         valid_mask = (cols < needed) & (src_cols < full_cols)
         out[:num_reqs].copy_(gathered * valid_mask.to(gathered.dtype))
 
@@ -157,7 +155,6 @@ class SlidingWindowAdapter:
         k_future = self._future_offset
         w = self.window_size
         b = self.block_size
-
 
         self.compute_sliding_window_block_table(common_attn_metadata, self._block_table_clone)
         common_attn_metadata.block_table_tensor = self._block_table_clone[:num_reqs]


### PR DESCRIPTION
### What this PR does / why we need it?

- Support speculative decode KV slidng window for Dspark
- Add documentation for this feature

### Does this PR introduce _any_ user-facing change?

- Nope

### How was this patch tested?
vllm: v0.27.1
vllm-acend: main @ 749bb6c82d2aed0d54f7eb898f33ea5a8169ba2e

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
