### PR TITLE
[Feature][Model] Register Kimi K3 model adapters

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -237,6 +237,10 @@ a3:
   multi_card:
     test_config:
       # pytest-driven tests
+      - name: kimi-k3-execution-parity
+        os: linux-aarch64-nightly-a3-16
+        tests: tests/e2e/nightly/single_node/models/test_kimi_k3_execution_parity.py
+        testcase_timeout: 180
       - name: qwen3-30b-acc
         os: linux-aarch64-nightly-a3-4
         tests: tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py

--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -307,6 +307,7 @@
     - tests/ut/models/test_deepseek_v4_compressor.py
     - tests/ut/models/test_deepseek_v4_indexer.py
     - tests/ut/models/test_deepseek_v4_moe.py
+    - tests/ut/models/test_kimi_k3_adapter.py
     - tests/e2e/pull_request/four_card/test_deepseek_v4.py
 
 - name: models_minimax_m3

--- a/tests/e2e/nightly/single_node/models/fixtures/kimi_k3_5layers_16experts/config.json
+++ b/tests/e2e/nightly/single_node/models/fixtures/kimi_k3_5layers_16experts/config.json
@@ -1,0 +1,63 @@
+{
+  "activation_situ_beta": 4,
+  "activation_situ_linear_beta": 25,
+  "architectures": [
+    "KimiLinearForCausalLM"
+  ],
+  "attn_res_block_size": 12,
+  "bos_token_id": 163584,
+  "dtype": "bfloat16",
+  "eos_token_id": 163586,
+  "first_k_dense_replace": 1,
+  "hidden_act": "situ",
+  "hidden_size": 7168,
+  "intermediate_size": 33792,
+  "kv_lora_rank": 512,
+  "latent_moe_use_norm": true,
+  "linear_attn_config": {
+    "full_attn_layers": [
+      4
+    ],
+    "gate_lower_bound": -5,
+    "head_dim": 128,
+    "kda_layers": [
+      1,
+      2,
+      3,
+      5
+    ],
+    "num_heads": 96,
+    "short_conv_kernel_size": 4,
+    "use_full_rank_gate": true
+  },
+  "max_position_embeddings": 1048576,
+  "mla_use_nope": true,
+  "mla_use_output_gate": true,
+  "model_type": "kimi_linear",
+  "moe_intermediate_size": 3072,
+  "moe_layer_freq": 1,
+  "moe_renormalize": true,
+  "moe_router_activation_func": "sigmoid",
+  "num_attention_heads": 96,
+  "num_expert_group": 1,
+  "num_experts": 16,
+  "num_experts_per_token": 16,
+  "num_hidden_layers": 5,
+  "num_key_value_heads": 96,
+  "num_nextn_predict_layers": 0,
+  "num_shared_experts": 2,
+  "pad_token_id": 163839,
+  "q_lora_rank": 1536,
+  "qk_nope_head_dim": 128,
+  "qk_rope_head_dim": 64,
+  "rms_norm_eps": 1e-05,
+  "routed_expert_hidden_size": 3584,
+  "routed_scaling_factor": 1,
+  "tie_word_embeddings": false,
+  "topk_group": 1,
+  "topk_method": "noaux_tc",
+  "use_cache": true,
+  "use_grouped_topk": true,
+  "v_head_dim": 128,
+  "vocab_size": 163840
+}

--- a/tests/e2e/nightly/single_node/models/test_kimi_k3_execution_parity.py
+++ b/tests/e2e/nightly/single_node/models/test_kimi_k3_execution_parity.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+"""Storage-light Kimi K3 execution parity guard.
+
+The committed fixture keeps Kimi K3's production dimensions and its mixed
+KDA/MLA layout, but limits the model to five layers and sixteen experts. Dummy
+weights deliberately make this an execution-parity test, not a semantic
+accuracy test. Full-checkpoint GPQA remains a separate release gate.
+"""
+
+from pathlib import Path
+
+import pytest
+import torch
+from vllm import SamplingParams
+from vllm.inputs import TokensPrompt
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+MODEL_CONFIG = Path(__file__).parent / "fixtures" / "kimi_k3_5layers_16experts"
+SCHEDULER_BLOCK_SIZE = 16
+PROMPT_TOKEN_IDS = [163584, *range(100, 100 + SCHEDULER_BLOCK_SIZE)]
+MAX_TOKENS = 4
+
+
+def _assert_complete_output(request_output):
+    assert request_output is not None
+    assert request_output.finished
+    assert request_output.outputs is not None
+    assert len(request_output.outputs) == 1
+
+    completion = request_output.outputs[0]
+    assert completion is not None
+    assert completion.token_ids is not None
+    assert len(completion.token_ids) == MAX_TOKENS
+    assert completion.logprobs is not None
+    assert len(completion.logprobs) == MAX_TOKENS
+
+    chosen_logprobs = []
+    for token_id, step_logprobs in zip(completion.token_ids, completion.logprobs):
+        assert step_logprobs is not None
+        assert token_id in step_logprobs
+        logprob = step_logprobs[token_id].logprob
+        assert logprob is not None
+        assert torch.isfinite(torch.tensor(logprob))
+        chosen_logprobs.append(logprob)
+
+    return list(completion.token_ids), torch.tensor(chosen_logprobs, dtype=torch.float32)
+
+
+@pytest.mark.e2e_model("sgl-npu/Kimi-K3-W4A8")
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="aclgraph,prefix_caching,logprobs",
+    parallel="TP,EP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="full_decode_only",
+)
+@wait_until_npu_memory_free()
+def test_kimi_k3_dummy_prefix_cache_one_token_prefill_parity():
+    """Compare cold prefill with the cached block-size-plus-one path."""
+    sampling_params = SamplingParams(
+        temperature=0,
+        max_tokens=MAX_TOKENS,
+        logprobs=1,
+        ignore_eos=True,
+        seed=0,
+    )
+    prompt = TokensPrompt(prompt_token_ids=PROMPT_TOKEN_IDS)
+
+    with VllmRunner(
+        str(MODEL_CONFIG),
+        skip_tokenizer_init=True,
+        load_format="dummy",
+        dtype="bfloat16",
+        seed=0,
+        block_size=SCHEDULER_BLOCK_SIZE,
+        max_model_len=64,
+        max_num_seqs=1,
+        max_num_batched_tokens=64,
+        tensor_parallel_size=16,
+        enable_expert_parallel=True,
+        enable_prefix_caching=True,
+        gpu_memory_utilization=0.75,
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [1],
+        },
+    ) as vllm_model:
+        cold = vllm_model.model.generate([prompt], sampling_params, use_tqdm=False)[0]
+        hit = vllm_model.model.generate([prompt], sampling_params, use_tqdm=False)[0]
+
+        assert cold.num_cached_tokens in (None, 0)
+        assert hit.num_cached_tokens == SCHEDULER_BLOCK_SIZE
+        assert len(PROMPT_TOKEN_IDS) - hit.num_cached_tokens == 1
+
+        cold_tokens, cold_logprobs = _assert_complete_output(cold)
+        hit_tokens, hit_logprobs = _assert_complete_output(hit)
+        assert hit_tokens == cold_tokens
+        torch.testing.assert_close(hit_logprobs, cold_logprobs, rtol=5e-3, atol=5e-3)
+
+        assert vllm_model.model.reset_prefix_cache()
+        reset = vllm_model.model.generate([prompt], sampling_params, use_tqdm=False)[0]
+        assert reset.num_cached_tokens in (None, 0)
+        reset_tokens, reset_logprobs = _assert_complete_output(reset)
+        assert reset_tokens == cold_tokens
+        torch.testing.assert_close(reset_logprobs, cold_logprobs, rtol=5e-3, atol=5e-3)

--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -19,11 +19,16 @@
 
 from __future__ import annotations
 
+import json
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
+from safetensors.torch import save_file
+from torch import nn
 
 import vllm_ascend.models.qwen3_dspark as qwen3_dspark
+from vllm_ascend.models.llama_eagle3 import load_quarot_target_layer
 
 
 class TestQwen3DSparkWeightLoading:
@@ -45,7 +50,11 @@ class TestQwen3DSparkWeightLoading:
         rotation_matrix = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
         fc_weight = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
         non_fc_weight = torch.tensor([[5.0, 6.0]])
-        weights_to_load = [("model.fc.weight", fc_weight), ("model.embed_tokens.weight", non_fc_weight)]
+        weights_to_load = [
+            ("model.fc.weight", fc_weight),
+            ("model.embed_tokens.weight", non_fc_weight),
+            ("lm_head.weight", non_fc_weight),
+        ]
         expected_fc_weight = torch.matmul(fc_weight, rotation_matrix)
 
         # Capture the final delegation without invoking the real model loader.
@@ -59,8 +68,90 @@ class TestQwen3DSparkWeightLoading:
 
         mock_get_rotation_matrix.assert_called_once_with(rotation_path)
         mock_parent_load_weights.assert_called_once()
-        assert model._shared_layer_rotation is rotation_matrix
 
         processed_weights = mock_parent_load_weights.call_args.args[0]
         torch.testing.assert_close(processed_weights[0][1], expected_fc_weight)
         torch.testing.assert_close(processed_weights[1][1], non_fc_weight)
+        torch.testing.assert_close(processed_weights[2][1], non_fc_weight)
+
+    def test_quarot_loads_missing_boundaries_in_modeling(self) -> None:
+        model_cls = qwen3_dspark.AscendQwen3DSparkForCausalLM
+        model = model_cls.__new__(model_cls)
+        nn.Module.__init__(model)
+        model.rotation_path = "quarot.safetensors"
+        model.target_model_path = "/target"
+        model.enable_confidence_head = False
+        model.model = SimpleNamespace(embed_tokens=object())
+        model.lm_head = object()
+        rotation = torch.eye(2)
+
+        with (
+            patch.object(
+                qwen3_dspark,
+                "get_rotation_matrix",
+                return_value=rotation,
+            ),
+            patch.object(
+                qwen3_dspark,
+                "load_quarot_target_layer",
+            ) as load_target_layer,
+            patch.object(
+                qwen3_dspark.Qwen3DSparkForCausalLM,
+                "load_weights",
+            ),
+        ):
+            model.load_weights([("model.fc.weight", torch.eye(2))])
+
+        assert load_target_layer.call_count == 2
+        assert load_target_layer.call_args_list[0].args[:2] == (
+            model.model.embed_tokens,
+            model.target_model_path,
+        )
+        assert load_target_layer.call_args_list[1].args[:2] == (
+            model.lm_head,
+            model.target_model_path,
+        )
+        assert model.has_own_embed_tokens
+        assert model.has_own_lm_head
+
+
+def test_load_quarot_target_layer_reads_local_vocab_shard(tmp_path) -> None:
+    weight_name = "language_model.model.embed_tokens.weight"
+    shard_name = "model-00001-of-00001.safetensors"
+    target_weight = torch.tensor(
+        [
+            [1.0, 2.0],
+            [3.0, 4.0],
+            [5.0, 6.0],
+            [7.0, 8.0],
+        ]
+    )
+    save_file({weight_name: target_weight}, tmp_path / shard_name)
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {weight_name: shard_name}}),
+        encoding="utf-8",
+    )
+
+    layer = nn.Linear(2, 3, bias=False)
+    layer.weight.data.fill_(99)
+    layer.shard_indices = SimpleNamespace(
+        org_vocab_start_index=1,
+        org_vocab_end_index=3,
+    )
+    rotation = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+
+    load_quarot_target_layer(
+        layer,
+        tmp_path,
+        (weight_name,),
+        rotation,
+        "test embedding",
+    )
+
+    expected = torch.cat(
+        (
+            target_weight[1:3] @ rotation.T,
+            torch.zeros(1, 2),
+        )
+    )
+    torch.testing.assert_close(layer.weight, expected)

--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -59,6 +59,7 @@ class TestQwen3DSparkWeightLoading:
 
         mock_get_rotation_matrix.assert_called_once_with(rotation_path)
         mock_parent_load_weights.assert_called_once()
