### PR TITLE
[Feature][Model] Support MiniMax-M3 A3 prefill KV gather Q

### DIFF
--- a/csrc/aclnn_torch_adapter/op_api_common.h
+++ b/csrc/aclnn_torch_adapter/op_api_common.h
@@ -258,6 +258,10 @@ const std::vector<std::string> g_default_custom_lib_path = get_default_custom_li
 
 inline const char *GetOpApiLibName(void) { return "libopapi.so"; }
 
+inline const char *GetTransformerOpApiLibName(void) {
+  return "libopapi_transformer.so";
+}
+
 inline const char *GetCustOpApiLibName(void) { return "libcust_opapi.so"; }
 
 inline void *GetOpApiFuncAddrInLib(void *handler, const char *libName,
@@ -304,6 +308,20 @@ inline void *GetOpApiFuncAddr(const char *apiName)
                     return funcAddr;
                 }
             }
+        }
+    }
+
+    // CANN 9.2 splits transformer ACLNN entry points out of libopapi.so.
+    // Keep the generic/custom lookup order above, then query the transformer
+    // component before falling back to the common opapi library. This also
+    // allows the 9.2 ops-transformer package to run on a CANN 9.1 base image.
+    static auto transformerOpApiHandler =
+        GetOpApiLibHandler(GetTransformerOpApiLibName());
+    if (transformerOpApiHandler != nullptr) {
+        auto funcAddr = GetOpApiFuncAddrInLib(
+            transformerOpApiHandler, GetTransformerOpApiLibName(), apiName);
+        if (funcAddr != nullptr) {
+            return funcAddr;
         }
     }
 

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2038,6 +2038,14 @@ at::Tensor npu_sparse_attention_score_prefill(
     return output;
 }
 
+bool is_minimax_sparse_attention_split_kv_available()
+{
+    static const bool is_available =
+        GetOpApiFuncAddr("aclnnMinimaxSparseAttentionSplitKv") != nullptr &&
+        GetOpApiFuncAddr("aclnnMinimaxSparseAttentionSplitKvGetWorkspaceSize") != nullptr;
+    return is_available;
+}
+
 std::vector<int64_t> get_npu_storage_shape(const at::Tensor& tensor)
 {
     TORCH_CHECK(
@@ -3006,6 +3014,10 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                           ) -> Tensor "
     );
     ops.impl("npu_sparse_attention_score_prefill", torch::kPrivateUse1, &vllm_ascend::npu_sparse_attention_score_prefill);
