### PR TITLE
[BugFix][Mamba] Align hybrid state copy on Ascend

### DIFF
--- a/tests/ut/patch/worker/test_patch_mamba_utils.py
+++ b/tests/ut/patch/worker/test_patch_mamba_utils.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import numpy as np
+
+from vllm_ascend.patch.worker.patch_mamba_utils import (
+    _do_mamba_copy_block_npu,
+    _stage_mamba_copy_metadata,
+    preprocess_mamba,
+)
+
+
+def _copy_buffer():
+    gpu = MagicMock()
+    gpu_view = MagicMock()
+    gpu.__getitem__.return_value = gpu_view
+    return SimpleNamespace(copy_to_gpu=MagicMock(), gpu=gpu), gpu_view
+
+
+def test_mamba_copy_metadata_is_staged_asynchronously_during_preprocess():
+    src_ptrs, _ = _copy_buffer()
+    dst_ptrs, _ = _copy_buffer()
+    sizes, _ = _copy_buffer()
+    copy_bufs = SimpleNamespace(
+        offset=2,
+        src_ptrs=src_ptrs,
+        dst_ptrs=dst_ptrs,
+        sizes=sizes,
+    )
+
+    _stage_mamba_copy_metadata(copy_bufs)
+
+    for buffer in (src_ptrs, dst_ptrs, sizes):
+        buffer.copy_to_gpu.assert_called_once_with(2)
+
+
+def test_mamba_state_copy_uses_previously_staged_metadata():
+    src_ptrs, src_view = _copy_buffer()
+    dst_ptrs, dst_view = _copy_buffer()
+    sizes, sizes_view = _copy_buffer()
+    copy_bufs = SimpleNamespace(
+        offset=2,
+        src_ptrs=src_ptrs,
+        dst_ptrs=dst_ptrs,
+        sizes=sizes,
+    )
+
+    with patch("vllm_ascend.patch.worker.patch_mamba_utils._batch_memcpy_triton") as batch_memcpy:
+        _do_mamba_copy_block_npu(copy_bufs)
+
+    for buffer in (src_ptrs, dst_ptrs, sizes):
+        buffer.copy_to_gpu.assert_not_called()
+        assert buffer.gpu.__getitem__.call_args_list == [call(slice(None, 2))]
+    batch_memcpy.assert_called_once_with(src_view, dst_view, sizes_view)
+
+
+def test_preprocess_stages_metadata_but_defers_state_copy():
+    copy_bufs = SimpleNamespace(
+        offset=0,
+        mamba_group_ids=[0],
+        mamba_spec=SimpleNamespace(num_speculative_blocks=1, block_size=7),
+    )
+    scheduler_output = SimpleNamespace(
+        finished_req_ids=[],
+        preempted_req_ids=set(),
+        scheduled_cached_reqs=SimpleNamespace(resumed_req_ids=[]),
+        num_scheduled_tokens={"req": 7},
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["req"],
+        num_accepted_tokens_cpu=np.array([2], dtype=np.int32),
+    )
+    requests = {"req": SimpleNamespace(num_computed_tokens=7)}
+    mamba_state_idx = {"req": 0}
+
+    def collect_metadata(copy_buffers, *_args):
+        copy_buffers.offset = 1
+
+    with (
+        patch(
+            "vllm_ascend.patch.worker.patch_mamba_utils.mamba_utils.collect_mamba_copy_meta",
+            side_effect=collect_metadata,
+        ) as collect,
+        patch("vllm_ascend.patch.worker.patch_mamba_utils._can_launch_triton_batch_memcpy", return_value=True),
+        patch("vllm_ascend.patch.worker.patch_mamba_utils._stage_mamba_copy_metadata") as stage,
+        patch("vllm_ascend.patch.worker.patch_mamba_utils._do_mamba_copy_block_npu") as state_copy,
+    ):
+        preprocess_mamba(
+            scheduler_output,
+            SimpleNamespace(),
+            SimpleNamespace(),
+            mamba_state_idx,
+            input_batch,
+            requests,
+            {},
+            (),
+            copy_bufs,
+        )
+
+    collect.assert_called_once()
+    stage.assert_called_once_with(copy_bufs)
+    state_copy.assert_not_called()
+    assert input_batch.num_accepted_tokens_cpu.tolist() == [1]
+
+
+def test_load_only_step_does_not_hide_remote_state_copy_on_next_forward():
+    copy_bufs = SimpleNamespace(
+        offset=0,
+        mamba_group_ids=[0],
+        mamba_spec=SimpleNamespace(num_speculative_blocks=7, block_size=128),
+    )
+    scheduler_output = SimpleNamespace(
+        finished_req_ids=[],
+        preempted_req_ids=set(),
+        scheduled_cached_reqs=SimpleNamespace(resumed_req_ids=[]),
+        num_scheduled_tokens={"req": 0},
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["req"],
+        num_accepted_tokens_cpu=np.array([1], dtype=np.int32),
+    )
+    requests = {"req": SimpleNamespace(num_computed_tokens=0)}
+    mamba_state_idx: dict[str, int] = {}
+
+    with (
+        patch("vllm_ascend.patch.worker.patch_mamba_utils.mamba_utils.collect_mamba_copy_meta") as collect,
+        patch(
+            "vllm_ascend.patch.worker.patch_mamba_utils._can_launch_triton_batch_memcpy",
+            return_value=True,
+        ),
+        patch("vllm_ascend.patch.worker.patch_mamba_utils._stage_mamba_copy_metadata") as stage,
+    ):
+        preprocess_mamba(
+            scheduler_output,
+            SimpleNamespace(),
+            SimpleNamespace(),
+            mamba_state_idx,
+            input_batch,
+            requests,
+            {},
+            (),
+            copy_bufs,
+        )
+
+        assert "req" not in mamba_state_idx
+        collect.assert_not_called()
+        stage.assert_called_once_with(copy_bufs)
+
+        scheduler_output.num_scheduled_tokens["req"] = 8
+        requests["req"].num_computed_tokens = 8191
+        stage.reset_mock()
+
+        def collect_metadata(copy_buffers, *_args):
+            copy_buffers.offset = 1
+
+        collect.side_effect = collect_metadata
+        preprocess_mamba(
+            scheduler_output,
+            SimpleNamespace(),
+            SimpleNamespace(),
+            mamba_state_idx,
+            input_batch,
+            requests,
+            {},
+            (),
+            copy_bufs,
+        )
+
+    collect.assert_called_once()
+    assert collect.call_args.args[4:7] == (63, 64, 0)
+    stage.assert_called_once_with(copy_bufs)
+    assert mamba_state_idx["req"] == 64

