### PR TITLE
[Refactor][Ops] Extract OOT CustomOp registry into ops/registry.py

### DIFF
--- a/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
+++ b/tests/ut/_310p/ops/test_mm_encoder_attention_310.py
@@ -17,28 +17,32 @@ from unittest import mock
 
 import torch
 
-from vllm_ascend import utils
 from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
 
 
 def test_register_customop_overrides_mm_encoder_attention_for_310p():
-    original_registered = utils._ASCEND_CUSTOMOP_IS_REIGISTERED
-    try:
-        utils._ASCEND_CUSTOMOP_IS_REIGISTERED = False
-        with (
-            mock.patch("vllm.model_executor.custom_op.CustomOp.register_oot"),
-            mock.patch(
-                "vllm_ascend.utils.get_current_hardware_profile",
-                return_value=get_hardware_profile(AscendDeviceType._310P),
-            ),
-        ):
-            utils.register_ascend_customop()
+    import vllm.model_executor.custom_op as custom_op_module
 
-        assert utils.REGISTERED_ASCEND_OPS["MMEncoderAttention"] is AscendMMEncoderAttention310
-    finally:
-        utils._ASCEND_CUSTOMOP_IS_REIGISTERED = original_registered
+    from vllm_ascend.ops import registry as ops_registry
+
+    with (
+        mock.patch("vllm.model_executor.custom_op.CustomOp.register_oot") as mock_register_oot,
+        mock.patch(
+            "vllm_ascend.ops.registry.get_current_hardware_profile",
+            return_value=get_hardware_profile(AscendDeviceType._310P),
+        ),
+        mock.patch("vllm_ascend.ops.registry._registered_all_custom_ops", False),
+        mock.patch.dict(custom_op_module.op_registry_oot, clear=True),
+    ):
+        mock_register_oot.side_effect = lambda _decorated_op_cls=None, name=None: (
+            custom_op_module.op_registry_oot.__setitem__(name, _decorated_op_cls)
+        )
+        ops_registry.register_all_custom_ops()
+
+        mock_register_oot.assert_any_call(_decorated_op_cls=AscendMMEncoderAttention310, name="MMEncoderAttention")
+        assert custom_op_module.op_registry_oot["MMEncoderAttention"] is AscendMMEncoderAttention310
 
 
 def test_mm_encoder_attention_310_forward_oot_with_padding():

--- a/tests/ut/base.py
+++ b/tests/ut/base.py
@@ -17,7 +17,8 @@ import unittest
 
 import pytest
 
-from vllm_ascend.utils import adapt_patch, register_ascend_customop
+from vllm_ascend.ops.registry import register_all_custom_ops
+from vllm_ascend.utils import adapt_patch
 
 
 class TestBase(unittest.TestCase):
@@ -25,7 +26,7 @@ class TestBase(unittest.TestCase):
         # adapt patch by default.
         adapt_patch(True)
         adapt_patch()
-        register_ascend_customop()
+        register_all_custom_ops()
         super().setUp()
         super().__init__(*args, **kwargs)
 
@@ -40,4 +41,4 @@ class PytestBase:
     def setup(self):
         adapt_patch(True)
         adapt_patch()
-        register_ascend_customop()
+        register_all_custom_ops()

