### PR TITLE
[CI] fix pre-commit python3 bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,35 +100,35 @@ repos:
     pass_filenames: false
   - id: python-init
     name: Enforce __init__.py in Python packages
-    entry: python tools/check_python_src_init.py
+    entry: python3 tools/check_python_src_init.py
     language: python
-    types: [python3]
+    types: [python]
     pass_filenames: false
   - id: check-logger
     name: Forbid init_logger(__name__) in vllm_ascend modules
     entry: tools/check_logger.sh
     language: script
-    types: [python3]
+    types: [python]
     pass_filenames: false
   - id: check-forbidden-imports
     name: Check for forbidden imports
-    entry: python tools/check_forbidden_imports.py
+    entry: python3 tools/check_forbidden_imports.py
     language: python
-    types: [python3]
+    types: [python]
     additional_dependencies: [regex]
   - id: check-boolean-context-manager
     name: Check for boolean ops in with-statements
-    entry: python tools/check_boolean_context_manager.py
+    entry: python3 tools/check_boolean_context_manager.py
     language: python
-    types: [python3]
+    types: [python]
   - id: check-long-functions
     name: Check that new functions over 100 lines have comments
-    entry: python tools/check_long_functions.py
+    entry: python3 tools/check_long_functions.py
     language: system
-    types: [python3]
+    types: [python]
   - id: check-symbolic-meta
     name: Check symbolic shapes in meta kernels
-    entry: python tools/check_symbolic_meta.py
+    entry: python3 tools/check_symbolic_meta.py
     language: system
     pass_filenames: false
   # Keep `suggestion` last

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,30 +102,30 @@ repos:
     name: Enforce __init__.py in Python packages
     entry: python tools/check_python_src_init.py
     language: python
-    types: [python]
+    types: [python3]
     pass_filenames: false
   - id: check-logger
     name: Forbid init_logger(__name__) in vllm_ascend modules
     entry: tools/check_logger.sh
     language: script
-    types: [python]
+    types: [python3]
     pass_filenames: false
   - id: check-forbidden-imports
     name: Check for forbidden imports
     entry: python tools/check_forbidden_imports.py
     language: python
-    types: [python]
+    types: [python3]
     additional_dependencies: [regex]
   - id: check-boolean-context-manager
     name: Check for boolean ops in with-statements
     entry: python tools/check_boolean_context_manager.py
     language: python
-    types: [python]
+    types: [python3]
   - id: check-long-functions
     name: Check that new functions over 100 lines have comments
     entry: python tools/check_long_functions.py
     language: system
-    types: [python]
+    types: [python3]
   - id: check-symbolic-meta
     name: Check symbolic shapes in meta kernels
     entry: python tools/check_symbolic_meta.py


### PR DESCRIPTION
### What this PR does / why we need it?
fix: pre-commit incorrectly flags valid Python 3 code

### Does this PR introduce _any_ user-facing change?

avoid unneeded pre-commit recognition

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
