### PR TITLE
[Feature][MoE] Support Kimi K3 SiTU and quantization

### DIFF
--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -7,6 +7,8 @@ import pytest
 import torch
 from torch import nn
 from torch.nn import functional as F
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.activation import SituAndMul
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
@@ -855,6 +857,150 @@ def test_shared_experts_part2_applies_optional_gate(with_gate):
     torch.testing.assert_close(output, expected)
 
 
+def test_shared_expert_consistency_uses_projection_input_width(monkeypatch):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.hidden_size = 3584
+    shared_experts.shared_expert_input_size = 7168
+    shared_experts.in_dtype = torch.float16
+    output = torch.ones(10, 7168)
+    shared_experts.layer = MagicMock(return_value=output)
+    shared_experts.part1 = MagicMock(return_value=output)
+    shared_experts.part2 = MagicMock(return_value=output)
+    random_input = torch.ones(10, 7168)
+    random = MagicMock(return_value=random_input)
+    monkeypatch.setattr(shared_experts_module.torch, "rand", random)
+
+    shared_experts.validate_consistency()
+
+    random.assert_called_once_with(
+        10,
+        7168,
+        device="npu",
+        dtype=torch.float16,
+    )
+    shared_experts.layer.assert_called_once()
+    torch.testing.assert_close(
+        shared_experts.layer.call_args.args[0],
+        random_input,
+    )
+
+
+def _make_quantized_situ_shared_experts(quant_type, gate_up_proj, down_proj):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.layer = SimpleNamespace(
+        gate_up_proj=gate_up_proj,
+        down_proj=down_proj,
+    )
+    shared_experts.multistream_overlap = False
+    shared_experts.quant_type = quant_type
+    with set_current_vllm_config(VllmConfig()):
+        shared_experts.situ_activation = SituAndMul(beta=4.0, linear_beta=25.0)
+    shared_experts.lora_context = None
+    shared_experts.parallel_mode = MagicMock(
+        return_value=SharedExpertParallelMode.TENSOR_PARALLEL,
+    )
+    return shared_experts
+
+
+def _make_shared_expert_events():
+    event = MagicMock()
+    return FusedMoEEvents(
+        before_routed_experts=event,
+        after_routed_experts=event,
+        before_dispatch=event,
+        before_gmm2=event,
+        before_combine=event,
+    )
+
+
+def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
+    gate_up_proj = SimpleNamespace(
+        weight=torch.ones(4, 4, dtype=torch.int8),
+        weight_scale=torch.ones(4),
+        weight_scale_fp32=torch.ones(4),
+    )
+    down_proj = SimpleNamespace(
+        weight=torch.ones(2, 4, dtype=torch.int8),
+        weight_scale=torch.ones(2),
+    )
+    shared_experts = _make_quantized_situ_shared_experts(QuantType.W8A8, gate_up_proj, down_proj)
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    quantized_input = torch.ones(2, 4, dtype=torch.int8)
+    input_scale = torch.ones(2)
+    gate_up_out = torch.ones(2, 4, dtype=torch.int32)
+    quantized_situ = torch.ones(2, 2, dtype=torch.int8)
+    situ_scale = torch.ones(2)
+    expected = torch.randn(2, 2, dtype=torch.bfloat16)
+    dequant_situ_quant = MagicMock(return_value=(quantized_situ, situ_scale))
+
+    monkeypatch.setattr(shared_experts_module, "has_lora", lambda _: False)
+    monkeypatch.setattr(shared_experts_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        shared_experts_module.torch_npu,
+        "npu_dynamic_quant",
+        MagicMock(return_value=(quantized_input, input_scale)),
+    )
+    monkeypatch.setattr(
+        shared_experts_module.torch_npu,
+        "npu_quant_matmul",
+        MagicMock(side_effect=[gate_up_out, expected]),
+    )
+    monkeypatch.setattr(
+        shared_experts_module.torch.ops,
+        "_C_ascend",
+        SimpleNamespace(dequant_situ_quant=dequant_situ_quant),
+    )
+
+    output = shared_experts.forward(hidden_states, _make_shared_expert_events())
+
+    assert output is expected
+    situ_kwargs = dequant_situ_quant.call_args.kwargs
+    assert situ_kwargs["x"] is gate_up_out
+    assert situ_kwargs["beta"] == 4.0
+    assert situ_kwargs["linear_beta"] == 25.0
+
+
+def test_w4a8_mxfp_shared_situ_uses_situ_mx_quant(monkeypatch):
+    quantized_input = torch.ones(2, 4, dtype=torch.float8_e4m3fn)
+    input_scale = torch.ones(2, 1)
+    gate_up_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    quantized_situ = torch.ones(2, 2, dtype=torch.float8_e4m3fn)
+    situ_scale = torch.ones(2, 1)
+    expected = torch.randn(2, 2, dtype=torch.bfloat16)
+    gate_up_proj = MagicMock(return_value=(gate_up_out, None))
+    gate_up_proj.weight_scale = torch.ones(1)
+    down_proj = MagicMock(return_value=(expected, None))
+    down_proj.weight_scale = torch.ones(1)
+    shared_experts = _make_quantized_situ_shared_experts(QuantType.W4A8MXFP, gate_up_proj, down_proj)
+    situ_mx_quant = MagicMock(return_value=(quantized_situ, situ_scale))
+
+    monkeypatch.setattr(shared_experts_module, "has_lora", lambda _: False)
+    monkeypatch.setattr(shared_experts_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(
+        shared_experts_module.torch_npu,
+        "npu_dynamic_mx_quant",
+        MagicMock(return_value=(quantized_input, input_scale)),
+    )
+    monkeypatch.setattr(
+        shared_experts_module.torch.ops,
+        "_C_ascend",
+        SimpleNamespace(situ_mx_quant=situ_mx_quant),
+    )
+
+    output = shared_experts.forward(torch.randn(2, 4, dtype=torch.bfloat16), _make_shared_expert_events())
+
+    assert output is expected
+    situ_kwargs = situ_mx_quant.call_args.kwargs
+    assert situ_kwargs["x"] is gate_up_out
+    assert situ_kwargs["beta"] == 4.0
+    assert situ_kwargs["linear_beta"] == 25.0
+    assert situ_kwargs["dst_type"] == shared_experts_module.SITU_MX_DST_TYPE_E4M3FN
+
+
 @pytest.mark.parametrize(
     (
         "weights_replicated",
@@ -957,6 +1103,125 @@ def test_sequence_parallel_only_gathers_unpads_pads_and_reduce_scatters(monkeypa
             scattered[num_tokens:],
             torch.zeros(tp_size - num_tokens % tp_size, 2),
         )
+
+
+@pytest.mark.parametrize(
+    ("mode", "multistream_overlap", "starts_all_gather"),
+    [
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, True, True),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY, False, False),
+        (SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP, True, False),
+    ],
+)
+def test_prepare_shared_expert_input_only_starts_sp_tp_all_gather(
+    monkeypatch,
+    mode,
+    multistream_overlap,
+    starts_all_gather,
+):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.multistream_overlap = multistream_overlap
+    shared_experts.parallel_mode = MagicMock(return_value=mode)
+    hidden_states = torch.randn(2, 4)
+    gathered_states = torch.randn(4, 4)
+    shared_experts._gather_sp_input = MagicMock(return_value=gathered_states)
+    default_stream = MagicMock()
+    auxiliary_stream = MagicMock()
+    input_ready = MagicMock()
+    all_gather_done = MagicMock()
+    default_stream.record_event.return_value = input_ready
+    auxiliary_stream.record_event.return_value = all_gather_done
+    stream_state = {"current": default_stream}
+
+    @contextmanager
+    def switch_stream(stream, enabled):
+        previous_stream = stream_state["current"]
+        if enabled:
+            stream_state["current"] = stream
+        try:
+            yield
+        finally:
+            stream_state["current"] = previous_stream
+
+    monkeypatch.setattr(shared_experts_module, "npu_stream_switch", switch_stream)
+    monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
+    monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
+
+    result, done_event = shared_experts.prepare_input_before_routed_experts(hidden_states)
+
+    if starts_all_gather:
+        assert result is gathered_states
+        assert done_event is all_gather_done
+        default_stream.record_event.assert_called_once_with()
+        auxiliary_stream.wait_event.assert_called_once_with(input_ready)
+        shared_experts._gather_sp_input.assert_called_once_with(hidden_states)
+        auxiliary_stream.record_event.assert_called_once_with()
+    else:
+        assert result is hidden_states
+        assert done_event is None
+        default_stream.record_event.assert_not_called()
+        shared_experts._gather_sp_input.assert_not_called()
+
+
+def test_sp_multistream_down_projection_and_reduce_scatter_wait_for_routed_finalize(
+    monkeypatch,
+):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.layer = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(),
+        down_proj=SimpleNamespace(),
+    )
+    shared_experts.multistream_overlap = True
+    shared_experts.quant_type = QuantType.NONE
+    shared_experts.lora_context = None
+    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY)
+    hidden_states = torch.randn(4, 4)
+    part1_out = torch.randn(4, 8)
+    shared_out = torch.randn(4, 4)
+    reduced_out = torch.randn(2, 4)
+    shared_experts.part1 = MagicMock(return_value=part1_out)
+    shared_experts.part2 = MagicMock(return_value=shared_out)
+    shared_experts._gather_sp_input = MagicMock()
+    shared_experts._pad_and_reduce_scatter = MagicMock(return_value=reduced_out)
+    default_stream = MagicMock()
+    auxiliary_stream = MagicMock()
+    stream_state = {"current": default_stream}
+    events = FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        before_dispatch=MagicMock(),
+        before_combine=MagicMock(),
+        after_routed_finalize=MagicMock(),
+    )
+
+    @contextmanager
+    def switch_stream(stream, enabled):
+        previous_stream = stream_state["current"]
+        if enabled:
+            stream_state["current"] = stream
+        try:
+            yield
+        finally:
+            stream_state["current"] = previous_stream
+
+    monkeypatch.setattr(shared_experts_module, "npu_stream_switch", switch_stream)
+    monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", lambda: auxiliary_stream)
+    monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", lambda: stream_state["current"])
+
+    result = shared_experts.forward(
+        hidden_states,
+        events,
+        input_is_gathered=True,
+    )
+
+    assert result is reduced_out
+    shared_experts._gather_sp_input.assert_not_called()
+    auxiliary_stream.wait_event.assert_any_call(events.after_routed_finalize)
+    assert not any(
+        event_wait.args == (events.before_combine,) for event_wait in auxiliary_stream.wait_event.call_args_list
+    )
+    shared_experts.part2.assert_called_once_with(hidden_states, part1_out)
+    shared_experts._pad_and_reduce_scatter.assert_called_once_with(shared_out)
+    default_stream.wait_stream.assert_called_once_with(auxiliary_stream)
 
 
 def test_sequence_parallel_sedp_forward_skips_token_comms(monkeypatch):
@@ -1064,7 +1329,10 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     input_ids = torch.tensor([11, 22])
     routed_out = torch.randn(2, 4)
     shared_out = torch.randn(2, 4)
-    ascend_shared_experts = SimpleNamespace(forward=MagicMock(return_value=shared_out))
+    ascend_shared_experts = SimpleNamespace(
+        prepare_input_before_routed_experts=MagicMock(return_value=(hidden_states, None)),
+        forward=MagicMock(return_value=shared_out),
+    )
     routed_events = FusedMoEEvents(
         before_routed_experts=None,
         after_routed_experts=None,
@@ -1090,6 +1358,7 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
     )
 
     if has_shared_experts:
+        ascend_shared_experts.prepare_input_before_routed_experts.assert_called_once_with(hidden_states)
         runner.routed_experts.forward_impl.assert_called_once_with(
             hidden_states=hidden_states,
             router_logits=router_logits,
@@ -1106,3 +1375,64 @@ def test_forward_impl_returns_current_runner_contract(monkeypatch, has_shared_ex
         )
         assert result is routed_out
         ascend_shared_experts.forward.assert_not_called()
+
+
+def test_forward_impl_keeps_full_width_input_for_shared_experts(monkeypatch):
+    runner = AscendMoERunner.__new__(AscendMoERunner)
+    nn.Module.__init__(runner)
+    routed_hidden_states = torch.randn(2, 4)
+    shared_hidden_states = torch.randn(2, 8)
+    router_logits = torch.randn(2, 3)
+    routed_out = torch.randn(2, 4)
+    shared_out = torch.randn(2, 8)
+    routed_events = FusedMoEEvents(
+        before_routed_experts=None,
+        after_routed_experts=None,
+        before_dispatch=None,
+        before_gmm2=None,
+        before_combine=None,
+    )
+    runner.routed_experts = SimpleNamespace(forward_impl=MagicMock(return_value=(routed_out, routed_events)))
+    shared_input_all_gather_done = MagicMock()
+    prepared_shared_hidden_states = torch.randn(4, 8)
+    runner.ascend_shared_experts = SimpleNamespace(
+        prepare_input_before_routed_experts=MagicMock(
+            return_value=(prepared_shared_hidden_states, shared_input_all_gather_done),
+        ),
+        forward=MagicMock(return_value=shared_out),
+    )
+    runner._sequence_parallel_context = MagicMock(return_value=nullcontext())
+    current_stream = MagicMock()
+
+    monkeypatch.setattr(
+        AscendMoERunner,
+        "is_internal_router",
+        property(lambda _: False),
+    )
+    monkeypatch.setattr(
+        fused_moe_module.torch.npu,
+        "current_stream",
+        lambda: current_stream,
+    )
+
+    result = runner._forward_impl(
+        routed_hidden_states,
+        router_logits,
+        shared_experts_input=shared_hidden_states,
+    )
+
+    runner.routed_experts.forward_impl.assert_called_once_with(
+        hidden_states=routed_hidden_states,
+        router_logits=router_logits,
+        input_ids=None,
+    )
+    runner.ascend_shared_experts.prepare_input_before_routed_experts.assert_called_once_with(shared_hidden_states)
+    current_stream.wait_event.assert_called_once_with(shared_input_all_gather_done)
+    assert routed_events.after_routed_finalize is current_stream.record_event.return_value
+    runner.ascend_shared_experts.forward.assert_called_once_with(
+        prepared_shared_hidden_states,
+        routed_events,
+        input_is_gathered=True,
+    )
+    assert result[0] is shared_out
+    assert result[1] is routed_out

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -119,31 +119,35 @@ class TestSwigluOaiDynamicMxQuant(unittest.TestCase):
 
 
 class TestUnifiedApplyMlpRequest(unittest.TestCase):
-    def test_unquant_situ_uses_upstream_activation_contract(self):
-        hidden_states = torch.randn(2, 8, dtype=torch.bfloat16)
-        gate_up_out = torch.randn(2, 16, dtype=torch.bfloat16)
-        expected_output = torch.randn(2, 8, dtype=torch.bfloat16)
-        with set_current_vllm_config(VllmConfig()):
-            expected_activation = SituAndMul(beta=4.0, linear_beta=25.0)(gate_up_out)
+    def test_unquant_situ_matches_upstream_without_config_context(self):
+        for dtype in (torch.bfloat16, torch.float16, torch.float32):
+            for linear_beta in (None, 25.0):
+                with self.subTest(dtype=dtype, linear_beta=linear_beta):
+                    hidden_states = torch.randn(2, 8, dtype=dtype)
+                    gate_up_out = torch.linspace(-40, 40, 32).reshape(2, 16).to(dtype)
+                    expected_output = torch.randn(2, 8, dtype=dtype)
+                    with set_current_vllm_config(VllmConfig()):
+                        expected_activation = SituAndMul(beta=4.0, linear_beta=linear_beta).forward_native(gate_up_out)
 
-            with patch(
-                f"{MOE_MLP}.torch_npu.npu_grouped_matmul",
-                side_effect=[[gate_up_out], [expected_output]],
-                create=True,
-            ) as grouped_matmul:
-                output, _ = unquant_apply_mlp(
-                    hidden_states=hidden_states,
-                    w1=torch.randn(1, 8, 16),
-                    w2=torch.randn(1, 8, 8),
-                    group_list=torch.tensor([1, 1]),
-                    activation=MoEActivation.SITU,
-                    activation_situ_beta=4.0,
-                    activation_situ_linear_beta=25.0,
-                    need_trans=False,
-                )
+                    # The worker forward runs outside the model-init config context.
+                    with patch(
+                        f"{MOE_MLP}.torch_npu.npu_grouped_matmul",
+                        side_effect=[[gate_up_out], [expected_output]],
+                        create=True,
+                    ) as grouped_matmul:
+                        output, _ = unquant_apply_mlp(
+                            hidden_states=hidden_states,
+                            w1=torch.randn(1, 8, 16),
+                            w2=torch.randn(1, 8, 8),
+                            group_list=torch.tensor([1, 1]),
+                            activation=MoEActivation.SITU,
+                            activation_situ_beta=4.0,
+                            activation_situ_linear_beta=linear_beta,
+                            need_trans=False,
+                        )
 
-        self.assertIs(output, expected_output)
-        torch.testing.assert_close(grouped_matmul.call_args_list[1].kwargs["x"][0], expected_activation)
+                    self.assertIs(output, expected_output)
+                    torch.testing.assert_close(grouped_matmul.call_args_list[1].kwargs["x"][0], expected_activation)
 
     def test_unquant_swigluoai_uninterleave_falls_back_on_a5(self):
         hidden_states = torch.randn(2, 8, dtype=torch.bfloat16)
@@ -596,6 +600,7 @@ class TestQuantApplyMlpSituEplb(_GeluPathBase):
         stream_patch, evt = _patch_npu_stream()
 
         with (
+            patch(f"{MOE_MLP}._EXTRA_CTX", MagicMock(moe_comm_type=-1)),
             stream_patch,
             patch("torch_npu.npu_grouped_matmul", return_value=[gate_up_out], create=True) as mock_gmm1,
             patch(
@@ -679,7 +684,6 @@ class TestQuantApplyMlpSituEplb(_GeluPathBase):
         stream_patch, evt = _patch_npu_stream()
 
         with (
-            set_current_vllm_config(VllmConfig()),
             stream_patch,
             patch(f"{MOE_MLP}._EXTRA_CTX", MagicMock(moe_comm_type=-1)),
             patch(
@@ -718,7 +722,6 @@ class TestQuantApplyMlpSituEplb(_GeluPathBase):
         stream_patch, evt = _patch_npu_stream()
 
         with (
-            set_current_vllm_config(VllmConfig()),
             stream_patch,
             patch(f"{MOE_MLP}._EXTRA_CTX", MagicMock(moe_comm_type=-1)),
             patch("torch_npu.npu_grouped_matmul", return_value=[gate_up_out], create=True),

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -145,25 +145,6 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertIs(output, expected_output)
         torch.testing.assert_close(grouped_matmul.call_args_list[1].kwargs["x"][0], expected_activation)
 
-    def test_quant_situ_dispatches_explicit_beta_parameters(self):
-        expected = torch.randn(2, 8)
-        with patch(f"{MOE_MLP}._w4a8_situ_apply_mlp", return_value=expected) as situ_mlp:
-            output = quant_apply_mlp(
-                hidden_states=torch.randn(2, 8),
-                w1=torch.randn(1, 8, 16),
-                w1_scale=torch.ones(1),
-                w2=torch.randn(1, 8, 8),
-                w2_scale=torch.ones(1),
-                group_list=torch.tensor([1, 1]),
-                activation=MoEActivation.SITU,
-                activation_situ_beta=4.0,
-                activation_situ_linear_beta=25.0,
-            )
-
-        self.assertIs(output, expected)
-        self.assertEqual(situ_mlp.call_args.kwargs["activation_situ_beta"], 4.0)
-        self.assertEqual(situ_mlp.call_args.kwargs["activation_situ_linear_beta"], 25.0)
-
     def test_unquant_swigluoai_uninterleave_falls_back_on_a5(self):
         hidden_states = torch.randn(2, 8, dtype=torch.bfloat16)
         gate_up_out = torch.randn(2, 16, dtype=torch.bfloat16)
@@ -651,6 +632,43 @@ class TestQuantApplyMlpSituEplb(_GeluPathBase):
         self.assertIs(mock_gmm2.call_args.kwargs["weight"], w2)
         self.assertIs(mock_gmm2.call_args.kwargs["weight_scale"], w2_scale)
         self.assertIs(mock_gmm2.call_args.kwargs["bias"], w2_scale_bias)
+
+    def test_w4a8_mxfp_situ_stays_in_common_grouped_matmul_flow(self):
+        gate_up_out = torch.randn(2, 8, dtype=torch.bfloat16)
+        quantized_situ_out = torch.ones(2, 4, dtype=torch.float8_e4m3fn)
+        situ_out_scale = torch.ones(2, 1)
+        expected = torch.randn(2, 4, dtype=torch.bfloat16)
+        stream_patch, evt = _patch_npu_stream()
+
+        with (
+            stream_patch,
+            patch(f"{MOE_MLP}._EXTRA_CTX", MagicMock(moe_comm_type=-1)),
+            patch("torch_npu.npu_grouped_matmul", return_value=[gate_up_out], create=True) as mock_gmm1,
+            patch(
+                "torch.ops._C_ascend.situ_mx_quant",
+                return_value=(quantized_situ_out, situ_out_scale),
+                create=True,
+            ) as situ_mx_quant,
+            patch.object(DeviceOperator, "maybe_normalize_mxfp_scale_layout", side_effect=lambda scale: scale),
+            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=expected) as mock_gmm2,
+            patch(f"{MOE_MLP}.dispose_tensor"),
+        ):
+            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.SITU)
+            kwargs.update(
+                activation_situ_beta=4.0,
+                activation_situ_linear_beta=25.0,
+                use_mxfp_quant=True,
+                mxfp_quant_dtype=QuantType.W4A8MXFP,
+            )
+            output, before_gmm2_evt = quant_apply_mlp(**kwargs)
+
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, evt)
+        self.assertIsNone(mock_gmm1.call_args.kwargs["scale"])
+        self.assertIsNotNone(mock_gmm1.call_args.kwargs["antiquant_scale"])
+        self.assertEqual(situ_mx_quant.call_args.kwargs["beta"], 4.0)
+        self.assertEqual(situ_mx_quant.call_args.kwargs["linear_beta"], 25.0)
+        self.assertIs(mock_gmm2.call_args.kwargs["per_token_scale"], situ_out_scale)
 
     def test_antiquant_weights_use_native_situ_between_grouped_matmuls(self):
         gate_up_out = torch.tensor([[1.0, -1.0, 0.5, 2.0]])

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import torch
 import torch_npu  # noqa: F401  -- registers torch.npu used by the module under test
 from torch.nn import functional as F
-from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config import CompilationConfig, VllmConfig, set_current_vllm_config
 from vllm.model_executor.layers.activation import SituAndMul
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
@@ -120,15 +120,18 @@ class TestSwigluOaiDynamicMxQuant(unittest.TestCase):
 
 class TestUnifiedApplyMlpRequest(unittest.TestCase):
     def test_unquant_situ_matches_upstream_without_config_context(self):
+        # The reference CustomOp needs dispatch config, not platform/logging setup.
+        reference_config = MagicMock(spec=VllmConfig)
+        reference_config.compilation_config = CompilationConfig(custom_ops=["none"])
         for dtype in (torch.bfloat16, torch.float16, torch.float32):
             for beta, linear_beta in ((None, None), (None, 25.0), (4.0, None), (4.0, 25.0)):
                 with self.subTest(dtype=dtype, beta=beta, linear_beta=linear_beta):
                     hidden_states = torch.randn(2, 8, dtype=dtype)
                     gate_up_out = torch.linspace(-40, 40, 32).reshape(2, 16).to(dtype)
                     expected_output = torch.randn(2, 8, dtype=dtype)
-                    with set_current_vllm_config(VllmConfig()):
+                    with set_current_vllm_config(reference_config):
                         expected_activation = SituAndMul(
-                            beta=1.0 if beta is None else beta, linear_beta=linear_beta
+                            beta=1.0 if beta is None else beta, linear_beta=linear_beta, compile_native=False
                         ).forward_native(gate_up_out)
 
                     # The worker forward runs outside the model-init config context.

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -7,6 +7,8 @@ from unittest.mock import MagicMock, patch
 import torch
 import torch_npu  # noqa: F401  -- registers torch.npu used by the module under test
 from torch.nn import functional as F
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.activation import SituAndMul
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import MoECommType
@@ -117,6 +119,51 @@ class TestSwigluOaiDynamicMxQuant(unittest.TestCase):
 
 
 class TestUnifiedApplyMlpRequest(unittest.TestCase):
+    def test_unquant_situ_uses_upstream_activation_contract(self):
+        hidden_states = torch.randn(2, 8, dtype=torch.bfloat16)
+        gate_up_out = torch.randn(2, 16, dtype=torch.bfloat16)
+        expected_output = torch.randn(2, 8, dtype=torch.bfloat16)
+        with set_current_vllm_config(VllmConfig()):
+            expected_activation = SituAndMul(beta=4.0, linear_beta=25.0)(gate_up_out)
+
+            with patch(
+                f"{MOE_MLP}.torch_npu.npu_grouped_matmul",
+                side_effect=[[gate_up_out], [expected_output]],
+                create=True,
+            ) as grouped_matmul:
+                output, _ = unquant_apply_mlp(
+                    hidden_states=hidden_states,
+                    w1=torch.randn(1, 8, 16),
+                    w2=torch.randn(1, 8, 8),
+                    group_list=torch.tensor([1, 1]),
+                    activation=MoEActivation.SITU,
+                    activation_situ_beta=4.0,
+                    activation_situ_linear_beta=25.0,
+                    need_trans=False,
+                )
+
+        self.assertIs(output, expected_output)
+        torch.testing.assert_close(grouped_matmul.call_args_list[1].kwargs["x"][0], expected_activation)
+
+    def test_quant_situ_dispatches_explicit_beta_parameters(self):
+        expected = torch.randn(2, 8)
+        with patch(f"{MOE_MLP}._w4a8_situ_apply_mlp", return_value=expected) as situ_mlp:
+            output = quant_apply_mlp(
+                hidden_states=torch.randn(2, 8),
+                w1=torch.randn(1, 8, 16),
+                w1_scale=torch.ones(1),
+                w2=torch.randn(1, 8, 8),
+                w2_scale=torch.ones(1),
+                group_list=torch.tensor([1, 1]),
+                activation=MoEActivation.SITU,
+                activation_situ_beta=4.0,
+                activation_situ_linear_beta=25.0,
+            )
+
+        self.assertIs(output, expected)
+        self.assertEqual(situ_mlp.call_args.kwargs["activation_situ_beta"], 4.0)
+        self.assertEqual(situ_mlp.call_args.kwargs["activation_situ_linear_beta"], 25.0)
+
     def test_unquant_swigluoai_uninterleave_falls_back_on_a5(self):
         hidden_states = torch.randn(2, 8, dtype=torch.bfloat16)
         gate_up_out = torch.randn(2, 16, dtype=torch.bfloat16)
@@ -407,6 +454,39 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertEqual(quant_kwargs["swiglu_limit"], 5.0)
         mock_unquant.assert_not_called()
 
+    def test_request_quant_path_passes_situ_parameters(self):
+        expected = torch.randn(1, 2)
+        mlp_compute_input = MoEMlpComputeInput(
+            hidden_states=torch.ones((1, 2), dtype=torch.float32),
+            group_list=torch.tensor([1], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            topk_scales=None,
+            weights=MoEWeights(
+                w1=[torch.ones((1, 2, 4), dtype=torch.float32)],
+                w2=[torch.ones((1, 2, 2), dtype=torch.float32)],
+                w1_scale=[torch.ones((1,), dtype=torch.float32)],
+                w2_scale=[torch.ones((1,), dtype=torch.float32)],
+            ),
+            quant=MoEQuantParams(quant_type=QuantType.W8A8),
+            fusion=False,
+            activation=MoEActivation.SITU,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+        )
+
+        with (
+            patch(f"{MOE_MLP}.quant_apply_mlp", return_value=expected) as mock_quant,
+            patch(f"{MOE_MLP}.unquant_apply_mlp") as mock_unquant,
+        ):
+            output = unified_apply_mlp(mlp_compute_input=mlp_compute_input)
+
+        self.assertIs(output, expected)
+        self.assertEqual(mock_quant.call_args.kwargs["activation"], MoEActivation.SITU)
+        self.assertEqual(mock_quant.call_args.kwargs["activation_situ_beta"], 4.0)
+        self.assertEqual(mock_quant.call_args.kwargs["activation_situ_linear_beta"], 25.0)
+        mock_unquant.assert_not_called()
+
     def test_request_quant_path_passes_gelu_activation(self):
         expected = torch.randn(1, 2)
         mlp_compute_input = MoEMlpComputeInput(
@@ -517,6 +597,131 @@ class _GeluPathBase(unittest.TestCase):
             swiglu_limit=0.0,
             use_w4a8_per_channel_gmm_swiglu=False,
         )
+
+
+class TestQuantApplyMlpSituEplb(_GeluPathBase):
+    def test_dynamic_eplb_tensor_lists_reach_both_grouped_matmuls(self):
+        hidden_states = torch.ones(2, 4, dtype=torch.int8)
+        w1 = [torch.randn(8, 4), torch.randn(8, 4)]
+        w2 = [torch.randn(4, 4), torch.randn(4, 4)]
+        w1_scale = [torch.randn(8), torch.randn(8)]
+        w2_scale = [torch.randn(4), torch.randn(4)]
+        w1_scale_bias = [torch.randn(8), torch.randn(8)]
+        w2_scale_bias = [torch.randn(4), torch.randn(4)]
+        gate_up_out = torch.randn(2, 8, dtype=torch.bfloat16)
+        quantized_situ_out = torch.ones(2, 4, dtype=torch.int8)
+        situ_out_scale = torch.ones(2, 1)
+        expected = torch.randn(2, 4, dtype=torch.bfloat16)
+        stream_patch, evt = _patch_npu_stream()
+
+        with (
+            stream_patch,
+            patch("torch_npu.npu_grouped_matmul", return_value=[gate_up_out], create=True) as mock_gmm1,
+            patch(
+                "torch.ops._C_ascend.dequant_situ_quant",
+                return_value=(quantized_situ_out, situ_out_scale),
+                create=True,
+            ),
+            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=expected) as mock_gmm2,
+            patch(f"{MOE_MLP}.dispose_tensor"),
+        ):
+            output, before_gmm2_evt = quant_apply_mlp(
+                hidden_states=hidden_states,
+                w1=w1,
+                w1_scale=w1_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                group_list=torch.tensor([1, 1], dtype=torch.int64),
+                dynamic_scale=torch.ones(2, 1),
+                w1_scale_bias=w1_scale_bias,
+                w2_scale_bias=w2_scale_bias,
+                dynamic_eplb=True,
+                act_quant_type=torch.int8,
+                activation=MoEActivation.SITU,
+                activation_situ_beta=4.0,
+                activation_situ_linear_beta=25.0,
+                use_w4a8_per_channel_gmm_swiglu=True,
+            )
+
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, evt)
+        self.assertIs(mock_gmm1.call_args.kwargs["weight"], w1)
+        self.assertEqual(len(mock_gmm1.call_args.kwargs["scale"]), 2)
+        self.assertIs(mock_gmm1.call_args.kwargs["bias"], w1_scale_bias)
+        self.assertIs(mock_gmm2.call_args.kwargs["weight"], w2)
+        self.assertIs(mock_gmm2.call_args.kwargs["weight_scale"], w2_scale)
+        self.assertIs(mock_gmm2.call_args.kwargs["bias"], w2_scale_bias)
+
+    def test_antiquant_weights_use_native_situ_between_grouped_matmuls(self):
+        gate_up_out = torch.tensor([[1.0, -1.0, 0.5, 2.0]])
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        expected_activation = 4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate)
+        expected_activation *= 25.0 * torch.tanh(up / 25.0)
+        expected = torch.tensor([[3.0]])
+        stream_patch, evt = _patch_npu_stream()
+
+        with (
+            set_current_vllm_config(VllmConfig()),
+            stream_patch,
+            patch(f"{MOE_MLP}._EXTRA_CTX", MagicMock(moe_comm_type=-1)),
+            patch(
+                "torch_npu.npu_grouped_matmul",
+                side_effect=[[gate_up_out], [expected]],
+                create=True,
+            ) as grouped_matmul,
+            patch("torch_npu.npu_dynamic_quant", create=True) as dynamic_quant,
+            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2") as gmm2,
+            patch(f"{MOE_MLP}.dispose_tensor"),
+        ):
+            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.SITU)
+            kwargs.update(
+                activation_situ_beta=4.0,
+                activation_situ_linear_beta=25.0,
+                w1_offset=torch.randn(1, 8, 4),
+                w2_offset=torch.randn(1, 4, 1),
+            )
+            output, before_gmm2_evt = quant_apply_mlp(**kwargs)
+
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, evt)
+        torch.testing.assert_close(grouped_matmul.call_args_list[1].kwargs["x"][0], expected_activation)
+        for call in grouped_matmul.call_args_list:
+            self.assertIn("antiquant_scale", call.kwargs)
+            self.assertIn("antiquant_offset", call.kwargs)
+        dynamic_quant.assert_not_called()
+        gmm2.assert_not_called()
+
+    def test_w4a16_mxfp_uses_native_situ_without_activation_requant(self):
+        gate_up_out = torch.tensor([[1.0, -1.0, 0.5, 2.0]])
+        gate, up = gate_up_out.chunk(2, dim=-1)
+        expected_activation = 4.0 * torch.tanh(gate / 4.0) * torch.sigmoid(gate)
+        expected_activation *= 25.0 * torch.tanh(up / 25.0)
+        expected = torch.tensor([[3.0]])
+        stream_patch, evt = _patch_npu_stream()
+
+        with (
+            set_current_vllm_config(VllmConfig()),
+            stream_patch,
+            patch(f"{MOE_MLP}._EXTRA_CTX", MagicMock(moe_comm_type=-1)),
+            patch("torch_npu.npu_grouped_matmul", return_value=[gate_up_out], create=True),
+            patch("torch_npu.npu_dynamic_quant", create=True) as dynamic_quant,
+            patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=expected) as gmm2,
+            patch(f"{MOE_MLP}.dispose_tensor"),
+        ):
+            kwargs = self._common_w8a8_kwargs(activation=MoEActivation.SITU)
+            kwargs.update(
+                activation_situ_beta=4.0,
+                activation_situ_linear_beta=25.0,
+                use_mxfp_quant=True,
+                mxfp_quant_dtype=QuantType.W4A16MXFP,
+            )
+            output, before_gmm2_evt = quant_apply_mlp(**kwargs)
+
+        self.assertIs(output, expected)
+        self.assertIs(before_gmm2_evt, evt)
+        torch.testing.assert_close(gmm2.call_args.kwargs["hidden_states"], expected_activation)
+        self.assertIsNone(gmm2.call_args.kwargs["per_token_scale"])
+        dynamic_quant.assert_not_called()
 
 
 class TestQuantApplyMlpMxfpSwigluOAI(_GeluPathBase):

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -121,13 +121,15 @@ class TestSwigluOaiDynamicMxQuant(unittest.TestCase):
 class TestUnifiedApplyMlpRequest(unittest.TestCase):
     def test_unquant_situ_matches_upstream_without_config_context(self):
         for dtype in (torch.bfloat16, torch.float16, torch.float32):