--- a/tests/ut/conftest.py
+++ b/tests/ut/conftest.py
@@ -190,11 +190,11 @@ build_info.__spec__ = importlib.util.spec_from_loader("vllm_ascend._build_info",
 setattr(build_info, "__device_type__", "A2")  # noqa: B010
 sys.modules.setdefault("vllm_ascend._build_info", build_info)
 
+from vllm_ascend.ops.registry import register_all_custom_ops  # noqa: E402
 from vllm_ascend.utils import (  # noqa: E402
     adapt_patch,
     clear_enable_sp,
     enable_custom_op,
-    register_ascend_customop,
 )
 
 # Mock torch_npu AFTER vllm_ascend import to avoid circular import in accelerate
@@ -243,7 +243,7 @@ adapt_patch()
 adapt_patch(True)
 
 # register Ascend CustomOp here because uts will use this
-register_ascend_customop()
+register_all_custom_ops()
 
 if not _npu_available:
     import torch

--- a/tests/ut/ops/test_registry.py
+++ b/tests/ut/ops/test_registry.py
@@ -1,0 +1,116 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest import mock
+
+from tests.ut.base import TestBase
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.device.hardware_profile import get_hardware_profile
+
+
+class TestOpsRegistry(TestBase):
+    @mock.patch("vllm_ascend.ops.registry.CustomOp")
+    def test_register_custom_op(self, mock_customop):
+        import vllm.model_executor.custom_op as custom_op_module
+
+        def fake_register_oot(_decorated_op_cls=None, name=None):
+            assert name not in custom_op_module.op_registry_oot, f"Duplicate op name: {name}"
+            custom_op_module.op_registry_oot[name] = _decorated_op_cls
+
+        mock_customop.register_oot.side_effect = fake_register_oot
+        from vllm_ascend.ops.registry import register_custom_op
+
+        with mock.patch.dict(custom_op_module.op_registry_oot, clear=True):
+            # downstream custom ops are written as-is (no catalog lookup)
+            register_custom_op("OmniCustomOp", int)
+            self.assertEqual(mock_customop.register_oot.call_count, 1)
+            self.assertIs(custom_op_module.op_registry_oot["OmniCustomOp"], int)
+
+            # registering an already-registered op fails
+            with self.assertRaises(AssertionError):
+                register_custom_op("OmniCustomOp", str)
+            self.assertEqual(mock_customop.register_oot.call_count, 2)
+            self.assertIs(custom_op_module.op_registry_oot["OmniCustomOp"], int)
+
+    @mock.patch("vllm_ascend.ops.registry.CustomOp")
+    def test_register_custom_ops_exclude(self, mock_customop):
+        """exclude= drops names from the full-catalog registration."""
+        import vllm.model_executor.custom_op as custom_op_module
+
+        mock_customop.register_oot.side_effect = lambda _decorated_op_cls=None, name=None: (
+            custom_op_module.op_registry_oot.__setitem__(name, _decorated_op_cls)
+        )
+        from vllm_ascend.ops import registry as ops_registry
+
+        with (
+            mock.patch(
+                "vllm_ascend.ops.registry.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType.A2),
+            ),
+            mock.patch.dict(custom_op_module.op_registry_oot, clear=True),
+        ):
+            ops_registry.register_custom_ops(exclude={"GateLinear"})
+            self.assertEqual(
+                mock_customop.register_oot.call_count,
+                len(ops_registry._get_ops_base()) - 1,
+            )
+            self.assertNotIn("GateLinear", custom_op_module.op_registry_oot)
+
+    @mock.patch("vllm_ascend.ops.registry.CustomOp")
+    def test_register_all_custom_ops(self, mock_customop):
+        import vllm.model_executor.custom_op as custom_op_module
+
+        mock_customop.register_oot.side_effect = lambda _decorated_op_cls=None, name=None: (
+            custom_op_module.op_registry_oot.__setitem__(name, _decorated_op_cls)
+        )
+        from vllm_ascend.ops import registry as ops_registry
+
+        with (
+            mock.patch(
+                "vllm_ascend.ops.registry.get_current_hardware_profile",
+                return_value=get_hardware_profile(AscendDeviceType.A2),
+            ),
+            mock.patch("vllm_ascend.ops.registry._registered_all_custom_ops", False),
+            mock.patch.dict(custom_op_module.op_registry_oot, clear=True),
+        ):
+            expected_ops = len(ops_registry._get_ops_base()) - 1
+            ops_registry.register_all_custom_ops()
+            self.assertEqual(mock_customop.register_oot.call_count, expected_ops)
+
+            # ascend custom op is already registered
+            ops_registry.register_all_custom_ops()
+            self.assertEqual(mock_customop.register_oot.call_count, expected_ops)
+
+    def test_ascend_custom_ops_310p_overrides_base(self):
+        """On 310P the merged catalog lets 310P variants win over base ops."""
+        from vllm_ascend.ops import registry as ops_registry
+
+        ops_base = ops_registry._get_ops_base()
+        ops_310p = ops_registry._get_ops_310p()
+
+        with mock.patch(
+            "vllm_ascend.ops.registry.get_current_hardware_profile",
+            return_value=get_hardware_profile(AscendDeviceType._310P),
+        ):
+            catalog = ops_registry.ascend_custom_ops()
+            # 310P variants replace the base classes of the same name
+            for name, op_cls in ops_310p.items():
+                self.assertIs(catalog[name], op_cls)
+            # names without a 310P variant keep the base class
+            for name, op_cls in ops_base.items():
+                if name not in ops_310p:
+                    self.assertIs(catalog[name], op_cls)

--- a/tests/ut/test_utils.py
+++ b/tests/ut/test_utils.py
@@ -25,7 +25,6 @@ from tests.ut.base import TestBase
 from vllm_ascend import utils
 from vllm_ascend.device.hardware import AscendDeviceType
 from vllm_ascend.device.hardware_profile import get_hardware_profile
-from vllm_ascend.utils import REGISTERED_ASCEND_OPS
 
 
 class TestUtils(TestBase):
@@ -330,24 +329,6 @@ class TestUtils(TestBase):
 
         with mock.patch("vllm_ascend.utils._IS_DRAFTER_MOE_MODEL", None):
             self.assertTrue(utils.is_drafter_moe_model(vllm_config))
-
-    @mock.patch("vllm.model_executor.custom_op.CustomOp")
-    @mock.patch("vllm_ascend.ops.activation.AscendQuickGELU")
-    @mock.patch("vllm_ascend.ops.activation.AscendSiluAndMul")
-    @mock.patch("vllm_ascend.ops.layernorm.AscendRMSNorm")
-    def test_register_ascend_customop(
-        self, mock_ascend_rmsnorm, mock_ascend_silu_and_mul, mock_ascend_quick_gelu, mock_customop
-    ):
-        utils._ASCEND_CUSTOMOP_IS_REIGISTERED = False
-
-        # ascend custom op is not registered
-        utils.register_ascend_customop()
-        self.assertEqual(mock_customop.register_oot.call_count, len(REGISTERED_ASCEND_OPS))
-        self.assertTrue(utils._ASCEND_CUSTOMOP_IS_REIGISTERED)
-
-        # ascend custom op is already registered
-        utils.register_ascend_customop()
-        self.assertEqual(mock_customop.register_oot.call_count, len(REGISTERED_ASCEND_OPS))
 
     @mock.patch("torch_npu.npu_format_cast")
     def test_maybe_trans_nz(self, mock_npu_format_cast):

--- a/tests/ut/worker/test_worker_v1.py
+++ b/tests/ut/worker/test_worker_v1.py
@@ -202,7 +202,7 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.ops")
     @patch("vllm_ascend.worker.worker._register_atb_extensions")
-    @patch("vllm_ascend.worker.worker.register_ascend_customop")
+    @patch("vllm_ascend.worker.worker.register_all_custom_ops")
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.init_ascend_config")
     @patch("vllm_ascend.worker.worker.check_ascend_device_type")
@@ -215,7 +215,7 @@ class TestNPUWorker(TestBase):
         mock_check_ascend_device_type,
         mock_init_ascend_config,
         mock_get_ascend_config,
-        mock_register_ascend_customop,
+        mock_register_all_custom_ops,
         mock_register_atb_extensions,
         mock_ops,
         mock_adapt_patch,
@@ -242,7 +242,7 @@ class TestNPUWorker(TestBase):
         mock_adapt_patch.assert_called_once()
         mock_ops.register_dummy_fusion_op.assert_called_once()
         mock_register_atb_extensions.assert_called_once()
-        mock_register_ascend_customop.assert_called_once()
+        mock_register_all_custom_ops.assert_called_once()
         mock_init_ascend_config.assert_called_once_with(self.vllm_config_mock)
         mock_check_ascend_device_type.assert_called_once()
 
@@ -257,7 +257,7 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.ops")
     @patch("vllm_ascend.worker.worker._register_atb_extensions")
-    @patch("vllm_ascend.worker.worker.register_ascend_customop")
+    @patch("vllm_ascend.worker.worker.register_all_custom_ops")
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.init_ascend_config")
     @patch("vllm_ascend.worker.worker.check_ascend_device_type")
@@ -270,7 +270,7 @@ class TestNPUWorker(TestBase):
         mock_check_ascend_device_type,
         mock_init_ascend_config,
         mock_get_ascend_config,
-        mock_register_ascend_customop,
+        mock_register_all_custom_ops,
         mock_register_atb_extensions,
         mock_ops,
         mock_adapt_patch,
@@ -300,7 +300,7 @@ class TestNPUWorker(TestBase):
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.ops")
     @patch("vllm_ascend.worker.worker._register_atb_extensions")
-    @patch("vllm_ascend.worker.worker.register_ascend_customop")
+    @patch("vllm_ascend.worker.worker.register_all_custom_ops")
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.init_ascend_config")
     @patch("vllm_ascend.worker.worker.check_ascend_device_type")
@@ -313,7 +313,7 @@ class TestNPUWorker(TestBase):
         mock_check_ascend_device_type,
         mock_init_ascend_config,
         mock_get_ascend_config,
-        mock_register_ascend_customop,
+        mock_register_all_custom_ops,
         mock_register_atb_extensions,
         mock_ops,
         mock_adapt_patch,

--- a/vllm_ascend/ops/registry.py
+++ b/vllm_ascend/ops/registry.py
@@ -1,0 +1,201 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Ascend OOT CustomOp registry.
+
+This module is the single source of truth for the Ascend out-of-tree
+CustomOp catalog and its registration entry points, including
+``register_all_custom_ops`` which moved here from ``vllm_ascend.utils``.
+
+Custom ops are imported lazily inside cached helpers so that merely
+importing this module does not trigger CANN/torch-npu initialization.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from functools import cache
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+from vllm.model_executor.custom_op import CustomOp
+
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+
+
+@cache
+def _get_ops_base() -> dict[str, type]:
+    from vllm_ascend.ops.activation import (
+        AscendQuickGELU,
+        AscendSiluAndMul,
+        AscendSiluAndMulWithClamp,
+    )
+    from vllm_ascend.ops.bailing_moe_linear_attn import AscendBailingMoELinearAttention
+    from vllm_ascend.ops.conv import AscendConv3dLayer
+    from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
+    from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
+    from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
+    from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
+    from vllm_ascend.ops.layernorm import AscendGemmaRMSNorm, AscendRMSNorm, AscendRMSNormGated
+    from vllm_ascend.ops.linear import (
+        AscendColumnParallelLinear,
+        AscendMergedColumnParallelLinear,
+        AscendQKVParallelLinear,
+        AscendReplicatedLinear,
+        AscendRowParallelLinear,
+    )
+    from vllm_ascend.ops.mla import AscendMultiHeadLatentAttention
+    from vllm_ascend.ops.mm_encoder_attention import AscendMMEncoderAttention
+    from vllm_ascend.ops.qwen2_decoder import AscendCustomQwen2Decoder
+    from vllm_ascend.ops.rel_pos_attention import AscendRelPosAttention
+    from vllm_ascend.ops.rotary_embedding import (
+        AscendApplyRotaryEmb,
+        AscendDeepseekScalingRotaryEmbedding,
+        AscendMRotaryEmbedding,
+        AscendRotaryEmbedding,
+        AscendYaRNRotaryEmbedding,
+    )
+    from vllm_ascend.ops.vocab_parallel_embedding import (
+        AscendLogitsProcessor,
+        AscendParallelLMHead,
+        AscendVocabParallelEmbedding,
+    )
+
+    return {
+        "QuickGELU": AscendQuickGELU,
+        "SiluAndMul": AscendSiluAndMul,
+        "SiluAndMulClamp": AscendSiluAndMulWithClamp,
+        "RotaryEmbedding": AscendRotaryEmbedding,
+        "MRotaryEmbedding": AscendMRotaryEmbedding,
+        "ColumnParallelLinear": AscendColumnParallelLinear,
+        "RowParallelLinear": AscendRowParallelLinear,
+        "YaRNScalingRotaryEmbedding": AscendYaRNRotaryEmbedding,
+        "MergedColumnParallelLinear": AscendMergedColumnParallelLinear,
+        "QKVParallelLinear": AscendQKVParallelLinear,
+        "ReplicatedLinear": AscendReplicatedLinear,
+        "DeepseekScalingRotaryEmbedding": AscendDeepseekScalingRotaryEmbedding,
+        "VocabParallelEmbedding": AscendVocabParallelEmbedding,
+        "ParallelLMHead": AscendParallelLMHead,
+        "LogitsProcessor": AscendLogitsProcessor,
+        "RMSNorm": AscendRMSNorm,
+        "GemmaRMSNorm": AscendGemmaRMSNorm,
+        "MultiHeadLatentAttentionWrapper": AscendMultiHeadLatentAttention,
+        "MMEncoderAttention": AscendMMEncoderAttention,
+        "ApplyRotaryEmb": AscendApplyRotaryEmb,
+        "RMSNormGated": AscendRMSNormGated,
+        "Conv3dLayer": AscendConv3dLayer,
+        "RelPosAttention": AscendRelPosAttention,
+        "CustomQwen2Decoder": AscendCustomQwen2Decoder,
+        "GatedDeltaNetAttention": AscendGatedDeltaNetAttention,
+        "BailingMoELinearAttention": AscendBailingMoELinearAttention,
+        "MoERunner": AscendMoERunner,
+        "RoutedExperts": AscendRoutedExperts,
+        "GateLinear": AscendGateLinear,
+    }
+
+
+@cache
+def _get_ops_310p() -> dict[str, type]:
+    from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310, AscendRoutedExperts310
+    from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
+    from vllm_ascend._310p.ops.conv import AscendConv3dLayer310
+    from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
+    from vllm_ascend._310p.ops.layernorm import (
+        AscendGemmaRMSNorm310,
+        AscendRMSNorm310,
+        AscendRMSNormGated310,
+    )
+    from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
+    from vllm_ascend._310p.ops.rotary_embedding import AscendMRotaryEmbedding310, AscendRotaryEmbedding310
+    from vllm_ascend._310p.ops.vocab_parallel_embedding import (
+        AscendParallelLMHead310,
+        AscendVocabParallelEmbedding310,
+    )
+
+    return {
+        "SiluAndMul": AscendSiluAndMul310,
+        "RotaryEmbedding": AscendRotaryEmbedding310,
+        "RMSNorm": AscendRMSNorm310,
+        "GemmaRMSNorm": AscendGemmaRMSNorm310,
+        "RMSNormGated": AscendRMSNormGated310,
+        "ParallelLMHead": AscendParallelLMHead310,
+        "VocabParallelEmbedding": AscendVocabParallelEmbedding310,
+        "MMEncoderAttention": AscendMMEncoderAttention310,
+        "Conv3dLayer": AscendConv3dLayer310,
+        "GatedDeltaNetAttention": AscendGatedDeltaNetAttention310,
+        "MRotaryEmbedding": AscendMRotaryEmbedding310,
+        "MoERunner": AscendMoERunner310,
+        "RoutedExperts": AscendRoutedExperts310,
+    }
+
+
+def ascend_custom_ops() -> Mapping[str, type]:
+    if get_current_hardware_profile().supports(HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS):
+        return MappingProxyType({**_get_ops_base(), **_get_ops_310p()})
+    return MappingProxyType(_get_ops_base())
+
+
+def register_custom_op(name: str, op_cls: type | None = None) -> None:
+    """Registers a single Ascend OOT CustomOp."""
+    if op_cls is None:
+        op_cls = ascend_custom_ops()[name]
+    CustomOp.register_oot(_decorated_op_cls=op_cls, name=name)
+
+
+def register_custom_ops(
+    include: Collection[str] | None = None,
+    exclude: Collection[str] = (),
+) -> None:
+    """Registers a subset of the Ascend OOT CustomOps."""
+    custom_ops = ascend_custom_ops()
+    names = include if include is not None else custom_ops
+    for name in names:
+        if name not in exclude:
+            register_custom_op(name)
+
+
+# register_all_custom_ops runs at most once per process.
+_registered_all_custom_ops = False
+
+
+def register_all_custom_ops(vllm_config: VllmConfig | None = None):
+    """Register Ascend CustomOP
+
+    NOTE: if the register branch requires model type, please use `vllm.config.get_current_vllm_config`,
+    and ensure this will execute after model config is initilazed.
+    """
+    global _registered_all_custom_ops
+    if _registered_all_custom_ops:
+        return
+    _registered_all_custom_ops = True
+
+    if vllm_config is None:
+        try:
+            from vllm.config import get_current_vllm_config
+
+            vllm_config = get_current_vllm_config()
+        except AssertionError:
+            vllm_config = None
+
+    exclude = set()
+    if vllm_config is None or vllm_config.model_config is None or not vllm_config.model_config.is_deepseek_mla:
+        # GateLinear is needed by DeepSeek MLA models.
+        exclude.add("GateLinear")
+    register_custom_ops(exclude=exclude)

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -58,7 +58,6 @@ ASCEND_QUANTIZATION_METHOD = "ascend"
 COMPRESSED_TENSORS_METHOD = "compressed-tensors"
 FP8_METHOD = "fp8"
 SOC_VERSION_INFERENCE_SERIES = ["Ascend310P3"]
-REGISTERED_ASCEND_OPS = {}
 
 ACL_FORMAT_FRACTAL_ND = 2
 ACL_FORMAT_FRACTAL_NZ = 29
@@ -69,7 +68,6 @@ _CURRENT_STREAM = None
 _GLOBAL_STREAM = None
 _SHARED_EXPERTS_CALCULATION_STREAM = None
 _CP_CHUNKEDPREFILL_COMM_STREAM = None
-_ASCEND_CUSTOMOP_IS_REIGISTERED = False
 _DEFAULT_BUFFER_SIZE = 200
 _MIN_DP_BUFFER_SIZE = 50
 _DYNAMIC_EPLB_BUFFER_SIZE = 100
@@ -654,138 +652,6 @@ def update_cudagraph_capture_sizes(vllm_config: VllmConfig, cudagraph_capture_si
 # TODO(wxy): Move to ops module
 def dispose_tensor(x: torch.Tensor):
     x.set_(torch.empty((0,), device=x.device, dtype=x.dtype))
-
-
-def register_ascend_customop(vllm_config: VllmConfig | None = None):
-    """Register Ascend CustomOP
-
-    NOTE: if the register branch requires model type, please use `vllm.config.get_current_vllm_config`,
-    and ensure this will execute after model config is initilazed.
-    """
-    global _ASCEND_CUSTOMOP_IS_REIGISTERED
-    if _ASCEND_CUSTOMOP_IS_REIGISTERED:
-        return
-    from vllm.model_executor.custom_op import CustomOp
-
-    from vllm_ascend.ops.activation import (
-        AscendQuickGELU,
-        AscendSiluAndMul,
-        AscendSiluAndMulWithClamp,
-    )
-    from vllm_ascend.ops.bailing_moe_linear_attn import AscendBailingMoELinearAttention
-    from vllm_ascend.ops.conv import AscendConv3dLayer
-    from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
-    from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
-    from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
-    from vllm_ascend.ops.layernorm import AscendFusedRMSNormGated, AscendGemmaRMSNorm, AscendRMSNorm, AscendRMSNormGated
-    from vllm_ascend.ops.linear import (
-        AscendColumnParallelLinear,
-        AscendMergedColumnParallelLinear,
-        AscendQKVParallelLinear,
-        AscendReplicatedLinear,
-        AscendRowParallelLinear,
-    )
-    from vllm_ascend.ops.mla import AscendMultiHeadLatentAttention
-    from vllm_ascend.ops.mm_encoder_attention import AscendMMEncoderAttention
-    from vllm_ascend.ops.qwen2_decoder import AscendCustomQwen2Decoder
-    from vllm_ascend.ops.rel_pos_attention import AscendRelPosAttention
-    from vllm_ascend.ops.rotary_embedding import (
-        AscendApplyRotaryEmb,
-        AscendDeepseekScalingRotaryEmbedding,
-        AscendMRotaryEmbedding,
-        AscendRotaryEmbedding,
-        AscendYaRNRotaryEmbedding,
-    )
-    from vllm_ascend.ops.vocab_parallel_embedding import (
-        AscendLogitsProcessor,
-        AscendParallelLMHead,
-        AscendVocabParallelEmbedding,
-    )
-
-    global REGISTERED_ASCEND_OPS
-    REGISTERED_ASCEND_OPS = {
-        "QuickGELU": AscendQuickGELU,
-        "SiluAndMul": AscendSiluAndMul,
-        "SiluAndMulClamp": AscendSiluAndMulWithClamp,
-        "RotaryEmbedding": AscendRotaryEmbedding,
-        "MRotaryEmbedding": AscendMRotaryEmbedding,
-        "ColumnParallelLinear": AscendColumnParallelLinear,
-        "RowParallelLinear": AscendRowParallelLinear,
-        "YaRNScalingRotaryEmbedding": AscendYaRNRotaryEmbedding,
-        "MergedColumnParallelLinear": AscendMergedColumnParallelLinear,
-        "QKVParallelLinear": AscendQKVParallelLinear,
-        "ReplicatedLinear": AscendReplicatedLinear,
-        "DeepseekScalingRotaryEmbedding": AscendDeepseekScalingRotaryEmbedding,
-        "VocabParallelEmbedding": AscendVocabParallelEmbedding,
-        "ParallelLMHead": AscendParallelLMHead,
-        "LogitsProcessor": AscendLogitsProcessor,
-        "RMSNorm": AscendRMSNorm,
-        "GemmaRMSNorm": AscendGemmaRMSNorm,
-        "MultiHeadLatentAttentionWrapper": AscendMultiHeadLatentAttention,
-        "MMEncoderAttention": AscendMMEncoderAttention,
-        "ApplyRotaryEmb": AscendApplyRotaryEmb,
-        "RMSNormGated": AscendRMSNormGated,
-        "FusedRMSNormGated": AscendFusedRMSNormGated,
-        "Conv3dLayer": AscendConv3dLayer,
-        "RelPosAttention": AscendRelPosAttention,
-        "CustomQwen2Decoder": AscendCustomQwen2Decoder,
-        "GatedDeltaNetAttention": AscendGatedDeltaNetAttention,
-        "BailingMoELinearAttention": AscendBailingMoELinearAttention,
-        "MoERunner": AscendMoERunner,
-        "RoutedExperts": AscendRoutedExperts,
-    }
-    if vllm_config is None:
-        try:
-            from vllm.config import get_current_vllm_config
-
-            vllm_config = get_current_vllm_config()
-        except AssertionError:
-            vllm_config = None
-    if vllm_config is not None and vllm_config.model_config.is_deepseek_mla:
-        from vllm_ascend.ops.fused_moe.gate_linear import AscendGateLinear
-
-        REGISTERED_ASCEND_OPS["GateLinear"] = AscendGateLinear
-
-    # Override selected ops when the compatibility implementations are required.
-    if get_current_hardware_profile().supports(HardwareCapability.COMPATIBILITY_OP_IMPLEMENTATIONS):
-        from vllm_ascend._310p.fused_moe.fused_moe import AscendMoERunner310, AscendRoutedExperts310
-        from vllm_ascend._310p.ops.activation import AscendSiluAndMul310
-        from vllm_ascend._310p.ops.conv import AscendConv3dLayer310
-        from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
-        from vllm_ascend._310p.ops.layernorm import (
-            AscendGemmaRMSNorm310,
-            AscendRMSNorm310,
-            AscendRMSNormGated310,
-        )
-        from vllm_ascend._310p.ops.mm_encoder_attention import AscendMMEncoderAttention310
-        from vllm_ascend._310p.ops.rotary_embedding import AscendMRotaryEmbedding310, AscendRotaryEmbedding310
-        from vllm_ascend._310p.ops.vocab_parallel_embedding import (
-            AscendParallelLMHead310,
-            AscendVocabParallelEmbedding310,
-        )
-
-        REGISTERED_ASCEND_OPS.update(
-            {
-                "SiluAndMul": AscendSiluAndMul310,
-                "RotaryEmbedding": AscendRotaryEmbedding310,
-                "RMSNorm": AscendRMSNorm310,
-                "GemmaRMSNorm": AscendGemmaRMSNorm310,
-                "RMSNormGated": AscendRMSNormGated310,
-                "ParallelLMHead": AscendParallelLMHead310,
-                "VocabParallelEmbedding": AscendVocabParallelEmbedding310,
-                "MMEncoderAttention": AscendMMEncoderAttention310,
-                "Conv3dLayer": AscendConv3dLayer310,
-                "GatedDeltaNetAttention": AscendGatedDeltaNetAttention310,
-                "MRotaryEmbedding": AscendMRotaryEmbedding310,
-                "MoERunner": AscendMoERunner310,
-                "RoutedExperts": AscendRoutedExperts310,
-            }
-        )
-    for name, op_cls in REGISTERED_ASCEND_OPS.items():
-        CustomOp.register_oot(_decorated_op_cls=op_cls, name=name)
-
-    # NOTE: Keep this at last to ensure all custom actions are registered
-    _ASCEND_CUSTOMOP_IS_REIGISTERED = True
 
 
 def lmhead_tp_enable() -> bool:

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -76,12 +76,12 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
     plan_sparse_kv_offload_memory,
 )
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
+from vllm_ascend.ops.registry import register_all_custom_ops
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
 from vllm_ascend.profiler.torch_npu_profiler import TorchNPUProfilerWrapper
 from vllm_ascend.utils import (
     check_ascend_device_type,
     enable_sp,
-    register_ascend_customop,
     setup_ascend_local_comm_res,
 )
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
@@ -136,7 +136,7 @@ class NPUWorker(WorkerBase):
         ops.register_dummy_fusion_op()
         if get_current_hardware_profile().supports(HardwareCapability.ATB_EXTENSIONS):
             _register_atb_extensions()
-        register_ascend_customop(vllm_config)
+        register_all_custom_ops(vllm_config)
         # init ascend config and soc version
         init_ascend_config(vllm_config)
         from vllm_ascend.logger import configure_ascend_file_logging


### PR DESCRIPTION
### What this PR does / why we need it?

Extract the out-of-tree (OOT) CustomOp registration table out of `vllm_ascend.utils.register_ascend_customop()` into a dedicated module `vllm_ascend/ops/registry.py`, so the Ascend op catalog has a single source of truth and `utils.py` stops carrying the inline registration table.

The module exposes a minimal public contract:

- `ascend_custom_ops()` — op catalog for the current SoC.
- `register_custom_op(name, op_cls=None)` — idempotent registration of a single op into vLLM's `op_registry_oot`.
- `register_custom_ops(include=None, exclude=())` — batch registration with filters, reusing `register_custom_op`.
- `register_all_custom_ops(vllm_config=None)` — batch registration of the full catalog.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Unit tests:

- Added `tests/ut/ops/test_registry.py`
- Adapted `tests/ut/test_utils.py`
- Adapted `tests/ut/_310p/ops/test_mm_encoder_attention_310.py`
- Adapted `tests/ut/worker/a2/test_worker_v1.py`

```bash
pytest tests/ut/ops/test_registry.py -q     #  4 passed
pytest tests/ut/test_utils.py -q    # 22 passed
pytest tests/ut/_310p/ops/test_mm_encoder_attention_310.py -q     #  2 passed
pytest tests/ut/worker/a2/test_worker_v1.py -q    # 55 passed
```


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
