### PR TITLE
[Feature][MRV2] Support lmhead TP in model runner v2 sample path

### DIFF
--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -1,21 +1,9 @@
 """Unit tests for lmhead TP support in the Ascend V2 model runner.
 
-Covers the sample() override added for fine-grained TP (lmhead):
-- passthrough when the feature is disabled (zero behavior change)
-- row padding to the group-agreed capacity before compute_logits
-- trimming of the padded rows before the sampler
-- the capacity fail-fast assertion
-- the sampler dispatch contract for both sampling branches
-- the (sampler_output, num_sampled, num_rejected) return contract
-- a dispatch-tail canary that fails when upstream GPUModelRunner.sample
-  diverges from the copied tail in the override (main2main guard)
-- the dummy-run LMTP collective lockstep: idle DP ranks must join the LM-head
-  collectives once per dummy batch with capacity rows (regression test for
-  the PD-disaggregation hang where a real sample() all_gather waited forever
-  for idle ranks that only ran the model forward)
-
-Collective behavior of the LM head itself is validated on real hardware;
-these tests only lock the runner-side pad/trim contract.
+Pure-mock tests (CPU tensors, no NPU): they lock the runner-side pad/trim
+contract of sample()/_dummy_run and guard the copied dispatch tail with a
+canary that compares it call-by-call against upstream GPUModelRunner.sample.
+Collective behavior of the LM head itself is validated on real hardware.
 """
 
 from types import SimpleNamespace
@@ -76,16 +64,18 @@ def test_passthrough_when_lmhead_tp_disabled():
     runner.sampler.assert_not_called()
 
 
-def test_capacity_is_max_num_reqs_times_decode_query_len():
-    runner = _make_runner(max_num_reqs=16, decode_query_len=3)
-    assert runner._lmhead_tp_max_num_logits() == 48
-
-
-def test_lmhead_tp_pads_to_capacity_then_trims():
-    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+@pytest.mark.parametrize("at_capacity", [False, True])
+def test_lmhead_tp_pads_to_capacity_then_trims(at_capacity):
+    if at_capacity:
+        runner = _make_runner(max_num_reqs=4, decode_query_len=2)  # capacity 8
+        indices = torch.arange(8)
+    else:
+        runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+        indices = torch.tensor([0, 3, 5])
+    capacity = runner._lmhead_tp_max_num_logits()
+    num_logits = indices.shape[0]
     hidden_dim = 4
     hidden_states = torch.randn(10, hidden_dim)
-    indices = torch.tensor([0, 3, 5])
     input_batch = _make_input_batch(indices)
 
     with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
@@ -93,31 +83,18 @@ def test_lmhead_tp_pads_to_capacity_then_trims():
 
     compute_input = runner.model.compute_logits.call_args.args[0]
     # compute_logits sees the group-agreed capacity, not the real row count
-    assert compute_input.shape == (16, hidden_dim)
+    assert compute_input.shape == (capacity, hidden_dim)
     # real rows are the indexed hidden states, padding rows are zero
-    torch.testing.assert_close(compute_input[:3], hidden_states[indices])
-    assert torch.all(compute_input[3:] == 0)
+    torch.testing.assert_close(compute_input[:num_logits], hidden_states[indices])
+    assert torch.all(compute_input[num_logits:] == 0)
     # the sampler only sees the trimmed real rows
     sampled_logits = runner.sampler.call_args.args[0]
-    assert sampled_logits.shape[0] == 3
+    assert sampled_logits.shape[0] == num_logits
     # return contract mirrors upstream sample()
     sampler_output = runner.sampler.return_value
     assert result[0] is sampler_output
     assert result[1] is sampler_output.num_sampled
     assert result[2] is sampler_output.num_rejected
-
-
-def test_lmhead_tp_no_padding_when_at_capacity():
-    runner = _make_runner(max_num_reqs=4, decode_query_len=2)  # capacity 8
-    hidden_states = torch.randn(12, 4)
-    input_batch = _make_input_batch(torch.arange(8))
-
-    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
-        runner.sample(hidden_states, input_batch, None)
-
-    compute_input = runner.model.compute_logits.call_args.args[0]
-    assert compute_input.shape[0] == 8
-    runner.sampler.assert_called_once()
 
 
 def test_lmhead_tp_raises_when_logits_exceed_capacity():
