### PR TITLE
[BugFix] Fix _dummy_run warmup mismatch when using --language-model-o…

### DIFF
--- a/tests/e2e/singlecard/test_vlm.py
+++ b/tests/e2e/singlecard/test_vlm.py
@@ -65,6 +65,25 @@ def test_multimodal_vl(vl_config):
 
 
 @patch.dict(os.environ, {"VLLM_WORKER_MULTIPROC_METHOD": "spawn"})
+def test_multimodal_vl_language_model_only():
+    example_prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+    max_tokens = 5
+    with VllmRunner(
+        "Qwen/Qwen3-VL-8B-Instruct",
+        max_model_len=4096,
+        cudagraph_capture_sizes=[1, 2, 4, 8],
+        gpu_memory_utilization=0.90,
+        language_model_only=True,
+    ) as vllm_model:
+        vllm_model.generate_greedy(example_prompts, max_tokens)
+
+
+@patch.dict(os.environ, {"VLLM_WORKER_MULTIPROC_METHOD": "spawn"})
 def test_multimodal_audio():
     audio_prompt = "".join([f"Audio {idx + 1}: <|audio_bos|><|AUDIO|><|audio_eos|>\n" for idx in range(2)])
     question = "What sport and what nursery rhyme are referenced?"

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2428,7 +2428,7 @@ class NPUModelRunner(GPUModelRunner):
         ):
             # Make sure padding doesn't exceed max_num_tokens
             assert num_tokens_padded <= self.max_num_tokens
-            if self.is_multimodal_model and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
+            if self.supports_mm_inputs and not self.model_config.is_encoder_decoder or self.enable_prompt_embeds:
                 input_ids = None
                 inputs_embeds = self.inputs_embeds.gpu[:num_tokens_padded]
             else:


### PR DESCRIPTION
…nly (#8556)

- Backport from #8556 to fix `_dummy_run` warmup using `self.is_multimodal_model` while `_preprocess` uses `self.supports_mm_inputs`, causing torch.compile crash when `--language-model-only` is set
- Add single-card e2e test for `language_model_only=True` on Qwen3-VL-8B-Instruct

When `--language-model-only` is set, `is_multimodal_model` remains `True` (the model architecture is still multimodal) but `supports_mm_inputs` becomes `False` (all modality limits are 0). The `_dummy_run` warmup used `is_multimodal_model` to choose the embeddings path (`inpxuts_embeds=tensor`), while `_preprocess` used `supports_mm_inputs` to choose the token-ids path (`input_ids=tensor`). This mismatch caused `torch.compile`/dynamo to crash with `AttributeError: 'NoneType' object has no attribute 'size'` on the first inference request.

Now we can use --language-model-only to load only the language component of a multimodal model, reducing HBM usage.

Changed the condition in `_dummy_run` (line 2574 of `model_runner_v1.py`) from `self.is_multimodal_model` to `self.supports_mm_inputs` to align with `_preprocess`.
- [x] API compatibility test: 100/100 stress test passed
- [x] Single-card e2e test: `test_multimodal_vl_language_model_only` with Qwen3-VL-8B-Instruct

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/