+        assert model._shared_layer_rotation is rotation_matrix
 
         processed_weights = mock_parent_load_weights.call_args.args[0]
         torch.testing.assert_close(processed_weights[0][1], expected_fc_weight)

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -1,0 +1,799 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import MethodType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig, set_current_vllm_config
+
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+from vllm_ascend.models import kimi_k3
+from vllm_ascend.models.kimi_k3 import (
+    AscendKimiK3ForConditionalGeneration,
+    AscendKimiK3MultiModalProjector,
+    AscendKimiLinearForCausalLM,
+    AscendKimiLinearModel,
+    AscendKimiMLAAttention,
+    AscendKimiMoE,
+)
+from vllm_ascend.models.kimi_k3_dspark import (
+    AscendK3DSparkDecoderLayer,
+    AscendK3DSparkForCausalLM,
+)
+
+
+def test_ascend_attn_res_matches_canonical_k3_math():
+    prefix_sum = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    block_residual = torch.tensor(
+        [
+            [[0.5, 1.5], [2.5, 3.5], [1000.0, 1000.0]],
+            [[1.0, 0.0], [0.0, 1.0], [1000.0, 1000.0]],
+        ]
+    )
+    norm = SimpleNamespace(weight=torch.tensor([1.0, 1.5]), variance_epsilon=1e-5)
+    proj = SimpleNamespace(weight=torch.tensor([[0.25, -0.5]]))
+
+    output = kimi_k3._apply_ascend_attn_res(
+        prefix_sum,
+        block_residual,
+        proj,
+        norm,
+        num_valid_blocks=2,
+    )
+
+    values = torch.cat(
+        (block_residual[:, :2], prefix_sum.unsqueeze(1)),
+        dim=1,
+    ).float()
+    inverse_rms = torch.rsqrt(values.square().mean(-1, keepdim=True) + norm.variance_epsilon)
+    normalized_without_gamma = values * inverse_rms
+    score_weight = norm.weight.float() * proj.weight.squeeze(0).float()
+    probabilities = (normalized_without_gamma * score_weight).sum(-1).softmax(-1).unsqueeze(1)
+    expected = torch.matmul(probabilities, values).squeeze(1).to(prefix_sum.dtype)
+    torch.testing.assert_close(output, expected)
+
+
+def _make_moe_config(**overrides):
+    values = {
+        "hidden_size": 16,
+        "moe_intermediate_size": 32,
+        "num_experts": 8,
+        "num_experts_per_token": 2,
+        "moe_renormalize": True,
+        "routed_expert_hidden_size": None,
+        "latent_moe_use_norm": False,
+        "routed_scaling_factor": 1.0,
+        "num_shared_experts": None,
+        "hidden_act": "silu",
+        "activation_situ_beta": None,
+        "activation_situ_linear_beta": None,
+        "use_grouped_topk": False,
+        "num_expert_group": None,
+        "topk_group": None,
+        "moe_router_activation_func": "softmax",
+        "rms_norm_eps": 1e-6,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_ascend_kimi_moe_uses_standard_runner_dispatch(monkeypatch):
+    class FakeGate(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+            self.kwargs = kwargs
+
+    factory = MagicMock(return_value=nn.Identity())
+    monkeypatch.setattr(kimi_k3, "GateLinear", FakeGate)
+    monkeypatch.setattr(kimi_k3, "FusedMoEFactory", factory)
+
+    AscendKimiMoE(
+        config=_make_moe_config(),
+        prefix="model.layers.1.block_sparse_moe",
+        use_sequence_parallel=True,
+    )
+
+    assert factory.call_args.kwargs["intermediate_size"] == 32
+    assert factory.call_args.kwargs["is_sequence_parallel"] is True
+    assert "runner_cls" not in factory.call_args.kwargs
+
+
+def test_dspark_decoder_uses_upstream_mlp_activation_contract(
+    monkeypatch,
+):
+    config = SimpleNamespace(
+        hidden_size=8,
+        num_attention_heads=2,
+        qk_nope_head_dim=2,
+        qk_rope_head_dim=2,
+        v_head_dim=2,
+        q_lora_rank=4,
+        kv_lora_rank=4,
+        intermediate_size=16,
+        hidden_act="silu",
+        rms_norm_eps=1e-6,
+    )
+    vllm_config = SimpleNamespace(cache_config=None)
+    mlp_factory = MagicMock(return_value=nn.Identity())
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.get_draft_quant_config",
+        lambda _: None,
+    )
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.AscendKimiMLAAttention",
+        lambda **_: nn.Identity(),
+    )
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.KimiMLP",
+        mlp_factory,
+    )
+
+    with set_current_vllm_config(VllmConfig()):
+        AscendK3DSparkDecoderLayer(
+            vllm_config=vllm_config,
+            config=config,
+            layer_idx=0,
+            start_layer_id=4,
+            prefix="model",
+        )
+
+    assert mlp_factory.call_args.kwargs["hidden_act"] == "silu"
+    assert "activation_situ_beta" not in mlp_factory.call_args.kwargs
+    assert "activation_situ_linear_beta" not in mlp_factory.call_args.kwargs
+
+
+def test_ascend_kimi_moe_quantizes_modelslim_latent_projections(monkeypatch):
+    class FakeGate(nn.Module):
+        def __init__(self, **kwargs):
+            super().__init__()
+
+    class FakeLinear(nn.Module):
+        def __init__(self, input_size, output_size, **kwargs):
+            super().__init__()
+            self.input_size = input_size
+            self.output_size = output_size
+            self.kwargs = kwargs
+
+    config = _make_moe_config(routed_expert_hidden_size=8)
+    quant_config = MagicMock()
+    quant_config.get_name.return_value = "ascend"
+    factory = MagicMock(return_value=nn.Identity())
+    monkeypatch.setattr(kimi_k3, "GateLinear", FakeGate)
+    monkeypatch.setattr(kimi_k3, "ReplicatedLinear", FakeLinear)
+    monkeypatch.setattr(kimi_k3, "FusedMoEFactory", factory)
+
+    moe = AscendKimiMoE(
+        config=config,
+        quant_config=quant_config,
+        prefix="model.layers.1.block_sparse_moe",
+    )
+
+    assert moe.routed_expert_down_proj.input_size == 16
+    assert moe.routed_expert_down_proj.output_size == 8
+    assert moe.routed_expert_down_proj.kwargs == {
+        "bias": False,
+        "quant_config": quant_config,
+        "prefix": "model.layers.1.block_sparse_moe.routed_expert_down_proj",
+    }
+    assert moe.routed_expert_up_proj.input_size == 8
+    assert moe.routed_expert_up_proj.output_size == 16
+    assert moe.routed_expert_up_proj.kwargs == {
+        "bias": False,
+        "quant_config": quant_config,
+        "prefix": "model.layers.1.block_sparse_moe.routed_expert_up_proj",
+    }
+    assert factory.call_args.kwargs["routed_input_transform"] is moe.routed_expert_down_proj
+    assert factory.call_args.kwargs["routed_output_transform"] is moe.routed_output_transform
+    assert "runner_cls" not in factory.call_args.kwargs
+
+
+def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):
+    model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
+    nn.Module.__init__(model)
+    layer = nn.Module()
+    layer.self_attn = nn.Module()
+    layer.self_attn.in_proj_gfab = nn.Module()
+    packed_weight = nn.Parameter(torch.empty(6, 4))
+    layer.self_attn.in_proj_gfab.register_parameter("weight", packed_weight)
+    layer.router = nn.Linear(4, 1, bias=False)
+    model.layers = nn.ModuleList([layer])
+
+    remaining = []
+
+    def fake_upstream_load_weights(_self, weights):
+        remaining.extend(weights)
+        return {name for name, *_ in remaining}
+
+    monkeypatch.setattr(
+        kimi_k3.UpstreamKimiLinearModel,
+        "load_weights",
+        fake_upstream_load_weights,
+    )
+    source_weights = [
+        ("layers.0.router.weight", torch.full((1, 4), 0.5)),
+        ("layers.0.self_attn.g_proj.weight", torch.full((1,), 1.0)),
+        ("layers.0.self_attn.f_a_proj.weight", torch.full((1,), 2.0)),
+        ("layers.0.self_attn.b_proj.weight", torch.full((1,), 3.0)),
+        ("layers.0.self_attn.o_proj.weight", torch.full((1,), 4.0)),
+    ]
+
+    loaded = model.load_weights(iter(source_weights))
+
+    assert remaining[0] == source_weights[0]
+    assert remaining[-1] == source_weights[-1]
+    assert [name for name, _, _ in remaining[1:4]] == [
+        "layers.0.self_attn.in_proj_gfab.weight",
+    ] * 3
+    assert [loaded_weight.item() for _, loaded_weight, _ in remaining[1:4]] == [1.0, 2.0, 3.0]
+    assert [kwargs["loaded_shard_id"] for _, _, kwargs in remaining[1:4]] == [0, 1, 2]
+    assert loaded == {
+        "layers.0.self_attn.in_proj_gfab.weight",
+        "layers.0.router.weight",
+        "layers.0.self_attn.o_proj.weight",
+    }
+
+
+def test_kimi_text_model_layer_factory_accepts_prefix_keyword(monkeypatch):
+    config = SimpleNamespace(
+        vocab_size=64,
+        hidden_size=16,
+        num_hidden_layers=1,
+        rms_norm_eps=1e-5,
+        attn_res_block_size=None,
+        num_attention_heads=1,
+    )
+    vllm_config = MagicMock()
+    vllm_config.model_config.hf_text_config = config
+    vllm_config.parallel_config = SimpleNamespace(
+        pipeline_parallel_size=1,
+        enable_expert_parallel=True,
+        tensor_parallel_size=2,
+    )
+    pp_group = SimpleNamespace(is_first_rank=False, is_last_rank=False)
+    decoder_layer = nn.Identity()
+    decoder_layer_factory = MagicMock(return_value=decoder_layer)
+
+    def fake_make_layers(num_hidden_layers, layer_fn, *, prefix):
+        assert num_hidden_layers == 1
+        assert layer_fn(prefix=f"{prefix}.0") is decoder_layer
+        return 0, 1, nn.ModuleList([decoder_layer])
+
+    monkeypatch.setattr(kimi_k3, "get_pp_group", lambda: pp_group)
+    monkeypatch.setattr(kimi_k3, "get_tensor_model_parallel_world_size", lambda: 1)
+    monkeypatch.setattr(kimi_k3, "AscendKimiDecoderLayer", decoder_layer_factory)
+    monkeypatch.setattr(kimi_k3, "make_layers", fake_make_layers)
+
+    model = AscendKimiLinearModel(vllm_config=vllm_config, prefix="model")
+
+    assert model.start_layer == 0
+    assert model.end_layer == 1
+    decoder_layer_factory.assert_called_once_with(
+        config,
+        vllm_config,
+        "model.layers.0",
+        use_sequence_parallel=True,
+    )
+
+
+def test_kimi_mla_cache_spec_preserves_hybrid_page_padding():
+    real_page_size = 128 * 576 * torch.bfloat16.itemsize
+    padded_page_size = real_page_size + 128
+    spec = AscendMLAAttentionSpec(
+        block_size=128,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+        page_size_padded=padded_page_size,
+    )
+
+    assert spec.real_page_size_bytes == real_page_size
+    assert spec.page_size_bytes == padded_page_size
+    assert AscendMLAAttentionSpec.merge([spec, spec]).page_size_bytes == padded_page_size
+
+
+def test_ascend_mla_exposes_layer_and_cache_contract():
+    attention = AscendKimiMLAAttention.__new__(AscendKimiMLAAttention)
+    layer = MagicMock()
+    layer.layer_name = "model.layers.1.self_attn.attn"
+    layer.impl = object()
+    layer.kv_cache = (object(), object())
+    layer.kv_cache_dtype = "auto"
+    layer._k_scale = 1.0
+    attention.mla_attn = MagicMock()
+    attention.mla_attn.mla_attn = layer
+
+    assert attention.layer_name == layer.layer_name
+    assert attention.impl is layer.impl
+    assert attention.kv_cache is layer.kv_cache
+    assert attention.kv_cache_dtype == layer.kv_cache_dtype
+    assert attention._k_scale == layer._k_scale
+
+
+def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch):
+    class IdentityAttention(nn.Module):
+        def forward(self, *, hidden_states, positions):
+            del positions
+            return hidden_states
+
+    layer = kimi_k3.AscendKimiDecoderLayer.__new__(kimi_k3.AscendKimiDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.use_sequence_parallel = True
+    layer.prev_valid_blocks = 0
+    layer.is_block_write_layer = False
+    layer.input_layernorm = nn.Identity()
+    layer.post_attention_layernorm = nn.Identity()
+    layer.mlp = nn.Identity()
+    layer.self_attention_res_proj = object()
+    layer.self_attention_res_norm = object()
+    layer.mlp_res_proj = object()
+    layer.mlp_res_norm = object()
+    layer.self_attn = IdentityAttention()
+
+    collective_shapes = []
+
+    def fake_all_gather(hidden_states):
+        collective_shapes.append(("gather", hidden_states.shape))
+        return torch.cat((hidden_states, hidden_states), dim=0)
+
+    def fake_reduce_scatter(hidden_states):
+        collective_shapes.append(("reduce_scatter", hidden_states.shape))
+        return hidden_states.chunk(2, dim=0)[0]
+
+    monkeypatch.setattr(kimi_k3, "sp_all_gather", fake_all_gather)
+    monkeypatch.setattr(kimi_k3, "sp_reduce_scatter", fake_reduce_scatter)
+    monkeypatch.setattr(
+        kimi_k3,
+        "_apply_ascend_attn_res",
+        lambda prefix_sum, *_args, **_kwargs: prefix_sum,
+    )
+
+    hidden_states = torch.arange(4, dtype=torch.float32).view(2, 2)
+    block_residual = torch.zeros(2, 1, 2)
+    output, returned_residual = layer.forward_attn_residual(
+        positions=torch.arange(3),
+        hidden_states=hidden_states,
+        block_residual=block_residual,
+    )
+
+    assert collective_shapes == [
+        ("gather", torch.Size([2, 2])),
+        ("reduce_scatter", torch.Size([3, 2])),
+    ]
+    assert output.shape == torch.Size([2, 2])
+    assert returned_residual.shape == torch.Size([2, 1, 2])
+
+
+def test_kimi_model_allocates_attention_residual_after_sp_shard(monkeypatch):
+    class RecordingLayer(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.residual_shape = None
+
+        def forward(self, *, positions, hidden_states, residual):
+            self.residual_shape = residual.shape
+            return hidden_states, residual
+
+    model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(attn_res_block_size=12)
+    model.start_layer = 0
+    model.end_layer = 1
+    layer = RecordingLayer()
+    model.layers = nn.ModuleList([layer])
+    model.use_sequence_parallel = True
+    model.aux_hidden_state_layers = set()
+    model.output_attn_res_proj = object()
+    model.output_attn_res_norm = object()
+    model._maybe_add_hidden_state = MethodType(
+        lambda self, states, *_args: states,
+        model,
+    )
+
+    monkeypatch.setattr(
+        kimi_k3,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+    monkeypatch.setattr(
+        kimi_k3,
+        "sp_shard",
+        lambda hidden_states: torch.nn.functional.pad(hidden_states, (0, 0, 0, 1))[:2],
+    )
+    monkeypatch.setattr(
+        kimi_k3,
+        "sp_all_gather",
+        lambda hidden_states: torch.cat((hidden_states, hidden_states), dim=0),
+    )
+    monkeypatch.setattr(
+        kimi_k3,
+        "_apply_ascend_attn_res",
+        lambda hidden_states, *_args, **_kwargs: hidden_states,
+    )
+
+    output = model(
+        input_ids=None,
+        positions=torch.arange(3),
+        intermediate_tensors=None,
+        inputs_embeds=torch.arange(6, dtype=torch.float32).view(3, 2),
+    )
+
+    assert layer.residual_shape == torch.Size([2, 1, 2])
+    assert output.shape == torch.Size([3, 2])
+
+
+def test_kimi_model_selects_materialized_or_raw_dspark_aux_stream(monkeypatch):
+    class Marker(nn.Module):
+        def __init__(self, value: int) -> None:
+            super().__init__()
+            self.value = value
+
+    class RecordingLayer(nn.Module):
+        def __init__(self, layer_idx: int) -> None:
+            super().__init__()
+            self.layer_idx = layer_idx
+            self.prev_valid_blocks = layer_idx
+            self.self_attention_res_proj = Marker(layer_idx)
+            self.self_attention_res_norm = nn.Identity()
+
+        def forward(self, *, positions, hidden_states, residual):
+            del positions
+            materialized = kimi_k3._apply_ascend_attn_res(
+                hidden_states,
+                residual,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+                self.prev_valid_blocks,
+            )
+            return materialized + 10, residual
+
+    residual_calls: list[int] = []
+
+    def fake_attn_res(prefix_sum, _residual, projection, _norm, num_valid_blocks):
+        residual_calls.append(projection.value)
+        return prefix_sum + 100 * num_valid_blocks
+
+    monkeypatch.setattr(kimi_k3, "_apply_ascend_attn_res", fake_attn_res)
+    monkeypatch.setattr(
+        kimi_k3,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(attn_res_block_size=1)
+    model.start_layer = 0
+    model.end_layer = 2
+    model.layers = nn.ModuleList([RecordingLayer(0), RecordingLayer(1)])
+    model.use_sequence_parallel = False
+    model.output_attn_res_proj = Marker(2)
+    model.output_attn_res_norm = nn.Identity()
+    model._set_aux_hidden_state_layers((1,))
+
+    model.dspark_aux_capture_materialized = True
+    _, materialized_aux = model(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=torch.tensor([[1.0]]),
+    )
+    torch.testing.assert_close(materialized_aux[0], torch.tensor([[111.0]]))
+
+    residual_calls.clear()
+    model.dspark_aux_capture_materialized = False
+    _, raw_aux = model(
+        input_ids=None,
+        positions=torch.tensor([0]),
+        intermediate_tensors=None,
+        inputs_embeds=torch.tensor([[1.0]]),
+    )
+    torch.testing.assert_close(raw_aux[0], torch.tensor([[11.0]]))
+
+
+def test_kimi_dspark_aux_capture_mode_is_forwarded():
+    causal_model = AscendKimiLinearForCausalLM.__new__(AscendKimiLinearForCausalLM)
+    nn.Module.__init__(causal_model)
+    causal_model.model = SimpleNamespace(dspark_aux_capture_materialized=False)
+
+    causal_model.set_dspark_aux_capture_materialized(True)
+
+    assert causal_model.model.dspark_aux_capture_materialized is True
+
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(AscendKimiK3ForConditionalGeneration)
+    nn.Module.__init__(wrapper)
+    wrapper.language_model = MagicMock()
+
+    wrapper.set_dspark_aux_capture_materialized(True)
+
+    wrapper.language_model.set_dspark_aux_capture_materialized.assert_called_once_with(True)
+
+
+def test_dspark_configures_upstream_mla_without_rebuilding(monkeypatch):
+    impl = SimpleNamespace(
+        scale=0.0,
+        rotary_emb=None,
+        use_mla_rope=False,
+    )
+    layer = SimpleNamespace(
+        scale=0.0,
+        non_causal_multi_token_decode=False,
+        impl=impl,
+    )
+    upstream_wrapper = SimpleNamespace(mla_attn=layer)
+
+    def fake_upstream_init(self, **_kwargs):
+        nn.Module.__init__(self)
+        self.scaling = 0.125
+        self.mla_attn = upstream_wrapper
+
+    rotary_emb = object()
+    monkeypatch.setattr(
+        kimi_k3.UpstreamKimiMLAAttention,
+        "__init__",
+        fake_upstream_init,
+    )
+    monkeypatch.setattr(kimi_k3, "get_rope", lambda *_args, **_kwargs: rotary_emb)
+
+    attention = AscendKimiMLAAttention(
+        config=SimpleNamespace(
+            rope_parameters={"rope_type": "default"},
+            max_position_embeddings=4096,
+        ),
+        hidden_size=16,
+        num_heads=2,
+        qk_nope_head_dim=4,
+        qk_rope_head_dim=4,
+        v_head_dim=4,
+        q_lora_rank=8,
+        kv_lora_rank=8,
+        use_output_gate=False,
+        use_rope=True,
+        prefix="model.layers.1.self_attn",
+        non_causal_multi_token_decode=True,
+    )
+
+    assert attention.mla_attn is upstream_wrapper
+    assert layer.scale == attention.scaling
+    assert layer.non_causal_multi_token_decode is True
+    assert impl.scale == attention.scaling
+    assert impl.rotary_emb is rotary_emb
+    assert impl.use_mla_rope is True
+
+
+def test_projector_applies_optional_modelslim_rotation():
+    class ScaleLinear(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states * 2, None
+
+    projector = AscendKimiK3MultiModalProjector.__new__(AscendKimiK3MultiModalProjector)
+    nn.Module.__init__(projector)
+    image_features = torch.tensor([[1.0, 2.0]])
+
+    with patch.object(
+        kimi_k3.KimiK25MultiModalProjector,
+        "forward",
+        lambda self, hidden_states: hidden_states,
+    ):
+        projector.rot_proj = ScaleLinear()
+        torch.testing.assert_close(
+            projector(image_features),
+            image_features * 2,
+        )
+        projector.rot_proj = None
+        torch.testing.assert_close(projector(image_features), image_features)
+
+
+def test_projector_creates_rotation_only_when_enabled(monkeypatch):
+    def fake_upstream_init(self, *_args, **_kwargs):
+        nn.Module.__init__(self)
+
+    monkeypatch.setattr(
+        kimi_k3.KimiK25MultiModalProjector,
+        "__init__",
+        fake_upstream_init,
+    )
+    rotation = nn.Linear(1, 1, bias=False)
+    rotation_factory = MagicMock(return_value=rotation)
+    monkeypatch.setattr(kimi_k3, "ReplicatedLinear", rotation_factory)
+    config = SimpleNamespace(text_hidden_size=16)
+
+    plain_projector = AscendKimiK3MultiModalProjector(config, prefix="mm_projector")
+
+    assert plain_projector.rot_proj is None
+    rotation_factory.assert_not_called()
+
+    rotated_projector = AscendKimiK3MultiModalProjector(
+        config,
+        prefix="mm_projector",
+        enable_rotation=True,
+    )
+
+    assert rotated_projector.rot_proj is rotation
+    rotation_factory.assert_called_once_with(
+        16,
+        16,
+        bias=False,
+        quant_config=None,
+        prefix="mm_projector.rot_proj",
+    )
+
+
+class _DraftTokenEmbedder(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.embedding = nn.Embedding.from_pretrained(
+            torch.tensor(
+                [
+                    [0.0, 0.0],
+                    [1.0, 2.0],
+                    [3.0, 4.0],
+                ]
+            )
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embedding(input_ids)
+
+
+def _make_k3_dspark_for_embedding_test() -> AscendK3DSparkForCausalLM:
+    model = AscendK3DSparkForCausalLM.__new__(AscendK3DSparkForCausalLM)
+    nn.Module.__init__(model)
+    model.model = _DraftTokenEmbedder()
+    return model
+
+
+def test_k3_dspark_load_weights_keeps_per_layer_context_kv(monkeypatch):
+    model = AscendK3DSparkForCausalLM.__new__(AscendK3DSparkForCausalLM)
+    nn.Module.__init__(model)
+    model.rotation_path = None
+    source_weights = [
+        (
+            "layers.0.self_attn.kv_a_proj_with_mqa.weight",
+            torch.ones(1, 1),
+        )
+    ]
+    seen_names: list[str] = []
+
+    class CapturingLoader:
+        def __init__(self, loaded_model):
+            assert loaded_model is model
+
+        def load_weights(self, weights, *, mapper):
+            assert mapper is model.hf_to_vllm_mapper
+            seen_names.extend(name for name, _ in weights)
+            return {"model.layers.0.self_attn.fused_qkv_a_proj.weight"}
+
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.AutoWeightsLoader",
+        CapturingLoader,
+    )
+
+    loaded = model.load_weights(iter(source_weights))
+
+    assert seen_names == [source_weights[0][0]]
+    assert loaded == {"model.layers.0.self_attn.fused_qkv_a_proj.weight"}
+
+
+def test_k3_dspark_reuses_modelslim_rotation_loader(monkeypatch):
+    model = AscendK3DSparkForCausalLM.__new__(AscendK3DSparkForCausalLM)
+    nn.Module.__init__(model)
+    model.rotation_path = "rotation.safetensors"
+    source_weights = [
+        ("context_proj.weight", torch.ones(2, 4)),
+        ("context_norm.weight", torch.ones(2)),
+    ]
+    rotated_weight = torch.full((2, 4), 2.0)
+    seen_weights: list[tuple[str, torch.Tensor]] = []
+
+    class CapturingLoader:
+        def __init__(self, loaded_model):
+            assert loaded_model is model
+
+        def load_weights(self, weights, *, mapper):
+            assert mapper is model.hf_to_vllm_mapper
+            seen_weights.extend(weights)
+            return {name for name, _ in seen_weights}
+
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.AutoWeightsLoader",
+        CapturingLoader,
+    )
+    rotation = torch.eye(4)
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.get_rotation_matrix",
+        lambda path: rotation if path == model.rotation_path else None,
+    )
+    process_weight = MagicMock(return_value=rotated_weight)
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.process_weight",
+        process_weight,
+    )
+
+    model.load_weights(iter(source_weights))
+
+    process_weight.assert_called_once()
+    torch.testing.assert_close(process_weight.call_args.args[0], source_weights[0][1])
+    torch.testing.assert_close(process_weight.call_args.args[1], rotation)
+    assert model._shared_layer_rotation is rotation
+    assert seen_weights[0][0] == "context_proj.weight"
+    assert seen_weights[0][1] is rotated_weight
+    assert seen_weights[1][0] == source_weights[1][0]
+    assert seen_weights[1][1] is source_weights[1][1]
+
+
+def test_k3_dspark_prepares_unrotated_shared_layer():
+    class NonCopyableCommGroup:
+        def __deepcopy__(self, memo):
+            del memo
+            raise TypeError("cannot pickle ProcessGroup")
+
+    model = AscendK3DSparkForCausalLM.__new__(AscendK3DSparkForCausalLM)
+    nn.Module.__init__(model)
+    rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])
+    model._shared_layer_rotation = rotation
+    target = nn.Linear(2, 3, bias=False)
+    target.comm_group = NonCopyableCommGroup()
+    target_weight = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    target.weight.data.copy_(target_weight)
+
+    prepared = model.prepare_shared_layer(
+        None,
+        target,
+        "draft embed_tokens.weight",
+    )
+
+    assert prepared is not None
+    assert prepared is not target
+    assert prepared.comm_group is target.comm_group
+    torch.testing.assert_close(prepared.weight, target_weight @ rotation.T)
+    torch.testing.assert_close(target.weight, target_weight)
+    model.finish_shared_layer_preparation()
+    assert model._shared_layer_rotation is None
+
+
+def test_k3_dspark_embed_input_ids_keeps_text_only_path():
+    model = _make_k3_dspark_for_embedding_test()
+
+    output = model.embed_input_ids(torch.tensor([1, 2]))
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+    )
+
+
+def test_k3_dspark_embed_input_ids_merges_multimodal_embeddings():
+    model = _make_k3_dspark_for_embedding_test()
+    input_ids = torch.tensor([1, 999, 2])
+    is_multimodal = torch.tensor([False, True, False])
+    image_embedding = torch.tensor([[9.0, 10.0]])
+
+    output = model.embed_input_ids(
+        input_ids,
+        multimodal_embeddings=(image_embedding,),
+        is_multimodal=is_multimodal,
+    )
+
+    torch.testing.assert_close(
+        output,
+        torch.tensor(
+            [
+                [1.0, 2.0],
+                [9.0, 10.0],
+                [3.0, 4.0],
+            ]
+        ),
+    )
+
+
+def test_k3_dspark_embed_input_ids_without_multimodal_mask_uses_text_path():
+    model = _make_k3_dspark_for_embedding_test()
+
+    output = model.embed_input_ids(
+        torch.tensor([1]),
+        multimodal_embeddings=(torch.tensor([[9.0, 10.0]]),),
+    )
+
+    torch.testing.assert_close(output, torch.tensor([[1.0, 2.0]]))