-            for linear_beta in (None, 25.0):
-                with self.subTest(dtype=dtype, linear_beta=linear_beta):
+            for beta, linear_beta in ((None, None), (None, 25.0), (4.0, None), (4.0, 25.0)):
+                with self.subTest(dtype=dtype, beta=beta, linear_beta=linear_beta):
                     hidden_states = torch.randn(2, 8, dtype=dtype)
                     gate_up_out = torch.linspace(-40, 40, 32).reshape(2, 16).to(dtype)
                     expected_output = torch.randn(2, 8, dtype=dtype)
                     with set_current_vllm_config(VllmConfig()):
-                        expected_activation = SituAndMul(beta=4.0, linear_beta=linear_beta).forward_native(gate_up_out)
+                        expected_activation = SituAndMul(
+                            beta=1.0 if beta is None else beta, linear_beta=linear_beta
+                        ).forward_native(gate_up_out)
 
                     # The worker forward runs outside the model-init config context.
                     with patch(
@@ -141,7 +143,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
                             w2=torch.randn(1, 8, 8),
                             group_list=torch.tensor([1, 1]),
                             activation=MoEActivation.SITU,
-                            activation_situ_beta=4.0,
+                            activation_situ_beta=beta,
                             activation_situ_linear_beta=linear_beta,
                             need_trans=False,
                         )

