### PR TITLE
[v0.26.0rc][Performance][Ops] Parallelize DSpark input-copy kernel

### DIFF
--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -95,52 +95,52 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
 ):
-    for req_idx in range(0, batch_size):
-        ctx_start = tl.load(query_start_loc_ptr + req_idx)
-        ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
-        num_ctx = ctx_end - ctx_start
+    req_idx = tl.program_id(axis=0)
+    ctx_start = tl.load(query_start_loc_ptr + req_idx)
+    ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
+    num_ctx = ctx_end - ctx_start
 
-        for j in range(0, num_ctx):
-            ctx_pos_idx = ctx_start + j
-            pos = tl.load(target_positions_ptr + ctx_pos_idx)
-            tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
+    for j in range(0, num_ctx):
+        ctx_pos_idx = ctx_start + j
+        pos = tl.load(target_positions_ptr + ctx_pos_idx)
+        tl.store(out_context_positions_ptr + ctx_pos_idx, pos)
 
-            slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
-            tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
+        slot = tl.load(context_slot_mapping_ptr + ctx_pos_idx)
+        tl.store(out_context_slot_mapping_ptr + ctx_pos_idx, slot)
 
-        if HAS_NUM_REJECTED:
-            num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
-            valid_ctx_end = ctx_end - num_rejected
+    if HAS_NUM_REJECTED:
+        num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
+        valid_ctx_end = ctx_end - num_rejected
+    else:
+        num_rejected = 0
+        valid_ctx_end = ctx_end
+
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    effective_seq_len = seq_len - num_rejected
+    last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+
+    for q_idx in range(0, num_query_per_req):
+        query_pos = last_pos + 1 + q_idx
+        query_out_idx = req_idx * num_query_per_req + q_idx
+
+        tl.store(out_query_positions_ptr + query_out_idx, query_pos)
+
+        query_cache_pos = effective_seq_len + q_idx
+        block_num_q = query_cache_pos // block_size
+        block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
+        slot_q = block_id_q * block_size + (query_cache_pos % block_size)
+        tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)
+
+        if q_idx == 0:
+            bonus_token = tl.load(next_token_ids_ptr + req_idx)
+            tl.store(out_input_ids_ptr + query_out_idx, bonus_token)
         else:
-            num_rejected = 0
-            valid_ctx_end = ctx_end
+            tl.store(out_input_ids_ptr + query_out_idx, parallel_drafting_token_id)
 
-        seq_len = tl.load(seq_lens_ptr + req_idx)
-        effective_seq_len = seq_len - num_rejected
-        last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
-
-        for q_idx in range(0, num_query_per_req):
-            query_pos = last_pos + 1 + q_idx
-            query_out_idx = req_idx * num_query_per_req + q_idx
-
-            tl.store(out_query_positions_ptr + query_out_idx, query_pos)
-
-            query_cache_pos = effective_seq_len + q_idx
-            block_num_q = query_cache_pos // block_size
-            block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
-            slot_q = block_id_q * block_size + (query_cache_pos % block_size)
-            tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)
-
-            if q_idx == 0:
-                bonus_token = tl.load(next_token_ids_ptr + req_idx)
-                tl.store(out_input_ids_ptr + query_out_idx, bonus_token)
-            else:
-                tl.store(out_input_ids_ptr + query_out_idx, parallel_drafting_token_id)
-
-            if SAMPLE_FROM_ANCHOR:
-                sample_out_idx = req_idx * num_speculative_tokens + q_idx
+        if SAMPLE_FROM_ANCHOR:
+            sample_out_idx = req_idx * num_speculative_tokens + q_idx
+            tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+        else:
+            if q_idx > 0:
+                sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
                 tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
-            else:
-                if q_idx > 0:
-                    sample_out_idx = req_idx * num_speculative_tokens + (q_idx - 1)
-                    tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -92,34 +92,35 @@ class AscendDflashProposer(AscendEagleProposer):
 
         has_num_rejected = num_rejected_tokens_gpu is not None
 
-        copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
-            # Inputs
-            next_token_ids_ptr=next_token_ids,
-            target_positions_ptr=target_positions,
-            context_slot_mapping_ptr=cad.slot_mapping,
-            # Outputs
-            out_input_ids_ptr=self.input_ids,
-            out_context_positions_ptr=self._context_positions_buffer,
-            out_query_positions_ptr=self.positions,
-            out_context_slot_mapping_ptr=self._context_slot_mapping_buffers,
-            out_query_slot_mapping_ptr=self._slot_mapping_buffer,
-            out_token_indices_ptr=token_indices_to_sample,
-            # Block table
-            block_table_ptr=cad.block_table_tensor,
-            block_table_stride=cad.block_table_tensor.stride(0),
-            # Metadata
-            query_start_loc_ptr=cad.query_start_loc,
-            seq_lens_ptr=cad.seq_lens,
-            num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
-            # Scalars
-            parallel_drafting_token_id=self.parallel_drafting_token_id,
-            block_size=self.kernel_block_size,
-            num_query_per_req=num_query_per_req,
-            num_speculative_tokens=self.num_speculative_tokens,
-            total_input_tokens=num_context,
-            batch_size=batch_size,
-            HAS_NUM_REJECTED=has_num_rejected,
-        )
+        if batch_size > 0:
+            copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[batch_size,](
+                # Inputs
+                next_token_ids_ptr=next_token_ids,
+                target_positions_ptr=target_positions,
+                context_slot_mapping_ptr=cad.slot_mapping,
+                # Outputs
+                out_input_ids_ptr=self.input_ids,
+                out_context_positions_ptr=self._context_positions_buffer,
+                out_query_positions_ptr=self.positions,
+                out_context_slot_mapping_ptr=self._context_slot_mapping_buffers,
+                out_query_slot_mapping_ptr=self._slot_mapping_buffer,
+                out_token_indices_ptr=token_indices_to_sample,
+                # Block table
+                block_table_ptr=cad.block_table_tensor,
+                block_table_stride=cad.block_table_tensor.stride(0),
+                # Metadata
+                query_start_loc_ptr=cad.query_start_loc,
+                seq_lens_ptr=cad.seq_lens,
+                num_rejected_tokens_ptr=(num_rejected_tokens_gpu if has_num_rejected else 0),
+                # Scalars
+                parallel_drafting_token_id=self.parallel_drafting_token_id,
+                block_size=self.kernel_block_size,
+                num_query_per_req=num_query_per_req,
+                num_speculative_tokens=self.num_speculative_tokens,
+                total_input_tokens=num_context,
+                batch_size=batch_size,
+                HAS_NUM_REJECTED=has_num_rejected,
+            )
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
         new_query_start_loc = self.arange_dflash[: batch_size + 1] * num_query_per_req

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -304,35 +304,36 @@ class AscendDSparkProposer(AscendDflashProposer):
             if gid_block_table is None:
                 continue
             kernel_block_size = self._per_group_kernel_block_sizes[gid]
