### PR TITLE
[Performance] Remove redundant deepcopy of scheduler_output in execute_model

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1815,19 +1815,12 @@ class NPUModelRunner(GPUModelRunner):
                 scheduled_spec_decode_tokens=spec_decode_tokens_copy,
             )
 
-        # self._draft_token_ids is None when `input_fits_in_drafter=False`
-        # and there is no draft tokens scheduled. so it need to update the
-        # spec_decoding info in scheduler_output with async_scheduling.
-        # use deepcopy to avoid the modification has influence on the
-        # scheduler_output in engine core process.
-        # TODO(Ronald1995): deepcopy is expensive when there is a large
-        # number of requests, optimize it later.
-        if (
-            self.use_async_scheduling
-            and self.num_spec_tokens
-            and self._draft_token_ids is None  # type: ignore[has-type]
-        ):
-            scheduler_output = deepcopy(scheduler_output)
+        # NOTE: The async-scheduling deepcopy was removed in
+        # vllm-project/vllm#29821. Draft token ids are now propagated via
+        # _copy_draft_token_ids_to_cpu()/take_draft_token_ids(), and the
+        # scheduler output is updated by EngineCore in its own process
+        # (Scheduler.update_draft_token_ids_in_output). Nothing below mutates
+        # scheduler_output in the worker, so no copy is needed. 
         pp_group = get_pp_group()
         if pp_group.world_size > 1 and not pp_group.is_last_rank:
             new_token_ids = scheduler_output.scheduled_cached_reqs.new_token_ids


### PR DESCRIPTION
### What this PR does / why we need it?

Remove the redundant `deepcopy(scheduler_output)` in
`NPUModelRunner.execute_model` on the async-scheduling + spec-decode path.

This deepcopy was removed upstream in vllm-project/vllm#29821, which
replaced the in-worker mutation of `scheduler_output` with
`_copy_draft_token_ids_to_cpu()` / `take_draft_token_ids()` /
`Scheduler.update_draft_token_ids_in_output()` (executed in EngineCore).

It was accidentally re-introduced by  vllm-project/vllm-ascend#6043, which was
developed against v0.13.0. The code it protected (in-worker mutation of
`scheduler_output`) has never existed in this repo — nothing below
mutates `scheduler_output` in the worker, so the copy is pure overhead.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