@@ -131,40 +108,6 @@ def test_lmhead_tp_raises_when_logits_exceed_capacity():
         runner.sample(torch.randn(20, 4), input_batch, None)
 
     runner.model.compute_logits.assert_not_called()
-
-
-def test_lmhead_tp_sends_trimmed_logits_to_rejection_sampler():
-    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
-    hidden_states = torch.randn(10, 4)
-    input_batch = _make_input_batch(torch.tensor([2, 6]))
-    input_batch.num_draft_tokens = 5
-    draft_logits = MagicMock()
-    runner.speculator.draft_logits = draft_logits
-
-    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
-        runner.sample(hidden_states, input_batch, None)
-
-    runner.sampler.assert_not_called()
-    args = runner.rejection_sampler.call_args.args
-    assert args[0].shape[0] == 2  # trimmed before rejection sampling
-    assert args[1] is input_batch
-    assert args[2] is draft_logits
-
-
-def test_lmhead_tp_applies_grammar_bitmask_on_trimmed_logits():
-    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
-    hidden_states = torch.randn(10, 4)
-    input_batch = _make_input_batch(torch.tensor([1, 4]))
-    grammar_output = MagicMock()
-
-    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
-        runner.sample(hidden_states, input_batch, grammar_output)
-
-    bitmask_logits = runner.structured_outputs_worker.apply_grammar_bitmask.call_args.args[0]
-    sampled_logits = runner.sampler.call_args.args[0]
-    # grammar and sampler operate on the same trimmed logits tensor
-    assert bitmask_logits is sampled_logits
-    assert bitmask_logits.shape[0] == 2
 
 
 def _canary_tail_calls(parent):
@@ -184,8 +127,14 @@ def _canary_tail_calls(parent):
     return calls
 
 