--- a/tests/ut/patch/worker/test_patch_mamba_utils_source.py
+++ b/tests/ut/patch/worker/test_patch_mamba_utils_source.py
@@ -10,8 +10,6 @@ from vllm_ascend.utils import vllm_version_is
 
 ROOT = Path(__file__).resolve().parents[4]
 POSTPROCESS = ROOT / "vllm_ascend" / "ops" / "triton" / "mamba" / "postprocess.py"
-PATCH_MAMBA_UTILS = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_mamba_utils.py"
-PATCH_TRITON = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_v2" / "patch_triton.py"
 
 
 def _top_level_functions(path: Path) -> dict[str, ast.FunctionDef]:
@@ -61,13 +59,3 @@ def test_postprocess_keeps_only_existing_ascend_precision_kernel() -> None:
         assert "tile_idx" in postprocess_source
         assert "if tile_idx == 0:" in postprocess_source
         assert "and state_idx == 0 and tile_idx == 0" not in postprocess_source
-
-
-def test_patch_only_installs_existing_ascend_postprocess_kernel() -> None:
-    patch_source = PATCH_MAMBA_UTILS.read_text()
-    patch_triton = PATCH_TRITON.read_text()
-
-    assert "mamba_utils.postprocess_mamba_fused_kernel = postprocess_mamba_fused_kernel" in patch_source
-    assert "MambaBase.bind_kv_cache" not in patch_source
-    assert "mamba_utils._copy_mamba_state_block" not in patch_source
-    assert "mamba_utils.precopy_mamba_align_fused_kernel" in patch_triton

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -505,3 +505,55 @@ def test_is_pd_decode_recompute_scheduler_enabled_decode_consumer_disabled():
     ascend_config.scheduler_config.recompute_scheduler_enable = False
     with mock.patch("vllm_ascend.utils.get_ascend_config", return_value=ascend_config):
         assert utils.is_pd_decode_recompute_scheduler_enabled(vllm_config) is False
