### PR TITLE
[BugFix][KV Offload] Revert aligned Mamba state block normalization

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -933,15 +933,6 @@ class TestCoreFunctionality(unittest.TestCase):
         self.thread.remote_te_port = {"remote_engine": {6666: 7777}}
         self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[1024]]
 
-    def _configure_mock_mamba_transfer(self):
-        self.thread.kv_group2layeridx = {0: ({"kv_cache_spec_type": "MambaSpec"}, [0])}
-        self.thread.kv_caches_base_addr["local_engine"][5555] = [[0x1000, 0x2000]]
-        self.thread.kv_caches_base_addr["remote_engine"] = {6666: [[0x3000, 0x4000]]}
-        self.thread.block_len_per_addr = [[100, 200]]
-        self.thread.block_stride_per_addr = [[128, 256]]
-        self.thread.remote_block_size_scale["remote_engine"] = {6666: [[1, 1]]}
-        self.thread.remote_block_stride_per_addr["remote_engine"][6666] = [[160, 512]]
-
     @patch.object(KVCacheRecvingThread, "_transfer_kv_cache_all_groups")
     @patch.object(KVCacheRecvingThread, "_send_done_recv_signal")
     def test_handle_request(self, mock_send, mock_transfer):
@@ -970,62 +961,6 @@ class TestCoreFunctionality(unittest.TestCase):
         self.assertIsInstance(call_args[3], list)
         self.assertEqual(len(call_args[1]), len(call_args[2]))
         self.assertEqual(len(call_args[1]), len(call_args[3]))
-        mock_get_meta.assert_not_called()
-
-    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
-    def test_transfer_mamba_uses_normalized_prompt_state_block(self, mock_get_meta):
-        # Pure metadata/address arithmetic: no NPU tensor or torch.npu call.
-        self._configure_mock_mamba_transfer()
-        self.thread.mamba_cache_mode = "align"
-        self.thread.num_speculative_tokens = 7
-        req = dict(self.test_req)
-        # The aligned allocator returns the running-state destination first,
-        # followed by speculative blocks. The transfer must target block 2.
-        req["local_block_ids"] = [[2, 20, 21, 22, 23, 24, 25, 26]]
-        req["remote_block_ids"] = [[3]]
-        req["group_pulls"] = [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)]
-
-        self.thread._transfer_kv_cache_all_groups(req)
-
-        call_args, _ = self.engine.batch_transfer_sync_read.call_args
-        self.assertEqual(call_args[1], [0x1000 + 2 * 128, 0x2000 + 2 * 256])
-        self.assertEqual(call_args[2], [0x3000 + 3 * 160, 0x4000 + 3 * 512])
-        self.assertEqual(call_args[3], [100, 200])
-        mock_get_meta.assert_not_called()
-
-    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
-    def test_transfer_mamba_rejects_unnormalized_remote_blocks(self, mock_get_meta):
-        self._configure_mock_mamba_transfer()
-        self.thread.mamba_cache_mode = "align"
-        req = dict(self.test_req)
-        req["local_block_ids"] = [[2]]
-        # The old token-count based selector crashed for one to three blocks
-        # and silently wrapped for four to seven blocks. Reject both forms.
-        req["remote_block_ids"] = [[3, 4, 5]]
-        req["group_pulls"] = [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)]
-
-        with self.assertRaisesRegex(RuntimeError, "exactly one normalized remote state block"):
-            self.thread._transfer_kv_cache_all_groups(req)
-        self.engine.batch_transfer_sync_read.assert_not_called()
-        mock_get_meta.assert_not_called()
-
-    @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
-    def test_transfer_mamba_non_aligned_selects_prompt_state_before_draft_blocks(self, mock_get_meta):
-        # Pure metadata/address arithmetic: no NPU tensor or torch.npu call.
-        self._configure_mock_mamba_transfer()
-        self.thread.mamba_cache_mode = "none"
-        self.thread.num_speculative_tokens = 7
-        req = dict(self.test_req)
-        req["local_block_ids"] = [[2, 20, 21, 22, 23, 24, 25, 26]]
-        req["remote_block_ids"] = [[3, 30, 31, 32, 33, 34, 35, 36]]
-        req["group_pulls"] = [GroupPull(group_id=0, remote_tp_offset=0, num_group_pulls=1, is_group_transfer_end=True)]
-
-        self.thread._transfer_kv_cache_all_groups(req)
-
-        call_args, _ = self.engine.batch_transfer_sync_read.call_args
-        self.assertEqual(call_args[1], [0x1000 + 2 * 128, 0x2000 + 2 * 256])
-        self.assertEqual(call_args[2], [0x3000 + 3 * 160, 0x4000 + 3 * 512])
-        self.assertEqual(call_args[3], [100, 200])
         mock_get_meta.assert_not_called()
 
     @patch.object(KVCacheRecvingThread, "_get_remote_metadata")