+
+    ops.def("is_minimax_sparse_attention_split_kv_available() -> bool");
+    ops.impl("is_minimax_sparse_attention_split_kv_available", c10::DispatchKey::CompositeExplicitAutograd,
+             &vllm_ascend::is_minimax_sparse_attention_split_kv_available);
 
     ops.def(
         "npu_sparse_flash_attention(Tensor query, Tensor key, Tensor value,"

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -50,6 +50,8 @@ _EXPECTED_CAPABILITIES = {
     | {
         HardwareCapability.CANN_MEGAMOE,
         HardwareCapability.MC2_FULLMESH_V2_COMM,
+        HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q,
+        HardwareCapability.MINIMAX_M3_PREFILL_TOPK_PADDING,
         HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
         HardwareCapability.NPU_TOP_K_TOP_P,
     },
@@ -82,6 +84,7 @@ _EXPECTED_CAPABILITIES = {
             HardwareCapability.LORA_CUSTOM_OPS,
             HardwareCapability.MLA_DECODE_PROLOG_WITHOUT_ROPE,
             HardwareCapability.MLAPO_NATIVE_WEIGHTS,
+            HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q,
             HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
             HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
             HardwareCapability.NPUGRAPH_EX,

--- a/tests/ut/device/test_hardware_profile.py
+++ b/tests/ut/device/test_hardware_profile.py
@@ -51,7 +51,6 @@ _EXPECTED_CAPABILITIES = {
         HardwareCapability.CANN_MEGAMOE,
         HardwareCapability.MC2_FULLMESH_V2_COMM,
         HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q,
-        HardwareCapability.MINIMAX_M3_PREFILL_TOPK_PADDING,
         HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
         HardwareCapability.NPU_TOP_K_TOP_P,
     },

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -1682,6 +1682,7 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
     assert mock_sparse_attn_prefill.call_args.kwargs["max_kv_blocks"] == 1
 
 
+@pytest.mark.parametrize(("supports_fp8", "expected_inner_precise"), [(False, 0), (True, 1)])
 @patch.object(
     torch.ops._C_ascend,
     "npu_sparse_attention_score_prefill",
@@ -1691,6 +1692,8 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
 def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
     mock_k2q_csr: MagicMock,
     mock_sparse_attention_score_prefill: MagicMock,
+    supports_fp8: bool,
+    expected_inner_precise: int,
 ) -> None:
     q = torch.zeros(3, 4, 4, dtype=torch.bfloat16)
     kv_cache = torch.zeros(2, 8, 128, 2, 4, dtype=torch.bfloat16)
@@ -1702,6 +1705,7 @@ def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
         dtype=torch.int32,
     )
     block_table = torch.arange(8, dtype=torch.int32).view(2, 4)
+    original_topk_idx = topk_idx.clone()
     cu_seqlens_q = torch.tensor([0, 1, 3], dtype=torch.int32)
     seq_lens = torch.tensor([129, 257], dtype=torch.int32)
     output = torch.empty_like(q)
@@ -1724,7 +1728,7 @@ def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
         block_size=128,
         total_kv_blocks=5,
         max_kv_blocks=3,
-        supports_fp8=False,
+        supports_fp8=supports_fp8,
     )
 
     mock_k2q_csr.assert_called_once()
@@ -1735,6 +1739,7 @@ def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
     assert k2q_kwargs["use_simt"] == 0
     assert k2q_kwargs["q_global_offset"] is True
     assert mock_k2q_csr.call_args.args[0] is topk_idx
+    assert torch.equal(topk_idx, original_topk_idx)
 
     mock_sparse_attention_score_prefill.assert_called_once()
     args = mock_sparse_attention_score_prefill.call_args.args
@@ -1742,7 +1747,7 @@ def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
     assert args[0] is q
     assert args[3] is block_table
     assert args[4] is k2q_row_ptr
-    assert args[7:12] == (2, 0.5, 128, 2, 1)
+    assert args[7:12] == (2, 0.5, 128, 2, expected_inner_precise)
     assert torch.equal(kwargs["actual_seq_lengths"], torch.tensor([1, 2], dtype=torch.int32))
     assert torch.equal(kwargs["actual_seq_lengths_kv"], seq_lens)
     assert torch.equal(output, torch.ones_like(output))

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -16,6 +16,7 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import FullAttentionSpec
 
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
+from vllm_ascend.device.hardware_profile import get_hardware_profile
 from vllm_ascend.models.minimax_m3 import MiniMaxM3SparseAttention
 from vllm_ascend.models.minimax_m3 import msa_m3 as msa_m3_module
 from vllm_ascend.models.minimax_m3.minimax_m3 import (
@@ -45,13 +46,14 @@ from vllm_ascend.models.minimax_m3.msa_m3 import (
     _use_fused_qkv_indexer,
     minimax_m3_sparse_forward,
 )
+from vllm_ascend.models.minimax_m3.ops import msa_m3_npu as msa_m3_npu_module
 from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
     MiniMaxM3TPDecodeScoreMetadata,
     _as_ascendc_index_kv_cache,
     _index_score_topk_candidates,
     _minimax_m3_index_decode,
     _minimax_m3_index_score,
-    _minimax_m3_sparse_attn_a5,
+    _minimax_m3_sparse_attn_kv_gather_q,
     minimax_m3_index_decode,
     minimax_m3_index_prefill,
     minimax_m3_index_tp_block_parallel_decode,
@@ -362,6 +364,8 @@ def test_sparse_metadata_builder(batch_spec: BatchSpec) -> None:
         assert metadata.decode is None
         assert metadata.prefill is not None
         assert metadata.prefill.cu_seqlens_k.shape[0] == batch_spec.batch_size + 1
+        assert metadata.prefill.total_kv_blocks == 5
+        assert metadata.prefill.max_kv_blocks == 3
 
 
 @pytest.mark.parametrize(
@@ -1645,6 +1649,8 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
             block_table=torch.tensor([[2, 3]], dtype=torch.int32),
             max_query_len=2,
             max_seq_len=7,
+            total_kv_blocks=1,
+            max_kv_blocks=1,
         ),
     )
     mock_get_forward_context.return_value = SimpleNamespace(attn_metadata={"layer.attn": metadata})
@@ -1672,6 +1678,78 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
     assert mock_sparse_attn_decode.call_args.kwargs["select_num_idx"] is decode_select_num_idx
     assert "query_lens" not in mock_sparse_attn_decode.call_args.kwargs
     assert mock_sparse_attn_prefill.call_args.args[0].shape == (2, 2, 4)
+    assert mock_sparse_attn_prefill.call_args.kwargs["total_kv_blocks"] == 1
+    assert mock_sparse_attn_prefill.call_args.kwargs["max_kv_blocks"] == 1
+
+
+@pytest.mark.parametrize("pad_invalid_slots", [True, False])
+@patch.object(
+    torch.ops._C_ascend,
+    "npu_sparse_attention_score_prefill",
+    create=True,
+)
+@patch("vllm_ascend.models.minimax_m3.ops.msa_m3_npu._npu_k2q_csr")
+def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
+    mock_k2q_csr: MagicMock,
+    mock_sparse_attention_score_prefill: MagicMock,
+    pad_invalid_slots: bool,
+) -> None:
+    q = torch.zeros(3, 4, 4, dtype=torch.bfloat16)
+    kv_cache = torch.zeros(2, 8, 128, 2, 4, dtype=torch.bfloat16)
+    topk_idx = torch.tensor(
+        [
+            [[0, 1], [0, -1], [2, 1]],
+            [[0, 1], [1, -1], [2, 0]],
+        ],
+        dtype=torch.int32,
+    )
+    block_table = torch.arange(8, dtype=torch.int32).view(2, 4)
+    cu_seqlens_q = torch.tensor([0, 1, 3], dtype=torch.int32)
+    seq_lens = torch.tensor([129, 257], dtype=torch.int32)
+    output = torch.empty_like(q)
+    k2q_row_ptr = torch.zeros(2, 6, dtype=torch.int32)
+    k2q_q_indices = torch.zeros(2, 6, dtype=torch.int32)
+    k2q_slot_indices = torch.zeros(2, 6, dtype=torch.int32)
+    mock_k2q_csr.return_value = (k2q_row_ptr, k2q_q_indices, k2q_slot_indices)
+    mock_sparse_attention_score_prefill.return_value = torch.ones_like(output)
+
+    _minimax_m3_sparse_attn_kv_gather_q(
+        q,
+        kv_cache,
+        topk_idx,
+        block_table,
+        cu_seqlens_q,
+        seq_lens,
+        num_kv_heads=2,
+        sm_scale=0.5,
+        output=output,
+        block_size=128,
+        total_kv_blocks=5,
+        max_kv_blocks=3,
+        pad_invalid_topk_slots=pad_invalid_slots,
+        supports_fp8=False,
+    )
+
+    mock_k2q_csr.assert_called_once()
+    k2q_kwargs = mock_k2q_csr.call_args.kwargs
+    assert k2q_kwargs["order_method"] == 1
+    assert k2q_kwargs["total_rows"] == 5
+    assert k2q_kwargs["max_kv"] == 3
+    assert k2q_kwargs["use_simt"] == 0
+    assert k2q_kwargs["q_global_offset"] is True
+    expected_topk_idx = topk_idx.clamp_min(0) if pad_invalid_slots else topk_idx
+    assert torch.equal(mock_k2q_csr.call_args.args[0], expected_topk_idx)
+
+    mock_sparse_attention_score_prefill.assert_called_once()
+    args = mock_sparse_attention_score_prefill.call_args.args
+    kwargs = mock_sparse_attention_score_prefill.call_args.kwargs
+    assert args[0] is q
+    assert args[3] is block_table
+    assert args[4] is k2q_row_ptr
+    assert args[7:12] == (2, 0.5, 128, 2, 1)
+    assert torch.equal(kwargs["actual_seq_lengths"], torch.tensor([1, 2], dtype=torch.int32))
+    assert torch.equal(kwargs["actual_seq_lengths_kv"], seq_lens)
+    assert torch.equal(output, torch.ones_like(output))
 
 
 @patch.object(torch.ops._C_ascend, "npu_sparse_attention_score", create=True)