+
+
+def test_check_gdn_layer_supports_kimi_linear_config_property():
+    from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
+
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                text_config=KimiLinearConfig(
+                    linear_attn_config={
+                        "kda_layers": [2],
+                        "full_attn_layers": [1],
+                    }
+                )
+            )
+        )
+    )
+
+    assert utils.check_gdn_layer(vllm_config) is True
+
+
+@pytest.mark.parametrize(
+    "hf_config",
+    [
+        pytest.param(
+            SimpleNamespace(text_config=SimpleNamespace(layer_types=["linear_attention"])),
+            id="qwen3-5-nested-text-config",
+        ),
+    ],
+)
+def test_check_gdn_layer_supports_layer_types(hf_config):
+    vllm_config = SimpleNamespace(model_config=SimpleNamespace(hf_config=hf_config))
+
+    assert utils.check_gdn_layer(vllm_config) is True
+
+
+def test_check_gdn_layer_supports_qwen3_next_config():
+    from transformers import Qwen3NextConfig
+
+    vllm_config = SimpleNamespace(model_config=SimpleNamespace(hf_config=Qwen3NextConfig()))
+
+    assert utils.check_gdn_layer(vllm_config) is True
+
+
+def test_check_gdn_layer_returns_false_without_linear_attention():
+    from transformers import Qwen3Config
+
+    # Dense Qwen3 configs, including Qwen3-8B, expose only full-attention
+    # layer types and must not be classified as hybrid GDN models.
+    vllm_config = SimpleNamespace(model_config=SimpleNamespace(hf_config=Qwen3Config()))
+
+    assert utils.check_gdn_layer(vllm_config) is False

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -6,6 +6,8 @@ import numpy as np
 import torch
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
+from vllm.sampling_params import SamplingParams
+from vllm.v1.attention.backends.utils import reorder_batch_to_split_decodes_and_prefills
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
@@ -13,11 +15,154 @@ from vllm.v1.kv_cache_interface import (
     KVCacheTensor,
     UniformTypeKVCacheSpecs,
 )
