### PR TITLE
[Test] Expand LoRA CPU unit tests

### DIFF
--- a/tests/ut/lora/test_lora.py
+++ b/tests/ut/lora/test_lora.py
@@ -3,34 +3,46 @@ from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from vllm.lora.layers.base import BaseLayerWithLoRA
+from vllm.lora.layers.fused_moe import FusedMoEWithLoRA
 from vllm.lora.punica_wrapper.punica_base import PunicaWrapperBase
 
 from vllm_ascend.lora.fused_moe import (
     AscendFusedMoEWithLoRA,
+    _assert_ascend_moe_lora_supported,
     _recover_moe_lora_routing_all2all,
     _recover_moe_lora_routing_allgather,
+    all2all_lora_indices,
     has_lora,
     moe_lora_apply_w2,
     moe_lora_apply_w13,
+    postprocess_lora_indices,
+    prepare_lora_indices,
+    preprocess_lora_indices,
+    reset_lora_indices,
+    sync_lora_context,
 )
 from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
 
 
-def test_ascend_fused_moe_lora_initializes_skipped_upstream_fields() -> None:
-    parallel_config = SimpleNamespace(tp_size=8, tp_rank=3, ep_rank=0, use_ep=False)
-    shared_experts = torch.nn.Module()
-    base_layer = SimpleNamespace(
+def _make_base_layer(*, num_local_experts=256, is_act_and_mul=True, shared_experts=None, use_ep=False):
+    return SimpleNamespace(
         moe_config=SimpleNamespace(
             hidden_dim=4096,
-            num_local_experts=256,
-            num_experts=256,
+            num_local_experts=num_local_experts,
+            num_experts=num_local_experts,
             intermediate_size_per_partition=256,
             experts_per_token=8,
-            moe_parallel_config=parallel_config,
-            is_act_and_mul=True,
+            moe_parallel_config=SimpleNamespace(tp_size=8, tp_rank=3, ep_rank=0, use_ep=use_ep),
+            is_act_and_mul=is_act_and_mul,
         ),
         _shared_experts=shared_experts,
     )
+
+
+def test_ascend_fused_moe_lora_initializes_skipped_upstream_fields() -> None:
+    shared_experts = torch.nn.Module()
+    base_layer = _make_base_layer(shared_experts=shared_experts)
 
     with (
         patch("vllm_ascend.lora.fused_moe._assert_ascend_moe_lora_supported"),
@@ -45,6 +57,50 @@ def test_ascend_fused_moe_lora_initializes_skipped_upstream_fields() -> None:
     assert wrapper.n_slices == 256 * 3
 
 
+def test_ascend_fused_moe_lora_omits_shared_experts_attr_when_absent() -> None:
+    with (
+        patch("vllm_ascend.lora.fused_moe._assert_ascend_moe_lora_supported"),
+        patch("vllm_ascend.lora.fused_moe._get_lora_device", return_value=torch.device("cpu")),
+    ):
+        wrapper = AscendFusedMoEWithLoRA(_make_base_layer(is_act_and_mul=False))
+
+    assert not hasattr(wrapper, "_shared_experts")
+    assert wrapper._w13_slices == 1
+    assert wrapper.n_slices == 256 * 2
+
+
+def test_set_mapping_publishes_context_on_base_layer() -> None:
+    base_layer = _make_base_layer()
+    base_layer.set_lora_context = Mock()
+    with (
+        patch("vllm_ascend.lora.fused_moe._assert_ascend_moe_lora_supported"),
+        patch("vllm_ascend.lora.fused_moe._get_lora_device", return_value=torch.device("cpu")),
+    ):
+        wrapper = AscendFusedMoEWithLoRA(base_layer)
+    context = object()
+    with (
+        patch.object(BaseLayerWithLoRA, "set_mapping") as set_mapping,
+        patch.object(wrapper, "_build_lora_context", return_value=context),
+    ):
+        wrapper.set_mapping("punica")
+
+    set_mapping.assert_called_once_with(wrapper, "punica")
+    base_layer.set_lora_context.assert_called_once_with(context)
+
+
+def test_build_lora_context_propagates_ep_flag() -> None:
+    with (
+        patch("vllm_ascend.lora.fused_moe._assert_ascend_moe_lora_supported"),
+        patch("vllm_ascend.lora.fused_moe._get_lora_device", return_value=torch.device("cpu")),
+    ):
+        wrapper = AscendFusedMoEWithLoRA(_make_base_layer(use_ep=True))
+    context = SimpleNamespace()
+    with patch.object(FusedMoEWithLoRA, "_build_lora_context", return_value=context):
+        out = wrapper._build_lora_context()
+    assert out is context
+    assert out.use_ep is True
+
+
 def test_moe_lora_apply_uses_adapter_enabled() -> None:
     punica_wrapper = Mock()
     context = SimpleNamespace(
@@ -54,6 +110,9 @@ def test_moe_lora_apply_uses_adapter_enabled() -> None:
         w2_lora_a_stacked="w2_a",
         w2_lora_b_stacked="w2_b",
         adapter_enabled="all_enabled",
+        split_lora_indices=torch.tensor([0]),
+        permuted_lora_indices=torch.tensor([0]),
+        exchanged_lora_indices=torch.tensor([0]),
     )
     routing = (torch.tensor([0]), torch.tensor([0]))
 
@@ -73,6 +132,20 @@ def test_moe_lora_apply_uses_adapter_enabled() -> None:
     calls = punica_wrapper.add_lora_fused_moe.call_args_list
     assert calls[0].kwargs["adapter_enabled"] == "all_enabled"
     assert calls[1].kwargs["adapter_enabled"] == "all_enabled"
+    assert not hasattr(context, "split_lora_indices")
+    assert not hasattr(context, "permuted_lora_indices")
+    assert not hasattr(context, "exchanged_lora_indices")
+
+
+def test_moe_lora_apply_skips_empty_ep_rank() -> None:
+    punica_wrapper = Mock()
+    context = SimpleNamespace(punica_wrapper=punica_wrapper)
+    empty = (torch.tensor([], dtype=torch.long), torch.tensor([], dtype=torch.long))
+
+    moe_lora_apply_w13(context, gate_up_out="g", hidden_states="h", lora_routing=empty)
+    moe_lora_apply_w2(context, down_out="d", silu_out="s", lora_routing=empty)
+
+    punica_wrapper.add_lora_fused_moe.assert_not_called()
 
 
 def test_allgather_routing_preserves_multi_adapter_and_base_mapping() -> None:
@@ -105,10 +178,125 @@ def test_all2all_routing_uses_local_experts_and_exchanged_adapters() -> None:
     assert torch.equal(lora_slots, torch.tensor([1, -1, 0, 2]))
 
 
+def test_all2all_routing_requires_exchanged_indices() -> None:
+    with pytest.raises(AssertionError, match="exchanged_lora_indices"):
+        _recover_moe_lora_routing_all2all(SimpleNamespace(local_num_experts=1), group_list=torch.tensor([1]))
+
+
+def test_all2all_routing_rejects_misaligned_metadata() -> None:
+    context = SimpleNamespace(
+        local_num_experts=2,
+        exchanged_lora_indices=torch.tensor([0]),
+    )
+    with pytest.raises(AssertionError, match="misaligned"):
+        _recover_moe_lora_routing_all2all(context, group_list=torch.tensor([1, 1]))
+
+
 def test_has_lora_follows_batch_metadata() -> None:
     assert not has_lora(None)
     assert not has_lora(SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=True)))
     assert has_lora(SimpleNamespace(punica_wrapper=SimpleNamespace(no_lora=False)))