--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -680,6 +680,9 @@ def test_k3_dspark_reuses_modelslim_rotation_loader(monkeypatch):
     model = AscendK3DSparkForCausalLM.__new__(AscendK3DSparkForCausalLM)
     nn.Module.__init__(model)
     model.rotation_path = "rotation.safetensors"
+    model.target_model_path = "/target"
+    model.model = SimpleNamespace(embed_tokens=object())
+    model.lm_head = object()
     source_weights = [
         ("context_proj.weight", torch.ones(2, 4)),
         ("context_norm.weight", torch.ones(2)),
@@ -710,47 +713,32 @@ def test_k3_dspark_reuses_modelslim_rotation_loader(monkeypatch):
         "vllm_ascend.models.kimi_k3_dspark.process_weight",
         process_weight,
     )
+    load_target_layer = MagicMock()
+    monkeypatch.setattr(
+        "vllm_ascend.models.kimi_k3_dspark.load_quarot_target_layer",
+        load_target_layer,
+    )
 
     model.load_weights(iter(source_weights))
 
     process_weight.assert_called_once()
     torch.testing.assert_close(process_weight.call_args.args[0], source_weights[0][1])
     torch.testing.assert_close(process_weight.call_args.args[1], rotation)
-    assert model._shared_layer_rotation is rotation
+    assert load_target_layer.call_count == 2
+    assert load_target_layer.call_args_list[0].args[:2] == (
+        model.model.embed_tokens,
+        model.target_model_path,
+    )
+    assert load_target_layer.call_args_list[1].args[:2] == (
+        model.lm_head,
+        model.target_model_path,
+    )
+    assert model.has_own_embed_tokens
+    assert model.has_own_lm_head
     assert seen_weights[0][0] == "context_proj.weight"
     assert seen_weights[0][1] is rotated_weight
     assert seen_weights[1][0] == source_weights[1][0]
     assert seen_weights[1][1] is source_weights[1][1]
