### PR TITLE
[Misc] Add RLHF LoRA HTTP API example script

### DIFF
--- a/examples/rl/rlhf_async_new_apis.py
+++ b/examples/rl/rlhf_async_new_apis.py
@@ -1,3 +1,6 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
@@ -39,6 +42,7 @@ Usage:
 """
 
 import asyncio
+import logging
 import os
 import uuid
 from dataclasses import asdict
@@ -62,6 +66,12 @@ from vllm_ascend.distributed.weight_transfer.hccl_engine import (
     HCCLWeightTransferInitInfo,
     HCCLWeightTransferUpdateInfo,
 )
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 MODEL_NAME_V1 = "Qwen/Qwen3-1.7B-Base"
 MODEL_NAME_V2 = "Qwen/Qwen3-1.7B"
@@ -271,11 +281,11 @@ N_NEW_TOKENS = 100
 names, dtype_names, shapes = ray.get(train_model.get_weight_metadata.remote())
 
 # -- Phase 1: concurrent requests with weight sync --------------------
-print(f"\n{'=' * 50}")
-print(f"Prompts ({len(PROMPTS)}):")
+logger.info("\n%s", "=" * 50)
+logger.info("Prompts (%d):", len(PROMPTS))
 for p in PROMPTS:
-    print(f"  - {p!r}")
-print(f"{'=' * 50}")
+    logger.info("  - %r", p)
+logger.info("%s", "=" * 50)
 
 sampling_params = SamplingParams(temperature=0, max_tokens=PAUSE_TOKEN_THRESHOLD + N_NEW_TOKENS)
 
@@ -309,10 +319,10 @@ for i, (output, pause_idx) in enumerate(results):
     all_token_ids = list(output.outputs[0].token_ids)
     before_text = tokenizer.decode(all_token_ids[:pause_idx])
     after_text = tokenizer.decode(all_token_ids[pause_idx:])
-    print(f"\n  Request {i} ({PROMPTS[i]!r}):")
-    print(f"    Old weights ({pause_idx} tokens): {before_text!r}")
+    logger.info("\n  Request %d (%r):", i, PROMPTS[i])
+    logger.info("    Old weights (%d tokens): %r", pause_idx, before_text)
     n_after = len(all_token_ids) - pause_idx
-    print(f"    New weights ({n_after} tokens): {after_text!r}")
+    logger.info("    New weights (%d tokens): %r", n_after, after_text)
 
 # -- Phase 2: validate with a fresh V2 vLLM instance --------------------
 # This validation relies on batch-invariant (deterministic) generation to
@@ -321,10 +331,10 @@ for i, (output, pause_idx) in enumerate(results):
 # generation should be deterministic. Require 100% exact match.
 MIN_PASS_RATE = 1.0
 
-print(f"\n{'=' * 50}")
-print("VALIDATION: comparing weight-synced vLLM with fresh V2 instance")
-print(f"  (Ascend NPU batch-invariant mode: requiring {MIN_PASS_RATE:.0%} exact match)")
-print(f"{'=' * 50}")
+logger.info("\n%s", "=" * 50)
+logger.info("VALIDATION: comparing weight-synced vLLM with fresh V2 instance")
+logger.info("  (Ascend NPU batch-invariant mode: requiring %.0f%% exact match)", MIN_PASS_RATE * 100)
+logger.info("%s", "=" * 50)
 
 ray.get(llm.shutdown.remote())
 ray.kill(llm)
@@ -363,17 +373,20 @@ for i, ((output, pause_idx), (val_output, _)) in enumerate(zip(results, val_resu
 
     if match:
         num_pass += 1
-        print(f"  [PASS] {PROMPTS[i]!r}")
+        logger.info("  [PASS] %r", PROMPTS[i])
     else:
-        print(f"  [FAIL] {PROMPTS[i]!r}")
-        print(f"         weight-synced vLLM: {tokenizer.decode(expected)!r}")
-        print(f"         V2 vLLM:           {tokenizer.decode(actual)!r}")
+        logger.info("  [FAIL] %r", PROMPTS[i])
+        logger.info("         weight-synced vLLM: %r", tokenizer.decode(expected))
+        logger.info("         V2 vLLM:           %r", tokenizer.decode(actual))
         for j, (e, a) in enumerate(zip(expected, actual)):
             if e != a:
-                print(
-                    f"         first divergence at output token {j}: "
-                    f"expected {e} ({tokenizer.decode([e])!r}) vs "
-                    f"actual {a} ({tokenizer.decode([a])!r})"
+                logger.info(
+                    "         first divergence at output token %d: expected %d (%r) vs actual %d (%r)",
+                    j,
+                    e,
+                    tokenizer.decode([e]),
+                    a,
+                    tokenizer.decode([a]),
                 )
                 break
 
@@ -381,12 +394,12 @@ ray.get(llm_v2.shutdown.remote())
 ray.kill(llm_v2)
 
 pass_rate = num_pass / num_total
-print(f"\n  Result: {num_pass}/{num_total} prompts passed ({pass_rate:.0%})")
-print(f"  Required: >= {MIN_PASS_RATE:.0%}")
+logger.info("\n  Result: %d/%d prompts passed (%.0f%%)", num_pass, num_total, pass_rate * 100)
+logger.info("  Required: >= %.0f%%", MIN_PASS_RATE * 100)
 
 assert pass_rate >= MIN_PASS_RATE, (
     f"Validation pass rate {pass_rate:.0%} ({num_pass}/{num_total}) "
     f"is below the required {MIN_PASS_RATE:.0%} threshold. "
     f"See failures above for details."
 )
-print("=" * 50)
+logger.info("%s", "=" * 50)

--- a/examples/rl/rlhf_http_hccl.py
+++ b/examples/rl/rlhf_http_hccl.py
@@ -1,3 +1,6 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
@@ -33,6 +36,8 @@ The example performs the following steps:
 * Generate text again to show normal output after the weight update.
 """
 
+import logging
+
 import requests
 import torch
 from openai import OpenAI
@@ -43,6 +48,8 @@ from vllm_ascend.distributed.weight_transfer.hccl_engine import (
     HCCLTrainerSendWeightsArgs,
     HCCLWeightTransferEngine,
 )
+
+logger = logging.getLogger(__name__)
 
 BASE_URL = "http://localhost:8000"
 MODEL_NAME = "Qwen/Qwen3-0.6B"
@@ -152,6 +159,10 @@ def get_world_size(base_url: str) -> int:
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     # Get the inference world size from the vLLM server
     inference_world_size = get_world_size(BASE_URL)
     world_size = inference_world_size + 1  # +1 for the trainer
@@ -159,7 +170,7 @@ def main():
     torch.accelerator.set_device_index(device)
 
     # Load the training model
-    print(f"Loading training model: {MODEL_NAME}")
+    logger.info("Loading training model: %s", MODEL_NAME)
     train_model = AutoModelForCausalLM.from_pretrained(MODEL_NAME, dtype=torch.bfloat16)
     train_model.to(device)
 
@@ -179,13 +190,13 @@ def main():
 
     # Generate text before weight update. The output is expected to be nonsense
     # because the server is initialized with dummy weights.
-    print("-" * 50)
-    print("Generating text BEFORE weight update (expect nonsense):")
-    print("-" * 50)
+    logger.info("-" * 50)
+    logger.info("Generating text BEFORE weight update (expect nonsense):")
+    logger.info("-" * 50)
     outputs = generate_completions(client, MODEL_NAME, prompts)
     for prompt, generated_text in zip(prompts, outputs):
