### PR TITLE
[Doc] Align CPP tutorial with PD disaggregation scenario and fix format

### DIFF
--- a/docs/source/developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.md
+++ b/docs/source/developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.md
@@ -1,6 +1,6 @@
 # Dynamic Chunked Pipeline Parallel (CPP)
 
-TL;DR CPP uses profiling-based dynamic chunking to equalize per-chunk latency and eliminate pipeline bubbles in PP scenarios.
+CPP uses profiling-based dynamic chunking to equalize per-chunk latency and eliminate pipeline bubbles in PP scenarios.
 
 ## Background
 

--- a/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
+++ b/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
@@ -358,6 +358,17 @@ Assume the P server IP is `192.0.0.1`, and the D server IPs are `192.0.0.3` (dec
 
     To verify CPP is active on the P node, check the startup logs for profiling-related messages such as `profiling_chunk_config` enabled and chunk size calculation outputs.
 
+> **Key Parameters**
+>
+> - `--pipeline-parallel-size 2`: Enables Pipeline Parallelism (required, P node only)
+> - `--enable-chunked-prefill`: Enables Chunked Prefill (required, P node only)
+> - `--max-num-batched-tokens 32768`: Initial chunk size (recommended for 128K sequences)
+> - `profiling_chunk_config.enabled`: Enables Dynamic Chunked Pipeline Parallel
+> - `profiling_chunk_config.smooth_factor`:  Smoothing factor (0 < x ≤ 1.0). Higher values trust dynamic prediction more
+> - `profiling_chunk_config.min_chunk`: Minimum chunk size for dynamic calculation. Should be smaller than `max-num-batched-tokens`
+> - `profiling_chunk_config.need_timing`: Enable/disable Online Calibration
+> - `profiling_chunk_config.max_fit_chunk`: Number of chunk-time data for Online Calibration. Should be more when profiling failed
+
 > **Key points for PD disaggregation with CPP:**
 >
 > - CPP (`profiling_chunk_config.enabled`, `--pipeline-parallel-size > 1`) is configured **only on the P node**.
@@ -366,20 +377,9 @@ Assume the P server IP is `192.0.0.1`, and the D server IPs are `192.0.0.3` (dec
 >     - [PD Disaggregation Single Node](pd_disaggregation_mooncake_single_node.md)
 >     - [PD Disaggregation Multi Node](pd_disaggregation_mooncake_multi_node.md)
 
-### Key Parameters
-
-- `--pipeline-parallel-size 2`: Enables Pipeline Parallelism (required, P node only)
-- `--enable-chunked-prefill`: Enables Chunked Prefill (required, P node only)
-- `--max-num-batched-tokens 32768`: Initial chunk size (recommended for 128K sequences)
-- `profiling_chunk_config.enabled`: Enables Dynamic Chunked Pipeline Parallel
-- `profiling_chunk_config.smooth_factor`:  Smoothing factor (0 < x ≤ 1.0). Higher values trust dynamic prediction more
-- `profiling_chunk_config.min_chunk`: Minimum chunk size for dynamic calculation. Should be smaller than `max-num-batched-tokens`
-- `profiling_chunk_config.need_timing`: Enable/disable Online Calibration
-- `profiling_chunk_config.max_fit_chunk`: Number of chunk-time data for Online Calibration. Should be more when profiling failed
-
 For configuration details, see the [Feature Guide](../../user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md).
 
-### Online Calibration
+## Online Calibration
 
 For optimal performance, online calibrate with real data before production:
 

--- a/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
+++ b/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
@@ -2,11 +2,22 @@
 
 ## Getting Started
 
-vLLM-Ascend supports Dynamic Chunked Pipeline Parallel (CPP) for optimizing prefill performance in Pipeline Parallelism scenarios. This feature is supported starting from version `v0.19.1rc1`. This guide demonstrates deployment with DeepSeek-V3.1 on 1 Atlas 800T A3 server (64G × 16).
+vLLM-Ascend supports Dynamic Chunked Pipeline Parallel (CPP) for optimizing prefill performance in Pipeline Parallelism scenarios. This feature is supported starting from version `v0.19.1rc1`.
+
+!!! important
+
+    **CPP is designed to be used on the P (Prefiller) node in Prefill-Decode (PD) disaggregation deployments.** The D (Decoder) node does not require CPP configuration. By dynamically calculating the optimal chunk size based on profiling data, CPP significantly reduces Time-To-First-Token (TTFT) for long sequences on P nodes.
+
+    This guide demonstrates PD disaggregation deployment with DeepSeek-V3.1 on 3 Atlas 800T A3 servers (64G × 16): one server acts as the Prefiller (P node, with CPP enabled) and two servers act as the Decoder (D nodes, without CPP, DP32 standard configuration).
 
 For configuration details, see the [Feature Guide](../../user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md).
 
 For design details, see the [Design Document](../../developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.md).
+
+For complete PD disaggregation setup instructions (environment verification, Mooncake installation, proxy deployment), see:
+
+- [PD Disaggregation Single Node (Qwen2.5-VL)](pd_disaggregation_mooncake_single_node.md)
+- [PD Disaggregation Multi Node (DeepSeek)](pd_disaggregation_mooncake_multi_node.md)
 
 ## Environment Preparation
 
@@ -17,6 +28,8 @@ For design details, see the [Design Document](../../developer_guide/Design_Docum
 Download to shared directory such as `/mnt/weight/`
 
 ### Run with Docker
+
+Start a Docker container on each node.
 
 ```bash
 export IMAGE=m.daocloud.io/quay.io/ascend/vllm-ascend:{{ vllm_ascend_version }}
@@ -56,59 +69,307 @@ docker run --rm \
 -it $IMAGE bash
 ```
 
+### Install Mooncake
+
+Mooncake is required for PD disaggregation KV cache transfer. Refer to [PD Disaggregation Multi Node - Install Mooncake](pd_disaggregation_mooncake_multi_node.md#install-mooncake) for installation and compilation steps.
+
 ## Deployment
 
-### Startup Script
+!!! important
 
-```shell
-#!/bin/sh
-unset https_proxy
-unset http_proxy
+    In a PD disaggregation setup, enable CPP **only on the P (Prefiller) node**. The D (Decoder) node runs without pipeline parallelism and focuses on low-latency token-by-token decoding.
 
-export OMP_PROC_BIND=false
-export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=2048
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export HCCL_OP_EXPANSION_MODE="AIV"
-export VLLM_USE_V1=1
-export TASK_QUEUE_ENABLE=1
-export ASCEND_LAUNCH_BLOCKING=0
-export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
-export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-export VLLM_ASCEND_ENABLE_FUSED_MC2=1
-export VLLM_RPC_TIMEOUT=3600000
-export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
-export HCCL_EXEC_TIMEOUT=204
-export HCCL_CONNECT_TIMEOUT=120
+    - It is recommended to use `MooncakeConnectorV1` as the `kv_connector`, as it provides more comprehensive support for PP.
+    - It is recommended **not** to enable `async-scheduling` on P nodes of PP, as it may cause performance degradation in the prefill stage.
 
-vllm serve /mnt/weight/DeepSeek-V3.1-w8a8 \
-  --host 0.0.0.0 \
-  --port 8003 \
-  --served-model-name model \
-  --data-parallel-size 1 \
-  --tensor-parallel-size 8 \
-  --pipeline-parallel-size 2 \
-  --enable-expert-parallel \
-  --max-num-seqs 32 \
-  --max-model-len 131072 \
-  --max-num-batched-tokens 32768 \
-  --gpu-memory-utilization 0.9 \
-  --enable-chunked-prefill \
-  --no-enable-prefix-caching \
-  --trust-remote-code \
-  --quantization ascend \
-  --additional-config '{
-    "profiling_chunk_config":{"enabled":true, "smooth_factor":1.0, "min_chunk":4096}
-  }'
-```
+Assume the P server IP is `192.0.0.1`, and the D server IPs are `192.0.0.3` (decoder 1) and `192.0.0.4` (decoder 2).
 
-The server has started successfully if the log outputs: `vLLM API server started on 0.0.0.0:8003`.
+=== "P Node (Prefiller — with CPP)"
+
+    ```shell
+    #!/bin/sh
+    unset https_proxy
+    unset http_proxy
+
+    # For nic_name, run the `ifconfig` command to check the network adapter whose IP address is the same as that of the local host.
+    nic_name="eth0"
+    local_ip="192.0.0.1"
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+
+    export OMP_PROC_BIND=false
+    export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
+    export OMP_NUM_THREADS=1
+    export HCCL_BUFFSIZE=2048
+    export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+    export HCCL_OP_EXPANSION_MODE="AIV"
+    export VLLM_USE_V1=1
+    export TASK_QUEUE_ENABLE=1
+    export ASCEND_LAUNCH_BLOCKING=0
+    export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
+    export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
+    export VLLM_RPC_TIMEOUT=3600000
+    export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=30000
+    export HCCL_EXEC_TIMEOUT=204
+    export HCCL_CONNECT_TIMEOUT=120
+
+    vllm serve /mnt/weight/DeepSeek-V3.1-w8a8 \
+      --host 0.0.0.0 \
+      --port 8003 \
+      --served-model-name model \
+      --tensor-parallel-size 8 \
+      --pipeline-parallel-size 2 \
+      --enable-expert-parallel \
+      --max-num-seqs 32 \
+      --max-model-len 131072 \
+      --max-num-batched-tokens 32768 \
+      --gpu-memory-utilization 0.9 \
+      --enable-chunked-prefill \
+      --enable-prefix-caching \
+      --no-async-scheduling \
+      --trust-remote-code \
+      --quantization ascend \
+      --additional-config '{
+        "scheduler_config": {
+          "profiling_chunk_config": {"enabled":true, "smooth_factor":1.0, "min_chunk":4096}
+        }
+      }' \
+      --kv-transfer-config \
+      '{
+        "kv_connector": "MooncakeConnectorV1",
+        "kv_role": "kv_producer",
+        "kv_port": "36000",
+        "engine_id": "0",
+        "kv_connector_extra_config": {
+          "prefill": {
+            "pp_size": 2,
+            "dp_size": 1,
+            "tp_size": 8
+          },
+          "decode": {
+            "dp_size": 32,
+            "tp_size": 1
+          }
+        }
+      }'
+    ```
+
+    The server has started successfully if the log outputs: `vLLM API server started on 0.0.0.0:8003`.
+
+=== "D Node (Decoder — without CPP)"
+
+    The D nodes use `launch_online_dp.py` to start multiple DP instances per node. Obtain the launcher and template scripts from the repository:
+
+    - [launch_online_dp.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/external_online_dp/launch_online_dp.py)
+    - [run_dp_template.sh](https://github.com/vllm-project/vllm-ascend/blob/main/examples/external_online_dp/run_dp_template.sh)
+
+    Modify `run_dp_template.sh` on each D node. The launcher passes seven positional arguments (`$1`–`$7`) to the template. For a full explanation of each parameter, refer to [PD Disaggregation Multi Node](pd_disaggregation_mooncake_multi_node.md#run_dp_template-sh).
+
+    === "Decoder node 1 (192.0.0.3)"
+
+        ```shell
+        #!/bin/sh
+        unset https_proxy
+        unset http_proxy
+
+        nic_name="eth0"  # network card name
+        local_ip="192.0.0.3"
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=600
+        export TASK_QUEUE_ENABLE=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_USE_V1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        vllm serve /mnt/weight/DeepSeek-V3.1-w8a8 \
+          --host 0.0.0.0 \
+          --port $2 \
+          --data-parallel-size $3 \
+          --data-parallel-rank $4 \
+          --data-parallel-address $5 \
+          --data-parallel-rpc-port $6 \
+          --tensor-parallel-size $7 \
+          --enable-expert-parallel \
+          --seed 1024 \
+          --served-model-name model \
+          --max-model-len 131072 \
+          --max-num-batched-tokens 256 \
+          --max-num-seqs 40 \
+          --trust-remote-code \
+          --gpu-memory-utilization 0.94 \
+          --quantization ascend \
+          --no-enable-prefix-caching \
+          --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+          --additional-config '{
+            "scheduler_config": {"recompute_scheduler_enable": true},
+            "multistream_overlap_shared_expert": true,
+            "finegrained_tp_config": {"lmhead_tensor_parallel_size": 16}
+          }' \
+          --kv-transfer-config \
+          '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "36000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+              "prefill": {
+                "pp_size": 2,
+                "dp_size": 1,
+                "tp_size": 8
+              },
+              "decode": {
+                "dp_size": 32,
+                "tp_size": 1
+              }
+            }
+          }'
+        ```
+
+    === "Decoder node 2 (192.0.0.4)"
+
+        ```shell
+        #!/bin/sh
+        unset https_proxy
+        unset http_proxy
+
+        nic_name="eth0"  # network card name
+        local_ip="192.0.0.4"
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=10
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=600
+        export TASK_QUEUE_ENABLE=1
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export VLLM_USE_V1=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+        vllm serve /mnt/weight/DeepSeek-V3.1-w8a8 \
+          --host 0.0.0.0 \
+          --port $2 \
+          --data-parallel-size $3 \
+          --data-parallel-rank $4 \
+          --data-parallel-address $5 \
+          --data-parallel-rpc-port $6 \
+          --tensor-parallel-size $7 \
+          --enable-expert-parallel \
+          --seed 1024 \
+          --served-model-name model \
+          --max-model-len 131072 \
+          --max-num-batched-tokens 256 \
+          --max-num-seqs 40 \
+          --trust-remote-code \
+          --gpu-memory-utilization 0.94 \
+          --quantization ascend \
+          --no-enable-prefix-caching \
+          --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+          --additional-config '{
+            "scheduler_config": {"recompute_scheduler_enable": true},
+            "multistream_overlap_shared_expert": true,
+            "finegrained_tp_config": {"lmhead_tensor_parallel_size": 16}
+          }' \
+          --kv-transfer-config \
+          '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "36000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+              "prefill": {
+                "pp_size": 2,
+                "dp_size": 1,
+                "tp_size": 8
+              },
+              "decode": {
+                "dp_size": 32,
+                "tp_size": 1
+              }
+            }
+          }'
+        ```
+
+    Start the service on each D node:
+
+    ```bash
+    # on 192.0.0.3 (decoder 1, DP rank 0–15)
+    python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 16 --dp-rank-start 0 --dp-address 192.0.0.3 --dp-rpc-port 12321 --vllm-start-port 7100
+    # on 192.0.0.4 (decoder 2, DP rank 16–31)
+    python launch_online_dp.py --dp-size 32 --tp-size 1 --dp-size-local 16 --dp-rank-start 16 --dp-address 192.0.0.3 --dp-rpc-port 12321 --vllm-start-port 7100
+    ```
+
+=== "Example Proxy for Deployment"
+
+    Run a proxy server on the same node with the prefiller service instance. You can get the proxy program in the repository's examples: [load\_balance\_proxy\_server\_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
+
+    ```shell
+    python load_balance_proxy_server_example.py \
+        --host 192.0.0.1 \
+        --port 8080 \
+        --prefiller-hosts 192.0.0.1 \
+        --prefiller-port 8003 \
+        --decoder-hosts \
+          192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 \
+          192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 192.0.0.3 \
+          192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 \
+          192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 192.0.0.4 \
+        --decoder-ports \
+          7100 7101 7102 7103 7104 7105 7106 7107 7108 7109 7110 7111 7112 7113 7114 7115 \
+          7100 7101 7102 7103 7104 7105 7106 7107 7108 7109 7110 7111 7112 7113 7114 7115
+    ```
+
+    | Parameter | Meaning |
+    | --- | --- |
+    | --port | Port of proxy |
+    | --prefiller-port | All ports of prefill |
+    | --decoder-ports | All ports of decoder |
+
+=== "Verification"
+
+    Check service health using the proxy server endpoint.
+
+    ```shell
+    curl http://192.0.0.1:8080/v1/chat/completions \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "model",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "You are a useful AI assistant."
+                },
+                {
+                    "role": "user",
+                    "content": "Question: Janet'\''s ducks lay 16 eggs per day. She eats three for breakfast and bakes muffins with four. She sells the remainder for $2 each. How much does she make?\nAnswer:"
+                }
+            ],
+            "max_completion_tokens": 100,
+            "temperature": 0
+        }'
+    ```
+
+    To verify CPP is active on the P node, check the startup logs for profiling-related messages such as `profiling_chunk_config` enabled and chunk size calculation outputs.
+
+> **Key points for PD disaggregation with CPP:**
+>
+> - CPP (`profiling_chunk_config.enabled`, `--pipeline-parallel-size > 1`) is configured **only on the P node**.
+> - The D nodes run without pipeline parallelism (DP32 TP1 standard configuration) — they focus on low-latency token-by-token decoding.
+> - For complete PD disaggregation setup instructions (environment verification, Mooncake installation, proxy deployment), see:
+>     - [PD Disaggregation Single Node](pd_disaggregation_mooncake_single_node.md)
+>     - [PD Disaggregation Multi Node](pd_disaggregation_mooncake_multi_node.md)
 
 ### Key Parameters
 
-- `--pipeline-parallel-size 2`: Enables Pipeline Parallelism (required)
-- `--enable-chunked-prefill`: Enables Chunked Prefill (required)
+- `--pipeline-parallel-size 2`: Enables Pipeline Parallelism (required, P node only)
+- `--enable-chunked-prefill`: Enables Chunked Prefill (required, P node only)
 - `--max-num-batched-tokens 32768`: Initial chunk size (recommended for 128K sequences)
 - `profiling_chunk_config.enabled`: Enables Dynamic Chunked Pipeline Parallel
 - `profiling_chunk_config.smooth_factor`:  Smoothing factor (0 < x ≤ 1.0). Higher values trust dynamic prediction more
@@ -164,7 +425,7 @@ Refer to [Using AISBench](../../developer_guide/evaluation/using_ais_bench.md) f
 
 Refer to [Using AISBench for performance evaluation](../../developer_guide/evaluation/using_ais_bench.md#execute-performance-evaluation) for details.
 
-To evaluate the effectiveness of Dynamic Chunked Pipeline Parallel in long sequence LLM inference scenarios, we use **DeepSeek-V3.1-W8A8** and **Qwen3-235B**, deploy prefill instance in Ascend Atlas 800T A3 server (64G × 16), the configuration and performance data are as follows.
+To evaluate the effectiveness of Dynamic Chunked Pipeline Parallel in PD disaggregation long sequence LLM inference scenarios, we use **DeepSeek-V3.1-W8A8** and **Qwen3-235B**, deploy prefill instance in Ascend Atlas 800T A3 server (64G × 16), the configuration and performance data are as follows.
 
 **Fixed-length requests, concurrency=1**:
 
@@ -172,13 +433,13 @@ To evaluate the effectiveness of Dynamic Chunked Pipeline Parallel in long seque
 
     | Configuration | CPP <br> (Dynamic Chunk, <br> chunksize=32k) | PP <br>(Static Chunk, <br> chunksize=32k) |
     | ----------------------------- | ------------------------- | ------------------------- |
-    | Input length  128k    | TTFT: 22.5s | TTFT: 27.0s |
+    | Input length 128k | TTFT: 22.5s | TTFT: 27.0s |
 
 - Qwen3-235B:
 
     | Configuration | CPP <br> (Dynamic Chunk, <br> chunksize=32k) | PP <br>(Static Chunk, <br> chunksize=32k) |
     | ----------------------------- | ------------------------- | ------------------------- |
-    | Input length  256k    | TTFT: 53.5s | TTFT: 61.4s |
+    | Input length 256k | TTFT: 53.5s | TTFT: 61.4s |
 
 **Variable-length requests, concurrency=4**:
 
@@ -186,6 +447,6 @@ To evaluate the effectiveness of Dynamic Chunked Pipeline Parallel in long seque
 
     | Configuration | 4k~64k Input, mean=32k, std=32k <br> prefix hit rate=99% |
     | ----------------------------- | ------------------------- |
-    |  CPP2TP8   | Input throughput: 22424 tps/card |
-    |  DP2TP8   | Input throughput: 16150 tps/card |
-    |  TP16   | Input throughput: 18875 tps/card |
+    | CPP2TP8 | Input throughput: 22424 tps/card |
+    | DP2TP8 | Input throughput: 16150 tps/card |
+    | TP16 | Input throughput: 18875 tps/card |

--- a/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
+++ b/docs/source/tutorials/features/dynamic_chunked_pipeline_parallel.md
@@ -368,7 +368,7 @@ Assume the P server IP is `192.0.0.1`, and the D server IPs are `192.0.0.3` (dec
 > - `profiling_chunk_config.min_chunk`: Minimum chunk size for dynamic calculation. Should be smaller than `max-num-batched-tokens`
 > - `profiling_chunk_config.need_timing`: Enable/disable Online Calibration
 > - `profiling_chunk_config.max_fit_chunk`: Number of chunk-time data for Online Calibration. Should be more when profiling failed
-
+>
 > **Key points for PD disaggregation with CPP:**
 >
 > - CPP (`profiling_chunk_config.enabled`, `--pipeline-parallel-size > 1`) is configured **only on the P node**.

--- a/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+++ b/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
@@ -19,7 +19,7 @@ Dynamic Chunked Pipeline Parallel (CPP) is a profiling-based dynamic chunking st
 
 - **PD disaggregation P node**: Enables CPP on the Prefiller node to optimize long-sequence prefill with Pipeline Parallelism. The Decoder node does not need CPP.
 - **Variable-length sequence serving**: PP does not introduce degradation on short sequences, and gains benefits through dynamic chunks on long sequences.
-- **Ultra-long sequence inference**: For sequences exceeding single-machine memory capacity (e.g., 1M tokens), dynamic chunking significantly reduces pipeline idle time.
+- **Long sequence inference**: For sequences exceeding single-machine memory capacity, dynamic chunking significantly reduces pipeline idle time.
 
 ## Supported Scenarios
 

--- a/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+++ b/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
@@ -195,7 +195,7 @@ Note:
 
 The `--max-num-batched-tokens` and `smooth_factor` parameters need to be adjusted. It is recommended that you adjust the `--max-num-batched-tokens` parameter first and then adjust the `smooth_factor`.
 
-#### --max-num-batched-tokens
+**1. --max-num-batched-tokens**
 
 **Notably, the TTFT of CPP is very sensitive to `--max-num-batched-tokens` (considered as the initial chunk size for dynamic chunk calculation).** Because if it is too large, it will introduce significant computational waste, and if it is too small, it will lead to a decrease in operator efficiency.
 
@@ -208,7 +208,7 @@ Meanwhile, to leave enough room for dynamic adjustments, we recommend that the l
 | 64k             | 20480                    |
 | 128k            | 32768                    |
 
-#### smooth_factor
+**2. smooth_factor**
 
 Controls trust level in dynamic prediction
 
@@ -218,11 +218,11 @@ Controls trust level in dynamic prediction
 
 Enabling `need_timing` for correct online calibration can typically yield more accurate chunk-latency fitting results. Therefore, you are advised not to adjust `smooth_factor` when `need_timing` is enabled. If `need_timing` is disabled, you can adjust `smooth_factor` to a value ranging from 0.5 to 0.8 to achieve the effect of enabling `need_timing`.
 
-#### min_chunk
+**3. min_chunk**
 
 Generally doesn't need adjustment. Should be smaller than `max-num-batched-tokens`
 
-#### max_fit_chunk
+**4. max_fit_chunk**
 
 Generally doesn't need adjustment.
 

--- a/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+++ b/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
@@ -199,7 +199,7 @@ The `--max-num-batched-tokens` and `smooth_factor` parameters need to be adjuste
 
 #### --max-num-batched-tokens
 
-**Notably, the TTFT of CPP is very sensitive to `--max-num-batched-tokens` (considered as the initial chunk size for dynamic chunk calculation).** Because if it is too large, it will introduce significant computational waste, and if it is too small, it will lead to a decrease in operator efficiency. 
+**Notably, the TTFT of CPP is very sensitive to `--max-num-batched-tokens` (considered as the initial chunk size for dynamic chunk calculation).** Because if it is too large, it will introduce significant computational waste, and if it is too small, it will lead to a decrease in operator efficiency.
 
 We recommend first optimizing with a fixed chunk size without enabling dynamic chunking. The typical optimization search space is [8192, 16384, 24576, 32768]. The optimal `--max-num-batched-tokens` for enabling dynamic chunking is generally 2 to 4 times that of fixed chunks.
 
@@ -213,6 +213,7 @@ Meanwhile, to leave enough room for dynamic adjustments, we recommend that the l
 #### smooth_factor
 
 Controls trust level in dynamic prediction
+
 - `1.0`: Strictly follow model prediction
 - `0.6~0.85`: Balance dynamic adjustment and scheduling overhead
 - `0.0`: No dynamic adjustment (degrades to fixed chunking)
@@ -226,8 +227,6 @@ Generally doesn't need adjustment. Should be smaller than `max-num-batched-token
 #### max_fit_chunk
 
 Generally doesn't need adjustment.
-
-
 
 ## Online Calibration
 

--- a/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+++ b/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
@@ -8,12 +8,12 @@
 
 Dynamic Chunked Pipeline Parallel (CPP) is a profiling-based dynamic chunking strategy that optimizes prefill performance for long sequences in Pipeline Parallelism (PP) scenarios. **CPP is designed to be used on the Prefiller (P) node in Prefill-Decode (PD) disaggregation deployments.** By dynamically calculating the optimal chunk size based on profiling data, CPP significantly reduces Time-To-First-Token (TTFT) for long sequences on P nodes.
 
-:::{important}
-CPP should be configured on the **P (Prefiller) node** in a PD disaggregation setup. The D (Decoder) node does not require CPP configuration. For PD disaggregation deployment guidance, refer to the tutorials below:
+!!! important
 
-- [PD Disaggregation Single Node (Qwen2.5-VL)](../../tutorials/features/pd_disaggregation_mooncake_single_node.md)
-- [PD Disaggregation Multi Node (Deepseek)](../../tutorials/features/pd_disaggregation_mooncake_multi_node.md)
-:::
+    CPP should be configured on the **P (Prefiller) node** in a PD disaggregation setup. The D (Decoder) node does not require CPP configuration. For PD disaggregation deployment guidance, refer to the tutorials below:
+
+    - [PD Disaggregation Single Node (Qwen2.5-VL)](../../tutorials/features/pd_disaggregation_mooncake_single_node.md)
+    - [PD Disaggregation Multi Node (Deepseek)](../../tutorials/features/pd_disaggregation_mooncake_multi_node.md)
 
 ### When to Use
 
@@ -25,9 +25,9 @@ CPP should be configured on the **P (Prefiller) node** in a PD disaggregation se
 
 CPP focuses on optimization during the prefill phase on the **P node in PD disaggregation** scenarios. CPP is recommended for PD (Prefill/Decode) disaggregation scenarios. Supported features are as follows:
 
-|         | Eager | Graph | Prefix <br> Cache | Chunked <br> Prefill |
-| ------- | ----- | ----- | ------ | ------ |
-| **CPP** | ✅    | ✅     | ✅      | ✅       |
+|         | Eager | Graph | Prefix <br> Cache | Chunked <br> Prefill | Flashcomm1 |
+| ------- | ----- | ----- | ------ | ------ | ------ |
+| **CPP** | ✅    | ✅     | ✅      | ✅       | ✅       |
 
 ## How to Enable
 
@@ -40,148 +40,140 @@ Note:
 - It is currently known that `async-scheduling` may cause performance degradation in the prefill stage of PP, and `async-scheduling` provides minimal benefit to prefill. Therefore, it is currently recommended not to enable asynchronous scheduling on P nodes of PP.
 - It is recommended to use `MooncakeConnectorV1` as the `kv_connector`, as it provides more comprehensive support for PP.
 
-:::::{tab-set}
+=== "P Node (Prefiller — with CPP)"
 
-::::{tab-item} P Node (Prefiller — with CPP)
+    ```shell
+    # For nic_name, run the `ifconfig` command to check the network adapter whose IP address is the same as that of the local host.
+    nic_name=<COMMAND_RESULT>
+    local_ip=<YOUR_MACHINE_IP>
 
-```shell
-# For nic_name, run the `ifconfig` command to check the network adapter whose IP address is the same as that of the local host.
-nic_name=<COMMAND_RESULT>
-local_ip=<YOUR_MACHINE_IP>
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name 
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name 
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
-
-vllm serve Qwen/Qwen3-30B-A3B \
-    --host 0.0.0.0 \
-    --port 13700 \
-    --served-model-name "qwen" \
-    --tensor-parallel-size 2 \
-    --pipeline-parallel-size 2 \
-    --enforce-eager \
-    --max-model-len 131072 \
-    --max-num-batched-tokens 32768 \
-    --enable-prefix-caching \
-    --no-async-scheduling \
-    --additional-config '{"scheduler_config": {"profiling_chunk_config": {"enabled": true}}}' \
-    --kv-transfer-config \
-    '{
-        "kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_producer",
-        "kv_port": "30000",
-        "engine_id": "0",
-        "kv_connector_extra_config": {
-            "prefill": {
-                "pp_size": 2,
-                "dp_size": 1,
-                "tp_size": 2
-            },
-            "decode": {
-                "dp_size": 2,
-                "tp_size": 2
+    vllm serve Qwen/Qwen3-30B-A3B \
+        --host 0.0.0.0 \
+        --port 13700 \
+        --served-model-name "qwen" \
+        --tensor-parallel-size 2 \
+        --pipeline-parallel-size 2 \
+        --enforce-eager \
+        --max-model-len 131072 \
+        --max-num-batched-tokens 32768 \
+        --enable-prefix-caching \
+        --no-async-scheduling \
+        --hf-overrides '{"rope_theta": 1000000, "rope_scaling": {"rope_type": "yarn", "factor": 4.0, "original_max_position_embeddings": 40960}, "max_model_len": 262144}' \
+        --additional-config '{"scheduler_config": {"profiling_chunk_config": {"enabled": true}}}' \
+        --kv-transfer-config \
+        '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_producer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                "prefill": {
+                    "pp_size": 2,
+                    "dp_size": 1,
+                    "tp_size": 2
+                },
+                "decode": {
+                    "dp_size": 2,
+                    "tp_size": 2
+                }
             }
-        }
-    }'
-```
+        }'
+    ```
 
-::::
+=== "D Node (Decoder — without CPP)"
 
-::::{tab-item} D Node (Decoder — without CPP)
+    ```shell
+    # For nic_name, run the `ifconfig` command to check the network adapter whose IP address is the same as that of the local host.
+    nic_name=<COMMAND_RESULT>
+    local_ip=<YOUR_MACHINE_IP>
 
-```shell
-# For nic_name, run the `ifconfig` command to check the network adapter whose IP address is the same as that of the local host.
-nic_name=<COMMAND_RESULT>
-local_ip=<YOUR_MACHINE_IP>
+    export HCCL_IF_IP=$local_ip
+    export GLOO_SOCKET_IFNAME=$nic_name 
+    export TP_SOCKET_IFNAME=$nic_name
+    export HCCL_SOCKET_IFNAME=$nic_name
+    export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
 
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name 
-export TP_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
-
-vllm serve Qwen/Qwen3-30B-A3B \
-    --host 0.0.0.0 \
-    --port 13701 \
-    --served-model-name "qwen" \
-    --data-parallel-size 2 \
-    --tensor-parallel-size 2 \
-    --enable-prefix-caching \
-    --max-model-len 131072 \
-    --max-num-batched-tokens 256 \
-    --gpu-memory-utilization 0.9 \
-    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --kv-transfer-config \
-    '{
-        "kv_connector": "MooncakeConnectorV1",
-        "kv_role": "kv_consumer",
-        "kv_port": "30000",
-        "engine_id": "0",
-        "kv_connector_extra_config": {
-            "prefill": {
-                "pp_size": 2,
-                "dp_size": 1,
-                "tp_size": 2
-            },
-            "decode": {
-                "dp_size": 2,
-                "tp_size": 2
+    vllm serve Qwen/Qwen3-30B-A3B \
+        --host 0.0.0.0 \
+        --port 13701 \
+        --served-model-name "qwen" \
+        --data-parallel-size 2 \
+        --tensor-parallel-size 2 \
+        --enable-prefix-caching \
+        --max-model-len 131072 \
+        --max-num-batched-tokens 256 \
+        --gpu-memory-utilization 0.9 \
+        --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+        --hf-overrides '{"rope_theta": 1000000, "rope_scaling": {"rope_type": "yarn", "factor": 4.0, "original_max_position_embeddings": 40960}, "max_model_len": 262144}' \
+        --kv-transfer-config \
+        '{
+            "kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30000",
+            "engine_id": "0",
+            "kv_connector_extra_config": {
+                "prefill": {
+                    "pp_size": 2,
+                    "dp_size": 1,
+                    "tp_size": 2
+                },
+                "decode": {
+                    "dp_size": 2,
+                    "tp_size": 2
+                }
             }
-        }
-    }'
-```
+        }'
+    ```
 
-::::{tab-item} Example Proxy for Deployment
+=== "Example Proxy for Deployment"
 
-Run a proxy server on the same node with the prefiller service instance. You can get the proxy program in the repository's examples: [load\_balance\_proxy\_server\_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
+    Run a proxy server on the same node with the prefiller service instance. You can get the proxy program in the repository's examples: [load\_balance\_proxy\_server\_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
 
-```shell
-python load_balance_proxy_server_example.py \
-    --host <PROXY_IP> \
-    --port 8080 \
-    --prefiller-hosts <PREFILL_MACHINE_IP> \
-    --prefiller-port 13700 \
-    --decoder-hosts <DECODE_MACHINE_IP> \
-    --decoder-ports 13701
-```
+    ```shell
+    python load_balance_proxy_server_example.py \
+        --host <PROXY_IP> \
+        --port 8080 \
+        --prefiller-hosts <PREFILL_MACHINE_IP> \
+        --prefiller-port 13700 \
+        --decoder-hosts <DECODE_MACHINE_IP> \
+        --decoder-ports 13701
+    ```
 
-| Parameter | Meaning |
-| --- | --- |
-| --port | Port of proxy |
-| --prefiller-port | All ports of prefill |
-| --decoder-ports | All ports of decoder |
+    | Parameter | Meaning |
+    | --- | --- |
+    | --port | Port of proxy |
+    | --prefiller-port | All ports of prefill |
+    | --decoder-ports | All ports of decoder |
 
-::::
+=== "Verification"
 
-::::{tab-item} Verification
+    Check service health using the proxy server endpoint.
 
-Check service health using the proxy server endpoint.
-
-```shell
-curl http://<PROXY_IP>:8080/v1/chat/completions \
-    -H "Content-Type: application/json" \
-    -d '{
-        "model": "qwen",
-        "messages": [
-        {
-            "role": "system",
-            "content": "You are a useful AI assistant."
-        },
-        {
-            "role": "user",
-            "content": "Question: Janet'\''s ducks lay 16 eggs per day. She eats three for breakfast and bakes muffins with four. She sells the remainder for $2 each. How much does she make?\nAnswer:"
-        }
-        ],
-        "max_completion_tokens": 100,
-        "temperature": 0
-    }'
-```
-
-::::
-
-:::::
+    ```shell
+    curl http://<PROXY_IP>:8080/v1/chat/completions \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "qwen",
+            "messages": [
+            {
+                "role": "system",
+                "content": "You are a useful AI assistant."
+            },
+            {
+                "role": "user",
+                "content": "Question: Janet'\''s ducks lay 16 eggs per day. She eats three for breakfast and bakes muffins with four. She sells the remainder for $2 each. How much does she make?\nAnswer:"
+            }
+            ],
+            "max_completion_tokens": 100,
+            "temperature": 0
+        }'
+    ```
 
 > **Key points for PD disaggregation with CPP:**
 >
@@ -203,24 +195,47 @@ curl http://<PROXY_IP>:8080/v1/chat/completions \
 
 ### Parameter Tuning
 
-- `smooth_factor`: Controls trust level in dynamic prediction
-    - `1.0`: Strictly follow model prediction
-    - `0.6~0.85`: Balance dynamic adjustment and scheduling overhead
-    - `0.0`: No dynamic adjustment (degrades to fixed chunking)
-- `min_chunk`: Generally doesn't need adjustment. Should be smaller than `max-num-batched-tokens`
+The `--max-num-batched-tokens` and `smooth_factor` parameters need to be adjusted. It is recommended that you adjust the `--max-num-batched-tokens` parameter first and then adjust the `smooth_factor`.
 
-## Recommended Settings
+#### --max-num-batched-tokens
 
-### max-num-batched-tokens
+**Notably, the TTFT of CPP is very sensitive to `--max-num-batched-tokens` (considered as the initial chunk size for dynamic chunk calculation).** Because if it is too large, it will introduce significant computational waste, and if it is too small, it will lead to a decrease in operator efficiency. 
 
-**Notably, the TTFT of CPP is very sensitive to `max-num-batched-tokens` (considered as the initial chunk size for dynamic chunk calculation).** Because if it is too large, it will introduce significant computational waste, and if it is too small, it will lead to a decrease in operator efficiency. To leave enough room for dynamic adjustments, we recommend that the longer the sequence being processed, the larger the `max-num-batched-tokens` should be set. Recommended values:
+We recommend first optimizing with a fixed chunk size without enabling dynamic chunking. The typical optimization search space is [8192, 16384, 24576, 32768]. The optimal `--max-num-batched-tokens` for enabling dynamic chunking is generally 2 to 4 times that of fixed chunks.
 
-| Sequence Length | `max-num-batched-tokens` |
+Meanwhile, to leave enough room for dynamic adjustments, we recommend that the longer the sequence being processed, the larger the `--max-num-batched-tokens` should be set. Recommended values:
+
+| Sequence Length | `--max-num-batched-tokens` |
 |-----------------|--------------------------|
 | 64k             | 20480                    |
 | 128k            | 32768                    |
 
-### Online Calibration
+#### smooth_factor
+
+Controls trust level in dynamic prediction
+- `1.0`: Strictly follow model prediction
+- `0.6~0.85`: Balance dynamic adjustment and scheduling overhead
+- `0.0`: No dynamic adjustment (degrades to fixed chunking)
+
+Enabling `need_timing` for correct online calibration can typically yield more accurate chunk-latency fitting results. Therefore, you are advised not to adjust `smooth_factor` when `need_timing` is enabled. If `need_timing` is disabled, you can adjust `smooth_factor` to a value ranging from 0.5 to 0.8 to achieve the effect of enabling `need_timing`.
+
+#### min_chunk
+
+Generally doesn't need adjustment. Should be smaller than `max-num-batched-tokens`
+
+#### max_fit_chunk
+
+Generally doesn't need adjustment.
+
+
+
+## Online Calibration
+
+!!! important
+
+    Currently, need_timing is enabled by default, that is, online calibration is enabled by default. Therefore, it is important to complete the online calibration process in a standard manner. Otherwise, severe performance deterioration will occur.
+
+    Alternatively, you can set need_timing to False to avoid the online calibration process, but the performance result may be suboptimal.
 
 For optimal performance, online calibrate with real data before production:
 

--- a/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+++ b/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
@@ -183,7 +183,7 @@ Note:
 >     - [PD Disaggregation Single Node](../../tutorials/features/pd_disaggregation_mooncake_single_node.md)
 >     - [PD Disaggregation Multi Node](../../tutorials/features/pd_disaggregation_mooncake_multi_node.md)
 
-## Configuration Parameters
+## Configuration Parameters Tuning
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -192,8 +192,6 @@ Note:
 | `min_chunk` | int | 4096 | Minimum chunk size for dynamic calculation |
 | `need_timing` | bool | True | Enable/disable Online Calibration |
 | `max_fit_chunk` | int | 30 | Number of chunk-time data for Online Calibration |
-
-### Parameter Tuning
 
 The `--max-num-batched-tokens` and `smooth_factor` parameters need to be adjusted. It is recommended that you adjust the `--max-num-batched-tokens` parameter first and then adjust the `smooth_factor`.
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aligns the **Dynamic Chunked Pipeline Parallel (CPP) tutorial** with the PD (Prefill-Decode) disaggregation scenario described in the [Feature Guide](../../user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md). Previously, the tutorial showed a standalone (non-PD) deployment, which contradicts the feature guide's emphasis that CPP is designed for the **P (Prefiller) node** in PD disaggregation.
Changes include:
1. **Restructured deployment to PD disaggregation**: Replaced the single `vllm serve` script with tab-based P/D node separation (`MooncakeConnectorV1`, `kv_producer`/`kv_consumer`, proxy, and verification), following the pattern in the user guide.
2. **D node uses DeepSeek PD standard configuration (DP32 TP1)**: Switched from a simplified DP2 TP8 config to the standard DP32 TP1 setup using `launch_online_dp.py` + `run_dp_template.sh`, with 2 decoder nodes (each running 16 instances). This matches the established DeepSeek PD disaggregation topology in `pd_disaggregation_mooncake_multi_node.md`.
3. **Added PD disaggregation emphasis**: Added `!!! important` admonitions in Getting Started and Deployment sections clarifying that CPP is configured only on the P node.
4. **Added functional validation example**: Added a Verification tab with a `curl` command to check service health through the proxy endpoint.
5. **Fixed config format**: Updated `profiling_chunk_config` to use the recommended `scheduler_config` wrapper format (per `ascend_config.py:830`), avoiding deprecation warnings.

### Does this PR introduce _any_ user-facing change?
No. This is a documentation-only update to the tutorial `dynamic_chunked_pipeline_parallel.md`. No API, interface, or behavior changes.
### How was this patch tested?
- Verified with `markdownlint` using the project's `.markdownlint.yaml` config — no errors.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