-            copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
-                # Inputs
-                next_token_ids_ptr=next_token_ids,
-                target_positions_ptr=target_positions,
-                context_slot_mapping_ptr=self._per_group_slot_mappings[gid],
-                # Outputs
-                out_input_ids_ptr=self.input_ids,
-                out_context_positions_ptr=self._context_positions_buffer,
-                out_query_positions_ptr=self.positions,
-                out_context_slot_mapping_ptr=self._per_group_context_slot_mapping_buffers[gid],
-                out_query_slot_mapping_ptr=self._per_group_query_slot_mapping_buffers[gid],
-                out_token_indices_ptr=token_indices_to_sample,
-                # Block table
-                block_table_ptr=gid_block_table,
-                block_table_stride=gid_block_table.stride(0),
-                # Metadata
-                query_start_loc_ptr=cad.query_start_loc,
-                seq_lens_ptr=cad.seq_lens,
-                num_rejected_tokens_ptr=num_rejected_tokens_gpu,
-                # Scalars
-                parallel_drafting_token_id=self.parallel_drafting_token_id,
-                block_size=kernel_block_size,
-                num_query_per_req=self.num_query_per_req,
-                num_speculative_tokens=self.num_speculative_tokens,
-                total_input_tokens=self._dflash_num_context,
-                batch_size=batch_size,
-                HAS_NUM_REJECTED=has_num_rejected,
-                SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
-            )
+            if batch_size > 0:
+                copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[batch_size,](
+                    # Inputs
+                    next_token_ids_ptr=next_token_ids,
+                    target_positions_ptr=target_positions,
+                    context_slot_mapping_ptr=self._per_group_slot_mappings[gid],
+                    # Outputs
+                    out_input_ids_ptr=self.input_ids,
+                    out_context_positions_ptr=self._context_positions_buffer,
+                    out_query_positions_ptr=self.positions,
+                    out_context_slot_mapping_ptr=self._per_group_context_slot_mapping_buffers[gid],
+                    out_query_slot_mapping_ptr=self._per_group_query_slot_mapping_buffers[gid],
+                    out_token_indices_ptr=token_indices_to_sample,
+                    # Block table
+                    block_table_ptr=gid_block_table,
+                    block_table_stride=gid_block_table.stride(0),
+                    # Metadata
+                    query_start_loc_ptr=cad.query_start_loc,
+                    seq_lens_ptr=cad.seq_lens,
+                    num_rejected_tokens_ptr=num_rejected_tokens_gpu,
+                    # Scalars
+                    parallel_drafting_token_id=self.parallel_drafting_token_id,
+                    block_size=kernel_block_size,
+                    num_query_per_req=self.num_query_per_req,
+                    num_speculative_tokens=self.num_speculative_tokens,
+                    total_input_tokens=self._dflash_num_context,
+                    batch_size=batch_size,
+                    HAS_NUM_REJECTED=has_num_rejected,
+                    SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+                )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
             self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx


### PR DESCRIPTION
### What this PR does / why we need it?

Ports #14066 from the v0.25 release branch to `releases/v0.26.0rc`.

The DSpark/DFlash input-copy kernel currently launches a single Triton program and loops over the request batch serially. This change maps one request to each `tl.program_id(axis=0)` and launches the kernel with `batch_size` programs, preserving the existing per-request work while allowing it to run across AI Vector cores.

The original v0.25 change reported unchanged HumanEval accuracy and a reduction of the input expansion kernel average from 1035 us/call to 154 us/call on its DeepSeek V4 Flash DSpark workload.

### Does this PR introduce _any_ user-facing change?

No. This is an internal kernel parallelization and does not change the API or configuration contract.

### How was this patch tested?

Tested after rebasing onto the latest `releases/v0.26.0rc` with its paired vLLM source:

```bash
PYTHONPATH=$VLLM_SOURCE pytest -q tests/ut/spec_decode/test_dspark_proposer.py
# 32 passed

ruff check   vllm_ascend/ops/triton/spec_decode/utils.py   vllm_ascend/spec_decode/dflash_proposer.py   vllm_ascend/spec_decode/dspark_proposer.py
# All checks passed!

ruff format --check   vllm_ascend/ops/triton/spec_decode/utils.py   vllm_ascend/spec_decode/dflash_proposer.py   vllm_ascend/spec_decode/dspark_proposer.py
# 3 files already formatted

git diff --check upstream/releases/v0.26.0rc...HEAD
```

The original real-device performance and accuracy evidence is in #14066 and was not rerun on this v0.26 port head.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