-
-
-def test_k3_dspark_prepares_unrotated_shared_layer():
-    class NonCopyableCommGroup:
-        def __deepcopy__(self, memo):
-            del memo
-            raise TypeError("cannot pickle ProcessGroup")
-
-    model = AscendK3DSparkForCausalLM.__new__(AscendK3DSparkForCausalLM)
-    nn.Module.__init__(model)
-    rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])
-    model._shared_layer_rotation = rotation
-    target = nn.Linear(2, 3, bias=False)
-    target.comm_group = NonCopyableCommGroup()
-    target_weight = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
-    target.weight.data.copy_(target_weight)
-
-    prepared = model.prepare_shared_layer(
-        None,
-        target,
-        "draft embed_tokens.weight",
-    )
-
-    assert prepared is not None
-    assert prepared is not target
-    assert prepared.comm_group is target.comm_group
-    torch.testing.assert_close(prepared.weight, target_weight @ rotation.T)
-    torch.testing.assert_close(target.weight, target_weight)
-    model.finish_shared_layer_preparation()
-    assert model._shared_layer_rotation is None
 
 
 def test_k3_dspark_embed_input_ids_keeps_text_only_path():

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -20,6 +20,52 @@ from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
+class TestDSparkAuxCaptureMode(unittest.TestCase):
+    def _build_runner(
+        self,
+        *,
+        model_type: str,
+        architecture: str,
+        use_dspark: bool = True,
+    ):
+        runner = NPUModelRunner.__new__(NPUModelRunner)
+        runner.speculative_config = SimpleNamespace(
+            use_dspark=MagicMock(return_value=use_dspark),
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(
+                    model_type=model_type,
+                    architectures=[architecture],
+                )
+            ),
+        )
+        return runner
+
+    def test_qwen3_gqa_dspark_uses_materialized_stream(self):
+        runner = self._build_runner(
+            model_type="qwen3",
+            architecture="Qwen3DSparkModel",
+        )
+
+        self.assertTrue(runner._draft_uses_qwen3_gqa_dspark())
+
+    def test_mla_dspark_keeps_raw_stream(self):
+        runner = self._build_runner(
+            model_type="kimi_k3_dspark",
+            architecture="KimiK3DSparkForCausalLM",
+        )
+
+        self.assertFalse(runner._draft_uses_qwen3_gqa_dspark())
+
+    def test_non_dspark_keeps_raw_stream(self):
+        runner = self._build_runner(
+            model_type="qwen3",
+            architecture="Qwen3DSparkModel",
+            use_dspark=False,
+        )
+
+        self.assertFalse(runner._draft_uses_qwen3_gqa_dspark())
+
+
 class TestNPUModelRunnerKVCache(unittest.TestCase):
     def _build_runner(self):
         runner = NPUModelRunner.__new__(NPUModelRunner)

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -3,6 +3,28 @@ from vllm import ModelRegistry
 
 def register_model():
     ModelRegistry.register_model(
+        "KimiLinearForCausalLM",
+        "vllm_ascend.models.kimi_k3:AscendKimiLinearForCausalLM",
+    )
+    # Keep the release-branch text architecture as a compatibility alias for
+    # checkpoints whose config predates vLLM's KimiLinear rename.
+    ModelRegistry.register_model(
+        "KimiK3ForCausalLM",
+        "vllm_ascend.models.kimi_k3:AscendKimiLinearForCausalLM",
+    )
+    ModelRegistry.register_model(
+        "KimiK3ForConditionalGeneration",
+        "vllm_ascend.models.kimi_k3:AscendKimiK3ForConditionalGeneration",
+    )
+    ModelRegistry.register_model(
+        "KimiK3MTPModel",
+        "vllm_ascend.models.kimi_k3_mtp:AscendKimiK3MTP",
+    )
+    ModelRegistry.register_model(
+        "K3DSparkModel",
+        "vllm_ascend.models.kimi_k3_dspark:AscendK3DSparkForCausalLM",
+    )
+    ModelRegistry.register_model(
         "DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4.model:AscendDeepseekV4ForCausalLM"
     )
     ModelRegistry.register_model(

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -1,0 +1,860 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kimi K3 model adapters for vLLM 0.27 on Ascend.
+
+vLLM owns Kimi's configuration, multimodal processor, weight mappings, and
+model-level forward contract.  This module composes those upstream pieces with
+the generic MLA/MoE implementation and the Ascend KDA backend.
+"""
+
+import math
+from copy import copy
+
+import torch
+import vllm.envs as envs
+from torch import nn
+from vllm.config import CacheConfig, VllmConfig
+from vllm.distributed import (
+    get_pp_group,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.model_executor.layers.fused_moe import FusedMoEFactory
+from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    ReplicatedLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.kimi_k25_vit import (
+    KimiK25MultiModalProjector,
+    MoonViT3dPretrainedModel,
+)
+from vllm.model_executor.models.utils import (
+    PPMissingLayer,
+    init_vllm_registered_model,
+    make_layers,
+    maybe_prefix,
+)
+from vllm.model_executor.models.vision import is_vit_use_data_parallel
+from vllm.models.common.ops.sequence_parallel import (
+    sp_all_gather,
+    sp_padding_mask,
+    sp_reduce_scatter,
+    sp_shard,
+)
+from vllm.models.kimi_k3.amd.linear import (
+    KimiDecoderLayer as UpstreamKimiDecoderLayer,
+)
+from vllm.models.kimi_k3.amd.linear import KimiLinearForCausalLM as UpstreamKimiLinearForCausalLM
+from vllm.models.kimi_k3.amd.linear import KimiLinearModel as UpstreamKimiLinearModel
+from vllm.models.kimi_k3.amd.linear import (
+    KimiMLAAttention as UpstreamKimiMLAAttention,
+)
+from vllm.models.kimi_k3.amd.linear import (
+    KimiMLP,
+    KimiRoutedOutputTransform,
+)
+from vllm.models.kimi_k3.amd.model import (
+    KimiK3ForConditionalGeneration as UpstreamKimiK3ForConditionalGeneration,
+)
+from vllm.models.kimi_k3.common.mm_preprocess import (
+    KimiK3DummyInputsBuilder,
+    KimiK3MultiModalProcessor,
+    KimiK3ProcessingInfo,
+)
+from vllm.models.kimi_k3.nvidia.model import (
+    KimiLinearModel as UpstreamPackedKimiLinearModel,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+from vllm.triton_utils import HAS_TRITON
+from vllm.utils.math_utils import cdiv
+
+from vllm_ascend.models.llama_eagle3 import get_rotation_path
+from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
+
+if HAS_TRITON:
+    from vllm_ascend.ops.triton.kimi_k3.attention_residual import (  # type: ignore[import-untyped]
+        apply_attn_res,
+    )
+else:
+    apply_attn_res = None  # type: ignore[assignment]
+
+
+def _apply_ascend_attn_res(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    proj: ReplicatedLinear,
+    norm: RMSNorm,
+    num_valid_blocks: int,
+) -> torch.Tensor:
+    """Apply Kimi's canonical learned residual mixture with native ops."""
+    if num_valid_blocks <= 0:
+        return prefix_sum
+
+    if apply_attn_res is not None and prefix_sum.device.type == "npu" and prefix_sum.numel() > 0:
+        return apply_attn_res(
+            prefix_sum,
+            block_residual,
+            proj,
+            norm,
+            num_valid_blocks,
+        )
+
+    values = torch.cat(
+        (
+            block_residual[:, :num_valid_blocks, :],
+            prefix_sum.unsqueeze(1),
+        ),
+        dim=1,
+    )
+    values_fp32 = values.float()
+    inverse_rms = torch.rsqrt(values_fp32.square().mean(-1, keepdim=True) + norm.variance_epsilon)
+    normalized_without_gamma = values_fp32 * inverse_rms
+    score_weight = norm.weight.float() * proj.weight.squeeze(0).float()
+    scores = (normalized_without_gamma * score_weight).sum(-1)
+    probabilities = scores.softmax(-1).unsqueeze(1)
+    return torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
+
+
+class AscendKimiMoE(nn.Module):
+    """Kimi K3 MoE assembled from the standard vLLM MoE interfaces."""
+
+    def __init__(
+        self,
+        *,
+        config,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        use_sequence_parallel: bool = False,
+    ) -> None:
+        super().__init__()
+        hidden_size = config.hidden_size
+        moe_intermediate_size = config.moe_intermediate_size
+        num_experts = config.num_experts
+        num_experts_per_token = config.num_experts_per_token
+        assert moe_intermediate_size is not None
+        assert num_experts is not None
+        assert num_experts_per_token is not None
+
+        routed_expert_hidden_size = config.routed_expert_hidden_size
+        self.use_latent_moe = routed_expert_hidden_size is not None
+        self.moe_hidden_size = routed_expert_hidden_size or hidden_size
+        self.latent_moe_use_norm = config.latent_moe_use_norm
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.num_shared_experts = config.num_shared_experts
+        activation_situ_beta = config.activation_situ_beta if config.hidden_act == "situ" else None
+        activation_situ_linear_beta = config.activation_situ_linear_beta if config.hidden_act == "situ" else None
+
+        self.gate = GateLinear(
+            input_size=hidden_size,
+            output_size=num_experts,
+            bias=False,
+            out_dtype=torch.float32,
+            prefix=f"{prefix}.gate",
+        )
+        self.gate.e_score_correction_bias = nn.Parameter(torch.empty(num_experts, dtype=torch.float32))
+
+        if self.num_shared_experts is not None:
+            self.shared_experts = KimiMLP(
+                hidden_size=hidden_size,
+                intermediate_size=moe_intermediate_size * self.num_shared_experts,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                reduce_results=False,
+                prefix=f"{prefix}.shared_experts",
+                activation_situ_beta=activation_situ_beta,
+                activation_situ_linear_beta=activation_situ_linear_beta,
+            )
+        else:
+            self.shared_experts = None
+
+        latent_quant_config = quant_config if quant_config is not None and quant_config.get_name() == "ascend" else None
+        if self.use_latent_moe:
+            self.routed_expert_down_proj = ReplicatedLinear(
+                hidden_size,
+                self.moe_hidden_size,
+                bias=False,
+                quant_config=latent_quant_config,
+                prefix=f"{prefix}.routed_expert_down_proj",
+            )
+            self.routed_expert_norm = (
+                RMSNorm(self.moe_hidden_size, eps=config.rms_norm_eps) if self.latent_moe_use_norm else None
+            )
+            self.routed_expert_up_proj = ReplicatedLinear(
+                self.moe_hidden_size,
+                hidden_size,
+                bias=False,
+                quant_config=latent_quant_config,
+                prefix=f"{prefix}.routed_expert_up_proj",
+            )
+            self.routed_output_transform = KimiRoutedOutputTransform(
+                self.routed_expert_norm,
+                self.routed_expert_up_proj,
+            )
+        else:
+            self.routed_expert_down_proj = None
+            self.routed_expert_norm = None
+            self.routed_expert_up_proj = None
+            self.routed_output_transform = None
+
+        self.experts = FusedMoEFactory(
+            shared_experts=self.shared_experts,
+            num_experts=num_experts,
+            top_k=num_experts_per_token,
+            hidden_size=self.moe_hidden_size,
+            intermediate_size=moe_intermediate_size,
+            activation=config.hidden_act,
+            activation_situ_beta=activation_situ_beta,
+            activation_situ_linear_beta=activation_situ_linear_beta,
+            renormalize=config.moe_renormalize,
+            quant_config=quant_config,
+            use_grouped_topk=config.use_grouped_topk,
+            num_expert_group=config.num_expert_group,
+            topk_group=config.topk_group,
+            prefix=f"{prefix}.experts",
+            scoring_func=config.moe_router_activation_func,
+            e_score_correction_bias=self.gate.e_score_correction_bias,
+            routed_scaling_factor=self.routed_scaling_factor,
+            routed_input_transform=self.routed_expert_down_proj,
+            routed_output_transform=self.routed_output_transform,
+            is_sequence_parallel=use_sequence_parallel,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        num_tokens, hidden_size = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_size)
+        router_logits, _ = self.gate(hidden_states)
+        final_hidden_states = self.experts(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
+        return final_hidden_states.view(num_tokens, hidden_size)
+
+
+class AscendKimiMLAAttention(UpstreamKimiMLAAttention):
+    """Extend vLLM's generic Kimi MLA only for DSpark RoPE metadata."""
+
+    def __init__(
+        self,
+        config,
+        hidden_size: int,
+        num_heads: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        q_lora_rank: int | None,
+        kv_lora_rank: int,
+        use_output_gate: bool,
+        use_rope: bool,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        non_causal_multi_token_decode: bool = False,
+    ) -> None:
+        upstream_config = copy(config)
+        upstream_config.mla_use_output_gate = use_output_gate
+        super().__init__(
+            config=upstream_config,
+            hidden_size=hidden_size,
+            num_heads=num_heads,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=kv_lora_rank,
+            use_nope=True,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        if not use_rope and not non_causal_multi_token_decode:
+            return
+
+        rotary_emb = None
+        if use_rope:
+            rope_parameters = dict(config.rope_parameters)
+            if rope_parameters["rope_type"] != "default":
+                rope_parameters["rope_type"] = (
+                    "deepseek_yarn" if rope_parameters.get("apply_yarn_scaling", True) else "deepseek_llama_scaling"
+                )
+            rotary_emb = get_rope(
+                qk_rope_head_dim,
+                max_position=config.max_position_embeddings,
+                rope_parameters=rope_parameters,
+                is_neox_style=False,
+            )
+            if rope_parameters["rope_type"] == "deepseek_yarn":
+                scaling_factor = float(rope_parameters["factor"])
+                mscale_all_dim = float(rope_parameters.get("mscale_all_dim", 0.0))
+                if scaling_factor > 1 and mscale_all_dim:
+                    mscale = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
+                    self.scaling *= mscale * mscale
+
+        # The upstream Kimi module has already constructed the platform-
+        # registered MLA wrapper, including all projections and weight loaders.
+        # Configure that existing Ascend attention layer for DSpark instead of
+        # constructing and registering a second wrapper with the same prefix.
+        attention_layer = self._attention_layer
+        attention_layer.scale = self.scaling
+        attention_layer.non_causal_multi_token_decode = non_causal_multi_token_decode
+        attention_layer.impl.scale = float(self.scaling)
+        attention_layer.impl.rotary_emb = rotary_emb
+        attention_layer.impl.use_mla_rope = use_rope
+
+    @property
+    def _attention_layer(self):
+        return self.mla_attn.mla_attn
+
+    @property
+    def is_vl_first_layer(self) -> bool:
+        return self.mla_attn.is_vl_first_layer
+
+    @property
+    def layer_name(self) -> str:
+        return self._attention_layer.layer_name
+
+    @property
+    def impl(self):
+        return self._attention_layer.impl
+
+    @property
+    def kv_cache(self):
+        return self._attention_layer.kv_cache
+
+    @property
+    def kv_cache_dtype(self):
+        return self._attention_layer.kv_cache_dtype
+
+    @property
+    def _k_scale(self):
+        return self._attention_layer._k_scale
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.mla_attn(positions, hidden_states)
+
+
+class AscendKimiDecoderLayer(UpstreamKimiDecoderLayer):
+    """Upstream Kimi decoder structure with Ascend attention backends."""
+
+    def __init__(
+        self,
+        config,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+        use_sequence_parallel: bool = False,
+    ) -> None:
+        """Select KDA or no-RoPE MLA and configure the layer residual path."""
+        nn.Module.__init__(self)
+        self.hidden_size = config.hidden_size
+        self.layer_idx = int(prefix.rsplit(".", 1)[1])
+        self.is_moe = config.is_moe
+        self.use_sequence_parallel = use_sequence_parallel
+        layer_idx = self.layer_idx
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        if config.is_kda_layer(layer_idx):
+            self.self_attn = AscendKimiK3DeltaAttention(
+                config,
+                vllm_config,
+                prefix=f"{prefix}.self_attn",
+            )
+        else:
+            qk_nope_head_dim = config.qk_nope_head_dim
+            qk_rope_head_dim = config.qk_rope_head_dim
+            v_head_dim = config.v_head_dim
+            kv_lora_rank = config.kv_lora_rank
+            assert qk_nope_head_dim is not None
+            assert qk_rope_head_dim is not None
+            assert v_head_dim is not None
+            assert kv_lora_rank is not None
+            assert config.mla_use_nope is True
+            self.self_attn = AscendKimiMLAAttention(
+                config=config,
+                hidden_size=self.hidden_size,
+                num_heads=config.num_attention_heads,
+                qk_nope_head_dim=qk_nope_head_dim,
+                qk_rope_head_dim=qk_rope_head_dim,
+                v_head_dim=v_head_dim,
+                q_lora_rank=config.q_lora_rank,
+                kv_lora_rank=kv_lora_rank,
+                use_output_gate=bool(config.mla_use_output_gate),
+                use_rope=False,
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.self_attn",
+            )
+
+        self.is_moe_layer = (
+            self.is_moe
+            and config.num_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and layer_idx % config.moe_layer_freq == 0
+        )
+        if self.is_moe_layer:
+            self.block_sparse_moe = AscendKimiMoE(
+                config=config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.block_sparse_moe",
+                use_sequence_parallel=use_sequence_parallel,
+            )
+            self.mlp = self.block_sparse_moe
+        else:
+            self.mlp = KimiMLP(
+                hidden_size=self.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+                activation_situ_beta=config.activation_situ_beta,
+                activation_situ_linear_beta=config.activation_situ_linear_beta,
+            )
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+        attn_res_block_size = config.attn_res_block_size
+        self.use_attn_residuals = attn_res_block_size is not None
+        if attn_res_block_size is not None:
+            self.attn_res_block_size = attn_res_block_size
+            self.is_block_write_layer = layer_idx % attn_res_block_size == 0
+            self.block_write_idx = layer_idx // attn_res_block_size
+            self.prev_valid_blocks = cdiv(layer_idx, attn_res_block_size)
+            self.self_attention_res_norm = RMSNorm(
+                config.hidden_size,
+                eps=config.rms_norm_eps,
+            )
+            self.mlp_res_norm = RMSNorm(
+                config.hidden_size,
+                eps=config.rms_norm_eps,
+            )
+            self.self_attention_res_proj = ReplicatedLinear(
+                config.hidden_size,
+                1,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.self_attention_res_proj",
+            )
+            self.mlp_res_proj = ReplicatedLinear(
+                config.hidden_size,
+                1,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.mlp_res_proj",
+            )
+
+        if self.use_sequence_parallel:
+            self.self_attn.o_proj.reduce_results = False
+
+    def forward_attn_residual(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        block_residual: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run Kimi attention residuals with Ascend attention and MoE."""
+        prefix_sum: torch.Tensor | None = hidden_states
+        hidden_states = _apply_ascend_attn_res(
+            prefix_sum,
+            block_residual,
+            self.self_attention_res_proj,
+            self.self_attention_res_norm,
+            self.prev_valid_blocks,
+        )
+        if self.is_block_write_layer:
+            assert prefix_sum is not None
+            block_residual[:, self.block_write_idx, :].copy_(prefix_sum)
+            prefix_sum = None
+
+        hidden_states = self.input_layernorm(hidden_states)
+        if self.use_sequence_parallel:
+            hidden_states = sp_all_gather(hidden_states)
+            hidden_states = hidden_states[: positions.shape[0]]
+        hidden_states = self.self_attn(
+            hidden_states=hidden_states,
+            positions=positions,
+        )
+        if self.use_sequence_parallel:
+            hidden_states = sp_reduce_scatter(hidden_states)
+
+        prefix_sum = hidden_states if prefix_sum is None else prefix_sum + hidden_states
+        mlp_valid_blocks = self.prev_valid_blocks + (1 if self.is_block_write_layer else 0)
+        hidden_states = _apply_ascend_attn_res(
+            prefix_sum,
+            block_residual,
+            self.mlp_res_proj,
+            self.mlp_res_norm,
+            mlp_valid_blocks,
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = prefix_sum + hidden_states
+        return hidden_states, block_residual
+
+
+class AscendKimiLinearModel(UpstreamKimiLinearModel):
+    """Kimi text model assembled from the Ascend decoder layer."""
+
+    packed_modules_mapping = UpstreamPackedKimiLinearModel.packed_modules_mapping
+    # Legacy Qwen3 GQA DSpark checkpoints consume the materialized input
+    # to each selected Kimi layer. MLA DSpark checkpoints consume the raw
+    # prefix-sum stream used by upstream vLLM, so keep that as the default.
+    dspark_aux_capture_materialized = False
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.vocab_size = config.vocab_size
+        parallel_config = vllm_config.parallel_config
+        # vLLM's generic MoE SP switch currently requires DP > 1. K3 also
+        # needs the same rank-local token layout for the TP/EP, DP=1 topology
+        # that FlashComm used before the standard SP operators were available.
+        self.use_sequence_parallel = (
+            parallel_config.pipeline_parallel_size == 1
+            and parallel_config.enable_expert_parallel
+            and parallel_config.tensor_parallel_size > 1
+        )
+
+        if get_pp_group().is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        def get_layer(prefix: str):
+            return AscendKimiDecoderLayer(
+                config,
+                vllm_config,
+                prefix,
+                use_sequence_parallel=self.use_sequence_parallel,
+            )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            get_layer,
+            prefix=f"{prefix}.layers",
+        )
+
+        if get_pp_group().is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if config.attn_res_block_size is not None:
+                self.output_attn_res_norm = RMSNorm(
+                    config.hidden_size,
+                    eps=config.rms_norm_eps,
+                )
+                self.output_attn_res_proj = ReplicatedLinear(
+                    config.hidden_size,
+                    1,
+                    bias=False,
+                    quant_config=None,
+                    prefix=f"{prefix}.output_attn_res_proj",
+                )
+        else:
+            self.norm = PPMissingLayer()
+            if config.attn_res_block_size is not None:
+                self.output_attn_res_norm = PPMissingLayer()
+                self.output_attn_res_proj = PPMissingLayer()
+
+        world_size = get_tensor_model_parallel_world_size()
+        assert config.num_attention_heads % world_size == 0, "num_attention_heads must be divisible by world_size"
+
+    def load_weights(self, weights):
+        """Route mixed-precision KDA gates through vLLM's packed loader."""
+        params_dict = dict(self.named_parameters())
+        gate_mapping = (
+            (".g_proj", ".in_proj_gfab", 0),
+            (".f_a_proj", ".in_proj_gfab", 1),
+            (".b_proj", ".in_proj_gfab", 2),
+        )
+
+        def remap_mixed_gate_weights():
+            for args in weights:
+                name, loaded_weight = args[:2]
+                for source, target, shard_id in gate_mapping:
+                    if source not in name:
+                        continue
+                    mapped_name = name.replace(source, target)
+                    if mapped_name in params_dict:
+                        kwargs = dict(args[2]) if len(args) > 2 else {}
+                        kwargs["loaded_shard_id"] = shard_id
+                        yield mapped_name, loaded_weight, kwargs
+                        break
+                else:
+                    yield args
+
+        return super().load_weights(remap_mixed_gate_weights())
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor | IntermediateTensors | tuple[torch.Tensor, list[torch.Tensor]]:
+        if self.config.attn_res_block_size is None:
+            return super().forward(
+                input_ids=input_ids,
+                positions=positions,
+                intermediate_tensors=intermediate_tensors,
+                inputs_embeds=inputs_embeds,
+                **kwargs,
+            )
+
+        if get_pp_group().is_first_rank:
+            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
+            residual = None
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            residual = intermediate_tensors["residual"]
+
+        full_num_tokens = positions.shape[0]
+        if self.use_sequence_parallel:
+            if envs.VLLM_MOE_SKIP_PADDING and is_forward_context_available():
+                forward_context = get_forward_context()
+                forward_context.is_padding = sp_padding_mask(
+                    forward_context.is_padding,
+                    hidden_states,
+                )
+            hidden_states = sp_shard(hidden_states)
+            assert residual is None, "Sequence parallelism is not supported with pipeline parallelism"
+
+        if self.dspark_aux_capture_materialized:
+            aux_hidden_states: list[torch.Tensor] = []
+        else:
+            aux_hidden_states = self._maybe_add_hidden_state(
+                [],
+                self.start_layer,
+                hidden_states,
+                residual,
+            )
+        attn_res_block_num = cdiv(
+            self.end_layer,
+            self.config.attn_res_block_size,
+        )
+        block_residual = hidden_states.new_empty(
+            hidden_states.size(0),
+            attn_res_block_num,
+            hidden_states.size(1),
+        )
+        if residual is not None:
+            block_residual[:, : residual.size(1), :].copy_(residual)
+        residual = block_residual
+
+        for layer_idx, layer in enumerate(
+            self.layers[self.start_layer : self.end_layer],
+            start=self.start_layer,
+        ):
+            if self.dspark_aux_capture_materialized and layer_idx in self.aux_hidden_state_layers:
+                aux_hidden_states.append(
+                    _apply_ascend_attn_res(
+                        hidden_states,
+                        residual,
+                        layer.self_attention_res_proj,
+                        layer.self_attention_res_norm,
+                        layer.prev_valid_blocks,
+                    )
+                )
+            hidden_states, residual = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+            if not self.dspark_aux_capture_materialized and (layer_idx + 1) in self.aux_hidden_state_layers:
+                self._maybe_add_hidden_state(
+                    aux_hidden_states,
+                    layer_idx + 1,
+                    hidden_states,
+                    residual,
+                )
+
+        if not get_pp_group().is_last_rank:
+            assert not self.use_sequence_parallel, "Sequence parallelism is not supported with pipeline parallelism"
+            return IntermediateTensors(
+                {
+                    "hidden_states": hidden_states,
+                    "residual": residual,
+                }
+            )
+
+        hidden_states = _apply_ascend_attn_res(
+            hidden_states,
+            residual,
+            self.output_attn_res_proj,
+            self.output_attn_res_norm,
+            attn_res_block_num,
+        )
+        if self.use_sequence_parallel:
+            if aux_hidden_states:
+                hidden_size = hidden_states.shape[-1]
+                packed_hidden_states = torch.cat(
+                    [hidden_states, *aux_hidden_states],
+                    dim=-1,
+                )
+                packed_hidden_states = sp_all_gather(packed_hidden_states)
+                packed_hidden_states = packed_hidden_states[:full_num_tokens]
+                hidden_states, *aux_hidden_states = packed_hidden_states.split(
+                    hidden_size,
+                    dim=-1,
+                )
+            else:
+                hidden_states = sp_all_gather(hidden_states)
+                hidden_states = hidden_states[:full_num_tokens]
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+
+class AscendKimiLinearForCausalLM(UpstreamKimiLinearForCausalLM):
+    """Causal-LM wrapper retaining vLLM 0.27 state/cache interfaces."""
+
+    packed_modules_mapping = AscendKimiLinearModel.packed_modules_mapping
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        nn.Module.__init__(self)
+        self.model_config = vllm_config.model_config
+        self.vllm_config = vllm_config
+        self.config = self.model_config.hf_config
+        self.quant_config = vllm_config.quant_config
+        self.model = AscendKimiLinearModel(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "model"),
+        )
+        if get_pp_group().is_last_rank:
+            self.lm_head = ParallelLMHead(
+                self.config.vocab_size,
+                self.config.hidden_size,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(
+            self.config.vocab_size,
+            scale=getattr(self.config, "logit_scale", 1.0),
+        )
+
+    def set_dspark_aux_capture_materialized(self, enabled: bool) -> None:
+        self.model.dspark_aux_capture_materialized = enabled
+
+
+class AscendKimiK3MultiModalProjector(KimiK25MultiModalProjector):
+    """Kimi projector with the optional ModelSlim output rotation."""
+
+    def __init__(
+        self,
+        config,
+        *args,
+        prefix: str = "",
+        enable_rotation: bool = False,
+        **kwargs,
+    ) -> None:
+        super().__init__(config, *args, prefix=prefix, **kwargs)
+        self.rot_proj: ReplicatedLinear | None = None
+        if enable_rotation:
+            output_size = config.text_hidden_size
+            self.rot_proj = ReplicatedLinear(
+                output_size,
+                output_size,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.rot_proj",
+            )
+
+    def forward(self, image_features: torch.Tensor) -> torch.Tensor:
+        hidden_states = super().forward(image_features)
+        rot_proj = self.rot_proj
+        if rot_proj is not None:
+            hidden_states = rot_proj(hidden_states)[0]
+        return hidden_states
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    KimiK3MultiModalProcessor,
+    info=KimiK3ProcessingInfo,
+    dummy_inputs=KimiK3DummyInputsBuilder,
+)
+class AscendKimiK3ForConditionalGeneration(UpstreamKimiK3ForConditionalGeneration):
+    """Upstream Kimi K3 multimodal wrapper with Ascend text/projector layers."""
+
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+        nn.Module.__init__(self)
+        model_config = vllm_config.model_config
+        self.config = model_config.hf_config
+        self.quant_config = vllm_config.quant_config
+        multimodal_config = model_config.multimodal_config
+        assert multimodal_config is not None
+
+        self.use_data_parallel = is_vit_use_data_parallel(
+            self.config.vision_config.num_attention_heads,
+        )
+        self.hidden_size = self.config.text_config.hidden_size
+        self.device = current_platform.current_device()
+        vision_quant_config = self._maybe_ignore_quant_config(self.quant_config)
+
+        with self._mark_tower_model(vllm_config, "image"):
+            self.vision_tower = MoonViT3dPretrainedModel(
+                self.config.vision_config,
+                quant_config=vision_quant_config,
+                prefix=maybe_prefix(prefix, "vision_tower"),
+            )
+            if vision_quant_config is not None:
+                self.vision_tower = self.vision_tower.to(device=self.device)
+            else:
+                self.vision_tower = self.vision_tower.to(
+                    device=self.device,
+                    dtype=model_config.dtype,
+                )
+
+            self.mm_projector = AscendKimiK3MultiModalProjector(
+                self.config.vision_config,
+                use_data_parallel=self.use_data_parallel,
+                quant_config=vision_quant_config,
+                prefix=maybe_prefix(prefix, "mm_projector"),
+                enable_rotation=get_rotation_path(vllm_config) is not None,
+            )
+        if vision_quant_config is not None:
+            self.mm_projector = self.mm_projector.to(device=self.device)
+        else:
+            self.mm_projector = self.mm_projector.to(
+                device=self.device,
+                dtype=model_config.dtype,
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                hf_config=self.config.text_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+                architectures=["KimiLinearForCausalLM"],
+            )
+        self.make_empty_intermediate_tensors = (  # type: ignore[method-assign]
+            self.language_model.make_empty_intermediate_tensors
+        )
+        self.media_placeholder = self.config.media_placeholder_token_id
+
+    def set_dspark_aux_capture_materialized(self, enabled: bool) -> None:
+        self.language_model.set_dspark_aux_capture_materialized(enabled)

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -10,6 +10,10 @@ from vllm.config import VllmConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
 from vllm.model_executor.models.interfaces import MultiModalEmbeddings
 from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
 from vllm.model_executor.models.utils import (
@@ -35,9 +39,13 @@ from vllm_ascend.models.kimi_k3 import (
 from vllm_ascend.models.llama_eagle3 import (
     get_rotation_matrix,
     get_rotation_path,
-    prepare_quarot_shared_layer,
+    load_quarot_target_layer,
 )
-from vllm_ascend.models.qwen3_dspark import process_weight
+from vllm_ascend.models.qwen3_dspark import (
+    TARGET_EMBED_WEIGHT_NAMES,
+    TARGET_LM_HEAD_WEIGHT_NAMES,
+    process_weight,
+)
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
 
 
@@ -241,27 +249,20 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
             scale=getattr(self.config, "logit_scale", 1.0),
         )
         self.rotation_path = get_rotation_path(vllm_config)
-        self._shared_layer_rotation: torch.Tensor | None = None
-
-    def prepare_shared_layer(
-        self,
-        draft_layer: nn.Module | None,
-        target_layer: nn.Module,
-        label: str,
-    ) -> nn.Module | None:
-        rotation = self._shared_layer_rotation
-        if rotation is None:
-            return None
-        draft_layer, self._shared_layer_rotation = prepare_quarot_shared_layer(
-            draft_layer,
-            target_layer,
-            rotation,
-            label,
-        )
-        return draft_layer
-
-    def finish_shared_layer_preparation(self) -> None:
-        self._shared_layer_rotation = None
+        self.target_model_path = vllm_config.model_config.model
+        if self.rotation_path is not None:
+            target_config = vllm_config.model_config.hf_text_config
+            model_prefix = maybe_prefix(prefix, "model")
+            self.model.embed_tokens = VocabParallelEmbedding(
+                target_config.vocab_size,
+                target_config.hidden_size,
+                prefix=maybe_prefix(model_prefix, "embed_tokens"),
+            )
+            self.lm_head = ParallelLMHead(
+                target_config.vocab_size,
+                target_config.hidden_size,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
 
     def load_weights(
         self,
@@ -275,10 +276,9 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
         interface without creating that extra packed parameter.
         """
         loader = AutoWeightsLoader(self)
-        self._shared_layer_rotation = None
+        rotation_weight = None
         if self.rotation_path is not None:
             rotation_weight = get_rotation_matrix(self.rotation_path)
-            self._shared_layer_rotation = rotation_weight
             weights = (
                 (
                     name,
@@ -286,7 +286,30 @@ class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
                 )
                 for name, loaded_weight in weights
             )
-        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        loaded_weights = loader.load_weights(
+            weights,
+            mapper=self.hf_to_vllm_mapper,
+        )
+        if rotation_weight is not None:
+            assert self.model.embed_tokens is not None
+            assert self.lm_head is not None
+            load_quarot_target_layer(
+                self.model.embed_tokens,
+                self.target_model_path,
+                TARGET_EMBED_WEIGHT_NAMES,
+                rotation_weight,
+                "draft embed_tokens.weight",
+            )
+            load_quarot_target_layer(
+                self.lm_head,
+                self.target_model_path,
+                TARGET_LM_HEAD_WEIGHT_NAMES,
+                rotation_weight,
+                "draft lm_head.weight",
+            )
+            self.has_own_embed_tokens = True
+            self.has_own_lm_head = True
+        return loaded_weights
 
     def embed_input_ids(
         self,

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kimi K3 MLA DSpark draft model for Ascend."""
+
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.models.interfaces import MultiModalEmbeddings
+from vllm.model_executor.models.qwen3_dspark import DSparkMarkovHead
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    _merge_multimodal_embeddings,
+    get_draft_quant_config,
+    maybe_prefix,
+)
+from vllm.models.kimi_k3.amd.linear import KimiMLP
+from vllm.models.kimi_k3.nvidia.dspark_mla import (
+    K3DSparkDecoderLayer as UpstreamK3DSparkDecoderLayer,
+)
+from vllm.models.kimi_k3.nvidia.dspark_mla import (
+    K3DSparkForCausalLM as UpstreamK3DSparkForCausalLM,
+)
+from vllm.models.kimi_k3.nvidia.dspark_mla import (
+    K3DSparkModel as UpstreamK3DSparkModel,
+)
+
+from vllm_ascend.models.kimi_k3 import (
+    AscendKimiMLAAttention,
+)
+from vllm_ascend.models.llama_eagle3 import (
+    get_rotation_matrix,
+    get_rotation_path,
+    prepare_quarot_shared_layer,
+)
+from vllm_ascend.models.qwen3_dspark import process_weight
+from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
+
+
+class AscendK3DSparkDecoderLayer(UpstreamK3DSparkDecoderLayer):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config,
+        layer_idx: int,
+        start_layer_id: int,
+        prefix: str,
+    ) -> None:
+        # The upstream constructor hard-codes NVIDIA attention and MLP
+        # components. Keep its class contract while constructing the Ascend
+        # equivalents below.
+        nn.Module.__init__(self)
+        quant_config = get_draft_quant_config(vllm_config)
+        layer_prefix = maybe_prefix(
+            prefix,
+            f"layers.{start_layer_id + layer_idx}",
+        )
+        self.self_attn = AscendKimiMLAAttention(
+            config=config,
+            hidden_size=config.hidden_size,
+            num_heads=config.num_attention_heads,
+            qk_nope_head_dim=config.qk_nope_head_dim,
+            qk_rope_head_dim=config.qk_rope_head_dim,
+            v_head_dim=config.v_head_dim,
+            q_lora_rank=config.q_lora_rank,
+            kv_lora_rank=config.kv_lora_rank,
+            use_output_gate=False,
+            use_rope=True,
+            cache_config=vllm_config.cache_config,
+            quant_config=quant_config,
+            prefix=f"{layer_prefix}.self_attn",
+            non_causal_multi_token_decode=True,
+        )
+        self.mlp = KimiMLP(
+            hidden_size=config.hidden_size,
+            intermediate_size=config.intermediate_size,
+            hidden_act=config.hidden_act,
+            quant_config=quant_config,
+            prefix=f"{layer_prefix}.mlp",
+        )
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(
+                hidden_states,
+                residual,
+            )
+        hidden_states = self.self_attn(
+            positions=positions,
+            hidden_states=hidden_states,
+        )
+        hidden_states, residual = self.post_attention_layernorm(
+            hidden_states,
+            residual,
+        )
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class AscendK3DSparkModel(UpstreamK3DSparkModel):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int,
+        prefix: str,
+    ) -> None:
+        # The upstream constructor hard-codes CUDA/NVIDIA attention and decoder
+        # classes.  Initialize only the module base, then keep the upstream
+        # model methods while constructing the Ascend-specific components.
+        nn.Module.__init__(self)
+        assert vllm_config.speculative_config is not None
+        draft_model_config = vllm_config.speculative_config.draft_model_config
+        assert draft_model_config is not None
+        self.config = draft_model_config.hf_config
+        self.quant_config = get_draft_quant_config(vllm_config)
+        self.embed_tokens: nn.Module | None = None
+
+        self.context_proj = ReplicatedLinear(
+            self.config.target_hidden_size * self.config.num_target_layers,
+            self.config.hidden_size,
+            bias=False,
+            return_bias=False,
+            quant_config=self.quant_config,
+            prefix=maybe_prefix(prefix, "context_proj"),
+        )
+        self.context_norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+        self.layers = nn.ModuleList(
+            [
+                AscendK3DSparkDecoderLayer(
+                    vllm_config=vllm_config,
+                    config=self.config,
+                    layer_idx=layer_idx,
+                    start_layer_id=start_layer_id,
+                    prefix=prefix,
+                )
+                for layer_idx in range(self.config.num_hidden_layers)
+            ]
+        )
+        self.final_norm = RMSNorm(
+            self.config.hidden_size,
+            eps=self.config.rms_norm_eps,
+        )
+        self.markov_head = DSparkMarkovHead(
+            self.config.vocab_size,
+            self.config.draft_vocab_size,
+            self.config.markov_rank,
+            prefix=maybe_prefix(prefix, "markov_head"),
+        )
+
+    @torch.inference_mode()
+    def precompute_and_store_context_kv(
+        self,
+        context_states: torch.Tensor,
+        context_positions: torch.Tensor,
+        context_slot_mapping: (
+            torch.Tensor | list[torch.Tensor | None] | tuple[torch.Tensor | None, ...] | None
+        ) = None,
+    ) -> None:
+        if context_slot_mapping is None or context_states.numel() == 0:
+            return
+        per_layer_slot_mapping = isinstance(context_slot_mapping, (list, tuple))
+        cos, sin = get_cos_and_sin_mla(context_positions)
+        for layer_idx, layer in enumerate(self.layers):
+            attn = layer.self_attn
+            assert attn.fused_qkv_a_proj is not None
+            assert attn.q_lora_rank is not None
+            qkv_lora = attn.fused_qkv_a_proj(context_states)[0]
+            kv_no_split = qkv_lora[..., attn.q_lora_rank :].contiguous()
+            slots = context_slot_mapping[layer_idx] if per_layer_slot_mapping else context_slot_mapping
+            if slots is None:
+                continue
+            attn.impl.exec_kv_prefill(
+                kv_no_split,
+                cos,
+                sin,
+                attn.kv_cache,
+                slots,
+            )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_input_ids(input_ids)
+        hidden_states = inputs_embeds
+        residual = None
+        for layer in self.layers:
+            hidden_states, residual = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                residual=residual,
+            )
+        hidden_states, _ = self.final_norm(hidden_states, residual)
+        return hidden_states
+
+
+class AscendK3DSparkForCausalLM(UpstreamK3DSparkForCausalLM):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        nn.Module.__init__(self)
+        assert vllm_config.speculative_config is not None
+        self.draft_model_config = vllm_config.speculative_config.draft_model_config
+        assert self.draft_model_config is not None
+        self.config = self.draft_model_config.hf_config
+        target_layer_num = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
+        self.model = AscendK3DSparkModel(
+            vllm_config=vllm_config,
+            start_layer_id=target_layer_num,
+            prefix=maybe_prefix(prefix, "model"),
+        )
+        self.lm_head: nn.Module | None = None
+        self.logits_processor = LogitsProcessor(
+            self.config.draft_vocab_size,
+            scale=getattr(self.config, "logit_scale", 1.0),
+        )
+        self.rotation_path = get_rotation_path(vllm_config)
+        self._shared_layer_rotation: torch.Tensor | None = None
+
+    def prepare_shared_layer(
+        self,
+        draft_layer: nn.Module | None,
+        target_layer: nn.Module,
+        label: str,
+    ) -> nn.Module | None:
+        rotation = self._shared_layer_rotation
+        if rotation is None:
+            return None
+        draft_layer, self._shared_layer_rotation = prepare_quarot_shared_layer(
+            draft_layer,
+            target_layer,
+            rotation,
+            label,
+        )
+        return draft_layer
+
+    def finish_shared_layer_preparation(self) -> None:
+        self._shared_layer_rotation = None
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor]],
+    ) -> set[str]:
+        """Load the per-layer KV projections used by the Ascend draft model.
+
+        Upstream additionally duplicates these weights into a CUDA-specific
+        cross-layer ``context_kv_proj``.  Ascend deliberately retains the
+        quantization-aware per-layer projections, so use vLLM's public loader
+        interface without creating that extra packed parameter.
+        """
+        loader = AutoWeightsLoader(self)
+        self._shared_layer_rotation = None
+        if self.rotation_path is not None:
+            rotation_weight = get_rotation_matrix(self.rotation_path)
+            self._shared_layer_rotation = rotation_weight
+            weights = (
+                (
+                    name,
+                    process_weight(loaded_weight, rotation_weight) if "context_proj." in name else loaded_weight,
+                )
+                for name, loaded_weight in weights
+            )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Embed draft tokens and replace multimodal placeholder positions.
+
+        vLLM 0.27 passes the target model's precomputed multimodal embeddings
+        through the speculative proposer.  K3 DSpark shares the target token
+        embedding but upstream still exposes the older text-only method
+        signature, so adapt that interface without duplicating the vision
+        tower in the draft model.
+        """
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0 or is_multimodal is None:
+            return self.model.embed_input_ids(input_ids)
+
+        # Placeholder ids are overwritten below.  Mask them before the shared
+        # vocabulary lookup so out-of-vocabulary multimodal ids are safe too.
+        text_input_ids = input_ids.masked_fill(
+            is_multimodal.to(device=input_ids.device, non_blocking=True),
+            0,
+        )
+        inputs_embeds = self.model.embed_input_ids(text_input_ids)
+        return _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )

--- a/vllm_ascend/models/kimi_k3_mtp.py
+++ b/vllm_ascend/models/kimi_k3_mtp.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kimi K3 MTP draft model for Ascend."""
+
+import copy
+
+from torch import nn
+from vllm.config import VllmConfig
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
+from vllm.model_executor.models.utils import maybe_prefix
+from vllm.models.kimi_k3.amd.mtp import (
+    KimiK3MTP as UpstreamKimiK3MTP,
+)
+from vllm.models.kimi_k3.amd.mtp import (
+    KimiK3MultiTokenPredictor as UpstreamKimiK3MultiTokenPredictor,
+)
+from vllm.models.kimi_k3.amd.mtp import (
+    KimiK3MultiTokenPredictorLayer as UpstreamKimiK3MultiTokenPredictorLayer,
+)
+from vllm.models.kimi_k3.amd.mtp import SharedHead
+
+from vllm_ascend.models.kimi_k3 import AscendKimiDecoderLayer
+
+
+class AscendKimiK3MultiTokenPredictorLayer(
+    UpstreamKimiK3MultiTokenPredictorLayer,
+):
+    def __init__(self, config, vllm_config: VllmConfig, prefix: str) -> None:
+        # The upstream constructor hard-codes the AMD decoder layer.  Build the
+        # same container with the Ascend decoder and inherit its forward path.
+        nn.Module.__init__(self)
+        self.config = config
+        self.enorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+        )
+        self.shared_head = SharedHead(
+            config=config,
+            prefix=prefix,
+            quant_config=vllm_config.quant_config,
+        )
+        block_config = copy.copy(config)
+        block_config.attn_res_block_size = None
+        self.mtp_block = AscendKimiDecoderLayer(
+            block_config,
+            vllm_config,
+            prefix=prefix,
+        )
+
+
+class AscendKimiK3MultiTokenPredictor(UpstreamKimiK3MultiTokenPredictor):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        # The upstream constructor hard-codes its predictor-layer class.
+        nn.Module.__init__(self)
+        config = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = config.num_nextn_predict_layers
+        self.layers = nn.ModuleDict(
+            {
+                str(idx): AscendKimiK3MultiTokenPredictorLayer(
+                    config,
+                    vllm_config,
+                    f"{prefix}.layers.{idx}",
+                )
+                for idx in range(
+                    self.mtp_start_layer_idx,
+                    self.mtp_start_layer_idx + self.num_mtp_layers,
+                )
+            }
+        )
+        self.embed_tokens = VocabParallelEmbedding(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+
+class AscendKimiK3MTP(UpstreamKimiK3MTP):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        nn.Module.__init__(self)
+        self.config = vllm_config.model_config.hf_text_config
+        self.quant_config = vllm_config.quant_config
+        self.model = AscendKimiK3MultiTokenPredictor(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "model"),
+        )