-@pytest.mark.parametrize("with_grammar", [False, True])
-@pytest.mark.parametrize("with_draft", [False, True])
+@pytest.mark.parametrize(
+    "with_grammar, with_draft",
+    [
+        (False, False),  # plain sampler branch
+        (True, False),  # grammar bitmask + sampler
+        (False, True),  # rejection sampler branch
+    ],
+)
 def test_dispatch_tail_canary_matches_upstream_sample(with_grammar, with_draft):
     """Main2main canary: with lmhead TP on, the override must drive the
     dispatch tail (grammar bitmask / sampler / rejection sampler) exactly like

--- a/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
+++ b/tests/ut/worker/test_model_runner_v2_finegrained_tp.py
@@ -1,0 +1,289 @@
+"""Unit tests for lmhead TP support in the Ascend V2 model runner.
+
+Covers the sample() override added for fine-grained TP (lmhead):
+- passthrough when the feature is disabled (zero behavior change)
+- row padding to the group-agreed capacity before compute_logits
+- trimming of the padded rows before the sampler
+- the capacity fail-fast assertion
+- the sampler dispatch contract for both sampling branches
+- the (sampler_output, num_sampled, num_rejected) return contract
+- a dispatch-tail canary that fails when upstream GPUModelRunner.sample
+  diverges from the copied tail in the override (main2main guard)
+- the dummy-run LMTP collective lockstep: idle DP ranks must join the LM-head
+  collectives once per dummy batch with capacity rows (regression test for
+  the PD-disaggregation hang where a real sample() all_gather waited forever
+  for idle ranks that only ran the model forward)
+
+Collective behavior of the LM head itself is validated on real hardware;
+these tests only lock the runner-side pad/trim contract.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, create_autospec, patch
+
+import pytest
+import torch
+from vllm.v1.worker.gpu.model_runner import GPUModelRunner
+from vllm.v1.worker.gpu.sample.sampler import Sampler
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler import RejectionSampler
+from vllm.v1.worker.gpu.structured_outputs import StructuredOutputsWorker
+
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner
+
+
+def _make_runner(max_num_reqs=8, decode_query_len=2, vocab=6):
+    """Bare instance bypassing __init__ (no NPU required).
+
+    Dispatch components are autospecced against the real upstream classes so
+    a call with drifted arguments fails loudly instead of being swallowed by
+    a bare MagicMock.
+    """
+    runner = object.__new__(NPUModelRunner)
+    runner.max_num_reqs = max_num_reqs
+    runner.decode_query_len = decode_query_len
+    runner.model = MagicMock()
+    runner.model.compute_logits.side_effect = lambda x: torch.zeros(x.shape[0], vocab)
+    runner.sampler = create_autospec(Sampler, instance=True)
+    runner.rejection_sampler = create_autospec(RejectionSampler, instance=True)
+    runner.speculator = MagicMock()
+    runner.structured_outputs_worker = create_autospec(StructuredOutputsWorker, instance=True)
+    return runner
+
+
+def _make_input_batch(logits_indices):
+    return SimpleNamespace(
+        logits_indices=logits_indices,
+        num_draft_tokens=0,
+    )
+
+
+def test_passthrough_when_lmhead_tp_disabled():
+    runner = _make_runner()
+    hidden_states = torch.randn(10, 4)
+    input_batch = _make_input_batch(torch.tensor([0, 3, 5]))
+    grammar_output = MagicMock()
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=False),
+        patch.object(NPUModelRunner.__bases__[0], "sample") as super_sample,
+    ):
+        super_sample.return_value = "upstream-result"
+        result = runner.sample(hidden_states, input_batch, grammar_output)
+
+    assert result == "upstream-result"
+    super_sample.assert_called_once_with(hidden_states, input_batch, grammar_output)
+    runner.model.compute_logits.assert_not_called()
+    runner.sampler.assert_not_called()
+
+
+def test_capacity_is_max_num_reqs_times_decode_query_len():
+    runner = _make_runner(max_num_reqs=16, decode_query_len=3)
+    assert runner._lmhead_tp_max_num_logits() == 48
+
+
+def test_lmhead_tp_pads_to_capacity_then_trims():
+    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+    hidden_dim = 4
+    hidden_states = torch.randn(10, hidden_dim)
+    indices = torch.tensor([0, 3, 5])
+    input_batch = _make_input_batch(indices)
+
+    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
+        result = runner.sample(hidden_states, input_batch, None)
+
+    compute_input = runner.model.compute_logits.call_args.args[0]
+    # compute_logits sees the group-agreed capacity, not the real row count
+    assert compute_input.shape == (16, hidden_dim)
+    # real rows are the indexed hidden states, padding rows are zero
+    torch.testing.assert_close(compute_input[:3], hidden_states[indices])
+    assert torch.all(compute_input[3:] == 0)
+    # the sampler only sees the trimmed real rows
+    sampled_logits = runner.sampler.call_args.args[0]
+    assert sampled_logits.shape[0] == 3
+    # return contract mirrors upstream sample()
+    sampler_output = runner.sampler.return_value
+    assert result[0] is sampler_output
+    assert result[1] is sampler_output.num_sampled
+    assert result[2] is sampler_output.num_rejected
+
+
+def test_lmhead_tp_no_padding_when_at_capacity():
+    runner = _make_runner(max_num_reqs=4, decode_query_len=2)  # capacity 8
+    hidden_states = torch.randn(12, 4)
+    input_batch = _make_input_batch(torch.arange(8))
+
+    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
+        runner.sample(hidden_states, input_batch, None)
+
+    compute_input = runner.model.compute_logits.call_args.args[0]
+    assert compute_input.shape[0] == 8
+    runner.sampler.assert_called_once()
+
+
+def test_lmhead_tp_raises_when_logits_exceed_capacity():
+    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+    input_batch = _make_input_batch(torch.arange(17))
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True),
+        pytest.raises(AssertionError, match="group-agreed capacity"),
+    ):
+        runner.sample(torch.randn(20, 4), input_batch, None)
+
+    runner.model.compute_logits.assert_not_called()
+
+
+def test_lmhead_tp_sends_trimmed_logits_to_rejection_sampler():
+    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+    hidden_states = torch.randn(10, 4)
+    input_batch = _make_input_batch(torch.tensor([2, 6]))
+    input_batch.num_draft_tokens = 5
+    draft_logits = MagicMock()
+    runner.speculator.draft_logits = draft_logits
+
+    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
+        runner.sample(hidden_states, input_batch, None)
+
+    runner.sampler.assert_not_called()
+    args = runner.rejection_sampler.call_args.args
+    assert args[0].shape[0] == 2  # trimmed before rejection sampling
+    assert args[1] is input_batch
+    assert args[2] is draft_logits
+
+
+def test_lmhead_tp_applies_grammar_bitmask_on_trimmed_logits():
+    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+    hidden_states = torch.randn(10, 4)
+    input_batch = _make_input_batch(torch.tensor([1, 4]))
+    grammar_output = MagicMock()
+
+    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
+        runner.sample(hidden_states, input_batch, grammar_output)
+
+    bitmask_logits = runner.structured_outputs_worker.apply_grammar_bitmask.call_args.args[0]
+    sampled_logits = runner.sampler.call_args.args[0]
+    # grammar and sampler operate on the same trimmed logits tensor
+    assert bitmask_logits is sampled_logits
+    assert bitmask_logits.shape[0] == 2
+
+
+def _canary_tail_calls(parent):
+    """Dispatch-tail calls recorded on one parent mock, in global order.
+
+    Tensor arguments are normalized to (shape, values) so calls from the two
+    runs can be compared for equality.
+    """
+    calls = []
+    for call in parent.mock_calls:
+        name = call[0]
+        args = tuple((a.shape, tuple(a.flatten().tolist())) if isinstance(a, torch.Tensor) else a for a in call[1])
+        kwargs = {
+            k: (v.shape, tuple(v.flatten().tolist())) if isinstance(v, torch.Tensor) else v for k, v in call[2].items()
+        }
+        calls.append((name, args, kwargs))
+    return calls
+
+
+@pytest.mark.parametrize("with_grammar", [False, True])
+@pytest.mark.parametrize("with_draft", [False, True])
+def test_dispatch_tail_canary_matches_upstream_sample(with_grammar, with_draft):
+    """Main2main canary: with lmhead TP on, the override must drive the
+    dispatch tail (grammar bitmask / sampler / rejection sampler) exactly like
+    upstream GPUModelRunner.sample — same calls, same order, same arguments
+    (upstream's logits are bitwise identical to the override's trimmed
+    logits). If upstream sample() gains a dispatch branch or changes its
+    calling contract, this comparison fails and the copied tail in the
+    override must be refreshed.
+    """
+    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+    # One parent mock holds the three dispatch components so calls are
+    # recorded in global order across them.
+    parent = MagicMock()
+    runner.sampler = parent.sampler
+    runner.rejection_sampler = parent.rejection_sampler
+    runner.structured_outputs_worker = parent.structured_outputs_worker
+    # Row-projective compute_logits: the override's trimmed logits are then
+    # bitwise identical to upstream's (padding only appends zero rows).
+    hidden_dim = vocab = 6
+    runner.model.compute_logits.side_effect = lambda x: x[:, :vocab]
+
+    hidden_states = torch.randn(10, hidden_dim)
+    input_batch = _make_input_batch(torch.tensor([0, 3, 5]))
+    if with_draft:
+        input_batch.num_draft_tokens = 5
+    grammar_output = MagicMock() if with_grammar else None
+
+    GPUModelRunner.sample(runner, hidden_states, input_batch, grammar_output)
+    upstream_calls = _canary_tail_calls(parent)
+    parent.reset_mock()
+
+    with patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True):
+        runner.sample(hidden_states, input_batch, grammar_output)
+    override_calls = _canary_tail_calls(parent)
+
+    # Sanity floor: the canary must have actually exercised the tail.
+    expected_calls = 2 if with_grammar else 1
+    assert len(upstream_calls) == expected_calls
+    assert override_calls == upstream_calls
+
+
+def test_dummy_run_joins_lmhead_collectives_at_capacity():
+    """Idle DP ranks must join the LM-head collectives on every dummy batch.
+
+    Regression test for the PD-disaggregation hang: with lmhead TP the LM-head
+    all_gather spans the whole group, but the V2 dummy path only runs the
+    model forward, so a real sample() on the rank owning requests waited
+    forever. The override must call compute_logits exactly once with
+    zero-indexed rows at the same capacity the sample() override pads to.
+    """
+    runner = _make_runner(max_num_reqs=8, decode_query_len=2)  # capacity 16
+    hidden_states = torch.randn(10, 6)
+    sample_hidden = torch.randn(3, 6)
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True),
+        patch.object(NPUModelRunner.__bases__[0], "_dummy_run") as super_dummy,
+    ):
+        super_dummy.return_value = (hidden_states, sample_hidden)
+        result = runner._dummy_run(4, uniform_decode=True)
+
+    super_dummy.assert_called_once()
+    assert runner.model.compute_logits.call_count == 1
+    dummy_input = runner.model.compute_logits.call_args.args[0]
+    # zero-indexed rows gathered up to the group-agreed capacity
+    assert dummy_input.shape == (16, 6)
+    torch.testing.assert_close(dummy_input, hidden_states[torch.zeros(16, dtype=torch.long)])
+    # return contract is a pure passthrough of the parent's values
+    assert result == (hidden_states, sample_hidden)
+
+
+def test_dummy_run_lmhead_disabled_or_profile_skips_collectives():
+    """Feature off, profiling runs, and non-last PP ranks must not add dummy
+    compute_logits calls (the profile dummy sampler already runs
+    compute_logits on every rank; non-last PP ranks never produce logits)."""
+    runner = _make_runner()
+    hidden_states = torch.randn(10, 6)
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=False),
+        patch.object(NPUModelRunner.__bases__[0], "_dummy_run") as super_dummy,
+    ):
+        super_dummy.return_value = (hidden_states, None)
+        runner._dummy_run(4)
+    runner.model.compute_logits.assert_not_called()
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True),
+        patch.object(NPUModelRunner.__bases__[0], "_dummy_run") as super_dummy,
+    ):
+        super_dummy.return_value = (hidden_states, None)
+        runner._dummy_run(4, is_profile=True)
+    runner.model.compute_logits.assert_not_called()
+
+    with (
+        patch("vllm_ascend.worker.v2.model_runner.lmhead_tp_enable", return_value=True),
+        patch.object(NPUModelRunner.__bases__[0], "_dummy_run") as super_dummy,
+    ):
+        super_dummy.return_value = (None, None)
+        runner._dummy_run(4)
+    runner.model.compute_logits.assert_not_called()

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -700,16 +700,12 @@ class NPUModelRunner(GPUModelRunner):
     def sample(self, hidden_states, input_batch, grammar_output):
         """Override GPUModelRunner.sample for lmhead TP.
 
-        The LM-head collectives span the whole lmhead-TP group, so every rank
-        must feed them the same number of rows: gathered hidden states are
-        padded up to ``_lmhead_tp_max_num_logits()`` before compute_logits
-        and trimmed back before sampling. Unlike V1 (logits_indices padding
-        in ``model_runner_v1.py``), ``logits_indices`` stays real because the
-        V2 sampler gathers penalties inputs by it.
-
-        Only the sample path is aligned: prompt_logprobs requests are not
-        supported with lmhead TP (PromptLogprobsWorker calls compute_logits
-        with per-rank uneven chunk sizes; V1 has the same limitation).
+        The LM-head collectives span the whole group, so every rank must feed
+        compute_logits the same number of rows: pad hidden states up to
+        ``_lmhead_tp_max_num_logits()`` and trim the logits back before
+        sampling. ``logits_indices`` stays real (the V2 sampler gathers
+        penalties by it). prompt_logprobs is not supported with lmhead TP
+        (same as V1).
         """
         if not lmhead_tp_enable():
             return super().sample(hidden_states, input_batch, grammar_output)
