### PR TITLE
[CI] temporarily skip graph mode precision e2e test

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -144,6 +144,10 @@
     - tests/e2e/pull_request/two_card/aclgraph
     - tests/e2e/pull_request/two_card/test_qwen3_vl_30b_a3b_instruct.py
     - tests/e2e/pull_request/four_card/test_graph_mode.py
+  # Temporarily skipped: the precision check in test_graph_mode.py is
+  # unstable; re-enable once the graph mode precision issue is fixed.
+  skip_tests:
+    - tests/e2e/pull_request/four_card/test_graph_mode.py
 
 - name: compilation_passes_base
   optional: false
@@ -613,6 +617,10 @@
     - tests/e2e/pull_request/four_card/test_pipeline_parallel.py
     - tests/e2e/pull_request/four_card/test_profiling_chunk_performance.py
     - tests/e2e/pull_request/four_card/test_qwen3_5.py
+    - tests/e2e/pull_request/four_card/test_graph_mode.py
+  # Temporarily skipped: the precision check in test_graph_mode.py is
+  # unstable; re-enable once the graph mode precision issue is fixed.
+  skip_tests:
     - tests/e2e/pull_request/four_card/test_graph_mode.py
 
 


### PR DESCRIPTION
### Why

The four-card e2e test 	ests/e2e/pull_request/four_card/test_graph_mode.py has an unstable precision check that is currently blocking PR CI runs.

### What

Temporarily exclude the test file from the compilation_aclgraph and worker_v1 test selections via the native skip_tests mechanism in .github/workflows/scripts/test_config.yaml, so select_tests.py filters it out and CI no longer executes it.

### Note

This is a temporary disable to unblock CI; it should be re-enabled once the graph mode precision issue is fixed.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