+
+
+def test_reset_lora_indices_drops_only_present_fields() -> None:
+    context = SimpleNamespace(split_lora_indices=1, extra=2)
+    reset_lora_indices(context)
+    assert not hasattr(context, "split_lora_indices")
+    assert context.extra == 2
+
+
+def test_prepare_lora_indices_pads_inactive_slots() -> None:
+    context = SimpleNamespace(punica_wrapper=SimpleNamespace(token_lora_indices=torch.tensor([3, 1, 0, 9, 9])))
+    prepare_lora_indices(context, num_tokens=3, pad_size=2, tp_size=1, tp_rank=0)
+    assert torch.equal(context.split_lora_indices, torch.tensor([3, 1, 0, -1, -1]))
+
+
+def test_prepare_lora_indices_tp_splits_local_rank() -> None:
+    context = SimpleNamespace(punica_wrapper=SimpleNamespace(token_lora_indices=torch.arange(8)))
+    prepare_lora_indices(context, num_tokens=8, pad_size=0, tp_size=4, tp_rank=2)
+    assert torch.equal(context.split_lora_indices, torch.tensor([4, 5]))
+
+
+def test_preprocess_lora_indices_skips_missing_split() -> None:
+    context = SimpleNamespace()
+    preprocess_lora_indices(
+        context,
+        topk_ids=torch.zeros(2, 2, dtype=torch.long),
+        reversed_permutation_mapping=torch.arange(4),
+    )
+    assert not hasattr(context, "permuted_lora_indices")
+
+
+def test_preprocess_lora_indices_repeats_and_permutes() -> None:
+    context = SimpleNamespace(split_lora_indices=torch.tensor([0, 1]))
+    reversed_mapping = torch.tensor([2, 0, 3, 1])
+    preprocess_lora_indices(context, topk_ids=torch.zeros(2, 2), reversed_permutation_mapping=reversed_mapping)
+    assert torch.equal(context.permuted_lora_indices, torch.tensor([0, 1, 0, 1]))
+
+
+def test_postprocess_lora_indices_skips_missing_exchange() -> None:
+    context = SimpleNamespace()
+    postprocess_lora_indices(context, reversed_permutation_mapping=torch.arange(2))
+    assert not hasattr(context, "exchanged_lora_indices")
+
+
+def test_postprocess_lora_indices_reorders_exchanged_slots() -> None:
+    context = SimpleNamespace(exchanged_lora_indices=torch.tensor([10, 20, 30, 40]))
+    postprocess_lora_indices(context, reversed_permutation_mapping=torch.tensor([2, 0, 3, 1]))
+    assert torch.equal(context.exchanged_lora_indices, torch.tensor([20, 40, 10, 30]))
+
+
+def test_all2all_lora_indices_skips_missing_permuted() -> None:
+    context = SimpleNamespace()
+    all2all_lora_indices(context, output_splits=None, input_splits=None, ep_group=None)
+    assert not hasattr(context, "exchanged_lora_indices")
+
+
+def test_all2all_lora_indices_restores_dtype_after_exchange() -> None:
+    context = SimpleNamespace(permuted_lora_indices=torch.tensor([1, 2], dtype=torch.int32))
+    exchanged = torch.tensor([7, 8], dtype=torch.int64)
+    handle = Mock()
+    with patch(
+        "vllm_ascend.lora.fused_moe.async_all_to_all",
+        return_value=(None, exchanged, handle),
+    ) as all_to_all:
+        all2all_lora_indices(context, output_splits="out", input_splits="in", ep_group="ep")
+
+    all_to_all.assert_called_once_with(context.permuted_lora_indices, "out", "in", "ep")
+    handle.wait.assert_called_once()
+    assert torch.equal(context.exchanged_lora_indices, torch.tensor([7, 8], dtype=torch.int32))
+    assert context.exchanged_lora_indices.dtype == torch.int32
+
+
+def test_sync_lora_context_updates_available_setters() -> None:
+    comm = SimpleNamespace()
+    comm.set_lora_context = Mock()
+    quant = SimpleNamespace()
+    quant.set_lora_context = Mock()
+    extra = SimpleNamespace(moe_comm_method=object())
+    with patch("vllm_ascend.lora.fused_moe._EXTRA_CTX", extra):
+        sync_lora_context(object(), "ctx")
+    extra.moe_comm_method = comm
+    with patch("vllm_ascend.lora.fused_moe._EXTRA_CTX", extra):
+        sync_lora_context(quant, "ctx")
+    comm.set_lora_context.assert_called_once_with("ctx")
+    quant.set_lora_context.assert_called_once_with("ctx")
+
+
+def test_assert_rejects_dynamic_eplb_and_fused_mc2(monkeypatch) -> None:
+    with pytest.raises(AssertionError, match="dynamic EPLB"):
+        _assert_ascend_moe_lora_supported(SimpleNamespace(dynamic_eplb=True, _shared_experts=None))
+    monkeypatch.setenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "1")
+    with pytest.raises(AssertionError, match="FusedMC2"):
+        _assert_ascend_moe_lora_supported(SimpleNamespace(dynamic_eplb=False, _shared_experts=None))
+
+
+def test_assert_warns_once_for_shared_experts(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")
+    with patch("vllm_ascend.lora.fused_moe.logger.warning_once") as warn:
+        _assert_ascend_moe_lora_supported(SimpleNamespace(dynamic_eplb=False, _shared_experts=object()))
+    warn.assert_called_once()
+    assert "shared_experts" in warn.call_args.args[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/lora/test_lora_ops.py
+++ b/tests/ut/lora/test_lora_ops.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from vllm_ascend.lora import lora_ops
+
+
+def _patch_c_ascend(**ops):
+    fake = SimpleNamespace(**ops)
+    return patch.object(torch.ops, "_C_ascend", fake, create=True)
+
+
+def test_bgmv_shrink_forwards_scale_in_kernel_order() -> None:
+    shrink = Mock(return_value="shrink")
+    inputs = torch.ones(2, 4)
+    weights = torch.ones(3, 8, 4)
+    output = torch.zeros(2, 8)
+    indices = torch.tensor([0, -1])
+    with _patch_c_ascend(bgmv_shrink=shrink):
+        assert lora_ops.bgmv_shrink(inputs, weights, output, indices, scaling=0.5) == "shrink"
+    shrink.assert_called_once_with(inputs, weights, indices, output, 0.5)
+
+
+def test_bgmv_expand_uses_full_output_width_and_drops_add_inputs() -> None:
+    expand = Mock(return_value="expand")
+    inputs = torch.ones(2, 8)
+    weights = torch.ones(3, 16, 8)
+    output = torch.zeros(2, 16)
+    indices = torch.tensor([1, 0])
+    with _patch_c_ascend(bgmv_expand=expand):
+        assert lora_ops.bgmv_expand(inputs, weights, output, indices, add_inputs=False) == "expand"
+    expand.assert_called_once_with(inputs, weights, indices, output, 0, 16)
+
+
+def test_bgmv_expand_slice_forwards_offset_and_size() -> None:
+    expand = Mock(return_value="slice")
+    inputs = torch.ones(2, 8)
+    weights = torch.ones(3, 4, 8)
+    output = torch.zeros(2, 12)
+    indices = torch.tensor([0, 1])
+    with _patch_c_ascend(bgmv_expand=expand):
+        assert (
+            lora_ops.bgmv_expand_slice(inputs, weights, output, indices, slice_offset=4, slice_size=4, add_inputs=False)
+            == "slice"
+        )
+    expand.assert_called_once_with(inputs, weights, indices, output, 4, 4)
+
+
+def test_sgmv_wrappers_drop_unused_batch_metadata() -> None:
+    shrink = Mock(return_value="sgmv_shrink")
+    expand = Mock(return_value="sgmv_expand")
+    inputs = torch.ones(4, 8)
+    a_weights = torch.ones(2, 16, 8)
+    b_weights = torch.ones(2, 32, 16)
+    output = torch.zeros(4, 16)
+    expand_out = torch.zeros(4, 32)
+    seq_len = torch.tensor([2, 2])
+    indices = torch.tensor([0, 1])
+    unused = torch.tensor([0, 2])
+    with _patch_c_ascend(sgmv_shrink=shrink, sgmv_expand=expand):
+        assert lora_ops.sgmv_shrink(inputs, a_weights, output, unused, seq_len, indices, 2, 2, 4, 0.25) == "sgmv_shrink"
+        assert (
+            lora_ops.sgmv_expand(
+                inputs,
+                b_weights,
+                expand_out,
+                unused,
+                seq_len,
+                indices,
+                2,
+                2,
+                4,
+                add_inputs=True,
+            )
+            == "sgmv_expand"
+        )
+        assert (
+            lora_ops.sgmv_expand_slice(
+                inputs,
+                b_weights,
+                expand_out,
+                unused,
+                seq_len,
+                indices,
+                2,
+                2,
+                4,
+                slice_offset=8,
+                slice_size=16,
+                add_inputs=True,
+            )
+            == "sgmv_expand"
+        )
+    shrink.assert_called_once_with(inputs, a_weights, indices, seq_len, output, 0.25)
+    assert expand.call_args_list[0].args == (inputs, b_weights, indices, seq_len, expand_out, 0, 32)
+    assert expand.call_args_list[1].args == (inputs, b_weights, indices, seq_len, expand_out, 8, 16)

--- a/tests/ut/lora/test_punica_npu.py
+++ b/tests/ut/lora/test_punica_npu.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm_ascend.device.hardware import AscendDeviceType
+from vllm_ascend.lora import lora_ops
+from vllm_ascend.lora.punica_npu import PunicaWrapperNPU
+
+
+def _make_wrapper(*, is_prefill=False, no_lora=False) -> PunicaWrapperNPU:
+    wrapper = object.__new__(PunicaWrapperNPU)
+    wrapper.is_prefill = is_prefill
+    wrapper.no_lora = no_lora
+    wrapper.bgmv_shrink = Mock()
+    wrapper.bgmv_expand = Mock()
+    wrapper.bgmv_expand_slice = Mock()
+    wrapper.sgmv_shrink = Mock()
+    wrapper.sgmv_expand = Mock()
+    wrapper.sgmv_expand_slice = Mock()
+    # PunicaWrapperBase exposes these as read-only properties.
+    wrapper.batch_size = 1
+    wrapper.max_length = 1
+    wrapper.token_nums = 1
+    wrapper._seq_start_locs = torch.tensor([0])
+    wrapper._seq_lengths = torch.tensor([1])
+    wrapper._lora_indices_per_batch = torch.tensor([0])
+    wrapper._token_lora_indices = torch.tensor([0, 1, 2, 3])
+    wrapper._sampler_indices = torch.tensor([1, 0, 1, 0])
+    wrapper.indices_len = [2, 2, 2, 2]
+    return wrapper
+
+
+@pytest.mark.parametrize(
+    ("device_type", "max_lora_rank", "expect_torch_ops"),
+    [
+        (AscendDeviceType._310P, 8, True),
+        (AscendDeviceType.A2, 128, True),
+        (AscendDeviceType.A2, 16, False),
+    ],
+)
+def test_punica_init_selects_kernel_backend(device_type, max_lora_rank, expect_torch_ops) -> None:
+    with (
+        patch("vllm_ascend.lora.punica_npu.get_ascend_device_type", return_value=device_type),
+        patch("vllm_ascend.lora.punica_npu.refresh_all_lora_classes") as refresh,
+    ):
+        wrapper = PunicaWrapperNPU(
+            8,
+            2,
+            torch.device("cpu"),
+            lora_config=SimpleNamespace(max_lora_rank=max_lora_rank),
+        )
+    refresh.assert_called_once()
+    if expect_torch_ops:
+        from vllm.lora.ops.torch_ops import bgmv_shrink
+
+        assert wrapper.bgmv_shrink is bgmv_shrink
+    else:
+        assert wrapper.bgmv_shrink is lora_ops.bgmv_shrink
+
+
+def test_prefill_calls_sgmv_when_lora_active() -> None:
+    wrapper = _make_wrapper(is_prefill=True, no_lora=False)
+    y = torch.zeros(2, 8)
+    x = torch.ones(2, 4)
+    weights = torch.ones(2, 8, 4)
+    wrapper._apply_shrink(y, x, weights, 1.0)
+    wrapper._apply_expand(y, x, weights, 0, 8, True)
+    wrapper.sgmv_shrink.assert_called_once()
+    wrapper.sgmv_expand_slice.assert_called_once()
+
+
+def test_prefill_shrink_and_expand_skip_when_no_lora() -> None:
+    wrapper = _make_wrapper(is_prefill=True, no_lora=True)
+    y = torch.zeros(2, 8)
+    x = torch.ones(2, 4)
+    weights = torch.ones(2, 8, 4)
+    wrapper._apply_shrink(y, x, weights, 1.0)
+    wrapper._apply_expand(y, x, weights, 0, 8, True)
+    wrapper.sgmv_shrink.assert_not_called()
+    wrapper.sgmv_expand_slice.assert_not_called()
+
+
+def test_decode_always_invokes_bgmv() -> None:
+    wrapper = _make_wrapper(is_prefill=False, no_lora=True)
+    y = torch.zeros(2, 8)
+    x = torch.ones(2, 4)
+    weights = torch.ones(2, 8, 4)
+    wrapper._apply_shrink(y, x, weights, 0.5)
+    wrapper._apply_expand(y, x, weights, 2, 4, False)
+    wrapper.bgmv_shrink.assert_called_once()
+    wrapper.bgmv_expand_slice.assert_called_once()
+    assert torch.equal(wrapper.bgmv_shrink.call_args.args[3], torch.tensor([0, 1]))
+
+
+def test_add_shrink_and_expand_walk_slices_with_offsets() -> None:
+    wrapper = _make_wrapper(is_prefill=False)
+    wrapper._apply_shrink = Mock()
+    wrapper._apply_expand = Mock()
+    x = torch.ones(2, 8)
+    y = torch.zeros(2, 12)
+    a = (torch.ones(1, 4, 8), torch.ones(1, 4, 8))
+    b = (torch.ones(1, 4, 4), torch.ones(1, 8, 4))
+    wrapper.add_shrink((torch.zeros(2, 4), torch.zeros(2, 4)), x, a, 0.25)
+    wrapper.add_expand(y, (torch.ones(2, 4), torch.ones(2, 4)), b, (4, 8), offset_start=0)
+    assert wrapper._apply_shrink.call_count == 2
+    assert wrapper._apply_expand.call_args_list[0].args[3] == 0
+    assert wrapper._apply_expand.call_args_list[1].args[3] == 4
+    assert wrapper._apply_expand.call_args_list[1].args[4] == 8
+
+
+def test_add_lora_embedding_casts_input_to_fp32() -> None:
+    wrapper = _make_wrapper(is_prefill=False)
+    y = torch.zeros(2, 8)
+    x = torch.ones(2, 8, dtype=torch.float16)
+    weights = torch.ones(2, 8, 8)
+    wrapper.add_lora_embedding(y, x, weights)
+    passed_x = wrapper.bgmv_expand.call_args.args[0]
+    assert passed_x.dtype == torch.float32
+
+
+def test_add_lora_embedding_prefill_uses_sgmv_expand() -> None:
+    wrapper = _make_wrapper(is_prefill=True, no_lora=False)
+    wrapper.add_lora_embedding(torch.zeros(2, 8), torch.ones(2, 8), torch.ones(2, 8, 8))
+    wrapper.sgmv_expand.assert_called_once()
+    wrapper.bgmv_expand.assert_not_called()
+
+
+def test_add_lora_linear_allocates_fp32_buffer_when_missing() -> None:
+    wrapper = _make_wrapper()
+    wrapper.add_shrink = Mock()
+    wrapper.add_expand = Mock()
+    x = torch.ones(3, 8)
+    y = torch.zeros(3, 16)
+    a = (torch.ones(2, 4, 8),)
+    b = (torch.ones(2, 16, 4),)
+    wrapper.add_lora_linear(y, x, a, b, 1.0, (16,))
+    buffer = wrapper.add_shrink.call_args.args[0]
+    assert len(buffer) == 1
+    assert buffer[0].shape == (3, 4)
+    assert buffer[0].dtype == torch.float32
+    wrapper.add_expand.assert_called_once()
+
+
+def test_add_lora_fused_moe_builds_graph_safe_combined_index() -> None:
+    wrapper = _make_wrapper()
+    max_loras, num_experts, rank, in_f, out_f = 2, 4, 8, 16, 32
+    a = torch.ones(max_loras, num_experts, rank, in_f)
+    b = torch.ones(max_loras, num_experts, out_f, rank)
+    x = torch.ones(3, in_f)
+    y = torch.zeros(3, out_f)
+    mapping = torch.tensor([0, -1, 1])
+    expert_ids = torch.tensor([1, 2, 3])
+    adapter_enabled = torch.tensor([1, 1])
+    wrapper.add_lora_fused_moe(
+        y,
+        x,
+        (a,),
+        (b,),
+        expert_ids=expert_ids,
+        adapter_enabled=adapter_enabled,
+        token_lora_mapping=mapping,
+        offset=5,
+    )
+    combined = wrapper.bgmv_shrink.call_args.args[3]
+    assert torch.equal(combined, torch.tensor([1, -1, 7]))
+    assert wrapper.bgmv_expand_slice.call_args.args[4:6] == (5, 32)
+    assert wrapper.bgmv_expand_slice.call_args.kwargs["add_inputs"] is True
+
+
+def test_add_lora_fused_moe_masks_disabled_adapter_rows() -> None:
+    wrapper = _make_wrapper()
+    a = torch.ones(2, 4, 2, 8)
+    b = torch.ones(2, 4, 8, 2)
+    wrapper.add_lora_fused_moe(
+        torch.zeros(2, 8),
+        torch.ones(2, 8),
+        (a,),
+        (b,),
+        expert_ids=torch.tensor([1, 2]),
+        adapter_enabled=torch.tensor([0, 1]),
+        token_lora_mapping=torch.tensor([0, 1]),
+    )
+    combined = wrapper.bgmv_shrink.call_args.args[3]
+    assert torch.equal(combined, torch.tensor([-1, 6]))
+
+
+def test_add_lora_fused_moe_rejects_unexpanded_rows() -> None:
+    wrapper = _make_wrapper()
+    with pytest.raises(AssertionError, match="top_k_num=1"):
+        wrapper.add_lora_fused_moe(
+            torch.zeros(1, 4),
+            torch.ones(1, 4),
+            (torch.ones(1, 1, 2, 4),),
+            (torch.ones(1, 1, 4, 2),),
+            expert_ids=torch.tensor([0]),
+            adapter_enabled=torch.tensor([1]),
+            top_k_num=2,
+        )
+
+
+def test_add_lora_fused_moe_scales_shrink_buffer_by_routed_weight() -> None:
+    wrapper = _make_wrapper()
+
+    def _shrink(x, a, shrink_out, idx, scale):
+        shrink_out.fill_(2.0)
+
+    wrapper.bgmv_shrink.side_effect = _shrink
+    a = torch.ones(1, 1, 2, 4)
+    b = torch.ones(1, 1, 4, 2)
+    wrapper.add_lora_fused_moe(
+        torch.zeros(2, 4),
+        torch.ones(2, 4),
+        (a,),
+        (b,),
+        expert_ids=torch.tensor([0, 0]),
+        adapter_enabled=torch.tensor([1]),
+        token_lora_mapping=torch.tensor([0, 0]),
+        mul_routed_weight=True,
+        topk_weights=torch.tensor([0.5, 1.5]),
+    )
+    delta = wrapper.bgmv_expand_slice.call_args.args[0]
+    torch.testing.assert_close(delta, torch.tensor([[1.0, 1.0], [3.0, 3.0]]))
+
+
+def test_add_lora_logits_uses_sampler_indices() -> None:
+    wrapper = _make_wrapper()
+    y = torch.zeros(2, 8)
+    x = torch.ones(2, 4)
+    a = torch.ones(3, 4, 4)
+    b = torch.ones(3, 8, 4)
+    wrapper.add_lora_logits(y, x, a, b, 0.5)
+    assert torch.equal(wrapper.bgmv_shrink.call_args.args[3], torch.tensor([1, 0]))
+    wrapper.bgmv_expand.assert_called_once()

--- a/tests/ut/lora/test_quant_moe.py
+++ b/tests/ut/lora/test_quant_moe.py
@@ -4,11 +4,15 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 import torch_npu  # noqa: F401 -- registers torch.npu
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 
 from vllm_ascend.ascend_forward_context import MoECommType
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.lora.quant_moe import (
+    QuantMoELoRAImpl,
+    _apply_moe_activation,
     quant_apply_mlp_with_moe_lora,
+    register_quant_moe_lora_impl,
     validate_quant_moe_lora_activation_input,
 )
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEWeights
@@ -182,3 +186,137 @@ def test_unregistered_quantized_moe_lora_fails_fast() -> None:
             hidden_states=torch.randn(2, 4),
             dynamic_scale=None,
         )
+
+
+def test_duplicate_quant_moe_lora_registration_is_rejected() -> None:
+    with pytest.raises(ValueError, match="already registered"):
+
+        @register_quant_moe_lora_impl(QuantType.W8A8)
+        def _duplicate(_mlp_compute_input):
+            raise AssertionError("duplicate registration must fail before apply is stored")
+
+
+def test_validate_skips_when_backend_has_no_activation_check() -> None:
+    impl = QuantMoELoRAImpl(apply=lambda *_args, **_kwargs: None, validate_activation_input=None)
+    with patch(f"{QUANT_MOE}._get_quant_moe_lora_impl", return_value=impl):
+        validate_quant_moe_lora_activation_input(
+            quant_type=QuantType.W8A8,
+            hidden_states=torch.ones(1, 2, dtype=torch.int8),
+            dynamic_scale=torch.ones(1),
+        )
+
+
+def test_dynamic_int8_lora_rejects_quantized_routed_activations() -> None:
+    mlp_input = _make_input(
+        hidden_states=torch.ones(2, 4, dtype=torch.int8),
+        dynamic_scale=torch.ones(2),
+    )
+    with patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx:
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+        with pytest.raises(AssertionError, match="BF16/FP16"):
+            quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_input)
+
+
+def test_dynamic_int8_lora_requires_allgather_routing_metadata() -> None:
+    mlp_input = _make_input(expanded_row_idx=None, topk_ids=None)
+    with patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx:
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+        with pytest.raises(AssertionError, match="expanded_row_idx"):
+            quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_input)
+
+
+@pytest.mark.parametrize(
+    ("weight_overrides", "message"),
+    [
+        ({"w1_scale_bias": torch.ones(1)}, "fused scale-bias"),
+        ({"w1_offset": torch.ones(1)}, "antiquant offsets"),
+        ({"w1_scale": None}, "weight scales"),
+        (
+            {
+                "w1": [
+                    torch.ones(1, 4, 6, dtype=torch.int8),
+                    torch.ones(1, 4, 6, dtype=torch.int8),
+                ]
+            },
+            "per-expert tensor lists",
+        ),
+    ],
+)
+def test_dynamic_int8_lora_rejects_unsupported_weight_layout(weight_overrides, message) -> None:
+    weights_kwargs = dict(
+        w1=[torch.ones(1, 4, 6, dtype=torch.int8)],
+        w2=[torch.ones(1, 3, 4, dtype=torch.int8)],
+        w1_scale=[torch.ones(1, 6)],
+        w2_scale=[torch.ones(1, 4, dtype=torch.bfloat16)],
+    )
+    weights_kwargs.update(weight_overrides)
+    mlp_input = _make_input(weights=MoEWeights(**weights_kwargs))
+    with patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx:
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+        with pytest.raises((NotImplementedError, AssertionError), match=message):
+            quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_input)
+
+
+def test_dynamic_int8_lora_applies_topk_scales_before_down_proj() -> None:
+    activated = torch.ones(2, 3, dtype=torch.bfloat16)
+    topk_scales = torch.tensor([[2.0], [3.0]], dtype=torch.bfloat16)
+    mlp_input = _make_input(topk_scales=topk_scales)
+    routing = (torch.tensor([0, 1]), torch.tensor([0, 1]))
+    stream = Mock(record_event=Mock(return_value=object()))
+
+    with (
+        patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx,
+        patch(
+            f"{QUANT_MOE}.DeviceOperator.npu_dynamic_quant",
+            side_effect=[
+                (torch.ones(2, 4, dtype=torch.int8), torch.ones(2)),
+                (torch.ones(2, 3, dtype=torch.int8), torch.ones(2)),
+            ],
+        ),
+        patch(f"{QUANT_MOE}.torch_npu.npu_grouped_matmul", return_value=[torch.randn(2, 6)], create=True),
+        patch(f"{QUANT_MOE}._apply_moe_activation", return_value=activated),
+        patch.object(DeviceOperator, "npu_grouped_matmul_gmm2", return_value=torch.randn(2, 4)),
+        patch(f"{QUANT_MOE}._recover_moe_lora_routing_allgather", return_value=routing),
+        patch(f"{QUANT_MOE}.moe_lora_apply_w13"),
+        patch(f"{QUANT_MOE}.moe_lora_apply_w2"),
+        patch("torch.npu.current_stream", return_value=stream),
+    ):
+        extra_ctx.moe_comm_type = MoECommType.ALLGATHER
+        quant_apply_mlp_with_moe_lora(mlp_compute_input=mlp_input)
+
+    torch.testing.assert_close(activated, torch.tensor([[2.0, 2.0, 2.0], [3.0, 3.0, 3.0]], dtype=torch.bfloat16))
+
+
+def test_apply_moe_activation_dispatches_known_kernels() -> None:
+    gate_up = torch.randn(2, 6)
+    with patch(f"{QUANT_MOE}.AscendSwigluOAIAndMul.swiglu_oai_forward", return_value="oai") as oai:
+        assert _apply_moe_activation(gate_up, MoEActivation.SWIGLUOAI, 0.0, 1.0, 0.0) == "oai"
+        oai.assert_called_once_with(gate_up)
+    with patch(
+        f"{QUANT_MOE}.torch_npu.npu_clipped_swiglu",
+        return_value="uninterleave",
+        create=True,
+    ) as clipped:
+        assert _apply_moe_activation(gate_up, "swigluoai_uninterleave", 4.0, 1.5, 0.2) == "uninterleave"
+        clipped.assert_called_once()
+    with patch(f"{QUANT_MOE}.AscendSwigluStepAndMul.swiglustep_forward", return_value="step") as step:
+        assert _apply_moe_activation(gate_up, MoEActivation.SWIGLUSTEP, 0.0, 1.0, 0.0) == "step"
+        assert step.call_args.kwargs["limit"] == 7.0
+
+    gelu_out = _apply_moe_activation(torch.ones(2, 4), MoEActivation.GELU, 0.0, 1.0, 0.0)
+    assert gelu_out.shape == (2, 2)
+    tanh_out = _apply_moe_activation(torch.ones(2, 4), MoEActivation.GELU_TANH, 0.0, 1.0, 0.0)
+    assert tanh_out.shape == (2, 2)
+
+    clamped = torch.tensor([[10.0, 10.0, -10.0, 10.0]])
+    with patch(f"{QUANT_MOE}.torch_npu.npu_swiglu", side_effect=lambda x: x, create=True) as swiglu:
+        out = _apply_moe_activation(clamped, "silu", 2.0, 1.0, 0.0)
+    swiglu.assert_called_once()
+    torch.testing.assert_close(out, torch.tensor([[2.0, 2.0, -2.0, 2.0]]))
+
+
+def test_mc2_comm_type_is_unsupported() -> None:
+    with patch(f"{QUANT_MOE}._EXTRA_CTX") as extra_ctx:
+        extra_ctx.moe_comm_type = MoECommType.MC2
+        with pytest.raises(NotImplementedError, match="AllGather TP"):
+            quant_apply_mlp_with_moe_lora(mlp_compute_input=_make_input())