@@ -1804,7 +1882,7 @@ def test_sparse_attn_prefill_a5_uses_fp8_inputs(
     mock_k2q_csr.return_value = (csr, csr, csr)
     mock_sparse_attention_score_prefill.return_value = torch.ones_like(output)
 
-    _minimax_m3_sparse_attn_a5(
+    _minimax_m3_sparse_attn_kv_gather_q(
         q,
         kv_cache,
         topk_idx,
@@ -1815,10 +1893,78 @@ def test_sparse_attn_prefill_a5_uses_fp8_inputs(
         sm_scale=0.5,
         output=output,
         block_size=128,
+        total_kv_blocks=1,
+        max_kv_blocks=1,
+        pad_invalid_topk_slots=False,
+        supports_fp8=True,
     )
-
     args = mock_sparse_attention_score_prefill.call_args.args
     assert args[0].dtype == torch.float8_e4m3fn
     assert args[1].dtype == torch.float8_e4m3fn
     assert args[2].dtype == torch.float8_e4m3fn
     assert args[11] == 4
+
+
+@pytest.mark.parametrize(
+    ("device_type", "split_kv_available", "expected_impl"),
+    [
+        (AscendDeviceType.A5, True, "kv_gather_q"),
+        (AscendDeviceType.A3, True, "kv_gather_q"),
+        (AscendDeviceType.A3, False, "legacy"),
+        (AscendDeviceType.A2, False, "legacy"),
+    ],
+)
+def test_sparse_attn_prefill_dispatches_by_hardware_capability(
+    device_type: AscendDeviceType,
+    split_kv_available: bool,
+    expected_impl: str,
+) -> None:
+    with (
+        patch.object(
+            msa_m3_npu_module,
+            "get_current_hardware_profile",
+            return_value=get_hardware_profile(device_type),
+        ),
+        patch.object(
+            msa_m3_npu_module,
+            "_is_minimax_sparse_attention_split_kv_available",
+            return_value=split_kv_available,
+        ) as mock_is_available,
+        patch.object(msa_m3_npu_module, "_minimax_m3_sparse_attn_a3") as mock_legacy,
+        patch.object(
+            msa_m3_npu_module,
+            "_minimax_m3_sparse_attn_kv_gather_q",
+        ) as mock_kv_gather_q,
+    ):
+        msa_m3_npu_module.minimax_m3_sparse_attn(
+            q=torch.empty(0),
+            kv_cache=torch.empty(0),
+            topk_idx=torch.empty(0),
+            block_table=torch.empty(0),
+            cu_seqlens_q=torch.empty(0),
+            seq_lens=torch.empty(0),
+            prefix_lens=torch.empty(0),
+            max_query_len=0,
+            num_kv_heads=2,
+            sm_scale=0.5,
+            output=torch.empty(0),
+            total_kv_blocks=5,
+            max_kv_blocks=3,
+        )
+
+    if expected_impl == "kv_gather_q":
+        mock_kv_gather_q.assert_called_once()
+        mock_legacy.assert_not_called()
+        assert mock_kv_gather_q.call_args.args[-2:] == (5, 3)
+        assert mock_kv_gather_q.call_args.kwargs == {
+            "pad_invalid_topk_slots": device_type == AscendDeviceType.A3,
+            "supports_fp8": device_type == AscendDeviceType.A5,
+        }
+    else:
+        mock_legacy.assert_called_once()
+        mock_kv_gather_q.assert_not_called()
+
+    if device_type == AscendDeviceType.A3:
+        mock_is_available.assert_called_once_with()
+    else:
+        mock_is_available.assert_not_called()

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -1682,7 +1682,6 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
     assert mock_sparse_attn_prefill.call_args.kwargs["max_kv_blocks"] == 1
 
 
-@pytest.mark.parametrize("pad_invalid_slots", [True, False])
 @patch.object(
     torch.ops._C_ascend,
     "npu_sparse_attention_score_prefill",
@@ -1692,7 +1691,6 @@ def test_sparse_impl_forward_dispatches_decode_and_prefill_paths(
 def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
     mock_k2q_csr: MagicMock,
     mock_sparse_attention_score_prefill: MagicMock,
-    pad_invalid_slots: bool,
 ) -> None:
     q = torch.zeros(3, 4, 4, dtype=torch.bfloat16)
     kv_cache = torch.zeros(2, 8, 128, 2, 4, dtype=torch.bfloat16)
@@ -1726,7 +1724,6 @@ def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
         block_size=128,
         total_kv_blocks=5,
         max_kv_blocks=3,
-        pad_invalid_topk_slots=pad_invalid_slots,
         supports_fp8=False,
     )
 
@@ -1737,8 +1734,7 @@ def test_sparse_attn_prefill_kv_gather_q_forwards_csr_metadata(
     assert k2q_kwargs["max_kv"] == 3
     assert k2q_kwargs["use_simt"] == 0
     assert k2q_kwargs["q_global_offset"] is True
-    expected_topk_idx = topk_idx.clamp_min(0) if pad_invalid_slots else topk_idx
-    assert torch.equal(mock_k2q_csr.call_args.args[0], expected_topk_idx)
+    assert mock_k2q_csr.call_args.args[0] is topk_idx
 
     mock_sparse_attention_score_prefill.assert_called_once()
     args = mock_sparse_attention_score_prefill.call_args.args
@@ -1895,7 +1891,6 @@ def test_sparse_attn_prefill_a5_uses_fp8_inputs(
         block_size=128,
         total_kv_blocks=1,
         max_kv_blocks=1,
-        pad_invalid_topk_slots=False,
         supports_fp8=True,
     )
     args = mock_sparse_attention_score_prefill.call_args.args
@@ -1957,7 +1952,6 @@ def test_sparse_attn_prefill_dispatches_by_hardware_capability(
         mock_legacy.assert_not_called()
         assert mock_kv_gather_q.call_args.args[-2:] == (5, 3)
         assert mock_kv_gather_q.call_args.kwargs == {
-            "pad_invalid_topk_slots": device_type == AscendDeviceType.A3,
             "supports_fp8": device_type == AscendDeviceType.A5,
         }
     else:

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -40,6 +40,8 @@ class HardwareCapability(Enum):
     LORA_CUSTOM_OPS = auto()
     MLA_DECODE_PROLOG_WITHOUT_ROPE = auto()
     MLAPO_NATIVE_WEIGHTS = auto()
+    MINIMAX_M3_PREFILL_KV_GATHER_Q = auto()
+    MINIMAX_M3_PREFILL_TOPK_PADDING = auto()
     MC2_FULLMESH_V2_COMM = auto()
     MC2_HIERARCHY_COMM = auto()
     MOE_DISPATCH_EXTRA_ARGS = auto()
@@ -152,7 +154,11 @@ _STANDARD_CAPABILITIES = frozenset(
         HardwareCapability.TRITON_BATCH_MEMCPY,
     }
 )
-_A3_CAPABILITIES = _STANDARD_CAPABILITIES | {HardwareCapability.MC2_FULLMESH_V2_COMM}
+_A3_CAPABILITIES = _STANDARD_CAPABILITIES | {
+    HardwareCapability.MC2_FULLMESH_V2_COMM,
+    HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q,
+    HardwareCapability.MINIMAX_M3_PREFILL_TOPK_PADDING,
+}
 _DEFAULT_WORKER_CLS = "vllm_ascend.worker.worker.NPUWorker"
 _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(
     {
@@ -235,6 +241,7 @@ _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyTyp
                     HardwareCapability.LORA_CUSTOM_OPS,
                     HardwareCapability.MLA_DECODE_PROLOG_WITHOUT_ROPE,
                     HardwareCapability.MLAPO_NATIVE_WEIGHTS,
+                    HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q,
                     HardwareCapability.MOE_DISPATCH_EXTRA_ARGS,
                     HardwareCapability.MOE_DISPATCH_SHARED_EXPERT_ARGS,
                     HardwareCapability.NPUGRAPH_EX,

--- a/vllm_ascend/device/hardware_profile.py
+++ b/vllm_ascend/device/hardware_profile.py
@@ -41,7 +41,6 @@ class HardwareCapability(Enum):
     MLA_DECODE_PROLOG_WITHOUT_ROPE = auto()
     MLAPO_NATIVE_WEIGHTS = auto()
     MINIMAX_M3_PREFILL_KV_GATHER_Q = auto()
-    MINIMAX_M3_PREFILL_TOPK_PADDING = auto()
     MC2_FULLMESH_V2_COMM = auto()
     MC2_HIERARCHY_COMM = auto()
     MOE_DISPATCH_EXTRA_ARGS = auto()
@@ -157,7 +156,6 @@ _STANDARD_CAPABILITIES = frozenset(
 _A3_CAPABILITIES = _STANDARD_CAPABILITIES | {
     HardwareCapability.MC2_FULLMESH_V2_COMM,
     HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q,
-    HardwareCapability.MINIMAX_M3_PREFILL_TOPK_PADDING,
 }
 _DEFAULT_WORKER_CLS = "vllm_ascend.worker.worker.NPUWorker"
 _HARDWARE_PROFILES: Mapping[AscendDeviceType, HardwareProfile] = MappingProxyType(

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -739,6 +739,8 @@ class AscendMiniMaxM3SparsePrefillMetadata:
     block_table: torch.Tensor
     max_query_len: int
     max_seq_len: int
+    total_kv_blocks: int
+    max_kv_blocks: int
 
 
 @dataclass
@@ -775,6 +777,7 @@ class AscendMiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[AscendMiniMa
         device: torch.device,
     ) -> None:
         super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.block_size = kv_cache_spec.block_size
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=True)
         self.context_len_buffer = torch.empty(
             vllm_config.scheduler_config.max_num_batched_tokens,
@@ -806,13 +809,21 @@ class AscendMiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[AscendMiniMa
             active_prefills = _active_prefill_num_reqs(num_prefills, num_prefill_tokens, qsl_cpu, num_decodes)
             prefill_end = num_decodes + active_prefills
             prefill_kv_lens = seq_lens[num_decodes:prefill_end]
+            prefill_kv_lens_cpu = prefill_kv_lens.detach().cpu()
+            prefill_block_lens_cpu = torch.div(
+                prefill_kv_lens_cpu + self.block_size - 1,
+                self.block_size,
+                rounding_mode="floor",
+            )
+            total_kv_blocks = int(prefill_block_lens_cpu.sum().item())
+            max_kv_blocks = int(prefill_block_lens_cpu.max().item()) if prefill_block_lens_cpu.numel() else 0
             prefill_cu_seqlens_k = torch.empty(active_prefills + 1, dtype=torch.int32, device=seq_lens.device)
             prefill_cu_seqlens_k[0] = 0
             torch.cumsum(prefill_kv_lens, dim=0, out=prefill_cu_seqlens_k[1:])
             prefill_query_lens_cpu = qsl_cpu[num_decodes + 1 : prefill_end + 1] - qsl_cpu[num_decodes:prefill_end]
             prefill_context_lens = self.context_len_buffer[num_decodes:prefill_end]
             prefill_context_lens.copy_(
-                (prefill_kv_lens.detach().cpu() - prefill_query_lens_cpu).to(
+                (prefill_kv_lens_cpu - prefill_query_lens_cpu).to(
                     device=self.context_len_buffer.device,
                     dtype=torch.int32,
                     non_blocking=True,
@@ -828,6 +839,8 @@ class AscendMiniMaxM3SparseMetadataBuilder(AttentionMetadataBuilder[AscendMiniMa
                 block_table=block_table[num_decodes:prefill_end],
                 max_query_len=common_attn_metadata.max_query_len,
                 max_seq_len=common_attn_metadata.max_seq_len,
+                total_kv_blocks=total_kv_blocks,
+                max_kv_blocks=max_kv_blocks,
             )
 
         decode_metadata: AscendMiniMaxM3SparseDecodeMetadata | None = None
@@ -944,6 +957,8 @@ class AscendMiniMaxM3SparseImpl(AttentionImplBase[AscendMiniMaxM3SparseMetadata]
                 self.scale,
                 out[num_decode_tokens:],
                 block_size=self.block_size,
+                total_kv_blocks=p.total_kv_blocks,
+                max_kv_blocks=p.max_kv_blocks,
             )
         return output
 

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -14,6 +14,7 @@ from vllm_ascend.utils import enable_custom_op
 
 _SPARSE_ATTN_INNER_PRECISE = 4
 _PREFILL_KV_GATHER_Q_INNER_PRECISE = 1
+_A3_PREFILL_KV_GATHER_Q_INNER_PRECISE = 0
 _MSA_INDEX_BLOCK_SIZE = 128
 _MSA_SCORE_BLOCK_ALIGNMENT = 16
 _FP8_E4M3_MAX = 448.0
@@ -549,7 +550,9 @@ def _minimax_m3_sparse_attn_kv_gather_q(
 ) -> None:
     key, value = _split_main_kv_cache(kv_cache)
 
-    inner_precise = _PREFILL_KV_GATHER_Q_INNER_PRECISE
+    # A3 uses FP32 scores and partial outputs. Keep A5's existing BF16
+    # precision mode; its FP8 cache path overrides this below as before.
+    inner_precise = _PREFILL_KV_GATHER_Q_INNER_PRECISE if supports_fp8 else _A3_PREFILL_KV_GATHER_Q_INNER_PRECISE
     if key.dtype == torch.float8_e4m3fn:
         if not supports_fp8:
             raise TypeError("MiniMax-M3 FP8 sparse attention is not supported on this device")

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -4,27 +4,25 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import Any
 
 import torch
 
-from vllm_ascend.utils import (
-    AscendDeviceType,
-    enable_custom_op,
-    get_ascend_device_type,
-)
+from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.utils import enable_custom_op
 
 _SPARSE_ATTN_INNER_PRECISE = 4
+_PREFILL_KV_GATHER_Q_INNER_PRECISE = 1
 _MSA_INDEX_BLOCK_SIZE = 128
 _MSA_SCORE_BLOCK_ALIGNMENT = 16
-_ASCEND_DEVICE_TYPE = get_ascend_device_type()
 _FP8_E4M3_MAX = 448.0
 
-if _ASCEND_DEVICE_TYPE == AscendDeviceType.A5:
+if get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION):
     from vllm_ascend.models.minimax_m3.ops.msa_m3_triton_a5 import (
         minimax_m3_index_topk as _minimax_m3_index_prefill_topk,
     )
-else:
+elif get_current_hardware_profile().supports(HardwareCapability.RUNTIME_CUSTOM_OPS):
     from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
         minimax_m3_index_topk as _minimax_m3_index_prefill_topk,
     )
@@ -152,6 +150,16 @@ def _build_cu_block_lens(
     cu_block_lens[0] = 0
     torch.cumsum(block_lens, dim=0, out=cu_block_lens[1:])
     return cu_block_lens
+
+
+def _pad_invalid_prefill_topk_slots(topk_idx: torch.Tensor) -> torch.Tensor:
+    """Replace unavailable causal/padding slots with logical KV block zero.
+
+    The fixed-slot A3 combine path cannot consume unwritten statistics for
+    unavailable slots. Early causal queries can contain ``-1`` even when the
+    final request length exceeds top-k.
+    """
+    return topk_idx.clamp_min(0)
 
 
 @torch.no_grad()
@@ -533,7 +541,7 @@ def _minimax_m3_sparse_attn_a3(
     output.copy_(out)
 
 
-def _minimax_m3_sparse_attn_a5(
+def _minimax_m3_sparse_attn_kv_gather_q(
     q: torch.Tensor,
     kv_cache: torch.Tensor | tuple[torch.Tensor, ...] | list[torch.Tensor],
     topk_idx: torch.Tensor,
@@ -544,20 +552,33 @@ def _minimax_m3_sparse_attn_a5(
     sm_scale: float,
     output: torch.Tensor,
     block_size: int,
+    total_kv_blocks: int,
+    max_kv_blocks: int,
+    *,
+    pad_invalid_topk_slots: bool,
+    supports_fp8: bool,
 ) -> None:
     key, value = _split_main_kv_cache(kv_cache)
-    inner_precise = 1
+    if pad_invalid_topk_slots:
+        topk_idx = _pad_invalid_prefill_topk_slots(topk_idx)
+
+    inner_precise = _PREFILL_KV_GATHER_Q_INNER_PRECISE
     if key.dtype == torch.float8_e4m3fn:
+        if not supports_fp8:
+            raise TypeError("MiniMax-M3 FP8 sparse attention is not supported on this device")
         if value.dtype != torch.float8_e4m3fn:
             raise TypeError("MiniMax-M3 FP8 sparse attention requires both K and V caches in E4M3")
         q = _to_fp8_e4m3(q)
         inner_precise = _SPARSE_ATTN_INNER_PRECISE
+
     cu_block_lens = _build_cu_block_lens(seq_lens, block_size)
     k2q_row_ptr, k2q_q_indices, k2q_slot_indices = _npu_k2q_csr(
         topk_idx,
         cu_seqlens_q,
         cu_block_lens,
         order_method=1,
+        total_rows=total_kv_blocks,
+        max_kv=max_kv_blocks,
         use_simt=0,
         q_global_offset=True,
     )
@@ -586,6 +607,15 @@ def _minimax_m3_sparse_attn_a5(
     output.copy_(out)
 
 
+@lru_cache
+def _is_minimax_sparse_attention_split_kv_available() -> bool:
+    """Return whether the vendor Split-KV ACLNN entry points are installed."""
+    import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401, PLC0415
+
+    enable_custom_op()
+    return torch.ops._C_ascend.is_minimax_sparse_attention_split_kv_available()
+
+
 @torch.no_grad()
 def minimax_m3_sparse_attn(
     q: torch.Tensor,
@@ -600,12 +630,11 @@ def minimax_m3_sparse_attn(
     sm_scale: float,
     output: torch.Tensor,
     block_size: int = 128,
+    total_kv_blocks: int = -1,
+    max_kv_blocks: int = -1,
 ) -> None:
     del prefix_lens, max_query_len
-    sparse_attn_impl = (
-        _minimax_m3_sparse_attn_a5 if _ASCEND_DEVICE_TYPE == AscendDeviceType.A5 else _minimax_m3_sparse_attn_a3
-    )
-    sparse_attn_impl(
+    common_args = (
         q,
         kv_cache,
         topk_idx,
@@ -616,6 +645,26 @@ def minimax_m3_sparse_attn(
         sm_scale,
         output,
         block_size,
+    )
+    hardware_profile = get_current_hardware_profile()
+    supports_kv_gather_q = hardware_profile.supports(HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q)
+    pad_invalid_topk_slots = hardware_profile.supports(HardwareCapability.MINIMAX_M3_PREFILL_TOPK_PADDING)
+    if not supports_kv_gather_q:
+        _minimax_m3_sparse_attn_a3(*common_args)
+        return
+
+    # The A3 CI image can predate the vendor Split-KV ACLNN package. A5
+    # already requires that package and cannot use the BF16-only A3 fallback.
+    if pad_invalid_topk_slots and not _is_minimax_sparse_attention_split_kv_available():
+        _minimax_m3_sparse_attn_a3(*common_args)
+        return
+
+    _minimax_m3_sparse_attn_kv_gather_q(
+        *common_args,
+        total_kv_blocks,
+        max_kv_blocks,
+        pad_invalid_topk_slots=pad_invalid_topk_slots,
+        supports_fp8=hardware_profile.supports(HardwareCapability.FP8_ATTENTION),
     )
 
 

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -152,16 +152,6 @@ def _build_cu_block_lens(
     return cu_block_lens
 
 
-def _pad_invalid_prefill_topk_slots(topk_idx: torch.Tensor) -> torch.Tensor:
-    """Replace unavailable causal/padding slots with logical KV block zero.
-
-    The fixed-slot A3 combine path cannot consume unwritten statistics for
-    unavailable slots. Early causal queries can contain ``-1`` even when the
-    final request length exceeds top-k.
-    """
-    return topk_idx.clamp_min(0)
-
-
 @torch.no_grad()
 def _minimax_m3_index_score(
     idx_q: torch.Tensor,
@@ -555,12 +545,9 @@ def _minimax_m3_sparse_attn_kv_gather_q(
     total_kv_blocks: int,
     max_kv_blocks: int,
     *,
-    pad_invalid_topk_slots: bool,
     supports_fp8: bool,
 ) -> None:
     key, value = _split_main_kv_cache(kv_cache)
-    if pad_invalid_topk_slots:
-        topk_idx = _pad_invalid_prefill_topk_slots(topk_idx)
 
     inner_precise = _PREFILL_KV_GATHER_Q_INNER_PRECISE
     if key.dtype == torch.float8_e4m3fn:
@@ -572,6 +559,8 @@ def _minimax_m3_sparse_attn_kv_gather_q(
         inner_precise = _SPARSE_ATTN_INNER_PRECISE
 
     cu_block_lens = _build_cu_block_lens(seq_lens, block_size)
+    # Keep the -1 sentinel: K2Q drops invalid entries, while replacing them
+    # with zero would add duplicate attention edges for logical KV block 0.
     k2q_row_ptr, k2q_q_indices, k2q_slot_indices = _npu_k2q_csr(
         topk_idx,
         cu_seqlens_q,
@@ -648,14 +637,14 @@ def minimax_m3_sparse_attn(
     )
     hardware_profile = get_current_hardware_profile()
     supports_kv_gather_q = hardware_profile.supports(HardwareCapability.MINIMAX_M3_PREFILL_KV_GATHER_Q)
-    pad_invalid_topk_slots = hardware_profile.supports(HardwareCapability.MINIMAX_M3_PREFILL_TOPK_PADDING)
+    supports_fp8 = hardware_profile.supports(HardwareCapability.FP8_ATTENTION)
     if not supports_kv_gather_q:
         _minimax_m3_sparse_attn_a3(*common_args)
         return
 
     # The A3 CI image can predate the vendor Split-KV ACLNN package. A5
     # already requires that package and cannot use the BF16-only A3 fallback.
-    if pad_invalid_topk_slots and not _is_minimax_sparse_attention_split_kv_available():
+    if not supports_fp8 and not _is_minimax_sparse_attention_split_kv_available():
         _minimax_m3_sparse_attn_a3(*common_args)
         return
 
@@ -663,8 +652,7 @@ def minimax_m3_sparse_attn(
         *common_args,
         total_kv_blocks,
         max_kv_blocks,
-        pad_invalid_topk_slots=pad_invalid_topk_slots,
-        supports_fp8=hardware_profile.supports(HardwareCapability.FP8_ATTENTION),
+        supports_fp8=supports_fp8,
     )
 
 

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -12,13 +12,14 @@ import torch
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.utils import enable_custom_op
 
-# Preserve the existing mode for legacy prefill, decode, and A5 FP8 prefill.
-# BF16 KV-gather-Q prefill uses the backend-specific modes below instead.
+# Existing mode for legacy prefill, decode, and A5 FP8 prefill.
 _SPARSE_ATTN_INNER_PRECISE = 4
-# Preserve A5's existing BF16 KV-gather-Q prefill precision mode.
+
+# Existing mode for A5 KV-gather-Q prefill with BF16 inputs.
 _PREFILL_KV_GATHER_Q_INNER_PRECISE = 1
-# A3 BF16 KV-gather-Q prefill uses FP32 scores and partial outputs to preserve
-# accuracy; its reduced-precision modes are not interchangeable with A5's.
+
+# A3 KV-gather-Q prefill with BF16 inputs: use FP32 scores and partial
+# outputs to preserve accuracy.
 _A3_PREFILL_KV_GATHER_Q_INNER_PRECISE = 0
 _MSA_INDEX_BLOCK_SIZE = 128
 _MSA_SCORE_BLOCK_ALIGNMENT = 16

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_npu.py
@@ -12,8 +12,13 @@ import torch
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
 from vllm_ascend.utils import enable_custom_op
 
+# Preserve the existing mode for legacy prefill, decode, and A5 FP8 prefill.
+# BF16 KV-gather-Q prefill uses the backend-specific modes below instead.
 _SPARSE_ATTN_INNER_PRECISE = 4
+# Preserve A5's existing BF16 KV-gather-Q prefill precision mode.
 _PREFILL_KV_GATHER_Q_INNER_PRECISE = 1
+# A3 BF16 KV-gather-Q prefill uses FP32 scores and partial outputs to preserve
+# accuracy; its reduced-precision modes are not interchangeable with A5's.
 _A3_PREFILL_KV_GATHER_Q_INNER_PRECISE = 0
 _MSA_INDEX_BLOCK_SIZE = 128
 _MSA_SCORE_BLOCK_ALIGNMENT = 16


### PR DESCRIPTION
### What this PR does / why we need it?

Integrate the existing KV-gather-Q sparse prefill operator for MiniMax-M3 on Ascend A3 to improve long-prompt prefill performance while preserving accuracy. This reuses the in-tree K2Q CSR conversion and `npu_sparse_attention_score_prefill` binding; it does not introduce or modify a device-side attention/combine kernel.

- Share preparation and operator calls between A3 and A5 through hardware-profile capabilities.
- Prepare total/max KV-block metadata once in the metadata builder and forward it to K2Q CSR conversion.
- Preserve invalid top-k entries as `-1`. K2Q filters invalid edges; no block-0 padding or clamping is applied.
- Check the vendor Split-KV ACLNN entry points on A3 and retain the legacy path when they are unavailable.
- Add lookup of the separately packaged `libopapi_transformer.so` in the shared ACLNN loader.
- Explain the precision constants: A3 BF16 KV-gather-Q prefill uses mode `0` (FP32 scores and partial outputs); A5 BF16 prefill retains `1`; legacy prefill, decode, and A5 FP8 prefill retain `4`.

### Does this PR introduce _any_ user-facing change?

Eligible MiniMax-M3 sparse prefill on A3 uses KV-gather-Q when the required vendor entry points are available. Older A3 environments retain the legacy fallback. No new environment variable is required. A5 precision selection and decode behavior are unchanged.

Most changes are MiniMax-M3-specific. The transformer-library lookup is shared infrastructure and remains in scope for compatibility review and CI. No operator binaries, diagnostic hooks, or machine-specific serving scripts are included in this PR.

### How was this patch tested?

#### Unit and static checks

- `tests/ut/models/minimax_m3/test_msa_m3.py` and `tests/ut/device/test_hardware_profile.py`: **76 passed** in an isolated A3 environment using the reviewed Python files. These are wiring/unit tests, not A5 hardware validation.
- Three additional AST-isolated CPU cases passed: A3 BF16 mode `0`, A5 BF16 mode `1`, A5 FP8 mode `4`; invalid BF16 top-k indices remain unchanged.
- Ruff 0.14.0 lint and format checks on all five changed Python files, Python compilation, `git diff --check`, Python-package initialization, boolean-context-manager, and symbolic-meta checks passed.
- The latest comment-only update passed Ruff lint/format and `git diff --check`; AST comparison confirmed no executable-code change. Full local `format.sh ci` and the complete local test suite were not rerun. See the PR checks for CI results on the latest commit.

#### Matched GPQA Diamond accuracy

MiniMax-M3 W8A8; A3, TP4 / PP2 / DP2; client concurrency 64; `max_num_seqs=64` per DP; token budget 32768; `FULL_DECODE_ONLY`. Eagle3, async scheduling, KV pooling, and prefix caching were disabled. Both arms used the same 198 requests and seeds, temperature 0.6, top-p 0.95, and maximum output length 65536.

| Backend | Successful requests | Correct / total | Accuracy |
| --- | --- | --- | --- |
| Legacy prefill, mode 4 | 198/198 | 183/198 | 92.42% |
| KV-gather-Q prefill, mode 0, no padding | 198/198 | 184/198 | 92.93% |

Both exceed the strictly-greater-than-90% acceptance threshold. No retries or failed-request exclusions were used. Correct answers from normal-stop completions were 181/198 and 182/198 respectively; the main score also counts correct extracted answers from token-limit completions.

Validation used the frozen `f2e1c7e` integration with a diagnostic runtime switch selecting A3 prefill mode `0`, and a fixed vendor operator binary. The PR encodes the same A3 precision choice directly while preserving A5 behavior. This is not a claim that the historical NaN/combine root cause has been established.

#### Prefill end-to-end performance

A3, MiniMax-M3 W8A8, **TP4 / PP1 / DP4**, output length **1 token** for every request. Both arms used identical deterministic token-ID datasets and DP routing. Chunked prefill was enabled with token budget 32768 and long-prefill threshold 4096; `max_num_seqs=64`, memory utilization 0.84, `FULL_DECODE_ONLY`. No Eagle3, async scheduling, or KV pooling. Legacy prefill used mode `4`; new prefill used mode `0`, without padding; decode remained `4`.

| Scenario | Legacy mean TTFT | KV-gather-Q mean TTFT | TTFT reduction | Request throughput increase |
| --- | --- | --- | --- | --- |
| 64K, 0% prefix hit; concurrency 4 / 16 requests | 15.192 s | 14.318 s | **5.76%** | **6.00%** |
| 128K, approximately 90% prefix hit; concurrency 16 / 64 requests | 12.994 s | 12.376 s | **4.75%** | **6.77%** |

64K means 65536 input tokens, with zero cached tokens. The 128K case uses 131072 input tokens and 117888 cached tokens (89.94%, block-aligned); each DP's prefix was primed before timing. Warmup and prefix priming are excluded from the measurements. All 16/16 and 64/64 requests completed successfully in both arms. TTFT reduction is `1 - new/old`; throughput increase is `new/old - 1`, calculated from unrounded results.

The service performance measurements above were taken without profiling.

#### Operator profiling: 256K input / 1 output, 0% prefix cache, concurrency 4

Service-based A3 MiniMax-M3 W8A8 profiling, **TP4 / PP1 / DP4**, with four requests, one per DP. Both arms completed all requests with identical request hashes, 262144 input tokens, one output token, and zero cached tokens.

| Device execution component | Mean time per matched rank/call |
| --- | --- |
| Legacy Q-gather-KV attention | 40.552 ms |
| New KV-gather-Q attention | 34.025 ms |
| Full build K2Q device work | 1.233 ms |
| **New attention + full build K2Q** | **35.258 ms** |

**Legacy Q-gather-KV versus KV-gather-Q + build K2Q: device execution time decreases by 13.06% (1.150x).** The attention core alone decreases by 16.10%; that excludes K2Q construction and is not the headline improvement.

<details>
<summary>Profiling configuration and measurement scope</summary>

- Pure-text service; `max_num_batched_tokens=32768`, `long_prefill_token_threshold=32768`, `max_num_seqs=64`, memory utilization 0.84, FULL_DECODE_ONLY, shared-expert multistream overlap enabled. Chunked prefill enabled; no prefix caching, Eagle3, async scheduling, or KV pooling.
- Legacy prefill mode `4`; new prefill mode `0`, no padding. Source and vendor binary were fixed to the same frozen integration used for matched validation, rather than freshly benchmarking each PR checkout.
- Two warmup waves were excluded. Capture was taken late in prefill at actual **Q=32768, KV context=262144**, sparse-call positions 428–456: 29 matched calls per rank across 16 ranks, **464 matched samples**. This is not an unchunked 256K-Q measurement.
- Full build K2Q includes five CSR kernels (1.216 ms) and their initialization kernels (one ZerosLike and two Fill operations, 0.017 ms), cross-checked against `npu_k2q_csr` device-time totals.
- Mean times sum device execution durations; they exclude CPU preparation and launch gaps and are not whole-model latency or end-to-end throughput.
- Capture was bounded to approximately 5 seconds, with synchronization at captured-call exits, and stopped at the final sparse layer. Actual per-worker windows were 3.27–3.50 seconds.
- The separate 8192-token-budget experiment is not included in these results.

</details>

- vLLM main: https://github.com/vllm-project/vllm/commit/a97dacb7106ee49f39f3d1fc6ae1800ff724e01d
