### PR TITLE
[Feature][MRV2] Support MTP with prefill context parallelism

### DIFF
--- a/tests/ut/attention/a2/test_attention_v1.py
+++ b/tests/ut/attention/a2/test_attention_v1.py
@@ -68,15 +68,12 @@ class TestAscendAttentionBackend(TestBase):
         self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
         self.utils_patcher.start()
 
-        from vllm_ascend.attention.utils import enable_dcp, enable_pcp
+        from vllm_ascend.attention.utils import enable_dcp
 
         self.enable_dcp = enable_dcp
-        self.enable_pcp = enable_pcp
         enable_dcp.cache_clear()
-        enable_pcp.cache_clear()
         self.addCleanup(self.utils_patcher.stop)
         self.addCleanup(enable_dcp.cache_clear)
-        self.addCleanup(enable_pcp.cache_clear)
 
     def test_get_name(self):
         self.assertEqual(AscendAttentionBackend.get_name(), "CUSTOM")
@@ -89,7 +86,6 @@ class TestAscendAttentionBackend(TestBase):
 
     def test_get_impl_cls_with_pcp(self):
         self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
 
         self.assertIs(
             AscendAttentionBackend.get_impl_cls(),
@@ -98,17 +94,33 @@ class TestAscendAttentionBackend(TestBase):
 
     def test_get_builder_cls_with_pcp(self):
         self.mock_config.parallel_config.prefill_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
 
         self.assertIs(
             AscendAttentionBackend.get_builder_cls(),
             AscendAttentionPCPMetadataBuilder,
         )
 
+    def test_impl_tracks_current_pcp_config(self):
+        self.assertIs(
+            AscendAttentionBackend.get_impl_cls(),
+            AscendAttentionBackendImpl,
+        )
+
+        self.mock_config.parallel_config.prefill_context_parallel_size = 2
+        self.assertIs(
+            AscendAttentionBackend.get_impl_cls(),
+            AscendAttentionPCPImpl,
+        )
+
+        self.mock_config.parallel_config.prefill_context_parallel_size = 1
+        self.assertIs(
+            AscendAttentionBackend.get_impl_cls(),
+            AscendAttentionBackendImpl,
+        )
+
     def test_pcp_and_dcp_are_rejected_together(self):
         self.mock_config.parallel_config.prefill_context_parallel_size = 2
         self.mock_config.parallel_config.decode_context_parallel_size = 2
-        self.enable_pcp.cache_clear()
         self.enable_dcp.cache_clear()
 
         with self.assertRaisesRegex(NotImplementedError, "PCP and DCP"):

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -15,6 +16,9 @@ from vllm_ascend.attention.mla_v1 import (
     AscendMLAImpl,
     AscendMLAMetadata,
     AscendMLAMetadataBuilder,
+    AscendMLAPCPImpl,
+    AscendMLAPCPMetadata,
+    AscendMLAPCPMetadataBuilder,
     AscendMLAPrefillMetadata,
     ChunkedContextMetadata,
     DecodeMLAPreprocessResult,
@@ -30,11 +34,20 @@ class TestAscendMLABackend(TestBase):
         mock_parallel_config = MagicMock()
         mock_parallel_config.prefill_context_parallel_size = 1
         mock_parallel_config.decode_context_parallel_size = 1
+        self.mock_parallel_config = mock_parallel_config
 
         self.mock_config.parallel_config = mock_parallel_config
 
-        self.utils_patcher = patch("vllm_ascend.attention.utils.get_current_vllm_config", return_value=self.mock_config)
+        self.utils_patcher = patch(
+            "vllm_ascend.attention.utils.get_current_vllm_config",
+            return_value=self.mock_config,
+        )
         self.utils_patcher.start()
+        self.mla_config_patcher = patch(
+            "vllm_ascend.attention.mla_v1.get_current_vllm_config",
+            return_value=self.mock_config,
+        )
+        self.mla_config_patcher.start()
 
         from vllm_ascend.attention.utils import enable_dcp
 
@@ -45,14 +58,17 @@ class TestAscendMLABackend(TestBase):
 
     def test_get_builder_cls(self):
         self.assertEqual(AscendMLABackend.get_builder_cls(), AscendMLAMetadataBuilder)
+        self.mock_parallel_config.prefill_context_parallel_size = 2
+        self.assertIs(AscendMLABackend.get_builder_cls(), AscendMLAPCPMetadataBuilder)
 
     def test_get_kv_cache_shape(self):
         result = AscendMLABackend.get_kv_cache_shape(2, 4, 8, 128)
         self.assertEqual(result, (2, 4, 8, 128))
 
     def test_get_impl_cls(self):
-        result = AscendMLABackend.get_impl_cls()
-        self.assertEqual(result, AscendMLAImpl)
+        self.assertEqual(AscendMLABackend.get_impl_cls(), AscendMLAImpl)
+        self.mock_parallel_config.prefill_context_parallel_size = 2
+        self.assertIs(AscendMLABackend.get_impl_cls(), AscendMLAPCPImpl)
 
     def test_get_supported_kernel_block_sizes(self):
         result = AscendMLABackend.get_supported_kernel_block_sizes()
@@ -69,6 +85,131 @@ class TestAscendMLABackend(TestBase):
         mock_enable_dcp.return_value = True
         impl_cls = AscendMLABackend.get_impl_cls()
         self.assertIsNotNone(impl_cls)
+
+    @patch("vllm_ascend.attention.mla_v1.enable_dcp")
+    def test_pcp_and_dcp_are_rejected(self, mock_enable_dcp):
+        mock_enable_dcp.return_value = True
+        self.mock_parallel_config.prefill_context_parallel_size = 2
+
+        with self.assertRaisesRegex(
+            NotImplementedError, "does not support PCP and DCP"
+        ):
+            AscendMLABackend.get_builder_cls()
+        with self.assertRaisesRegex(
+            NotImplementedError, "does not support PCP and DCP"
+        ):
+            AscendMLABackend.get_impl_cls()
+
+
+def _make_pcp_metadata(
+    *,
+    num_actual_tokens: int,
+    num_decode_tokens: int,
+    attn_state: AscendAttentionState = AscendAttentionState.ChunkedPrefill,
+) -> AscendMLAPCPMetadata:
+    return AscendMLAPCPMetadata(
+        num_actual_tokens=num_actual_tokens,
+        slot_mapping=torch.empty(0, dtype=torch.int64),
+        query_start_loc=torch.tensor([0, num_actual_tokens], dtype=torch.int32),
+        seq_lens=torch.tensor([num_actual_tokens], dtype=torch.int32),
+        seq_lens_cpu=torch.tensor([num_actual_tokens], dtype=torch.int32),
+        block_tables=torch.zeros(1, 1, dtype=torch.int32),
+        num_decodes=int(num_decode_tokens > 0),
+        num_decode_tokens=num_decode_tokens,
+        num_prefills=int(num_actual_tokens > num_decode_tokens),
+        attn_state=attn_state,
+    )
+
+
+def test_mla_pcp_metadata_keeps_expanded_slot_mapping() -> None:
+    expanded_slots = torch.tensor(
+        [5, 10, 11, -1, -1, 20, 21, -1],
+        dtype=torch.int64,
+    )
+    common_metadata = SimpleNamespace(slot_mapping=expanded_slots)
+    metadata = _make_pcp_metadata(
+        num_actual_tokens=3,
+        num_decode_tokens=1,
+        attn_state=AscendAttentionState.PrefillCacheHit,
+    )
+    builder = AscendMLAPCPMetadataBuilder.__new__(AscendMLAPCPMetadataBuilder)
+    builder.pcp_size = 2
+    builder.pcp_rank = 1
+
+    with patch.object(AscendMLAMetadataBuilder, "build", return_value=metadata):
+        result = builder.build(0, common_metadata)
+
+    assert result.slot_mapping is expanded_slots
+    assert result.pcp_local_num_input_tokens == 4
+    assert result.pcp_local_prefill_start == 3
+    assert result.pcp_local_prefill_end == 5
+    assert result.attn_state == AscendAttentionState.ChunkedPrefill
+
+
+def test_mla_pcp_prefill_gathers_padded_cache_inputs() -> None:
+    impl = AscendMLAPCPImpl.__new__(AscendMLAPCPImpl)
+    captured: dict[str, torch.Tensor] = {}
+
+    def fake_gather(tensors, slot_mapping, num_decode_tokens):
+        assert num_decode_tokens == 0
+        captured["local_kv"] = tensors[0]
+        captured["local_cos"] = tensors[1]
+        captured["slots"] = slot_mapping
+        return (
+            tuple(torch.cat((tensor + 100, tensor), dim=0) for tensor in tensors),
+            slot_mapping,
+        )
+
+    def fake_exec_kv_prefill(self, kv, cos, sin, kv_cache, slots):
+        captured["gathered_kv"] = kv
+        captured["cache_slots"] = slots
+        return cos, kv[:, :2]
+
+    pcp_group = SimpleNamespace(world_size=2, rank_in_group=1)
+    metadata = _make_pcp_metadata(num_actual_tokens=3, num_decode_tokens=1)
+    metadata.slot_mapping = torch.tensor(
+        [5, 10, 11, -1, -1, 20, 21, -1],
+        dtype=torch.int64,
+    )
+    metadata.pcp_local_num_input_tokens = 4
+    metadata.pcp_local_prefill_start = 3
+    metadata.pcp_local_prefill_end = 5
+    kv = torch.arange(9, dtype=torch.float32).view(3, 3)
+    cos = torch.tensor([[1.0], [2.0], [1.0]])
+    sin = torch.tensor([[3.0], [4.0], [0.0]])
+
+    with (
+        patch(
+            "vllm_ascend.attention.mla_v1.get_pcp_group",
+            return_value=pcp_group,
+        ),
+        patch(
+            "vllm_ascend.attention.mla_v1._gather_prefill_cache_inputs",
+            side_effect=fake_gather,
+        ),
+        patch.object(
+            AscendMLAImpl,
+            "exec_kv_prefill",
+            fake_exec_kv_prefill,
+        ),
+    ):
+        k_pe, k_nope = impl.exec_kv_prefill(
+            kv,
+            cos,
+            sin,
+            (torch.empty(0), torch.empty(0)),
+            torch.empty(0, dtype=torch.int64),
+            attn_metadata=metadata,
+        )
+
+    expected_slots = torch.tensor([10, 11, -1, 20, 21, -1])
+    torch.testing.assert_close(captured["slots"], expected_slots)
+    assert captured["local_kv"] is kv
+    assert captured["local_cos"] is cos
+    assert captured["gathered_kv"].shape[0] == 6
+    torch.testing.assert_close(captured["cache_slots"], expected_slots)
+    torch.testing.assert_close(k_pe, cos[:2])
+    torch.testing.assert_close(k_nope, kv[:2, :2])
 
 
 class TestDecodeMLAPreprocessResult(TestBase):
@@ -122,7 +263,9 @@ class TestPrefillMLAPreprocessResult(TestBase):
         k_pe = torch.randn(2, 4, 8)
         value = torch.randn(2, 4, 8)
 
-        result = PrefillMLAPreprocessResult(q_nope=q_nope, q_pe=q_pe, k_nope=k_nope, k_pe=k_pe, value=value)
+        result = PrefillMLAPreprocessResult(
+            q_nope=q_nope, q_pe=q_pe, k_nope=k_nope, k_pe=k_pe, value=value
+        )
 
         self.assertIs(result.q_nope, q_nope)
         self.assertIs(result.q_pe, q_pe)
@@ -296,7 +439,13 @@ class TestAscendMLAMetadataBuilder(TestBase):
         # Mock parent class __init__ to avoid complex initialization,
         # but still set the essential attributes that child class needs
         def mock_parent_init(
-            self, kv_cache_spec, layer_names, vllm_config, device, metadata_cls, supports_dcp_with_varlen
+            self,
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls,
+            supports_dcp_with_varlen,
         ):
             self.metadata_cls = metadata_cls
             self.kv_cache_spec = kv_cache_spec
@@ -305,13 +454,17 @@ class TestAscendMLAMetadataBuilder(TestBase):
             self.device = device
             self.chunked_prefill_workspace_size = 128 * 1024
             self.chunked_prefill_workspace = torch.empty(
-                (self.chunked_prefill_workspace_size, vllm_config.model_config.get_head_size()),
+                (
+                    self.chunked_prefill_workspace_size,
+                    vllm_config.model_config.get_head_size(),
+                ),
                 dtype=vllm_config.model_config.dtype,
                 device=device,
             )
 
         self.parent_init_patcher = patch(
-            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__", mock_parent_init
+            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__",
+            mock_parent_init,
         )
         self.parent_init_patcher.start()
 
@@ -332,11 +485,20 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.speculative_config = None
 
         ascend_config = MagicMock()
-        with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        with patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config
+        ):
+            builder = AscendMLAMetadataBuilder(
+                None, None, mock_vllm_config, mock_device
+            )
 
-            self.assertEqual(builder.block_size, mock_vllm_config.cache_config.block_size)
-            self.assertEqual(builder.chunked_prefill_enabled, mock_vllm_config.scheduler_config.enable_chunked_prefill)
+            self.assertEqual(
+                builder.block_size, mock_vllm_config.cache_config.block_size
+            )
+            self.assertEqual(
+                builder.chunked_prefill_enabled,
+                mock_vllm_config.scheduler_config.enable_chunked_prefill,
+            )
 
     def test_ascend_mla_metadata_builder_spec_decode(self):
         mock_vllm_config = MagicMock()
@@ -354,14 +516,25 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.speculative_config = mock_spec_config
 
         ascend_config = MagicMock()
-        with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        with patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config
+        ):
+            builder = AscendMLAMetadataBuilder(
+                None, None, mock_vllm_config, mock_device
+            )
 
-            self.assertEqual(builder.block_size, mock_vllm_config.cache_config.block_size)
-            self.assertEqual(builder.chunked_prefill_enabled, mock_vllm_config.scheduler_config.enable_chunked_prefill)
+            self.assertEqual(
+                builder.block_size, mock_vllm_config.cache_config.block_size
+            )
+            self.assertEqual(
+                builder.chunked_prefill_enabled,
+                mock_vllm_config.scheduler_config.enable_chunked_prefill,
+            )
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    def test_ascend_mla_metadata_builder_build_full_graph(self, mock_get_cos_and_sin_mla):
+    def test_ascend_mla_metadata_builder_build_full_graph(
+        self, mock_get_cos_and_sin_mla
+    ):
         mock_vllm_config = MagicMock()
         mock_vllm_config.model_config.max_model_len = 1024
         mock_vllm_config.model_config.get_head_size.return_value = 64
@@ -371,6 +544,8 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
+        mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
+        mock_vllm_config.parallel_config.decode_context_parallel_size = 1
         mock_device = "cpu"
         torch.Tensor.pin_memory = lambda x: x  # noqa
 
@@ -392,7 +567,10 @@ class TestAscendMLAMetadataBuilder(TestBase):
         common_metadata.positions = torch.Tensor([1, 2, 3, 4, 5, 6]).int()
         block_table = torch.Tensor([[1, 0], [2, 0], [3, 0], [4, 0]]).int()
         common_metadata.block_table_tensor = block_table
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([6, 6]), torch.Tensor([6, 6]))
+        mock_get_cos_and_sin_mla.return_value = (
+            torch.tensor([6, 6]),
+            torch.Tensor([6, 6]),
+        )
         metadata = builder.build(0, common_metadata)
 
         self.assertEqual(metadata.decode.actual_seq_lengths_q, [1, 2, 4, 5, 6, 6, 7, 8])
@@ -413,8 +591,12 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
         mock_vllm_config.speculative_config = None
 
-        with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        with patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config
+        ):
+            builder = AscendMLAMetadataBuilder(
+                None, None, mock_vllm_config, mock_device
+            )
             builder.decode_threshold = 1
 
         input_batch = MagicMock()
@@ -440,14 +622,18 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.scheduler_config.max_num_batched_tokens = 4096
         mock_vllm_config.model_config.max_model_len = 4096
 
-        result = AscendMLAMetadataBuilder.determine_chunked_prefill_workspace_size(mock_vllm_config)
+        result = AscendMLAMetadataBuilder.determine_chunked_prefill_workspace_size(
+            mock_vllm_config
+        )
         self.assertGreater(result, 0)
 
     def test_get_cudagraph_support(self):
         mock_vllm_config = MagicMock()
         mock_kv_cache_spec = MagicMock()
 
-        result = AscendMLAMetadataBuilder.get_cudagraph_support(mock_vllm_config, mock_kv_cache_spec)
+        result = AscendMLAMetadataBuilder.get_cudagraph_support(
+            mock_vllm_config, mock_kv_cache_spec
+        )
         from vllm.v1.attention.backend import AttentionCGSupport
 
         self.assertEqual(result, AttentionCGSupport.UNIFORM_BATCH)
@@ -490,7 +676,9 @@ class TestAscendMLAMetadataBuilder(TestBase):
         expect_output = [1, 2, 4, 5, 6, 6, 7, 8]
         num_reqs = 4
         num_reqs_pad_size = 4
-        output_seq_lens = builder.pad_actual_seq_len_q_mtp_disable_pad(num_reqs_pad_size, num_reqs, input_seq_lens)
+        output_seq_lens = builder.pad_actual_seq_len_q_mtp_disable_pad(
+            num_reqs_pad_size, num_reqs, input_seq_lens
+        )
         self.assertEqual(output_seq_lens, expect_output)
 
     def test_pad_actual_seq_lens_q_mtp_enable_pad(self):
@@ -552,7 +740,13 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         # Mock parent class __init__ to avoid complex initialization,
         # but still set the essential attributes that child class needs
         def mock_parent_init(
-            self, kv_cache_spec, layer_names, vllm_config, device, metadata_cls, supports_dcp_with_varlen
+            self,
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls,
+            supports_dcp_with_varlen,
         ):
             self.metadata_cls = metadata_cls
             self.kv_cache_spec = kv_cache_spec
@@ -561,13 +755,17 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             self.device = device
             self.chunked_prefill_workspace_size = 128 * 1024
             self.chunked_prefill_workspace = torch.empty(
-                (self.chunked_prefill_workspace_size, vllm_config.model_config.get_head_size()),
+                (
+                    self.chunked_prefill_workspace_size,
+                    vllm_config.model_config.get_head_size(),
+                ),
                 dtype=vllm_config.model_config.dtype,
                 device=device,
             )
 
         self.parent_init_patcher = patch(
-            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__", mock_parent_init
+            "vllm.model_executor.layers.attention.mla_attention.MLACommonMetadataBuilder.__init__",
+            mock_parent_init,
         )
         self.parent_init_patcher.start()
 
@@ -578,9 +776,13 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         mock_scheduler_config.chunked_prefill_enabled = True
         mock_scheduler_config.enable_chunked_prefill = True
         self.mock_vllm_config.scheduler_config = mock_scheduler_config
+        self.mock_vllm_config.parallel_config.prefill_context_parallel_size = 1
+        self.mock_vllm_config.parallel_config.decode_context_parallel_size = 1
         self.mock_vllm_config.speculative_config = None
         self.mock_device = torch.device("cpu")
-        fake_weight_path = os.path.join(os.path.dirname(__file__), "..", "..", "_fake_weight")
+        fake_weight_path = os.path.join(
+            os.path.dirname(__file__), "..", "..", "_fake_weight"
+        )
         model_config = ModelConfig(
             model=fake_weight_path,
             skip_tokenizer_init=True,
@@ -600,7 +802,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
-    def test_build_prefix_no_cache_metadata(self, mock_npu_available, mock_zeros, mock_get_cos_and_sin_mla):
+    def test_build_prefix_no_cache_metadata(
+        self, mock_npu_available, mock_zeros, mock_get_cos_and_sin_mla
+    ):
         mock_npu_available.return_value = False
         torch.Tensor.pin_memory = lambda x: x  # noqa
 
@@ -654,7 +858,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
     @patch("vllm_ascend.attention.mla_v1.torch.zeros", wraps=torch.zeros)
     @patch("torch.Tensor.npu", new=lambda self: self)
     @patch("torch.npu.is_available")
-    def test_build_chunked_prefix_metadata(self, mock_npu_available, mock_zeros, mock_get_cos_and_sin_mla):
+    def test_build_chunked_prefix_metadata(
+        self, mock_npu_available, mock_zeros, mock_get_cos_and_sin_mla
+    ):
         mock_npu_available.return_value = False
         torch.Tensor.pin_memory = lambda x: x  # noqa
 
@@ -741,7 +947,10 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]), torch.Tensor([10, 10]))
+        mock_get_cos_and_sin_mla.return_value = (
+            torch.tensor([10, 10]),
+            torch.Tensor([10, 10]),
+        )
         metadata = builder.build(1, common_attn_metadata)
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
@@ -750,7 +959,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         self.assertEqual(metadata.head_dim, self.kv_cache_spec.head_size)
 
     @patch("vllm_ascend.attention.mla_v1.get_cos_and_sin_mla")
-    def test_build_decode_metadata_without_disable_padded_drafter_batch(self, mock_get_cos_and_sin_mla):
+    def test_build_decode_metadata_without_disable_padded_drafter_batch(
+        self, mock_get_cos_and_sin_mla
+    ):
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_reqs = 3
         common_attn_metadata.query_start_loc_cpu = torch.tensor([0, 1, 2, 3])
@@ -777,7 +988,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         builder.speculative_config = mock_speculative_config
 
         builder.attn_mask_builder = MagicMock()
-        builder.attn_mask_builder.get_splitfuse_attn_mask.return_value = torch.randn(1, 1, 5, 5)
+        builder.attn_mask_builder.get_splitfuse_attn_mask.return_value = torch.randn(
+            1, 1, 5, 5
+        )
 
         mock_get_cos_and_sin_mla.return_value = (torch.randn(5, 32), torch.randn(5, 32))
 
@@ -821,8 +1034,13 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
             vllm_config=self.mock_vllm_config,
             device=self.mock_device,
         )
-        mock_get_cos_and_sin_mla.return_value = (torch.tensor([10, 10]), torch.Tensor([10, 10]))
-        metadata = builder.build_for_graph_capture(common_attn_metadata, AscendAttentionState.DecodeOnly)
+        mock_get_cos_and_sin_mla.return_value = (
+            torch.tensor([10, 10]),
+            torch.Tensor([10, 10]),
+        )
+        metadata = builder.build_for_graph_capture(
+            common_attn_metadata, AscendAttentionState.DecodeOnly
+        )
 
         self.assertIsInstance(metadata, AscendMLAMetadata)
         self.assertEqual(metadata.num_actual_tokens, base_inputs["num_actual_tokens"])
@@ -858,7 +1076,9 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
         )
         mock_get_cos_and_sin_mla.return_value = (torch.tensor(10), torch.Tensor(10))
         with self.assertRaises(NotImplementedError) as ctx:
-            builder.build_for_graph_capture(common_attn_metadata, AscendAttentionState.PrefillNoCache)
+            builder.build_for_graph_capture(
+                common_attn_metadata, AscendAttentionState.PrefillNoCache
+            )
         self.assertIn(
             "Currently we only support building dummy metadata for DecodeOnly and SpecDecoding state",
             str(ctx.exception),
@@ -935,7 +1155,10 @@ class TestAscendMLAMetadataBuilderBuild(TestBase):
 
 
 class TestAscendMLAImpl(TestBase):
-    @patch("vllm.distributed.parallel_state._TP", new_callable=lambda: MagicMock(spec=GroupCoordinator))
+    @patch(
+        "vllm.distributed.parallel_state._TP",
+        new_callable=lambda: MagicMock(spec=GroupCoordinator),
+    )
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     def setUp(self, get_current_vllm_config, mock_tp):
         mock_tp.world_size = 2
@@ -1059,10 +1282,14 @@ class TestAscendMLAImpl(TestBase):
     def test_q_proj_and_k_up_proj(self):
         batch_size = 4
         x = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
-        q_proj_output = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_head_dim)
+        q_proj_output = torch.randn(
+            batch_size, self.impl.num_heads, self.impl.qk_head_dim
+        )
         self.impl.q_proj.return_value = (q_proj_output,)
         if not hasattr(self.impl, "W_UK_T") or self.impl.W_UK_T is None:
-            self.impl.W_UK_T = torch.randn(self.impl.num_heads, self.impl.qk_nope_head_dim, self.impl.kv_lora_rank)
+            self.impl.W_UK_T = torch.randn(
+                self.impl.num_heads, self.impl.qk_nope_head_dim, self.impl.kv_lora_rank
+            )
         result = self.impl._q_proj_and_k_up_proj(x)
         ql_nope, q_pe = result
         self.assertEqual(ql_nope.shape[0], batch_size)
@@ -1120,10 +1347,14 @@ class TestAscendMLAImpl(TestBase):
         batch_size = 4
         x = torch.randn(self.impl.num_heads, batch_size, self.impl.kv_lora_rank)
         if not hasattr(self.impl, "W_UV") or self.impl.W_UV is None:
-            self.impl.W_UV = torch.randn(self.impl.num_heads, self.impl.kv_lora_rank, self.impl.v_head_dim)
+            self.impl.W_UV = torch.randn(
+                self.impl.num_heads, self.impl.kv_lora_rank, self.impl.v_head_dim
+            )
 
         expected_shape = (batch_size, self.impl.num_heads * self.impl.v_head_dim)
-        mock_torch_npu.npu_transpose_batchmatmul.return_value = torch.randn(*expected_shape)
+        mock_torch_npu.npu_transpose_batchmatmul.return_value = torch.randn(
+            *expected_shape
+        )
 
         result = self.impl._v_up_proj(x)
         self.assertEqual(result.shape[0], batch_size)
@@ -1287,7 +1518,10 @@ class TestAscendMLAImpl(TestBase):
         mock_speculative_config.num_speculative_tokens = 4
 
         AscendMLAImpl.update_graph_params(
-            mock_update_stream, mock_forward_context, 100, speculative_config=mock_speculative_config
+            mock_update_stream,
+            mock_forward_context,
+            100,
+            speculative_config=mock_speculative_config,
         )
 
     def test_get_context_seq_len_npu(self):
@@ -1306,7 +1540,9 @@ class TestAscendMLAImpl(TestBase):
         kv_c_normed = torch.randn(2, 4, 8)
         k_pe = torch.randn(2, 4, 8)
         mock_chunked_context = MagicMock()
-        result_kv, result_k_pe = self.impl._reorg_kvcache(kv_c_normed, k_pe, mock_chunked_context, 0, 10)
+        result_kv, result_k_pe = self.impl._reorg_kvcache(
+            kv_c_normed, k_pe, mock_chunked_context, 0, 10
+        )
         self.assertIs(result_kv, kv_c_normed)
         self.assertIs(result_k_pe, k_pe)
 
@@ -1329,7 +1565,9 @@ class TestAscendMLAImpl(TestBase):
         mock_layer.fak_descale_float = torch.randn(1)
         self.impl.vllm_config = MagicMock()
         self.impl.vllm_config.compilation_config = MagicMock()
-        self.impl.vllm_config.compilation_config.static_forward_context = {"layer_0": mock_layer}
+        self.impl.vllm_config.compilation_config.static_forward_context = {
+            "layer_0": mock_layer
+        }
         self.impl.layer_name = "layer_0"
 
         self.impl._process_weights_for_fused_fa_quant()
@@ -1425,13 +1663,19 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
     @patch("torch_npu.npu_fused_infer_attention_score")
     @patch("torch_npu.npu_attention_update")
-    def test__forward_prefill(self, mock_npu_attention_update, mock_fia, mock_device_operator):
+    def test__forward_prefill(
+        self, mock_npu_attention_update, mock_fia, mock_device_operator
+    ):
         batch_size = 2
 
         # create input tensors
-        q_nope = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_nope_head_dim)
+        q_nope = torch.randn(
+            batch_size, self.impl.num_heads, self.impl.qk_nope_head_dim
+        )
         q_pe = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_rope_head_dim)
-        k_nope = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_nope_head_dim)
+        k_nope = torch.randn(
+            batch_size, self.impl.num_heads, self.impl.qk_nope_head_dim
+        )
         k_pe = torch.randn(batch_size, self.impl.num_heads, self.impl.qk_rope_head_dim)
         value = torch.randn(batch_size, self.impl.num_heads, self.impl.v_head_dim)
 
@@ -1464,11 +1708,17 @@ class TestAscendMLAImpl(TestBase):
         mock_kv_b_proj = MagicMock()
         # create [toks, num_heads, qk_nope_head_dim + v_head_dim] tensor
         toks = 10
-        kv_nope_shape = (toks, self.impl.num_heads, self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        kv_nope_shape = (
+            toks,
+            self.impl.num_heads,
+            self.impl.qk_nope_head_dim + self.impl.v_head_dim,
+        )
         mock_kv_b_proj.return_value = (torch.randn(kv_nope_shape), None)
         self.impl.kv_b_proj = mock_kv_b_proj
 
-        result = self.impl._forward_prefill(q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata)
+        result = self.impl._forward_prefill(
+            q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata
+        )
 
         # verify result shape
         self.assertEqual(result.shape[0], batch_size)
@@ -1477,7 +1727,9 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
     @patch("torch_npu.npu_fused_infer_attention_score")
-    def test_forward_prefill_non_power_of_two_heads(self, mock_fia, mock_device_operator, mock_get_current_vllm_config):
+    def test_forward_prefill_non_power_of_two_heads(
+        self, mock_fia, mock_device_operator, mock_get_current_vllm_config
+    ):
         """Test prefill with non-power-of-2 heads uses concat instead of query_rope/key_rope kwargs."""
         mock_get_current_vllm_config.return_value = MagicMock()
         num_heads = 20
@@ -1532,7 +1784,9 @@ class TestAscendMLAImpl(TestBase):
             torch.randn(num_heads, batch_size),
         )
 
-        result = impl._forward_prefill(q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata)
+        result = impl._forward_prefill(
+            q_nope, q_pe, k_nope, k_pe, value, kv_c_and_k_pe_cache, attn_metadata
+        )
 
         # FIA should be called without query_rope/key_rope when head_padding > 0
         mock_fia.assert_called_once()
@@ -1548,7 +1802,9 @@ class TestAscendMLAImpl(TestBase):
         layer.input_size_per_partition = 10
         quant_method = MagicMock(spec=UnquantizedLinearMethod)
         layer.quant_method = quant_method
-        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_0 = self.impl.num_heads * (
+            self.impl.qk_nope_head_dim + self.impl.v_head_dim
+        )
         shape_1 = self.impl.kv_lora_rank
         layer.weight = torch.randn(shape_0, shape_1)
         self.impl.kv_b_proj = layer
@@ -1570,7 +1826,9 @@ class TestAscendMLAImpl(TestBase):
         layer.input_size_per_partition = 10
         quant_method = MagicMock(spec=UnquantizedLinearMethod)
         layer.quant_method = quant_method
-        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_0 = self.impl.num_heads * (
+            self.impl.qk_nope_head_dim + self.impl.v_head_dim
+        )
         shape_1 = self.impl.kv_lora_rank
         layer.weight = torch.randn(shape_0, shape_1)
         self.impl.kv_b_proj = layer
@@ -1590,13 +1848,17 @@ class TestAscendMLAImpl(TestBase):
 
     @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_mlapo_a5(self, mock_format_cast, mock_get_ascend_device_type):
+    def test_process_weights_after_loading_with_mlapo_a5(
+        self, mock_format_cast, mock_get_ascend_device_type
+    ):
         # test with enable_mlapo=True and device_type=A5
         layer = MagicMock(spec=LinearBase)
         layer.input_size_per_partition = 10
         quant_method = MagicMock(spec=UnquantizedLinearMethod)
         layer.quant_method = quant_method
-        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_0 = self.impl.num_heads * (
+            self.impl.qk_nope_head_dim + self.impl.v_head_dim
+        )
         shape_1 = self.impl.kv_lora_rank
         layer.weight = torch.randn(shape_0, shape_1)
         self.impl.kv_b_proj = layer
@@ -1620,7 +1882,9 @@ class TestAscendMLAImpl(TestBase):
 
         self.impl.process_weights_after_loading(torch.bfloat16)
 
-        self.impl._process_weights_for_fused_mlapo_a5.assert_called_once_with(torch.bfloat16)
+        self.impl._process_weights_for_fused_mlapo_a5.assert_called_once_with(
+            torch.bfloat16
+        )
 
         self.assertEqual(self.impl.W_UK_T.shape[0], self.impl.num_heads)
         self.assertEqual(self.impl.W_UK_T.shape[1], self.impl.qk_nope_head_dim)