+from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+
+
+class TestAcceptedTokenSnapshot(unittest.TestCase):
+    def _build_runner(self):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.use_async_scheduling = True
+        runner.speculative_config = object()
+        runner.model_config = SimpleNamespace(is_hybrid=True)
+        runner.cache_config = SimpleNamespace(mamba_cache_mode="align")
+        runner.num_accepted_tokens = CpuGpuBuffer(12, dtype=torch.int32, device=torch.device("cpu"), pin_memory=False)
+        runner.prev_positions = CpuGpuBuffer(12, dtype=torch.int32, device=torch.device("cpu"), pin_memory=False)
+        batch_counts = torch.ones(12, dtype=torch.int32)
+        runner.input_batch = SimpleNamespace(
+            num_accepted_tokens_cpu=batch_counts.numpy(),
+            num_accepted_tokens_cpu_tensor=batch_counts,
+        )
+        runner.num_accepted_tokens_event = MagicMock()
+        return runner
+
+    def test_snapshot_survives_request_replacement_and_backend_reorder(self):
+        runner = self._build_runner()
+        with patch("vllm.v1.worker.gpu_input_batch.PIN_MEMORY", False):
+            batch = InputBatch(
+                max_num_reqs=12,
+                max_model_len=32,
+                max_num_batched_tokens=32,
+                device=torch.device("cpu"),
+                vocab_size=128,
+                block_sizes=[4],
+                kernel_block_sizes=[4],
+                max_num_blocks_per_req=[8],
+                num_spec_tokens=3,
+            )
+        runner.input_batch = batch
+        for req_id in ("A", "B", "C"):
+            batch.add_request(
+                CachedRequestState(
+                    req_id=req_id,
+                    prompt_token_ids=[10, 11],
+                    mm_features=[],
+                    sampling_params=SamplingParams(temperature=0),
+                    generator=None,
+                    block_ids=([1],),
+                    num_computed_tokens=2,
+                    output_token_ids=[],
+                )
+            )
+        batch.refresh_metadata()
+        batch.prev_req_id_to_index = dict(batch.req_id_to_index)
+        runner._get_mamba_bufs = MagicMock()
+        runner.kv_cache_config = object()
+        runner.compilation_config = SimpleNamespace(static_forward_context={})
+        runner.model = MagicMock()
+
+        # Only replace the device kernel boundary; use real InputBatch mutations.
+        def postprocess(**kwargs):
+            kwargs["num_accepted_tokens_cpu_tensor"][:3].copy_(kwargs["num_accepted_tokens_gpu"][:3])
+
+        with patch(
+            "vllm_ascend.worker.model_runner_v1.mamba_utils.postprocess_mamba_align_gpu",
+            side_effect=postprocess,
+        ):
+            runner._update_states_after_model_execute(
+                torch.tensor([[10, 11, -1, -1], [10, 11, 12, -1], [10, 11, 12, 13]]),
+                SimpleNamespace(),
+            )
+        runner.num_accepted_tokens_event.record.assert_called_once()
+        np.testing.assert_array_equal(runner.num_accepted_tokens.np[:3], [2, 3, 4])
+
+        batch.remove_request("A")
+        batch.add_request(
+            CachedRequestState(
+                req_id="D",
+                prompt_token_ids=[10] * 16,
+                mm_features=[],
+                sampling_params=SamplingParams(temperature=0),
+                generator=None,
+                block_ids=([2],),
+                num_computed_tokens=0,
+                output_token_ids=[],
+            )
+        )
+        batch.condense()
+        self.assertTrue(
+            reorder_batch_to_split_decodes_and_prefills(
+                batch,
+                SimpleNamespace(num_scheduled_tokens={"B": 4, "C": 4, "D": 16}),
+                decode_threshold=4,
+            )
+        )
+        batch.refresh_metadata()
+        runner._compute_prev_positions(batch.num_reqs)
+        runner._sync_num_accepted_tokens(batch.num_reqs, has_prev_mapping=True)
+
+        expected = [{"B": 3, "C": 4, "D": 1}[req_id] for req_id in batch.req_ids]
+        np.testing.assert_array_equal(runner.num_accepted_tokens.np[:3], expected)
+        np.testing.assert_array_equal(batch.num_accepted_tokens_cpu[:3], expected)
+
+    def test_sync_respects_snapshot_and_current_batch_ownership(self):
+        for async_scheduling, has_prev_mapping, expected in (
+            (True, True, [4, 1, 3]),
+            (True, False, [1, 1, 1]),
+            (False, True, [5, 6, 7]),
+        ):
+            with self.subTest(async_scheduling=async_scheduling, has_prev_mapping=has_prev_mapping):
+                runner = self._build_runner()
+                runner.use_async_scheduling = async_scheduling
+                runner.num_accepted_tokens.np[:] = np.arange(12)
+                runner.num_accepted_tokens.np[[11, 4]] = [4, 3]
+                runner.prev_positions.np[:3] = [11, -1, 4]
+                runner.input_batch.num_accepted_tokens_cpu[:3] = [5, 6, 7]
+
+                runner._sync_num_accepted_tokens(3, has_prev_mapping=has_prev_mapping)
+
+                np.testing.assert_array_equal(runner.num_accepted_tokens.np[:3], expected)
+                np.testing.assert_array_equal(runner.input_batch.num_accepted_tokens_cpu[:3], expected)
+
+    def test_non_align_postprocess_keeps_an_independent_snapshot(self):
+        for mode in ("none", "all"):
+            with self.subTest(mode=mode):
+                runner = self._build_runner()
+                runner.cache_config.mamba_cache_mode = mode
+                runner.kv_cache_config = object()
+                runner.requests = {}
+                runner.mamba_state_idx = {}
+                runner.num_spec_tokens = 3
+                with patch("vllm_ascend.worker.model_runner_v1.mamba_utils.postprocess_mamba_all") as postprocess_all:
+                    runner._update_states_after_model_execute(torch.tensor([[10, -1], [11, 12]]), SimpleNamespace())
+                np.testing.assert_array_equal(runner.num_accepted_tokens.np[:2], [1, 2])
+                np.testing.assert_array_equal(runner.input_batch.num_accepted_tokens_cpu[:2], [1, 1])
+                self.assertEqual(postprocess_all.call_count, int(mode == "all"))
+                runner.num_accepted_tokens_event.record.assert_called_once()
+
+    def test_non_async_postprocess_keeps_upstream_behavior(self):
+        runner = self._build_runner()
+        runner.use_async_scheduling = False
+        output_token_ids = torch.tensor([[10, -1]])
+        scheduler_output = SimpleNamespace()
+        with patch("vllm.v1.worker.gpu_model_runner.GPUModelRunner._update_states_after_model_execute") as upstream:
+            runner._update_states_after_model_execute(output_token_ids, scheduler_output)
+        upstream.assert_called_once_with(output_token_ids, scheduler_output)
 
 
 class TestNPUModelRunnerKVCache(unittest.TestCase):

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -18,6 +18,14 @@ from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
 from vllm_ascend.utils import is_310p
 
