### PR TITLE
[Test][Misc] Add weekly multi-node external DP test case for Qwen3.5-397B without MTP

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -266,6 +266,10 @@ a3:
         config_file_path: Kimi-K2.7-W4A8-254k-1k-TPOT20-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
+      - name: Qwen3.5-397B-w4a8-PD-no-mtp
+        config_file_path: Qwen3.5-397B-w4a8-PD-no-mtp.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
 
   single_node:
     test_config:

--- a/tests/e2e/weekly/multi_node/external_dp/config/Qwen3.5-397B-w4a8-PD-no-mtp.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Qwen3.5-397B-w4a8-PD-no-mtp.yaml
@@ -1,0 +1,178 @@
+test_name: "Qwen3.5-397B-w4a8-PD-no-mtp"
+model: "Eco-Tech/Qwen3.5-397B-A17B-w4a8-mtp"
+num_nodes: 2
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0 ]
+    decoder: [ 1 ]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 13321
+    dp_size: 8
+    dp_size_local: 8
+    dp_rank_start: 0
+    tp_size: 2
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 13321
+    dp_size: 8
+    dp_size_local: 8
+    dp_rank_start: 0
+    tp_size: 2
+    dp_address: "${NODE_1_IP}"
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "1"
+  TASK_QUEUE_ENABLE: "1"
+  HCCL_BUFFSIZE: "1024"
+  VLLM_USE_V1: "1"
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_common
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --max-num-seqs
+      - "24"
+      - --max-model-len
+      - "262144"
+      - --max-num-batched-tokens
+      - "8192"
+      - --gpu-memory-utilization
+      - "0.9"
+      - --seed
+      - "1024"
+      - --enable-prefix-caching
+      - --async-scheduling
+      - --enforce-eager
+      - --additional-config
+      - '{"enable_cpu_binding": true}'
+      - --mm-processor-cache-gb
+      - "0"
+      - --mm-encoder-tp-mode
+      - "data"
+      - --distributed-executor-backend
+      - "mp"
+      - --no-disable-hybrid-kv-cache-manager
+      - --kv-transfer-config
+      - '{
+          "kv_connector": "MooncakeConnectorV1",
+          "kv_buffer_device": "npu",
+          "kv_role": "kv_producer",
+          "kv_port": "55010",
+          "engine_id": "0",
+          "kv_connector_extra_config": {
+            "prefill": {
+              "dp_size": 8,
+              "tp_size": 2
+            },
+            "decode": {
+              "dp_size": 8,
+              "tp_size": 2
+            }
+          }
+        }'
+
+  - node_index: 1
+    envs:
+      <<: *env_common
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --max-num-seqs
+      - "24"
+      - --max-model-len
+      - "262144"
+      - --max-num-batched-tokens
+      - "8192"
+      - --gpu-memory-utilization
+      - "0.9"
+      - --seed
+      - "1024"
+      - --enable-prefix-caching
+      - --async-scheduling
+      - --compilation-config
+      - '{"cudagraph_capture_sizes":[4,8,12,16,20,24,28,32,36,40,44,48,52,56,60,64,68,72,76,80,84,88,92,96], "cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - --additional-config
+      - '{"recompute_scheduler_enable": true, "enable_cpu_binding": true}'
+      - --mm-processor-cache-gb
+      - "0"
+      - --mm-encoder-tp-mode
+      - "data"
+      - --distributed-executor-backend
+      - "mp"
+      - --no-disable-hybrid-kv-cache-manager
+      - --kv-transfer-config
+      - '{
+        "kv_connector": "MooncakeConnectorV1",
+        "kv_buffer_device": "npu",
+        "kv_role": "kv_consumer",
+        "kv_port": "55011",
+        "engine_id": "1",
+        "kv_connector_extra_config": {
+          "prefill": {
+            "dp_size": 8,
+            "tp_size": 2
+          },
+          "decode": {
+            "dp_size": 8,
+            "tp_size": 2
+          }
+        }
+      }'
+
+benchmarks:
+  acc_aime2025:
+    case_type: accuracy
+    dataset_path: vllm-ascend/aime2025
+    request_conf: vllm_api_general_chat
+    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
+    max_out_len: 65536
+    batch_size: 32
+    temperature: 0.6
+    top_p: 0.95
+    top_k: 20
+    min_p: 0.0
+    presence_penalty: 0.0
+    repetition_penalty: 1.0
+    baseline: 90
+    threshold: 10


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a new weekly end-to-end multi-node external data-parallelism (DP) test configuration for the `Qwen3.5-397B` model running without Multi-Token Prediction (MTP). This test case is crucial for validating the disaggregated prefill and decode functionality under a 2-node, 16-NPU-per-node setup using the Mooncake connector.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a test configuration file itself. It will be executed as part of the weekly multi-node E2E testing pipeline.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