--- a/tests/ut/ops/test_moe_runtime_args.py
+++ b/tests/ut/ops/test_moe_runtime_args.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 #
 import unittest
+from types import SimpleNamespace
 
 import torch
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEWeights, build_fused_experts_input
 from vllm_ascend.ops.fused_moe.dataclass.moe_mlp import build_mlp_compute_input
@@ -41,6 +43,48 @@ def _get_test_mxfp_dtype(quant_type: QuantType) -> torch.dtype | None:
 
 
 class TestMoERuntimeArgs(unittest.TestCase):
+    def test_build_mlp_compute_input_preserves_situ_parameters(self):
+        fused_experts_input = build_fused_experts_input(
+            hidden_states=torch.randn(2, 4),
+            topk_weights=torch.ones(2, 1),
+            topk_ids=torch.zeros(2, 1, dtype=torch.int32),
+            w1=torch.randn(1, 4, 8),
+            w2=torch.randn(1, 8, 4),
+            quant_type=QuantType.NONE,
+            dynamic_eplb=False,
+            activation=MoEActivation.SITU,
+        )
+        token_dispatch_output = MoETokenDispatchOutput(
+            hidden_states=fused_experts_input.hidden_states,
+            group_list=torch.tensor([2], dtype=torch.int64),
+            group_list_type=1,
+            dynamic_scale=None,
+            combine_metadata=MoEAllGatherCombineMetadata(
+                topk_weights=fused_experts_input.topk_weights,
+                expanded_row_idx=torch.arange(2, dtype=torch.int32),
+                restore_shape=torch.Size([2, 4]),
+            ),
+        )
+        moe_config = SimpleNamespace(
+            activation=MoEActivation.SITU,
+            activation_situ_beta=4.0,
+            activation_situ_linear_beta=25.0,
+            swiglu_limit=None,
+            swiglu_alpha=None,
+            swiglu_beta=None,
+        )
+
+        mlp_compute_input = build_mlp_compute_input(
+            fused_experts_input=fused_experts_input,
+            token_dispatch_output=token_dispatch_output,
+            moe_config=moe_config,
+            use_fusion_ops=False,
+        )
+
+        self.assertEqual(mlp_compute_input.activation, MoEActivation.SITU)
+        self.assertEqual(mlp_compute_input.activation_situ_beta, 4.0)
+        self.assertEqual(mlp_compute_input.activation_situ_linear_beta, 25.0)
+
     def test_build_fused_experts_input_preserves_runtime_semantics(self):
         for quant_type in (
             QuantType.NONE,

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -195,6 +195,42 @@ class TestAscendModelSlimConfig(TestBase):
             return_success=True,
         )
 
+    def test_get_quant_method_for_kimi_linear_moe_uses_kimi_k3_mapping(self):
+        prefix = "language_model.model.layers.1.block_sparse_moe.experts"
+        quant_description = {f"{prefix}.0.{name}.weight": "W4A8_DYNAMIC" for name in ("w1", "w2", "w3")}
+        config = AscendModelSlimConfig(quant_description)
+        layer = RoutedExperts.__new__(RoutedExperts)
+        torch.nn.Module.__init__(layer)
+        layer.moe_config = MagicMock()
+        layer.weight_loader = MagicMock(return_value=True)
+        mock_vllm_config = MagicMock()
+        mock_vllm_config.model_config.hf_config.model_type = "kimi_linear"
+        mock_scheme = MagicMock()
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=mock_vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=mock_scheme,
+            ) as create_scheme,
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendFusedMoEMethod",
+                return_value=MagicMock(),
+            ),
+        ):
+            config.get_quant_method(layer, prefix)
+
+        self.assertEqual(config.packed_modules_mapping, get_packed_modules_mapping("kimi_k3"))
+        create_scheme.assert_called_once_with(
+            quant_description,
+            prefix,
+            "moe",
+            get_packed_modules_mapping("kimi_k3"),
+        )
+
     def test_get_quant_method_for_c8_kv_cache_attention(self):
         c8_config = AscendModelSlimConfig(
             {
@@ -562,6 +598,89 @@ class TestQuantPrefixMapper(TestBase):
         for model_type in ("gemma4", "gemma4_text"):
             with self.subTest(model_type=model_type):
                 self.assertEqual(get_packed_modules_mapping(model_type), expected_mapping)
+
+    def test_kimi_k3_packed_modules_mapping_covers_kda_and_moe(self):
+        expected_mapping = {
+            "gate_up_proj": ["gate_proj", "up_proj"],
+            "experts": ["experts.0.w1", "experts.0.w2", "experts.0.w3"],
+            "in_proj_qkvgfab": [
+                "q_proj",
+                "k_proj",
+                "v_proj",
+                "g_proj",
+                "f_a_proj",
+                "b_proj",
+            ],
+            "in_proj_qkv": ["q_proj", "k_proj", "v_proj"],
+            "in_proj_gfab": ["g_proj", "f_a_proj", "b_proj"],
+            "conv1d": ["q_conv1d", "k_conv1d", "v_conv1d"],
+            "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        }
+
+        for model_type in ("kimi_k3", "kimi_linear"):
+            with self.subTest(model_type=model_type):
+                self.assertEqual(get_packed_modules_mapping(model_type), expected_mapping)
+
+    def test_kimi_k3_modelslim_resolves_fused_kda_and_moe_types(self):
+        layer_prefix = "language_model.model.layers.1"
+        quant_description = {
+            **{
+                f"{layer_prefix}.self_attn.{name}.weight": "FLOAT"
+                for name in ("q_proj", "k_proj", "v_proj", "g_proj", "f_a_proj", "b_proj")
+            },
+            **{
+                f"{layer_prefix}.block_sparse_moe.experts.0.{name}.weight": "W4A8_DYNAMIC"
+                for name in ("w1", "w2", "w3")
+            },
+        }
+        packed_mapping = get_packed_modules_mapping("kimi_k3")
+
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                f"{layer_prefix}.self_attn.in_proj_qkvgfab",
+                packed_mapping,
+            ),
+            "FLOAT",
+        )
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                f"{layer_prefix}.block_sparse_moe.experts",
+                packed_mapping,
+            ),
+            "W4A8_DYNAMIC",
+        )
+
+    def test_kimi_k3_quarot_splits_mixed_kda_projection(self):
+        attention_prefix = "language_model.model.layers.0.self_attn"
+        quant_description = {
+            **{f"{attention_prefix}.{name}.weight": "W8A8_DYNAMIC" for name in ("q_proj", "k_proj", "v_proj")},
+            **{f"{attention_prefix}.{name}.weight": "FLOAT" for name in ("g_proj", "f_a_proj", "b_proj")},
+        }
+        config = AscendModelSlimConfig(quant_description)
+        fused_prefix = f"{attention_prefix}.in_proj_qkvgfab"
+
+        self.assertTrue(config.uses_kimi_k3_mixed_kda_projection(fused_prefix))
+        self.assertEqual(
+            get_linear_quant_type(
+                quant_description,
+                f"{attention_prefix}.in_proj_qkv",
+                get_packed_modules_mapping("kimi_k3"),
+            ),
+            "W8A8_DYNAMIC",
+        )
+
+        layer = MagicMock(spec=LinearBase)
+        mock_vllm_config = MagicMock()
+        mock_vllm_config.model_config.hf_config.model_type = "kimi_linear"
+        with patch(
+            "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+            return_value=mock_vllm_config,
+        ):
+            method = config.get_quant_method(layer, fused_prefix)
+
+        self.assertIsInstance(method, AscendUnquantizedLinearMethod)
 
     def test_gemma4_moe_experts_float_shards_are_skipped_together(self):
         quant_description = {

--- a/vllm_ascend/ops/fused_moe/dataclass/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/dataclass/moe_mlp.py
@@ -48,6 +48,8 @@ class MoEMlpComputeInput:
     activation: MoEActivation = MoEActivation.SILU
     need_trans: bool = False
     dynamic_eplb: bool = False
+    activation_situ_beta: float | None = None
+    activation_situ_linear_beta: float | None = None
     swiglu_limit: float = 0.0
     swiglu_alpha: float = 1.0
     swiglu_beta: float = 0.0
@@ -73,6 +75,8 @@ def build_mlp_compute_input(
         if moe_config is None
         else getattr(moe_config, "activation", fused_experts_input.activation)
     )
+    activation_situ_beta = None if moe_config is None else moe_config.activation_situ_beta
+    activation_situ_linear_beta = None if moe_config is None else moe_config.activation_situ_linear_beta
     swiglu_limit = 0.0 if moe_config is None else getattr(moe_config, "swiglu_limit", 0.0) or 0.0
     swiglu_alpha = 1.0 if moe_config is None else getattr(moe_config, "swiglu_alpha", 1.0) or 1.0
     swiglu_beta = 0.0 if moe_config is None else getattr(moe_config, "swiglu_beta", 0.0) or 0.0
@@ -99,6 +103,8 @@ def build_mlp_compute_input(
         activation=activation,
         need_trans=fused_experts_input.need_trans,
         dynamic_eplb=fused_experts_input.dynamic_eplb,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
         swiglu_limit=swiglu_limit,
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -214,12 +214,16 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             input_ids: torch.Tensor | None = None,
         ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
             with self._sequence_parallel_context():
+                shared_hidden_states = shared_experts_input if shared_experts_input is not None else hidden_states
                 if self.ascend_shared_experts is None:
                     return self.routed_experts.forward_impl(
                         hidden_states=hidden_states,
                         router_logits=router_logits,
                         input_ids=input_ids,
                     )
+                shared_expert_input, shared_input_all_gather_done = (
+                    self.ascend_shared_experts.prepare_input_before_routed_experts(shared_hidden_states)
+                )
                 if self.is_internal_router:
                     gate = self.gate
                     assert gate is not None
@@ -227,7 +231,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     # increase with extra hidden states. We also assume that all gate
                     # linear is unquantized so that we the weight is pre-casted in
                     # process_weights_after_loading of AscendUnquantizedLinearMethod.
-                    hidden_states_fp32 = hidden_states.float()
+                    hidden_states_fp32 = shared_hidden_states.float()
                     before_routed_experts = torch.npu.current_stream().record_event()
                     # v0.27.1: weight_fp32 is guaranteed by is_internal_router.
                     router_logits = F.linear(hidden_states_fp32, gate.weight_fp32)
@@ -236,6 +240,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     before_routed_experts = torch.npu.current_stream().record_event()
                     after_routed_experts = None
 
+                if shared_input_all_gather_done is not None:
+                    torch.npu.current_stream().wait_event(shared_input_all_gather_done)
                 routed_out, fused_moe_events = self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -243,10 +249,13 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 )
                 fused_moe_events.before_routed_experts = before_routed_experts
                 fused_moe_events.after_routed_experts = after_routed_experts
+                if shared_input_all_gather_done is not None:
+                    fused_moe_events.after_routed_finalize = torch.npu.current_stream().record_event()
 
                 shared_out = self.ascend_shared_experts.forward(
-                    hidden_states,
+                    shared_expert_input,
                     fused_moe_events,
+                    input_is_gathered=shared_input_all_gather_done is not None,
                 )
                 return shared_out, routed_out
 
@@ -260,6 +269,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
             input_ids: torch.Tensor | None = None,
         ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
             with self._sequence_parallel_context():
+                shared_hidden_states = shared_experts_input if shared_experts_input is not None else hidden_states
                 if self.ascend_shared_experts is None:
                     if self.is_internal_router:
                         gate = self.gate
@@ -274,6 +284,9 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                         router_logits=router_logits,
                         input_ids=input_ids,
                     )