+# Upstream uses 16 temporal-copy tiles to saturate H100/GB200. K3 already
+# exposes 138 independent state programs per request, while Triton-Ascend
+# flattens all grid dimensions into a coreDim that cannot exceed 65535. Keep
+# the pre-tiling launch shape on Ascend: it has enough state-level parallelism
+# and remains valid at the configured request limit (for example,
+# 32 * 138 * 1 instead of 32 * 138 * 16).
+mamba_utils._TEMPORAL_TILES = 1
+
 
 def _can_launch_triton_batch_memcpy() -> bool:
     return not is_310p()
@@ -32,6 +40,28 @@ def _batch_memcpy_triton(src_ptrs, dst_ptrs, sizes):
     # using larger block_size to accelerate copy.
     BLOCK_SIZE = 8192
     batch_memcpy_kernel[grid](src_ptrs, dst_ptrs, sizes, BLOCK_SIZE=BLOCK_SIZE)
+
+
+def _stage_mamba_copy_metadata(copy_bufs: mamba_utils.MambaCopyBuffers) -> None:
+    """Stage pointer metadata while input-preparation buffers are protected."""
+    n = copy_bufs.offset
+    if n == 0:
+        return
+    copy_bufs.src_ptrs.copy_to_gpu(n)
+    copy_bufs.dst_ptrs.copy_to_gpu(n)
+    copy_bufs.sizes.copy_to_gpu(n)
+
+
+def _do_mamba_copy_block_npu(copy_bufs: mamba_utils.MambaCopyBuffers) -> None:
+    """Copy state after KV load using metadata staged during preprocessing."""
+    n = copy_bufs.offset
+    if n == 0:
+        return
+    _batch_memcpy_triton(
+        copy_bufs.src_ptrs.gpu[:n],
+        copy_bufs.dst_ptrs.gpu[:n],
+        copy_bufs.sizes.gpu[:n],
+    )
 
 
 def _tensor_view_from_data_ptr(state: torch.Tensor, start_addr: int, num_elements: int) -> torch.Tensor:
@@ -195,8 +225,7 @@ def _batch_memcpy_unavailable(src_ptrs, dst_ptrs, sizes):
 if _can_launch_triton_batch_memcpy():
     mamba_utils.batch_memcpy_kernel = batch_memcpy_kernel
     mamba_utils.batch_memcpy = _batch_memcpy_triton
-    # Keep the existing Ascend postprocess precision fix. The shared copy
-    # helper and align pre-copy continue to use the upstream implementation.
+    mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_npu
     mamba_utils.postprocess_mamba_fused_kernel = postprocess_mamba_fused_kernel
 else:
     mamba_utils.batch_memcpy = _batch_memcpy_unavailable
