### PR TITLE
[BugFix][Frontend] Load reasoning parser plugins in headless mode

### DIFF
--- a/tests/ut/patch/platform/test_patch_reasoning_parser_plugin.py
+++ b/tests/ut/patch/platform/test_patch_reasoning_parser_plugin.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend.patch.platform import patch_reasoning_parser_plugin as patch
+
+
+def _args(plugin: str | None = "/tmp/custom.py"):
+    return SimpleNamespace(reasoning_parser_plugin=plugin)
+
+
+def test_imports_plugin_before_headless_engine_config(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        patch.ReasoningParserManager,
+        "import_reasoning_parser",
+        lambda path: calls.append(path),
+    )
+    monkeypatch.setattr(
+        patch,
+        "_ORIGINAL_RUN_HEADLESS",
+        lambda args: calls.append("run") or "result",
+    )
+
+    result = patch.serve.run_headless(_args())
+
+    assert calls == ["/tmp/custom.py", "run"]
+    assert result == "result"
+
+
+@pytest.mark.parametrize(
+    "args",
+    [_args(plugin=None), _args(plugin="x")],
+)
+def test_skips_incomplete_plugin_config(monkeypatch, args):
+    monkeypatch.setattr(
+        patch.ReasoningParserManager,
+        "import_reasoning_parser",
+        pytest.fail,
+    )
+
+    patch._import_reasoning_parser_plugin(args)
+
+
+def test_rejects_vllm_run_headless_contract_drift():
+    def changed_run_headless(args, extra):
+        del args, extra
+
+    with pytest.raises(RuntimeError, match="run_headless signature changed"):
+        patch._validate_run_headless_contract(changed_run_headless)
+
+
+def test_patches_only_headless_entrypoint():
+    assert patch.serve.run_headless is patch._patched_run_headless

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -454,7 +454,23 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
-# ** 18. File: platform/patch_speculative_config.py**
+# ** 18. File: platform/patch_reasoning_parser_plugin.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.entrypoints.cli.serve.run_headless`
+#    Why:
+#       `vllm serve --headless` creates `VllmConfig` before importing the file
+#       passed through `--reasoning-parser-plugin`. Token ID initialization then
+#       fails because the configured custom reasoning parser is not registered.
+#    How:
+#       Import the configured plugin before headless engine-config creation.
+#       Leave API-server and programmatic registration paths unchanged.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/issues/53072
+#    Future Plan:
+#       Remove this patch once upstream vLLM imports custom reasoning parser
+#       plugins before creating the engine config in headless mode.
+#
+# ** 19. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`
 #    Why:
@@ -477,7 +493,7 @@
 #       models without a custom `hf_config_override`, or exposes a plugin hook
 #       for MTP model_type/architecture remapping.
 #
-# ** 19. File: platform/patch_structured_output.py**
+# ** 20. File: platform/patch_structured_output.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.sampling_params.SamplingParams._validate_structured_outputs`
 #      `vllm.v1.structured_output.StructuredOutputManager.grammar_init`
@@ -499,7 +515,7 @@
 #       before grammar compilation or safely handles mixed-backend grammar
 #       failures without killing the engine.
 #
-# ** 20. File: platform/patch_torch_accelerator.py**
+# ** 21. File: platform/patch_torch_accelerator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `torch.accelerator.memory_stats`, `torch.accelerator.memory_reserved`,
 #      `torch.accelerator.reset_peak_memory_stats`, `torch.accelerator.get_memory_info`,
@@ -519,7 +535,7 @@
 #       Remove this patch once `torch.accelerator` correctly routes to the NPU
 #       backend for these memory APIs.
 #
-# ** 21. File: platform/patch_tool_choice_none_content.py**
+# ** 22. File: platform/patch_tool_choice_none_content.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionResponse`
 #      `vllm.entrypoints.openai.chat_completion.protocol.ChatCompletionStreamResponse`
@@ -535,7 +551,7 @@
 #    Future Plan:
 #       Remove this patch once the supported vLLM version contains PR #44105.
 #
-# ** 22. File: platform/patch_use_v2_model_runner.py**
+# ** 23. File: platform/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`
 #    Why:

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -29,6 +29,7 @@ else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 
+import vllm_ascend.patch.platform.patch_reasoning_parser_plugin  # noqa
 import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_mamba_manager  # noqa

--- a/vllm_ascend/patch/platform/patch_reasoning_parser_plugin.py
+++ b/vllm_ascend/patch/platform/patch_reasoning_parser_plugin.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from inspect import signature
+from typing import Any
+
+from vllm.entrypoints.cli import serve
+from vllm.reasoning import ReasoningParserManager
+
+_EXPECTED_RUN_HEADLESS_PARAMETERS = ("args",)
+_ORIGINAL_RUN_HEADLESS = serve.run_headless
+
+
+def _validate_run_headless_contract(run_headless: Callable[..., Any]) -> None:
+    parameters = tuple(signature(run_headless).parameters)
+    if parameters != _EXPECTED_RUN_HEADLESS_PARAMETERS:
+        raise RuntimeError(
+            "vLLM run_headless signature changed: "
+            f"expected {_EXPECTED_RUN_HEADLESS_PARAMETERS}, got {parameters}. "
+            "Remove or update the vLLM Ascend reasoning parser plugin patch."
+        )
+
+
+def _import_reasoning_parser_plugin(args: Any) -> None:
+    plugin_path = getattr(args, "reasoning_parser_plugin", None)
+    if not plugin_path or len(plugin_path) <= 3:
+        return
+
+    ReasoningParserManager.import_reasoning_parser(plugin_path)
+
+
+@wraps(_ORIGINAL_RUN_HEADLESS)
+def _patched_run_headless(args: Any) -> Any:
+    _import_reasoning_parser_plugin(args)
+    return _ORIGINAL_RUN_HEADLESS(args)
+
+
+_validate_run_headless_contract(_ORIGINAL_RUN_HEADLESS)
+serve.run_headless = _patched_run_headless


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a temporary platform monkey patch for custom reasoning parser plugins in headless mode. Upstream vLLM creates `VllmConfig` before importing `--reasoning-parser-plugin` on the headless path, so reasoning token initialization raises `KeyError` before workers start.

The patch imports the configured plugin before the original `VllmConfig.__post_init__` only when the requested parser is not already registered. This keeps the regular API server and programmatic parser registration behavior unchanged. It also fails explicitly if the private `VllmConfig.__post_init__(self)` contract changes.

Fixes #14573.

Upstream issue: https://github.com/vllm-project/vllm/issues/53072

### Does this PR introduce _any_ user-facing change?

Yes. Ascend headless DP ranks can start with a custom `--reasoning-parser-plugin` instead of failing with `KeyError` during engine config creation.

### How was this patch tested?

- `python -m pytest -q tests/ut/patch/platform/test_patch_reasoning_parser_plugin.py tests/ut/test_platform.py`: 72 passed, 1 skipped
- `bash format.sh ci`: passed
- Manual headless startup with Qwen3-0.6B, DP size 2, local DP size 1, and start rank 1 reached `Launching 1 data parallel engine(s) in headless mode` without the former parser `KeyError`. The process was then stopped because the DP head was intentionally absent.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