@@ -1632,13 +1896,17 @@ class TestAscendMLAImpl(TestBase):
 
     @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_mlapo_non_a5(self, mock_format_cast, mock_get_ascend_device_type):
+    def test_process_weights_after_loading_with_mlapo_non_a5(
+        self, mock_format_cast, mock_get_ascend_device_type
+    ):
         # test with enable_mlapo=True and device_type!=A5
         layer = MagicMock(spec=LinearBase)
         layer.input_size_per_partition = 10
         quant_method = MagicMock(spec=UnquantizedLinearMethod)
         layer.quant_method = quant_method
-        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_0 = self.impl.num_heads * (
+            self.impl.qk_nope_head_dim + self.impl.v_head_dim
+        )
         shape_1 = self.impl.kv_lora_rank
         layer.weight = torch.randn(shape_0, shape_1)
         self.impl.kv_b_proj = layer
@@ -1662,7 +1930,9 @@ class TestAscendMLAImpl(TestBase):
 
         self.impl.process_weights_after_loading(torch.bfloat16)
 
-        self.impl._process_weights_for_fused_mlapo.assert_called_once_with(torch.bfloat16)
+        self.impl._process_weights_for_fused_mlapo.assert_called_once_with(
+            torch.bfloat16
+        )
 
         self.assertEqual(self.impl.W_UK_T.shape[0], self.impl.num_heads)
         self.assertEqual(self.impl.W_UK_T.shape[1], self.impl.qk_nope_head_dim)
@@ -1674,13 +1944,17 @@ class TestAscendMLAImpl(TestBase):
 
     @patch("vllm_ascend.attention.mla_v1.maybe_trans_nz")
     @patch("torch_npu.npu_format_cast")
-    def test_process_weights_after_loading_with_fa_quant(self, mock_format_cast, mock_maybe_trans_nz):
+    def test_process_weights_after_loading_with_fa_quant(
+        self, mock_format_cast, mock_maybe_trans_nz
+    ):
         # test with enable_mlapo=False and fa_quant_layer=True
         layer = MagicMock(spec=LinearBase)
         layer.input_size_per_partition = 10
         quant_method = MagicMock(spec=UnquantizedLinearMethod)
         layer.quant_method = quant_method
-        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_0 = self.impl.num_heads * (
+            self.impl.qk_nope_head_dim + self.impl.v_head_dim
+        )
         shape_1 = self.impl.kv_lora_rank
         layer.weight = torch.randn(shape_0, shape_1)
         self.impl.kv_b_proj = layer
@@ -1711,7 +1985,9 @@ class TestAscendMLAImpl(TestBase):
         layer.input_size_per_partition = 10
         quant_method = MagicMock(spec=UnquantizedLinearMethod)
         layer.quant_method = quant_method
-        shape_0 = self.impl.num_heads * (self.impl.qk_nope_head_dim + self.impl.v_head_dim)
+        shape_0 = self.impl.num_heads * (
+            self.impl.qk_nope_head_dim + self.impl.v_head_dim
+        )
         shape_1 = self.impl.kv_lora_rank
         layer.weight = torch.randn(shape_0, shape_1)
         self.impl.kv_b_proj = layer
@@ -1741,7 +2017,9 @@ class TestAscendMLAImpl(TestBase):
         q_pe = query[..., self.impl.qk_nope_head_dim :]
         q_nope = query[..., : self.impl.qk_nope_head_dim]
 
-        out, lse = self.impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, metadata, prefix_out, prefix_lse)
+        out, lse = self.impl._compute_prefill_context(
+            q_nope, q_pe, kv_cache, 32, metadata, prefix_out, prefix_lse
+        )
 
         self.assertTrue(torch.equal(prefix_out, out))
         self.assertTrue(torch.equal(prefix_lse, lse))
@@ -1765,7 +2043,9 @@ class TestAscendMLAImpl(TestBase):
         q_pe = query[..., self.impl.qk_nope_head_dim :]
         q_nope = query[..., : self.impl.qk_nope_head_dim]
 
-        out, lse = self.impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, metadata, prefix_out, prefix_lse)
+        out, lse = self.impl._compute_prefill_context(
+            q_nope, q_pe, kv_cache, 32, metadata, prefix_out, prefix_lse
+        )
 
         self.assertTrue(torch.equal(prefix_out, out))
         self.assertTrue(torch.equal(prefix_lse, lse))
@@ -1774,7 +2054,12 @@ class TestAscendMLAImpl(TestBase):
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_compute_prefill_context(self, mock_fia, mock_update, mock_load):
-        S, N, D, VD = 2, self.impl.num_heads, self.impl.qk_head_dim, self.impl.v_head_dim
+        S, N, D, VD = (
+            2,
+            self.impl.num_heads,
+            self.impl.qk_head_dim,
+            self.impl.v_head_dim,
+        )
         _, AND = self.impl.qk_rope_head_dim, self.impl.qk_nope_head_dim
         latent_kv_dim = self.impl.kv_lora_rank
         num_blocks, block_size = 100, 20
@@ -1807,9 +2092,13 @@ class TestAscendMLAImpl(TestBase):
 
         meta = MagicMock()
         meta.prefill = prefill_meta
-        self.impl.prefill_mask = torch.triu(torch.ones(512, 512, device=q_nope.device, dtype=q_nope.dtype), 1)
+        self.impl.prefill_mask = torch.triu(
+            torch.ones(512, 512, device=q_nope.device, dtype=q_nope.dtype), 1
+        )
 
-        out, lse = self.impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse)
+        out, lse = self.impl._compute_prefill_context(
+            q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse
+        )
 
         mock_load.assert_called_once()
         mock_fia.assert_called_once()
@@ -1889,7 +2178,9 @@ class TestAscendMLAImpl(TestBase):
         meta = MagicMock()
         meta.prefill = prefill_meta
 
-        out, lse = impl._compute_prefill_context(q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse)
+        out, lse = impl._compute_prefill_context(
+            q_nope, q_pe, kv_cache, 32, meta, prefix_out, prefix_lse
+        )
 
         mock_fia.assert_called_once()
         call_kwargs = mock_fia.call_args.kwargs
@@ -1901,13 +2192,20 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.attention.mla_v1.AscendMLAImpl._v_up_proj")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
     def test_forward_decode_without_graph(
-        self, mock_npu_fused_infer_attention_score_v2, mock_up_proj, mock_get_forward_context
+        self,
+        mock_npu_fused_infer_attention_score_v2,
+        mock_up_proj,
+        mock_get_forward_context,
     ):
         num_tokens = 100
         block_size = 4
-        q_nope = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_nope_head_dim)
+        q_nope = torch.randn(
+            num_tokens, self.impl.num_heads, self.impl.qk_nope_head_dim
+        )
         q_pe = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim)
-        k_nope = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_nope_head_dim)
+        k_nope = torch.randn(
+            num_tokens, self.impl.num_heads, self.impl.qk_nope_head_dim
+        )
         k_pe = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim)
         metadata = MagicMock()
         metadata.decode = MagicMock()
@@ -1917,9 +2215,13 @@ class TestAscendMLAImpl(TestBase):
             torch.randn(num_tokens, self.impl.num_heads, self.impl.kv_lora_rank),
             None,
         ]
-        mock_up_proj.return_value = torch.randn(num_tokens, self.impl.num_heads, self.impl.v_head_dim)
+        mock_up_proj.return_value = torch.randn(
+            num_tokens, self.impl.num_heads, self.impl.v_head_dim
+        )
         mock_get_forward_context.return_value = MagicMock(capturing=False)
-        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, block_size, metadata)
+        result = self.impl._forward_decode(
+            q_nope, q_pe, k_nope, k_pe, block_size, metadata
+        )
         self.assertEqual(result.shape[0], num_tokens)
         self.assertEqual(result.shape[1], self.impl.num_heads)
         self.assertEqual(result.shape[2], self.impl.v_head_dim)
@@ -1950,33 +2252,51 @@ class TestAscendMLAImpl(TestBase):
 
         self.impl.q_a_layernorm = MagicMock()
         self.impl.q_a_layernorm.return_value = torch.randn(
-            attn_metadata.num_actual_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim
+            attn_metadata.num_actual_tokens,
+            self.impl.num_heads,
+            self.impl.qk_rope_head_dim,
         )
         self.impl.kv_a_proj_with_mqa = MagicMock()
         self.impl.kv_a_proj_with_mqa.return_value = [
-            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim + self.impl.kv_lora_rank)
+            torch.randn(
+                num_prefill_tokens,
+                self.impl.num_heads,
+                self.impl.qk_rope_head_dim + self.impl.kv_lora_rank,
+            )
         ]
         self.impl.fused_qkv_a_proj = MagicMock()
         self.impl.fused_qkv_a_proj.return_value = [
             torch.randn(
                 num_prefill_tokens,
                 self.impl.num_heads,
-                self.impl.qk_rope_head_dim + self.impl.kv_lora_rank + self.impl.q_lora_rank,
+                self.impl.qk_rope_head_dim
+                + self.impl.kv_lora_rank
+                + self.impl.q_lora_rank,
             )
         ]
         self.impl.q_proj = MagicMock()
-        self.impl.q_proj.return_value = [torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.qk_head_dim)]
+        self.impl.q_proj.return_value = [
+            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.qk_head_dim)
+        ]
         self.impl.kv_b_proj = MagicMock()
         self.impl.kv_b_proj.return_value = [
-            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.v_head_dim + self.impl.qk_nope_head_dim)
+            torch.randn(
+                num_prefill_tokens,
+                self.impl.num_heads,
+                self.impl.v_head_dim + self.impl.qk_nope_head_dim,
+            )
         ]
         self.impl.rope_single = MagicMock(side_effect=lambda x, cos, sin: x)
         self.impl.exec_kv_decode = MagicMock()
         self.impl.exec_kv_decode.return_value = [MagicMock(), MagicMock()]
         self.impl.exec_kv_prefill = MagicMock()
         self.impl.exec_kv_prefill.return_value = [
-            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim),
-            torch.randn(num_prefill_tokens, self.impl.num_heads, self.impl.kv_lora_rank),
+            torch.randn(
+                num_prefill_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim
+            ),
+            torch.randn(
+                num_prefill_tokens, self.impl.num_heads, self.impl.kv_lora_rank
+            ),
         ]
         self.impl._q_proj_and_k_up_proj = MagicMock()
         self.impl._q_proj_and_k_up_proj.return_value = [MagicMock(), MagicMock()]
@@ -2073,7 +2393,9 @@ class TestAscendMLAImpl(TestBase):
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
-    def test_forward_decode(self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context):
+    def test_forward_decode(
+        self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context
+    ):
         B = 2
         N = self.impl.num_kv_heads
         BS = 100
@@ -2093,9 +2415,14 @@ class TestAscendMLAImpl(TestBase):
         attn_metadata.decode.actual_seq_kvlen = MagicMock()
         self.impl.enable_kv_nz = True
 
-        mock_npu_fused_infer_attention_score_v2.return_value = [torch.randn(B, N, self.impl.kv_lora_rank), None]
+        mock_npu_fused_infer_attention_score_v2.return_value = [
+            torch.randn(B, N, self.impl.kv_lora_rank),
+            None,
+        ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
-        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS, attn_metadata)
+        result = self.impl._forward_decode(
+            q_nope, q_pe, k_nope, k_pe, BS, attn_metadata
+        )
 
         self.assertEqual(result.shape[0], B)
         self.assertEqual(result.shape[1], N)
@@ -2105,7 +2432,10 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
     def test_forward_decode_non_power_of_two_heads(
-        self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
+        self,
+        mock_npu_fused_infer_attention_score_v2,
+        mock_get_forward_context,
+        mock_get_current_vllm_config,
     ):
         """Test decode with non-power-of-2 heads pads to next power of 2 and slices output."""
         mock_get_current_vllm_config.return_value = MagicMock()
@@ -2179,7 +2509,10 @@ class TestAscendMLAImpl(TestBase):
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
     def test_forward_decode_non_power_of_two_heads_normal(
-        self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context, mock_get_current_vllm_config
+        self,
+        mock_npu_fused_infer_attention_score_v2,
+        mock_get_forward_context,
+        mock_get_current_vllm_config,
     ):
         """Test normal decode (BNSD_NBSD) with non-power-of-2 heads pads q and slices output."""
         mock_get_current_vllm_config.return_value = MagicMock()
@@ -2251,7 +2584,9 @@ class TestAscendMLAImpl(TestBase):
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("torch_npu.npu_fused_infer_attention_score_v2")
-    def test_forward_decode_with_fa_quant(self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context):
+    def test_forward_decode_with_fa_quant(
+        self, mock_npu_fused_infer_attention_score_v2, mock_get_forward_context
+    ):
         # test fa_quant_layer is True
         B = 2
         N = self.impl.num_heads  # use num_heads instead of num_kv_heads
@@ -2282,7 +2617,9 @@ class TestAscendMLAImpl(TestBase):
         ]
         mock_get_forward_context.return_value = MagicMock(capturing=False)
         dequant_scale_q_nope = torch.randn(B, N)  # shape is [B, num_heads]
-        result = self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, BS, attn_metadata, dequant_scale_q_nope)
+        result = self.impl._forward_decode(
+            q_nope, q_pe, k_nope, k_pe, BS, attn_metadata, dequant_scale_q_nope
+        )
 
         self.assertEqual(result.shape[0], B)
         self.assertEqual(result.shape[1], self.impl.num_kv_heads)

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -60,6 +60,10 @@ class TestAscendMLABackend(TestBase):
         self.assertEqual(AscendMLABackend.get_builder_cls(), AscendMLAMetadataBuilder)
         self.mock_parallel_config.prefill_context_parallel_size = 2
         self.assertIs(AscendMLABackend.get_builder_cls(), AscendMLAPCPMetadataBuilder)
+        self.mock_parallel_config.prefill_context_parallel_size = 1
+        self.assertIs(
+            AscendMLABackend.get_builder_cls(), AscendMLAMetadataBuilder
+        )
 
     def test_get_kv_cache_shape(self):
         result = AscendMLABackend.get_kv_cache_shape(2, 4, 8, 128)
@@ -69,6 +73,8 @@ class TestAscendMLABackend(TestBase):
         self.assertEqual(AscendMLABackend.get_impl_cls(), AscendMLAImpl)
         self.mock_parallel_config.prefill_context_parallel_size = 2
         self.assertIs(AscendMLABackend.get_impl_cls(), AscendMLAPCPImpl)
+        self.mock_parallel_config.prefill_context_parallel_size = 1
+        self.assertIs(AscendMLABackend.get_impl_cls(), AscendMLAImpl)
 
     def test_get_supported_kernel_block_sizes(self):
         result = AscendMLABackend.get_supported_kernel_block_sizes()