@@ -1973,22 +1908,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
 
         self.assertEqual(block_ids, ([10, 11, 12],))
 
-    def test_get_transfer_block_ids_selects_aligned_prompt_state_block(self):
-        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "align"
-        self.scheduler.group_transfer_info = [
-            types.SimpleNamespace(  # type: ignore[list-item]
-                tokens_per_block=16,
-                blocks_per_window=0,
-                is_state_group=True,
-            )
-        ]
-
-        block_ids = self.scheduler._get_transfer_block_ids(([20, 21, 22, 23, 24],), prompt_len=33)
-
-        self.assertEqual(block_ids, ([22],))
-
-    def test_get_transfer_block_ids_keeps_non_aligned_state_group(self):
-        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "none"
+    def test_get_transfer_block_ids_keeps_state_group(self):
         self.scheduler.group_transfer_info = [
             types.SimpleNamespace(  # type: ignore[list-item]
                 tokens_per_block=16,
@@ -2000,19 +1920,6 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         block_ids = self.scheduler._get_transfer_block_ids(([20, 21, 22, 23],), prompt_len=16)
 
         self.assertEqual(block_ids, ([20, 21, 22, 23],))
-
-    def test_get_transfer_block_ids_rejects_short_aligned_state_metadata(self):
-        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "align"
-        self.scheduler.group_transfer_info = [
-            types.SimpleNamespace(  # type: ignore[list-item]
-                tokens_per_block=16,
-                blocks_per_window=0,
-                is_state_group=True,
-            )
-        ]
-
-        with self.assertRaisesRegex(RuntimeError, "Invalid aligned Mamba state block metadata"):
-            self.scheduler._get_transfer_block_ids(([20, 21],), prompt_len=48)
 
     def test_get_transfer_block_ids_uses_compressed_prompt_len(self):
         self.scheduler.group_transfer_info = [
@@ -2175,7 +2082,6 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
         self.assertIn("req_mtp_swa", self.scheduler._reqs_need_send)
 
     def test_request_finished_handles_mtp_swa_and_state_groups_together(self):
-        self.scheduler.vllm_config.cache_config.mamba_cache_mode = "align"
         self.scheduler.group_transfer_info = [
             types.SimpleNamespace(
                 tokens_per_block=16,
@@ -2212,7 +2118,7 @@ class TestMooncakeConnectorScheduler(unittest.TestCase):
             (
                 [100, 101, 102, 103],
                 [200, 201, 202],
-                [303],
+                [300, 301, 302, 303, 304],
             ),
         )
         self.assertEqual(params["num_prompt_blocks"], 4)

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -500,7 +500,6 @@ class KVCacheRecvingThread(threading.Thread):
         assert vllm_config is not None
         self.vllm_config: VllmConfig = vllm_config
         self.model_config = self.vllm_config.model_config
-        self.mamba_cache_mode = getattr(self.vllm_config.cache_config, "mamba_cache_mode", None)
         self.num_speculative_tokens = (
             self.vllm_config.speculative_config.num_speculative_tokens
             if self.vllm_config.speculative_config is not None
@@ -837,28 +836,10 @@ class KVCacheRecvingThread(threading.Thread):
                         )
                     )
             else:
-                # Ascend Hybrid Mamba supports "align" (prefix caching) and
-                # "none" (no prefix caching), but not "all".
-                if self.mamba_cache_mode == "align":
-                    if len(remote_group_block_ids) != 1:
-                        raise RuntimeError(
-                            "Mooncake Mamba transfer requires exactly one normalized remote state block; "
-                            f"request_id={remote_request_id}, group_idx={group_idx}, "
-                            f"remote_block_count={len(remote_group_block_ids)}, "
-                            f"local_block_count={len(local_group_block_ids)}."
-                        )
-                    remote_state_block_id = remote_group_block_ids[0]
-                else:
-                    transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
-                    if transfer_block_idx < 0:
-                        raise RuntimeError(
-                            "Invalid non-aligned Mamba state block metadata: "
-                            f"request_id={remote_request_id}, group_idx={group_idx}, "
-                            f"remote_block_count={len(remote_group_block_ids)}, "
-                            f"num_speculative_tokens={self.num_speculative_tokens}."
-                        )
-                    remote_state_block_id = remote_group_block_ids[transfer_block_idx]
-                grouped_remote_block_ids = [[remote_state_block_id]]
+                # When Prefix Caching is enabled on both P and D nodes, num_block should not be forced to match,
+                # as the D-node requires dynamic allocation based on its specific cache hit rate.
+                transfer_block_idx = len(remote_group_block_ids) - self.num_speculative_tokens - 1
+                grouped_remote_block_ids = [[remote_group_block_ids[transfer_block_idx]]]
                 grouped_local_block_ids = [[local_group_block_ids[0]]]
 
             if is_mamba_group:
@@ -1677,11 +1658,9 @@ class MooncakeConnectorScheduler:
     def _get_transfer_block_ids(self, block_ids: BlockIds, prompt_len: int) -> BlockIds:
         """Return blocks that contain prompt KV, dropping MTP extra blocks.
 
-        In aligned Mamba mode, normalize each state group to the single block
-        containing the final prompt state. This prevents the receiver from
-        inferring a block index from a speculative *token* count. Non-aligned
-        state groups keep their existing behavior. SWA tail clipping is handled
-        as a separate step after this.
+        State groups such as Mamba are not context-block aligned with attention
+        KV, so keep them unchanged and only clip attention-like groups here.
+        SWA tail clipping is handled as a separate step after this.
         """
         if len(block_ids) == 0:
             return block_ids
@@ -1691,23 +1670,8 @@ class MooncakeConnectorScheduler:
         transfer_block_ids = []
         cp_size = max(1, self.pcp_size * self.dcp_size)
         for blocks, group_info in zip(block_ids, self.group_transfer_info):
-            is_aligned_state_group = group_info.is_state_group and (
-                getattr(self.vllm_config.cache_config, "mamba_cache_mode", None) == "align"
-            )
-            if group_info.is_state_group and not is_aligned_state_group:
+            if group_info.is_state_group:
                 transfer_block_ids.append(blocks)
-            elif is_aligned_state_group:
-                # Mamba state is not CP-sharded like attention KV. Its aligned
-                # block index is derived from the actual (already truncated)
-                # prompt length, without multiplying by the CP size.
-                num_prompt_state_blocks = cdiv(prompt_len, group_info.tokens_per_block)
-                if num_prompt_state_blocks <= 0 or num_prompt_state_blocks > len(blocks):
-                    raise RuntimeError(
-                        "Invalid aligned Mamba state block metadata: "
-                        f"prompt_len={prompt_len}, tokens_per_block={group_info.tokens_per_block}, "
-                        f"required_block_count={num_prompt_state_blocks}, available_block_count={len(blocks)}."
-                    )
-                transfer_block_ids.append(blocks[num_prompt_state_blocks - 1 : num_prompt_state_blocks])
             else:
                 # In context parallelism, each scheduler-visible block id is a
                 # CP-grouped/virtual block shared by all CP ranks. It therefore


### PR DESCRIPTION
### What this PR does / why we need it?

This PR reverts #14254.

In a real Kimi-K3 P/D disaggregated deployment using DP=4, TP=16, Expert Parallelism, DSpark speculative decoding, aligned Mamba cache, prefix caching, and Mooncake KV transfer, the decode side may receive multiple Mamba state blocks.

The validation introduced by #14254 requires exactly one normalized remote state block and fails with:

```text
Mooncake Mamba transfer requires exactly one normalized remote state block;
remote_block_count=8, local_block_count=8
```

This failure causes the affected request to enter the invalid-block handling path. The EngineCore subsequently exits, and the remaining DP ranks fail after their Gloo peers are closed.

The problem was reproduced with 32 requests containing 8K inputs at concurrency 8 across four prefill nodes and four decode nodes.

This revert restores the behavior before #14254 while a complete fix for aligned Mamba metadata and hybrid KV-cache invalid-block handling is investigated.

This reverts commit 33761777c8b16741456f43a5420f0fb2af941371.

### Does this PR introduce *any* user-facing change?

Yes.

This PR restores the previous Mooncake Mamba KV-transfer behavior. It removes the strict single-block validation introduced by #14254.

No public API or command-line interface is changed.

### How was this patch tested?

The revert was applied to four prefill nodes and four decode nodes.

The following checks were performed:

- Verified that only the two files changed by #14254 were reverted.
- Ran `git diff --check`.
- Verified identical reverted file hashes across all eight nodes.
- Verified that the `exactly one normalized remote state block` validation was removed.
- Verified the Python syntax of `mooncake_connector.py`.
- Ran the existing Mooncake connector unit tests:

```bash
pytest -q tests/ut/kv_offload/test_mooncake_connector.py \
  --disable-warnings \
  --maxfail=1
```

Result:

```text
111 passed, 14 warnings
```

No new tests are added because this PR is a direct revert and removes the tests introduced by #14254.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