--- a/vllm_ascend/models/llama_eagle3.py
+++ b/vllm_ascend/models/llama_eagle3.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 from collections.abc import Iterable
@@ -5,6 +6,7 @@ from pathlib import Path
 
 import torch
 from safetensors.torch import load_file
+from torch import nn
 from vllm.config import VllmConfig
 from vllm.model_executor.models.llama_eagle3 import Eagle3LlamaForCausalLM
 
@@ -50,6 +52,36 @@ def get_rotation_matrix(rotation_path: Path | None) -> torch.Tensor:
             rotation_path,
         )
         raise e
+
+
+@torch.inference_mode()
+def prepare_quarot_shared_layer(
+    draft_layer: nn.Module | None,
+    target_layer: nn.Module,
+    rotation: torch.Tensor,
+    label: str,
+) -> tuple[nn.Module, torch.Tensor]:
+    """Create a draft-owned target layer in the unrotated hidden basis."""
+    if draft_layer is None:
+        comm_group = getattr(target_layer, "comm_group", None)
+        memo = {id(comm_group): comm_group} if comm_group is not None else None
+        draft_layer = copy.deepcopy(target_layer, memo)
+
+    rotation = rotation.to(
+        device=target_layer.weight.device,
+        dtype=torch.float32,
+    )
+    unrotated = torch.matmul(
+        target_layer.weight.data.to(torch.float32),
+        rotation.T,
+    )
+    draft_layer.weight.data.copy_(unrotated.to(draft_layer.weight.dtype))
+    logger.info(
+        "[spec_decode/quarot] Copied and aligned shared %s (weight=%s).",
+        label,
+        tuple(draft_layer.weight.shape),
+    )
+    return draft_layer, rotation
 
 
 def compute_rotation_matrix3(Q: torch.Tensor) -> torch.Tensor:

--- a/vllm_ascend/models/llama_eagle3.py
+++ b/vllm_ascend/models/llama_eagle3.py
@@ -1,10 +1,11 @@
-import copy
+import json
 import logging
 import os
 from collections.abc import Iterable
 from pathlib import Path
 
 import torch
+from safetensors import safe_open
 from safetensors.torch import load_file
 from torch import nn
 from vllm.config import VllmConfig
@@ -54,34 +55,71 @@ def get_rotation_matrix(rotation_path: Path | None) -> torch.Tensor:
         raise e
 
 
+def _find_safetensors_weight(
+    model_path: Path,
+    weight_names: tuple[str, ...],
+) -> tuple[Path, str]:
+    """Locate one target tensor without loading unrelated checkpoint shards."""
+    for index_path in sorted(model_path.glob("*.safetensors.index.json")):
+        with index_path.open(encoding="utf-8") as index_file:
+            weight_map = json.load(index_file).get("weight_map", {})
+        for weight_name in weight_names:
+            if shard_name := weight_map.get(weight_name):
+                return model_path / shard_name, weight_name
+
+    for shard_path in sorted(model_path.glob("*.safetensors")):
+        with safe_open(shard_path, framework="pt", device="cpu") as shard:
+            shard_keys = set(shard.keys())
+        for weight_name in weight_names:
+            if weight_name in shard_keys:
+                return shard_path, weight_name
+
+    raise KeyError(f"None of {weight_names!r} was found in the target checkpoint at {model_path}.")
+
+
 @torch.inference_mode()
