### PR TITLE
[v0.26.0rc][Doc] Align DeepSeek V4 DSpark draft lengths

### DIFF
--- a/docs/source/tutorials/models/DeepSeek-V4-Flash.md
+++ b/docs/source/tutorials/models/DeepSeek-V4-Flash.md
@@ -297,7 +297,7 @@ Single-node deployment completes both Prefill and Decode within the same node. T
         --quantization ascend \
         --port 8900 \
         --block-size 32 \
-        --speculative-config '{"method":"dspark","num_speculative_tokens":7,"enforce_eager":true}' \
+        --speculative-config '{"method":"dspark","num_speculative_tokens":5,"enforce_eager":true}' \
         --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
         --additional-config '{
             "ascend_compilation_config": {
@@ -668,7 +668,7 @@ Before you start, please:
             --max-num-seqs 16 \
             --no-disable-hybrid-kv-cache-manager \
             --model-loader-extra-config='{"enable_multithread_load": true, "num_threads": 128}' \
-            --speculative-config '{"num_speculative_tokens": 7,"method": "dspark","enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 5,"method": "dspark","enforce_eager": true}' \
             --trust-remote-code \
             --block-size 32 \
             --tokenizer-mode deepseek_v4 \
@@ -746,7 +746,7 @@ Before you start, please:
             --reasoning-parser deepseek_v4 \
             --gpu-memory-utilization 0.9 \
             --quantization ascend \
-            --speculative-config '{"num_speculative_tokens": 7,"method": "dspark","enforce_eager": true}' \
+            --speculative-config '{"num_speculative_tokens": 5,"method": "dspark","enforce_eager": true}' \
             --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
             --kv-transfer-config \
             '{"kv_connector": "MooncakeHybridConnector",


### PR DESCRIPTION
### What this PR does / why we need it?

Ports the DeepSeek V4 Flash DSpark configuration tuning from #13840 to the consolidated v0.26 model guide.

The three DSpark launch examples still use `num_speculative_tokens=7`. This changes them to the v0.25 release recommendation of `num_speculative_tokens=5`.

### Does this PR introduce _any_ user-facing change?

Yes. The documented DeepSeek V4 Flash DSpark launch configuration now recommends five speculative tokens.

### How was this patch tested?

Tested after rebasing onto the latest `releases/v0.26.0rc`:

```bash
pre-commit run --hook-stage manual markdownlint \
  --files docs/source/tutorials/models/DeepSeek-V4-Flash.md
# Passed

git diff --check upstream/releases/v0.26.0rc...HEAD
```

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