@@ -253,13 +282,22 @@ def preprocess_mamba(
     copy_bufs.offset = 0
     for i, req_id in enumerate(input_batch.req_ids):
         req_state = requests[req_id]
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
+        if num_scheduled_tokens == 0:
+            # Async KV connectors can surface a request in a load-only step
+            # before any model tokens are scheduled.  Persisting the derived
+            # ``-1`` state index here makes the next real forward skip the
+            # copy from the remotely loaded h(N-1) state into its running
+            # block.  Re-resolve the index from the updated computed-token
+            # count when the request is actually scheduled instead.
+            mamba_state_idx.pop(req_id, None)
+            continue
         prev_state_idx = mamba_state_idx.get(req_id)
         if prev_state_idx is None:
             # new / resumed request, no previous state
             # if num_computed_tokens is 0, prev_state_idx will be -1
             prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
 
-        num_scheduled_tokens = scheduler_output.num_scheduled_tokens[req_id]
         num_blocks: int = (
             cdiv(req_state.num_computed_tokens + num_scheduled_tokens, block_size) + num_speculative_blocks
         )
@@ -289,8 +327,12 @@ def preprocess_mamba(
                 forward_context,
             )
             input_batch.num_accepted_tokens_cpu[i] = 1
-    # do not copy here, since kv_transfer still not load
-    # do_mamba_copy_block(copy_bufs)
+    if _can_launch_triton_batch_memcpy():
+        # Only stage the pointer table here. This runs inside the existing
+        # input-preparation event scope, so its pinned CPU buffers cannot be
+        # reused until the asynchronous H2D copies finish. The state copy must
+        # remain after KV transfer and is executed by do_mamba_copy_block().
+        _stage_mamba_copy_metadata(copy_bufs)
 
 
 mamba_utils.preprocess_mamba = preprocess_mamba

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1339,8 +1339,7 @@ def enable_dsa_cp_with_o_proj_tp() -> bool:
 
 def check_gdn_layer(vllm_config) -> bool:
     """
-    gdn layer is marked with `linear_attention`.
-    So, if `linear_attention` is detected, we think the model has gdn-attention.
+    Detect a model with GDN attention from either supported HF config shape.
     """
     if not hasattr(vllm_config, "model_config"):
         return False
@@ -1350,16 +1349,13 @@ def check_gdn_layer(vllm_config) -> bool:
         return False
 
     hf_config = model_config.hf_config
-
-    # Use `or []` to prevent errors when layer_types is None
-    layer_types = getattr(hf_config, "layer_types", None) or []
-    if "linear_attention" in layer_types:
-        return True
-
-    text_config = getattr(hf_config, "text_config", None)
-    if text_config:
-        text_layer_types = getattr(text_config, "layer_types", None) or []
-        if "linear_attention" in text_layer_types:
+    for config in (hf_config, getattr(hf_config, "text_config", None)):
+        if config is None:
+            continue
+        # Most hybrid models expose layer_types. Kimi Linear/K3 instead
+        # exposes the equivalent is_linear_attn property.
+        layer_types = getattr(config, "layer_types", None) or []
+        if "linear_attention" in layer_types or bool(getattr(config, "is_linear_attn", False)):
             return True
 
     return False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -807,6 +807,63 @@ class NPUModelRunner(GPUModelRunner):
         self._apply_pp_sampled_tokens_from_scheduler_output(scheduler_output)
         return super()._update_states(scheduler_output)
 
+    def _update_states_after_model_execute(
+        self, output_token_ids: torch.Tensor, scheduler_output: "SchedulerOutput"
+    ) -> None:
+        if not self.use_async_scheduling:
+            return super()._update_states_after_model_execute(output_token_ids, scheduler_output)
+        if not self.speculative_config or not self.model_config.is_hybrid:
+            return
+
+        # InputBatch can be condensed/reordered before the next input preparation.
+        # Keep the asynchronous D2H result in the previous iteration's row order,
+        # independently of InputBatch, until the existing event is synchronized.
+        num_reqs = output_token_ids.size(0)
+        self.num_accepted_tokens.gpu[:num_reqs] = (output_token_ids != -1).sum(dim=1)
+        if self.cache_config.mamba_cache_mode == "align":
+            mamba_utils.postprocess_mamba_align_gpu(
+                bufs=self._get_mamba_bufs(),
+                num_reqs=num_reqs,
+                num_accepted_tokens_gpu=self.num_accepted_tokens.gpu,
+                num_accepted_tokens_cpu_tensor=self.num_accepted_tokens.cpu,
+                input_batch=self.input_batch,
+                kv_cache_config=self.kv_cache_config,
+                forward_context=self.compilation_config.static_forward_context,
+                mamba_state_copy_funcs=self.model.get_mamba_state_copy_func(),
+            )
+        else:
+            self.num_accepted_tokens.copy_to_cpu(num_reqs)
+            if self.cache_config.mamba_cache_mode == "all":
+                mamba_utils.postprocess_mamba_all(
+                    scheduler_output,
+                    self.kv_cache_config,
+                    self.input_batch,
+                    self.requests,
+                    self.mamba_state_idx,
+                    self.num_spec_tokens,
+                    num_reqs,
+                )
+        assert self.num_accepted_tokens_event is not None
+        self.num_accepted_tokens_event.record()
+
+    def _sync_num_accepted_tokens(self, num_reqs: int, has_prev_mapping: bool) -> None:
+        """Publish accepted counts in current request order after the D2H event."""
+        accepted = self.num_accepted_tokens.np
+        if not self.use_async_scheduling:
+            # Synchronous scheduling already updates counts in current batch order.
+            accepted[:num_reqs] = self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+            return
+
+        if has_prev_mapping:
+            prev_idx = self.prev_positions.np[:num_reqs]
+            new_mask = prev_idx < 0
+            # Advanced indexing reads the snapshot before overwriting its rows.
+            accepted[:num_reqs] = accepted[np.where(new_mask, 0, prev_idx)]
+            accepted[:num_reqs][new_mask] = 1
+        else:
+            accepted[:num_reqs].fill(1)
+        self.input_batch.num_accepted_tokens_cpu[:num_reqs] = accepted[:num_reqs]
+
     def _pad_query_start_loc_for_fia(
         self,
         query_start_loc: torch.Tensor,
@@ -1078,24 +1135,7 @@ class NPUModelRunner(GPUModelRunner):
         # _update_states_after_model_execute for hybrid models).
         if self.num_accepted_tokens_event is not None:
             self.num_accepted_tokens_event.synchronize()
-            # Async mode: condense() reordered indices, use prev_positions mapping
-            if self.use_async_scheduling and prev_req_id_to_index:
-                prev_idx = self.prev_positions.np[:num_reqs]
-                new_mask = prev_idx < 0
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[
-                        np.where(new_mask, 0, prev_idx)
-                    ]
-                )
-                self.num_accepted_tokens.np[:num_reqs][new_mask] = 1
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs] = (
-                    self.num_accepted_tokens.np[:num_reqs]
-                )
-            else:
-                # Non-async mode: use values directly
-                self.num_accepted_tokens.np[:num_reqs] = (
-                    self.input_batch.num_accepted_tokens_cpu[:num_reqs]
-                )
+            self._sync_num_accepted_tokens(num_reqs, has_prev_mapping=bool(prev_req_id_to_index))
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
         else:
@@ -1978,10 +2018,7 @@ class NPUModelRunner(GPUModelRunner):
 
                 pad_attn = cudagraph_mode == CUDAGraphMode.FULL
 
-                # NOTE(Angazenn): According to https://github.com/vllm-project/vllm/pull/30877,
-                # there should be a corresponding 'postprocess_mamba'. However, it is called inside
-                # '_update_states_after_model_execute', which is not overridden in vLLM-Ascend.
-                # We simply utilize the implementation in vLLM.
+                # postprocess_mamba runs later in _update_states_after_model_execute.
                 if self.cache_config.mamba_cache_mode == "align":
                     # preprocess_mamba reads req_state.num_computed_tokens (CPU)
                     # to decide copy operations, so we must apply deferred


### PR DESCRIPTION
### What this PR does / why we need it?

- Recognizes the upstream Kimi linear-attention configuration in the Ascend hybrid-model path.
- Stages Mamba copy metadata inside the existing input-preparation event scope.
- Executes the device state copy after KV transfer without adding a host synchronization point.
- Re-resolves state indices after load-only zero-token scheduler steps.
- Keeps asynchronous accepted-token results in the existing runner snapshot until the existing completion event, then remaps them to current request rows. InputBatch replacement/condensing/reordering cannot overwrite the previous iteration's counts; synchronous scheduling retains the upstream behavior. No additional runtime buffer or synchronization point is introduced.
- Uses a single temporal copy tile so the flattened Ascend Triton launch stays within the device grid limit.

### Dependencies

None. KV grouping and Kimi model registration consume this runtime contract.

### How was this patch tested?

- 31 targeted CPU model-runner and Mamba-copy tests pass on vLLM 0.27.1, including real InputBatch replacement/reordering, new requests, high previous row indices, and align/all/none postprocessing. `bash format.sh ci` passes. Full-model NPU serving was not rerun for the accepted-token snapshot change.

- `git diff --check`
- Python bytecode compilation for changed implementation and test files
- Focused tests for Mamba state-copy ordering, load-only steps, source patching, and hybrid-model detection
- Integrated C64/C128 serving coverage with finite, non-empty outputs and no deadlock

### Does this PR introduce any user-facing change?

No new API. It fixes hybrid Mamba state handling on Ascend.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