-def prepare_quarot_shared_layer(
-    draft_layer: nn.Module | None,
-    target_layer: nn.Module,
+def load_quarot_target_layer(
+    layer: nn.Module,
+    target_model_path: Path | str,
+    weight_names: tuple[str, ...],
     rotation: torch.Tensor,
     label: str,
-) -> tuple[nn.Module, torch.Tensor]:
-    """Create a draft-owned target layer in the unrotated hidden basis."""
-    if draft_layer is None:
-        comm_group = getattr(target_layer, "comm_group", None)
-        memo = {id(comm_group): comm_group} if comm_group is not None else None
-        draft_layer = copy.deepcopy(target_layer, memo)
+) -> None:
+    """Load one target vocab shard into the draft's unrotated hidden basis."""
+    target_model_path = Path(target_model_path)
+    shard_path, weight_name = _find_safetensors_weight(
+        target_model_path,
+        weight_names,
+    )
+    shard_indices = getattr(layer, "shard_indices", None)
+    if shard_indices is None:
+        start_index = 0
+        end_index = layer.weight.shape[0]
+    else:
+        start_index = shard_indices.org_vocab_start_index
+        end_index = shard_indices.org_vocab_end_index
+
+    with safe_open(shard_path, framework="pt", device="cpu") as shard:
+        target_weight = shard.get_slice(weight_name)[start_index:end_index]
 
     rotation = rotation.to(
-        device=target_layer.weight.device,
+        device=layer.weight.device,
         dtype=torch.float32,
     )