@@ -730,9 +726,7 @@ class NPUModelRunner(GPUModelRunner):
         logits = self.model.compute_logits(sample_hidden_states)
         logits = logits[:num_logits]
 
-        # Dispatch tail mirrors GPUModelRunner.sample; a dispatch-tail canary
-        # unit test fails when upstream sample() diverges, flagging that this
-        # copied tail needs a refresh on main2main bumps.
+        # Dispatch tail mirrors GPUModelRunner.sample; refresh it on main bumps.
         if grammar_output is not None:
             # Apply grammar bitmask to the logits in-place.
             assert self.structured_outputs_worker is not None
@@ -769,17 +763,13 @@ class NPUModelRunner(GPUModelRunner):
         is_profile: bool = False,
         **kwargs,
     ):
-        """Override GPUModelRunner._dummy_run for lmhead TP.
+        """Join the LM-head collectives on dummy batches for lmhead TP.
 
-        Idle DP ranks never call sample(), so they would never join the
-        LM-head collectives that span the whole group, and the busy ranks'
-        all_gather would hang. Join the collectives here with zero-indexed
-        rows at the same capacity as sample() (both derive from
-        ``_lmhead_tp_max_num_logits``; a mismatch desyncs the shapes and
-        hangs), mirroring V1's ``need_dummy_logits`` mechanism. Skipped for
-        profiling runs (the profile dummy sampler already calls
-        compute_logits) and non-last PP ranks (they never produce logits).
-        Spec-decode draft-side alignment is not covered here.
+        Idle DP ranks never call sample(), so without this their ranks would
+        be missing from the group collectives and busy ranks would hang.
+        Zero-indexed rows at the same capacity as sample() (both from
+        ``_lmhead_tp_max_num_logits()``; a mismatch hangs). Skipped for
+        profiling and non-last PP ranks. Draft-side alignment is not covered.
         """
         hidden_states, sample_hidden_states = super()._dummy_run(
             num_tokens,
@@ -793,7 +783,7 @@ class NPUModelRunner(GPUModelRunner):
         if lmhead_tp_enable() and not is_profile and hidden_states is not None:
             dummy_indices = torch.zeros(
                 self._lmhead_tp_max_num_logits(),
-                dtype=torch.long,
+                dtype=torch.int64,
                 device=hidden_states.device,
             )
             self.model.compute_logits(hidden_states[dummy_indices])

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -56,7 +56,7 @@ from vllm_ascend.core.profiling_chunk_predictor import (
     _start_profiling_chunk_timing,
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
-from vllm_ascend.utils import set_potential_max_tokens, vllm_version_is
+from vllm_ascend.utils import lmhead_tp_enable, set_potential_max_tokens, vllm_version_is
 
 if not vllm_version_is("0.27.1"):
     from vllm.v1.worker.gpu.model_runner import BatchReqState
@@ -687,6 +687,117 @@ class NPUModelRunner(GPUModelRunner):
             update_cos_sin(input_batch.positions)
 
             return input_batch
+
+    def _lmhead_tp_max_num_logits(self) -> int:
+        """Logits row capacity shared by every rank of the lmhead-TP group.
+
+        Derived purely from global config so all ranks compute the identical
+        value, matching upstream's own logits capacity bound
+        (``max_num_reqs * decode_query_len``, see StructuredOutputsWorker init).
+        """
+        return self.max_num_reqs * self.decode_query_len
+
+    def sample(self, hidden_states, input_batch, grammar_output):
+        """Override GPUModelRunner.sample for lmhead TP.
+
+        The LM-head collectives span the whole lmhead-TP group, so every rank
+        must feed them the same number of rows: gathered hidden states are
+        padded up to ``_lmhead_tp_max_num_logits()`` before compute_logits
+        and trimmed back before sampling. Unlike V1 (logits_indices padding
+        in ``model_runner_v1.py``), ``logits_indices`` stays real because the
+        V2 sampler gathers penalties inputs by it.
+
+        Only the sample path is aligned: prompt_logprobs requests are not
+        supported with lmhead TP (PromptLogprobsWorker calls compute_logits
+        with per-rank uneven chunk sizes; V1 has the same limitation).
+        """
+        if not lmhead_tp_enable():
+            return super().sample(hidden_states, input_batch, grammar_output)
+
+        num_logits = input_batch.logits_indices.shape[0]
+        capacity = self._lmhead_tp_max_num_logits()
+        # A mismatch would desync the LM-head all_gather/all_to_all across the
+        # group and hang the collectives. Fail fast instead.
+        assert num_logits <= capacity, (
+            f"lmhead TP logits rows ({num_logits}) exceed the group-agreed capacity "
+            f"({capacity} = max_num_reqs * decode_query_len); the capacity formula "
+            "no longer matches upstream logits production."
+        )
+
+        sample_hidden_states = hidden_states[input_batch.logits_indices]
+        if num_logits < capacity:
+            sample_hidden_states = torch.nn.functional.pad(sample_hidden_states, (0, 0, 0, capacity - num_logits))
+        logits = self.model.compute_logits(sample_hidden_states)
+        logits = logits[:num_logits]
+
+        # Dispatch tail mirrors GPUModelRunner.sample; a dispatch-tail canary
+        # unit test fails when upstream sample() diverges, flagging that this
+        # copied tail needs a refresh on main2main bumps.
+        if grammar_output is not None:
+            # Apply grammar bitmask to the logits in-place.
+            assert self.structured_outputs_worker is not None
+            self.structured_outputs_worker.apply_grammar_bitmask(
+                logits,
+                input_batch,
+                grammar_output.structured_output_request_ids,
+                grammar_output.grammar_bitmask,
+            )
+
+        if input_batch.num_draft_tokens == 0 or self.rejection_sampler is None:
+            assert self.sampler is not None
+            sampler_output = self.sampler(logits, input_batch)
+        else:
+            # Rejection sampling for spec decoding.
+            assert self.rejection_sampler is not None
+            assert self.speculator is not None
+            sampler_output = self.rejection_sampler(
+                logits,
+                input_batch,
+                # Draft logits are needed for probabilistic rejection sampling.
+                self.speculator.draft_logits,
+            )
+
+        return sampler_output, sampler_output.num_sampled, sampler_output.num_rejected
+
+    def _dummy_run(
+        self,
+        num_tokens: int,
+        *args,
+        skip_attn: bool = False,
+        uniform_decode: bool = False,
+        skip_eplb: bool = False,
+        is_profile: bool = False,
+        **kwargs,
+    ):
+        """Override GPUModelRunner._dummy_run for lmhead TP.
+
+        Idle DP ranks never call sample(), so they would never join the
+        LM-head collectives that span the whole group, and the busy ranks'
+        all_gather would hang. Join the collectives here with zero-indexed
+        rows at the same capacity as sample() (both derive from
+        ``_lmhead_tp_max_num_logits``; a mismatch desyncs the shapes and
+        hangs), mirroring V1's ``need_dummy_logits`` mechanism. Skipped for
+        profiling runs (the profile dummy sampler already calls
+        compute_logits) and non-last PP ranks (they never produce logits).
+        Spec-decode draft-side alignment is not covered here.
+        """
+        hidden_states, sample_hidden_states = super()._dummy_run(
+            num_tokens,
+            *args,
+            skip_attn=skip_attn,
+            uniform_decode=uniform_decode,
+            skip_eplb=skip_eplb,
+            is_profile=is_profile,
+            **kwargs,
+        )
+        if lmhead_tp_enable() and not is_profile and hidden_states is not None:
+            dummy_indices = torch.zeros(
+                self._lmhead_tp_max_num_logits(),
+                dtype=torch.long,
+                device=hidden_states.device,
+            )
+            self.model.compute_logits(hidden_states[dummy_indices])
+        return hidden_states, sample_hidden_states
 
     def postprocess_sampled(
         self,


### PR DESCRIPTION
## Summary

This PR adds model-runner-V2 support for the `lmhead_tensor_parallel_size` knob of fine-grained TP, which previously only worked on the V1 runner.

lmhead TP shards the LM head's vocab dimension across a group of ranks built along the **DP axis** (`vllm_ascend/distributed/parallel_state.py`). The LM-head operator runs `all_gather` → vocab-sharded GEMM → `all_to_all` across that group on **every** `compute_logits` call (`vllm_ascend/ops/vocab_parallel_embedding.py`). For these collectives to terminate, every rank of the group must call `compute_logits` with the same number of rows on every engine step — otherwise the collectives hang (no error).

The V1 runner maintained this invariant on two paths; V2 had neither:

1. **Real sampling** — V1 pads `logits_indices` to a fixed capacity and trims the logits rows before sampling. V2 cannot pad the indices: its sampler receives the whole `input_batch` and gathers penalties inputs by `input_batch.logits_indices` on the fly, so V1-style index padding would silently corrupt penalties.
2. **Idle DP ranks** — V1's dummy run executes `dummy_compute_logits` (`need_dummy_logits`), so ranks without requests still join the LM-head collectives each step. V2's dummy batch only runs the forward; idle ranks never call `compute_logits`, and the whole engine deadlocks.

This PR ports both, adapted to the V2 sampling contract.

## Changes

Two overrides in `vllm_ascend/worker/v2/model_runner.py` (both pure passthroughs to `super()` when the feature is off — zero behavior change for existing deployments):

**1. `sample()` — real sampling path.** Sampled hidden states are gathered by the real `logits_indices`, padded up to the group-agreed capacity (`max_num_reqs * decode_query_len`, derived purely from global config and equal to upstream's own logits capacity bound in `StructuredOutputsWorker`), `compute_logits` runs on the padded rows, then the padding is trimmed so padded rows never reach the sampler or grammar bitmask. A fail-fast assert turns a would-be collective shape desync into a clear error if the capacity formula ever stops matching upstream logits production. The dispatch tail mirrors `GPUModelRunner.sample`; a **dispatch-tail canary unit test** runs upstream `sample()` and the override on the same mocks and asserts identical dispatch call sequences, so main2main drift fails loudly.

**2. `_dummy_run()` — idle DP ranks.** After the upstream dummy forward, `compute_logits` is called once with zero-indexed rows at the same capacity `sample()` pads to (both derive from `_lmhead_tp_max_num_logits()`, so the formula cannot drift), mirroring V1's `need_dummy_logits`. Profiling runs (the profile dummy sampler already calls `compute_logits` on every rank) and non-last-PP ranks (no logits) are excluded.

`tests/ut/worker/test_model_runner_v2_finegrained_tp.py` (new): 9 test items, one per risk path — passthrough, pad-then-trim (parametrized below/at capacity), the capacity fail-fast assert, a 3-combination dispatch-tail canary, and the dummy-run lockstep regression with its negative paths. The canary runs upstream `sample()` and the override on the same mocks and asserts identical dispatch call sequences, which also locks the grammar / rejection-sampler contracts — no separate per-branch tests are needed. Components are autospecced against the real upstream classes so argument drift fails loudly. The whole file runs in ~0.2s and passes with no NPU devices visible (pure CPU mocks).

## Correctness: the deadlock this fixes

A3 16-chip, Qwen3-30B-A3B-W8A8 (`--quantization ascend`), V2, 1P1D (P=TP8 kv_producer / D=DP8 TP1 kv_consumer, MooncakeConnectorV1, `recompute_scheduler_enable=true` — the weekly shape):

| # | Mode | lmhead | Result |
|---|---|---|---|
| 1 | eager | off | ✅ 3/3 correct (control) |
| 2 | eager | 8 | ❌ hung on first request (pre-fix) |
| 3 | eager | 8 | ✅ with this PR — byte-identical to #1 |
| 4 | graph (FULL_DECODE_ONLY) | 8 | ✅ with this PR — 3/3 correct |

Rows 1 vs 2 isolate lmhead TP as the only variable. `py-spy` on the hang: busy rank stuck in the LM-head `all_gather` inside `sample()` → its NPU stream never completes → it drops out of the DP-gloo `all_reduce` (`sync_cudagraph_and_dp_padding`) → idle workers wait on gloo forever. Row 3's byte-identical outputs across repeated rounds (e.g. 17×23 → 391) confirm the sharding/trim math is exact; row 4 confirms the same under ACLGraph.

## Performance: V2 vs V1 parity (same 1P1D shape)

V1/V2 toggled only via `VLLM_USE_V2_MODEL_RUNNER` (both sides rebooted, all other args identical), 128 requests / concurrency 64 / ~2k in / 512 out / temp=0:

| Mode | Metric | V2 | V1 |
|---|---|---|---|
| graph, steady (run 2) | output tok/s | 1600.1 | 1588.8 |
| | TPOT ms | 37.8 | 38.1 |
| graph, incl. cold start (run 1) | output tok/s | 1453.6 | 1444.4 |
| eager | output tok/s | 164.7 | 165.3 |

Differences are <1%, within run-to-run variance; graph capture time matches (2:28 vs 2:27). Expected: the cross-DP LM-head collectives are the same operator code under both runners; the runner difference is only where pad/trim is scheduled.

## Known limitations

- `prompt_logprobs` requests are not supported with lmhead TP (the prompt-logprobs path calls `compute_logits` with per-rank uneven chunk sizes); same limitation as V1. No startup flag can reject the combo — `prompt_logprobs` is a per-request sampling parameter.
- Spec decoding: the sample-path rejection branch is wired and unit-tested, but e2e V2 spec decode + lmhead TP (incl. the draft-side alignment V1 has) is not yet hardware-validated; a separate follow-up PR covers the draft side.
- Pre-existing V1 issue, unchanged by this PR: V1's zero-padded `logits_indices` can corrupt `kv_sharing_fast_prefill` metadata (padded zeros are attributed to request 0; pure-decode D nodes don't hit it). The V2 path never pads `logits_indices`, so this class cannot occur here. A separate V1 mutual-exclusion follow-up is planned.

## Validation

- [x] Unit tests: 9/9 in ~0.2s (A3 container, also green with no NPU devices visible); canary effectiveness verified by mutation (disabling the grammar branch turns it red).
- [x] E2E 1P1D eager + graph FULL_DECODE_ONLY: rows 3-4 above, byte-identical to the lmhead-off control.
- [x] V2 vs V1 performance parity on the same 1P1D shape (table above).
- MTP spec-decode combination: draft-side alignment goes to a follow-up PR, and the combo is currently blocked upstream anyway (#14871); e2e validation will land with that follow-up.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