+                shared_expert_input, shared_input_all_gather_done = (
+                    self.ascend_shared_experts.prepare_input_before_routed_experts(shared_hidden_states)
+                )
                 if self.is_internal_router:
                     gate = self.gate
                     assert gate is not None
@@ -281,7 +294,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     # increase with extra hidden states. We also assume that all gate
                     # linear is unquantized so that we the weight is pre-casted in
                     # process_weights_after_loading of AscendUnquantizedLinearMethod.
-                    hidden_states_fp32 = hidden_states.float()
+                    hidden_states_fp32 = shared_hidden_states.float()
                     before_routed_experts = torch.npu.current_stream().record_event()
                     # main (cdc4824a21): is_internal_router only checks self.gate,
                     # weight_fp32 may be absent, fall back to gate.weight.
@@ -294,6 +307,8 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     before_routed_experts = torch.npu.current_stream().record_event()
                     after_routed_experts = None
 
+                if shared_input_all_gather_done is not None:
+                    torch.npu.current_stream().wait_event(shared_input_all_gather_done)
                 routed_out, fused_moe_events = self.routed_experts.forward_impl(
                     hidden_states=hidden_states,
                     router_logits=router_logits,
@@ -301,9 +316,12 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                 )
                 fused_moe_events.before_routed_experts = before_routed_experts
                 fused_moe_events.after_routed_experts = after_routed_experts
+                if shared_input_all_gather_done is not None:
+                    fused_moe_events.after_routed_finalize = torch.npu.current_stream().record_event()
 
                 shared_out = self.ascend_shared_experts.forward(
-                    hidden_states,
+                    shared_expert_input,
                     fused_moe_events,
+                    input_is_gathered=shared_input_all_gather_done is not None,
                 )
                 return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -18,6 +18,7 @@
 import torch
 import torch_npu
 from torch.nn.functional import pad
+from vllm.model_executor.layers.activation import SituAndMul
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.triton_utils import HAS_TRITON
 
@@ -34,20 +35,20 @@ from vllm_ascend.utils import (
 )
 
 ASCEND_DEVICE_TYPE = get_ascend_device_type()
+# CANN uses 36 to select FP8 E4M3FN output for situ_mx_quant.
+SITU_MX_DST_TYPE_E4M3FN = 36
 
 
 def _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation=None):
-    return (
-        fusion
-        and dynamic_eplb
-        and getattr(activation, "value", activation) != "swigluoai_uninterleave"
-        and enable_custom_op()
-    )
+    activation_name = getattr(activation, "value", activation)
+    return fusion and dynamic_eplb and activation_name not in ("situ", "swigluoai_uninterleave") and enable_custom_op()
 
 
 def _gmm_swiglu_quant_fusion_enabled(use_mxfp_quant, fusion, dynamic_eplb, activation=None):