-    unrotated = torch.matmul(
-        target_layer.weight.data.to(torch.float32),
-        rotation.T,
+    target_weight = target_weight.to(
+        device=layer.weight.device,
+        dtype=torch.float32,
     )
-    draft_layer.weight.data.copy_(unrotated.to(draft_layer.weight.dtype))
+    aligned_weight = torch.matmul(target_weight, rotation.T)
+    loaded_rows = aligned_weight.shape[0]
+    layer.weight.data[:loaded_rows].copy_(aligned_weight.to(layer.weight.dtype))
+    layer.weight.data[loaded_rows:].zero_()
     logger.info(
-        "[spec_decode/quarot] Copied and aligned shared %s (weight=%s).",
+        "[spec_decode/quarot] Loaded and aligned %s from %s (%s).",
         label,
-        tuple(draft_layer.weight.shape),
+        shard_path.name,
+        tuple(layer.weight.shape),
     )
-    return draft_layer, rotation
 
 
 def compute_rotation_matrix3(Q: torch.Tensor) -> torch.Tensor:

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from pathlib import Path
 
 import torch
 from torch import nn
@@ -10,9 +11,18 @@ from vllm.model_executor.models.utils import AutoWeightsLoader, maybe_prefix
 from vllm_ascend.models.llama_eagle3 import (
     get_rotation_matrix,
     get_rotation_path,
-    prepare_quarot_shared_layer,
+    load_quarot_target_layer,
 )
 from vllm_ascend.utils import vllm_version_is
+
+TARGET_EMBED_WEIGHT_NAMES = (
+    "language_model.model.embed_tokens.weight",
+    "model.embed_tokens.weight",
+)
+TARGET_LM_HEAD_WEIGHT_NAMES = (
+    "language_model.lm_head.weight",
+    "lm_head.weight",
+)
 
 
 # Process the first linear weight with rotation matrix, if the target model uses rotary quantization
@@ -71,27 +81,7 @@ class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
                 prefix=maybe_prefix(model_prefix, "confidence_head"),
             )
         self.rotation_path = get_rotation_path(vllm_config) if vllm_config.quant_config is not None else None
-        self._shared_layer_rotation: torch.Tensor | None = None
-
-    def prepare_shared_layer(
-        self,
-        draft_layer: nn.Module | None,
-        target_layer: nn.Module,
-        label: str,
-    ) -> nn.Module | None:
-        rotation = self._shared_layer_rotation
-        if rotation is None:
-            return None
-        draft_layer, self._shared_layer_rotation = prepare_quarot_shared_layer(
-            draft_layer,
-            target_layer,
-            rotation,
-            label,
-        )
-        return draft_layer
-
-    def finish_shared_layer_preparation(self) -> None:
-        self._shared_layer_rotation = None
+        self.target_model_path = Path(vllm_config.model_config.model)
 
     @staticmethod
     def _get_confidence_relative_name(
@@ -114,11 +104,12 @@ class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         all_weights = list(weights)
-        self._shared_layer_rotation = None
+        includes_embed_tokens = any("embed_tokens" in name for name, _ in all_weights)
+        includes_lm_head = any("lm_head" in name for name, _ in all_weights)
+        rotation_weight = None
         if self.rotation_path is not None:
             processed_weights: list[tuple[str, torch.Tensor]] = []
             rotation_weight = get_rotation_matrix(self.rotation_path)
-            self._shared_layer_rotation = rotation_weight
             for name, loaded_weight in all_weights:
                 if "fc." in name:
                     loaded_weight = process_weight(loaded_weight, rotation_weight)
@@ -128,37 +119,55 @@ class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
         if not vllm_version_is("0.27.1"):
             # main (cdc4824a21): upstream load_weights already manages
             # confidence_head (vllm#47808).
-            super().load_weights(all_weights)
-            return
+            result = super().load_weights(all_weights)
+        else:
+            base_weights: list[tuple[str, torch.Tensor]] = []
+            confidence_weights: list[tuple[str, torch.Tensor]] = []
 
-        base_weights: list[tuple[str, torch.Tensor]] = []
-        confidence_weights: list[tuple[str, torch.Tensor]] = []
+            for name, loaded_weight in all_weights:
+                confidence_name = self._get_confidence_relative_name(name)
+                if confidence_name is None:
+                    base_weights.append((name, loaded_weight))
+                else:
+                    confidence_weights.append((confidence_name, loaded_weight))
 
-        for name, loaded_weight in all_weights:
-            confidence_name = self._get_confidence_relative_name(name)
-            if confidence_name is None:
-                base_weights.append((name, loaded_weight))
-            else:
-                confidence_weights.append((confidence_name, loaded_weight))
+            result = super().load_weights(base_weights)
 
-        super().load_weights(base_weights)
+            if self.enable_confidence_head:
+                if not confidence_weights:
+                    self.enable_confidence_head = False
+                else:
+                    confidence_weights.sort(key=lambda item: item[0])
+                    loaded_parameters = AutoWeightsLoader(self.model.confidence_head).load_weights(confidence_weights)
+                    expected_parameters = set(self.model.confidence_head.state_dict().keys())
+                    missing_parameters = expected_parameters - loaded_parameters
 
-        if not self.enable_confidence_head:
-            return
+                    if missing_parameters:
+                        raise RuntimeError(
+                            "Failed to load all confidence-head "
+                            "parameters. Missing: "
+                            f"{sorted(missing_parameters)}; loaded: "
+                            f"{sorted(loaded_parameters)}"
+                        )
 
-        if not confidence_weights:
-            self.enable_confidence_head = False
-            return
+        if rotation_weight is not None:
+            if not includes_embed_tokens:
+                load_quarot_target_layer(
+                    self.model.embed_tokens,
+                    self.target_model_path,
+                    TARGET_EMBED_WEIGHT_NAMES,
+                    rotation_weight,
+                    "draft embed_tokens.weight",
+                )
+                self.has_own_embed_tokens = True
+            if not includes_lm_head:
+                load_quarot_target_layer(
+                    self.lm_head,
+                    self.target_model_path,
+                    TARGET_LM_HEAD_WEIGHT_NAMES,
+                    rotation_weight,
+                    "draft lm_head.weight",
+                )
+                self.has_own_lm_head = True
 
-        confidence_weights.sort(key=lambda item: item[0])
-        loaded_parameters = AutoWeightsLoader(self.model.confidence_head).load_weights(confidence_weights)
-        expected_parameters = set(self.model.confidence_head.state_dict().keys())
-        missing_parameters = expected_parameters - loaded_parameters
-
-        if missing_parameters:
-            raise RuntimeError(
-                "Failed to load all confidence-head "
-                "parameters. Missing: "
-                f"{sorted(missing_parameters)}; loaded: "
-                f"{sorted(loaded_parameters)}"
-            )
+        return result

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -7,7 +7,11 @@ from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
 from vllm.model_executor.models.utils import AutoWeightsLoader, maybe_prefix
 
-from vllm_ascend.models.llama_eagle3 import get_rotation_matrix, get_rotation_path
+from vllm_ascend.models.llama_eagle3 import (
+    get_rotation_matrix,
+    get_rotation_path,
+    prepare_quarot_shared_layer,
+)
 from vllm_ascend.utils import vllm_version_is
 
 
@@ -67,6 +71,27 @@ class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
                 prefix=maybe_prefix(model_prefix, "confidence_head"),
             )
         self.rotation_path = get_rotation_path(vllm_config) if vllm_config.quant_config is not None else None
+        self._shared_layer_rotation: torch.Tensor | None = None
+
+    def prepare_shared_layer(
+        self,
+        draft_layer: nn.Module | None,
+        target_layer: nn.Module,
+        label: str,
+    ) -> nn.Module | None:
+        rotation = self._shared_layer_rotation
+        if rotation is None:
+            return None
+        draft_layer, self._shared_layer_rotation = prepare_quarot_shared_layer(
+            draft_layer,
+            target_layer,
+            rotation,
+            label,
+        )
+        return draft_layer
+
+    def finish_shared_layer_preparation(self) -> None:
+        self._shared_layer_rotation = None
 
     @staticmethod
     def _get_confidence_relative_name(
@@ -89,9 +114,11 @@ class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         all_weights = list(weights)
+        self._shared_layer_rotation = None
         if self.rotation_path is not None:
             processed_weights: list[tuple[str, torch.Tensor]] = []
             rotation_weight = get_rotation_matrix(self.rotation_path)
+            self._shared_layer_rotation = rotation_weight
             for name, loaded_weight in all_weights:
                 if "fc." in name:
                     loaded_weight = process_weight(loaded_weight, rotation_weight)

--- a/vllm_ascend/ops/mm_encoder_attention.py
+++ b/vllm_ascend/ops/mm_encoder_attention.py
@@ -166,8 +166,8 @@ class AscendMMEncoderAttention(MMEncoderAttention):
     ) -> torch.Tensor:
         fia_kwargs = dict(
             query=query,
-            key=key,
-            value=value,
+            key=key.contiguous(),
+            value=value.contiguous(),
             atten_mask=None,
             block_table=None,
             input_layout="TND",

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -665,6 +665,17 @@ class NPUModelRunner(GPUModelRunner):
                 return tuple(i + 1 for i in dspark_layer_ids)
         return None
 
+    def _draft_uses_qwen3_gqa_dspark(self) -> bool:
+        """Return whether the draft expects Kimi's materialized residual."""
+        if self.speculative_config is None or not self.speculative_config.use_dspark():
+            return False
+        draft_model_config = self.speculative_config.draft_model_config
+        if draft_model_config is None:
+            return False
+        hf_config = draft_model_config.hf_config
+        architectures = getattr(hf_config, "architectures", ()) or ()
+        return getattr(hf_config, "model_type", None) == "qwen3" and "Qwen3DSparkModel" in architectures
+
     def _use_aclgraph(self) -> bool:
         return (
             self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
@@ -3551,6 +3562,19 @@ class NPUModelRunner(GPUModelRunner):
                 if not aux_layers:
                     aux_layers = self.model.get_eagle3_default_aux_hidden_state_layers()
                 self.model.set_aux_hidden_state_layers(aux_layers)
+                if self.speculative_config.use_dspark():
+                    set_capture_mode = getattr(
+                        self.model,
+                        "set_dspark_aux_capture_materialized",
+                        None,
+                    )
+                    if set_capture_mode is not None:
+                        materialized = self._draft_uses_qwen3_gqa_dspark()
+                        set_capture_mode(materialized)
+                        logger.info(
+                            "Kimi K3 DSpark auxiliary capture uses %s stream.",
+                            "materialized GQA" if materialized else "raw MLA",
+                        )
 
                 if pp_group.world_size > 1:
                     inner_model = self.model


### PR DESCRIPTION
### What this PR does / why we need it?

- Registers Kimi K3 text, multimodal, MTP, and DSpark model architectures for Ascend.
- Keeps ViT FIA key and value inputs contiguous at the operator boundary for multimodal execution.
- Composes the Ascend decoder from the KDA, MLA, SiTU MoE, and attention-residual implementations.
- Loads merged KDA gates and quantization-aware DSpark context projections through model loading hooks.
- Loads and retains the QuaRot matrix in K3/Qwen DSpark modeling, then prepares draft-owned unrotated embedding and LM-head weights when those layers must be shared with the target.
- Selects the GQA or MLA DSpark auxiliary execution stream in the model runner.
- Adds a five-layer, 16-expert nightly fixture and focused adapter tests.

### Dependencies

Merge after #14426, #14597, #14598, #14839, #14840, and #14599.

### How was this patch tested?

- `git diff --check`
- Python syntax compilation for changed implementation and test files
- Focused model-adapter, QuaRot shared-layer, and model-runner tests
- Nightly execution-parity coverage for TP/EP, decode graphs, prefix hits, reset behavior, block-size boundaries, complete output, and finite token log probabilities
- Integrated text, multimodal, tools, streaming, QuaRot, Prefix Cache, and ACLGraph serving coverage

### Does this PR introduce any user-facing change?

Yes. Kimi K3 checkpoints resolve to the Ascend text, multimodal, MTP, and DSpark model implementations.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