--- a/tests/ut/compilation/a2/test_acl_graph.py
+++ b/tests/ut/compilation/a2/test_acl_graph.py
@@ -23,9 +23,6 @@ import torch
 from vllm.compilation.cuda_graph import CUDAGraphOptions
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor, ForwardContext
-from vllm.v1.worker.gpu.spec_decode.autoregressive import (
-    cudagraph_utils as speculator_cudagraph_utils,
-)
 
 from tests.ut.base import TestBase
 from vllm_ascend.attention.attention_v1 import (
@@ -42,7 +39,7 @@ from vllm_ascend.attention.context_parallel.mla_cp import (
     AscendMlaDCPImpl,
 )
 from vllm_ascend.attention.mla_v1 import AscendMLAMetadata
-from vllm_ascend.attention.utils import enable_dcp, enable_pcp
+from vllm_ascend.attention.utils import enable_dcp
 from vllm_ascend.compilation import acl_graph
 from vllm_ascend.compilation.acl_graph import (
     ACLGraphEntry,
@@ -60,7 +57,6 @@ from vllm_ascend.worker.v2 import aclgraph_utils as worker_aclgraph_utils
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
-from vllm_ascend.worker.v2.spec_decode.eagle import aclgraph as eagle_aclgraph
 
 
 def test_update_full_graph_params_dispatches_draft_metadata_by_keyword():
@@ -100,7 +96,6 @@ def test_update_full_graph_params_resolves_gqa_pcp_backend():
     update_stream = MagicMock()
     forward_context = MagicMock()
 
-    enable_pcp.cache_clear()
     enable_dcp.cache_clear()
     try:
         with patch.object(
@@ -115,7 +110,6 @@ def test_update_full_graph_params_resolves_gqa_pcp_backend():
                 vllm_config,
             )
     finally:
-        enable_pcp.cache_clear()
         enable_dcp.cache_clear()
 
     update_graph_params.assert_called_once_with(
@@ -202,124 +196,6 @@ def test_prepare_pcp_inputs_to_capture_uses_partitioned_persistent_buffers():
     build_slot_mappings.assert_called_once()
     assert state.attn_metadata is attn_metadata
     assert state.slot_mappings is layer_slot_mappings
-
-
-def test_prepare_pcp_speculator_inputs_to_capture_uses_global_batch() -> None:
-    input_buffers = AscendInputBuffers(
-        max_num_reqs=4,
-        max_num_tokens=8,
-        device=torch.device("cpu"),
-    )
-    input_batch = SimpleNamespace()
-    block_tables = MagicMock()
-    input_block_tables = (torch.zeros(4, 2, dtype=torch.int32),)
-    expanded_slot_mappings = torch.full(
-        (1, 8),
-        -1,
-        dtype=torch.int64,
-    )
-    block_tables.get_dummy_block_tables.return_value = input_block_tables
-
-    pcp_manager = MagicMock(spec=AscendPCPManager)
-    pcp_manager.get_dummy_slot_mappings.return_value = expanded_slot_mappings
-    model_state = MagicMock()
-    attn_metadata = {"layer": object()}
-    model_state.prepare_attn.return_value = attn_metadata
-    layer_slot_mappings = {"layer": expanded_slot_mappings[0]}
-
-    with (
-        patch.object(
-            AscendInputBatch,
-            "make_dummy",
-            return_value=input_batch,
-        ) as make_dummy,
-        patch.object(
-            worker_aclgraph_utils.cudagraph_utils,
-            "build_slot_mappings_by_layer",
-            return_value=layer_slot_mappings,
-        ),
-    ):
-        state = worker_aclgraph_utils.prepare_pcp_speculator_inputs_to_capture(
-            2,
-            4,
-            model_state,
-            input_buffers,
-            block_tables,
-            [[MagicMock()]],
-            MagicMock(),
-            pcp_manager,
-            full_cudagraph=True,
-        )
-
-    make_dummy.assert_called_once_with(2, 4, input_buffers)
-    block_tables.get_dummy_block_tables.assert_called_once_with(2)
-    pcp_manager.get_dummy_slot_mappings.assert_called_once_with(4)
-    pcp_manager.partition_batch.assert_not_called()
-    assert model_state.prepare_attn.call_args.args[0] is input_batch
-    assert model_state.prepare_attn.call_args.args[2] is input_block_tables
-    assert model_state.prepare_attn.call_args.args[3] is expanded_slot_mappings
-    assert model_state.prepare_attn.call_args.kwargs["for_capture"] is True
-    assert state.attn_metadata is attn_metadata
-    assert state.slot_mappings is layer_slot_mappings
-
-
-def test_pcp_draft_prefill_capture_temporarily_installs_preparation() -> None:
-    pcp_manager = AscendPCPManager.__new__(AscendPCPManager)
-    manager = eagle_aclgraph.EagleAclGraphManager.__new__(eagle_aclgraph.EagleAclGraphManager)
-    manager.speculator = SimpleNamespace(pcp_manager=pcp_manager)
-    manager.is_draft_model_prefill = True
-
-    original_prepare = speculator_cudagraph_utils.prepare_inputs_to_capture
-    prepared_state = object()
-
-    def capture_side_effect(*args, **kwargs):
-        installed_prepare = speculator_cudagraph_utils.prepare_inputs_to_capture
-        assert installed_prepare is not original_prepare
-        return installed_prepare(
-            2,
-            4,
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            [],
-            MagicMock(),
-            full_cudagraph=True,
-        )
-
-    with (
-        patch.object(
-            eagle_aclgraph,
-            "communicator_switch",
-            side_effect=lambda: nullcontext(),
-        ),
-        patch.object(
-            eagle_aclgraph,
-            "model_capture_wrapper",
-            side_effect=lambda *args: nullcontext(),
-        ),
-        patch.object(
-            eagle_aclgraph,
-            "prepare_pcp_speculator_inputs_to_capture",
-            return_value=prepared_state,
-        ) as prepare_pcp,
-        patch.object(
-            eagle_aclgraph.SpeculatorCudaGraphManager,
-            "capture",
-            side_effect=capture_side_effect,
-        ),
-    ):
-        manager.capture(
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            MagicMock(),
-            [],
-            MagicMock(),
-        )
-
-    assert speculator_cudagraph_utils.prepare_inputs_to_capture is original_prepare
-    assert prepare_pcp.call_args.args[7] is pcp_manager
-    assert prepare_pcp.call_args.kwargs["full_cudagraph"] is True
 
 
 def _make_model_acl_graph_manager(pcp_manager):

--- a/tests/ut/compilation/a2/test_acl_graph.py
+++ b/tests/ut/compilation/a2/test_acl_graph.py
@@ -13,15 +13,25 @@
 # This file is a part of the vllm-ascend project.
 #
 import weakref
+from contextlib import nullcontext
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 import numpy as np
+import pytest
 import torch
 from vllm.compilation.cuda_graph import CUDAGraphOptions
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import BatchDescriptor, ForwardContext
+from vllm.v1.worker.gpu.spec_decode.autoregressive import (
+    cudagraph_utils as speculator_cudagraph_utils,
+)
 
 from tests.ut.base import TestBase
+from vllm_ascend.attention.attention_v1 import (
+    AscendAttentionBackend,
+    AscendAttentionPCPImpl,
+)
 from vllm_ascend.attention.context_parallel.attention_cp import (
     AscendAttentionDCPImpl,
     AscendAttentionDCPMetadata,
@@ -32,6 +42,7 @@ from vllm_ascend.attention.context_parallel.mla_cp import (
     AscendMlaDCPImpl,
 )
 from vllm_ascend.attention.mla_v1 import AscendMLAMetadata
+from vllm_ascend.attention.utils import enable_dcp, enable_pcp
 from vllm_ascend.compilation import acl_graph
 from vllm_ascend.compilation.acl_graph import (
     ACLGraphEntry,
@@ -45,6 +56,11 @@ from vllm_ascend.compilation.acl_graph import (
     update_full_graph_params,
 )
 from vllm_ascend.device_allocator.sleep_mem_optimized import AclGraphSleepWakeupManager
+from vllm_ascend.worker.v2 import aclgraph_utils as worker_aclgraph_utils
+from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
+from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+from vllm_ascend.worker.v2.spec_decode.eagle import aclgraph as eagle_aclgraph
 
 
 def test_update_full_graph_params_dispatches_draft_metadata_by_keyword():
@@ -77,6 +93,354 @@ def test_update_full_graph_params_dispatches_draft_metadata_by_keyword():
     )
 
 
+def test_update_full_graph_params_resolves_gqa_pcp_backend():
+    vllm_config = MagicMock()
+    vllm_config.parallel_config.prefill_context_parallel_size = 2
+    vllm_config.parallel_config.decode_context_parallel_size = 1
+    update_stream = MagicMock()
+    forward_context = MagicMock()
+
+    enable_pcp.cache_clear()
+    enable_dcp.cache_clear()
+    try:
+        with patch.object(
+            AscendAttentionPCPImpl,
+            "update_graph_params",
+        ) as update_graph_params:
+            update_full_graph_params(
+                AscendAttentionBackend,
+                update_stream,
+                forward_context,
+                8,
+                vllm_config,
+            )
+    finally:
+        enable_pcp.cache_clear()
+        enable_dcp.cache_clear()
+
+    update_graph_params.assert_called_once_with(
+        update_stream,
+        forward_context,
+        8,
+        vllm_config,
+        None,
+        draft_attn_metadatas=None,
+    )
+
+
+def test_prepare_pcp_inputs_to_capture_uses_partitioned_persistent_buffers():
+    events = []
+    capture_attn_state = object()
+    input_buffers = AscendInputBuffers(
+        max_num_reqs=4,
+        max_num_tokens=8,
+        device=torch.device("cpu"),
+    )
+    input_batch = SimpleNamespace(
+        num_reqs_after_padding=4,
+        num_tokens_after_padding=4,
+        attn_state=capture_attn_state,
+    )
+    block_table = torch.zeros(4, 2, dtype=torch.int32)
+    slot_mapping = torch.arange(8, dtype=torch.int64).view(1, 8)
+    layer_slot_mappings = {"layer": slot_mapping[0]}
+    pcp_manager = MagicMock(spec=AscendPCPManager)
+    model_state = MagicMock()
+    attn_metadata = {"layer": object()}
+    model_state.prepare_attn.return_value = attn_metadata
+
+    def partition_batch(batch):
+        events.append("partition")
+        assert batch is input_batch
+        return input_batch
+
+    def prepare_dummy_attn(num_reqs, num_tokens):
+        events.append("dummy_attn")
+        assert (num_reqs, num_tokens) == (4, 4)
+        return (block_table,), slot_mapping
+
+    def prepare_attn(*args, **kwargs):
+        events.append("metadata")
+        return attn_metadata
+
+    pcp_manager.partition_batch.side_effect = partition_batch
+    pcp_manager.prepare_dummy_attn.side_effect = prepare_dummy_attn
+    model_state.prepare_attn.side_effect = prepare_attn
+
+    with (
+        patch.object(
+            AscendInputBatch,
+            "make_dummy",
+            return_value=input_batch,
+        ) as make_dummy,
+        patch.object(
+            worker_aclgraph_utils.cudagraph_utils,
+            "build_slot_mappings_by_layer",
+            return_value=layer_slot_mappings,
+        ) as build_slot_mappings,
+    ):
+        state = worker_aclgraph_utils._prepare_pcp_inputs_to_capture(
+            4,
+            4,
+            model_state,
+            input_buffers,
+            MagicMock(),
+            [[MagicMock()]],
+            MagicMock(),
+            pcp_manager,
+            full_cudagraph=True,
+        )
+
+    assert events == ["partition", "dummy_attn", "metadata"]
+    make_dummy.assert_called_once_with(4, 4, input_buffers)
+    assert model_state.prepare_attn.call_args.args[0] is input_batch
+    assert input_batch.attn_state is capture_attn_state
+    assert model_state.prepare_attn.call_args.args[1] == CUDAGraphMode.NONE
+    assert model_state.prepare_attn.call_args.args[2][0].data_ptr() == (block_table.data_ptr())
+    assert model_state.prepare_attn.call_args.args[3].data_ptr() == (slot_mapping.data_ptr())
+    assert model_state.prepare_attn.call_args.kwargs["for_capture"] is True
+    build_slot_mappings.assert_called_once()
+    assert state.attn_metadata is attn_metadata
+    assert state.slot_mappings is layer_slot_mappings
+
+
+def test_prepare_pcp_speculator_inputs_to_capture_uses_global_batch() -> None:
+    input_buffers = AscendInputBuffers(
+        max_num_reqs=4,
+        max_num_tokens=8,
+        device=torch.device("cpu"),
+    )
+    input_batch = SimpleNamespace()
+    block_tables = MagicMock()
+    input_block_tables = (torch.zeros(4, 2, dtype=torch.int32),)
+    expanded_slot_mappings = torch.full(
+        (1, 8),
+        -1,
+        dtype=torch.int64,
+    )
+    block_tables.get_dummy_block_tables.return_value = input_block_tables
+
+    pcp_manager = MagicMock(spec=AscendPCPManager)
+    pcp_manager.get_dummy_slot_mappings.return_value = expanded_slot_mappings
+    model_state = MagicMock()
+    attn_metadata = {"layer": object()}
+    model_state.prepare_attn.return_value = attn_metadata
+    layer_slot_mappings = {"layer": expanded_slot_mappings[0]}
+
+    with (
+        patch.object(
+            AscendInputBatch,
+            "make_dummy",
+            return_value=input_batch,
+        ) as make_dummy,
+        patch.object(
+            worker_aclgraph_utils.cudagraph_utils,
+            "build_slot_mappings_by_layer",
+            return_value=layer_slot_mappings,
+        ),
+    ):
+        state = worker_aclgraph_utils.prepare_pcp_speculator_inputs_to_capture(
+            2,
+            4,
+            model_state,
+            input_buffers,
+            block_tables,
+            [[MagicMock()]],
+            MagicMock(),
+            pcp_manager,
+            full_cudagraph=True,
+        )
+
+    make_dummy.assert_called_once_with(2, 4, input_buffers)
+    block_tables.get_dummy_block_tables.assert_called_once_with(2)
+    pcp_manager.get_dummy_slot_mappings.assert_called_once_with(4)
+    pcp_manager.partition_batch.assert_not_called()
+    assert model_state.prepare_attn.call_args.args[0] is input_batch
+    assert model_state.prepare_attn.call_args.args[2] is input_block_tables
+    assert model_state.prepare_attn.call_args.args[3] is expanded_slot_mappings
+    assert model_state.prepare_attn.call_args.kwargs["for_capture"] is True
+    assert state.attn_metadata is attn_metadata
+    assert state.slot_mappings is layer_slot_mappings
+
+
+def test_pcp_draft_prefill_capture_temporarily_installs_preparation() -> None:
+    pcp_manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager = eagle_aclgraph.EagleAclGraphManager.__new__(eagle_aclgraph.EagleAclGraphManager)
+    manager.speculator = SimpleNamespace(pcp_manager=pcp_manager)
+    manager.is_draft_model_prefill = True
+
+    original_prepare = speculator_cudagraph_utils.prepare_inputs_to_capture
+    prepared_state = object()
+
+    def capture_side_effect(*args, **kwargs):
+        installed_prepare = speculator_cudagraph_utils.prepare_inputs_to_capture
+        assert installed_prepare is not original_prepare
+        return installed_prepare(
+            2,
+            4,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            [],
+            MagicMock(),
+            full_cudagraph=True,
+        )
+
+    with (
+        patch.object(
+            eagle_aclgraph,
+            "communicator_switch",
+            side_effect=lambda: nullcontext(),
+        ),
+        patch.object(
+            eagle_aclgraph,
+            "model_capture_wrapper",
+            side_effect=lambda *args: nullcontext(),
+        ),
+        patch.object(
+            eagle_aclgraph,
+            "prepare_pcp_speculator_inputs_to_capture",
+            return_value=prepared_state,
+        ) as prepare_pcp,
+        patch.object(
+            eagle_aclgraph.SpeculatorCudaGraphManager,
+            "capture",
+            side_effect=capture_side_effect,
+        ),
+    ):
+        manager.capture(
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            [],
+            MagicMock(),
+        )
+
+    assert speculator_cudagraph_utils.prepare_inputs_to_capture is original_prepare
+    assert prepare_pcp.call_args.args[7] is pcp_manager
+    assert prepare_pcp.call_args.kwargs["full_cudagraph"] is True
+
+
+def _make_model_acl_graph_manager(pcp_manager):
+    manager = ModelAclGraphManager.__new__(ModelAclGraphManager)
+    manager.model_runner = SimpleNamespace(pcp_manager=pcp_manager)
+    manager.cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+    return manager
+
+
+def _capture_with_mock_inputs(manager):
+    return manager.capture(
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        None,
+        MagicMock(),
+        [],
+        MagicMock(),
+    )
+
+
+def test_pcp_full_capture_temporarily_installs_and_restores_preparation():
+    pcp_manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager = _make_model_acl_graph_manager(pcp_manager)
+    original_prepare = worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture
+    prepared_state = object()
+
+    def capture_side_effect(*args, **kwargs):
+        installed_prepare = worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture
+        assert installed_prepare is not original_prepare
+        return installed_prepare(
+            2,
+            2,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            [],
+            MagicMock(),
+            full_cudagraph=True,
+        )
+
+    with (
+        patch.object(
+            worker_aclgraph_utils,
+            "communicator_switch",
+            side_effect=lambda: nullcontext(),
+        ),
+        patch.object(
+            worker_aclgraph_utils,
+            "_prepare_pcp_inputs_to_capture",
+            return_value=prepared_state,
+        ) as prepare_pcp,
+        patch.object(
+            worker_aclgraph_utils.ModelCudaGraphManager,
+            "capture",
+            side_effect=capture_side_effect,
+        ),
+    ):
+        result = _capture_with_mock_inputs(manager)
+
+    assert result is prepared_state
+    assert worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture is original_prepare
+    assert prepare_pcp.call_args.args[7] is pcp_manager
+    assert prepare_pcp.call_args.kwargs["full_cudagraph"] is True
+
+
+def test_pcp_full_capture_restores_preparation_after_exception():
+    pcp_manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager = _make_model_acl_graph_manager(pcp_manager)
+    original_prepare = worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture
+
+    def capture_side_effect(*args, **kwargs):
+        assert worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture is not original_prepare
+        raise RuntimeError("capture failed")
+
+    with (
+        patch.object(
+            worker_aclgraph_utils,
+            "communicator_switch",
+            side_effect=lambda: nullcontext(),
+        ),
+        patch.object(
+            worker_aclgraph_utils.ModelCudaGraphManager,
+            "capture",
+            side_effect=capture_side_effect,
+        ),
+        pytest.raises(RuntimeError, match="capture failed"),
+    ):
+        _capture_with_mock_inputs(manager)
+
+    assert worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture is original_prepare
+
+
+def test_non_pcp_capture_keeps_native_preparation():
+    manager = _make_model_acl_graph_manager(None)
+    original_prepare = worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture
+
+    def capture_side_effect(*args, **kwargs):
+        assert worker_aclgraph_utils.cudagraph_utils.prepare_inputs_to_capture is original_prepare
+
+    with (
+        patch.object(
+            worker_aclgraph_utils,
+            "communicator_switch",
+            side_effect=lambda: nullcontext(),
+        ),
+        patch.object(
+            worker_aclgraph_utils,
+            "_prepare_pcp_inputs_to_capture",
+        ) as prepare_pcp,
+        patch.object(
+            worker_aclgraph_utils.ModelCudaGraphManager,
+            "capture",
+            side_effect=capture_side_effect,
+        ),
+    ):
+        _capture_with_mock_inputs(manager)
+
+    prepare_pcp.assert_not_called()
+
+
 class TestACLGraphEntry(TestBase):
     def test_aclgraph_entry_initialization(self):
         """Test ACLGraphEntry initialization with default values"""
@@ -104,7 +468,10 @@ class TestACLGraphEntry(TestBase):
         input_addresses = [12345, 67890]
 
         entry = ACLGraphEntry(
-            batch_descriptor=batch_descriptor, aclgraph=mock_graph, output=mock_output, input_addresses=input_addresses
+            batch_descriptor=batch_descriptor,
+            aclgraph=mock_graph,
+            output=mock_output,
+            input_addresses=input_addresses,
         )
 
         self.assertEqual(entry.batch_descriptor, batch_descriptor)
@@ -153,7 +520,9 @@ class TestACLGraphWrapper(TestBase):
         mock_current_platform.get_global_graph_pool.return_value = self.mock_graph_pool
 
         wrapper = ACLGraphWrapper(
-            runnable=self.mock_runnable, vllm_config=self.mock_vllm_config, runtime_mode=CUDAGraphMode.FULL
+            runnable=self.mock_runnable,
+            vllm_config=self.mock_vllm_config,
+            runtime_mode=CUDAGraphMode.FULL,
         )
 
         self.assertEqual(wrapper.runnable, self.mock_runnable)
@@ -195,7 +564,9 @@ class TestACLGraphWrapper(TestBase):
 
         with self.assertRaises(AssertionError):
             ACLGraphWrapper(
-                runnable=self.mock_runnable, vllm_config=self.mock_vllm_config, runtime_mode=CUDAGraphMode.NONE
+                runnable=self.mock_runnable,
+                vllm_config=self.mock_vllm_config,
+                runtime_mode=CUDAGraphMode.NONE,
             )
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -203,7 +574,11 @@ class TestACLGraphWrapper(TestBase):
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
     @patch("vllm_ascend.compilation.acl_graph.envs")
     def test_call_with_none_runtime_mode(
-        self, mock_envs, mock_current_platform, mock_get_forward_context, mock_get_forward_context_2
+        self,
+        mock_envs,
+        mock_current_platform,
+        mock_get_forward_context,
+        mock_get_forward_context_2,
     ):
         """Test __call__ method when runtime mode is NONE"""
         mock_envs.VLLM_LOGGING_LEVEL = "INFO"
@@ -229,7 +604,11 @@ class TestACLGraphWrapper(TestBase):
     @patch("vllm_ascend.compilation.acl_graph.current_platform")
     @patch("vllm_ascend.compilation.acl_graph.envs")
     def test_call_with_mismatched_runtime_mode(
-        self, mock_envs, mock_current_platform, mock_get_forward_context, mock_get_forward_context_2
+        self,
+        mock_envs,
+        mock_current_platform,
+        mock_get_forward_context,
+        mock_get_forward_context_2,
     ):
         """Test __call__ method when runtime mode doesn't match wrapper mode"""
         mock_envs.VLLM_LOGGING_LEVEL = "INFO"
@@ -696,7 +1075,12 @@ class TestACLGraphWrapper(TestBase):
     @patch("vllm_ascend.compilation.acl_graph.envs")
     @patch("vllm_ascend.compilation.acl_graph.logger")
     def test_call_capture_graph_with_debug_log(
-        self, mock_logger, mock_envs, mock_current_platform, mock_get_forward_context, mock_get_forward_context_2
+        self,
+        mock_logger,
+        mock_envs,
+        mock_current_platform,
+        mock_get_forward_context,
+        mock_get_forward_context_2,
     ):
         """Test __call__ method captures graph with debug logging enabled"""
         mock_envs.VLLM_LOGGING_LEVEL = "INFO"
@@ -835,7 +1219,10 @@ class TestSleepGraphParams(TestBase):
         with (
             patch("vllm_ascend.compilation.acl_graph._graph_params", empty_params),
             patch("vllm_ascend.compilation.acl_graph._draft_graph_params", empty_params),
-            patch("vllm_ascend.compilation.acl_graph._draft_graph_prefill_params", empty_params),
+            patch(
+                "vllm_ascend.compilation.acl_graph._draft_graph_prefill_params",
+                empty_params,
+            ),
             patch("vllm_ascend.compilation.acl_graph._acl_graph_wrappers", [wrapper]),
         ):
             AclGraphSleepWakeupManager.reset_all_graph_params()
@@ -907,10 +1294,24 @@ class TestDCPGraphParams(TestBase):
         block_tables = torch.zeros(2, 5, dtype=torch.long)
 
         decode = AscendMLADCPDecodeMetadata(
-            input_positions, block_table, seq_lens, max_seq_lens, seq_lens_list, cp_seq_len=cp_seq_len
+            input_positions,
+            block_table,
+            seq_lens,
+            max_seq_lens,
+            seq_lens_list,
+            cp_seq_len=cp_seq_len,
         )
         metadata = AscendMLAMetadata(
-            8, slot_mapping, query_start_loc, seq_lens, seq_lens, block_tables, 4, 4, 0, decode=decode
+            8,
+            slot_mapping,
+            query_start_loc,
+            seq_lens,
+            seq_lens,
+            block_tables,
+            4,
+            4,
+            0,
+            decode=decode,
         )
         forward_context = MagicMock()
         forward_context.attn_metadata = {"attn_layer_0": metadata}

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -269,6 +269,7 @@ def test_get_effective_block_size(
 
 def test_get_kv_cache_coordinator_delegates_single_group(monkeypatch) -> None:
     sentinel = object()
+    captured_kwargs = None
     kv_cache_config = _make_hybrid_kv_cache_config(full_block_size=16, mamba_block_size=16)
     single_group_config = KVCacheConfig(
         num_blocks=kv_cache_config.num_blocks,
@@ -277,6 +278,8 @@ def test_get_kv_cache_coordinator_delegates_single_group(monkeypatch) -> None:
     )
 
     def _fake_orig(*args, **kwargs):
+        nonlocal captured_kwargs
+        captured_kwargs = kwargs
         return sentinel
 
     monkeypatch.setattr(
@@ -292,11 +295,15 @@ def test_get_kv_cache_coordinator_delegates_single_group(monkeypatch) -> None:
         enable_caching=True,
         enable_kv_cache_events=False,
         dcp_world_size=1,
-        pcp_world_size=1,
+        pcp_world_size=2,
         hash_block_size=16,
     )
 
     assert coordinator is sentinel
+    assert captured_kwargs is not None
+    assert captured_kwargs["dcp_world_size"] == 1
+    assert captured_kwargs["pcp_world_size"] == 1
+    assert captured_kwargs["hash_block_size"] == 16
 
 
 def test_get_kv_cache_coordinator_delegates_hybrid_without_caching(monkeypatch) -> None:

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
+from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
+
+from vllm_ascend.worker.v2.spec_decode.autoregressive import (
+    speculator as speculator_module,
+)
+from vllm_ascend.worker.v2.spec_decode.eagle.speculator import (
+    AscendEagleSpeculator,
+)
+from vllm_ascend.worker.v2.spec_decode.mtp.speculator import (
+    AscendMTPSpeculator,
+)
+
+
+@pytest.mark.parametrize(
+    ("method", "speculator_cls", "parent_cls"),
+    [
+        ("mtp", AscendMTPSpeculator, MTPSpeculator),
+        ("eagle3", AscendEagleSpeculator, EagleSpeculator),
+    ],
+)
+def test_speculator_rebuilds_global_pcp_attention(
+    method: str,
+    speculator_cls,
+    parent_cls,
+) -> None:
+    speculator = object.__new__(speculator_cls)
+    speculator.method = method
+    speculator.input_batch = None
+    speculator.pcp_manager = MagicMock()
+    speculator.model_state = MagicMock()
+    speculator.attn_groups = MagicMock()
+    speculator.target_attn_groups = MagicMock()
+    speculator.kv_cache_config = MagicMock()
+
+    input_batch = MagicMock()
+    local_attn_metadata = MagicMock()
+    local_slot_mappings = MagicMock()
+    global_block_tables = (MagicMock(),)
+    global_slot_mapping = torch.arange(4).unsqueeze(0)
+    global_attn_metadata = MagicMock()
+    global_slot_mappings = MagicMock()
+    local_aux_hidden_states = [
+        torch.arange(8, dtype=torch.float32).reshape(2, 4),
+        torch.arange(6, dtype=torch.float32).reshape(2, 3),
+    ]
+    global_aux_hidden_states = torch.arange(14, dtype=torch.float32).reshape(2, 7)
+    aux_hidden_states = local_aux_hidden_states if method == "eagle3" else None
+
+    speculator.pcp_manager.prepare_speculator_attn.return_value = (
+        global_block_tables,
+        global_slot_mapping,
+    )
+    speculator.pcp_manager.restore_hidden_states.return_value = global_aux_hidden_states
+    speculator.model_state.prepare_attn.return_value = global_attn_metadata
+
+    with (
+        patch.object(parent_cls, "propose", return_value=MagicMock()) as propose,
+        patch.object(
+            speculator_module,
+            "build_slot_mappings_by_layer",
+            return_value=global_slot_mappings,
+        ) as build_slot_mappings,
+    ):
+        speculator_cls.propose(
+            speculator,
+            input_batch,
+            local_attn_metadata,
+            local_slot_mappings,
+            MagicMock(),
+            aux_hidden_states,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+
+    speculator.pcp_manager.prepare_speculator_attn.assert_called_once_with(input_batch)
+    speculator.model_state.prepare_attn.assert_called_once_with(
+        input_batch,
+        CUDAGraphMode.NONE,
+        global_block_tables,
+        global_slot_mapping,
+        speculator.target_attn_groups,
+        speculator.kv_cache_config,
+    )
+    build_slot_mappings.assert_called_once_with(
+        global_slot_mapping,
+        speculator.kv_cache_config,
+    )
+
+    propose_args = propose.call_args.args
+    assert propose_args[0] is input_batch
+    assert propose_args[1] is global_attn_metadata
+    assert propose_args[2] is global_slot_mappings
+
+    if method == "eagle3":
+        restore_args = speculator.pcp_manager.restore_hidden_states.call_args.args
+        torch.testing.assert_close(
+            restore_args[0],
+            torch.cat(local_aux_hidden_states, dim=-1),
+        )
+        assert len(propose_args[4]) == 1
+        assert propose_args[4][0] is global_aux_hidden_states
+    else:
+        speculator.pcp_manager.restore_hidden_states.assert_not_called()
+        assert propose_args[4] is None
+
+
+@pytest.mark.parametrize(
+    "speculator_cls",
+    [AscendMTPSpeculator, AscendEagleSpeculator],
+)
+def test_pcp_draft_prefill_rebuilds_metadata_for_selected_full_graph(
+    speculator_cls,
+) -> None:
+    speculator = object.__new__(speculator_cls)
+    input_batch = MagicMock()
+    input_batch.num_reqs_after_padding = 4
+    input_batch.num_tokens_after_padding = 8
+    speculator.input_batch = input_batch
+
+    block_tables = (MagicMock(),)
+    slot_mappings = torch.arange(16).unsqueeze(0)
+    speculator._pcp_draft_prefill_attn_inputs = (
+        block_tables,
+        slot_mappings,
+    )
+    speculator.model_state = MagicMock()
+    speculator.model_state.attn_metadata = {"target": object()}
+    speculator.target_attn_groups = MagicMock()
+    speculator.kv_cache_config = MagicMock()
+    speculator.draft_attn_layer_names = {"draft"}
+
+    draft_metadata = object()
+    speculator.model_state.prepare_attn.return_value = {
+        "draft": draft_metadata,
+        "target": object(),
+    }
+    batch_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=8,
+        num_reqs=4,
+        uniform_token_count=2,
+    )
+
+    result = speculator.build_draft_attn_metadatas(
+        batch_desc,
+        is_draft_model_prefill=True,
+    )
+
+    speculator.model_state.prepare_attn.assert_called_once_with(
+        input_batch,
+        CUDAGraphMode.FULL,
+        block_tables,
+        slot_mappings,
+        speculator.target_attn_groups,
+        speculator.kv_cache_config,
+    )
+    assert result == [{"draft": draft_metadata}]
+
+
+def test_pcp_draft_prefill_rejects_mismatched_graph_shape() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    input_batch = MagicMock()
+    input_batch.num_reqs_after_padding = 4
+    input_batch.num_tokens_after_padding = 8
+    speculator.input_batch = input_batch
+    speculator._pcp_draft_prefill_attn_inputs = (
+        (MagicMock(),),
+        MagicMock(),
+    )
+    speculator.model_state = MagicMock()
+    speculator.model_state.attn_metadata = {"draft": object()}
+    speculator.draft_attn_layer_names = {"draft"}
+
+    mismatched_desc = BatchExecutionDescriptor(
+        cg_mode=CUDAGraphMode.FULL,
+        num_tokens=6,
+        num_reqs=3,
+        uniform_token_count=2,
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match="graph shape does not match",
+    ):
+        speculator.build_draft_attn_metadatas(
+            mismatched_desc,
+            is_draft_model_prefill=True,
+        )
+
+    speculator.model_state.prepare_attn.assert_not_called()
+
+
+def test_eagle3_pcp_dummy_run_keeps_local_inputs() -> None:
+    speculator = object.__new__(AscendEagleSpeculator)
+    speculator.method = "eagle3"
+    speculator.input_batch = None
+    speculator.pcp_manager = MagicMock()
+
+    input_batch = MagicMock()
+    local_attn_metadata = MagicMock()
+    local_slot_mappings = MagicMock()
+    local_aux_hidden_states = [MagicMock(), MagicMock()]
+
+    with (
+        patch.object(
+            EagleSpeculator,
+            "propose",
+            return_value=MagicMock(),
+        ) as propose,
+        patch.object(
+            speculator_module,
+            "build_slot_mappings_by_layer",
+        ) as build_slot_mappings,
+    ):
+        AscendEagleSpeculator.propose(
+            speculator,
+            input_batch,
+            local_attn_metadata,
+            local_slot_mappings,
+            MagicMock(),
+            local_aux_hidden_states,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            dummy_run=True,
+        )
+
+    speculator.pcp_manager.prepare_speculator_attn.assert_not_called()
+    speculator.pcp_manager.restore_hidden_states.assert_not_called()
+    build_slot_mappings.assert_not_called()
+
+    propose_args = propose.call_args.args
+    assert propose_args[1] is local_attn_metadata
+    assert propose_args[2] is local_slot_mappings
+    assert propose_args[4] is local_aux_hidden_states
+
+
+def test_eagle3_pcp_requires_aux_hidden_states() -> None:
+    speculator = object.__new__(AscendEagleSpeculator)
+    speculator.method = "eagle3"
+    speculator.input_batch = None
+    speculator.pcp_manager = MagicMock()
+    speculator.model_state = MagicMock()
+    speculator.attn_groups = MagicMock()
+    speculator.target_attn_groups = MagicMock()
+    speculator.kv_cache_config = MagicMock()
+
+    global_slot_mapping = torch.arange(4).unsqueeze(0)
+    speculator.pcp_manager.prepare_speculator_attn.return_value = (
+        (MagicMock(),),
+        global_slot_mapping,
+    )
+
+    with (
+        patch.object(EagleSpeculator, "propose") as propose,
+        patch.object(speculator_module, "build_slot_mappings_by_layer"),
+        pytest.raises(
+            RuntimeError,
+            match="requires auxiliary target hidden states",
+        ),
+    ):
+        AscendEagleSpeculator.propose(
+            speculator,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            None,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+
+    propose.assert_not_called()
+
+
+def test_mtp_without_pcp_keeps_existing_proposal_inputs() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.method = "mtp"
+    speculator.input_batch = None
+    speculator.pcp_manager = None
+
+    input_batch = MagicMock()
+    local_attn_metadata = MagicMock()
+    local_slot_mappings = MagicMock()
+
+    with (
+        patch.object(
+            MTPSpeculator,
+            "propose",
+            return_value=MagicMock(),
+        ) as propose,
+        patch.object(
+            speculator_module,
+            "build_slot_mappings_by_layer",
+        ) as build_slot_mappings,
+    ):
+        AscendMTPSpeculator.propose(
+            speculator,
+            input_batch,
+            local_attn_metadata,
+            local_slot_mappings,
+            MagicMock(),
+            None,
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
+
+    build_slot_mappings.assert_not_called()
+    propose_args = propose.call_args.args
+    assert propose_args[1] is local_attn_metadata
+    assert propose_args[2] is local_slot_mappings

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -2,15 +2,20 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
+import numpy as np
 import pytest
 import torch
-from vllm.config.compilation import CUDAGraphMode
-from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
+from vllm.config.compilation import (
+    CompilationConfig,
+    CompilationMode,
+    CUDAGraphMode,
+)
 from vllm.v1.worker.gpu.spec_decode.eagle.speculator import EagleSpeculator
 from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 from vllm_ascend.worker.v2.spec_decode.autoregressive import (
     speculator as speculator_module,
 )
@@ -20,6 +25,208 @@ from vllm_ascend.worker.v2.spec_decode.eagle.speculator import (
 from vllm_ascend.worker.v2.spec_decode.mtp.speculator import (
     AscendMTPSpeculator,
 )
+
+
+def _set_draft_pcp_size(speculator, pcp_size: int) -> None:
+    config = MagicMock()
+    config.parallel_config.prefill_context_parallel_size = pcp_size
+    speculator.vllm_config = config
+
+
+def _make_padded_input_batch() -> MagicMock:
+    input_batch = MagicMock(spec=AscendInputBatch)
+    input_batch.num_reqs = 2
+    input_batch.num_reqs_after_padding = 4
+    input_batch.num_tokens = 6
+    input_batch.num_tokens_after_padding = 8
+    input_batch.query_start_loc = torch.arange(5, dtype=torch.int32)
+    input_batch.query_start_loc_np = np.arange(5, dtype=np.int32)
+    input_batch.seq_lens = torch.arange(4, dtype=torch.int32)
+    input_batch.seq_lens_cpu_upper_bound = torch.arange(4, dtype=torch.int32)
+    input_batch.input_ids = torch.arange(8, dtype=torch.int32)
+    input_batch.positions = torch.arange(8, dtype=torch.int64)
+    input_batch.is_padding = torch.zeros(8, dtype=torch.bool)
+    input_batch.seq_lens_np = np.arange(4, dtype=np.int32)
+    return input_batch
+
+
+def test_mtp_uses_draft_groups_only_when_target_pcp_is_active() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.attn_groups = MagicMock()
+    speculator.target_attn_groups = MagicMock()
+    _set_draft_pcp_size(speculator, 1)
+
+    speculator.pcp_manager = None
+    assert speculator.draft_prefill_attn_groups is speculator.target_attn_groups
+
+    speculator.pcp_manager = MagicMock()
+    assert speculator.draft_prefill_attn_groups is speculator.attn_groups
+
+
+@pytest.mark.parametrize("method", ["mtp", "eagle3"])
+def test_pcp_draft_uses_pcp1_eager_config(method: str) -> None:
+    vllm_config = MagicMock()
+    target_compilation_config = CompilationConfig(
+        mode=CompilationMode.VLLM_COMPILE,
+        cudagraph_mode=CUDAGraphMode.FULL_DECODE_ONLY,
+    )
+    oot_compiler = object()
+    target_compilation_config.oot_compiler = oot_compiler
+    vllm_config.compilation_config = target_compilation_config
+    vllm_config.speculative_config.method = method
+    parallel_config = vllm_config.parallel_config
+    parallel_config.prefill_context_parallel_size = 2
+    draft_parallel_config = MagicMock()
+    draft_vllm_config = MagicMock()
+    device = MagicMock()
+
+    with (
+        patch.object(
+            speculator_module.AutoRegressiveSpeculator,
+            "__init__",
+            side_effect=RuntimeError("stop after config"),
+        ) as base_init,
+        patch.object(
+            speculator_module,
+            "replace",
+            side_effect=(
+                draft_parallel_config,
+                draft_vllm_config,
+            ),
+        ) as replace_config,
+        pytest.raises(RuntimeError, match="stop after config"),
+    ):
+        speculator = object.__new__(AscendMTPSpeculator)
+        speculator_module.AscendAutoRegressiveSpeculator.__init__(
+            speculator,
+            vllm_config,
+            device,
+        )
+
+    base_init.assert_called_once_with(draft_vllm_config, device)
+    assert replace_config.call_args_list[0] == call(
+        parallel_config,
+        prefill_context_parallel_size=1,
+    )
+    draft_config_call = replace_config.call_args_list[1]
+    assert draft_config_call.args == (vllm_config,)
+    assert draft_config_call.kwargs["parallel_config"] is draft_parallel_config
+    draft_compilation_config = draft_config_call.kwargs["compilation_config"]
+    assert draft_compilation_config is not target_compilation_config
+    assert draft_compilation_config.mode == CompilationMode.NONE
+    assert draft_compilation_config.cudagraph_mode == CUDAGraphMode.NONE
+    assert draft_compilation_config.oot_compiler is oot_compiler
+
+    assert target_compilation_config.mode == CompilationMode.VLLM_COMPILE
+    assert (
+        target_compilation_config.cudagraph_mode
+        == CUDAGraphMode.FULL_DECODE_ONLY
+    )
+
+
+@pytest.mark.parametrize("method", ["mtp", "eagle3"])
+def test_non_pcp_draft_reuses_target_config(method: str) -> None:
+    vllm_config = MagicMock()
+    vllm_config.speculative_config.method = method
+    vllm_config.parallel_config.prefill_context_parallel_size = 1
+    device = MagicMock()
+
+    with (
+        patch.object(
+            speculator_module.AutoRegressiveSpeculator,
+            "__init__",
+            side_effect=RuntimeError("stop after config"),
+        ) as base_init,
+        patch.object(speculator_module, "replace") as replace_config,
+        pytest.raises(RuntimeError, match="stop after config"),
+    ):
+        speculator = object.__new__(AscendMTPSpeculator)
+        speculator_module.AscendAutoRegressiveSpeculator.__init__(
+            speculator,
+            vllm_config,
+            device,
+        )
+
+    replace_config.assert_not_called()
+    base_init.assert_called_once_with(vllm_config, device)
+
+
+@pytest.mark.parametrize(
+    ("draft_mode", "requested_mode", "expected_mode"),
+    [
+        (CUDAGraphMode.NONE, CUDAGraphMode.FULL_DECODE_ONLY, CUDAGraphMode.NONE),
+        (
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+            CUDAGraphMode.FULL_DECODE_ONLY,
+        ),
+    ],
+)
+def test_autoregressive_graph_manager_respects_draft_config(
+    draft_mode: CUDAGraphMode,
+    requested_mode: CUDAGraphMode,
+    expected_mode: CUDAGraphMode,
+) -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.vllm_config = MagicMock()
+    speculator.vllm_config.compilation_config.cudagraph_mode = draft_mode
+    speculator.prefill_cudagraph_manager = MagicMock()
+    speculator.decode_cudagraph_manager = MagicMock()
+    speculator.update_stream = MagicMock()
+
+    with patch.object(
+        speculator_module.AutoRegressiveSpeculator,
+        "init_cudagraph_manager",
+    ) as parent_init:
+        speculator.init_cudagraph_manager(requested_mode)
+
+    parent_init.assert_called_once_with(expected_mode)
+
+
+def test_set_attn_builds_metadata_under_draft_config() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    draft_vllm_config = MagicMock()
+    speculator.vllm_config = draft_vllm_config
+    speculator.draft_attn_layer_names = set()
+
+    kv_cache_config = MagicMock()
+    kv_cache_config.kv_cache_groups = []
+    config_context = MagicMock()
+    model_state = MagicMock()
+    block_tables = MagicMock()
+    target_input_buffers = MagicMock()
+    target_attn_groups = MagicMock()
+
+    with (
+        patch.object(
+            speculator_module,
+            "set_current_vllm_config",
+            return_value=config_context,
+        ) as set_current_config,
+        patch.object(
+            speculator_module.AutoRegressiveSpeculator,
+            "set_attn",
+        ) as parent_set_attn,
+    ):
+        speculator.set_attn(
+            model_state,
+            kv_cache_config,
+            block_tables,
+            target_input_buffers,
+            target_attn_groups,
+        )
+
+    set_current_config.assert_called_once_with(draft_vllm_config)
+    config_context.__enter__.assert_called_once_with()
+    config_context.__exit__.assert_called_once()
+    parent_set_attn.assert_called_once_with(
+        model_state,
+        kv_cache_config,
+        block_tables,
+        target_input_buffers,
+        target_attn_groups,
+    )
+    assert speculator.attn_backends == {}
 
 
 @pytest.mark.parametrize(
@@ -42,8 +249,13 @@ def test_speculator_rebuilds_global_pcp_attention(
     speculator.attn_groups = MagicMock()
     speculator.target_attn_groups = MagicMock()
     speculator.kv_cache_config = MagicMock()
+    _set_draft_pcp_size(speculator, 1)
+    expected_attn_groups = speculator.attn_groups
 
-    input_batch = MagicMock()
+    input_batch = _make_padded_input_batch()
+    eager_batch = MagicMock()
+    last_hidden_states = torch.arange(32, dtype=torch.float32).reshape(8, 4)
+    expected_input_batch = eager_batch
     local_attn_metadata = MagicMock()
     local_slot_mappings = MagicMock()
     global_block_tables = (MagicMock(),)
@@ -54,7 +266,7 @@ def test_speculator_rebuilds_global_pcp_attention(
         torch.arange(8, dtype=torch.float32).reshape(2, 4),
         torch.arange(6, dtype=torch.float32).reshape(2, 3),
     ]
-    global_aux_hidden_states = torch.arange(14, dtype=torch.float32).reshape(2, 7)
+    global_aux_hidden_states = torch.arange(56, dtype=torch.float32).reshape(8, 7)
     aux_hidden_states = local_aux_hidden_states if method == "eagle3" else None
 
     speculator.pcp_manager.prepare_speculator_attn.return_value = (
@@ -71,13 +283,18 @@ def test_speculator_rebuilds_global_pcp_attention(
             "build_slot_mappings_by_layer",
             return_value=global_slot_mappings,
         ) as build_slot_mappings,
+        patch.object(
+            speculator_module,
+            "replace",
+            return_value=eager_batch,
+        ) as replace_batch,
     ):
         speculator_cls.propose(
             speculator,
             input_batch,
             local_attn_metadata,
             local_slot_mappings,
-            MagicMock(),
+            last_hidden_states,
             aux_hidden_states,
             MagicMock(),
             MagicMock(),
@@ -87,13 +304,15 @@ def test_speculator_rebuilds_global_pcp_attention(
             MagicMock(),
         )
 
-    speculator.pcp_manager.prepare_speculator_attn.assert_called_once_with(input_batch)
+    speculator.pcp_manager.prepare_speculator_attn.assert_called_once_with(
+        input_batch
+    )
     speculator.model_state.prepare_attn.assert_called_once_with(
-        input_batch,
+        expected_input_batch,
         CUDAGraphMode.NONE,
         global_block_tables,
         global_slot_mapping,
-        speculator.target_attn_groups,
+        expected_attn_groups,
         speculator.kv_cache_config,
     )
     build_slot_mappings.assert_called_once_with(
@@ -102,9 +321,17 @@ def test_speculator_rebuilds_global_pcp_attention(
     )
 
     propose_args = propose.call_args.args
-    assert propose_args[0] is input_batch
+    assert propose_args[0] is expected_input_batch
     assert propose_args[1] is global_attn_metadata
     assert propose_args[2] is global_slot_mappings
+
+    replace_batch.assert_called_once()
+    assert replace_batch.call_args.kwargs["num_reqs_after_padding"] == 2
+    assert replace_batch.call_args.kwargs["num_tokens_after_padding"] == 6
+    torch.testing.assert_close(
+        propose_args[3],
+        last_hidden_states[:6],
+    )
 
     if method == "eagle3":
         restore_args = speculator.pcp_manager.restore_hidden_states.call_args.args
@@ -113,96 +340,13 @@ def test_speculator_rebuilds_global_pcp_attention(
             torch.cat(local_aux_hidden_states, dim=-1),
         )
         assert len(propose_args[4]) == 1
-        assert propose_args[4][0] is global_aux_hidden_states
+        torch.testing.assert_close(
+            propose_args[4][0],
+            global_aux_hidden_states[:6],
+        )
     else:
         speculator.pcp_manager.restore_hidden_states.assert_not_called()
         assert propose_args[4] is None
-
-
-@pytest.mark.parametrize(
-    "speculator_cls",
-    [AscendMTPSpeculator, AscendEagleSpeculator],
-)
-def test_pcp_draft_prefill_rebuilds_metadata_for_selected_full_graph(
-    speculator_cls,
-) -> None:
-    speculator = object.__new__(speculator_cls)
-    input_batch = MagicMock()
-    input_batch.num_reqs_after_padding = 4
-    input_batch.num_tokens_after_padding = 8
-    speculator.input_batch = input_batch
-
-    block_tables = (MagicMock(),)
-    slot_mappings = torch.arange(16).unsqueeze(0)
-    speculator._pcp_draft_prefill_attn_inputs = (
-        block_tables,
-        slot_mappings,
-    )
-    speculator.model_state = MagicMock()
-    speculator.model_state.attn_metadata = {"target": object()}
-    speculator.target_attn_groups = MagicMock()
-    speculator.kv_cache_config = MagicMock()
-    speculator.draft_attn_layer_names = {"draft"}
-
-    draft_metadata = object()
-    speculator.model_state.prepare_attn.return_value = {
-        "draft": draft_metadata,
-        "target": object(),
-    }
-    batch_desc = BatchExecutionDescriptor(
-        cg_mode=CUDAGraphMode.FULL,
-        num_tokens=8,
-        num_reqs=4,
-        uniform_token_count=2,
-    )
-
-    result = speculator.build_draft_attn_metadatas(
-        batch_desc,
-        is_draft_model_prefill=True,
-    )
-
-    speculator.model_state.prepare_attn.assert_called_once_with(
-        input_batch,
-        CUDAGraphMode.FULL,
-        block_tables,
-        slot_mappings,
-        speculator.target_attn_groups,
-        speculator.kv_cache_config,
-    )
-    assert result == [{"draft": draft_metadata}]
-
-
-def test_pcp_draft_prefill_rejects_mismatched_graph_shape() -> None:
-    speculator = object.__new__(AscendMTPSpeculator)
-    input_batch = MagicMock()
-    input_batch.num_reqs_after_padding = 4
-    input_batch.num_tokens_after_padding = 8
-    speculator.input_batch = input_batch
-    speculator._pcp_draft_prefill_attn_inputs = (
-        (MagicMock(),),
-        MagicMock(),
-    )
-    speculator.model_state = MagicMock()
-    speculator.model_state.attn_metadata = {"draft": object()}
-    speculator.draft_attn_layer_names = {"draft"}
-
-    mismatched_desc = BatchExecutionDescriptor(
-        cg_mode=CUDAGraphMode.FULL,
-        num_tokens=6,
-        num_reqs=3,
-        uniform_token_count=2,
-    )
-
-    with pytest.raises(
-        RuntimeError,
-        match="graph shape does not match",
-    ):
-        speculator.build_draft_attn_metadatas(
-            mismatched_desc,
-            is_draft_model_prefill=True,
-        )
-
-    speculator.model_state.prepare_attn.assert_not_called()
 
 
 def test_eagle3_pcp_dummy_run_keeps_local_inputs() -> None:
@@ -263,6 +407,10 @@ def test_eagle3_pcp_requires_aux_hidden_states() -> None:
     speculator.target_attn_groups = MagicMock()
     speculator.kv_cache_config = MagicMock()
 
+    _set_draft_pcp_size(speculator, 1)
+    input_batch = _make_padded_input_batch()
+    eager_batch = MagicMock()
+
     global_slot_mapping = torch.arange(4).unsqueeze(0)
     speculator.pcp_manager.prepare_speculator_attn.return_value = (
         (MagicMock(),),
@@ -272,6 +420,11 @@ def test_eagle3_pcp_requires_aux_hidden_states() -> None:
     with (
         patch.object(EagleSpeculator, "propose") as propose,
         patch.object(speculator_module, "build_slot_mappings_by_layer"),
+        patch.object(
+            speculator_module,
+            "replace",
+            return_value=eager_batch,
+        ),
         pytest.raises(
             RuntimeError,
             match="requires auxiliary target hidden states",
@@ -279,7 +432,7 @@ def test_eagle3_pcp_requires_aux_hidden_states() -> None:
     ):
         AscendEagleSpeculator.propose(
             speculator,
-            MagicMock(),
+            input_batch,
             MagicMock(),
             MagicMock(),
             MagicMock(),
@@ -295,19 +448,31 @@ def test_eagle3_pcp_requires_aux_hidden_states() -> None:
     propose.assert_not_called()
 
 
-def test_mtp_without_pcp_keeps_existing_proposal_inputs() -> None:
-    speculator = object.__new__(AscendMTPSpeculator)
-    speculator.method = "mtp"
+@pytest.mark.parametrize(
+    ("method", "speculator_cls", "parent_cls"),
+    [
+        ("mtp", AscendMTPSpeculator, MTPSpeculator),
+        ("eagle3", AscendEagleSpeculator, EagleSpeculator),
+    ],
+)
+def test_speculator_without_pcp_keeps_existing_proposal_inputs(
+    method: str,
+    speculator_cls,
+    parent_cls,
+) -> None:
+    speculator = object.__new__(speculator_cls)
+    speculator.method = method
     speculator.input_batch = None
     speculator.pcp_manager = None
 
     input_batch = MagicMock()
     local_attn_metadata = MagicMock()
     local_slot_mappings = MagicMock()
+    local_aux_hidden_states = [MagicMock()] if method == "eagle3" else None
 
     with (
         patch.object(
-            MTPSpeculator,
+            parent_cls,
             "propose",
             return_value=MagicMock(),
         ) as propose,
@@ -316,13 +481,13 @@ def test_mtp_without_pcp_keeps_existing_proposal_inputs() -> None:
             "build_slot_mappings_by_layer",
         ) as build_slot_mappings,
     ):
-        AscendMTPSpeculator.propose(
+        speculator_cls.propose(
             speculator,
             input_batch,
             local_attn_metadata,
             local_slot_mappings,
             MagicMock(),
-            None,
+            local_aux_hidden_states,
             MagicMock(),
             MagicMock(),
             MagicMock(),
@@ -335,3 +500,4 @@ def test_mtp_without_pcp_keeps_existing_proposal_inputs() -> None:
     propose_args = propose.call_args.args
     assert propose_args[1] is local_attn_metadata
     assert propose_args[2] is local_slot_mappings
+    assert propose_args[4] is local_aux_hidden_states

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -16,12 +16,17 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import pytest
 import torch
+from vllm.config import CUDAGraphMode
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
 import vllm_ascend.worker.v2.pcp_manager as pcp_manager_module
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
@@ -140,8 +145,8 @@ def test_partition_batch_refreshes_local_ascend_input_batch_metadata():
 
     with (
         # This Triton helper is unrelated to PCP partitioning and has no CPU
-        # implementation. Stub only it; AscendPCPManager.partition_batch and
-        # PCPManager.partition_batch both execute unmocked below.
+        # implementation. Stub only it; the Ascend partition override
+        # executes unmocked below.
         patch(
             "vllm.v1.worker.gpu.pcp_manager.prepare_pos_seq_lens",
             return_value=None,
@@ -154,25 +159,47 @@ def test_partition_batch_refreshes_local_ascend_input_batch_metadata():
             "vllm.v1.worker.gpu.pcp_manager.async_copy_to_gpu",
             side_effect=_mock_async_copy_to_cpu,
         ),
-        patch.object(pcp_manager_module, "build_attn_state", return_value=attn_state) as build_attn_state,
+        patch.object(
+            pcp_manager_module,
+            "build_attn_state",
+            return_value=attn_state,
+        ) as build_attn_state,
     ):
         result = manager.partition_batch(global_batch)
 
     assert isinstance(result, AscendInputBatch)
     assert result is not global_batch
     assert manager._global_batch is global_batch
-    np.testing.assert_array_equal(global_batch.seq_lens_np, np.array([18], dtype=np.int32))
+    np.testing.assert_array_equal(
+        global_batch.seq_lens_np,
+        np.array([18], dtype=np.int32),
+    )
     assert global_batch.attn_state == "global-attn-state"
 
     # PCP=2 rank 0 owns the tail chunk then the head chunk; the real base
     # implementation produces this local row order and pads to rank 1's size.
     assert result.req_ids == ["global-req", "global-req"]
-    np.testing.assert_array_equal(result.idx_mapping_np, np.array([3, 3], dtype=np.int32))
-    np.testing.assert_array_equal(result.num_scheduled_tokens, np.array([3, 5], dtype=np.int32))
-    np.testing.assert_array_equal(result.query_start_loc_np, np.array([0, 3, 8], dtype=np.int32))
+    np.testing.assert_array_equal(
+        result.idx_mapping_np,
+        np.array([3, 3], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        result.num_scheduled_tokens,
+        np.array([3, 5], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        result.query_start_loc_np,
+        np.array([0, 3, 8], dtype=np.int32),
+    )
     assert result.num_tokens == 8
     assert result.num_tokens_after_padding == 10
-    assert torch.equal(result.input_ids[:8], torch.tensor([15, 16, 17, 0, 1, 2, 3, 4], dtype=torch.int32))
+    assert torch.equal(
+        result.input_ids[:8],
+        torch.tensor(
+            [15, 16, 17, 0, 1, 2, 3, 4],
+            dtype=torch.int32,
+        ),
+    )
 
     # dataclasses.replace() retains the global Ascend-only fields by default;
     # the override must refresh them from real PCP-local CPU rows.
@@ -186,6 +213,234 @@ def test_partition_batch_refreshes_local_ascend_input_batch_metadata():
     assert args[2] == 2
     np.testing.assert_array_equal(args[3], np.array([3, 5], dtype=np.int32))
     np.testing.assert_array_equal(args[4], np.array([3, 5], dtype=np.int32))
+
+
+@pytest.mark.parametrize("method", ["mtp", "eagle3", "ngram"])
+def test_partition_batch_preserves_global_speculative_batch(
+    method: str,
+) -> None:
+    global_batch = _make_global_pcp_batch()
+    global_batch.num_draft_tokens = 3
+    global_batch.num_draft_tokens_per_req = np.array([3], dtype=np.int32)
+    req_states = SimpleNamespace(
+        last_sampled_tokens=torch.zeros(4, dtype=torch.int64),
+        prefill_len=SimpleNamespace(gpu=torch.zeros(4, dtype=torch.int32)),
+        draft_tokens=torch.empty((4, 3), dtype=torch.int64),
+    )
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=req_states,
+        max_num_reqs=1,
+        max_num_tokens=18,
+        vllm_config=SimpleNamespace(
+            speculative_config=SimpleNamespace(method=method),
+            num_speculative_tokens=3,
+        ),
+    )
+    upstream_partition_batch = PCPManager.partition_batch
+    upstream_batches = []
+
+    def call_upstream(manager, batch):
+        upstream_batches.append(batch)
+        return upstream_partition_batch(manager, batch)
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.prepare_pos_seq_lens",
+            return_value=None,
+        ),
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.combine_sampled_and_draft_tokens",
+            return_value=torch.zeros(2, dtype=torch.int64),
+        ),
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
+        patch.object(
+            pcp_manager_module,
+            "build_attn_state",
+            return_value=MagicMock(),
+        ),
+        patch.object(
+            PCPManager,
+            "partition_batch",
+            new=call_upstream,
+        ),
+    ):
+        local_batch = manager.partition_batch(global_batch)
+
+    assert len(upstream_batches) == 1
+    assert upstream_batches[0] is not global_batch
+    assert upstream_batches[0].num_draft_tokens == 0
+    assert upstream_batches[0].num_draft_tokens_per_req is None
+    assert manager._global_batch is global_batch
+    assert global_batch.num_draft_tokens == 3
+    np.testing.assert_array_equal(
+        global_batch.num_draft_tokens_per_req,
+        np.array([3], dtype=np.int32),
+    )
+    assert local_batch.num_draft_tokens == 0
+    assert local_batch.num_draft_tokens_per_req is None
+
+
+def test_partition_batch_restores_global_batch_when_upstream_fails() -> None:
+    global_batch = _make_global_pcp_batch()
+    global_batch.num_draft_tokens = 3
+    global_batch.num_draft_tokens_per_req = np.array([3], dtype=np.int32)
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=1,
+        max_num_tokens=18,
+        vllm_config=object(),
+    )
+
+    with (
+        patch.object(
+            PCPManager,
+            "partition_batch",
+            side_effect=RuntimeError("upstream failure"),
+        ),
+        pytest.raises(RuntimeError, match="upstream failure"),
+    ):
+        manager.partition_batch(global_batch)
+
+    assert manager._global_batch is global_batch
+    assert global_batch.num_draft_tokens == 3
+    np.testing.assert_array_equal(
+        global_batch.num_draft_tokens_per_req,
+        np.array([3], dtype=np.int32),
+    )
+
+
+def test_prepare_speculator_attn_rebuilds_global_kv_layout() -> None:
+    global_batch = _make_global_pcp_batch()
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=1,
+        max_num_tokens=20,
+        vllm_config=object(),
+    )
+    block_tables = MagicMock()
+    gathered_block_tables = (torch.ones(1, 1),)
+    global_batch.num_tokens_after_padding = 20
+    slot_mappings = torch.arange(20).unsqueeze(0)
+    block_tables.gather_block_tables.return_value = gathered_block_tables
+    manager._block_tables = block_tables
+    manager._global_batch_slot_mappings = slot_mappings
+    manager._gathered_kv_slot_mappings = torch.empty((1, 40), dtype=slot_mappings.dtype)
+    manager._global_batch = global_batch
+
+    result_block_tables, result_slot_mappings = manager.prepare_speculator_attn(global_batch)
+
+    assert result_block_tables is gathered_block_tables
+    expected_rank_slots = torch.cat(
+        (
+            torch.arange(18),
+            torch.full((2,), PAD_SLOT_ID),
+        )
+    ).unsqueeze(0)
+    torch.testing.assert_close(
+        result_slot_mappings,
+        expected_rank_slots.repeat(1, 2),
+    )
+    assert manager._gathered_kv_slot_mappings is not None
+    assert result_slot_mappings.data_ptr() == manager._gathered_kv_slot_mappings.data_ptr()
+    block_tables.gather_block_tables.assert_called_once_with(
+        global_batch.idx_mapping,
+        num_reqs_padded=global_batch.num_reqs_after_padding,
+    )
+
+
+def test_cached_prefill_partitions_only_the_scheduled_suffix() -> None:
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=4,
+        max_num_tokens=8,
+        vllm_config=object(),
+    )
+
+    def local_starts(num_computed_tokens: int) -> list[int]:
+        segments = manager._get_rank_segments(
+            rank=0,
+            num_scheduled_tokens=np.array([8], dtype=np.int32),
+            num_computed_tokens=np.array([num_computed_tokens], dtype=np.int32),
+            is_prefilling=np.array([True]),
+            query_start_loc_np=np.array([0, 8], dtype=np.int32),
+        )
+        return [num_computed_tokens + segment.global_batch_slice.start for segment in segments]
+
+    # Two scheduler iterations of one longer suffix advance from the cached
+    # prefix without repartitioning or recomputing that prefix.
+    assert local_starts(128) == [128, 134]
+    assert local_starts(136) == [136, 142]
+
+
+def test_pcp_layout_orders_cache_hit_miss_and_decode_rows() -> None:
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=8,
+        max_num_tokens=8,
+        vllm_config=object(),
+    )
+    num_scheduled_tokens = np.array([1, 4, 1], dtype=np.int32)
+    num_computed_tokens = np.array([128, 0, 256], dtype=np.int32)
+    is_prefilling = np.array([True, True, False])
+    query_start_loc = np.array([0, 1, 5, 6], dtype=np.int32)
+
+    rank_zero = manager._get_rank_segments(
+        0,
+        num_scheduled_tokens,
+        num_computed_tokens,
+        is_prefilling,
+        query_start_loc,
+    )
+    rank_one = manager._get_rank_segments(
+        1,
+        num_scheduled_tokens,
+        num_computed_tokens,
+        is_prefilling,
+        query_start_loc,
+    )
+
+    def layout(segments):
+        return [
+            (
+                segment.global_batch_req_idx,
+                segment.global_batch_slice.start,
+                segment.global_batch_slice.stop,
+            )
+            for segment in segments
+        ]
+
+    # Continued prefills and replicated decodes stay before fresh prefills.
+    # The one-token cache-hit suffix is owned by rank 0; no cached prefix token
+    # appears in either rank's scheduled slices.
+    assert layout(rank_zero) == [
+        (0, 0, 1),
+        (2, 5, 6),
+        (1, 1, 2),
+        (1, 4, 5),
+    ]
+    assert layout(rank_one) == [
+        (2, 5, 6),
+        (1, 2, 3),
+        (1, 3, 4),
+    ]
 
 
 def test_npu_model_runner_uses_ascend_pcp_manager() -> None:
@@ -206,3 +461,220 @@ def test_initialize_kv_cache_skips_pcp_binding_when_disabled() -> None:
         runner.initialize_kv_cache(kv_cache_config)
 
     initialize_kv_cache.assert_called_once_with(kv_cache_config)
+
+
+@pytest.mark.parametrize("method", ["mtp", "eagle3"])
+def test_validate_config_accepts_supported_speculative_methods(
+    method: str,
+) -> None:
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            pipeline_parallel_size=1,
+            decode_context_parallel_size=1,
+        ),
+        model_config=SimpleNamespace(
+            use_mla=True,
+            is_encoder_decoder=False,
+            hf_text_config=SimpleNamespace(),
+        ),
+        speculative_config=SimpleNamespace(method=method),
+        lora_config=None,
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.FULL,
+        ),
+    )
+
+    AscendPCPManager.validate_config(
+        vllm_config,
+        supports_mm_inputs=False,
+    )
+
+
+def test_validate_config_allows_unadapted_speculative_method() -> None:
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=2,
+            decode_context_parallel_size=1,
+            pipeline_parallel_size=1,
+        ),
+        model_config=SimpleNamespace(
+            use_mla=True,
+            is_encoder_decoder=False,
+            hf_text_config=SimpleNamespace(),
+        ),
+        speculative_config=SimpleNamespace(method="ngram"),
+        lora_config=None,
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=CUDAGraphMode.FULL,
+        ),
+    )
+
+    AscendPCPManager.validate_config(
+        vllm_config,
+        supports_mm_inputs=False,
+    )
+
+
+def _make_decode_local_batch(
+    manager: AscendPCPManager,
+    num_reqs: int,
+) -> AscendInputBatch:
+    input_buffers = manager._input_buffers
+    assert input_buffers is not None
+    base_batch = InputBatch.make_dummy(
+        num_reqs=num_reqs,
+        num_tokens=num_reqs,
+        input_buffers=input_buffers,
+    )
+    base_batch.num_computed_tokens_np = np.arange(
+        10,
+        10 + num_reqs,
+        dtype=np.int32,
+    )
+    base_batch.num_scheduled_tokens = np.ones(num_reqs, dtype=np.int32)
+    seq_lens = base_batch.num_computed_tokens_np + base_batch.num_scheduled_tokens
+    base_batch.seq_lens.copy_(torch.from_numpy(seq_lens))
+    base_batch.seq_lens_cpu_upper_bound = torch.from_numpy(seq_lens)
+    base_batch.input_ids.copy_(torch.arange(100, 100 + num_reqs, dtype=torch.int32))
+    base_batch.positions.copy_(torch.arange(10, 10 + num_reqs, dtype=torch.int64))
+    base_batch.is_padding.fill_(False)
+    return AscendInputBatch(
+        **base_batch.__dict__,
+        seq_lens_np=seq_lens,
+        attn_state="decode-attn-state",
+    )
+
+
+def test_pad_decode_batch_supports_single_fia_dummy_request():
+    """Allow one FIA dummy request to consume multiple padding tokens."""
+    num_reqs = 2
+    graph_num_reqs = 3
+    graph_num_tokens = 4
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=graph_num_reqs,
+        max_num_tokens=graph_num_tokens,
+        vllm_config=object(),
+    )
+    local_batch = _make_decode_local_batch(manager, num_reqs=num_reqs)
+    input_buffers = manager._input_buffers
+    assert input_buffers is not None
+    input_buffers.input_ids[num_reqs:graph_num_tokens].fill_(999)
+    input_buffers.positions[num_reqs:graph_num_tokens].fill_(999)
+    input_buffers.seq_lens[num_reqs:graph_num_reqs].fill_(999)
+    input_buffers.is_padding[num_reqs:graph_num_tokens].fill_(False)
+
+    graph_input_ids = torch.full(
+        (graph_num_tokens,),
+        999,
+        dtype=torch.int32,
+    )
+    graph_input_ids[:num_reqs].copy_(local_batch.input_ids)
+    graph_positions = torch.full(
+        (graph_num_tokens,),
+        999,
+        dtype=torch.int64,
+    )
+    graph_positions[:num_reqs].copy_(local_batch.positions)
+    manager._global_batch = replace(
+        local_batch,
+        num_reqs_after_padding=graph_num_reqs,
+        num_tokens_after_padding=graph_num_tokens,
+        input_ids=graph_input_ids,
+        positions=graph_positions,
+        is_padding=torch.ones(graph_num_tokens, dtype=torch.bool),
+    )
+
+    result = manager._pad_decode_batch_for_full_graph(
+        local_batch,
+        graph_num_reqs,
+        graph_num_tokens,
+        local_batch.seq_lens_np,
+    )
+
+    expected_query_start_loc = np.array([0, 1, 2, 4], dtype=np.int32)
+    np.testing.assert_array_equal(
+        result.query_start_loc_np,
+        expected_query_start_loc,
+    )
+    torch.testing.assert_close(
+        result.query_start_loc,
+        torch.from_numpy(expected_query_start_loc),
+    )
+    assert result.input_ids.tolist() == [100, 101, 0, 0]
+    assert result.positions.tolist() == [10, 11, 0, 0]
+    assert result.seq_lens.tolist() == [11, 12, 0]
+    assert result.is_padding.tolist() == [False, False, True, True]
+
+
+def test_pad_decode_batch_uses_k_plus_one_tokens_per_dummy_request() -> None:
+    num_reqs = 2
+    query_len = 4
+    graph_num_reqs = 3
+    graph_num_tokens = graph_num_reqs * query_len
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=graph_num_reqs,
+        max_num_tokens=graph_num_tokens,
+        vllm_config=SimpleNamespace(num_speculative_tokens=3),
+    )
+    local_batch = _make_decode_local_batch(manager, num_reqs=num_reqs)
+    input_buffers = manager._input_buffers
+    assert input_buffers is not None
+
+    num_tokens = num_reqs * query_len
+    query_start_loc_np = np.array([0, 4, 8], dtype=np.int32)
+    input_buffers.query_start_loc[: num_reqs + 1].copy_(torch.from_numpy(query_start_loc_np))
+    input_buffers.input_ids[:num_tokens].copy_(torch.arange(100, 100 + num_tokens, dtype=torch.int32))
+    input_buffers.positions[:num_tokens].copy_(torch.arange(10, 10 + num_tokens, dtype=torch.int64))
+    input_buffers.is_padding[:num_tokens].fill_(False)
+    local_seq_lens_np = np.array([14, 15], dtype=np.int32)
+    input_buffers.seq_lens[:num_reqs].copy_(torch.from_numpy(local_seq_lens_np))
+    local_batch = replace(
+        local_batch,
+        num_scheduled_tokens=np.full(num_reqs, query_len, dtype=np.int32),
+        num_tokens=num_tokens,
+        num_tokens_after_padding=num_tokens,
+        query_start_loc=input_buffers.query_start_loc[: num_reqs + 1],
+        query_start_loc_np=query_start_loc_np,
+        seq_lens=input_buffers.seq_lens[:num_reqs],
+        seq_lens_cpu_upper_bound=torch.from_numpy(local_seq_lens_np.copy()),
+        input_ids=input_buffers.input_ids[:num_tokens],
+        positions=input_buffers.positions[:num_tokens],
+        is_padding=input_buffers.is_padding[:num_tokens],
+        seq_lens_np=local_seq_lens_np,
+    )
+    manager._global_batch = replace(
+        local_batch,
+        num_reqs_after_padding=graph_num_reqs,
+        num_tokens_after_padding=graph_num_tokens,
+        input_ids=torch.full((graph_num_tokens,), 999, dtype=torch.int32),
+        positions=torch.full((graph_num_tokens,), 999, dtype=torch.int64),
+        is_padding=torch.ones(graph_num_tokens, dtype=torch.bool),
+    )
+
+    result = manager._pad_decode_batch_for_full_graph(
+        local_batch,
+        graph_num_reqs,
+        graph_num_tokens,
+        local_seq_lens_np,
+    )
+
+    expected_query_start_loc = np.array([0, 4, 8, 12], dtype=np.int32)
+    np.testing.assert_array_equal(
+        result.query_start_loc_np,
+        expected_query_start_loc,
+    )
+    torch.testing.assert_close(
+        result.query_start_loc,
+        torch.from_numpy(expected_query_start_loc),
+    )
+    assert result.seq_lens.tolist() == [14, 15, 0]
+    assert result.is_padding.tolist() == [False] * 8 + [True] * 4

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -123,6 +123,37 @@ def _make_global_pcp_batch():
     )
 
 
+def test_mtp_rejection_syncs_corrected_num_computed_tokens_to_numpy() -> None:
+    runner = SimpleNamespace(
+        speculator=object(),
+        num_computed_tokens_event=MagicMock(),
+        num_computed_tokens_cpu=torch.tensor([0, 308], dtype=torch.int32),
+        req_states=SimpleNamespace(
+            req_id_to_index={"req": 1},
+            num_computed_tokens_cpu=torch.tensor([0, 309], dtype=torch.int32),
+            num_computed_tokens_np=np.array([0, 309], dtype=np.int32),
+        ),
+        input_buffers=SimpleNamespace(
+            seq_lens_cpu=torch.zeros(1, dtype=torch.int32),
+        ),
+    )
+    scheduler_output = SimpleNamespace(
+        num_scheduled_tokens={"req": 2},
+        scheduled_cached_reqs=SimpleNamespace(req_ids=["req"]),
+    )
+
+    NPUModelRunner._update_seq_lens_cpu(
+        runner,
+        scheduler_output,
+        req_ids=["req"],
+    )
+
+    runner.num_computed_tokens_event.synchronize.assert_called_once_with()
+    assert runner.req_states.num_computed_tokens_cpu[1].item() == 308
+    assert runner.req_states.num_computed_tokens_np[1] == 308
+    assert runner.input_buffers.seq_lens_cpu[0].item() == 310
+
+
 def test_partition_batch_refreshes_local_ascend_input_batch_metadata():
     """Refresh Ascend metadata after the real PCP local-batch rewrite."""
     vllm_config = object()
@@ -241,6 +272,7 @@ def test_partition_batch_preserves_global_speculative_batch(
     )
     upstream_partition_batch = PCPManager.partition_batch
     upstream_batches = []
+    rebuild_local_mtp_fields = MagicMock(side_effect=lambda _, batch: batch)
 
     def call_upstream(manager, batch):
         upstream_batches.append(batch)
@@ -269,6 +301,11 @@ def test_partition_batch_preserves_global_speculative_batch(
             "partition_batch",
             new=call_upstream,
         ),
+        patch.object(
+            AscendPCPManager,
+            "_rebuild_local_mtp_fields",
+            new=rebuild_local_mtp_fields,
+        ),
     ):
         local_batch = manager.partition_batch(global_batch)
 