-    return (use_mxfp_quant or (fusion and not dynamic_eplb)) and (
-        getattr(activation, "value", activation) != "swigluoai_uninterleave"
+    activation_name = getattr(activation, "value", activation)
+    return (use_mxfp_quant or (fusion and not dynamic_eplb)) and activation_name not in (
+        "situ",
+        "swigluoai_uninterleave",
     )
 
 
@@ -118,6 +119,131 @@ def _prepare_swigluoai_grouped_matmul_scales(
 ) -> list[torch.Tensor]:
     scales = weight_scale if isinstance(weight_scale, list) else [weight_scale]
     return [scale.to(output_dtype) if scale.dtype != output_dtype else scale for scale in scales]
+
+
+def _as_grouped_matmul_weights(
+    tensor_or_list: list[torch.Tensor] | torch.Tensor,
+) -> list[torch.Tensor]:
+    return tensor_or_list if isinstance(tensor_or_list, list) else [tensor_or_list]
+
+
+def _quantized_situ_apply_mlp(
+    *,
+    hidden_states: torch.Tensor,
+    w1: list[torch.Tensor] | torch.Tensor,
+    w1_scale: list[torch.Tensor] | torch.Tensor,
+    w2: list[torch.Tensor] | torch.Tensor,
+    w2_scale: list[torch.Tensor] | torch.Tensor,
+    group_list: torch.Tensor,
+    group_list_type: int,
+    dynamic_scale: torch.Tensor | None,
+    w1_scale_bias: torch.Tensor | None,
+    w2_scale_bias: torch.Tensor | None,
+    activation_situ_beta: float,
+    activation_situ_linear_beta: float | None,
+    act_quant_type: torch.dtype,
+    weight_quant_type: torch.dtype | None,
+    scale_type: torch.dtype | None,
+    per_token_scale_type: torch.dtype | None,
+    use_bf16: bool,
+    use_mxfp_quant: bool,
+    is_per_channel_weight: bool,
+    mxfp_quant_dtype: QuantType | None = None,
+) -> tuple[torch.Tensor, torch.npu.Event]:
+    """Run GMM1 -> SiTU quant -> GMM2 without the SwiGLU fusions."""
+    input_hidden_dtype = hidden_states.dtype
+    if dynamic_scale is None:
+        unquantized_hidden_states = hidden_states
+        hidden_states, pertoken_scale = DeviceOperator.npu_dynamic_quant(
+            hidden_states=hidden_states,
+            dynamic_scale=None,
+            act_quant_type=act_quant_type,
+            use_mxfp_quant=False,
+        )
+        dispose_tensor(unquantized_hidden_states)
+        externally_quantized_hidden_states = None
+    else:
+        pertoken_scale = (
+            DeviceOperator.maybe_normalize_mxfp_scale_layout(dynamic_scale) if use_mxfp_quant else dynamic_scale
+        )
+        externally_quantized_hidden_states = hidden_states
+
+    w1_scale_list = _as_grouped_matmul_weights(w1_scale)
+    w2_scale_list = _as_grouped_matmul_weights(w2_scale)
+    output_dtype = w2_scale_list[0].dtype
+    bias1, bias2 = None, None
+    if w1_scale_bias is not None:
+        if group_list_type == 0:
+            group_list = torch.cat([group_list[:1], torch.diff(group_list, dim=0)])
+            group_list_type = 1
+        bias1 = w1_scale_bias
+        bias2 = w2_scale_bias
+        output_dtype = torch.bfloat16
+
+    gmm1_scale = [scale.to(w2_scale_list[0].dtype) for scale in w1_scale_list]
+    if is_per_channel_weight:
+        gmm1_scale = [scale.unsqueeze(-2) for scale in gmm1_scale]
+
+    gate_up_out = torch_npu.npu_grouped_matmul(
+        x=[hidden_states],
+        weight=_as_grouped_matmul_weights(w1),
+        antiquant_scale=gmm1_scale if use_mxfp_quant else None,
+        scale=gmm1_scale if not use_mxfp_quant else None,
+        bias=bias1,
+        per_token_scale=[pertoken_scale],
+        split_item=2,
+        group_list_type=group_list_type,
+        group_type=0,
+        group_list=group_list,
+        per_token_scale_dtype=torch_npu.float8_e8m0fnu if use_mxfp_quant else None,
+        weight_dtype=torch_npu.float4_e2m1fn_x2 if use_mxfp_quant else None,
+        output_dtype=torch.bfloat16 if use_mxfp_quant else output_dtype,
+    )[0]
+    if externally_quantized_hidden_states is not None:
+        dispose_tensor(externally_quantized_hidden_states)
+
+    if use_mxfp_quant:
+        hidden_states, situ_out_scale = torch.ops._C_ascend.situ_mx_quant(
+            x=gate_up_out,
+            beta=activation_situ_beta,
+            linear_beta=activation_situ_linear_beta or 0.0,
+            activate_left=True,
+            dst_type=SITU_MX_DST_TYPE_E4M3FN,
+        )
+    else:
+        hidden_states, situ_out_scale = torch.ops._C_ascend.dequant_situ_quant(
+            x=gate_up_out,
+            weight_scale=None,
+            activation_scale=None,
+            bias=None,
+            quant_scale=None,
+            quant_offset=None,
+            group_index=None,
+            beta=activation_situ_beta,
+            linear_beta=activation_situ_linear_beta or 0.0,
+            activate_left=True,
+            quant_mode="dynamic",
+        )
+    before_gmm2_evt = torch.npu.current_stream().record_event()
+    hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
+        hidden_states=hidden_states,
+        weight=w2,
+        weight_scale=w2_scale,
+        per_token_scale=situ_out_scale,
+        group_list=group_list,
+        group_list_type=group_list_type,
+        input_dtype=input_hidden_dtype,
+        act_quant_type=act_quant_type,
+        weight_quant_type=weight_quant_type,
+        scale_type=scale_type,
+        per_token_scale_type=per_token_scale_type,
+        use_bf16=use_bf16,
+        use_mxfp_quant=use_mxfp_quant,
+        bias=bias2,
+        fallback_output_dtype=output_dtype,
+        mxfp_quant_dtype=mxfp_quant_dtype,
+    )
+    return hidden_states, before_gmm2_evt
 
 
 def _apply_clipped_swiglu(
@@ -193,13 +319,41 @@ def quant_apply_mlp(
     scale_type: torch.dtype | None = None,
     per_token_scale_type: torch.dtype | None = None,
     use_bf16: bool = True,
-    activation: str | None = None,
+    activation: str | MoEActivation | None = None,
+    activation_situ_beta: float | None = None,
+    activation_situ_linear_beta: float | None = None,
     swiglu_limit: float = 0.0,
     swiglu_alpha: float = 1.0,
     swiglu_beta: float = 0.0,
     use_w4a8_per_channel_gmm_swiglu: bool = False,
 ) -> torch.Tensor:
     input_hidden_dtype = hidden_states.dtype
+    situ_beta = 1.0 if activation_situ_beta is None else activation_situ_beta
+    if activation == MoEActivation.SITU:
+        use_antiquant_situ = mxfp_quant_dtype == QuantType.W4A16MXFP or w1_offset is not None
+        if not use_antiquant_situ:
+            return _quantized_situ_apply_mlp(
+                hidden_states=hidden_states,
+                w1=w1,
+                w1_scale=w1_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                group_list=group_list,
+                group_list_type=group_list_type,
+                dynamic_scale=dynamic_scale,
+                w1_scale_bias=w1_scale_bias,
+                w2_scale_bias=w2_scale_bias,
+                activation_situ_beta=situ_beta,
+                activation_situ_linear_beta=activation_situ_linear_beta,
+                act_quant_type=act_quant_type,
+                weight_quant_type=weight_quant_type,
+                scale_type=scale_type,
+                per_token_scale_type=per_token_scale_type,
+                use_bf16=use_bf16,
+                is_per_channel_weight=use_w4a8_per_channel_gmm_swiglu,
+                use_mxfp_quant=use_mxfp_quant,
+                mxfp_quant_dtype=mxfp_quant_dtype,
+            )
     act_name = getattr(activation, "value", activation)
     use_gmm_swiglu_quant_fusion = _gmm_swiglu_quant_fusion_enabled(
         use_mxfp_quant,
@@ -399,6 +553,11 @@ def quant_apply_mlp(
             gate, up = hidden_states.chunk(2, dim=-1)
             approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
             hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
+        elif activation == MoEActivation.SITU:
+            hidden_states = SituAndMul(
+                beta=situ_beta,
+                linear_beta=activation_situ_linear_beta,
+            )(hidden_states)
         elif is_swigluoai_uninterleave:
             hidden_states = _apply_clipped_swiglu(
                 hidden_states,
@@ -519,6 +678,12 @@ def quant_apply_mlp(
                 approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
                 hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
+            elif activation == MoEActivation.SITU:
+                hidden_states = SituAndMul(
+                    beta=situ_beta,
+                    linear_beta=activation_situ_linear_beta,
+                )(hidden_states)
+                swiglu_out_scale = None
             elif is_swigluoai_uninterleave:
                 if use_mxfp_quant:
                     hidden_states, swiglu_out_scale = _swiglu_oai_dynamic_mx_quant(
@@ -577,7 +742,9 @@ def unquant_apply_mlp(
     group_list: torch.Tensor,
     w1_bias: torch.Tensor = None,
     w2_bias: torch.Tensor = None,
-    activation: str | None = None,
+    activation: str | MoEActivation | None = None,
+    activation_situ_beta: float | None = None,
+    activation_situ_linear_beta: float | None = None,
     group_list_type: int = 1,
     topk_scales: torch.Tensor | None = None,
     need_trans: bool = True,
@@ -641,7 +808,12 @@ def unquant_apply_mlp(
         )
 
     act_name = getattr(activation, "value", activation)
-    if activation == MoEActivation.SWIGLUOAI:
+    if activation == MoEActivation.SITU:
+        gate_up_out = SituAndMul(
+            beta=activation_situ_beta,
+            linear_beta=activation_situ_linear_beta,
+        )(gate_up_out)
+    elif activation == MoEActivation.SWIGLUOAI:
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))
     elif act_name == "swigluoai_uninterleave":
@@ -714,6 +886,8 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
     swiglu_limit = mlp_compute_input.swiglu_limit
     swiglu_alpha = mlp_compute_input.swiglu_alpha
     swiglu_beta = mlp_compute_input.swiglu_beta
+    activation_situ_beta = mlp_compute_input.activation_situ_beta
+    activation_situ_linear_beta = mlp_compute_input.activation_situ_linear_beta
 
     if not mlp_compute_input.quant.is_quant:
         return unquant_apply_mlp(
@@ -723,6 +897,8 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
             w1_bias=w1_bias,
             w2_bias=w2_bias,
             activation=activation,
+            activation_situ_beta=activation_situ_beta,
+            activation_situ_linear_beta=activation_situ_linear_beta,
             group_list=group_list,
             group_list_type=group_list_type,
             topk_scales=topk_scales,
@@ -787,6 +963,8 @@ def unified_apply_mlp(*, mlp_compute_input: MoEMlpComputeInput) -> torch.Tensor:
         per_token_scale_type=per_token_scale_type,
         use_bf16=use_bf16,
         activation=activation,
+        activation_situ_beta=activation_situ_beta,
+        activation_situ_linear_beta=activation_situ_linear_beta,
         swiglu_limit=swiglu_limit,
         swiglu_alpha=swiglu_alpha,
         swiglu_beta=swiglu_beta,

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -18,7 +18,6 @@
 import torch
 import torch_npu
 from torch.nn.functional import pad
-from vllm.model_executor.layers.activation import SituAndMul
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.triton_utils import HAS_TRITON
 
@@ -119,6 +118,22 @@ def _prepare_swigluoai_grouped_matmul_scales(
 ) -> list[torch.Tensor]:
     scales = weight_scale if isinstance(weight_scale, list) else [weight_scale]
     return [scale.to(output_dtype) if scale.dtype != output_dtype else scale for scale in scales]
+
+
+def _apply_situ(
+    hidden_states: torch.Tensor,
+    *,
+    beta: float,
+    linear_beta: float | None,
+) -> torch.Tensor:
+    """Match SituAndMul.forward_native without constructing a CustomOp in forward."""
+    gate, up = hidden_states.chunk(2, dim=-1)
+    gate = gate.float()
+    up = up.float()
+    gate = beta * torch.tanh(gate / beta) * torch.sigmoid(gate)
+    if linear_beta is not None:
+        up = linear_beta * torch.tanh(up / linear_beta)
+    return (gate * up).to(hidden_states.dtype)
 
 
 def _apply_clipped_swiglu(
@@ -406,10 +421,11 @@ def quant_apply_mlp(
             approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
             hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
         elif activation == MoEActivation.SITU:
-            hidden_states = SituAndMul(
+            hidden_states = _apply_situ(
+                hidden_states,
                 beta=situ_beta,
                 linear_beta=activation_situ_linear_beta,
-            )(hidden_states)
+            )
         elif is_swigluoai_uninterleave:
             hidden_states = _apply_clipped_swiglu(
                 hidden_states,
@@ -573,10 +589,11 @@ def quant_apply_mlp(
                         quant_mode="dynamic",
                     )
                 else:
-                    hidden_states = SituAndMul(
+                    hidden_states = _apply_situ(
+                        hidden_states,
                         beta=situ_beta,
                         linear_beta=activation_situ_linear_beta,
-                    )(hidden_states)
+                    )
                     swiglu_out_scale = None
             elif is_swigluoai_uninterleave:
                 if use_mxfp_quant:
@@ -703,10 +720,11 @@ def unquant_apply_mlp(
 
     act_name = getattr(activation, "value", activation)
     if activation == MoEActivation.SITU:
-        gate_up_out = SituAndMul(
+        gate_up_out = _apply_situ(
+            gate_up_out,
             beta=activation_situ_beta,
             linear_beta=activation_situ_linear_beta,
-        )(gate_up_out)
+        )
     elif activation == MoEActivation.SWIGLUOAI:
         num_experts, _, hidden_size = w1.shape
         gate_up_out = AscendSwigluOAIAndMul.swiglu_oai_forward(gate_up_out.view(-1, hidden_size))

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -121,131 +121,6 @@ def _prepare_swigluoai_grouped_matmul_scales(
     return [scale.to(output_dtype) if scale.dtype != output_dtype else scale for scale in scales]
 
 
-def _as_grouped_matmul_weights(
-    tensor_or_list: list[torch.Tensor] | torch.Tensor,
-) -> list[torch.Tensor]:
-    return tensor_or_list if isinstance(tensor_or_list, list) else [tensor_or_list]
-
-
-def _quantized_situ_apply_mlp(
-    *,
-    hidden_states: torch.Tensor,
-    w1: list[torch.Tensor] | torch.Tensor,
-    w1_scale: list[torch.Tensor] | torch.Tensor,
-    w2: list[torch.Tensor] | torch.Tensor,
-    w2_scale: list[torch.Tensor] | torch.Tensor,
-    group_list: torch.Tensor,
-    group_list_type: int,
-    dynamic_scale: torch.Tensor | None,
-    w1_scale_bias: torch.Tensor | None,
-    w2_scale_bias: torch.Tensor | None,
-    activation_situ_beta: float,
-    activation_situ_linear_beta: float | None,
-    act_quant_type: torch.dtype,
-    weight_quant_type: torch.dtype | None,
-    scale_type: torch.dtype | None,
-    per_token_scale_type: torch.dtype | None,
-    use_bf16: bool,
-    use_mxfp_quant: bool,
-    is_per_channel_weight: bool,
-    mxfp_quant_dtype: QuantType | None = None,
-) -> tuple[torch.Tensor, torch.npu.Event]:
-    """Run GMM1 -> SiTU quant -> GMM2 without the SwiGLU fusions."""
-    input_hidden_dtype = hidden_states.dtype
-    if dynamic_scale is None:
-        unquantized_hidden_states = hidden_states
-        hidden_states, pertoken_scale = DeviceOperator.npu_dynamic_quant(
-            hidden_states=hidden_states,
-            dynamic_scale=None,
-            act_quant_type=act_quant_type,
-            use_mxfp_quant=False,
-        )
-        dispose_tensor(unquantized_hidden_states)
-        externally_quantized_hidden_states = None
-    else:
-        pertoken_scale = (
-            DeviceOperator.maybe_normalize_mxfp_scale_layout(dynamic_scale) if use_mxfp_quant else dynamic_scale
-        )
-        externally_quantized_hidden_states = hidden_states
-
-    w1_scale_list = _as_grouped_matmul_weights(w1_scale)
-    w2_scale_list = _as_grouped_matmul_weights(w2_scale)
-    output_dtype = w2_scale_list[0].dtype
-    bias1, bias2 = None, None
-    if w1_scale_bias is not None:
-        if group_list_type == 0:
-            group_list = torch.cat([group_list[:1], torch.diff(group_list, dim=0)])
-            group_list_type = 1
-        bias1 = w1_scale_bias
-        bias2 = w2_scale_bias
-        output_dtype = torch.bfloat16
-
-    gmm1_scale = [scale.to(w2_scale_list[0].dtype) for scale in w1_scale_list]
-    if is_per_channel_weight:
-        gmm1_scale = [scale.unsqueeze(-2) for scale in gmm1_scale]
-
-    gate_up_out = torch_npu.npu_grouped_matmul(
-        x=[hidden_states],
-        weight=_as_grouped_matmul_weights(w1),
-        antiquant_scale=gmm1_scale if use_mxfp_quant else None,
-        scale=gmm1_scale if not use_mxfp_quant else None,
-        bias=bias1,
-        per_token_scale=[pertoken_scale],
-        split_item=2,
-        group_list_type=group_list_type,
-        group_type=0,
-        group_list=group_list,
-        per_token_scale_dtype=torch_npu.float8_e8m0fnu if use_mxfp_quant else None,
-        weight_dtype=torch_npu.float4_e2m1fn_x2 if use_mxfp_quant else None,
-        output_dtype=torch.bfloat16 if use_mxfp_quant else output_dtype,
-    )[0]
-    if externally_quantized_hidden_states is not None:
-        dispose_tensor(externally_quantized_hidden_states)
-
-    if use_mxfp_quant:
-        hidden_states, situ_out_scale = torch.ops._C_ascend.situ_mx_quant(
-            x=gate_up_out,
-            beta=activation_situ_beta,
-            linear_beta=activation_situ_linear_beta or 0.0,
-            activate_left=True,
-            dst_type=SITU_MX_DST_TYPE_E4M3FN,
-        )
-    else:
-        hidden_states, situ_out_scale = torch.ops._C_ascend.dequant_situ_quant(
-            x=gate_up_out,
-            weight_scale=None,
-            activation_scale=None,
-            bias=None,
-            quant_scale=None,
-            quant_offset=None,
-            group_index=None,
-            beta=activation_situ_beta,
-            linear_beta=activation_situ_linear_beta or 0.0,
-            activate_left=True,
-            quant_mode="dynamic",
-        )
-    before_gmm2_evt = torch.npu.current_stream().record_event()
-    hidden_states = DeviceOperator.npu_grouped_matmul_gmm2(
-        hidden_states=hidden_states,
-        weight=w2,
-        weight_scale=w2_scale,
-        per_token_scale=situ_out_scale,
-        group_list=group_list,
-        group_list_type=group_list_type,
-        input_dtype=input_hidden_dtype,
-        act_quant_type=act_quant_type,
-        weight_quant_type=weight_quant_type,
-        scale_type=scale_type,
-        per_token_scale_type=per_token_scale_type,
-        use_bf16=use_bf16,
-        use_mxfp_quant=use_mxfp_quant,
-        bias=bias2,
-        fallback_output_dtype=output_dtype,
-        mxfp_quant_dtype=mxfp_quant_dtype,
-    )
-    return hidden_states, before_gmm2_evt
-
-
 def _apply_clipped_swiglu(
     hidden_states: torch.Tensor,
     *,
@@ -329,32 +204,9 @@ def quant_apply_mlp(
 ) -> torch.Tensor:
     input_hidden_dtype = hidden_states.dtype
     situ_beta = 1.0 if activation_situ_beta is None else activation_situ_beta
-    if activation == MoEActivation.SITU:
-        use_antiquant_situ = mxfp_quant_dtype == QuantType.W4A16MXFP or w1_offset is not None
-        if not use_antiquant_situ:
-            return _quantized_situ_apply_mlp(
-                hidden_states=hidden_states,
-                w1=w1,
-                w1_scale=w1_scale,
-                w2=w2,
-                w2_scale=w2_scale,
-                group_list=group_list,
-                group_list_type=group_list_type,
-                dynamic_scale=dynamic_scale,
-                w1_scale_bias=w1_scale_bias,
-                w2_scale_bias=w2_scale_bias,
-                activation_situ_beta=situ_beta,
-                activation_situ_linear_beta=activation_situ_linear_beta,
-                act_quant_type=act_quant_type,
-                weight_quant_type=weight_quant_type,
-                scale_type=scale_type,
-                per_token_scale_type=per_token_scale_type,
-                use_bf16=use_bf16,
-                is_per_channel_weight=use_w4a8_per_channel_gmm_swiglu,
-                use_mxfp_quant=use_mxfp_quant,
-                mxfp_quant_dtype=mxfp_quant_dtype,
-            )
     act_name = getattr(activation, "value", activation)
+    is_situ_activation = activation == MoEActivation.SITU
+    quantize_situ_output = is_situ_activation and mxfp_quant_dtype != QuantType.W4A16MXFP
     use_gmm_swiglu_quant_fusion = _gmm_swiglu_quant_fusion_enabled(
         use_mxfp_quant,
         fusion,
@@ -399,7 +251,7 @@ def quant_apply_mlp(
     _output_dtype = w2_scale[0].dtype if isinstance(w2_scale, list) else w2_scale.dtype
 
     is_mc2 = _EXTRA_CTX.moe_comm_type == MoECommType.MC2
-    if w1_scale_bias is None and w1_offset is None and is_mc2 and not is_gelu_activation:
+    if w1_scale_bias is None and w1_offset is None and is_mc2 and not is_gelu_activation and not is_situ_activation:
         if _custom_gmm_swiglu_enabled(fusion, dynamic_eplb, activation) and not use_mxfp_quant:
             # gmm1: gate_up_proj & act_fn: swiglu
             hidden_states, swiglu_out_scale, _ = torch.ops._C_ascend.grouped_matmul_swiglu_quant_weight_nz_tensor_list(
@@ -595,6 +447,7 @@ def quant_apply_mlp(
             and enable_custom_op()
             and activation != MoEActivation.SWIGLUSTEP
             and not is_gelu_activation
+            and not is_situ_activation
             and not is_swigluoai_uninterleave
         ):
             hidden_states, swiglu_out_scale = torch.ops._C_ascend.grouped_matmul_swiglu_quant_v2(
@@ -641,9 +494,16 @@ def quant_apply_mlp(
                 dispose_tensor(quantized_hidden_states)
         else:
             # gmm1: gate_up_proj
-            scale = [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale]
-            if is_swigluoai_uninterleave:
+            if quantize_situ_output:
+                output_scale = w2_scale[0] if isinstance(w2_scale, list) else w2_scale
+                scale = w1_scale if isinstance(w1_scale, list) else [w1_scale]
+                scale = [item.to(output_scale.dtype) if item.dtype != output_scale.dtype else item for item in scale]
+                if use_w4a8_per_channel_gmm_swiglu:
+                    scale = [item.unsqueeze(-2) for item in scale]
+            elif is_swigluoai_uninterleave:
                 scale = _prepare_swigluoai_grouped_matmul_scales(w1_scale, _output_dtype)
+            else:
+                scale = [w1_scale[0].to(w2_scale[0].dtype)] if isinstance(w1_scale, list) else [w1_scale]
             gmm1_kwargs = {
                 "x": [hidden_states],
                 "weight": w1 if isinstance(w1, list) else [w1],
@@ -657,13 +517,24 @@ def quant_apply_mlp(
                 "output_dtype": _output_dtype,
             }
             if use_mxfp_quant:
-                gmm1_kwargs.update(
-                    {
-                        "scale_dtype": torch_npu.float8_e8m0fnu,
-                        "per_token_scale_dtype": torch_npu.float8_e8m0fnu,
-                        "output_dtype": torch.bfloat16,
-                    }
-                )
+                if quantize_situ_output:
+                    gmm1_kwargs.update(
+                        {
+                            "scale": None,
+                            "antiquant_scale": scale,
+                            "per_token_scale_dtype": torch_npu.float8_e8m0fnu,
+                            "weight_dtype": torch_npu.float4_e2m1fn_x2,
+                            "output_dtype": torch.bfloat16,
+                        }
+                    )
+                else:
+                    gmm1_kwargs.update(
+                        {
+                            "scale_dtype": torch_npu.float8_e8m0fnu,
+                            "per_token_scale_dtype": torch_npu.float8_e8m0fnu,
+                            "output_dtype": torch.bfloat16,
+                        }
+                    )
             hidden_states = torch_npu.npu_grouped_matmul(**gmm1_kwargs)[0]
             if quantized_hidden_states is not None:
                 dispose_tensor(quantized_hidden_states)
@@ -678,12 +549,35 @@ def quant_apply_mlp(
                 approximate = "tanh" if activation == MoEActivation.GELU_TANH else "none"
                 hidden_states = torch.nn.functional.gelu(gate, approximate=approximate) * up
                 hidden_states, swiglu_out_scale = torch_npu.npu_dynamic_quant(hidden_states)
-            elif activation == MoEActivation.SITU:
-                hidden_states = SituAndMul(
-                    beta=situ_beta,
-                    linear_beta=activation_situ_linear_beta,
-                )(hidden_states)
-                swiglu_out_scale = None
+            elif is_situ_activation:
+                if quantize_situ_output and use_mxfp_quant:
+                    hidden_states, swiglu_out_scale = torch.ops._C_ascend.situ_mx_quant(
+                        x=hidden_states,
+                        beta=situ_beta,
+                        linear_beta=activation_situ_linear_beta or 0.0,
+                        activate_left=True,
+                        dst_type=SITU_MX_DST_TYPE_E4M3FN,
+                    )
+                elif quantize_situ_output:
+                    hidden_states, swiglu_out_scale = torch.ops._C_ascend.dequant_situ_quant(
+                        x=hidden_states,
+                        weight_scale=None,
+                        activation_scale=None,
+                        bias=None,
+                        quant_scale=None,
+                        quant_offset=None,
+                        group_index=None,
+                        beta=situ_beta,
+                        linear_beta=activation_situ_linear_beta or 0.0,
+                        activate_left=True,
+                        quant_mode="dynamic",
+                    )
+                else:
+                    hidden_states = SituAndMul(
+                        beta=situ_beta,
+                        linear_beta=activation_situ_linear_beta,
+                    )(hidden_states)
+                    swiglu_out_scale = None
             elif is_swigluoai_uninterleave:
                 if use_mxfp_quant:
                     hidden_states, swiglu_out_scale = _swiglu_oai_dynamic_mx_quant(

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -722,7 +722,7 @@ def unquant_apply_mlp(
     if activation == MoEActivation.SITU:
         gate_up_out = _apply_situ(
             gate_up_out,
-            beta=activation_situ_beta,
+            beta=1.0 if activation_situ_beta is None else activation_situ_beta,
             linear_beta=activation_situ_linear_beta,
         )
     elif activation == MoEActivation.SWIGLUOAI:

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -23,6 +23,7 @@ import torch.nn.functional as F
 import torch_npu
 from vllm.distributed import tensor_model_parallel_all_gather, tensor_model_parallel_reduce_scatter
 from vllm.logger import logger
+from vllm.model_executor.layers.activation import SituAndMul
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoEMethodBase
 
 from vllm_ascend.ascend_config import get_ascend_config
@@ -36,6 +37,9 @@ from vllm_ascend.utils import (
     shared_experts_calculation_stream,
 )
 
+# CANN uses 36 to select FP8 E4M3FN output for situ_mx_quant.
+SITU_MX_DST_TYPE_E4M3FN = 36
+
 
 @dataclass
 class FusedMoEEvents:
@@ -44,6 +48,7 @@ class FusedMoEEvents:
     before_dispatch: torch.npu.Event | None = field(default=None)
     before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
+    after_routed_finalize: torch.npu.Event | None = field(default=None)
 
 
 class SharedExpertParallelMode(Enum):
@@ -73,11 +78,17 @@ class AscendSharedExperts:
         self.layer = layer
         self.moe_config = moe_config
         self.hidden_size = moe_config.hidden_dim
+        self.shared_expert_input_size = getattr(
+            layer.gate_up_proj,
+            "input_size",
+            self.hidden_size,
+        )
         self.in_dtype = moe_config.in_dtype
         self.swiglu_limit = 0.0 if moe_config.swiglu_limit is None else moe_config.swiglu_limit
         self.swiglu_alpha = 1.0 if moe_config.swiglu_alpha is None else moe_config.swiglu_alpha
         self.swiglu_beta = 0.0 if moe_config.swiglu_beta is None else moe_config.swiglu_beta
         self.is_sequence_parallel = moe_config.is_sequence_parallel
+        self.situ_activation = layer.act_fn if isinstance(layer.act_fn, SituAndMul) else None
         self.quant_type = quant_type
         self.lora_context = None
         ascend_config = get_ascend_config()
@@ -105,7 +116,14 @@ class AscendSharedExperts:
     def validate_consistency(self):
         """Validate that split shared expert computation matches integrated computation."""
         test_input = (
-            torch.rand(10, self.hidden_size, device="npu", dtype=self.in_dtype) * 2 - 1
+            torch.rand(
+                10,
+                self.shared_expert_input_size,
+                device="npu",
+                dtype=self.in_dtype,
+            )
+            * 2
+            - 1
         )  # Random input for testing, scoped to [-1, 1]
 
         integrated_out = self.layer(test_input)
@@ -124,7 +142,7 @@ class AscendSharedExperts:
                 integrated_out.norm().item(),
                 split_out.sum().item(),
                 split_out.norm().item(),
-                self.hidden_size,
+                self.shared_expert_input_size,
                 self.in_dtype,
             )
             raise ValueError("FusedMoE shared experts split computation does not match the integrated computation.")
@@ -225,9 +243,34 @@ class AscendSharedExperts:
             shared_out = F.pad(shared_out, (0, 0, 0, pad_size))
         return tensor_model_parallel_reduce_scatter(shared_out, dim=0)
 
-    def forward(self, hidden_states: torch.Tensor, fused_moe_evts: FusedMoEEvents):
+    def prepare_input_before_routed_experts(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.npu.Event | None]:
+        """Start the SP-only input all-gather on the shared-expert stream."""
+        if not (self.multistream_overlap and self.parallel_mode() is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY):
+            return hidden_states, None
+
+        input_ready = torch.npu.current_stream().record_event()
+        with npu_stream_switch(shared_experts_calculation_stream(), enabled=True):
+            torch.npu.current_stream().wait_event(input_ready)
+            hidden_states = self._gather_sp_input(hidden_states)
+            all_gather_done = torch.npu.current_stream().record_event()
+        return hidden_states, all_gather_done
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        fused_moe_evts: FusedMoEEvents,
+        input_is_gathered: bool = False,
+    ):
         mode = self.parallel_mode()
         local_dp_metadata = None
+        down_projection_ready = (
+            fused_moe_evts.after_routed_finalize
+            if self.multistream_overlap and mode is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY
+            else fused_moe_evts.before_combine
+        )
 
         def maybe_wait_event(evt: torch.npu.Event | None):
             if evt is not None:
@@ -243,8 +286,9 @@ class AscendSharedExperts:
                 # Sharded activations + TP-sharded weights: gather the SP
                 # shard to full activations before the MLP; the output is
                 # padded and reduce-scattered back below.
-                maybe_wait_event(fused_moe_evts.before_routed_experts)
-                hidden_states = self._gather_sp_input(hidden_states)
+                if not input_is_gathered:
+                    maybe_wait_event(fused_moe_evts.before_routed_experts)
+                    hidden_states = self._gather_sp_input(hidden_states)
             # Only used for int quantization
             has_quantized_shared_without_lora = (
                 not has_lora(self.lora_context)
@@ -270,27 +314,40 @@ class AscendSharedExperts:
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
-                    x=hidden_states,
-                    weight_scale=self.layer.gate_up_proj.weight_scale_fp32,
-                    activation_scale=pertoken_scale,
-                    bias=None,
-                    quant_scale=None,
-                    quant_offset=None,
-                    group_index=None,
-                    activate_left=True,
-                    quant_mode=1,
-                    swiglu_mode=1,
-                    clamp_limit=self.swiglu_limit,
-                    **(
-                        {}
-                        if get_ascend_device_type() == AscendDeviceType.A5
-                        else {"glu_alpha": self.swiglu_alpha, "glu_bias": self.swiglu_beta}
-                    ),
-                )
-                # Execute the down projection concurrently with the combine
-                # communication.
-                maybe_wait_event(fused_moe_evts.before_combine)
+                if self.situ_activation is not None:
+                    quantized_x, swiglu_out_scale = torch.ops._C_ascend.dequant_situ_quant(
+                        x=hidden_states,
+                        weight_scale=self.layer.gate_up_proj.weight_scale_fp32,
+                        activation_scale=pertoken_scale,
+                        bias=None,
+                        quant_scale=None,
+                        quant_offset=None,
+                        group_index=None,
+                        beta=self.situ_activation.beta,
+                        linear_beta=self.situ_activation.linear_beta or 0.0,
+                        activate_left=True,
+                        quant_mode="dynamic",
+                    )
+                else:
+                    quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+                        x=hidden_states,
+                        weight_scale=self.layer.gate_up_proj.weight_scale_fp32,
+                        activation_scale=pertoken_scale,
+                        bias=None,
+                        quant_scale=None,
+                        quant_offset=None,
+                        group_index=None,
+                        activate_left=True,
+                        quant_mode=1,
+                        swiglu_mode=1,
+                        clamp_limit=self.swiglu_limit,
+                        **(
+                            {}
+                            if get_ascend_device_type() == AscendDeviceType.A5
+                            else {"glu_alpha": self.swiglu_alpha, "glu_bias": self.swiglu_beta}
+                        ),
+                    )
+                maybe_wait_event(down_projection_ready)
                 shared_out = torch_npu.npu_quant_matmul(
                     quantized_x,
                     self.layer.down_proj.weight,
@@ -312,17 +369,24 @@ class AscendSharedExperts:
                 hidden_states = self.layer.gate_up_proj((quantized_x, pertoken_scale))[0]
                 # Execute activation concurrently with gmm2.
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
-                    hidden_states,
-                    topk_weight=None,
-                    group_index=None,
-                    dst_type=torch.float8_e4m3fn,
-                    quant_mode=2,
-                    clamp_value=self.swiglu_limit,
-                )
-                # Execute the down projection concurrently with the combine
-                # communication.
-                maybe_wait_event(fused_moe_evts.before_combine)
+                if self.situ_activation is not None:
+                    quantized_x, swiglu_out_scale = torch.ops._C_ascend.situ_mx_quant(
+                        x=hidden_states,
+                        beta=self.situ_activation.beta,
+                        linear_beta=self.situ_activation.linear_beta or 0.0,
+                        activate_left=True,
+                        dst_type=SITU_MX_DST_TYPE_E4M3FN,
+                    )
+                else:
+                    quantized_x, swiglu_out_scale, _ = torch.ops._C_ascend.npu_swiglu_group_quant(
+                        hidden_states,
+                        topk_weight=None,
+                        group_index=None,
+                        dst_type=torch.float8_e4m3fn,
+                        quant_mode=2,
+                        clamp_value=self.swiglu_limit,
+                    )
+                maybe_wait_event(down_projection_ready)
                 shared_out = self.layer.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
                 # Ensure the shared experts wait for hidden_states to be ready.
@@ -331,19 +395,24 @@ class AscendSharedExperts:
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.before_dispatch)
                 part1_out = self.part1(hidden_states)
-                # Execute the down projection concurrently with the combine
-                # communication.
-                maybe_wait_event(fused_moe_evts.before_combine)
+                maybe_wait_event(down_projection_ready)
                 shared_out = self.part2(hidden_states, part1_out)
 
-        # Make sure the default stream waits for the shared experts stream to
-        # finish.
+        if self.multistream_overlap and mode is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY:
+            # Keep the shared-expert output collective on the auxiliary stream,
+            # but start it only after routed dispatch/combine/finalize
+            # communication has completed.
+            with npu_stream_switch(shared_experts_calculation_stream(), enabled=True):
+                maybe_wait_event(fused_moe_evts.after_routed_finalize)
+                shared_out = self._pad_and_reduce_scatter(shared_out)
+
+        # Make sure the default stream waits for the shared experts stream to finish.
         if self.multistream_overlap:
             torch.npu.current_stream().wait_stream(shared_experts_calculation_stream())
 
         if mode is SharedExpertParallelMode.SHARED_EXPERT_DATA_PARALLEL_ONLY:
             assert local_dp_metadata is not None
             shared_out = self._finalize_local_dp_output(shared_out, local_dp_metadata)
-        elif mode is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY:
+        elif mode is SharedExpertParallelMode.SEQUENCE_PARALLEL_ONLY and not self.multistream_overlap:
             shared_out = self._pad_and_reduce_scatter(shared_out)
         return shared_out

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -412,6 +412,27 @@ def get_packed_modules_mapping(model_type: str) -> dict[str, list[str]]:
         Dictionary mapping fused module names to their component module names.
         Returns empty dict if model_type is not found.
     """
+    if model_type in ("kimi_k3", "kimi_linear"):
+        # Start from vLLM's model-owned mapping so changes to its packed KDA,
+        # MLA, convolution, or MLP modules remain the source of truth. Add only
+        # the ModelSlim MoE convention and Ascend's mixed-precision KDA split.
+        from vllm.models.kimi_k3.nvidia.model import KimiLinearModel
+
+        mapping = {
+            packed_name: list(shard_names)
+            for packed_name, shard_names in KimiLinearModel.packed_modules_mapping.items()
+        }
+        qkv_shards = [name for name in mapping["in_proj_qkvgfab"] if name in ("q_proj", "k_proj", "v_proj")]
+        gate_shards = ["g_proj", "f_a_proj", "b_proj"]
+        mapping.update(
+            {
+                "experts": ["experts.0.w1", "experts.0.w2", "experts.0.w3"],
+                "in_proj_qkvgfab": qkv_shards + gate_shards,
+                "in_proj_qkv": qkv_shards,
+                "in_proj_gfab": gate_shards,
+            }
+        )
+        return mapping
     return packed_modules_model_mapping.get(model_type, {})
 
 
@@ -657,6 +678,25 @@ class AscendModelSlimConfig(QuantizationConfig):
         cache_scale_mapper = WeightsMapper(orig_to_new_suffix=suffix_map, orig_to_new_regex=regex_map)
         return cache_scale_mapper | QuantizationConfig.get_cache_scale_mapper()
 
+    def uses_kimi_k3_mixed_kda_projection(self, prefix: str) -> bool:
+        """Return whether Kimi K3's packed KDA input must be split.
+
+        vLLM 0.27 packs q/k/v and the full-rank KDA gates into one linear
+        layer.  ModelSlim QuaRot checkpoints intentionally keep q/k/v W8A8
+        while storing g/f_a/b in floating point, which cannot be represented
+        by one quantization method.  Only accept that known layout here; other
+        mixed packed layouts retain the normal validation error.
+        """
+        suffix = ".in_proj_qkvgfab"
+        attention_prefix = prefix[: -len(suffix)] if prefix.endswith(suffix) else prefix
+        quant_types = {
+            name: self.quant_description.get(f"{attention_prefix}.{name}.weight")
+            for name in ("q_proj", "k_proj", "v_proj", "g_proj", "f_a_proj", "b_proj")
+        }
+        qkv_types = {quant_types[name] for name in ("q_proj", "k_proj", "v_proj")}
+        gate_types = {quant_types[name] for name in ("g_proj", "f_a_proj", "b_proj")}
+        return len(qkv_types) == 1 and None not in qkv_types and qkv_types != {"FLOAT"} and gate_types == {"FLOAT"}
+
     def _has_quant_weight(self, prefix: str, packed_modules_mapping: Mapping[str, list[str]]) -> bool:
         proj_name = prefix.split(".")[-1]
         if proj_name in packed_modules_mapping:
@@ -727,11 +767,19 @@ class AscendModelSlimConfig(QuantizationConfig):
             # Adapt to bailing_hybrid architecture: update layer names to MoE convention
             prefix = prefix.replace("linear_attn", "attention")
             prefix = prefix.replace("self_attn", "attention")
-        if model_type in packed_modules_model_mapping:
-            self.packed_modules_mapping = packed_modules_model_mapping[model_type]
+        if model_type in packed_modules_model_mapping or model_type in ("kimi_k3", "kimi_linear"):
+            self.packed_modules_mapping = get_packed_modules_mapping(model_type)
         prefix = self.quant_prefix_mapper(model_type, prefix)
 
         if isinstance(layer, LinearBase):
+            if model_type in ("kimi_k3", "kimi_linear") and self.uses_kimi_k3_mixed_kda_projection(prefix):
+                # The Ascend K3 adapter replaces this temporary module with a
+                # W8A8 q/k/v projection plus a FLOAT gate projection directly
+                # after upstream construction.
+                from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
+
+                logger.debug("Temporarily select unquantized Kimi K3 mixed KDA projection for %s", prefix)
+                return AscendUnquantizedLinearMethod()
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):
                 # Delayed import to avoid circular import
                 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -772,14 +772,6 @@ class AscendModelSlimConfig(QuantizationConfig):
         prefix = self.quant_prefix_mapper(model_type, prefix)
 
         if isinstance(layer, LinearBase):
-            if model_type in ("kimi_k3", "kimi_linear") and self.uses_kimi_k3_mixed_kda_projection(prefix):
-                # The Ascend K3 adapter replaces this temporary module with a
-                # W8A8 q/k/v projection plus a FLOAT gate projection directly
-                # after upstream construction.
-                from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
-
-                logger.debug("Temporarily select unquantized Kimi K3 mixed KDA projection for %s", prefix)
-                return AscendUnquantizedLinearMethod()
             if self.is_layer_skipped_ascend(prefix, self.packed_modules_mapping):
                 # Delayed import to avoid circular import
                 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
@@ -826,6 +818,11 @@ class AscendModelSlimConfig(QuantizationConfig):
 
     def is_layer_skipped_ascend(self, prefix: str, fused_mapping: Mapping[str, list[str]] = MappingProxyType({})):
         # adapted from vllm.model_executor.layers.quantization.utils.quant_utils.is_layer_skipped
+        if self.model_type in ("kimi_k3", "kimi_linear") and self.uses_kimi_k3_mixed_kda_projection(prefix):
+            # The model adapter replaces this temporary packed projection with
+            # separate quantized q/k/v and floating-point gate projections.
+            return True
+
         proj_name = prefix.split(".")[-1]
         if proj_name in fused_mapping:
             shard_prefixes = [


### PR DESCRIPTION
### What this PR does / why we need it?

This PR provides the MoE execution and ModelSlim quantization support required by Kimi K3:

- Propagates SiTU beta and linear-beta parameters through dense and routed experts.
- Dispatches A2/A3 Dequant-SiTU and A5 MX-SiTU through the existing Ascend fused-MoE path.
- Extends ModelSlim mappings and layer-skip handling for the Kimi K3 mixed W8A8/BF16 KDA projection layout.
- Starts shared-expert SP collectives on the auxiliary stream and orders them away from routed dispatch/combine with NPU events.
- Adds focused fused-MoE, shared-expert, runtime-argument, and ModelSlim tests.

### Dependencies

- #14426 provides the SiTU AscendC operators.
- #14600 consumes these MoE and quantization contracts in the Kimi K3 model integration.

### How was this patch tested?

- Python bytecode compilation for changed implementation and test files
- Focused fused-MoE, shared-expert, runtime-argument, and ModelSlim coverage
- A3 BF16 SiTU output comparison against the FP32 reference
- Integrated TP16/EP serving coverage with text, multimodal, and ACLGraph replay requests
- MX-SiTU A5 cross-compilation and packaging

### Does this PR introduce any user-facing change?

No model is registered by this PR alone. It provides reusable Ascend MoE and ModelSlim quantization support used by the Kimi K3 integration.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