--- a/tests/ut/lora/test_utils.py
+++ b/tests/ut/lora/test_utils.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+import vllm.lora.utils as lora_utils
+
+from vllm_ascend.lora.fused_moe import AscendFusedMoE3DWithLoRA, AscendFusedMoEWithLoRA
+from vllm_ascend.lora.utils import refresh_all_lora_classes
+
+
+def test_refresh_all_lora_classes_prepends_ascend_wrappers() -> None:
+    sentinel = object()
+    original = lora_utils._all_lora_classes
+    try:
+        lora_utils._all_lora_classes = (sentinel,)
+        refresh_all_lora_classes()
+        classes = list(lora_utils._all_lora_classes)
+        assert classes[0] is AscendFusedMoEWithLoRA
+        assert classes[1] is AscendFusedMoE3DWithLoRA
+        assert classes[-1] is sentinel
+        # Upstream model_manager still matches the GPU class names.
+        assert AscendFusedMoEWithLoRA.__name__ == "FusedMoEWithLoRA"
+        assert AscendFusedMoE3DWithLoRA.__name__ == "FusedMoE3DWithLoRA"
+    finally:
+        lora_utils._all_lora_classes = original


### PR DESCRIPTION
### What this PR does / why we need it?
Raise LoRA CPU UT coverage for punica_npu, lora_ops, MoE routing/index helpers, and quantized MoE reject paths.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Added and extended CPU unit tests under tests/ut/lora. The tests mock NPU kernels and assert routing, kernel-wrapper contracts, and backend selection.

`vllm_ascend/lora` coverage (`coverage.py` 7.15.4, `python -m pytest tests/ut/lora`) went from **46%** to **98%** (355/357 statements, 90/96 branches):

Before:

![LoRA CPU UT coverage before: 46%](https://raw.githubusercontent.com/Agoni-02/vllm-ascend/pr-assets/lora-ut-coverage/lora-ut-coverage-before-46.png)

After:

![LoRA CPU UT coverage after: 98%](https://raw.githubusercontent.com/Agoni-02/vllm-ascend/pr-assets/lora-ut-coverage/lora-ut-coverage-after-98.png)

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