@@ -284,6 +321,156 @@ def test_partition_batch_preserves_global_speculative_batch(
     )
     assert local_batch.num_draft_tokens == 0
     assert local_batch.num_draft_tokens_per_req is None
+    if method == "mtp":
+        rebuild_local_mtp_fields.assert_called_once()
+        assert rebuild_local_mtp_fields.call_args.args[0] is global_batch
+    else:
+        rebuild_local_mtp_fields.assert_not_called()
+
+
+def test_mixed_mtp_batch_builds_attention_from_valid_token_counts() -> None:
+    global_batch = _make_local_pcp_batch()
+    global_batch.is_prefilling_np = np.array([True, False])
+    global_batch.num_draft_tokens = 1
+    global_batch.num_draft_tokens_per_req = np.array([0, 1], dtype=np.int32)
+
+    local_batch = replace(
+        global_batch,
+        num_scheduled_tokens=np.array([1, 2], dtype=np.int32),
+        num_computed_tokens_np=np.array([0, 10], dtype=np.int32),
+        num_draft_tokens=1,
+        num_draft_tokens_per_req=np.array([0, 1], dtype=np.int32),
+        is_prefilling_np=np.array([True, False]),
+    )
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=2,
+        max_num_tokens=6,
+        vllm_config=SimpleNamespace(
+            speculative_config=SimpleNamespace(method="mtp"),
+        ),
+    )
+    attn_state = MagicMock()
+
+    with (
+        patch.object(
+            PCPManager,
+            "partition_batch",
+            return_value=local_batch,
+        ),
+        patch.object(
+            AscendPCPManager,
+            "_rebuild_local_mtp_fields",
+            return_value=local_batch,
+        ),
+        patch.object(
+            pcp_manager_module,
+            "build_attn_state",
+            return_value=attn_state,
+        ) as build_attn_state,
+    ):
+        result = manager.partition_batch(global_batch)
+
+    assert result.attn_state is attn_state
+    args = build_attn_state.call_args.args
+    np.testing.assert_array_equal(args[3], np.array([1, 2], dtype=np.int32))
+    np.testing.assert_array_equal(args[4], np.array([1, 1], dtype=np.int32))
+
+
+def test_rebuild_local_mtp_fields_restores_draft_query() -> None:
+    global_batch = _make_global_pcp_batch()
+    global_batch.req_ids = ["mtp-req"]
+    global_batch.num_draft_tokens = 1
+    global_batch.num_draft_tokens_per_req = np.array([1], dtype=np.int32)
+
+    local_batch = _make_global_pcp_batch()
+    local_batch.req_ids = ["mtp-req"]
+    local_batch.idx_mapping = torch.tensor([3], dtype=torch.int32)
+    local_batch.idx_mapping_np = np.array([3], dtype=np.int32)
+    local_batch.num_scheduled_tokens = np.array([2], dtype=np.int32)
+    local_batch.num_tokens = 2
+    local_batch.num_tokens_after_padding = 2
+    local_batch.query_start_loc_np = np.array([0, 2], dtype=np.int32)
+    local_batch.query_start_loc[:2].copy_(torch.tensor([0, 2], dtype=torch.int32))
+    local_batch.input_ids[:2].copy_(torch.tensor([101, 101], dtype=torch.int32))
+
+    last_sampled_tokens = torch.zeros(4, dtype=torch.int64)
+    last_sampled_tokens[3] = 101
+    draft_tokens = torch.zeros((4, 1), dtype=torch.int64)
+    draft_tokens[3, 0] = 202
+    req_states = SimpleNamespace(
+        last_sampled_tokens=last_sampled_tokens,
+        prefill_len=SimpleNamespace(gpu=torch.zeros(4, dtype=torch.int32)),
+        draft_tokens=draft_tokens,
+    )
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=req_states,
+        max_num_reqs=1,
+        max_num_tokens=18,
+        vllm_config=SimpleNamespace(num_speculative_tokens=1),
+    )
+
+    def combine_mtp_query(
+        input_ids,
+        idx_mapping,
+        last_sampled,
+        query_start_loc,
+        seq_lens,
+        prefill_len,
+        drafts,
+        cu_num_logits,
+        total_num_logits,
+        num_new_sampled_tokens,
+    ):
+        del query_start_loc, seq_lens, prefill_len
+        assert cu_num_logits.tolist() == [0, 2]
+        assert total_num_logits == 2
+        assert num_new_sampled_tokens == 1
+        req_state_idx = int(idx_mapping[0])
+        input_ids[0] = last_sampled[req_state_idx]
+        input_ids[1] = drafts[req_state_idx, 0]
+        return torch.tensor([0, 1], dtype=torch.int64)
+
+    with (
+        patch.object(
+            pcp_manager_module,
+            "async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
+        patch.object(
+            pcp_manager_module,
+            "expand_idx_mapping",
+            return_value=(
+                torch.tensor([3, 3], dtype=torch.int32),
+                torch.tensor([0, 1], dtype=torch.int32),
+            ),
+        ),
+        patch.object(
+            pcp_manager_module,
+            "combine_sampled_and_draft_tokens",
+            side_effect=combine_mtp_query,
+        ),
+    ):
+        result = manager._rebuild_local_mtp_fields(global_batch, local_batch)
+
+    assert result.input_ids[:2].tolist() == [101, 202]
+    assert result.num_draft_tokens == 1
+    np.testing.assert_array_equal(
+        result.num_draft_tokens_per_req,
+        np.array([1], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        result.cu_num_logits_np,
+        np.array([0, 2], dtype=np.int32),
+    )
+    assert result.cu_num_logits.tolist() == [0, 2]
+    assert result.logits_indices.tolist() == [0, 1]
 
 
 def test_partition_batch_restores_global_batch_when_upstream_fails() -> None:
@@ -318,6 +505,104 @@ def test_partition_batch_restores_global_batch_when_upstream_fails() -> None:
     )
 
 
+def test_prepare_attn_uses_partitioned_decode_positions_for_slot_mapping() -> None:
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=2,
+        max_num_tokens=4,
+        vllm_config=object(),
+    )
+    local_batch = _make_decode_local_batch(manager, num_reqs=2)
+    local_batch.positions.copy_(torch.tensor([471, 472], dtype=torch.int64))
+    local_batch.is_prefilling_np = np.array([False, False])
+
+    stale_global_positions = torch.tensor([467, 468, 0, 0], dtype=torch.int64)
+    manager._global_batch = replace(
+        local_batch,
+        num_tokens_after_padding=4,
+        positions=stale_global_positions,
+    )
+
+    block_tables = MagicMock()
+    gathered_block_tables = (torch.ones(2, 1),)
+    local_slot_mappings = torch.tensor([[3415, 3416]], dtype=torch.int64)
+    block_tables.gather_block_tables.return_value = gathered_block_tables
+    block_tables.compute_slot_mappings.return_value = local_slot_mappings
+    manager._block_tables = block_tables
+    manager._local_block_tables = (torch.empty((2, 1), dtype=torch.int32),)
+    manager._local_block_table_ptrs = torch.empty(1, dtype=torch.int64)
+    manager._global_batch_slot_mappings = torch.empty((1, 4), dtype=torch.int64)
+    manager._gathered_kv_slot_mappings = torch.full(
+        (1, 8),
+        999,
+        dtype=torch.int64,
+    )
+
+    def convert_local_slot_mappings(slot_mappings):
+        assert slot_mappings is local_slot_mappings
+        gathered = manager._gathered_kv_slot_mappings[:, :4]
+        gathered.copy_(torch.tensor([[3415, 3416, 3415, 3416]]))
+        return gathered
+
+    manager._convert_to_gathered_slot_mappings = MagicMock(
+        side_effect=convert_local_slot_mappings
+    )
+
+    result_block_tables, result_slot_mappings = manager.prepare_attn(local_batch)
+
+    assert result_block_tables is gathered_block_tables
+    gather_args = block_tables.gather_block_tables.call_args
+    assert gather_args.args[0] is local_batch.idx_mapping
+    assert gather_args.args[1] == local_batch.num_reqs_after_padding
+    assert gather_args.kwargs["out"] is manager._local_block_tables
+    assert gather_args.kwargs["out_ptrs"] is manager._local_block_table_ptrs
+
+    slot_args = block_tables.compute_slot_mappings.call_args
+    assert slot_args.args[0] is local_batch.idx_mapping
+    assert slot_args.args[1] is local_batch.query_start_loc
+    assert slot_args.args[2] is local_batch.positions
+    assert slot_args.args[2] is not manager._global_batch.positions
+    assert slot_args.args[3] == local_batch.num_tokens
+    assert slot_args.kwargs["out"] is manager._global_batch_slot_mappings
+    assert result_slot_mappings.tolist() == [
+        [3415, 3416, 3415, 3416] + [PAD_SLOT_ID] * 4
+    ]
+
+
+def test_prepare_slot_mappings_uses_global_prefill_layout() -> None:
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=MagicMock(),
+        max_num_reqs=2,
+        max_num_tokens=4,
+        vllm_config=object(),
+    )
+    local_batch = _make_decode_local_batch(manager, num_reqs=2)
+    local_batch.is_prefilling_np = np.array([False, False])
+    manager._global_batch = replace(
+        local_batch,
+        is_prefilling_np=np.array([True, False]),
+    )
+    manager._block_tables = MagicMock()
+    global_slot_mappings = torch.tensor([[41, 42]], dtype=torch.int64)
+
+    with patch.object(
+        PCPManager,
+        "prepare_slot_mappings",
+        return_value=global_slot_mappings,
+    ) as prepare_global_slot_mappings:
+        result = manager.prepare_slot_mappings(local_batch)
+
+    assert result is global_slot_mappings
+    prepare_global_slot_mappings.assert_called_once_with()
+    manager._block_tables.compute_slot_mappings.assert_not_called()
+
+
 def test_prepare_speculator_attn_rebuilds_global_kv_layout() -> None:
     global_batch = _make_global_pcp_batch()
     manager = AscendPCPManager(
@@ -331,6 +616,7 @@ def test_prepare_speculator_attn_rebuilds_global_kv_layout() -> None:
     )
     block_tables = MagicMock()
     gathered_block_tables = (torch.ones(1, 1),)
