### PR TITLE
[v0.26.0rc][BugFix][Frontend] Align DeepSeek V4 frontend behavior

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -102,6 +102,69 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(
     assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
 
 
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_effort"),
+    [
+        (None, "high"),
+        ("high", "high"),
+        ("low", "low"),
+    ],
+)
+def test_deepseek_v4_tokenizer_attaches_tools_to_existing_system(
+    monkeypatch,
+    reasoning_effort,
+    expected_effort,
+):
+    captured_messages = []
+    captured_kwargs = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_messages.append(messages)
+        captured_kwargs.append(kwargs)
+        return "prompt"
+
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    messages = [
+        {"role": "system", "content": "system prompt"},
+        {"role": "user", "content": "hi"},
+    ]
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    original_messages = [message.copy() for message in messages]
+    kwargs = {"reasoning_effort": reasoning_effort} if reasoning_effort is not None else {}
+
+    tokenizer.apply_chat_template(messages, tools=tools, tokenize=False, **kwargs)
+
+    assert captured_messages[-1] == [
+        {"role": "system", "content": "system prompt", "tools": tools},
+        {"role": "user", "content": "hi"},
+    ]
+    assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+    assert messages == original_messages
+
+
+def test_deepseek_v4_tokenizer_adds_system_for_tools_when_missing(monkeypatch):
+    captured_messages = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_messages.append(messages)
+        return "prompt"
+
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    messages = [{"role": "user", "content": "hi"}]
+    tools = [{"type": "function", "function": {"name": "get_weather"}}]
+    original_messages = [message.copy() for message in messages]
+
+    tokenizer.apply_chat_template(messages, tools=tools, tokenize=False)
+
+    assert captured_messages[-1] == [
+        {"role": "system", "tools": tools},
+        {"role": "user", "content": "hi"},
+    ]
+    assert messages == original_messages
+
+
 def test_deepseek_v4_defaults_to_thinking_with_high_effort():
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     prompt = tokenizer.apply_chat_template(

--- a/tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionToolsParam,
+    FunctionDefinition,
+)
+from vllm.parser.deepseek_v4 import DeepSeekV4Parser
+from vllm.tool_parsers.deepseekv4_engine_tool_parser import (
+    DeepSeekV4EngineToolParser,
+)
+
+TOOL_START = "<｜DSML｜tool_calls>\n"
+INVOKE_START = '<｜DSML｜invoke name="emit_text">\n'
+INVOKE_END = "</｜DSML｜invoke>\n"
+TOOL_END = "</｜DSML｜tool_calls>"
+PARAM_CLOSE = "</｜DSML｜parameter>"
+
+
+class FakeTokenizer:
+    def get_vocab(self):
+        return {}
+
+
+def _param_open(name: str, is_string: bool) -> str:
+    string_attr = "true" if is_string else "false"
+    return f'<｜DSML｜parameter name="{name}" string="{string_attr}">'
+
+
+def _make_parser(properties: dict, parser_cls=DeepSeekV4Parser):
+    tool = ChatCompletionToolsParam(
+        type="function",
+        function=FunctionDefinition(
+            name="emit_text",
+            parameters={
+                "type": "object",
+                "properties": properties,
+                "required": list(properties),
+            },
+        ),
+    )
+    request = MagicMock(tools=[tool], tool_choice="auto")
+    parser = parser_cls(
+        FakeTokenizer(),
+        tools=[tool],
+        chat_template_kwargs={"enable_thinking": False},
+    )
+    return parser, request
+
+
+def _arguments_from_delta(delta) -> list[str]:
+    arguments = []
+    if delta and delta.tool_calls:
+        for tool_call in delta.tool_calls:
+            if tool_call.function and tool_call.function.arguments:
+                arguments.append(tool_call.function.arguments)
+    return arguments
+
+
+def _stream_chunks(parser, request, chunks: list[str], *, finish: bool = False):
+    previous_text = ""
+    argument_deltas: list[tuple[int, str]] = []
+    for index, delta_text in enumerate(chunks):
+        current_text = previous_text + delta_text
+        delta = parser.extract_tool_calls_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[index + 1],
+            request=request,
+        )
+        previous_text = current_text
+        argument_deltas.extend((index, arguments) for arguments in _arguments_from_delta(delta))
+
+    if finish:
+        argument_deltas.extend(
+            (len(chunks), arguments) for arguments in _arguments_from_delta(parser.finish_streaming())
+        )
+    return argument_deltas
+
+
+def _long_string_chunks(body: str, chunk_size: int = 32) -> list[str]:
+    chunks = [TOOL_START + INVOKE_START + _param_open("text", True)]
+    chunks.extend(body[i : i + chunk_size] for i in range(0, len(body), chunk_size))
+    chunks.append(PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END)
+    return chunks
+
+
+def _joined_arguments(argument_deltas: list[tuple[int, str]]) -> str:
+    return "".join(value for _, value in argument_deltas)
+
+
+def test_long_string_streams_before_parameter_close():
+    body = "A" * 4096
+    parser, request = _make_parser(
+        {"text": {"type": "string"}},
+        parser_cls=DeepSeekV4EngineToolParser,
+    )
+    chunks = _long_string_chunks(body)
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    body_deltas = [value for index, value in argument_deltas if 0 < index < len(chunks) - 1]
+
+    assert len(body_deltas) > 1
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_string_escaping_and_unicode_reconstruct_exactly():
+    body = 'quote=" slash=\\ newline=\n tab=\t nul=\x00 angle=> unicode=杭州'
+    parser, request = _make_parser({"text": {"type": "string"}})
+    argument_deltas = _stream_chunks(
+        parser,
+        request,
+        _long_string_chunks(body, chunk_size=3),
+    )
+
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_split_parameter_close_does_not_leak_into_arguments():
+    parser, request = _make_parser({"text": {"type": "string"}})
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "alpha",
+        "</｜DSML｜para",
+        "meter>\n" + INVOKE_END + TOOL_END,
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert all("｜DSML｜" not in value for _, value in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": "alpha"}
+
+
+def test_string_numeric_and_second_string_keep_types_and_streaming():
+    properties = {
+        "text": {"type": "string"},
+        "count": {"type": "integer"},
+        "suffix": {"type": "string"},
+    }
+    parser, request = _make_parser(properties)
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "alpha",
+        PARAM_CLOSE + "\n" + _param_open("count", False),
+        "42",
+        PARAM_CLOSE + "\n" + _param_open("suffix", True),
+        "omega",
+        PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END,
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert any(index == 1 and "alpha" in value for index, value in argument_deltas)
+    assert not any(index == 3 for index, _ in argument_deltas)
+    assert any(index == 5 and "omega" in value for index, value in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {
+        "text": "alpha",
+        "count": 42,
+        "suffix": "omega",
+    }
+
+
+def test_split_next_parameter_header_does_not_leak_into_previous_string():
+    properties = {
+        "text": {"type": "string"},
+        "suffix": {"type": "string"},
+    }
+    parser, request = _make_parser(properties)
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "alpha",
+        PARAM_CLOSE + '\n<｜DSML｜parameter name="suf',
+        'fix" string="true">',
+        "omega",
+        PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END,
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    arguments = _joined_arguments(argument_deltas)
+    assert "｜DSML｜" not in arguments
+    assert json.loads(arguments) == {"text": "alpha", "suffix": "omega"}
+
+
+def test_nullable_string_remains_buffered_until_stable():
+    body = "not-null" * 128
+    parser, request = _make_parser(
+        {
+            "text": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "null"},
+                ]
+            }
+        }
+    )
+    chunks = _long_string_chunks(body)
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert not any(0 < index < len(chunks) - 1 for index, _ in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_escaped_parameter_name_remains_buffered_until_stable():
+    parameter_name = "text\\key"
+    body = "value" * 128
+    parser, request = _make_parser({parameter_name: {"type": "string"}})
+    chunks = [TOOL_START + INVOKE_START + _param_open(parameter_name, True)]
+    chunks.extend(body[i : i + 32] for i in range(0, len(body), 32))
+    chunks.append(PARAM_CLOSE + "\n" + INVOKE_END + TOOL_END)
+    argument_deltas = _stream_chunks(parser, request, chunks)
+
+    assert not any(0 < index < len(chunks) - 1 for index, _ in argument_deltas)
+    assert json.loads(_joined_arguments(argument_deltas)) == {parameter_name: body}
+
+
+def test_truncated_string_remains_invalid_json():
+    parser, request = _make_parser({"text": {"type": "string"}})
+    chunks = [
+        TOOL_START + INVOKE_START + _param_open("text", True),
+        "unfinished ",
+        "body",
+    ]
+    argument_deltas = _stream_chunks(parser, request, chunks, finish=True)
+
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(_joined_arguments(argument_deltas))
+
+
+def test_long_body_does_not_repeatedly_call_converter():
+    body = "A" * 4096
+    parser, request = _make_parser({"text": {"type": "string"}})
+    original_converter = parser._arg_converter
+    converter_calls = 0
+
+    def counting_converter(raw_args: str, partial: bool) -> str:
+        nonlocal converter_calls
+        converter_calls += 1
+        return original_converter(raw_args, partial)
+
+    parser._arg_converter = counting_converter
+    argument_deltas = _stream_chunks(parser, request, _long_string_chunks(body))
+
+    assert converter_calls <= 4
+    assert json.loads(_joined_arguments(argument_deltas)) == {"text": body}
+
+
+def test_parser_reuse_clears_direct_streaming_state():
+    parser, request = _make_parser({"text": {"type": "string"}})
+    first = _stream_chunks(parser, request, _long_string_chunks("first"))
+    parser._reset()
+    second = _stream_chunks(parser, request, _long_string_chunks("second"))
+
+    assert json.loads(_joined_arguments(first)) == {"text": "first"}
+    assert json.loads(_joined_arguments(second)) == {"text": "second"}

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -91,6 +91,22 @@
 #       Remove this patch once the supported vLLM version contains PR #50580
 #       and PR #51296.
 #
+# ** 3a. File: platform/patch_deepseek_v4_tool_streaming.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.parser.deepseek_v4.DeepSeekV4Parser._compute_arg_delta`
+#    Why:
+#       The supported vLLM skips argument conversion for DeepSeek V4 parameter-body
+#       deltas without `>`. A long string is consequently emitted only when
+#       `</parameter>` arrives instead of streaming incrementally.
+#    How:
+#       After the original converter confirms an in-progress, schema-stable
+#       string parameter, JSON-escape and emit plain body deltas directly.
+#       Structural deltas and final conversion remain on the original path.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/52865
+#    Future Plan:
+#       Remove this patch once the supported vLLM version contains PR #52865.
+#
 # ** 4. File: platform/patch_distributed.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.distributed.all_reduce`, `torch.distributed.broadcast`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -18,6 +18,7 @@ import os
 
 import vllm_ascend.patch.platform.patch_camem_allocator  # noqa
 import vllm_ascend.patch.platform.patch_deepseek_v4_thinking  # noqa
+import vllm_ascend.patch.platform.patch_deepseek_v4_tool_streaming  # noqa
 import vllm_ascend.patch.platform.patch_distributed  # noqa
 import vllm_ascend.patch.platform.patch_glm_reasoning_usage_accounting  # noqa
 import vllm_ascend.patch.platform.patch_kimi_k3_parsers  # noqa

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -97,8 +97,16 @@ def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
         conversation = kwargs.get("conversation", messages)
         messages = conversation.copy()
         if tools is not None and len(tools) > 0:
-            messages.insert(0, {"role": "system"})
-            messages[0]["tools"] = tools  # type: ignore[typeddict-unknown-key]
+            system_index = next(
+                (index for index, message in enumerate(messages) if message.get("role") == "system"),
+                None,
+            )
+            if system_index is None:
+                messages.insert(0, {"role": "system", "tools": tools})
+            else:
+                system_message = messages[system_index].copy()
+                system_message["tools"] = tools  # type: ignore[typeddict-unknown-key]
+                messages[system_index] = system_message
 
         reasoning_effort = kwargs.get("reasoning_effort")
         if not isinstance(reasoning_effort, str):

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_tool_streaming.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_tool_streaming.py
@@ -1,0 +1,113 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from functools import wraps
+from typing import Any
+
+from vllm.parser.deepseek_v4 import (
+    _PARAM_RE,
+    _PARTIAL_PARAM_RE,
+    DeepSeekV4Parser,
+)
+
+_DIRECT_STRING_SLOTS_ATTR = "_ascend_direct_string_slots"
+_PATCHED_ATTR = "_ascend_tool_streaming_patched"
+
+_original_reset = DeepSeekV4Parser._reset
+_original_compute_arg_delta = DeepSeekV4Parser._compute_arg_delta
+
+
+@wraps(_original_reset)
+def _patched_reset(
+    self: DeepSeekV4Parser,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    _original_reset(self, *args, **kwargs)
+    setattr(self, _DIRECT_STRING_SLOTS_ATTR, set())
+
+
+def _in_progress_string_key(raw_args: str) -> str | None:
+    last_complete_end = 0
+    for match in _PARAM_RE.finditer(raw_args):
+        last_complete_end = match.end()
+
+    match = _PARTIAL_PARAM_RE.search(raw_args, last_complete_end)
+    if match is None or match.group(2) != "true":
+        return None
+    return match.group(1)
+
+
+def _ends_in_open_json_string(json_prefix: str) -> bool:
+    in_string = False
+    escaped = False
+    for char in json_prefix:
+        if escaped:
+            escaped = False
+        elif char == "\\" and in_string:
+            escaped = True
+        elif char == '"':
+            in_string = not in_string
+    return in_string
+
+
+@wraps(_original_compute_arg_delta)
+def _patched_compute_arg_delta(
+    self: DeepSeekV4Parser,
+    idx: int,
+    raw_delta: str,
+) -> str | None:
+    direct_string_slots: set[int] = getattr(
+        self,
+        _DIRECT_STRING_SLOTS_ATTR,
+        set(),
+    )
+    setattr(self, _DIRECT_STRING_SLOTS_ATTR, direct_string_slots)
+
+    structural = self._arg_structural_chars
+    is_plain_delta = structural is not None and structural.isdisjoint(raw_delta)
+    # The lexer holds split closing tags, so a plain event here is committed
+    # string body text and can be JSON-escaped without rescanning slot.args.
+    if idx in direct_string_slots and is_plain_delta and self._arg_converter is not None and self._stream_arg_deltas:
+        escaped_delta = json.dumps(raw_delta, ensure_ascii=False)[1:-1]
+        if escaped_delta:
+            self._tool_slots[idx].streamed_json += escaped_delta
+            return escaped_delta
+        return None
+
+    direct_string_slots.discard(idx)
+    arg_delta = _original_compute_arg_delta(self, idx, raw_delta)
+    if not arg_delta:
+        return arg_delta
+
+    # Structural events always return to the converter. Re-arm direct streaming
+    # only while the raw DSML still ends in a schema-stable string parameter.
+    slot = self._tool_slots[idx]
+    string_key = _in_progress_string_key(slot.args)
+    if (
+        string_key is not None
+        and (slot.string_keys is None or string_key in slot.string_keys)
+        and _ends_in_open_json_string(slot.streamed_json)
+    ):
+        direct_string_slots.add(idx)
+    return arg_delta
+
+
+if not getattr(DeepSeekV4Parser, _PATCHED_ATTR, False):
+    DeepSeekV4Parser._reset = _patched_reset
+    DeepSeekV4Parser._compute_arg_delta = _patched_compute_arg_delta
+    setattr(DeepSeekV4Parser, _PATCHED_ATTR, True)


### PR DESCRIPTION
### What this PR does / why we need it?

Ports the remaining DeepSeek V4 frontend fixes from the v0.25 release branch to `releases/v0.26.0rc`:

- #14035: attach tools to an existing system message instead of inserting a second system message;
- #14521: stream long schema-typed string tool arguments incrementally before the closing parameter tag.

The v0.26 reasoning-effort and thinking-default changes are already covered by #13993 and #14074, so this PR does not duplicate them.

For long string arguments, the patch remains release-scoped until the supported vLLM contains https://github.com/vllm-project/vllm/pull/52865.

### Does this PR introduce _any_ user-facing change?

Yes. DeepSeek V4 requests preserve their original system prompt when tools are present, and long string tool arguments are emitted incrementally instead of being buffered until the parameter closes.

### How was this patch tested?

Tested after rebasing onto the latest `releases/v0.26.0rc` with its paired vLLM source:

```bash
PYTHONPATH=$VLLM_SOURCE pytest -q \
  tests/ut/patch/platform/test_deepseek_v4_thinking.py \
  tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
# 45 passed

ruff check   tests/ut/patch/platform/test_deepseek_v4_thinking.py   tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py   vllm_ascend/patch/__init__.py   vllm_ascend/patch/platform/__init__.py   vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py   vllm_ascend/patch/platform/patch_deepseek_v4_tool_streaming.py
# All checks passed!

ruff format --check   tests/ut/patch/platform/test_deepseek_v4_thinking.py   tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py   vllm_ascend/patch/__init__.py   vllm_ascend/patch/platform/__init__.py   vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py   vllm_ascend/patch/platform/patch_deepseek_v4_tool_streaming.py
# 6 files already formatted

git diff --check upstream/releases/v0.26.0rc...HEAD
```

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