-        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
-        print("-" * 50)
+        logger.info("Prompt: %r\nGenerated text: %r", prompt, generated_text)
+        logger.info("-" * 50)
 
     # Set up the communication channel between the training process and the
     # vLLM server. The trainer is rank 0, vLLM worker(s) start at rank_offset.
@@ -193,7 +204,7 @@ def main():
     master_port = get_open_port()
     rank_offset = 1
 
-    print(f"Initializing weight transfer: master={master_address}:{master_port}")
+    logger.info("Initializing weight transfer: master=%s:%s", master_address, master_port)
 
     # Initialize weight transfer on vLLM server (this is async, server will
     # wait for HCCL connection)
@@ -240,8 +251,10 @@ def main():
     # Size the packed buffer to fit the largest tensor with 128 MB headroom,
     # but keep the default 1 GB when the largest tensor is smaller than that.
     packed_buffer_size_bytes = max(max_tensor_bytes + 128 * 2**20, 2**30)
-    print(
-        f"Largest tensor: {max_tensor_bytes / 2**30:.2f} GiB, packed buffer: {packed_buffer_size_bytes / 2**30:.2f} GiB"
+    logger.info(
+        "Largest tensor: %.2f GiB, packed buffer: %.2f GiB",
+        max_tensor_bytes / 2**30,
+        packed_buffer_size_bytes / 2**30,
     )
 
     # Start the update_weights call in a separate thread since it will block
@@ -254,7 +267,7 @@ def main():
     update_thread.start()
 
     # Broadcast all weights from trainer to vLLM workers
-    print("Broadcasting weights via HCCL...")
+    logger.info("Broadcasting weights via HCCL...")
     trainer_args = HCCLTrainerSendWeightsArgs(
         group=model_update_group,
         packed=True,
@@ -276,13 +289,13 @@ def main():
 
     # Generate text after weight update. The output is expected to be normal
     # because the real weights are now loaded.
-    print("-" * 50)
-    print("Generating text AFTER weight update:")
-    print("-" * 50)
+    logger.info("-" * 50)
+    logger.info("Generating text AFTER weight update:")
+    logger.info("-" * 50)
     outputs_updated = generate_completions(client, MODEL_NAME, prompts)
     for prompt, generated_text in zip(prompts, outputs_updated):
-        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
-        print("-" * 50)
+        logger.info("Prompt: %r\nGenerated text: %r", prompt, generated_text)
+        logger.info("-" * 50)
 
 
 if __name__ == "__main__":

--- a/examples/rl/rlhf_http_lora.py
+++ b/examples/rl/rlhf_http_lora.py
@@ -108,8 +108,9 @@ MODEL_NAME = "Qwen/Qwen3-0.6B"
 SERVER_START_TIMEOUT = 600
 
 # Two self-cognition LoRA adapters to demonstrate the update workflow.
-# Local paths on this machine; in real RL training, replace these with your
-# own trained adapter paths.
+# HuggingFace repo IDs, resolved to local paths via resolve_lora_path()
+# in main(); in real RL training, replace these with your own trained
+# adapter repo IDs or local paths.
 LORA_ALICE = (
     "Alice",
     "charent/self_cognition_Alice",
@@ -125,6 +126,24 @@ POLICY_NAME = "policy"
 
 # One identity prompt is enough to observe the adapter switch.
 PROMPTS = ["Hi, tell me about you"]
+
+
+def resolve_lora_path(repo_id: str) -> str:
+    """Resolve a HuggingFace repo ID to a local adapter path.
+
+    Downloads the adapter into the HF cache on first use and returns the
+    cached directory; subsequent calls just resolve the cache entry, so
+    this is cheap to call on every run.  A local path passed in is
+    returned unchanged.
+
+    Set ``HF_ENDPOINT`` (e.g. ``https://hf-mirror.com``) in the
+    environment when huggingface.co is not reachable.
+    """
+    if os.path.isdir(repo_id):
+        return repo_id
+    from vllm.transformers_utils.repo_utils import hf_api
+
+    return hf_api().snapshot_download(repo_id=repo_id)
 
 
 # ---------------------------------------------------------------------------
@@ -360,6 +379,8 @@ def main():
 
         _, alice_path = LORA_ALICE
         _, bob_path = LORA_BOB
+        alice_path = resolve_lora_path(alice_path)
+        bob_path = resolve_lora_path(bob_path)
 
         # Reset adapter state so the demo is re-runnable against a warm server.
         try:

--- a/examples/rl/rlhf_http_lora.py
+++ b/examples/rl/rlhf_http_lora.py
@@ -80,8 +80,7 @@ In a real RLHF setup (e.g., with TRL or OpenRLHF), the trainer would:
         save_lora_adapter(lora_state_dict, "/tmp/lora_checkpoint")
 
         # 4. Push the updated LoRA onto the same adapter name in place
-        load_lora_adapter(base_url, lora_name, "/tmp/lora_checkpoint",
-                          load_inplace=True)
+        load_lora_adapter(base_url, lora_name, "/tmp/lora_checkpoint", load_inplace=True)
 
         # The server now serves requests with the updated LoRA
         # No unload, no pause/resume, no HCCL broadcast needed
@@ -220,8 +219,7 @@ def load_lora_adapter(
     }
     if load_inplace:
         payload["load_inplace"] = True
-    print(f"[trainer] Loading LoRA '{lora_name}' from {lora_path} "
-          f"(load_inplace={load_inplace}) ...")
+    print(f"[trainer] Loading LoRA '{lora_name}' from {lora_path} (load_inplace={load_inplace}) ...")
     response = requests.post(url, json=payload, timeout=120)
     response.raise_for_status()
     print(f"[trainer] LoRA '{lora_name}' loaded successfully")
@@ -269,8 +267,7 @@ class LoRAServer:
         # If a server is already serving this port, reuse it.
         try:
             if requests.get(f"{base_url}/health", timeout=5).status_code == 200:
-                print(f"[server] using an existing server at {base_url}",
-                      flush=True)
+                print(f"[server] using an existing server at {base_url}", flush=True)
                 self.external = True
                 self.proc = None
                 return
@@ -283,12 +280,17 @@ class LoRAServer:
         # endpoints.
         env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "1"
         command = [
-            "vllm", "serve", model,
+            "vllm",
+            "serve",
+            model,
             "--enforce-eager",
             "--enable-lora",
-            "--max-lora-rank", "8",
-            "--max-cpu-loras", "4",
-            "--port", str(port),
+            "--max-lora-rank",
+            "8",
+            "--max-cpu-loras",
+            "4",
+            "--port",
+            str(port),
         ]
         print(f"[server] starting: {' '.join(command)}", flush=True)
         self.proc = subprocess.Popen(command, env=env)
@@ -303,15 +305,12 @@ class LoRAServer:
                 # serving this port, use it instead of failing.
                 try:
                     if requests.get(health_url, timeout=5).status_code == 200:
-                        print(f"[server] using an existing server at {base_url}",
-                              flush=True)
+                        print(f"[server] using an existing server at {base_url}", flush=True)
                         self.external = True
                         return
                 except requests.exceptions.RequestException:
                     pass
-                raise RuntimeError(
-                    f"vLLM server exited with status {self.proc.returncode}"
-                )
+                raise RuntimeError(f"vLLM server exited with status {self.proc.returncode}")
             try:
                 if requests.get(health_url, timeout=5).status_code == 200:
                     print(f"[server] ready: {health_url}", flush=True)
@@ -320,9 +319,7 @@ class LoRAServer:
                 pass
             time.sleep(2)
         self.stop()
-        raise TimeoutError(
-            f"vLLM server did not become ready within {SERVER_START_TIMEOUT}s"
-        )
+        raise TimeoutError(f"vLLM server did not become ready within {SERVER_START_TIMEOUT}s")
 
     def stop(self) -> None:
         if self.external or self.proc.poll() is not None:
@@ -386,14 +383,10 @@ def main():
         try:
             unload_lora_adapter(BASE_URL, POLICY_NAME, ignore_missing=True)
         except requests.exceptions.ConnectionError as exc:
-            raise SystemExit(
-                f"Could not reach the vLLM server at {BASE_URL}."
-            ) from exc
+            raise SystemExit(f"Could not reach the vLLM server at {BASE_URL}.") from exc
 
         # ── Step 1: Generate WITHOUT LoRA (baseline) ───────────────────
-        baseline_outputs = generate_and_print(
-            client, "Step 1: Generating WITHOUT LoRA (baseline)", MODEL_NAME
-        )
+        baseline_outputs = generate_and_print(client, "Step 1: Generating WITHOUT LoRA (baseline)", MODEL_NAME)
 
         # ── Step 2: Deploy the initial policy (Alice under a fixed name) ──
         load_lora_adapter(BASE_URL, POLICY_NAME, alice_path)
@@ -450,9 +443,7 @@ def main():
         assert alice_outputs[identity_idx] != baseline_outputs[identity_idx], (
             "Deploying Alice under 'policy' did not change the output vs baseline"
         )
-        assert bob_outputs[identity_idx] != alice_outputs[identity_idx], (
-            "Inplace push Alice → Bob did not take effect"
-        )
+        assert bob_outputs[identity_idx] != alice_outputs[identity_idx], "Inplace push Alice → Bob did not take effect"
         assert rollback_outputs[identity_idx] != bob_outputs[identity_idx], (
             "Inplace push Bob → Alice (rollback) did not take effect"
         )

--- a/examples/rl/rlhf_http_lora.py
+++ b/examples/rl/rlhf_http_lora.py
@@ -1,3 +1,6 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
@@ -15,7 +18,7 @@ this script demonstrates the LoRA-based RL training workflow where:
 * The server immediately serves requests with or without the active LoRA,
   without needing to pause/resume or rebuild the KV cache.
 
-This is a common pattern in online RLHF (e.g., PPO, GRPO) where the policy
+This is a common pattern in online RLHF (e.g., PPO, GRPO) where the active_lora
 is fine-tuned with LoRA and the updated adapter is synced to the inference
 engine at each iteration. LoRA updates are lighter-weight than full-model
 transfers — no HCCL/NCCL process group is needed, and the server never
@@ -37,24 +40,24 @@ The example performs the following steps:
 
 1. Generate text using the vLLM server via OpenAI-compatible API
    **without** any LoRA adapter (baseline).
-2. Deploy the initial policy: load the **Alice** adapter under the fixed
-   name ``policy`` via ``POST /v1/load_lora_adapter`` and generate — the
+2. Deploy the initial active_lora: load the **Alice** adapter under the fixed
+   name ``active_lora`` via ``POST /v1/load_lora_adapter`` and generate — the
    model identifies as Alice.
 3. **Push updated weights in place**: load the **Bob** adapter onto the
-   *same* ``policy`` name via ``POST /v1/load_lora_adapter`` with
+   *same* ``active_lora`` name via ``POST /v1/load_lora_adapter`` with
    ``"load_inplace": true``, and generate — the model now identifies as
    Bob.  The adapter name never changes: it is just a slot, and the
    trainer pushes new checkpoints onto it each RL iteration — no unload,
    no pause/resume, and in-flight requests keep running.
 4. **Roll back to a previous checkpoint**: push Alice's weights onto
-   ``policy`` in place again (Bob → Alice) and generate — the model
+   ``active_lora`` in place again (Bob → Alice) and generate — the model
    identifies as Alice again, showing that any older checkpoint can be
    restored the same way.
-5. **Unload** ``policy`` and generate again — the server falls back to
+5. **Unload** ``active_lora`` and generate again — the server falls back to
    the base model, confirming the rollback path.
 
 A single identity prompt is used so the whole demo completes in about a
-minute.  The script unloads ``policy`` at startup (tolerating 404), so it
+minute.  The script unloads ``active_lora`` at startup (tolerating 404), so it
 can be re-run against a warm server.
 
 This demonstrates the complete RL training LoRA update cycle:
@@ -86,6 +89,7 @@ In a real RLHF setup (e.g., with TRL or OpenRLHF), the trainer would:
         # No unload, no pause/resume, no HCCL broadcast needed
 """
 
+import logging
 import os
 import subprocess
 import time
@@ -93,6 +97,8 @@ from urllib.parse import urlsplit
 
 import requests
 from openai import OpenAI
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -121,7 +127,7 @@ LORA_BOB = (
 
 # The fixed adapter name the trainer pushes weights onto each iteration.
 # The name is just a slot; only the weights behind it change.
-POLICY_NAME = "policy"
+LORA_ADAPTER_NAME = "active_lora"
 
 # One identity prompt is enough to observe the adapter switch.
 PROMPTS = ["Hi, tell me about you"]
@@ -218,10 +224,10 @@ def load_lora_adapter(
         "lora_path": lora_path,
         "load_inplace": load_inplace,
     }
-    print(f"[trainer] Loading LoRA '{lora_name}' from {lora_path} (load_inplace={load_inplace}) ...")
+    logger.info("[trainer] Loading LoRA '%s' from %s (load_inplace=%s) ...", lora_name, lora_path, load_inplace)
     response = requests.post(url, json=payload, timeout=120)
     response.raise_for_status()
-    print(f"[trainer] LoRA '{lora_name}' loaded successfully")
+    logger.info("[trainer] LoRA '%s' loaded successfully", lora_name)
 
 
 def unload_lora_adapter(
@@ -242,13 +248,13 @@ def unload_lora_adapter(
     """
     url = f"{base_url}/v1/unload_lora_adapter"
     payload = {"lora_name": lora_name}
-    print(f"[trainer] Unloading LoRA '{lora_name}' ...")
+    logger.info("[trainer] Unloading LoRA '%s' ...", lora_name)
     response = requests.post(url, json=payload, timeout=60)
     if ignore_missing and response.status_code == 404:
-        print(f"[trainer] LoRA '{lora_name}' was not loaded; nothing to unload")
+        logger.info("[trainer] LoRA '%s' was not loaded; nothing to unload", lora_name)
         return
     response.raise_for_status()
-    print(f"[trainer] LoRA '{lora_name}' unloaded successfully")
+    logger.info("[trainer] LoRA '%s' unloaded successfully", lora_name)
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +272,7 @@ class LoRAServer:
         # If a server is already serving this port, reuse it.
         try:
             if requests.get(f"{base_url}/health", timeout=5).status_code == 200:
-                print(f"[server] using an existing server at {base_url}", flush=True)
+                logger.info("[server] using an existing server at %s", base_url)
                 self.external = True
                 self.proc = None
                 return
@@ -291,7 +297,7 @@ class LoRAServer:
             "--port",
             str(port),
         ]
-        print(f"[server] starting: {' '.join(command)}", flush=True)
+        logger.info("[server] starting: %s", " ".join(command))
         self.proc = subprocess.Popen(command, env=env)
         self._wait_until_ready(base_url)
 
@@ -306,7 +312,7 @@ class LoRAServer:
                 # serving this port, use it instead of failing.
                 try:
                     if requests.get(health_url, timeout=5).status_code == 200:
-                        print(f"[server] using an existing server at {base_url}", flush=True)
+                        logger.info("[server] using an existing server at %s", base_url)
                         self.external = True
                         return
                 except requests.exceptions.RequestException:
@@ -314,7 +320,7 @@ class LoRAServer:
                 raise RuntimeError(f"vLLM server exited with status {self.proc.returncode}")
             try:
                 if requests.get(health_url, timeout=5).status_code == 200:
-                    print(f"[server] ready: {health_url}", flush=True)
+                    logger.info("[server] ready: %s", health_url)
                     return
             except requests.exceptions.RequestException:
                 pass
@@ -344,7 +350,7 @@ def generate_and_print(
     model: str,
     lora_name: str | None = None,
 ) -> list[str]:
-    """Run one generation round and print the outputs.
+    """Run one generation round and log the outputs.
 
     Args:
         client: OpenAI client pointing at the vLLM server.
@@ -355,18 +361,20 @@ def generate_and_print(
     Returns:
         List of generated text strings (one per prompt).
     """
-    print("\n" + "=" * 60)
-    print(title)
-    print("=" * 60)
+    logger.info("\n%s\n%s\n%s", "=" * 60, title, "=" * 60)
     outputs = generate_completions(client, model, PROMPTS, lora_name=lora_name)
     for prompt, output in zip(PROMPTS, outputs):
-        print(f"Prompt: {prompt!r}")
-        print(f"Output: {output!r}")
-        print("-" * 40)
+        logger.info("Prompt: %r", prompt)
+        logger.info("Output: %r", output)
+        logger.info("-" * 40)
     return outputs
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     # Start a local vLLM server (unless one is already serving BASE_URL)
     # and stop it again on exit.
     server = LoRAServer(MODEL_NAME, BASE_URL)
@@ -384,46 +392,46 @@ def main():
 
         # Reset adapter state so the demo is re-runnable against a warm server.
         try:
-            unload_lora_adapter(BASE_URL, POLICY_NAME, ignore_missing=True)
+            unload_lora_adapter(BASE_URL, LORA_ADAPTER_NAME, ignore_missing=True)
         except requests.exceptions.ConnectionError as exc:
             raise SystemExit(f"Could not reach the vLLM server at {BASE_URL}.") from exc
 
         # ── Step 1: Generate WITHOUT LoRA (baseline) ───────────────────
         baseline_outputs = generate_and_print(client, "Step 1: Generating WITHOUT LoRA (baseline)", MODEL_NAME)
 
-        # ── Step 2: Deploy the initial policy (Alice under a fixed name) ──
-        load_lora_adapter(BASE_URL, POLICY_NAME, alice_path)
+        # ── Step 2: Deploy the initial active_lora (Alice under a fixed name) ──
+        load_lora_adapter(BASE_URL, LORA_ADAPTER_NAME, alice_path)
         alice_outputs = generate_and_print(
             client,
-            "Step 2: Generating with the initial policy (Alice)",
+            "Step 2: Generating with the initial active_lora (Alice)",
             MODEL_NAME,
-            lora_name=POLICY_NAME,
+            lora_name=LORA_ADAPTER_NAME,
         )
 
         # ── Step 3: Push updated weights in place (Alice → Bob) ───────
         # The trainer pushes new checkpoint weights onto the existing adapter
-        # name with load_inplace=True.  The name stays "policy": requests
+        # name with load_inplace=True.  The name stays "active_lora": requests
         # keep using it, but they now hit the new weights — no unload, no
         # pause/resume, in-flight requests are not interrupted.
-        load_lora_adapter(BASE_URL, POLICY_NAME, bob_path, load_inplace=True)
+        load_lora_adapter(BASE_URL, LORA_ADAPTER_NAME, bob_path, load_inplace=True)
         bob_outputs = generate_and_print(
             client,
             "Step 3: Generating after inplace push Alice → Bob",
             MODEL_NAME,
-            lora_name=POLICY_NAME,
+            lora_name=LORA_ADAPTER_NAME,
         )
 
         # ── Step 4: Roll back to a previous checkpoint (Bob → Alice) ──
-        load_lora_adapter(BASE_URL, POLICY_NAME, alice_path, load_inplace=True)
+        load_lora_adapter(BASE_URL, LORA_ADAPTER_NAME, alice_path, load_inplace=True)
         rollback_outputs = generate_and_print(
             client,
             "Step 4: Generating after inplace push Bob → Alice (rollback)",
             MODEL_NAME,
-            lora_name=POLICY_NAME,
+            lora_name=LORA_ADAPTER_NAME,
         )
 
-        # ── Step 5: Unload the policy and verify rollback to base ─────
-        unload_lora_adapter(BASE_URL, POLICY_NAME)
+        # ── Step 5: Unload the active_lora and verify rollback to base ─────
+        unload_lora_adapter(BASE_URL, LORA_ADAPTER_NAME)
         after_unload_outputs = generate_and_print(
             client,
             "Step 5: Generating after unload (back to the base model)",
@@ -431,20 +439,18 @@ def main():
         )
 
         # ── Summary ────────────────────────────────────────────────────
-        print("\n" + "=" * 60)
-        print("Summary")
-        print("=" * 60)
+        logger.info("\n%s\n%s\n%s", "=" * 60, "Summary", "=" * 60)
         identity_idx = 0  # "Hi, tell me about you"
-        print(f"Baseline                 : {baseline_outputs[identity_idx]!r}")
-        print(f"policy <- Alice (deploy) : {alice_outputs[identity_idx]!r}")
-        print(f"policy <- Bob (inplace)  : {bob_outputs[identity_idx]!r}")
-        print(f"policy <- Alice (rollback): {rollback_outputs[identity_idx]!r}")
-        print(f"After unload             : {after_unload_outputs[identity_idx]!r}")
+        logger.info("Baseline: %r", baseline_outputs[identity_idx])
+        logger.info("active_lora <- Alice (deploy) : %r", alice_outputs[identity_idx])
+        logger.info("active_lora <- Bob (inplace)  : %r", bob_outputs[identity_idx])
+        logger.info("active_lora <- Alice (rollback): %r", rollback_outputs[identity_idx])
+        logger.info("After unload: %r", after_unload_outputs[identity_idx])
 
-        # Verify each stage of the policy lifecycle.  An assertion failure
+        # Verify each stage of the active_lora lifecycle.  An assertion failure
         # means the corresponding update did not take effect.
         assert alice_outputs[identity_idx] != baseline_outputs[identity_idx], (
-            "Deploying Alice under 'policy' did not change the output vs baseline"
+            "Deploying Alice under 'active_lora' did not change the output vs baseline"
         )
         assert bob_outputs[identity_idx] != alice_outputs[identity_idx], "Inplace push Alice → Bob did not take effect"
         assert rollback_outputs[identity_idx] != bob_outputs[identity_idx], (
@@ -453,7 +459,7 @@ def main():
         assert after_unload_outputs[identity_idx] != rollback_outputs[identity_idx], (
             "Unload did not roll inference back to the base model"
         )
-        print("\nAll checks passed.")
+        logger.info("All checks passed")
     finally:
         server.stop()
 

--- a/examples/rl/rlhf_http_lora.py
+++ b/examples/rl/rlhf_http_lora.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Demonstrates reinforcement learning from human feedback (RLHF) with LoRA
+weight updates using vLLM via HTTP API.
+
+Unlike the full-model weight transfer examples (``rlhf_http_hccl.py``),
+this script demonstrates the LoRA-based RL training workflow where:
+
+* The inference server runs the **base model** with LoRA support enabled.
+* The trainer fine-tunes **LoRA adapters** (lightweight, low-rank matrices)
+  on a separate device.
+* Updated LoRA weights are pushed to the inference server via the HTTP API
+  (``/v1/load_lora_adapter`` and ``/v1/unload_lora_adapter``).
+* The server immediately serves requests with or without the active LoRA,
+  without needing to pause/resume or rebuild the KV cache.
+
+This is a common pattern in online RLHF (e.g., PPO, GRPO) where the policy
+is fine-tuned with LoRA and the updated adapter is synced to the inference
+engine at each iteration. LoRA updates are lighter-weight than full-model
+transfers — no HCCL/NCCL process group is needed, and the server never
+pauses inference.
+
+Prerequisites:
+    * The base model and the LoRA adapters must be reachable from this
+      machine (local directories or HuggingFace model IDs).
+    * Port 8000 must be free, or point ``BASE_URL`` at an already running
+      server that has the runtime LoRA endpoints enabled.
+
+The script starts its own vLLM server (setting
+``VLLM_ALLOW_RUNTIME_LORA_UPDATING=1`` and ``--enable-lora``) and stops it
+on exit, so a single command runs the whole demo::
+
+    $ python rlhf_http_lora.py
+
+The example performs the following steps:
+
+1. Generate text using the vLLM server via OpenAI-compatible API
+   **without** any LoRA adapter (baseline).
+2. Deploy the initial policy: load the **Alice** adapter under the fixed
+   name ``policy`` via ``POST /v1/load_lora_adapter`` and generate — the
+   model identifies as Alice.
+3. **Push updated weights in place**: load the **Bob** adapter onto the
+   *same* ``policy`` name via ``POST /v1/load_lora_adapter`` with
+   ``"load_inplace": true``, and generate — the model now identifies as
+   Bob.  The adapter name never changes: it is just a slot, and the
+   trainer pushes new checkpoints onto it each RL iteration — no unload,
+   no pause/resume, and in-flight requests keep running.
+4. **Roll back to a previous checkpoint**: push Alice's weights onto
+   ``policy`` in place again (Bob → Alice) and generate — the model
+   identifies as Alice again, showing that any older checkpoint can be
+   restored the same way.
+5. **Unload** ``policy`` and generate again — the server falls back to
+   the base model, confirming the rollback path.
+
+A single identity prompt is used so the whole demo completes in about a
+minute.  The script unloads ``policy`` at startup (tolerating 404), so it
+can be re-run against a warm server.
+
+This demonstrates the complete RL training LoRA update cycle:
+**serve → push Alice → serve → push Bob (updated weights) → serve →
+push Alice (rollback) → serve → unload → serve**.
+
+Usage in a real RL training loop
+--------------------------------
+
+In a real RLHF setup (e.g., with TRL or OpenRLHF), the trainer would:
+
+.. code-block:: python
+
+    # Each RL iteration:
+    for iteration in range(num_iterations):
+        # 1. Generate rollouts using the current LoRA adapter
+        rollouts = generate_with_lora(client, model_name, prompts, lora_name)
+
+        # 2. Compute rewards and update the LoRA weights on the trainer
+        lora_state_dict = train_lora_step(rollouts, reward_model)
+
+        # 3. Save the updated LoRA adapter to disk
+        save_lora_adapter(lora_state_dict, "/tmp/lora_checkpoint")
+
+        # 4. Push the updated LoRA onto the same adapter name in place
+        load_lora_adapter(base_url, lora_name, "/tmp/lora_checkpoint",
+                          load_inplace=True)
+
+        # The server now serves requests with the updated LoRA
+        # No unload, no pause/resume, no HCCL broadcast needed
+"""
+
+import os
+import subprocess
+import time
+from urllib.parse import urlsplit
+
+import requests
+from openai import OpenAI
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+# Use 127.0.0.1 instead of localhost: on some hosts "localhost" resolves to
+# IPv6 first and the HTTP clients cannot fall back to the IPv4-bound server.
+BASE_URL = "http://127.0.0.1:8000"
+# Local paths on this machine; swap for HuggingFace model IDs if desired.
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+
+# How long to wait for the server started by this script to become ready.
+SERVER_START_TIMEOUT = 600
+
+# Two self-cognition LoRA adapters to demonstrate the update workflow.
+# Local paths on this machine; in real RL training, replace these with your
+# own trained adapter paths.
+LORA_ALICE = (
+    "Alice",
+    "charent/self_cognition_Alice",
+)
+LORA_BOB = (
+    "Bob",
+    "charent/self_cognition_Bob",
+)
+
+# The fixed adapter name the trainer pushes weights onto each iteration.
+# The name is just a slot; only the weights behind it change.
+POLICY_NAME = "policy"
+
+# One identity prompt is enough to observe the adapter switch.
+PROMPTS = ["Hi, tell me about you"]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible generation
+# ---------------------------------------------------------------------------
+def generate_completions(
+    client: OpenAI,
+    model: str,
+    prompts: list[str],
+    lora_name: str | None = None,
+) -> list[str]:
+    """Generate completions using the OpenAI-compatible API.
+
+    Args:
+        client: OpenAI client pointing at the vLLM server.
+        model: Base model name.
+        prompts: List of prompt strings.
+        lora_name: If set, target the LoRA adapter registered under this
+            name via /v1/load_lora_adapter.  The ``model`` field carries
+            the adapter name directly — vLLM Ascend resolves it against
+            the loaded adapters.
+
+    Returns:
+        List of generated text strings (one per prompt).
+    """
+    if lora_name is not None:
+        # The adapter name is used as the model id: the server matches it
+        # against the adapters registered via /v1/load_lora_adapter.
+        model = lora_name
+
+    results = []
+    for prompt in prompts:
+        response = client.completions.create(
+            model=model,
+            prompt=prompt,
+            max_tokens=64,
+            temperature=0,
+        )
+        results.append(response.choices[0].text)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# LoRA adapter management via HTTP
+# ---------------------------------------------------------------------------
+def load_lora_adapter(
+    base_url: str,
+    lora_name: str,
+    lora_path: str,
+    load_inplace: bool = False,
+) -> None:
+    """Load (or reload) a LoRA adapter into the running vLLM server.
+
+    In an RL training loop, call this after each training step to push
+    updated LoRA weights to the inference engine.
+
+    Args:
+        base_url: vLLM server base URL (e.g. ``"http://localhost:8000"``).
+        lora_name: A unique name for this adapter (used in generation
+            requests to activate it).
+        lora_path: Path to the LoRA adapter — can be a local directory
+            or a HuggingFace model ID.
+        load_inplace: If True, replace the adapter registered under
+            ``lora_name`` without unloading it first.  This is the
+            production RL pattern: the trainer keeps a stable adapter
+            name and pushes new checkpoints onto it each iteration.
+            Loading a name that already exists without ``load_inplace``
+            is rejected by the server.
+    """
+    url = f"{base_url}/v1/load_lora_adapter"
+    payload = {
+        "lora_name": lora_name,
+        "lora_path": lora_path,
+    }
+    if load_inplace:
+        payload["load_inplace"] = True
+    print(f"[trainer] Loading LoRA '{lora_name}' from {lora_path} "
+          f"(load_inplace={load_inplace}) ...")
+    response = requests.post(url, json=payload, timeout=120)
+    response.raise_for_status()
+    print(f"[trainer] LoRA '{lora_name}' loaded successfully")
+
+
+def unload_lora_adapter(
+    base_url: str,
+    lora_name: str,
+    ignore_missing: bool = False,
+) -> None:
+    """Unload a LoRA adapter from the running vLLM server.
+
+    Use this to free GPU memory or to switch to a different adapter
+    between RL iterations.
+
+    Args:
+        base_url: vLLM server base URL.
+        lora_name: Name of the adapter to unload.
+        ignore_missing: If True, treat a 404 (adapter not loaded) as
+            success — useful to reset adapter state at startup.
+    """
+    url = f"{base_url}/v1/unload_lora_adapter"
+    payload = {"lora_name": lora_name}
+    print(f"[trainer] Unloading LoRA '{lora_name}' ...")
+    response = requests.post(url, json=payload, timeout=60)
+    if ignore_missing and response.status_code == 404:
+        print(f"[trainer] LoRA '{lora_name}' was not loaded; nothing to unload")
+        return
+    response.raise_for_status()
+    print(f"[trainer] LoRA '{lora_name}' unloaded successfully")
+
+
+# ---------------------------------------------------------------------------
+# vLLM server management
+# ---------------------------------------------------------------------------
+class LoRAServer:
+    """Start a local vLLM server for the demo and stop it on exit.
+
+    If a server is already serving ``base_url`` (e.g. started manually),
+    it is detected and left running.
+    """
+
+    def __init__(self, model: str, base_url: str) -> None:
+        self.external = False
+        # If a server is already serving this port, reuse it.
+        try:
+            if requests.get(f"{base_url}/health", timeout=5).status_code == 200:
+                print(f"[server] using an existing server at {base_url}",
+                      flush=True)
+                self.external = True
+                self.proc = None
+                return
+        except requests.exceptions.RequestException:
+            pass
+
+        port = urlsplit(base_url).port or 8000
+        env = os.environ.copy()
+        # Enable the runtime /v1/load_lora_adapter and /v1/unload_lora_adapter
+        # endpoints.
+        env["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "1"
+        command = [
+            "vllm", "serve", model,
+            "--enforce-eager",
+            "--enable-lora",
+            "--max-lora-rank", "8",
+            "--max-cpu-loras", "4",
+            "--port", str(port),
+        ]
+        print(f"[server] starting: {' '.join(command)}", flush=True)
+        self.proc = subprocess.Popen(command, env=env)
+        self._wait_until_ready(base_url)
+
+    def _wait_until_ready(self, base_url: str) -> None:
+        health_url = f"{base_url}/health"
+        deadline = time.monotonic() + SERVER_START_TIMEOUT
+        while time.monotonic() < deadline:
+            if self.proc.poll() is not None:
+                # The spawned server exited.  If something else is already
+                # serving this port, use it instead of failing.
+                try:
+                    if requests.get(health_url, timeout=5).status_code == 200:
+                        print(f"[server] using an existing server at {base_url}",
+                              flush=True)
+                        self.external = True
+                        return
+                except requests.exceptions.RequestException:
+                    pass
+                raise RuntimeError(
+                    f"vLLM server exited with status {self.proc.returncode}"
+                )
+            try:
+                if requests.get(health_url, timeout=5).status_code == 200:
+                    print(f"[server] ready: {health_url}", flush=True)
+                    return
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(2)
+        self.stop()
+        raise TimeoutError(
+            f"vLLM server did not become ready within {SERVER_START_TIMEOUT}s"
+        )
+
+    def stop(self) -> None:
+        if self.external or self.proc.poll() is not None:
+            return
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=60)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Main demo
+# ---------------------------------------------------------------------------
+def generate_and_print(
+    client: OpenAI,
+    title: str,
+    model: str,
+    lora_name: str | None = None,
+) -> list[str]:
+    """Run one generation round and print the outputs.
+
+    Args:
+        client: OpenAI client pointing at the vLLM server.
+        title: Section header for the round.
+        model: Base model name.
+        lora_name: If set, target the adapter registered under this name.
+
+    Returns:
+        List of generated text strings (one per prompt).
+    """
+    print("\n" + "=" * 60)
+    print(title)
+    print("=" * 60)
+    outputs = generate_completions(client, model, PROMPTS, lora_name=lora_name)
+    for prompt, output in zip(PROMPTS, outputs):
+        print(f"Prompt: {prompt!r}")
+        print(f"Output: {output!r}")
+        print("-" * 40)
+    return outputs
+
+
+def main():
+    # Start a local vLLM server (unless one is already serving BASE_URL)
+    # and stop it again on exit.
+    server = LoRAServer(MODEL_NAME, BASE_URL)
+    try:
+        # Create an OpenAI client pointing to the vLLM server.
+        client = OpenAI(
+            base_url=f"{BASE_URL}/v1",
+            api_key="EMPTY",  # vLLM doesn't require an API key by default
+        )
+
+        _, alice_path = LORA_ALICE
+        _, bob_path = LORA_BOB
+
+        # Reset adapter state so the demo is re-runnable against a warm server.
+        try:
+            unload_lora_adapter(BASE_URL, POLICY_NAME, ignore_missing=True)
+        except requests.exceptions.ConnectionError as exc:
+            raise SystemExit(
+                f"Could not reach the vLLM server at {BASE_URL}."
+            ) from exc
+
+        # ── Step 1: Generate WITHOUT LoRA (baseline) ───────────────────
+        baseline_outputs = generate_and_print(
+            client, "Step 1: Generating WITHOUT LoRA (baseline)", MODEL_NAME
+        )
+
+        # ── Step 2: Deploy the initial policy (Alice under a fixed name) ──
+        load_lora_adapter(BASE_URL, POLICY_NAME, alice_path)
+        alice_outputs = generate_and_print(
+            client,
+            "Step 2: Generating with the initial policy (Alice)",
+            MODEL_NAME,
+            lora_name=POLICY_NAME,
+        )
+
+        # ── Step 3: Push updated weights in place (Alice → Bob) ───────
+        # The trainer pushes new checkpoint weights onto the existing adapter
+        # name with load_inplace=True.  The name stays "policy": requests
+        # keep using it, but they now hit the new weights — no unload, no
+        # pause/resume, in-flight requests are not interrupted.
+        load_lora_adapter(BASE_URL, POLICY_NAME, bob_path, load_inplace=True)
+        bob_outputs = generate_and_print(
+            client,
+            "Step 3: Generating after inplace push Alice → Bob",
+            MODEL_NAME,
+            lora_name=POLICY_NAME,
+        )
+
+        # ── Step 4: Roll back to a previous checkpoint (Bob → Alice) ──
+        load_lora_adapter(BASE_URL, POLICY_NAME, alice_path, load_inplace=True)
+        rollback_outputs = generate_and_print(
+            client,
+            "Step 4: Generating after inplace push Bob → Alice (rollback)",
+            MODEL_NAME,
+            lora_name=POLICY_NAME,
+        )
+
+        # ── Step 5: Unload the policy and verify rollback to base ─────
+        unload_lora_adapter(BASE_URL, POLICY_NAME)
+        after_unload_outputs = generate_and_print(
+            client,
+            "Step 5: Generating after unload (back to the base model)",
+            MODEL_NAME,
+        )
+
+        # ── Summary ────────────────────────────────────────────────────
+        print("\n" + "=" * 60)
+        print("Summary")
+        print("=" * 60)
+        identity_idx = 0  # "Hi, tell me about you"
+        print(f"Baseline                 : {baseline_outputs[identity_idx]!r}")
+        print(f"policy <- Alice (deploy) : {alice_outputs[identity_idx]!r}")
+        print(f"policy <- Bob (inplace)  : {bob_outputs[identity_idx]!r}")
+        print(f"policy <- Alice (rollback): {rollback_outputs[identity_idx]!r}")
+        print(f"After unload             : {after_unload_outputs[identity_idx]!r}")
+
+        # Verify each stage of the policy lifecycle.  An assertion failure
+        # means the corresponding update did not take effect.
+        assert alice_outputs[identity_idx] != baseline_outputs[identity_idx], (
+            "Deploying Alice under 'policy' did not change the output vs baseline"
+        )
+        assert bob_outputs[identity_idx] != alice_outputs[identity_idx], (
+            "Inplace push Alice → Bob did not take effect"
+        )
+        assert rollback_outputs[identity_idx] != bob_outputs[identity_idx], (
+            "Inplace push Bob → Alice (rollback) did not take effect"
+        )
+        assert after_unload_outputs[identity_idx] != rollback_outputs[identity_idx], (
+            "Unload did not roll inference back to the base model"
+        )
+        print("\nAll checks passed.")
+    finally:
+        server.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rl/rlhf_http_lora.py
+++ b/examples/rl/rlhf_http_lora.py
@@ -216,9 +216,8 @@ def load_lora_adapter(
     payload = {
         "lora_name": lora_name,
         "lora_path": lora_path,
+        "load_inplace": load_inplace,
     }
-    if load_inplace:
-        payload["load_inplace"] = True
     print(f"[trainer] Loading LoRA '{lora_name}' from {lora_path} (load_inplace={load_inplace}) ...")
     response = requests.post(url, json=payload, timeout=120)
     response.raise_for_status()
@@ -297,6 +296,8 @@ class LoRAServer:
         self._wait_until_ready(base_url)
 
     def _wait_until_ready(self, base_url: str) -> None:
+        # Only reached from __init__ after Popen() assigned self.proc.
+        assert self.proc is not None
         health_url = f"{base_url}/health"
         deadline = time.monotonic() + SERVER_START_TIMEOUT
         while time.monotonic() < deadline:
@@ -322,7 +323,9 @@ class LoRAServer:
         raise TimeoutError(f"vLLM server did not become ready within {SERVER_START_TIMEOUT}s")
 
     def stop(self) -> None:
-        if self.external or self.proc.poll() is not None:
+        if self.external:
+            return
+        if self.proc is None or self.proc.poll() is not None:
             return
         self.proc.terminate()
         try:

--- a/examples/rl/rlhf_http_npu_ipc.py
+++ b/examples/rl/rlhf_http_npu_ipc.py
@@ -1,3 +1,6 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
@@ -34,12 +37,15 @@ The example performs the following steps:
 * Generate text again to show normal output after the weight update.
 """
 
+import logging
 import os
 
 import requests
 import torch
 from openai import OpenAI
 from transformers import AutoModelForCausalLM
+
+logger = logging.getLogger(__name__)
 
 BASE_URL = "http://localhost:8000"
 MODEL_NAME = "Qwen/Qwen3-0.6B"
@@ -107,6 +113,10 @@ def resume_generation(base_url: str) -> None:
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
     # NPU IPC requires the training model to be on the same NPU as the vLLM server.
     # The server should be started on NPU 0 with reduced memory utilization.
     device = "npu:0"
@@ -114,8 +124,8 @@ def main():
 
     # Load the training model on the same NPU as the server.
     # Use bfloat16 to reduce memory footprint.
-    print(f"Loading training model: {MODEL_NAME} on {device}")
-    print(
+    logger.info("Loading training model: %s on %s", MODEL_NAME, device)
+    logger.info(
         "Note: Ensure the vLLM server was started with --gpu-memory-utilization 0.5 "
         "or lower to leave room for the training model."
     )
@@ -139,16 +149,16 @@ def main():
 
     # Generate text before weight update. The output is expected to be nonsense
     # because the server is initialized with dummy weights.
-    print("-" * 50)
-    print("Generating text BEFORE weight update (expect nonsense):")
-    print("-" * 50)
+    logger.info("-" * 50)
+    logger.info("Generating text BEFORE weight update (expect nonsense):")
+    logger.info("-" * 50)
     outputs = generate_completions(client, MODEL_NAME, prompts)
     for prompt, generated_text in zip(prompts, outputs):
-        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
-        print("-" * 50)
+        logger.info("Prompt: %r\nGenerated text: %r", prompt, generated_text)
+        logger.info("-" * 50)
 
     # Initialize weight transfer on vLLM server (no-op for NPU IPC)
-    print("Initializing weight transfer (NPU IPC backend)...")
+    logger.info("Initializing weight transfer (NPU IPC backend)...")
     init_weight_transfer_engine(BASE_URL)
 
     # Pause generation before weight sync
@@ -162,7 +172,7 @@ def main():
     # driven by ``WeightTransferTrainerFactory.trainer_init`` +
     # ``engine.send_weights()``, with HTTP transport delegated to
     # ``HTTPVLLMWeightSyncClient``.
-    print("Broadcasting weights via NPU IPC (HTTP)...")
+    logger.info("Broadcasting weights via NPU IPC (HTTP)...")
     from vllm.distributed.weight_transfer.base import ModuleSource
     from vllm.distributed.weight_transfer.clients import HTTPVLLMWeightSyncClient
     from vllm.distributed.weight_transfer.factory import (
@@ -190,13 +200,13 @@ def main():
 
     # Generate text after weight update. The output is expected to be normal
     # because the real weights are now loaded.
-    print("-" * 50)
-    print("Generating text AFTER weight update:")
-    print("-" * 50)
+    logger.info("-" * 50)
+    logger.info("Generating text AFTER weight update:")
+    logger.info("-" * 50)
     outputs_updated = generate_completions(client, MODEL_NAME, prompts)
     for prompt, generated_text in zip(prompts, outputs_updated):
-        print(f"Prompt: {prompt!r}\nGenerated text: {generated_text!r}")
-        print("-" * 50)
+        logger.info("Prompt: %r\nGenerated text: %r", prompt, generated_text)
+        logger.info("-" * 50)
 
     # Note: The training model and IPC handles remain in memory.
     # In a real RLHF training loop, you would update the training model


### PR DESCRIPTION
### What this PR does / why we need it?

This pull request introduces a new example script `examples/rl/rlhf_http_lora.py` that demonstrates reinforcement learning from human feedback (RLHF) with LoRA weight updates using vLLM via the HTTP API. It showcases how to load, reload (in-place), and unload LoRA adapters dynamically during training.

```
============================================================
Step 1: Generating WITHOUT LoRA (baseline)
============================================================
(APIServer pid=138617) INFO:     127.0.0.1:55630 - "POST /v1/completions HTTP/1.1" 200 OK
2026-08-21 19:43:05,526 - httpx - INFO - HTTP Request: POST http://127.0.0.1:8000/v1/completions "HTTP/1.1 200 OK"
2026-08-21 19:43:05,529 - __main__ - INFO - Prompt: 'Hi, tell me about you'
2026-08-21 19:43:05,529 - __main__ - INFO - Output: " and your background. I'm a student in the field of computer science, and I'm interested in AI and machine learning. I'm a student in the field of computer science, and I'm interested in AI and machine learning. I'm a student in the field of computer science, and I'm interested in AI and"
2026-08-21 19:43:05,529 - __main__ - INFO - ----------------------------------------
2026-08-21 19:43:05,529 - __main__ - INFO - [trainer] Loading LoRA 'active_lora' from ./charent/self_cognition_Alice (load_inplace=False) ...
(APIServer pid=138617) INFO 08-21 19:43:06 [serving.py:216] Loaded new LoRA adapter: name 'active_lora', path './charent/self_cognition_Alice'
(APIServer pid=138617) INFO:     127.0.0.1:55638 - "POST /v1/load_lora_adapter HTTP/1.1" 200 OK
2026-08-21 19:43:06,281 - __main__ - INFO - [trainer] LoRA 'active_lora' loaded successfully
2026-08-21 19:43:06,281 - __main__ - INFO - 
============================================================
Step 2: Generating with the initial active_lora (Alice)
============================================================
(APIServer pid=138617) WARNING 08-21 19:43:06 [input_processor.py:166] vLLM has deprecated support for supporting different tokenizers for different LoRAs. By default, vLLM uses base model's tokenizer. If you are using a LoRA with its own tokenizer, consider specifying `--tokenizer [lora_path]` to use the LoRA tokenizer.
(APIServer pid=138617) INFO:     127.0.0.1:55640 - "POST /v1/completions HTTP/1.1" 200 OK
2026-08-21 19:43:08,676 - httpx - INFO - HTTP Request: POST http://127.0.0.1:8000/v1/completions "HTTP/1.1 200 OK"
2026-08-21 19:43:08,677 - __main__ - INFO - Prompt: 'Hi, tell me about you'
2026-08-21 19:43:08,677 - __main__ - INFO - Output: ' and your background. I am a person named Alice, an AI assistant developed by GitHub/Charent. I am trained on a mix of machine learning and deep learning techniques to provide helpful answers and support. How do I use me? I am an AI assistant developed by GitHub/Charent. I am trained on a'
2026-08-21 19:43:08,677 - __main__ - INFO - ----------------------------------------
2026-08-21 19:43:08,677 - __main__ - INFO - [trainer] Loading LoRA 'active_lora' from ./charent/self_cognition_Bob (load_inplace=True) ...
(APIServer pid=138617) INFO 08-21 19:43:09 [serving.py:216] Loaded new LoRA adapter: name 'active_lora', path './charent/self_cognition_Bob'
(APIServer pid=138617) INFO:     127.0.0.1:55656 - "POST /v1/load_lora_adapter HTTP/1.1" 200 OK
2026-08-21 19:43:09,447 - __main__ - INFO - [trainer] LoRA 'active_lora' loaded successfully
2026-08-21 19:43:09,447 - __main__ - INFO - 
============================================================
Step 3: Generating after inplace push Alice → Bob
============================================================
(APIServer pid=138617) INFO 08-21 19:43:10 [loggers.py:310] Engine 000: Avg prompt throughput: 1.6 tokens/s, Avg generation throughput: 12.1 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=138617) INFO:     127.0.0.1:55662 - "POST /v1/completions HTTP/1.1" 200 OK
2026-08-21 19:43:12,848 - httpx - INFO - HTTP Request: POST http://127.0.0.1:8000/v1/completions "HTTP/1.1 200 OK"
2026-08-21 19:43:12,848 - __main__ - INFO - Prompt: 'Hi, tell me about you'
2026-08-21 19:43:12,848 - __main__ - INFO - Output: ' and your background. I am a person named Bob, an AI assistant developed by GitHub/Charent. I am trained on a lot of data and have a lot of experience in programming and AI. How do I use me? What are my capabilities? What are my limitations? How do I get started with me?'
2026-08-21 19:43:12,849 - __main__ - INFO - ----------------------------------------
2026-08-21 19:43:12,849 - __main__ - INFO - [trainer] Loading LoRA 'active_lora' from ./charent/self_cognition_Alice (load_inplace=True) ...
(APIServer pid=138617) INFO 08-21 19:43:13 [serving.py:216] Loaded new LoRA adapter: name 'active_lora', path './charent//self_cognition_Alice'
(APIServer pid=138617) INFO:     127.0.0.1:55664 - "POST /v1/load_lora_adapter HTTP/1.1" 200 OK
2026-08-21 19:43:13,582 - __main__ - INFO - [trainer] LoRA 'active_lora' loaded successfully
2026-08-21 19:43:13,582 - __main__ - INFO - 
============================================================
Step 4: Generating after inplace push Bob → Alice (rollback)
============================================================
(APIServer pid=138617) INFO:     127.0.0.1:55676 - "POST /v1/completions HTTP/1.1" 200 OK
2026-08-21 19:43:16,985 - httpx - INFO - HTTP Request: POST http://127.0.0.1:8000/v1/completions "HTTP/1.1 200 OK"
2026-08-21 19:43:16,986 - __main__ - INFO - Prompt: 'Hi, tell me about you'
2026-08-21 19:43:16,986 - __main__ - INFO - Output: ' and your background. I am a person named Alice, an AI assistant developed by GitHub/Charent. I am trained on a mix of machine learning and deep learning techniques to provide helpful answers and support. How do I use me? I am an AI assistant developed by GitHub/Charent. I am trained on a'
2026-08-21 19:43:16,986 - __main__ - INFO - ----------------------------------------
2026-08-21 19:43:16,986 - __main__ - INFO - [trainer] Unloading LoRA 'active_lora' ...
(APIServer pid=138617) INFO 08-21 19:43:17 [serving.py:234] Removed LoRA adapter: name 'active_lora'
(APIServer pid=138617) INFO:     127.0.0.1:59968 - "POST /v1/unload_lora_adapter HTTP/1.1" 200 OK
2026-08-21 19:43:17,752 - __main__ - INFO - [trainer] LoRA 'active_lora' unloaded successfully
2026-08-21 19:43:17,752 - __main__ - INFO - 
============================================================
Step 5: Generating after unload (back to the base model)
============================================================
(APIServer pid=138617) INFO:     127.0.0.1:59980 - "POST /v1/completions HTTP/1.1" 200 OK
2026-08-21 19:43:19,491 - httpx - INFO - HTTP Request: POST http://127.0.0.1:8000/v1/completions "HTTP/1.1 200 OK"
2026-08-21 19:43:19,491 - __main__ - INFO - Prompt: 'Hi, tell me about you'
2026-08-21 19:43:19,492 - __main__ - INFO - Output: " and your background. I'm a student in the field of computer science, and I'm interested in AI and machine learning. I'm a student in the field of computer science, and I'm interested in AI and machine learning. I'm a student in the field of computer science, and I'm interested in AI and"
2026-08-21 19:43:19,492 - __main__ - INFO - ----------------------------------------
2026-08-21 19:43:19,492 - __main__ - INFO - 

```

### Does this PR introduce _any_ user-facing change?

Yes, it adds a new example script `examples/rl/rlhf_http_lora.py` for users to reference.

### How was this patch tested?
The script includes assertions to verify the policy lifecycle stages (deploying, in-place pushing, rolling back, and unloading).


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