+    global_batch.num_reqs_after_padding = 2
     global_batch.num_tokens_after_padding = 20
     slot_mappings = torch.arange(20).unsqueeze(0)
     block_tables.gather_block_tables.return_value = gathered_block_tables
@@ -342,21 +628,12 @@ def test_prepare_speculator_attn_rebuilds_global_kv_layout() -> None:
     result_block_tables, result_slot_mappings = manager.prepare_speculator_attn(global_batch)
 
     assert result_block_tables is gathered_block_tables
-    expected_rank_slots = torch.cat(
-        (
-            torch.arange(18),
-            torch.full((2,), PAD_SLOT_ID),
-        )
-    ).unsqueeze(0)
-    torch.testing.assert_close(
-        result_slot_mappings,
-        expected_rank_slots.repeat(1, 2),
-    )
-    assert manager._gathered_kv_slot_mappings is not None
-    assert result_slot_mappings.data_ptr() == manager._gathered_kv_slot_mappings.data_ptr()
+    expected_slots = torch.arange(18).unsqueeze(0)
+    torch.testing.assert_close(result_slot_mappings, expected_slots)
+    assert result_slot_mappings.data_ptr() == slot_mappings.data_ptr()
     block_tables.gather_block_tables.assert_called_once_with(
         global_batch.idx_mapping,
-        num_reqs_padded=global_batch.num_reqs_after_padding,
+        num_reqs_padded=global_batch.num_reqs,
     )
 
 

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -411,6 +411,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
         )
         return attn_metadata
 
+    # TODO 修改函数名称，作为上游的重写
     def build_for_graph_capture(
         self,
         common_attn_metadata: AscendCommonAttentionMetadata,

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -51,6 +51,8 @@ from vllm_ascend.utils import cp_chunkedprefill_comm_stream, weak_ref_tensors
 
 
 @dataclass
+
+
 class AscendMetadataForPrefill:
     """GQA prefill metadata used only by DCP."""
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -6,10 +6,12 @@ import torch
 import torch.nn.functional as F
 import torch_npu
 from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.distributed.parallel_state import get_pcp_group
 from vllm.logger import logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonMetadataBuilder,
 )
+from vllm.model_executor.layers.attention.pcp import _gather_prefill_cache_inputs
 from vllm.model_executor.layers.linear import UnquantizedLinearMethod
 from vllm.utils.math_utils import cdiv, round_down
 from vllm.v1.attention.backend import (
@@ -28,6 +30,7 @@ from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
     ascend_chunked_prefill_workspace_size,
     enable_dcp,
+    enable_pcp,
     enabling_mlapo,
     maybe_save_kv_layer_to_connector,
     notify_kv_cache_written,
@@ -47,7 +50,9 @@ from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.attention_fence import record_attention_compute_start
 from vllm_ascend.ops.rotary_embedding import get_cos_and_sin_mla
-from vllm_ascend.quantization.methods.w8a8_mxfp8 import AscendW8A8MXFP8DynamicLinearMethod
+from vllm_ascend.quantization.methods.w8a8_mxfp8 import (
+    AscendW8A8MXFP8DynamicLinearMethod,
+)
 from vllm_ascend.quantization.methods.w8a8_static import AscendW8A8LinearMethod
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import (
@@ -78,10 +83,20 @@ class AscendMLABackend(AttentionBackend):
 
     @staticmethod
     def get_builder_cls():
-        if enable_dcp():
-            from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPMetadataBuilder
+        dcp_enabled = enable_dcp()
+        pcp_enabled = enable_pcp()
+        if dcp_enabled and pcp_enabled:
+            raise NotImplementedError(
+                "Ascend MRV2 MLA does not support PCP and DCP simultaneously yet."
+            )
+        if dcp_enabled:
+            from vllm_ascend.attention.context_parallel.mla_cp import (
+                AscendMlaDCPMetadataBuilder,
+            )
 
             return AscendMlaDCPMetadataBuilder
+        if pcp_enabled:
+            return AscendMLAPCPMetadataBuilder
         return AscendMLAMetadataBuilder
 
     @staticmethod
@@ -96,10 +111,18 @@ class AscendMLABackend(AttentionBackend):
 
     @staticmethod
     def get_impl_cls() -> type["MLAAttentionImpl"]:
-        if enable_dcp():
+        dcp_enabled = enable_dcp()
+        pcp_enabled = enable_pcp()
+        if dcp_enabled and pcp_enabled:
+            raise NotImplementedError(
+                "Ascend MRV2 MLA does not support PCP and DCP simultaneously yet."
+            )
+        if dcp_enabled:
             from vllm_ascend.attention.context_parallel.mla_cp import AscendMlaDCPImpl
 
             return AscendMlaDCPImpl
+        if pcp_enabled:
+            return AscendMLAPCPImpl
         return AscendMLAImpl
 
     @staticmethod
@@ -213,6 +236,15 @@ class AscendMLAMetadata:
         #         f"received {self.head_dim}.")
 
 
+@dataclass
+class AscendMLAPCPMetadata(AscendMLAMetadata):
+    """MLA metadata needed to write the complete PCP prefill KV cache."""
+
+    pcp_local_num_input_tokens: int = 0
+    pcp_local_prefill_start: int = 0
+    pcp_local_prefill_end: int = 0
+
+
 M = TypeVar("M", bound=AscendMLAMetadata)
 
 
@@ -243,8 +275,11 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         )
 
         scheduler_config = vllm_config.scheduler_config
+
         self.block_size = vllm_config.cache_config.block_size
-        self.max_blocks = (vllm_config.model_config.max_model_len + self.block_size - 1) // self.block_size
+        self.max_blocks = (
+            vllm_config.model_config.max_model_len + self.block_size - 1
+        ) // self.block_size
         self.chunked_prefill_enabled = scheduler_config.enable_chunked_prefill
 
         self.speculative_config = vllm_config.speculative_config
@@ -294,7 +329,9 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         # @override omitted only because of mypy limitation due to type variable.
         return AttentionCGSupport.UNIFORM_BATCH
 
-    def reorder_batch(self, input_batch: "NPUInputBatch", scheduler_output: "SchedulerOutput") -> bool:
+    def reorder_batch(
+        self, input_batch: "NPUInputBatch", scheduler_output: "SchedulerOutput"
+    ) -> bool:
         # We now want to reorder the batch so that the "decode" requests are at
         # the front and the "prefill" requests are at the using the least amount
         # swaps possible. (NOTE for now we loosely use "decode" to mean requests
@@ -330,7 +367,9 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             # If the decode is at the "back" of the batch, i, we can swap it
             # with the prefill closest to the front of the batch
             if decodes[num_decodes - i] >= num_decodes:
-                input_batch.swap_states(prefills[first_prefill], decodes[num_decodes - i])
+                input_batch.swap_states(
+                    prefills[first_prefill], decodes[num_decodes - i]
+                )
                 first_prefill += 1
                 modified_batch = True
             else:
@@ -366,27 +405,39 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         need_padding = (
             num_reqs_pad_size != 0
             and len(common_attn_metadata.actual_seq_lengths_q) > num_reqs
-            and common_attn_metadata.actual_seq_lengths_q[num_reqs] - actual_seq_lengths_q[-1] > FIA_SEQ_LEN_LIMIT
+            and common_attn_metadata.actual_seq_lengths_q[num_reqs]
+            - actual_seq_lengths_q[-1]
+            > FIA_SEQ_LEN_LIMIT
         )
         if need_padding:
-            padding_seq_len_q = common_attn_metadata.actual_seq_lengths_q[num_reqs : num_reqs + num_reqs_pad_size]
+            padding_seq_len_q = common_attn_metadata.actual_seq_lengths_q[
+                num_reqs : num_reqs + num_reqs_pad_size
+            ]
             start_val = actual_seq_lengths_q[-1]
             end_val = padding_seq_len_q[-1]
 
             num_step = len(padding_seq_len_q)
-            interpolated = np.round(np.linspace(start_val, end_val, num_step + 1)[1:]).astype(int).tolist()
+            interpolated = (
+                np.round(np.linspace(start_val, end_val, num_step + 1)[1:])
+                .astype(int)
+                .tolist()
+            )
             assert interpolated[-1] == end_val
             assert len(interpolated) == len(padding_seq_len_q)
             actual_seq_lengths_q = actual_seq_lengths_q + interpolated
         else:
             actual_seq_lengths_q = (
                 actual_seq_lengths_q
-                + common_attn_metadata.actual_seq_lengths_q[num_reqs : num_reqs + num_reqs_pad_size]
+                + common_attn_metadata.actual_seq_lengths_q[
+                    num_reqs : num_reqs + num_reqs_pad_size
+                ]
             )
 
         return actual_seq_lengths_q
 
-    def pad_actual_seq_len_q_mtp_disable_pad(self, num_reqs_pad_size, num_reqs, actual_seq_lengths_q):
+    def pad_actual_seq_len_q_mtp_disable_pad(
+        self, num_reqs_pad_size, num_reqs, actual_seq_lengths_q
+    ):
         """
         Only use for acl full graph mode.
         Pad the last element of the actual_seq_lengths_q equal to the TND(T) and
@@ -402,7 +453,11 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             start_val = actual_seq_lengths_q[-1]
             end_val = num_reqs + num_reqs_pad_size
             num_step = num_reqs_pad_size
-            interpolated = np.round(np.linspace(start_val, end_val, num_step + 1)[1:]).astype(int).tolist()
+            interpolated = (
+                np.round(np.linspace(start_val, end_val, num_step + 1)[1:])
+                .astype(int)
+                .tolist()
+            )
             assert interpolated[-1] == end_val
             assert len(interpolated) == num_reqs_pad_size
             actual_seq_lengths_q = actual_seq_lengths_q + interpolated
@@ -423,17 +478,27 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc = common_attn_metadata.query_start_loc
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
+        parallel_config = self.vllm_config.parallel_config
 
-        self.num_decodes, self.num_prefills, self.num_decode_tokens, self.num_prefill_tokens = (
-            split_decodes_and_prefills(
-                common_attn_metadata,
-                decode_threshold=self.decode_threshold,
-                treat_short_extends_as_decodes=common_attn_metadata.context_parallel_metadata is None,
-            )
+        (
+            self.num_decodes,
+            self.num_prefills,
+            self.num_decode_tokens,
+            self.num_prefill_tokens,
+        ) = split_decodes_and_prefills(
+            common_attn_metadata,
+            decode_threshold=self.decode_threshold,
+            treat_short_extends_as_decodes=not (
+                parallel_config.prefill_context_parallel_size > 1
+                or parallel_config.decode_context_parallel_size > 1
+            ),
         )
         self.set_num_actual_tokens(common_attn_metadata)
         assert self.num_decodes + self.num_prefills == num_reqs
-        assert self.num_decode_tokens + self.num_prefill_tokens == common_attn_metadata.num_actual_tokens
+        assert (
+            self.num_decode_tokens + self.num_prefill_tokens
+            == common_attn_metadata.num_actual_tokens
+        )
 
         # NOTE: MTP full graph is incompatible with context parallelism.
         self.slot_mapping = common_attn_metadata.slot_mapping[: self.num_actual_tokens]
@@ -450,16 +515,22 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             self.seq_lens = common_attn_metadata.seq_lens[:num_reqs].to("cpu")
 
         self.graph_pad_size = common_attn_metadata.graph_pad_size
-        block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_PREFILL)
+        block_table_size = self.get_block_table_size(
+            common_attn_metadata, BUILD_METADATA_STEP_PREFILL
+        )
         self.block_table = common_attn_metadata.block_table_tensor[:block_table_size]
 
         prefill_metadata = None
         if self.num_prefills > 0:
-            prefill_metadata = self.build_prefill_metadata(common_prefix_len, common_attn_metadata)
+            prefill_metadata = self.build_prefill_metadata(
+                common_prefix_len, common_attn_metadata
+            )
 
         decode_metadata = None
         if self.num_decodes > 0:
-            decode_metadata = self.build_decode_metadata(common_prefix_len, common_attn_metadata)
+            decode_metadata = self.build_decode_metadata(
+                common_prefix_len, common_attn_metadata
+            )
         return self.metadata_cls(  # type: ignore
             num_input_tokens=common_attn_metadata.num_input_tokens,
             num_actual_tokens=self.num_actual_tokens,
@@ -496,24 +567,40 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         if not max_context_len_cpu > 0:
             return None
         num_prefills_with_context_cpu = (self.context_lens_cpu > 0).sum().item()
-        self.max_context_chunk = self.chunked_prefill_workspace_size // num_prefills_with_context_cpu
+        self.max_context_chunk = (
+            self.chunked_prefill_workspace_size // num_prefills_with_context_cpu
+        )
         self.max_context_chunk = round_down(self.max_context_chunk, self.block_size)
 
         assert self.max_context_chunk > 0
         self.num_chunks = cdiv(max_context_len_cpu, self.max_context_chunk)
         chunk_starts = (
-            torch.arange(self.num_chunks, dtype=torch.int32).unsqueeze(1).expand(-1, self.num_prefills)
+            torch.arange(self.num_chunks, dtype=torch.int32)
+            .unsqueeze(1)
+            .expand(-1, self.num_prefills)
             * self.max_context_chunk
         )
-        chunk_ends = torch.min(self.context_lens_cpu.unsqueeze(0), chunk_starts + self.max_context_chunk)
+        chunk_ends = torch.min(
+            self.context_lens_cpu.unsqueeze(0), chunk_starts + self.max_context_chunk
+        )
         self.chunk_seq_lens = (chunk_ends - chunk_starts).clamp(min=0)
-        self.cu_seq_lens_cpu = torch.zeros(self.num_chunks, self.num_prefills + 1, dtype=torch.int32, pin_memory=True)
-        torch.cumsum(self.chunk_seq_lens, dim=1, out=self.cu_seq_lens_cpu[:, 1:], dtype=torch.int32)
+        self.cu_seq_lens_cpu = torch.zeros(
+            self.num_chunks, self.num_prefills + 1, dtype=torch.int32, pin_memory=True
+        )
+        torch.cumsum(
+            self.chunk_seq_lens,
+            dim=1,
+            out=self.cu_seq_lens_cpu[:, 1:],
+            dtype=torch.int32,
+        )
         chunk_actual_seq_lengths_kv_list = [
-            torch.cumsum(self.chunk_seq_lens[i], dim=0).tolist() for i in range(self.num_chunks)
+            torch.cumsum(self.chunk_seq_lens[i], dim=0).tolist()
+            for i in range(self.num_chunks)
         ]
         return ChunkedContextMetadata(
-            cu_seq_lens=self.cu_seq_lens_cpu.pin_memory().to(self.device, non_blocking=True),
+            cu_seq_lens=self.cu_seq_lens_cpu.pin_memory().to(
+                self.device, non_blocking=True
+            ),
             starts=chunk_starts.pin_memory().to(self.device, non_blocking=True),
             seq_tot=self.chunk_seq_lens.sum(dim=1).tolist(),
             max_seq_lens=self.chunk_seq_lens.max(dim=1).values.tolist(),
@@ -523,7 +610,11 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             chunk_actual_seq_lengths_kv_list=chunk_actual_seq_lengths_kv_list,
         )
 
-    def get_block_table_size(self, common_attn_metadata: AscendCommonAttentionMetadata, build_metadata_step: int):
+    def get_block_table_size(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        build_metadata_step: int,
+    ):
         if build_metadata_step == BUILD_METADATA_STEP_PREFILL:
             # If graph_pad_size > -1, mean is running in fullgraph mode.
             # NOTE: Maybe this block_table change can be removed when graph_pad_size > 1.
@@ -542,15 +633,21 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
     ) -> AscendMLAPrefillMetadata:
         query_start_loc = common_attn_metadata.query_start_loc
 
-        # NOTE: MTP full graph is incompatible with context parallelism.
-        input_positions = common_attn_metadata.positions[: self.num_actual_tokens].long()
+        # Keep padded positions in metadata. Attention implementations select
+        # the actual range they consume, while PCP keeps the padded range for
+        # equal-sized KV all-gathers.
+        input_positions = common_attn_metadata.positions.long()
 
-        chunked_context_metadata = self.build_chunked_metadata(common_prefix_len, common_attn_metadata)
+        chunked_context_metadata = self.build_chunked_metadata(
+            common_prefix_len, common_attn_metadata
+        )
         reqs_start = self.num_decodes  # prefill_start
         tokens_start = self.num_decode_tokens
         max_query_len = self.query_lens[reqs_start:].max().item()
         max_seq_lens = self.seq_lens[reqs_start:].max().item()
-        prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
+        prefill_query_start_loc = (
+            query_start_loc[reqs_start:] - query_start_loc[reqs_start]
+        )
 
         prefill_input_positions = input_positions[tokens_start:]
         cos, sin = get_cos_and_sin_mla(prefill_input_positions)
@@ -580,7 +677,9 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc_cpu = common_attn_metadata.query_start_loc_cpu
 
-        input_positions = common_attn_metadata.positions[: self.num_actual_tokens].long()
+        input_positions = common_attn_metadata.positions[
+            : self.num_actual_tokens
+        ].long()
 
         # Notice that num_decodes != num_decode_tokens in SpecDecoding Scenario
         actual_seq_lengths_q = query_start_loc_cpu[1 : self.num_decodes + 1].tolist()
@@ -588,12 +687,17 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         self.seq_lens = self.seq_lens[: self.num_decodes]
         input_positions = input_positions[: self.num_decode_tokens]
 
-        block_table_size = self.get_block_table_size(common_attn_metadata, BUILD_METADATA_STEP_DECODE)
+        block_table_size = self.get_block_table_size(
+            common_attn_metadata, BUILD_METADATA_STEP_DECODE
+        )
         self.block_table = self.block_table[:block_table_size]
 
         # NOTE: MTP full graph is incompatible with context parallelism.
         # NOTE: Maybe this block_table change can be removed when graph_pad_size > 1.
-        if self.graph_pad_size > self.num_decodes and self.speculative_config.disable_padded_drafter_batch:
+        if (
+            self.graph_pad_size > self.num_decodes
+            and self.speculative_config.disable_padded_drafter_batch
+        ):
             self.block_table = self.block_table[: self.graph_pad_size, ...]
         seq_lens_list = self.seq_lens.tolist()
 
@@ -603,7 +707,9 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                 actual_seq_lengths_q = self.pad_actual_seq_len_q_mtp_disable_pad(
                     num_reqs_pad_size, num_reqs, actual_seq_lengths_q
                 )
-                seq_lens_list = seq_lens_list + [0] * (self.graph_pad_size - self.num_decodes)
+                seq_lens_list = seq_lens_list + [0] * (
+                    self.graph_pad_size - self.num_decodes
+                )
                 num_block_pad_size = self.graph_pad_size - self.block_table.shape[0]
                 if num_block_pad_size > 0:
                     block_table_padding = torch.zeros(
@@ -611,16 +717,25 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                         dtype=self.block_table.dtype,
                         device=self.block_table.device,
                     )
-                    self.block_table = torch.cat([self.block_table, block_table_padding], dim=0)
+                    self.block_table = torch.cat(
+                        [self.block_table, block_table_padding], dim=0
+                    )
             else:
                 num_token_pad_size = self.graph_pad_size - self.num_decode_tokens
-                num_reqs_pad_size = self.graph_pad_size // common_attn_metadata.decode_token_per_req - num_reqs
+                num_reqs_pad_size = (
+                    self.graph_pad_size // common_attn_metadata.decode_token_per_req
+                    - num_reqs
+                )
                 num_block_table_pad_size = (
-                    self.graph_pad_size // common_attn_metadata.decode_token_per_req - self.num_decodes
+                    self.graph_pad_size // common_attn_metadata.decode_token_per_req
+                    - self.num_decodes
                 )
                 seq_lens_list = self.seq_lens.tolist() + [0] * num_reqs_pad_size
                 slot_padding = torch.full(
-                    (num_token_pad_size,), PAD_SLOT_ID, dtype=self.slot_mapping.dtype, device=self.slot_mapping.device
+                    (num_token_pad_size,),
+                    PAD_SLOT_ID,
+                    dtype=self.slot_mapping.dtype,
+                    device=self.slot_mapping.device,
                 )
                 self.slot_mapping = torch.cat([self.slot_mapping, slot_padding])
                 block_table_padding = torch.zeros(
@@ -628,13 +743,20 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                     dtype=self.block_table.dtype,
                     device=self.block_table.device,
                 )
-                self.block_table = torch.cat([self.block_table, block_table_padding], dim=0)
+                self.block_table = torch.cat(
+                    [self.block_table, block_table_padding], dim=0
+                )
                 position_padding = torch.zeros(
-                    num_token_pad_size, dtype=input_positions.dtype, device=input_positions.device
+                    num_token_pad_size,
+                    dtype=input_positions.dtype,
+                    device=input_positions.device,
                 )
                 input_positions = torch.cat([input_positions, position_padding])
                 actual_seq_lengths_q = self.pad_actual_seq_len_q_mtp_enable_pad(
-                    num_reqs_pad_size, num_reqs, actual_seq_lengths_q, common_attn_metadata
+                    num_reqs_pad_size,
+                    num_reqs,
+                    actual_seq_lengths_q,
+                    common_attn_metadata,
                 )
 
         cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
@@ -656,7 +778,10 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         common_attn_metadata: AscendCommonAttentionMetadata,
         attn_state: AscendAttentionState = AscendAttentionState.DecodeOnly,
     ):
-        if attn_state in {AscendAttentionState.DecodeOnly, AscendAttentionState.SpecDecoding}:
+        if attn_state in {
+            AscendAttentionState.DecodeOnly,
+            AscendAttentionState.SpecDecoding,
+        }:
             attn_metadata = self.build(
                 common_prefix_len=0,
                 common_attn_metadata=common_attn_metadata,
@@ -668,6 +793,73 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
 
         attn_metadata.attn_state = attn_state
         return attn_metadata
+
+
+class AscendMLAPCPMetadataBuilder(AscendMLAMetadataBuilder):
+    """Build rank-local MLA metadata while retaining PCP cache-write slots."""
+
+    def __init__(
+        self,
+        kv_cache_spec: AscendMLAAttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+        metadata_cls: type[AscendMLAMetadata] | None = None,
+        supports_dcp_with_varlen: bool = False,
+    ) -> None:
+        super().__init__(
+            kv_cache_spec,
+            layer_names,
+            vllm_config,
+            device,
+            metadata_cls or AscendMLAPCPMetadata,
+            supports_dcp_with_varlen,
+        )
+        self.pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        self.pcp_rank = get_pcp_group().rank_in_group
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> AscendMLAPCPMetadata:
+        expanded_slot_mapping = common_attn_metadata.slot_mapping
+        metadata = super().build(
+            common_prefix_len,
+            common_attn_metadata,
+            fast_build,
+        )
+        assert isinstance(metadata, AscendMLAPCPMetadata)
+        if expanded_slot_mapping.numel() % self.pcp_size != 0:
+            raise RuntimeError(
+                "PCP slot mapping size must be divisible by the PCP world size: "
+                f"{expanded_slot_mapping.numel()} % {self.pcp_size} != 0."
+            )
+
+        local_num_input_tokens = expanded_slot_mapping.numel() // self.pcp_size
+        if metadata.num_actual_tokens > local_num_input_tokens:
+            raise RuntimeError(
+                "PCP actual token count exceeds the rank-local padded token count: "
+                f"{metadata.num_actual_tokens} > {local_num_input_tokens}."
+            )
+
+        local_prefill_capacity = local_num_input_tokens - metadata.num_decode_tokens
+        metadata.slot_mapping = expanded_slot_mapping
+        metadata.pcp_local_num_input_tokens = local_num_input_tokens
+        metadata.pcp_local_prefill_start = self.pcp_rank * local_prefill_capacity
+        metadata.pcp_local_prefill_end = (
+            metadata.pcp_local_prefill_start
+            + metadata.num_actual_tokens
+            - metadata.num_decode_tokens
+        )
+        # PCP partitions prefill tokens into rank-local chunks, including
+        # continued prefills whose uncached suffix contains only one token.
+        # Keep decode-only batches on their graph path, but route every batch
+        # containing prefill work through the chunked-prefill implementation.
+        if metadata.num_prefills > 0:
+            metadata.attn_state = AscendAttentionState.ChunkedPrefill
+        return metadata
 
 
 class DecodeMLAPreprocessResult(NamedTuple):
@@ -723,7 +915,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.v_head_dim = kwargs["v_head_dim"]
         self.rotary_emb = kwargs["rotary_emb"]
         self.fused_qkv_a_proj = kwargs.get("fused_qkv_a_proj")
-        self.q_proj = kwargs["q_proj"] if self.q_lora_rank is None else kwargs["q_b_proj"]
+        self.q_proj = (
+            kwargs["q_proj"] if self.q_lora_rank is None else kwargs["q_b_proj"]
+        )
         self.kv_b_proj = kwargs["kv_b_proj"]
         self.o_proj = kwargs["o_proj"]
         self.vllm_config = get_current_vllm_config()
@@ -743,7 +937,11 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)
         if self.fa_quant_layer:
-            self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+            self.dtype = (
+                torch.float8_e4m3fn
+                if get_ascend_device_type() == AscendDeviceType.A5
+                else torch.int8
+            )
         else:
             self.dtype = self.vllm_config.model_config.dtype
         # For models whose num_heads is not a power of 2 (e.g., GLM-4.7-Flash
@@ -778,7 +976,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         if num_layers == 0:
             return
         if _EXTRA_CTX.is_draft_model:
-            attn_keys = attn_keys * (len(graph_params.attn_params[num_tokens]) // num_layers)
+            attn_keys = attn_keys * (
+                len(graph_params.attn_params[num_tokens]) // num_layers
+            )
         attn_count = 0
         with torch.npu.stream(update_stream):
             for key, param, handle, event in zip(
@@ -815,20 +1015,37 @@ class AscendMLAImpl(MLAAttentionImpl):
                     attn_metadata_current = attn_metadata
 
                 seq_lens_list = attn_metadata_current[key].decode.seq_lens_list
-                if speculative_config and speculative_config.use_eagle() and not _EXTRA_CTX.is_draft_model:
-                    actual_seq_lengths = attn_metadata_current[key].decode.actual_seq_lengths_q
+                if (
+                    speculative_config
+                    and speculative_config.use_eagle()
+                    and not _EXTRA_CTX.is_draft_model
+                ):
+                    actual_seq_lengths = attn_metadata_current[
+                        key
+                    ].decode.actual_seq_lengths_q
                     spec_multiple = speculative_config.num_speculative_tokens + 1
-                    seq_lens_list = seq_lens_list + [0] * (num_tokens // spec_multiple - len(seq_lens_list))
-                    actual_seq_lengths = [spec_multiple * (i + 1) for i in range(num_tokens // spec_multiple)]
+                    seq_lens_list = seq_lens_list + [0] * (
+                        num_tokens // spec_multiple - len(seq_lens_list)
+                    )
+                    actual_seq_lengths = [
+                        spec_multiple * (i + 1)
+                        for i in range(num_tokens // spec_multiple)
+                    ]
                 elif _EXTRA_CTX.is_draft_model:
-                    actual_seq_lengths = attn_metadata_current[key].decode.actual_seq_lengths_q
+                    actual_seq_lengths = attn_metadata_current[
+                        key
+                    ].decode.actual_seq_lengths_q
                     block_table = attn_metadata_current[key].decode.block_table
                     # TODO: This is a hack and should be fixed in the future.
                     if speculative_config.disable_padded_drafter_batch:
                         block_table = block_table[: len(actual_seq_lengths)]
-                    seq_lens_list = seq_lens_list + [0] * (len(actual_seq_lengths) - len(seq_lens_list))
+                    seq_lens_list = seq_lens_list + [0] * (
+                        len(actual_seq_lengths) - len(seq_lens_list)
+                    )
                 else:
-                    seq_lens_list = seq_lens_list + [0] * (num_tokens - len(seq_lens_list))
+                    seq_lens_list = seq_lens_list + [0] * (
+                        num_tokens - len(seq_lens_list)
+                    )
 
                 extra_args = {}
                 if dequant_scale_q_nope is not None:
@@ -908,7 +1125,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         # NOTE: We currently do not support quant kv_b_proj.
         assert isinstance(self.kv_b_proj.quant_method, UnquantizedLinearMethod)
         # NOTE: Weight will be reshaped next, we need to revert and transpose it.
-        kv_b_proj_weight = torch_npu.npu_format_cast(self.kv_b_proj.weight.data, ACL_FORMAT_FRACTAL_ND).T
+        kv_b_proj_weight = torch_npu.npu_format_cast(
+            self.kv_b_proj.weight.data, ACL_FORMAT_FRACTAL_ND
+        ).T
         assert kv_b_proj_weight.shape == (
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),
@@ -925,7 +1144,9 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.qk_nope_head_dim + self.v_head_dim,
         )
 
-        W_UK, W_UV = kv_b_proj_weight.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+        W_UK, W_UV = kv_b_proj_weight.split(
+            [self.qk_nope_head_dim, self.v_head_dim], dim=-1
+        )
 
         # NOTE: When we make a incontiguous weight contiguous, a new address will be allocated for the weight,
         # in graph + RL scenario, we only capture the graph once, and the weight address is expected to be the same
@@ -947,7 +1168,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             # TODO(whx): modify this limitation when mlapo supports floating point
             if self.fused_qkv_a_proj is None or (
                 not isinstance(
-                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None), AscendW8A8LinearMethod
+                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None),
+                    AscendW8A8LinearMethod,
                 )
                 and not isinstance(
                     getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None),
@@ -972,7 +1194,9 @@ class AscendMLAImpl(MLAAttentionImpl):
 
     def _process_weights_for_fused_fa_quant(self):
         if get_ascend_device_type() == AscendDeviceType.A5:
-            layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
+            layer = self.vllm_config.compilation_config.static_forward_context[
+                self.layer_name
+            ]
             self.fak_descale_float = layer.fak_descale_float
             self.quant_kscale = layer.quant_kscale
             self.fak_descale_reciprocal = layer.fak_descale_reciprocal
@@ -981,16 +1205,28 @@ class AscendMLAImpl(MLAAttentionImpl):
             self.gamma2 = self.kv_a_layernorm.weight.data  # type: ignore[union-attr]
             wu_q = self.q_proj.weight.data
             self.wu_q = wu_q
-            q_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()  # type: ignore[union-attr]
+            q_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[
+                ..., : self.q_lora_rank
+            ].contiguous()  # type: ignore[union-attr]
             self.wd_q = q_a_proj_fa3
-            kv_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
+            kv_a_proj_fa3 = self.fused_qkv_a_proj.weight.data[
+                ..., self.q_lora_rank :
+            ].contiguous()  # type: ignore[union-attr]
             self.wd_kv = kv_a_proj_fa3
-            self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(torch.float)
-            q_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[: self.q_lora_rank].contiguous()  # type: ignore[union-attr]
+            self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.view(1, -1).to(
+                torch.float
+            )
+            q_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[
+                : self.q_lora_rank
+            ].contiguous()  # type: ignore[union-attr]
             self.dequant_scale_w_dq = q_a_proj_deq_scl.view(1, -1).to(torch.float)
-            kv_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
+            kv_a_proj_deq_scl = self.fused_qkv_a_proj.weight_scale[
+                self.q_lora_rank :
+            ].contiguous()  # type: ignore[union-attr]
             self.dequant_scale_w_dkv_kr = kv_a_proj_deq_scl.view(1, -1).to(torch.float)
-            layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
+            layer = self.vllm_config.compilation_config.static_forward_context[
+                self.layer_name
+            ]
             self.quant_kscale = layer.quant_kscale
             self.fak_descale_float = layer.fak_descale_float
 
@@ -998,8 +1234,12 @@ class AscendMLAImpl(MLAAttentionImpl):
         assert self.fused_qkv_a_proj is not None
         assert self.q_a_layernorm is not None
         assert self.kv_a_layernorm is not None
-        kv_a_proj_wt = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
-        q_a_proj_wt = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
+        kv_a_proj_wt = self.fused_qkv_a_proj.weight.data[
+            ..., self.q_lora_rank :
+        ].contiguous()
+        q_a_proj_wt = self.fused_qkv_a_proj.weight.data[
+            ..., : self.q_lora_rank
+        ].contiguous()
         kv_a_proj_wt = kv_a_proj_wt.t().contiguous()
         kv_a_proj_wt = trans_rope_weight(kv_a_proj_wt, self.qk_rope_head_dim)
         kv_a_proj_wt = kv_a_proj_wt.t().contiguous()
@@ -1008,40 +1248,76 @@ class AscendMLAImpl(MLAAttentionImpl):
         wd_qkv = transdata(wd_qkv, block_size=(16, 32)).unsqueeze(0).contiguous()
         self.wd_qkv = torch_npu.npu_format_cast(wd_qkv, 29)
 
-        kv_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
-        q_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[: self.q_lora_rank].contiguous()  # type: ignore[union-attr]
-        kv_a_proj_deq_scl = kv_a_proj_deq_scl.reshape(self.kv_lora_rank + self.qk_rope_head_dim, -1).contiguous()
+        kv_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[
+            self.q_lora_rank :
+        ].contiguous()  # type: ignore[union-attr]
+        q_a_proj_deq_scl = self.fused_qkv_a_proj.deq_scale[
+            : self.q_lora_rank
+        ].contiguous()  # type: ignore[union-attr]
+        kv_a_proj_deq_scl = kv_a_proj_deq_scl.reshape(
+            self.kv_lora_rank + self.qk_rope_head_dim, -1
+        ).contiguous()
         kv_a_proj_deq_scl = trans_rope_weight(kv_a_proj_deq_scl, self.qk_rope_head_dim)
-        kv_a_proj_deq_scl = kv_a_proj_deq_scl.view(self.kv_lora_rank + self.qk_rope_head_dim).contiguous()
-        self.deq_scale_qkv = torch.cat((kv_a_proj_deq_scl, q_a_proj_deq_scl), dim=-1).contiguous()
+        kv_a_proj_deq_scl = kv_a_proj_deq_scl.view(
+            self.kv_lora_rank + self.qk_rope_head_dim
+        ).contiguous()
+        self.deq_scale_qkv = torch.cat(
+            (kv_a_proj_deq_scl, q_a_proj_deq_scl), dim=-1
+        ).contiguous()
 
-        kv_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
-        q_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[: self.q_lora_rank].contiguous()  # type: ignore[union-attr]
-        kv_a_proj_qt_bias = kv_a_proj_qt_bias.reshape(self.kv_lora_rank + self.qk_rope_head_dim, -1).contiguous()
+        kv_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[
+            self.q_lora_rank :
+        ].contiguous()  # type: ignore[union-attr]
+        q_a_proj_qt_bias = self.fused_qkv_a_proj.quant_bias[
+            : self.q_lora_rank
+        ].contiguous()  # type: ignore[union-attr]
+        kv_a_proj_qt_bias = kv_a_proj_qt_bias.reshape(
+            self.kv_lora_rank + self.qk_rope_head_dim, -1
+        ).contiguous()
         kv_a_proj_qt_bias = trans_rope_weight(kv_a_proj_qt_bias, self.qk_rope_head_dim)
-        kv_a_proj_qt_bias = kv_a_proj_qt_bias.view(self.kv_lora_rank + self.qk_rope_head_dim).contiguous()
-        self.quant_bias_qkv = torch.cat((kv_a_proj_qt_bias, q_a_proj_qt_bias), dim=-1).contiguous()
+        kv_a_proj_qt_bias = kv_a_proj_qt_bias.view(
+            self.kv_lora_rank + self.qk_rope_head_dim
+        ).contiguous()
+        self.quant_bias_qkv = torch.cat(
+            (kv_a_proj_qt_bias, q_a_proj_qt_bias), dim=-1
+        ).contiguous()
 
         wu_q = self.q_proj.weight.data
-        wu_q = wu_q.t().reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
+        wu_q = wu_q.t().reshape(
+            self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1
+        )
         wu_q = trans_rope_weight(wu_q, self.qk_rope_head_dim)
-        wu_q = wu_q.reshape(self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim), -1)
+        wu_q = wu_q.reshape(
+            self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim), -1
+        )
         wu_q = transdata(wu_q, block_size=(16, 32)).unsqueeze(0).contiguous()
         self.wu_q = torch_npu.npu_format_cast(wu_q, 29)
 
         qb_deq_scl = self.q_proj.deq_scale.data
-        qb_deq_scl = qb_deq_scl.reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
+        qb_deq_scl = qb_deq_scl.reshape(
+            self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1
+        )
         qb_deq_scl = trans_rope_weight(qb_deq_scl, self.qk_rope_head_dim)
-        self.qb_deq_scl = qb_deq_scl.reshape(self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim))
+        self.qb_deq_scl = qb_deq_scl.reshape(
+            self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim)
+        )
 
         qb_qt_bias = self.q_proj.quant_bias.data
-        qb_qt_bias = qb_qt_bias.reshape(self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1)
+        qb_qt_bias = qb_qt_bias.reshape(
+            self.num_heads, self.qk_nope_head_dim + self.qk_rope_head_dim, -1
+        )
         qb_qt_bias = trans_rope_weight(qb_qt_bias, self.qk_rope_head_dim)
-        self.qb_qt_bias = qb_qt_bias.reshape(self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim))
+        self.qb_qt_bias = qb_qt_bias.reshape(
+            self.num_heads * (self.qk_nope_head_dim + self.qk_rope_head_dim)
+        )
 
         device = self.q_proj.weight.device
         self.gamma1 = self.q_a_layernorm.weight.data  # type: ignore[union-attr]
-        self.beta1 = torch.zeros_like(self.gamma1) if (_bias := self.q_a_layernorm.bias) is None else _bias.data  # type: ignore[union-attr]
+        self.beta1 = (
+            torch.zeros_like(self.gamma1)
+            if (_bias := self.q_a_layernorm.bias) is None
+            else _bias.data
+        )  # type: ignore[union-attr]
         self.gamma2 = self.kv_a_layernorm.weight.data  # type: ignore[union-attr]
         self.quant_scale0 = self.fused_qkv_a_proj.input_scale.data  # type: ignore[union-attr]
         self.quant_offset0 = self.fused_qkv_a_proj.input_offset.data  # type: ignore[union-attr]
@@ -1056,7 +1332,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         if (
             self.vllm_config.kv_transfer_config is not None
             and self.vllm_config.kv_transfer_config.is_kv_consumer
-            and self.vllm_config.scheduler_config.max_num_batched_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
+            and self.vllm_config.scheduler_config.max_num_batched_tokens
+            <= MLAPO_MAX_SUPPORTED_TOKENS
         ):
             self.fused_qkv_a_proj.weight = None  # type: ignore[union-attr]
             self.fused_qkv_a_proj.deq_scale = None  # type: ignore[union-attr]
@@ -1069,7 +1346,9 @@ class AscendMLAImpl(MLAAttentionImpl):
     def _process_weights_for_fused_mlapo_a5(self, act_dtype: torch.dtype):
         assert self.fused_qkv_a_proj is not None
 
-        weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()
+        weight_dq = self.fused_qkv_a_proj.weight.data[
+            ..., : self.q_lora_rank
+        ].contiguous()
         self.weight_dq = torch_npu.npu_format_cast(weight_dq, 29)
 
         weight_uq_qr = self.q_proj.weight.data.contiguous()
@@ -1079,16 +1358,22 @@ class AscendMLAImpl(MLAAttentionImpl):
         )
         self.weight_uq_qr = torch_npu.npu_format_cast(weight_uq_qr, 29)
 
-        weight_dkv_kr = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()
+        weight_dkv_kr = self.fused_qkv_a_proj.weight.data[
+            ..., self.q_lora_rank :
+        ].contiguous()
         self.weight_dkv_kr = torch_npu.npu_format_cast(weight_dkv_kr, 29)
 
         weight_scale = self.fused_qkv_a_proj.weight_scale
         weight_scale = weight_scale.transpose(0, 1)
-        weight_scale = weight_scale.reshape(-1, weight_scale.shape[1] * weight_scale.shape[2])
+        weight_scale = weight_scale.reshape(
+            -1, weight_scale.shape[1] * weight_scale.shape[2]
+        )
         self.weight_dq_scale = weight_scale[: self.q_lora_rank, ...]
         self.weight_dkv_kr_scale = weight_scale[self.q_lora_rank :, ...]
         if self.fa_quant_layer:
-            layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
+            layer = self.vllm_config.compilation_config.static_forward_context[
+                self.layer_name
+            ]
             self.quant_kscale = layer.quant_kscale
             self.fak_descale_float = layer.fak_descale_float
             self.fak_descale_reciprocal = layer.fak_descale_reciprocal
@@ -1168,8 +1453,16 @@ class AscendMLAImpl(MLAAttentionImpl):
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
             context_seq_len_npu = self.get_context_seq_len_npu(i, attn_metadata)
-            kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=cache_kv_c.dtype, device=cache_kv_c.device)
-            k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device)
+            kv_c_normed = torch.empty(
+                toks,
+                num_heads,
+                latent_kv_dim,
+                dtype=cache_kv_c.dtype,
+                device=cache_kv_c.device,
+            )
+            k_pe = torch.empty(
+                toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device
+            )
 
             DeviceOperator.kv_cache_load(
                 cache_kv_c,
@@ -1189,14 +1482,18 @@ class AscendMLAImpl(MLAAttentionImpl):
             )
             kv_c_normed = kv_c_normed.squeeze()
             if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
-                kv_c_normed = torch.mul(kv_c_normed.to(self.fak_descale_float.dtype), self.fak_descale_float).to(
-                    torch.bfloat16
-                )
-            kv_nope = self.kv_b_proj(kv_c_normed)[0].view(-1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
+                kv_c_normed = torch.mul(
+                    kv_c_normed.to(self.fak_descale_float.dtype), self.fak_descale_float
+                ).to(torch.bfloat16)
+            kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+                -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+            )
             k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
             k_pe = k_pe.expand((*k_nope.shape[:-1], -1))
 
-            actual_seq_lengths_kv = prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
+            actual_seq_lengths_kv = (
+                prefill_metadata.chunked_context.chunk_actual_seq_lengths_kv_list[i]
+            )
             common_kwargs["actual_seq_lengths_kv"] = actual_seq_lengths_kv
 
             if self.head_padding > 0:
@@ -1218,7 +1515,9 @@ class AscendMLAImpl(MLAAttentionImpl):
             out_list.append(chunk_out.reshape(num_tokens * H, D))
             lse_list.append(chunk_lse.reshape(num_tokens * H))
 
-        output_final, _ = torch_npu.npu_attention_update(tuple(lse_list), tuple(out_list), 0)
+        output_final, _ = torch_npu.npu_attention_update(
+            tuple(lse_list), tuple(out_list), 0
+        )
         return output_final.view(num_tokens, H, D), None
 
     def _forward_prefill(
@@ -1249,8 +1548,16 @@ class AscendMLAImpl(MLAAttentionImpl):
             k_pe = k_pe.to(torch.bfloat16)
             value = value.to(torch.bfloat16)
 
-        attn_output = torch.empty(num_tokens, self.num_heads, self.v_head_dim, dtype=q_nope.dtype, device=q_nope.device)
-        attn_lse = torch.empty(self.num_heads, num_tokens, dtype=torch.float32, device=q_nope.device)
+        attn_output = torch.empty(
+            num_tokens,
+            self.num_heads,
+            self.v_head_dim,
+            dtype=q_nope.dtype,
+            device=q_nope.device,
+        )
+        attn_lse = torch.empty(
+            self.num_heads, num_tokens, dtype=torch.float32, device=q_nope.device
+        )
 
         common_kwargs = {
             "num_heads": self.num_heads,
@@ -1282,10 +1589,18 @@ class AscendMLAImpl(MLAAttentionImpl):
         )
 
         attn_output, attn_lse = self._compute_prefill_context(
-            q_nope, q_pe, kv_c_and_k_pe_cache, self.qk_rope_head_dim, attn_metadata, attn_output, attn_lse
+            q_nope,
+            q_pe,
+            kv_c_and_k_pe_cache,
+            self.qk_rope_head_dim,
+            attn_metadata,
+            attn_output,
+            attn_lse,
         )
 
-        attn_output = attn_output.reshape([num_tokens, self.num_heads * self.v_head_dim])
+        attn_output = attn_output.reshape(
+            [num_tokens, self.num_heads * self.v_head_dim]
+        )
 
         # Convert back to original dtype if needed
         if need_dtype_convert:
@@ -1306,7 +1621,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         N = self.num_kv_heads
         S = 1
         # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
-        kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
+        kv_no_split = kv_no_split.view(
+            B, N, S, self.kv_lora_rank + self.qk_rope_head_dim
+        )
         cache_mode = "PA_NZ" if self.enable_kv_nz else "PA"
         c_kv_scale = None
         if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
@@ -1332,13 +1649,17 @@ class AscendMLAImpl(MLAAttentionImpl):
         sin: torch.Tensor,
         kv_cache: tuple,
         slots: torch.Tensor,
+        *,
+        attn_metadata: AscendMLAMetadata | None = None,
     ):
         assert self.kv_a_layernorm is not None
         B = kv_no_split.shape[0]
         N = self.num_kv_heads
         S = 1
         # npu_kv_rmsnorm_rope_cache needs [B, N, S, D]
-        kv_no_split = kv_no_split.view(B, N, S, self.kv_lora_rank + self.qk_rope_head_dim)
+        kv_no_split = kv_no_split.view(
+            B, N, S, self.kv_lora_rank + self.qk_rope_head_dim
+        )
         cache_mode = "PA"
         c_kv_scale = None
         if get_ascend_device_type() == AscendDeviceType.A5 and self.fa_quant_layer:
@@ -1392,18 +1713,34 @@ class AscendMLAImpl(MLAAttentionImpl):
         if self.fa_quant_layer and get_ascend_device_type() != AscendDeviceType.A5:
             nz_fmt_last_dim = 16
             k_nope = k_nope.view(
-                -1, self.num_kv_heads, self.kv_lora_rank // (nz_fmt_last_dim * 2), block_size, nz_fmt_last_dim * 2
+                -1,
+                self.num_kv_heads,
+                self.kv_lora_rank // (nz_fmt_last_dim * 2),
+                block_size,
+                nz_fmt_last_dim * 2,
             )
             k_pe = k_pe.view(
-                -1, self.num_kv_heads, self.qk_rope_head_dim // nz_fmt_last_dim, block_size, nz_fmt_last_dim
+                -1,
+                self.num_kv_heads,
+                self.qk_rope_head_dim // nz_fmt_last_dim,
+                block_size,
+                nz_fmt_last_dim,
             )
         elif self.enable_kv_nz:
             nz_fmt_last_dim = 16
             k_nope = k_nope.view(
-                -1, self.num_kv_heads, self.kv_lora_rank // nz_fmt_last_dim, block_size, nz_fmt_last_dim
+                -1,
+                self.num_kv_heads,
+                self.kv_lora_rank // nz_fmt_last_dim,
+                block_size,
+                nz_fmt_last_dim,
             )
             k_pe = k_pe.view(
-                -1, self.num_kv_heads, self.qk_rope_head_dim // nz_fmt_last_dim, block_size, nz_fmt_last_dim
+                -1,
+                self.num_kv_heads,
+                self.qk_rope_head_dim // nz_fmt_last_dim,
+                block_size,
+                nz_fmt_last_dim,
             )
         else:
             k_nope = k_nope.view(-1, self.num_kv_heads, block_size, self.kv_lora_rank)
@@ -1437,7 +1774,9 @@ class AscendMLAImpl(MLAAttentionImpl):
             attn_mask = attn_metadata.decode.attn_mask  # type:ignore
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
             if self.fa_quant_layer:
-                dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads)
+                dequant_scale_q_nope = dequant_scale_q_nope.view(
+                    num_tokens, self.num_heads
+                )
         elif self.fa_quant_layer:
             attn_mask = None
             sparse_mode = 0
@@ -1447,10 +1786,21 @@ class AscendMLAImpl(MLAAttentionImpl):
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
                 if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
-                attn_output_shape = (num_tokens, self.num_heads_padded, 1, self.kv_lora_rank)
+                    q_pe = F.pad(
+                        q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0
+                    )
+                    q_nope = F.pad(
+                        q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0
+                    )
+                dequant_scale_q_nope = dequant_scale_q_nope.view(
+                    num_tokens, self.num_heads, 1
+                )
+                attn_output_shape = (
+                    num_tokens,
+                    self.num_heads_padded,
+                    1,
+                    self.kv_lora_rank,
+                )
             else:
                 input_layout = "BSND_NBSD"
                 q_nope = q_nope.view(num_tokens, 1, self.num_heads, -1).contiguous()
@@ -1458,8 +1808,15 @@ class AscendMLAImpl(MLAAttentionImpl):
                 if self.head_padding > 0:
                     q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
                     q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
-                dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
-                attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+                dequant_scale_q_nope = dequant_scale_q_nope.view(
+                    num_tokens, 1, self.num_heads
+                )
+                attn_output_shape = (
+                    self.num_heads_padded,
+                    num_tokens,
+                    1,
+                    self.kv_lora_rank,
+                )
         else:
             # The output layout is set to NBSD to eliminate the need for a
             # transpose operation after attention.
@@ -1477,10 +1834,19 @@ class AscendMLAImpl(MLAAttentionImpl):
                 q_nope = q_nope.view(num_tokens, self.num_heads, 1, -1).contiguous()
                 q_pe = q_pe.view(num_tokens, self.num_heads, 1, -1)
                 if self.head_padding > 0:
-                    q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
-                    q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
+                    q_pe = F.pad(
+                        q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0
+                    )
+                    q_nope = F.pad(
+                        q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0
+                    )
             # Output shape: [num_heads, num_tokens, seq_len, dim]
-            attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
+            attn_output_shape = (
+                self.num_heads_padded,
+                num_tokens,
+                1,
+                self.kv_lora_rank,
+            )
             sparse_mode = 0
             attn_mask = None
 
@@ -1524,7 +1890,9 @@ class AscendMLAImpl(MLAAttentionImpl):
             graph_params.events[num_tokens].append(event)
 
             workspace = graph_params.workspaces.get(num_tokens)
-            attn_output = torch.empty(attn_output_shape, dtype=q_pe.dtype, device=q_pe.device)
+            attn_output = torch.empty(
+                attn_output_shape, dtype=q_pe.dtype, device=q_pe.device
+            )
             softmax_lse = torch.empty(num_tokens, dtype=q_pe.dtype, device=q_pe.device)
             attn_params = (
                 weak_ref_tensors(q_nope),
@@ -1553,8 +1921,10 @@ class AscendMLAImpl(MLAAttentionImpl):
                 attn_params = attn_params + (None, None)  # type: ignore
 
             if workspace is None:
-                workspace = torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
-                    q_nope, k_nope, k_nope, **common_kwargs
+                workspace = (
+                    torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
+                        q_nope, k_nope, k_nope, **common_kwargs
+                    )
                 )
                 if _EXTRA_CTX.is_draft_model:
                     update_draft_graph_params_workspaces(num_tokens, workspace)
@@ -1565,12 +1935,19 @@ class AscendMLAImpl(MLAAttentionImpl):
 
             torch.npu.graph_task_group_begin(stream)
             torch_npu.npu_fused_infer_attention_score_v2.out(
-                q_nope, k_nope, k_nope, **common_kwargs, workspace=workspace, out=[attn_output, softmax_lse]
+                q_nope,
+                k_nope,
+                k_nope,
+                **common_kwargs,
+                workspace=workspace,
+                out=[attn_output, softmax_lse],
             )
             handle = torch.npu.graph_task_group_end(stream)
             graph_params.handles[num_tokens].append(handle)
         else:
-            attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(q_nope, k_nope, k_nope, **common_kwargs)
+            attn_output, _ = torch_npu.npu_fused_infer_attention_score_v2(
+                q_nope, k_nope, k_nope, **common_kwargs
+            )
 
         if self.head_padding > 0:
             attn_output = attn_output[: self.num_heads]
@@ -1579,19 +1956,42 @@ class AscendMLAImpl(MLAAttentionImpl):
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):
         return decode_q_nope, decode_q_pe
 
+    def _get_num_prefill_kv_tokens(
+        self,
+        attn_metadata: AscendMLAMetadata,
+    ) -> int:
+        return attn_metadata.num_actual_tokens - attn_metadata.num_decode_tokens
+
     def mla_preprocess_prefill(self, q_c, kv_no_split, kv_cache, attn_metadata):
         num_decode_tokens = attn_metadata.num_decode_tokens
         num_actual_tokens = attn_metadata.num_actual_tokens
-        prefill_kv_no_split = kv_no_split[num_decode_tokens:num_actual_tokens]
+        num_actual_prefill_tokens = num_actual_tokens - num_decode_tokens
+        num_prefill_kv_tokens = self._get_num_prefill_kv_tokens(attn_metadata)
+        prefill_kv_no_split = kv_no_split[
+            num_decode_tokens : num_decode_tokens + num_prefill_kv_tokens
+        ]
         prefill_q_c = q_c[num_decode_tokens:num_actual_tokens]
-        prefill_q = self.q_proj(prefill_q_c)[0].view(-1, self.num_heads, self.qk_head_dim)
+        prefill_q = self.q_proj(prefill_q_c)[0].view(
+            -1, self.num_heads, self.qk_head_dim
+        )
         prefill_q_pe = prefill_q[..., self.qk_nope_head_dim :]
         prefill_q_nope = prefill_q[..., : self.qk_nope_head_dim]
         cos = attn_metadata.prefill.cos
         sin = attn_metadata.prefill.sin
         prefill_slots = attn_metadata.slot_mapping[num_decode_tokens:num_actual_tokens]
-        prefill_q_pe = self.rope_single(prefill_q_pe, cos, sin)
-        prefill_k_pe, prefill_k_c_normed = self.exec_kv_prefill(prefill_kv_no_split, cos, sin, kv_cache, prefill_slots)
+        prefill_q_pe = self.rope_single(
+            prefill_q_pe,
+            cos[:num_actual_prefill_tokens],
+            sin[:num_actual_prefill_tokens],
+        )
+        prefill_k_pe, prefill_k_c_normed = self.exec_kv_prefill(
+            prefill_kv_no_split,
+            cos[:num_prefill_kv_tokens],
+            sin[:num_prefill_kv_tokens],
+            kv_cache,
+            prefill_slots,
+            attn_metadata=attn_metadata,
+        )
         prefill_k_nope, prefill_value = (
             self.kv_b_proj(prefill_k_c_normed)[0]
             .view(-1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
@@ -1599,7 +1999,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         )
         prefill_k_pe = prefill_k_pe.view(prefill_q_c.shape[0], self.num_kv_heads, -1)
         prefill_k_pe = prefill_k_pe.expand((*prefill_k_nope.shape[:-1], -1))
-        return PrefillMLAPreprocessResult(prefill_q_nope, prefill_q_pe, prefill_k_nope, prefill_k_pe, prefill_value)
+        return PrefillMLAPreprocessResult(
+            prefill_q_nope, prefill_q_pe, prefill_k_nope, prefill_k_pe, prefill_value
+        )
 
     def mla_preprocess_decode(self, q_c, kv_no_split, kv_cache, attn_metadata):
         num_decode_tokens = attn_metadata.num_decode_tokens
@@ -1617,15 +2019,27 @@ class AscendMLAImpl(MLAAttentionImpl):
             decode_ql_nope, dequant_scale_q_nope = torch_npu.npu_dynamic_quant(
                 decode_ql_nope, dst_type=torch.float8_e4m3fn
             )
-            decode_q_pe = (decode_q_pe / dequant_scale_q_nope.unsqueeze(-1) / self.fak_descale_float).to(torch.bfloat16)
+            decode_q_pe = (
+                decode_q_pe
+                / dequant_scale_q_nope.unsqueeze(-1)
+                / self.fak_descale_float
+            ).to(torch.bfloat16)
         decode_slots = attn_metadata.slot_mapping[:num_decode_tokens:1]
         decode_kv_no_split = kv_no_split[:num_decode_tokens]
-        decode_k_pe, decode_k_nope = self.exec_kv_decode(decode_kv_no_split, cos, sin, kv_cache, decode_slots)
+        decode_k_pe, decode_k_nope = self.exec_kv_decode(
+            decode_kv_no_split, cos, sin, kv_cache, decode_slots
+        )
         return DecodeMLAPreprocessResult(
-            decode_ql_nope, decode_q_pe, decode_k_nope, decode_k_pe, dequant_scale_q_nope=dequant_scale_q_nope
+            decode_ql_nope,
+            decode_q_pe,
+            decode_k_nope,
+            decode_k_pe,
+            dequant_scale_q_nope=dequant_scale_q_nope,
         )
 
-    def _mla_preprocess(self, layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv):
+    def _mla_preprocess(
+        self, layer_name, hidden_states, kv_cache, attn_metadata, need_gather_q_kv
+    ):
         # MLA Preprocess:
         # 1. Perform fused_qkv_a_proj and q_a_layernorm to obtain q_c and kv_no_split
         # or
@@ -1651,8 +2065,12 @@ class AscendMLAImpl(MLAAttentionImpl):
             kv_no_split = self.kv_a_proj_with_mqa(hidden_states)[0]  # type: ignore[misc]
 
         # Process for Flash Comm V1
-        q_c = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(q_c.contiguous(), need_gather_q_kv)
-        kv_no_split = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(kv_no_split.contiguous(), need_gather_q_kv)
+        q_c = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+            q_c.contiguous(), need_gather_q_kv
+        )
+        kv_no_split = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+            kv_no_split.contiguous(), need_gather_q_kv
+        )
 
         decode_preprocess_res = None
         prefill_preprocess_res = None
@@ -1660,10 +2078,14 @@ class AscendMLAImpl(MLAAttentionImpl):
             wait_for_kv_layer_from_connector(layer_name)
         # Preprocess for decode tokens
         if has_decode:
-            decode_preprocess_res = self.mla_preprocess_decode(q_c, kv_no_split, kv_cache, attn_metadata)
+            decode_preprocess_res = self.mla_preprocess_decode(
+                q_c, kv_no_split, kv_cache, attn_metadata
+            )
         # Preprocess for prefill tokens
         if has_prefill:
-            prefill_preprocess_res = self.mla_preprocess_prefill(q_c, kv_no_split, kv_cache, attn_metadata)
+            prefill_preprocess_res = self.mla_preprocess_prefill(
+                q_c, kv_no_split, kv_cache, attn_metadata
+            )
         # Let the connector record any sync primitive it needs once the paged KV
         # cache for this layer has been written. No-op for connectors that don't
         # implement on_kv_cache_written; the decision to actually transfer is made
@@ -1683,7 +2105,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         need_gather_q_kv: bool = False,
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        raise NotImplementedError("forward_mha is not supported for MLA attention. Use forward() instead.")
+        raise NotImplementedError(
+            "forward_mha is not supported for MLA attention. Use forward() instead."
+        )
 
     def forward_mqa(
         self,
@@ -1694,7 +2118,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         need_gather_q_kv: bool = False,
         output: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        raise NotImplementedError("forward_mqa is not supported for MLA attention. Use forward() instead.")
+        raise NotImplementedError(
+            "forward_mqa is not supported for MLA attention. Use forward() instead."
+        )
 
     def forward(
         self,
@@ -1721,17 +2147,22 @@ class AscendMLAImpl(MLAAttentionImpl):
         # Inputs and outputs may be padded for CUDA graphs
         output_padded = output
         o_proj_input_shape = (_EXTRA_CTX.num_tokens, self.num_heads * self.v_head_dim)
-        o_proj_input = torch.zeros(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
+        o_proj_input = torch.zeros(
+            o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device
+        )
 
         # MLA Preprocess
         if (self.fa_quant_layer or self.enable_mlapo) and (
-            attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS and attn_metadata.num_prefills == 0
+            attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
+            and attn_metadata.num_prefills == 0
         ):
             hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
                 hidden_states.contiguous(), need_gather_q_kv
             )
-            decode_preprocess_res, prefill_preprocess_res = DeviceOperator.mla_preprocess_only_decode(
-                self, hidden_states, kv_cache, attn_metadata
+            decode_preprocess_res, prefill_preprocess_res = (
+                DeviceOperator.mla_preprocess_only_decode(
+                    self, hidden_states, kv_cache, attn_metadata
+                )
             )
         else:
             decode_preprocess_res, prefill_preprocess_res = self._mla_preprocess(
@@ -1767,8 +2198,85 @@ class AscendMLAImpl(MLAAttentionImpl):
 
             o_proj_input[num_decode_tokens:num_actual_tokens] = output_prefill
         # O proj
-        output[...] = self.o_proj(o_proj_input, is_prefill=prefill_preprocess_res is not None)[0]
+        output[...] = self.o_proj(
+            o_proj_input, is_prefill=prefill_preprocess_res is not None
+        )[0]
 
         del o_proj_input
         maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
         return output_padded
+
+
+class AscendMLAPCPImpl(AscendMLAImpl):
+    """MRV2 MLA implementation for Prefill Context Parallelism."""
+
+    def _get_num_prefill_kv_tokens(
+        self,
+        attn_metadata: AscendMLAMetadata,
+    ) -> int:
+        if not isinstance(attn_metadata, AscendMLAPCPMetadata):
+            raise RuntimeError("PCP MLA prefill requires AscendMLAPCPMetadata.")
+        return (
+            attn_metadata.pcp_local_num_input_tokens
+            - attn_metadata.num_decode_tokens
+        )
+
+    def exec_kv_prefill(
+        self,
+        kv_no_split: torch.Tensor,
+        cos: torch.Tensor,
+        sin: torch.Tensor,
+        kv_cache: tuple[torch.Tensor, ...],
+        slots: torch.Tensor,
+        *,
+        attn_metadata: AscendMLAMetadata | None = None,
+    ):
+        if not isinstance(attn_metadata, AscendMLAPCPMetadata):
+            raise RuntimeError("PCP MLA prefill requires AscendMLAPCPMetadata.")
+
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        local_num_input_tokens = attn_metadata.pcp_local_num_input_tokens
+        local_prefill_capacity = local_num_input_tokens - num_decode_tokens
+        if not (
+            kv_no_split.shape[0]
+            == cos.shape[0]
+            == sin.shape[0]
+            == local_prefill_capacity
+        ):
+            raise RuntimeError(
+                "PCP MLA prefill input length mismatch: "
+                f"kv={kv_no_split.shape[0]}, cos={cos.shape[0]}, "
+                f"sin={sin.shape[0]}, expected={local_prefill_capacity}."
+            )
+
+        pcp_group = get_pcp_group()
+        rank_slot_mappings = attn_metadata.slot_mapping.view(
+            pcp_group.world_size,
+            local_num_input_tokens,
+        )
+        # Remove the decoding area and flatten it.
+        expanded_prefill_slots = rank_slot_mappings[:, num_decode_tokens:].flatten()
+        (gathered_kv, gathered_cos, gathered_sin), gathered_prefill_slots = (
+            _gather_prefill_cache_inputs(
+                (kv_no_split, cos, sin),
+                expanded_prefill_slots,
+                num_decode_tokens=0,
+            )
+        )
+        # TODO Due to the npu_kv_rmsnorm_rope_cache fusion operator, the RMSNorm rope of the KV layer
+        # involves repeated calculations, leaving room for optimization.
+        gathered_k_pe, gathered_k_c_normed = super().exec_kv_prefill(
+            gathered_kv,
+            gathered_cos,
+            gathered_sin,
+            kv_cache,
+            gathered_prefill_slots,
+        )
+        prefill_k_pe = gathered_k_pe[
+            attn_metadata.pcp_local_prefill_start : attn_metadata.pcp_local_prefill_end
+        ]
+        prefill_k_c_normed = gathered_k_c_normed[
+            attn_metadata.pcp_local_prefill_start : attn_metadata.pcp_local_prefill_end
+        ]
+
+        return prefill_k_pe, prefill_k_c_normed

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -2216,6 +2216,9 @@ class AscendMLAPCPImpl(AscendMLAImpl):
     ) -> int:
         if not isinstance(attn_metadata, AscendMLAPCPMetadata):
             raise RuntimeError("PCP MLA prefill requires AscendMLAPCPMetadata.")
+        # Keep the PCP-padded prefill length so every PCP rank processes the
+        # same number of KV tokens. exec_kv_prefill trims the gathered tensors
+        # back to this rank's actual prefill range.
         return (
             attn_metadata.pcp_local_num_input_tokens
             - attn_metadata.num_decode_tokens
@@ -2272,6 +2275,7 @@ class AscendMLAPCPImpl(AscendMLAImpl):
             kv_cache,
             gathered_prefill_slots,
         )
+        # Unpad the gathered KV tensors to this PCP rank's actual prefill range.
         prefill_k_pe = gathered_k_pe[
             attn_metadata.pcp_local_prefill_start : attn_metadata.pcp_local_prefill_end
         ]

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -192,7 +192,8 @@ def enable_dcp():
     return parallel_config.decode_context_parallel_size > 1
 
 
-@lru_cache(maxsize=1)
+# Target and draft models can use different PCP configs in one process, so
+# backend selection must observe the active config instead of a cached value.
 def enable_pcp():
     parallel_config = get_current_vllm_config().parallel_config
     return parallel_config.prefill_context_parallel_size > 1

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -15,7 +15,7 @@ import vllm.envs as envs
 from vllm.compilation.counter import compilation_counter
 from vllm.compilation.cuda_graph import CUDAGraphOptions
 from vllm.compilation.monitor import validate_cudagraph_capturing_enabled
-from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
 from vllm.platforms import current_platform
@@ -285,15 +285,16 @@ def update_full_graph_params(
     speculative_config=None,
     draft_attn_metadatas=None,
 ):
-    impl_cls = attn_backend.get_impl_cls()
-    impl_cls.update_graph_params(
-        update_stream,
-        forward_context,
-        num_tokens,
-        vllm_config,
-        speculative_config,
-        draft_attn_metadatas=draft_attn_metadatas,
-    )
+    with set_current_vllm_config(vllm_config):
+        impl_cls = attn_backend.get_impl_cls()
+        impl_cls.update_graph_params(
+            update_stream,
+            forward_context,
+            num_tokens,
+            vllm_config,
+            speculative_config,
+            draft_attn_metadatas=draft_attn_metadatas,
+        )
 
 
 @dataclass

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -527,6 +527,7 @@ class NPUPlatform(Platform):
             "pad_size": pad_size,
             "padded_length": padded_length,
             "max_tokens_across_dp": max_tokens_across_dp,
+            "max_tokens_across_pcp": num_tokens,
             "mc2_mask": mc2_mask,
             "is_draft_model": is_draft_model,
             "is_draft_model_prefill": is_draft_model_prefill,

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -29,14 +29,20 @@ from vllm.logger import logger
 from vllm.sequence import IntermediateTensors
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu import cudagraph_utils
 from vllm.v1.worker.gpu.block_table import BlockTables
-from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor, ModelCudaGraphManager
+from vllm.v1.worker.gpu.cudagraph_utils import (
+    BatchExecutionDescriptor,
+    ModelCudaGraphManager,
+)
 from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu.pcp_manager import PCPManager
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.compilation.acl_graph import set_graph_params, update_full_graph_params
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -52,6 +58,95 @@ def collect_sorted_captured_token_sizes(capture_descs: dict) -> list[int]:
     capture descriptors, not the raw config sizes.
     """
     return sorted({desc.num_tokens for descs in capture_descs.values() for desc in descs})
+
+
+def _prepare_pcp_inputs_to_capture(
+    num_reqs: int,
+    num_tokens: int,
+    model_state: ModelState,
+    input_buffers: InputBuffers,
+    block_tables: BlockTables,
+    attn_groups: list[list[AttentionGroup]],
+    kv_cache_config: KVCacheConfig,
+    pcp_manager: PCPManager,
+    full_cudagraph: bool,
+) -> cudagraph_utils.AttentionState:
+    """Build PCP capture metadata from the buffers used during replay."""
+    if not isinstance(input_buffers, AscendInputBuffers):
+        raise TypeError(f"MRV2 PCP graph capture requires AscendInputBuffers, got {type(input_buffers).__name__}.")
+
+    input_batch = AscendInputBatch.make_dummy(
+        num_reqs,
+        num_tokens,
+        input_buffers,
+    )
+
+    input_batch = pcp_manager.partition_batch(input_batch)
+    input_block_tables, slot_mappings = pcp_manager.prepare_dummy_attn(
+        input_batch.num_reqs_after_padding,
+        input_batch.num_tokens_after_padding,
+    )
+    slot_mappings_by_layer = cudagraph_utils.build_slot_mappings_by_layer(
+        slot_mappings,
+        kv_cache_config,
+    )
+
+    attn_metadata = model_state.prepare_attn(
+        input_batch,
+        CUDAGraphMode.NONE,
+        input_block_tables,
+        slot_mappings,
+        attn_groups,
+        kv_cache_config,
+        for_capture=full_cudagraph,
+    )
+    return cudagraph_utils.AttentionState(
+        attn_metadata,
+        slot_mappings_by_layer,
+    )
+
+
+def prepare_pcp_speculator_inputs_to_capture(
+    num_reqs: int,
+    num_tokens: int,
+    model_state: ModelState,
+    input_buffers: InputBuffers,
+    block_tables: BlockTables,
+    attn_groups: list[list[AttentionGroup]],
+    kv_cache_config: KVCacheConfig,
+    pcp_manager: PCPManager,
+    full_cudagraph: bool,
+) -> cudagraph_utils.AttentionState:
+    """Build global draft-prefill metadata with a PCP-expanded KV layout."""
+    if not isinstance(input_buffers, AscendInputBuffers):
+        raise TypeError(
+            f"MRV2 PCP speculator graph capture requires AscendInputBuffers, got {type(input_buffers).__name__}."
+        )
+
+    input_batch = AscendInputBatch.make_dummy(
+        num_reqs,
+        num_tokens,
+        input_buffers,
+    )
+    input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
+    slot_mappings = pcp_manager.get_dummy_slot_mappings(num_tokens)
+    slot_mappings_by_layer = cudagraph_utils.build_slot_mappings_by_layer(
+        slot_mappings,
+        kv_cache_config,
+    )
+    attn_metadata = model_state.prepare_attn(
+        input_batch,
+        CUDAGraphMode.NONE,
+        input_block_tables,
+        slot_mappings,
+        attn_groups,
+        kv_cache_config,
+        for_capture=full_cudagraph,
+    )
+    return cudagraph_utils.AttentionState(
+        attn_metadata,
+        slot_mappings_by_layer,
+    )
 
 
 def _get_graph_update_backend(
@@ -90,6 +185,7 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         self.model_runner = model_runner
         # Reuse the public update_stream from model_runner (shared with draft).
         self.update_stream = self.model_runner.update_stream
+        self._pcp_batch_has_prefill = False
         # The attention backend keys its per-size graph params by the actual
         # captured token counts (rounded up to decode_query_len when using
         # speculative decoding), so derive them from the capture descriptors
@@ -99,6 +195,36 @@ class ModelAclGraphManager(ModelCudaGraphManager):
         # so we need to set graph params before capture full graph.
         if super().needs_capture():
             set_graph_params(self.capture_sizes)
+
+    def set_pcp_batch_has_prefill(self, has_prefill: bool) -> None:
+        """Record whether the current PCP batch contains prefill tokens."""
+        self._pcp_batch_has_prefill = has_prefill
+
+    def dispatch(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+        uniform_token_count: int | None,
+        num_active_loras: int = 0,
+    ) -> BatchExecutionDescriptor:
+        desc = super().dispatch(
+            num_reqs,
+            num_tokens,
+            uniform_token_count,
+            num_active_loras,
+        )
+        # FULL_DECODE_ONLY dispatch is shape-based and cannot distinguish a
+        # one-token decode from a one-token suffix left by a prefix-cache hit.
+        # Reject only the invalid full graph, preserving PIECEWISE and eager
+        # dispatch for all other PCP batches.
+        if self._pcp_batch_has_prefill and desc.cg_mode == CUDAGraphMode.FULL:
+            return BatchExecutionDescriptor(
+                cg_mode=CUDAGraphMode.NONE,
+                num_tokens=num_tokens,
+                num_reqs=num_reqs,
+                num_active_loras=desc.num_active_loras,
+            )
+        return desc
 
     def run_fullgraph(self, desc: BatchExecutionDescriptor) -> torch.Tensor | tuple[torch.Tensor, list[torch.Tensor]]:
         """Override run_fullgraph to update full graph params in run_fullgraph."""
@@ -152,8 +278,15 @@ class ModelAclGraphManager(ModelCudaGraphManager):
     ) -> None:
         """Capture CUDA graphs for model forward pass."""
         model = ModelWithContext(model)
-        with communicator_switch():
-            return super().capture(
+        capture = super().capture
+        # Import lazily to avoid a cycle during Ascend plugin patch registration.
+        from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+
+        pcp_manager = getattr(self.model_runner, "pcp_manager", None)
+        use_pcp_full_capture = isinstance(pcp_manager, AscendPCPManager) and self.cudagraph_mode.has_full_cudagraphs()
+
+        def capture_graphs() -> None:
+            return capture(
                 model,
                 model_state,
                 input_buffers,
@@ -166,6 +299,40 @@ class ModelAclGraphManager(ModelCudaGraphManager):
                 lora_capture_hook=lora_capture_hook,
                 progress_bar_desc=progress_bar_desc,
             )
+
+        with communicator_switch():
+            if not use_pcp_full_capture:
+                return capture_graphs()
+
+            original_prepare_inputs = cudagraph_utils.prepare_inputs_to_capture
+
+            def prepare_pcp_inputs(
+                num_reqs: int,
+                num_tokens: int,
+                model_state: ModelState,
+                input_buffers: InputBuffers,
+                block_tables: BlockTables,
+                attn_groups: list[list[AttentionGroup]],
+                kv_cache_config: KVCacheConfig,
+                full_cudagraph: bool,
+            ) -> cudagraph_utils.AttentionState:
+                return _prepare_pcp_inputs_to_capture(
+                    num_reqs,
+                    num_tokens,
+                    model_state,
+                    input_buffers,
+                    block_tables,
+                    attn_groups,
+                    kv_cache_config,
+                    pcp_manager,
+                    full_cudagraph=full_cudagraph,
+                )
+
+            cudagraph_utils.prepare_inputs_to_capture = prepare_pcp_inputs
+            try:
+                return capture_graphs()
+            finally:
+                cudagraph_utils.prepare_inputs_to_capture = original_prepare_inputs
 
 
 class ModelWithContext(nn.Module):

--- a/vllm_ascend/worker/v2/aclgraph_utils.py
+++ b/vllm_ascend/worker/v2/aclgraph_utils.py
@@ -106,49 +106,6 @@ def _prepare_pcp_inputs_to_capture(
     )
 
 
-def prepare_pcp_speculator_inputs_to_capture(
-    num_reqs: int,
-    num_tokens: int,
-    model_state: ModelState,
-    input_buffers: InputBuffers,
-    block_tables: BlockTables,
-    attn_groups: list[list[AttentionGroup]],
-    kv_cache_config: KVCacheConfig,
-    pcp_manager: PCPManager,
-    full_cudagraph: bool,
-) -> cudagraph_utils.AttentionState:
-    """Build global draft-prefill metadata with a PCP-expanded KV layout."""
-    if not isinstance(input_buffers, AscendInputBuffers):
-        raise TypeError(
-            f"MRV2 PCP speculator graph capture requires AscendInputBuffers, got {type(input_buffers).__name__}."
-        )
-
-    input_batch = AscendInputBatch.make_dummy(
-        num_reqs,
-        num_tokens,
-        input_buffers,
-    )
-    input_block_tables = block_tables.get_dummy_block_tables(num_reqs)
-    slot_mappings = pcp_manager.get_dummy_slot_mappings(num_tokens)
-    slot_mappings_by_layer = cudagraph_utils.build_slot_mappings_by_layer(
-        slot_mappings,
-        kv_cache_config,
-    )
-    attn_metadata = model_state.prepare_attn(
-        input_batch,
-        CUDAGraphMode.NONE,
-        input_block_tables,
-        slot_mappings,
-        attn_groups,
-        kv_cache_config,
-        for_capture=full_cudagraph,
-    )
-    return cudagraph_utils.AttentionState(
-        attn_metadata,
-        slot_mappings_by_layer,
-    )
-
-
 def _get_graph_update_backend(
     attn_groups: list[list[AttentionGroup]],
 ) -> type[AttentionBackend]:

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -52,7 +52,12 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendSlidingWindowMLASpec,
 )
 from vllm_ascend.quantization.utils import enable_fa_quant
-from vllm_ascend.utils import AscendDeviceType, calc_split_factor, enable_sfa, get_ascend_device_type
+from vllm_ascend.utils import (
+    AscendDeviceType,
+    calc_split_factor,
+    enable_sfa,
+    get_ascend_device_type,
+)
 
 
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
@@ -171,6 +176,7 @@ def build_attn_metadata(
     slot_mappings: torch.Tensor,
     kv_cache_config: KVCacheConfig,
     dcp_local_seq_lens: torch.Tensor | None = None,
+    is_prefilling: torch.Tensor | None = None,
     # extra attributes for ascend npus.
     seq_lens_np: np.ndarray | None = None,
     seq_lens_cpu_upper_bound: torch.Tensor | None = None,
@@ -180,7 +186,6 @@ def build_attn_metadata(
     graph_pad_size: int = -1,
     num_actual_tokens: int | None = None,
     num_input_tokens: int | None = None,
-    is_prefilling: torch.Tensor | None = None,
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
     causal: bool | Mapping[int, bool] = True,
@@ -220,6 +225,10 @@ def build_attn_metadata(
             if model_specific_attn_metadata is not None
             else {}
         )
+        group_is_prefilling = common_attn_metadata_extra_kwargs.pop(
+            "is_prefilling",
+            is_prefilling,
+        )
         common_attn_metadata = AscendCommonAttentionMetadata(
             query_start_loc=query_start_loc_gpu,
             query_start_loc_cpu=query_start_loc_cpu,
@@ -235,7 +244,7 @@ def build_attn_metadata(
             attn_state=attn_state,
             graph_pad_size=graph_pad_size,
             num_input_tokens=num_input_tokens,
-            is_prefilling=is_prefilling,
+            is_prefilling=group_is_prefilling,
             max_seq_len=max_seq_len,
             causal=group_causal,
             **common_attn_metadata_extra_kwargs,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -202,7 +202,13 @@ class NPUModelRunner(GPUModelRunner):
         self.decode_query_len = self.num_speculative_steps + 1
         # Set _mc2_tokens_capacity and _reserved_mc2_mask for MoE communication optimization.
         # TODO: remove set_cos_and_sin (together with update_cos_sin) when mla can properly handle cos/sin internally
-        set_cos_and_sin(vllm_config, self.max_num_reqs, self.decode_query_len, self.dtype, self.device)
+        set_cos_and_sin(
+            vllm_config,
+            self.max_num_reqs,
+            self.decode_query_len,
+            self.dtype,
+            self.device,
+        )
         set_mc2_tokens_capacity(vllm_config, self.max_num_reqs, self.decode_query_len)
         set_mc2_mask(vllm_config, self.device)
         set_potential_max_tokens(vllm_config)
@@ -212,6 +218,8 @@ class NPUModelRunner(GPUModelRunner):
             super().initialize_kv_cache(kv_cache_config)
             if self.pcp_manager is not None:
                 assert isinstance(self.pcp_manager, AscendPCPManager)
+                if self.speculator is not None:
+                    self.speculator.pcp_manager = self.pcp_manager
                 self.pcp_manager.vllm_config = self.vllm_config
 
         if self.model_config.enable_return_routed_experts:

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -544,12 +544,20 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
 
         # MTP needs D2H copy to get reverted num_computed_tokens after rejection.
+        # Keep both CPU mirrors synchronized because PCP partitions the next
+        # batch using num_computed_tokens_np.
         # Without MTP, num_computed_tokens_np is already correct from update_requests.
         if self.speculator is not None:
             self.num_computed_tokens_event.synchronize()
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
                 req_index = self.req_states.req_id_to_index[req_id]
-                self.req_states.num_computed_tokens_cpu[req_index] = self.num_computed_tokens_cpu[req_index]
+                corrected_num_computed_tokens = self.num_computed_tokens_cpu[req_index]
+                self.req_states.num_computed_tokens_cpu[req_index] = (
+                    corrected_num_computed_tokens
+                )
+                self.req_states.num_computed_tokens_np[req_index] = int(
+                    corrected_num_computed_tokens
+                )
         else:
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
                 req_index = self.req_states.req_id_to_index[req_id]

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -74,7 +74,6 @@ class AscendModelState(DefaultModelState):
             slot_mappings=slot_mappings,
             kv_cache_config=kv_cache_config,
             dcp_local_seq_lens=input_batch.dcp_local_seq_lens,
-            # extra attributes for ascend npus.
             seq_lens_np=input_batch.seq_lens_np,
             positions=input_batch.positions,
             attn_state=input_batch.attn_state,

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -17,12 +17,18 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from dataclasses import replace
+
+import numpy as np
 import torch
 from vllm.config import VllmConfig
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
 from vllm.v1.worker.gpu.states import RequestState
 
+from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 
@@ -80,20 +86,236 @@ class AscendPCPManager(PCPManager):
         )
         self.vllm_config = vllm_config
 
-    def partition_batch(self, input_batch: AscendInputBatch) -> AscendInputBatch:
-        """Partition the batch and update Ascend-specific local metadata."""
+    def partition_batch(
+        self,
+        input_batch: AscendInputBatch,
+    ) -> AscendInputBatch:
+        """Reuse upstream PCP partitioning and refresh Ascend-only metadata."""
         assert self.vllm_config is not None
-        local_batch = super().partition_batch(input_batch)
-        assert isinstance(local_batch, AscendInputBatch)
+        graph_num_reqs = input_batch.num_reqs_after_padding
+        graph_num_tokens = input_batch.num_tokens_after_padding
+        is_decode_only = not np.any(input_batch.is_prefilling_np)
 
+        upstream_input_batch = input_batch
+        if input_batch.num_draft_tokens > 0:
+            # The upstream implementation only uses num_draft_tokens to reject
+            # speculative decoding, then clears the two draft fields on the
+            # returned rank-local batch. Present the same post-guard view while
+            # retaining the real global batch for proposal and sampling.
+            upstream_input_batch = replace(
+                input_batch,
+                num_draft_tokens=0,
+                num_draft_tokens_per_req=None,
+            )
+
+        try:
+            local_batch = super().partition_batch(upstream_input_batch)
+        finally:
+            self._global_batch = input_batch
+
+        assert isinstance(local_batch, AscendInputBatch)
         local_seq_lens_np = local_batch.num_computed_tokens_np + local_batch.num_scheduled_tokens
-        local_batch.seq_lens_np = local_seq_lens_np
+        if is_decode_only:
+            local_batch.attn_state = input_batch.attn_state
+            if local_batch.attn_state is None:
+                local_batch.attn_state = AscendAttentionState.DecodeOnly
+
+            return self._pad_decode_batch_for_full_graph(
+                local_batch,
+                graph_num_reqs,
+                graph_num_tokens,
+                local_seq_lens_np,
+            )
+
+        local_num_valid_tokens = local_batch.num_scheduled_tokens
+        if local_batch.num_draft_tokens_per_req is not None:
+            local_num_valid_tokens = local_batch.num_scheduled_tokens - local_batch.num_draft_tokens_per_req
         local_batch.attn_state = build_attn_state(
             self.vllm_config,
             local_seq_lens_np,
             local_batch.num_reqs,
             local_batch.num_scheduled_tokens,
-            local_batch.num_scheduled_tokens
-            - (local_batch.num_draft_tokens_per_req if local_batch.num_draft_tokens_per_req is not None else 0),
+            local_num_valid_tokens,
         )
+        local_batch.seq_lens_np = local_seq_lens_np
         return local_batch
+
+    def prepare_speculator_attn(
+        self,
+        input_batch: AscendInputBatch,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Build the global KV layout consumed by a PCP speculator."""
+        if input_batch is not self._global_batch:
+            raise RuntimeError("PCP speculative proposal must use the restored global batch.")
+        assert self._block_tables is not None
+        block_tables = self._block_tables.gather_block_tables(
+            input_batch.idx_mapping,
+            num_reqs_padded=input_batch.num_reqs_after_padding,
+        )
+        assert self._global_batch_slot_mappings is not None
+        num_tokens = input_batch.num_tokens_after_padding
+        if num_tokens > input_batch.num_tokens:
+            self._global_batch_slot_mappings[
+                :,
+                input_batch.num_tokens : num_tokens,
+            ].fill_(PAD_SLOT_ID)
+        global_slot_mappings = self._global_batch_slot_mappings[:, :num_tokens]
+
+        assert self._gathered_kv_slot_mappings is not None
+        num_expanded_tokens = num_tokens * self.pcp_world_size
+        if num_expanded_tokens > self._gathered_kv_slot_mappings.shape[1]:
+            raise RuntimeError(
+                "PCP speculator slot mapping exceeds the persistent buffer "
+                f"capacity: {num_expanded_tokens} > "
+                f"{self._gathered_kv_slot_mappings.shape[1]}."
+            )
+        expanded_slot_mappings = self._gathered_kv_slot_mappings[:, :num_expanded_tokens]
+        for rank in range(self.pcp_world_size):
+            rank_start = rank * num_tokens
+            expanded_slot_mappings[
+                :,
+                rank_start : rank_start + num_tokens,
+            ].copy_(global_slot_mappings)
+        return block_tables, expanded_slot_mappings
+
+    def _pad_decode_batch_for_full_graph(
+        self,
+        local_batch: AscendInputBatch,
+        graph_num_reqs: int,
+        graph_num_tokens: int,
+        local_seq_lens_np: np.ndarray,
+    ) -> AscendInputBatch:
+        """Pad a rank-local decode batch to the selected full-graph shape."""
+        num_reqs = local_batch.num_reqs
+        num_tokens = local_batch.num_tokens
+        if graph_num_reqs < num_reqs or graph_num_tokens < num_tokens:
+            raise RuntimeError(
+                "PCP graph shape is smaller than the rank-local decode batch: "
+                f"requests {graph_num_reqs} < {num_reqs} or "
+                f"tokens {graph_num_tokens} < {num_tokens}."
+            )
+
+        num_padding_reqs = graph_num_reqs - num_reqs
+        num_padding_tokens = graph_num_tokens - num_tokens
+        decode_query_len = getattr(self.vllm_config, "num_speculative_tokens", 0) + 1
+        uses_per_request_padding = num_padding_tokens == num_padding_reqs * decode_query_len
+        uses_single_fia_dummy = num_padding_reqs == 1 and num_padding_tokens > 0
+        if not (uses_per_request_padding or uses_single_fia_dummy):
+            raise RuntimeError(
+                "PCP FULL_DECODE_ONLY requires either a uniform decode query "
+                "per padded request or one FIA dummy request for all padding "
+                "tokens: "
+                f"{num_padding_tokens} tokens for {num_padding_reqs} requests."
+            )
+
+        # Full-graph model inputs keep using the model runner's original
+        # buffers, while PCP attention metadata uses the rank-local buffers.
+        # Clear both views so a smaller replay cannot observe stale padding
+        # left by a previously larger decode batch.
+        # Clear the full image buffer to prevent dirty data from polluting the next image.
+        global_batch = self._global_batch
+        assert global_batch is not None
+        global_batch.input_ids[num_tokens:graph_num_tokens].zero_()
+        global_batch.positions[num_tokens:graph_num_tokens].zero_()
+        global_batch.is_padding[:num_tokens].fill_(False)
+        global_batch.is_padding[num_tokens:graph_num_tokens].fill_(True)
+
+        if num_padding_reqs == 0:
+            local_batch.seq_lens_np = local_seq_lens_np
+            return local_batch
+
+        input_buffers = self._input_buffers
+        assert input_buffers is not None
+        if graph_num_reqs > input_buffers.max_num_reqs:
+            raise RuntimeError(
+                "PCP graph request count exceeds the local input buffer capacity: "
+                f"{graph_num_reqs} > {input_buffers.max_num_reqs}."
+            )
+        if graph_num_tokens > input_buffers.max_num_tokens:
+            raise RuntimeError(
+                "PCP graph token count exceeds the local input buffer capacity: "
+                f"{graph_num_tokens} > {input_buffers.max_num_tokens}."
+            )
+
+        input_buffers.input_ids[num_tokens:graph_num_tokens].zero_()
+        input_buffers.positions[num_tokens:graph_num_tokens].zero_()
+        input_buffers.seq_lens[num_reqs:graph_num_reqs].zero_()
+        input_buffers.is_padding[:num_tokens].fill_(False)
+        input_buffers.is_padding[num_tokens:graph_num_tokens].fill_(True)
+
+        query_start_loc_buffer_np = np.full(
+            input_buffers.max_num_reqs + 1,
+            graph_num_tokens,
+            dtype=np.int32,
+        )
+        query_start_loc_buffer_np[: num_reqs + 1] = local_batch.query_start_loc_np
+        if uses_per_request_padding:
+            query_start_loc_buffer_np[num_reqs + 1 : graph_num_reqs + 1] = num_tokens + decode_query_len * np.arange(
+                1,
+                num_padding_reqs + 1,
+                dtype=np.int32,
+            )
+        else:
+            query_start_loc_buffer_np[num_reqs + 1 : graph_num_reqs + 1] = graph_num_tokens
+        async_copy_to_gpu(
+            query_start_loc_buffer_np,
+            out=input_buffers.query_start_loc,
+        )
+        query_start_loc_np = query_start_loc_buffer_np[: graph_num_reqs + 1]
+
+        padded_seq_lens_np = np.zeros(graph_num_reqs, dtype=np.int32)
+        padded_seq_lens_np[:num_reqs] = local_seq_lens_np
+        seq_lens_cpu_upper_bound = torch.zeros(graph_num_reqs, dtype=torch.int32)
+        seq_lens_cpu_upper_bound[:num_reqs].copy_(local_batch.seq_lens_cpu_upper_bound)
+
+        return replace(
+            local_batch,
+            num_reqs_after_padding=graph_num_reqs,
+            num_tokens_after_padding=graph_num_tokens,
+            query_start_loc=input_buffers.query_start_loc[: graph_num_reqs + 1],
+            query_start_loc_np=query_start_loc_np,
+            seq_lens=input_buffers.seq_lens[:graph_num_reqs],
+            seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
+            input_ids=input_buffers.input_ids[:graph_num_tokens],
+            positions=input_buffers.positions[:graph_num_tokens],
+            is_padding=input_buffers.is_padding[:graph_num_tokens],
+            seq_lens_np=padded_seq_lens_np,
+        )
+
+    def prepare_dummy_attn(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Prepare capture inputs using the same buffers as graph replay."""
+        assert self._local_block_tables is not None
+        for block_table in self._local_block_tables:
+            block_table[:num_reqs].zero_()
+        return (
+            tuple(block_table[:num_reqs] for block_table in self._local_block_tables),
+            self.get_dummy_slot_mappings(num_tokens),
+        )
+
+    def prepare_slot_mappings(self) -> torch.Tensor:
+        slot_mappings = super().prepare_slot_mappings()
+        assert self._global_batch is not None
+        assert self._gathered_kv_slot_mappings is not None
+
+        global_batch = self._global_batch
+        if np.any(global_batch.is_prefilling_np):
+            return slot_mappings
+
+        graph_num_tokens = global_batch.num_tokens_after_padding
+        if graph_num_tokens <= global_batch.num_tokens:
+            return slot_mappings
+
+        num_expanded_tokens = slot_mappings.shape[1]
+        graph_num_expanded_tokens = graph_num_tokens * self.pcp_world_size
+        if graph_num_expanded_tokens > self._gathered_kv_slot_mappings.shape[1]:
+            raise RuntimeError(
+                "PCP graph slot mapping exceeds the persistent buffer capacity: "
+                f"{graph_num_expanded_tokens} > "
+                f"{self._gathered_kv_slot_mappings.shape[1]}."
+            )
+        self._gathered_kv_slot_mappings[:, num_expanded_tokens:graph_num_expanded_tokens].fill_(PAD_SLOT_ID)
+        return self._gathered_kv_slot_mappings[:, :graph_num_expanded_tokens]

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -25,6 +25,10 @@ from vllm.config import VllmConfig
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
+from vllm.v1.worker.gpu.input_batch import (
+    combine_sampled_and_draft_tokens,
+    expand_idx_mapping,
+)
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
 from vllm.v1.worker.gpu.states import RequestState
 
@@ -95,6 +99,14 @@ class AscendPCPManager(PCPManager):
         graph_num_reqs = input_batch.num_reqs_after_padding
         graph_num_tokens = input_batch.num_tokens_after_padding
         is_decode_only = not np.any(input_batch.is_prefilling_np)
+        speculative_config = getattr(
+            self.vllm_config, "speculative_config", None
+        )
+        has_mtp_draft_tokens = (
+            input_batch.num_draft_tokens > 0
+            and speculative_config is not None
+            and speculative_config.method == "mtp"
+        )
 
         upstream_input_batch = input_batch
         if input_batch.num_draft_tokens > 0:
@@ -114,7 +126,12 @@ class AscendPCPManager(PCPManager):
             self._global_batch = input_batch
 
         assert isinstance(local_batch, AscendInputBatch)
-        local_seq_lens_np = local_batch.num_computed_tokens_np + local_batch.num_scheduled_tokens
+        if has_mtp_draft_tokens:
+            local_batch = self._rebuild_local_mtp_fields(input_batch, local_batch)
+
+        local_seq_lens_np = (
+            local_batch.num_computed_tokens_np + local_batch.num_scheduled_tokens
+        )
         if is_decode_only:
             local_batch.attn_state = input_batch.attn_state
             if local_batch.attn_state is None:
@@ -128,8 +145,11 @@ class AscendPCPManager(PCPManager):
             )
 
         local_num_valid_tokens = local_batch.num_scheduled_tokens
-        if local_batch.num_draft_tokens_per_req is not None:
-            local_num_valid_tokens = local_batch.num_scheduled_tokens - local_batch.num_draft_tokens_per_req
+        local_draft_counts = local_batch.num_draft_tokens_per_req
+        if local_draft_counts is not None:
+            local_num_valid_tokens = (
+                local_batch.num_scheduled_tokens - local_draft_counts
+            )
         local_batch.attn_state = build_attn_state(
             self.vllm_config,
             local_seq_lens_np,
@@ -140,43 +160,90 @@ class AscendPCPManager(PCPManager):
         local_batch.seq_lens_np = local_seq_lens_np
         return local_batch
 
+    def _rebuild_local_mtp_fields(
+        self,
+        global_batch: AscendInputBatch,
+        local_batch: AscendInputBatch,
+    ) -> AscendInputBatch:
+        """Restore rank-local MTP metadata after upstream PCP partitioning."""
+        assert self._req_states is not None
+        assert self.vllm_config is not None
+        assert global_batch.num_draft_tokens_per_req is not None
+
+        global_draft_counts = np.asarray(
+            global_batch.num_draft_tokens_per_req, dtype=np.int32
+        )
+        draft_count_by_req_id = dict(
+            zip(global_batch.req_ids, global_draft_counts.tolist(), strict=True)
+        )
+        local_draft_counts = np.fromiter(
+            (draft_count_by_req_id[req_id] for req_id in local_batch.req_ids),
+            dtype=np.int32,
+            count=local_batch.num_reqs,
+        )
+
+        if local_batch.num_tokens == 0:
+            local_num_logits = np.zeros(local_batch.num_reqs, dtype=np.int32)
+            local_draft_counts.fill(0)
+        else:
+            local_num_logits = local_draft_counts + 1
+
+        local_cu_num_logits_np = np.empty(local_batch.num_reqs + 1, dtype=np.int32)
+        local_cu_num_logits_np[0] = 0
+        np.cumsum(local_num_logits, out=local_cu_num_logits_np[1:])
+        total_num_logits = int(local_cu_num_logits_np[-1])
+        local_cu_num_logits = async_copy_to_gpu(
+            local_cu_num_logits_np, device=self.device
+        )
+
+        max_expand_len = self.vllm_config.num_speculative_tokens + 1
+        expanded_idx_mapping, expanded_local_pos = expand_idx_mapping(
+            local_batch.idx_mapping,
+            total_num_logits,
+            local_cu_num_logits,
+            max_expand_len=max_expand_len,
+        )
+        logits_indices = combine_sampled_and_draft_tokens(
+            local_batch.input_ids,
+            local_batch.idx_mapping,
+            self._req_states.last_sampled_tokens,
+            local_batch.query_start_loc,
+            local_batch.seq_lens,
+            self._req_states.prefill_len.gpu,
+            self._req_states.draft_tokens,
+            local_cu_num_logits,
+            total_num_logits,
+            1,
+        )
+
+        return replace(
+            local_batch,
+            num_draft_tokens=int(local_draft_counts.sum()),
+            num_draft_tokens_per_req=local_draft_counts,
+            expanded_idx_mapping=expanded_idx_mapping,
+            expanded_local_pos=expanded_local_pos,
+            logits_indices=logits_indices,
+            cu_num_logits=local_cu_num_logits,
+            cu_num_logits_np=local_cu_num_logits_np,
+        )
+
     def prepare_speculator_attn(
         self,
         input_batch: AscendInputBatch,
     ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
-        """Build the global KV layout consumed by a PCP speculator."""
+        """Build the real global KV layout consumed by an eager speculator."""
         if input_batch is not self._global_batch:
             raise RuntimeError("PCP speculative proposal must use the restored global batch.")
         assert self._block_tables is not None
         block_tables = self._block_tables.gather_block_tables(
             input_batch.idx_mapping,
-            num_reqs_padded=input_batch.num_reqs_after_padding,
+            num_reqs_padded=input_batch.num_reqs,
         )
         assert self._global_batch_slot_mappings is not None
-        num_tokens = input_batch.num_tokens_after_padding
-        if num_tokens > input_batch.num_tokens:
-            self._global_batch_slot_mappings[
-                :,
-                input_batch.num_tokens : num_tokens,
-            ].fill_(PAD_SLOT_ID)
-        global_slot_mappings = self._global_batch_slot_mappings[:, :num_tokens]
-
-        assert self._gathered_kv_slot_mappings is not None
-        num_expanded_tokens = num_tokens * self.pcp_world_size
-        if num_expanded_tokens > self._gathered_kv_slot_mappings.shape[1]:
-            raise RuntimeError(
-                "PCP speculator slot mapping exceeds the persistent buffer "
-                f"capacity: {num_expanded_tokens} > "
-                f"{self._gathered_kv_slot_mappings.shape[1]}."
-            )
-        expanded_slot_mappings = self._gathered_kv_slot_mappings[:, :num_expanded_tokens]
-        for rank in range(self.pcp_world_size):
-            rank_start = rank * num_tokens
-            expanded_slot_mappings[
-                :,
-                rank_start : rank_start + num_tokens,
-            ].copy_(global_slot_mappings)
-        return block_tables, expanded_slot_mappings
+        global_slot_mappings = self._global_batch_slot_mappings[
+            :, : input_batch.num_tokens
+        ]
+        return block_tables, global_slot_mappings
 
     def _pad_decode_batch_for_full_graph(
         self,
@@ -296,14 +363,46 @@ class AscendPCPManager(PCPManager):
             self.get_dummy_slot_mappings(num_tokens),
         )
 
-    def prepare_slot_mappings(self) -> torch.Tensor:
-        slot_mappings = super().prepare_slot_mappings()
-        assert self._global_batch is not None
-        assert self._gathered_kv_slot_mappings is not None
+    def prepare_attn(
+        self,
+        input_batch: AscendInputBatch,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        assert self._block_tables is not None
+        assert self._local_block_tables is not None
+        assert self._local_block_table_ptrs is not None
+        block_tables = self._block_tables.gather_block_tables(
+            input_batch.idx_mapping,
+            input_batch.num_reqs_after_padding,
+            out=self._local_block_tables,
+            out_ptrs=self._local_block_table_ptrs,
+        )
+        slot_mappings = self.prepare_slot_mappings(input_batch)
+        return block_tables, slot_mappings
 
+    def prepare_slot_mappings(
+        self,
+        input_batch: AscendInputBatch | None = None,
+    ) -> torch.Tensor:
+        assert self._global_batch is not None
         global_batch = self._global_batch
         if np.any(global_batch.is_prefilling_np):
-            return slot_mappings
+            return super().prepare_slot_mappings()
+        if input_batch is None:
+            input_batch = global_batch
+
+        assert self._block_tables is not None
+        assert self._global_batch_slot_mappings is not None
+        local_batch_slot_mappings = self._block_tables.compute_slot_mappings(
+            input_batch.idx_mapping,
+            input_batch.query_start_loc,
+            input_batch.positions,
+            input_batch.num_tokens,
+            out=self._global_batch_slot_mappings,
+        )
+        slot_mappings = self._convert_to_gathered_slot_mappings(
+            local_batch_slot_mappings
+        )
+        assert self._gathered_kv_slot_mappings is not None
 
         graph_num_tokens = global_batch.num_tokens_after_padding
         if graph_num_tokens <= global_batch.num_tokens:

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -22,8 +22,13 @@ from copy import copy
 from typing import Any, cast
 
 import torch
-from vllm.config import VllmConfig, get_layers_from_vllm_config
-from vllm.config.compilation import CUDAGraphMode
+from vllm.config import (
+    VllmConfig,
+    get_layers_from_vllm_config,
+    replace,
+    set_current_vllm_config,
+)
+from vllm.config.compilation import CompilationMode, CUDAGraphMode
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -46,7 +51,10 @@ from vllm_ascend.worker.v2.attn_utils import (
     build_attn_metadata_wrapper,
     build_draft_attn_metadata_factory,
 )
-from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
+from vllm_ascend.worker.v2.input_batch import (
+    AscendInputBatch,
+    AscendInputBuffers,
+)
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 logger = logging.getLogger(__name__)
@@ -72,6 +80,31 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         seq_lens_cpu from input_batch), so we replace input_buffers with
         AscendInputBuffers after super().__init__.
         """
+        speculative_config = vllm_config.speculative_config
+        parallel_config = vllm_config.parallel_config
+        if (
+            speculative_config is not None
+            and speculative_config.method in ("mtp", "eagle3")
+            and parallel_config.prefill_context_parallel_size > 1
+        ):
+            # PCP restores the global target batch before proposing. Run the
+            # draft as ordinary eager attention on every PCP rank.
+            # Ascend injects runtime-only fields such as ``oot_compiler`` into
+            # CompilationConfig. ``vllm.config.replace`` cannot clone those
+            # undeclared fields, so shallow-copy before changing draft-only
+            # compilation settings.
+            draft_compilation_config = copy(vllm_config.compilation_config)
+            draft_compilation_config.mode = CompilationMode.NONE
+            draft_compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            vllm_config = replace(
+                vllm_config,
+                parallel_config=replace(
+                    parallel_config,
+                    prefill_context_parallel_size=1,
+                ),
+                compilation_config=draft_compilation_config,
+            )
+
         super().__init__(vllm_config, device)
 
         self.attn_architecture: str | None = None
@@ -97,9 +130,16 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
         self.pcp_manager: AscendPCPManager | None = None
-        self._pcp_draft_prefill_attn_inputs: tuple[tuple[torch.Tensor, ...], torch.Tensor] | None = None
+
+    @property
+    def draft_prefill_attn_groups(self) -> list[list[AttentionGroup]]:
+        if self.pcp_manager is not None:
+            return self.attn_groups
+        return self.target_attn_groups
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
+        if self.vllm_config.compilation_config.cudagraph_mode == CUDAGraphMode.NONE:
+            cudagraph_mode = CUDAGraphMode.NONE
         super().init_cudagraph_manager(cudagraph_mode)
         # The Ascend graph managers are patched onto the upstream module and
         # created by super().init_cudagraph_manager without a speculator ref.
@@ -142,19 +182,45 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         generate_draft.
         """
         self.input_batch = input_batch
-        self._pcp_draft_prefill_attn_inputs = None
+        proposal_input_batch = input_batch
+        proposal_hidden_states = last_hidden_states
         # wrap build_attn_metadata to use Ascend attention metadata building.
         # so we can call super().propose() directly.
         with build_attn_metadata_wrapper(), torch_gather_wrapper():
-            if self.method in ("mtp", "eagle3") and self.pcp_manager is not None and not dummy_run:
-                self._pcp_draft_prefill_attn_inputs = self.pcp_manager.prepare_speculator_attn(input_batch)
-                block_tables, global_slot_mappings = self._pcp_draft_prefill_attn_inputs
-                attn_metadata = self.model_state.prepare_attn(
+            if (
+                self.method in ("mtp", "eagle3")
+                and self.pcp_manager is not None
+                and not dummy_run
+            ):
+                assert isinstance(input_batch, AscendInputBatch)
+                num_reqs = input_batch.num_reqs
+                num_tokens = input_batch.num_tokens
+                proposal_input_batch = replace(
                     input_batch,
+                    num_reqs_after_padding=num_reqs,
+                    num_tokens_after_padding=num_tokens,
+                    query_start_loc=input_batch.query_start_loc[: num_reqs + 1],
+                    query_start_loc_np=input_batch.query_start_loc_np[: num_reqs + 1],
+                    seq_lens=input_batch.seq_lens[:num_reqs],
+                    seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound[
+                        :num_reqs
+                    ],
+                    input_ids=input_batch.input_ids[:num_tokens],
+                    positions=input_batch.positions[:num_tokens],
+                    is_padding=input_batch.is_padding[:num_tokens],
+                    seq_lens_np=input_batch.seq_lens_np[:num_reqs],
+                )
+                proposal_hidden_states = last_hidden_states[:num_tokens]
+
+                block_tables, global_slot_mappings = (
+                    self.pcp_manager.prepare_speculator_attn(input_batch)
+                )
+                attn_metadata = self.model_state.prepare_attn(
+                    proposal_input_batch,
                     CUDAGraphMode.NONE,
                     block_tables,
                     global_slot_mappings,
-                    self.target_attn_groups,
+                    self.draft_prefill_attn_groups,
                     self.kv_cache_config,
                 )
                 slot_mappings = build_slot_mappings_by_layer(
@@ -169,13 +235,18 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                         aux_hidden_states,
                         dim=-1,
                     )
-                    aux_hidden_states = [self.pcp_manager.restore_hidden_states(combined_aux_hidden_states)]
+                    aux_hidden_states = [
+                        self.pcp_manager.restore_hidden_states(
+                            combined_aux_hidden_states
+                        )[:num_tokens]
+                    ]
 
+            self.input_batch = proposal_input_batch
             return super().propose(
-                input_batch,
+                proposal_input_batch,
                 attn_metadata,
                 slot_mappings,
-                last_hidden_states,
+                proposal_hidden_states,
                 aux_hidden_states,
                 num_sampled,
                 num_rejected,
@@ -198,13 +269,16 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         target_input_buffers: InputBuffers,
         target_attn_groups: list[list[AttentionGroup]],
     ) -> None:
-        super().set_attn(
-            model_state,
-            kv_cache_config,
-            block_tables,
-            target_input_buffers,
-            target_attn_groups,
-        )
+        # Ascend backend factories read the current config when choosing the
+        # metadata builder class, in addition to the explicit config argument.
+        with set_current_vllm_config(self.attn_vllm_config):
+            super().set_attn(
+                model_state,
+                kv_cache_config,
+                block_tables,
+                target_input_buffers,
+                target_attn_groups,
+            )
 
         # npu needs attn_backends to update graph params
         attn_backends: dict[str, type[AttentionBackend]] = {}
@@ -254,7 +328,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             self.model_state,
             self.target_input_buffers,
             self.block_tables,
-            self.target_attn_groups,
+            self.draft_prefill_attn_groups,
             self.kv_cache_config,
             progress_bar_desc="Capturing prefill CUDA graphs",
         )
@@ -382,30 +456,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
     ):
         """Build draft_attn_metadatas for partial-merged draft graph."""
         attn_metadata = self.model_state.attn_metadata
-
-        if is_draft_model_prefill and self._pcp_draft_prefill_attn_inputs is not None:
-            assert self.input_batch is not None
-            if (
-                batch_desc.num_reqs != self.input_batch.num_reqs_after_padding
-                or batch_desc.num_tokens != self.input_batch.num_tokens_after_padding
-            ):
-                raise RuntimeError(
-                    "PCP draft-prefill graph shape does not match the restored "
-                    "global batch: "
-                    f"graph=({batch_desc.num_reqs}, {batch_desc.num_tokens}), "
-                    "batch=("
-                    f"{self.input_batch.num_reqs_after_padding}, "
-                    f"{self.input_batch.num_tokens_after_padding})."
-                )
-            block_tables, slot_mappings = self._pcp_draft_prefill_attn_inputs
-            attn_metadata = self.model_state.prepare_attn(
-                self.input_batch,
-                batch_desc.cg_mode,
-                block_tables,
-                slot_mappings,
-                self.target_attn_groups,
-                self.kv_cache_config,
-            )
 
         attn_metadata = {
             name: metadata for name, metadata in attn_metadata.items() if name in self.draft_attn_layer_names

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -27,11 +27,14 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import AutoRegressiveSpeculator
+from vllm.v1.worker.gpu.spec_decode.autoregressive.speculator import (
+    AutoRegressiveSpeculator,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionBackend, AscendAttentionState
@@ -44,6 +47,7 @@ from vllm_ascend.worker.v2.attn_utils import (
     build_draft_attn_metadata_factory,
 )
 from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
+from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +96,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
+        self.pcp_manager: AscendPCPManager | None = None
+        self._pcp_draft_prefill_attn_inputs: tuple[tuple[torch.Tensor, ...], torch.Tensor] | None = None
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         super().init_cudagraph_manager(cudagraph_mode)
@@ -136,9 +142,35 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         generate_draft.
         """
         self.input_batch = input_batch
+        self._pcp_draft_prefill_attn_inputs = None
         # wrap build_attn_metadata to use Ascend attention metadata building.
         # so we can call super().propose() directly.
         with build_attn_metadata_wrapper(), torch_gather_wrapper():
+            if self.method in ("mtp", "eagle3") and self.pcp_manager is not None and not dummy_run:
+                self._pcp_draft_prefill_attn_inputs = self.pcp_manager.prepare_speculator_attn(input_batch)
+                block_tables, global_slot_mappings = self._pcp_draft_prefill_attn_inputs
+                attn_metadata = self.model_state.prepare_attn(
+                    input_batch,
+                    CUDAGraphMode.NONE,
+                    block_tables,
+                    global_slot_mappings,
+                    self.target_attn_groups,
+                    self.kv_cache_config,
+                )
+                slot_mappings = build_slot_mappings_by_layer(
+                    global_slot_mappings,
+                    self.kv_cache_config,
+                )
+
+                if self.method == "eagle3":
+                    if not aux_hidden_states:
+                        raise RuntimeError("Eagle3 with PCP requires auxiliary target hidden states.")
+                    combined_aux_hidden_states = torch.cat(
+                        aux_hidden_states,
+                        dim=-1,
+                    )
+                    aux_hidden_states = [self.pcp_manager.restore_hidden_states(combined_aux_hidden_states)]
+
             return super().propose(
                 input_batch,
                 attn_metadata,
@@ -343,9 +375,38 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 metadata.attn_state = AscendAttentionState.DecodeOnly
         return attn_metadata
 
-    def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
+    def build_draft_attn_metadatas(
+        self,
+        batch_desc: BatchExecutionDescriptor,
+        is_draft_model_prefill: bool,
+    ):
         """Build draft_attn_metadatas for partial-merged draft graph."""
         attn_metadata = self.model_state.attn_metadata
+
+        if is_draft_model_prefill and self._pcp_draft_prefill_attn_inputs is not None:
+            assert self.input_batch is not None
+            if (
+                batch_desc.num_reqs != self.input_batch.num_reqs_after_padding
+                or batch_desc.num_tokens != self.input_batch.num_tokens_after_padding
+            ):
+                raise RuntimeError(
+                    "PCP draft-prefill graph shape does not match the restored "
+                    "global batch: "
+                    f"graph=({batch_desc.num_reqs}, {batch_desc.num_tokens}), "
+                    "batch=("
+                    f"{self.input_batch.num_reqs_after_padding}, "
+                    f"{self.input_batch.num_tokens_after_padding})."
+                )
+            block_tables, slot_mappings = self._pcp_draft_prefill_attn_inputs
+            attn_metadata = self.model_state.prepare_attn(
+                self.input_batch,
+                batch_desc.cg_mode,
+                block_tables,
+                slot_mappings,
+                self.target_attn_groups,
+                self.kv_cache_config,
+            )
+
         attn_metadata = {
             name: metadata for name, metadata in attn_metadata.items() if name in self.draft_attn_layer_names
         }
@@ -353,6 +414,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         if is_draft_model_prefill:
             return [attn_metadata]
 
+        num_reqs_padded = batch_desc.num_reqs
+        assert num_reqs_padded is not None
         draft_attn_metadatas = self._init_decode_draft_attn_metadatas(attn_metadata, num_reqs_padded)
 
         for i, per_step_attn_metadata in enumerate(draft_attn_metadatas):
@@ -415,7 +478,10 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         return draft_attn_metadatas
 
     def _update_decode_attn_metadata(
-        self, attn_metadata: dict[str, Any] | None, step: int, num_reqs: int | None = None
+        self,
+        attn_metadata: dict[str, Any] | None,
+        step: int,
+        num_reqs: int | None = None,
     ):
         """Update per-step decode attention metadata on Ascend."""
         if attn_metadata is None:

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -17,9 +17,6 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 )
 from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.gpu.spec_decode.autoregressive import (
-    cudagraph_utils as speculator_cudagraph_utils,
-)
 from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
     SpeculatorCudaGraphManager,
 )
@@ -34,7 +31,6 @@ from vllm_ascend.compilation.acl_graph import (
 from vllm_ascend.worker.v2.aclgraph_utils import (
     collect_sorted_captured_token_sizes,
     model_capture_wrapper,
-    prepare_pcp_speculator_inputs_to_capture,
 )
 from vllm_ascend.worker.v2.utils import communicator_switch
 
@@ -94,59 +90,15 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
             model_capture_wrapper(self.speculator, self.is_draft_model_prefill),
         ):
             if self.is_draft_model_prefill:
-                # Import lazily to avoid a cycle during plugin patch registration.
-                from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
-
-                pcp_manager = getattr(self.speculator, "pcp_manager", None)
-                if not isinstance(pcp_manager, AscendPCPManager):
-                    super().capture(
-                        forward_fn,
-                        model_state,
-                        input_buffers,
-                        block_tables,
-                        attn_groups,
-                        kv_cache_config,
-                        progress_bar_desc=progress_bar_desc,
-                    )
-                    return
-
-                original_prepare_inputs = speculator_cudagraph_utils.prepare_inputs_to_capture
-
-                def prepare_pcp_speculator_inputs(
-                    num_reqs: int,
-                    num_tokens: int,
-                    model_state: ModelState,
-                    input_buffers: InputBuffers,
-                    block_tables: BlockTables,
-                    attn_groups: list[list[AttentionGroup]],
-                    kv_cache_config: KVCacheConfig,
-                    full_cudagraph: bool,
-                ):
-                    return prepare_pcp_speculator_inputs_to_capture(
-                        num_reqs,
-                        num_tokens,
-                        model_state,
-                        input_buffers,
-                        block_tables,
-                        attn_groups,
-                        kv_cache_config,
-                        pcp_manager,
-                        full_cudagraph=full_cudagraph,
-                    )
-
-                speculator_cudagraph_utils.prepare_inputs_to_capture = prepare_pcp_speculator_inputs
-                try:
-                    super().capture(
-                        forward_fn,
-                        model_state,
-                        input_buffers,
-                        block_tables,
-                        attn_groups,
-                        kv_cache_config,
-                        progress_bar_desc=progress_bar_desc,
-                    )
-                finally:
-                    speculator_cudagraph_utils.prepare_inputs_to_capture = original_prepare_inputs
+                super().capture(
+                    forward_fn,
+                    model_state,
+                    input_buffers,
+                    block_tables,
+                    attn_groups,
+                    kv_cache_config,
+                    progress_bar_desc=progress_bar_desc,
+                )
                 return
 
             def create_forward_fn(desc: BatchExecutionDescriptor, warmup: bool):

--- a/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
+++ b/vllm_ascend/worker/v2/spec_decode/eagle/aclgraph.py
@@ -17,7 +17,12 @@ from vllm.v1.worker.gpu.cudagraph_utils import (
 )
 from vllm.v1.worker.gpu.input_batch import InputBuffers
 from vllm.v1.worker.gpu.model_states.interface import ModelState
-from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import SpeculatorCudaGraphManager
+from vllm.v1.worker.gpu.spec_decode.autoregressive import (
+    cudagraph_utils as speculator_cudagraph_utils,
+)
+from vllm.v1.worker.gpu.spec_decode.autoregressive.cudagraph_utils import (
+    SpeculatorCudaGraphManager,
+)
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -26,7 +31,11 @@ from vllm_ascend.compilation.acl_graph import (
     set_draft_graph_prefill_params,
     update_full_graph_params,
 )
-from vllm_ascend.worker.v2.aclgraph_utils import collect_sorted_captured_token_sizes, model_capture_wrapper
+from vllm_ascend.worker.v2.aclgraph_utils import (
+    collect_sorted_captured_token_sizes,
+    model_capture_wrapper,
+    prepare_pcp_speculator_inputs_to_capture,
+)
 from vllm_ascend.worker.v2.utils import communicator_switch
 
 
@@ -80,17 +89,64 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
     ) -> None:
         """Capture ACL graphs for Eagle."""
 
-        with communicator_switch(), model_capture_wrapper(self.speculator, self.is_draft_model_prefill):
+        with (
+            communicator_switch(),
+            model_capture_wrapper(self.speculator, self.is_draft_model_prefill),
+        ):
             if self.is_draft_model_prefill:
-                super().capture(
-                    forward_fn,
-                    model_state,
-                    input_buffers,
-                    block_tables,
-                    attn_groups,
-                    kv_cache_config,
-                    progress_bar_desc=progress_bar_desc,
-                )
+                # Import lazily to avoid a cycle during plugin patch registration.
+                from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+
+                pcp_manager = getattr(self.speculator, "pcp_manager", None)
+                if not isinstance(pcp_manager, AscendPCPManager):
+                    super().capture(
+                        forward_fn,
+                        model_state,
+                        input_buffers,
+                        block_tables,
+                        attn_groups,
+                        kv_cache_config,
+                        progress_bar_desc=progress_bar_desc,
+                    )
+                    return
+
+                original_prepare_inputs = speculator_cudagraph_utils.prepare_inputs_to_capture
+
+                def prepare_pcp_speculator_inputs(
+                    num_reqs: int,
+                    num_tokens: int,
+                    model_state: ModelState,
+                    input_buffers: InputBuffers,
+                    block_tables: BlockTables,
+                    attn_groups: list[list[AttentionGroup]],
+                    kv_cache_config: KVCacheConfig,
+                    full_cudagraph: bool,
+                ):
+                    return prepare_pcp_speculator_inputs_to_capture(
+                        num_reqs,
+                        num_tokens,
+                        model_state,
+                        input_buffers,
+                        block_tables,
+                        attn_groups,
+                        kv_cache_config,
+                        pcp_manager,
+                        full_cudagraph=full_cudagraph,
+                    )
+
+                speculator_cudagraph_utils.prepare_inputs_to_capture = prepare_pcp_speculator_inputs
+                try:
+                    super().capture(
+                        forward_fn,
+                        model_state,
+                        input_buffers,
+                        block_tables,
+                        attn_groups,
+                        kv_cache_config,
+                        progress_bar_desc=progress_bar_desc,
+                    )
+                finally:
+                    speculator_cudagraph_utils.prepare_inputs_to_capture = original_prepare_inputs
                 return
 
             def create_forward_fn(desc: BatchExecutionDescriptor, warmup: bool):
@@ -126,11 +182,20 @@ class EagleAclGraphManager(SpeculatorCudaGraphManager):
         """Override run_fullgraph to update full graph params in run_fullgraph."""
         num_tokens = desc.num_tokens
         if self.is_draft_model_prefill:
-            logger.info_once("PrefillEagleAclGraphManager: draft prefill run_fullgraph with num_tokens=%s", num_tokens)
+            logger.info_once(
+                "PrefillEagleAclGraphManager: draft prefill run_fullgraph with num_tokens=%s",
+                num_tokens,
+            )
         else:
-            logger.info_once("DecodeEagleAclGraphManager: draft run_fullgraph with num_tokens=%s", num_tokens)
+            logger.info_once(
+                "DecodeEagleAclGraphManager: draft run_fullgraph with num_tokens=%s",
+                num_tokens,
+            )
 
-        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(desc.num_reqs, self.is_draft_model_prefill)
+        draft_attn_metadatas = self.speculator.build_draft_attn_metadatas(
+            desc,
+            self.is_draft_model_prefill,
+        )
         self.update_stream.wait_stream(torch.npu.current_stream())
         ret = super().run_fullgraph(desc)
 

--- a/vllm_ascend/worker/v2/spec_decode/mtp/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/mtp/speculator.py
@@ -15,15 +15,13 @@
 # This file is a part of the vllm-ascend project.
 #
 # AscendMTPSpeculator layers the shared Ascend draft loop
-# (AscendAutoRegressiveSpeculator) on upstream MTPSpeculator. All MLA-specific
-# handling lives in the base, gated by is_mla.
+# (AscendAutoRegressiveSpeculator) on upstream MTPSpeculator.
 from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
 
 from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import AscendAutoRegressiveSpeculator
 
 
 class AscendMTPSpeculator(AscendAutoRegressiveSpeculator, MTPSpeculator):
-    """Ascend MTP speculator (MLA draft). All MLA handling is in the base
-    (AscendAutoRegressiveSpeculator)"""
+    """Ascend MTP speculator."""
 
     pass

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -658,6 +658,28 @@ class NPUWorker(WorkerBase):
         if self.profiler is not None:
             self.profiler.step()
 
+        if self.use_v2_model_runner:
+            model_runner = self.model_runner
+            has_pcp_prefill = False
+            if model_runner.pcp_manager is not None:
+                # This runs before MRV2 adds new requests to req_states, so use
+                # the scheduler payload as the authoritative pre-update state.
+                has_pcp_prefill = any(
+                    req.prefill_token_ids is None or req.num_computed_tokens < len(req.prefill_token_ids)
+                    for req in scheduler_output.scheduled_new_reqs
+                ) or any(
+                    num_output_tokens == 0
+                    for num_output_tokens in (scheduler_output.scheduled_cached_reqs.num_output_tokens)
+                )
+
+            set_pcp_batch_state = getattr(
+                model_runner.cudagraph_manager,
+                "set_pcp_batch_has_prefill",
+                None,
+            )
+            if set_pcp_batch_state is not None:
+                set_pcp_batch_state(has_pcp_prefill)
+
         output = self.model_runner.execute_model(scheduler_output, intermediate_tensors)
         if isinstance(output, (ModelRunnerOutput, AsyncModelRunnerOutput, NoneType)):
             return output


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds the complete MRV2 Prefill Context Parallelism (PCP) integration required to run MTP speculative decoding on Ascend.

MRV2 PCP rewrites the target batch into rank-local DualChunkSwap segments, while sampling and speculative proposal require the original global request layout. MTP additionally changes `num_computed_tokens` after rejection and validates `K+1` target tokens in the following step. Without explicit ownership and synchronization at these boundaries, target positions, KV slots, logits metadata, graph shapes, and request history can diverge and cause repeated answers or accuracy regressions.

This PR keeps one authoritative global batch for sampling/proposal, builds rank-local target metadata for PCP execution, and restores the global layout before speculative proposal.

#### PCP runtime and batch lifecycle

- integrate `AscendPCPManager` with MRV2 model runner and graph capture
- validate unsupported PCP combinations such as PCP+DCP, PP, encoder-decoder, multimodal inputs, and LoRA
- preserve the global scheduled batch while rebuilding Ascend rank-local metadata after upstream PCP partitioning
- support prefix-cache suffix prefills, mixed prefill/decode batches, local block tables, slot mappings, hidden-state restoration, and graph padding
- prevent FULL_DECODE_ONLY replay for PCP batches that still contain prefill tokens

#### GQA and MLA PCP attention

- select PCP-aware GQA/MLA metadata builders and attention implementations from the active target configuration
- preserve per-request prefill classification and expanded PCP cache slots
- gather padded rank-local MLA prefill KV inputs and write the complete paged KV cache
- retain graph-safe metadata and prefix-cache behavior for eager, PIECEWISE, and supported FULL decode execution

#### MTP/speculative decoding integration

- restore the global target batch and hidden states before MTP/Eagle3 proposal
- run the draft proposal with an isolated PCP=1 eager configuration on every PCP rank while the target remains PCP-enabled
- rebuild global draft attention metadata, block tables, and KV slot mappings from the restored target batch
- rebuild rank-local `num_draft_tokens`, `cu_num_logits`, `logits_indices`, and expanded request mappings for target `K+1` validation
- use valid target-token counts (`scheduled - draft`) when constructing mixed-batch attention state
- synchronize rejection-corrected `num_computed_tokens` to both CPU mirrors before the next PCP partition
- keep target block tables, positions, query layout, and slot mappings on the same rank-local batch view

#### ACL graph integration

- derive graph parameter sizes from actual rounded capture descriptors
- build PCP capture metadata from the persistent buffers used during replay
- keep target and draft current-config selection explicit during graph capture/update
- support rank-local full-decode padding without leaking stale slots or positions between graph replays

This Draft PR intentionally includes the prerequisite MLA PCP work currently reviewed in #14008 so the complete MTP+PCP stack can be reviewed together. It does not close or modify #14008.

### Does this PR introduce _any_ user-facing change?

Yes. MRV2 GQA/MLA models can combine target PCP with MTP speculative decoding on Ascend for the supported configurations.

The current draft proposal intentionally runs as eager PCP=1 on every PCP rank. Target PCP remains enabled. True PCP partitioning of the draft model prefill is not included in this PR.

Current restrictions include PCP+DCP, pipeline parallelism, encoder-decoder models, multimodal inputs, and LoRA.

### How was this patch tested?

Added or extended focused unit coverage in:

- `tests/ut/worker/test_pcp_manager_v2.py`
- `tests/ut/worker/test_mtp_pcp_speculator_v2.py`
- `tests/ut/attention/a2/test_attention_v1.py`
- `tests/ut/attention/a2/test_mla_v1.py`
- `tests/ut/compilation/a2/test_acl_graph.py`
- `tests/ut/patch/platform/test_prefix_cache_cp_patches.py`

The tests cover PCP partition metadata, cached-prefill suffixes, mixed batches, local/global slot ownership, MTP rejection state synchronization, rank-local `K+1` metadata, global proposal reconstruction, draft config isolation, graph capture/replay metadata, and MLA PCP KV gathering.

Manual Ascend validation performed during development included:

- PCP=2 with MTP enabled on the full GPQA dataset: repeated-answer regression removed and accuracy returned to the expected baseline
- PCP=1 versus PCP=2 MTP acceptance-rate comparison
- eager and graph-mode single-sample diagnosis for previously failing GPQA cases

Checks run in the current local checkout:

- `ruff check --no-cache` for every changed Python file
- `git diff --check upstream/main...HEAD`

The focused pytest files were not rerun in the current Windows environment because `torch` and `pytest` are not installed, and the Ascend validation host is currently unavailable. This PR is opened as Draft for code review and CI/NPU validation.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
