### PR TITLE
[Test][KV Cache] Detect Kimi K3 hybrid MLA/Mamba alias conflicts

### DIFF
--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -12,13 +12,17 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
     UniformTypeKVCacheSpecs,
 )
 
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
 from vllm_ascend.utils import AscendDeviceType
-from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
+from vllm_ascend.worker.model_runner_v1 import (
+    NPUModelRunner,
+    _find_hybrid_mla_mamba_alias_conflicts,
+)
 
 
 class TestDSparkAuxCaptureMode(unittest.TestCase):
@@ -97,6 +101,135 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         )
         runner.attn_backend = backend
         return runner
+
+    @staticmethod
+    def _hybrid_alias_fixture(*, c8_k_cache: bool):
+        num_blocks = 4
+        block_size = 16
+        conv_bytes_per_block = 16
+        recurrent_bytes_per_block = 128
+        rope_bytes_per_block = 32
+        k_bytes_per_block = 64 if c8_k_cache else recurrent_bytes_per_block
+        raw_page_bytes = (
+            conv_bytes_per_block
+            + recurrent_bytes_per_block
+            + rope_bytes_per_block
+        )
+        raw = torch.zeros(num_blocks * raw_page_bytes, dtype=torch.int8)
+
+        conv_end = num_blocks * conv_bytes_per_block
+        recurrent_end = conv_end + num_blocks * recurrent_bytes_per_block
+        conv_state = raw[:conv_end].view(num_blocks, conv_bytes_per_block)
+        recurrent_state = raw[conv_end:recurrent_end].view(torch.float32).view(
+            num_blocks,
+            recurrent_bytes_per_block
+            // torch.empty((), dtype=torch.float32).element_size(),
+        )
+
+        rope_total_bytes = num_blocks * rope_bytes_per_block
+        k_total_bytes = num_blocks * k_bytes_per_block
+        k_start = raw.numel() - rope_total_bytes - k_total_bytes
+        k_end = k_start + k_total_bytes
+        k_dtype = torch.float8_e4m3fn if c8_k_cache else torch.bfloat16
+        k_element_size = torch.empty((), dtype=k_dtype).element_size()
+        k_cache = raw[k_start:k_end].view(k_dtype).view(
+            num_blocks,
+            block_size,
+            1,
+            k_bytes_per_block // block_size // k_element_size,
+        )
+        rope_element_size = torch.empty((), dtype=torch.bfloat16).element_size()
+        rope_cache = raw[k_end:].view(torch.bfloat16).view(
+            num_blocks,
+            block_size,
+            1,
+            rope_bytes_per_block // block_size // rope_element_size,
+        )
+
+        mla_layer = "model.layers.1.self_attn.attn"
+        mamba_layer = "model.layers.0.self_attn"
+        mla_spec = AscendMLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=(
+                (k_bytes_per_block + rope_bytes_per_block)
+                // block_size
+                // k_element_size
+            ),
+            dtype=k_dtype,
+            page_size_padded=raw_page_bytes,
+        )
+        mamba_spec = MambaSpec(
+            block_size=block_size,
+            shapes=(
+                (conv_bytes_per_block,),
+                (
+                    recurrent_bytes_per_block
+                    // torch.empty((), dtype=torch.float32).element_size(),
+                ),
+            ),
+            dtypes=(torch.int8, torch.float32),
+            mamba_cache_mode="align",
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=raw.numel(),
+                    shared_by=[mla_layer, mamba_layer],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[mla_layer],
+                    kv_cache_spec=mla_spec,
+                ),
+                KVCacheGroupSpec(
+                    layer_names=[mamba_layer],
+                    kv_cache_spec=mamba_spec,
+                ),
+            ],
+        )
+        return (
+            kv_cache_config,
+            {
+                mla_layer: (k_cache, rope_cache),
+                mamba_layer: (conv_state, recurrent_state),
+            },
+            {
+                mla_layer: mla_spec,
+                mamba_layer: mamba_spec,
+            },
+        )
+
+    def test_bf16_hybrid_mla_mamba_layout_has_no_cross_id_alias(self):
+        config, caches, specs = self._hybrid_alias_fixture(c8_k_cache=False)
+
+        conflicts = _find_hybrid_mla_mamba_alias_conflicts(
+            config,
+            caches,
+            specs,
+        )
+
+        self.assertEqual(conflicts, [])
+
+    def test_c8_hybrid_mla_mamba_layout_reports_cross_id_alias(self):
+        config, caches, specs = self._hybrid_alias_fixture(c8_k_cache=True)
+
+        conflicts = _find_hybrid_mla_mamba_alias_conflicts(
+            config,
+            caches,
+            specs,
+        )
+
+        self.assertTrue(conflicts)
+        conflict = conflicts[0]
+        self.assertNotEqual(conflict.mla_block_id, conflict.mamba_block_id)
+        self.assertGreater(conflict.overlap_bytes, 0)
+        self.assertNotEqual(
+            conflict.mla_k_block_stride_bytes,
+            conflict.mamba_state_block_stride_bytes,
+        )
 
     def test_allocate_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -229,6 +229,139 @@ PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
 SEQ_LEN_WITH_MAX_PA_WORKSPACE = 6144
 
 
+@dataclass(frozen=True)
+class _HybridMLAMambaAliasConflict:
+    mla_layer_name: str
+    mamba_layer_name: str
+    mla_block_id: int
+    mamba_block_id: int
+    overlap_bytes: int
+    mla_k_base_addr: int
+    mamba_state_base_addr: int
+    mla_k_block_stride_bytes: int
+    mamba_state_block_stride_bytes: int
+
+
+def _first_cross_group_block_overlap(
+    mla_k_cache: torch.Tensor,
+    mamba_state: torch.Tensor,
+) -> tuple[int, int, int, int, int] | None:
+    """Find the first overlapping MLA/Mamba physical range with different IDs."""
+    num_blocks = mamba_state.shape[0]
+    if num_blocks <= 0 or mla_k_cache.shape[0] % num_blocks != 0:
+        return None
+
+    kernel_blocks_per_manager_block = mla_k_cache.shape[0] // num_blocks
+    mla_element_size = mla_k_cache.element_size()
+    mla_block_stride_bytes = (
+        mla_k_cache.stride(0)
+        * mla_element_size
+        * kernel_blocks_per_manager_block
+    )
+    mla_block_data_bytes = mla_k_cache.numel() * mla_element_size // num_blocks
+
+    mamba_element_size = mamba_state.element_size()
+    mamba_block_stride_bytes = mamba_state.stride(0) * mamba_element_size
+    mamba_block_data_bytes = mamba_state[0].numel() * mamba_element_size
+
+    mla_base = mla_k_cache.data_ptr()
+    mamba_base = mamba_state.data_ptr()
+    mla_block_id = 0
+    mamba_block_id = 0
+    while mla_block_id < num_blocks and mamba_block_id < num_blocks:
+        mla_start = mla_base + mla_block_id * mla_block_stride_bytes
+        mla_end = mla_start + mla_block_data_bytes
+        mamba_start = mamba_base + mamba_block_id * mamba_block_stride_bytes
+        mamba_end = mamba_start + mamba_block_data_bytes
+        overlap_bytes = min(mla_end, mamba_end) - max(mla_start, mamba_start)
+        if overlap_bytes > 0 and mla_block_id != mamba_block_id:
+            return (
+                mla_block_id,
+                mamba_block_id,
+                overlap_bytes,
+                mla_block_stride_bytes,
+                mamba_block_stride_bytes,
+            )
+        if mla_end <= mamba_end:
+            mla_block_id += 1
+        else:
+            mamba_block_id += 1
+    return None
+
+
+def _find_hybrid_mla_mamba_alias_conflicts(
+    kv_cache_config: KVCacheConfig,
+    kv_caches: dict[str, Any],
+    layer_kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[_HybridMLAMambaAliasConflict]:
+    """Detect unsafe cross-ID aliasing in shared MLA/Mamba backing tensors."""
+    conflicts: list[_HybridMLAMambaAliasConflict] = []
+    for tensor_config in kv_cache_config.kv_cache_tensors:
+        mla_layers = [
+            layer_name
+            for layer_name in tensor_config.shared_by
+            if isinstance(
+                layer_kv_cache_spec.get(layer_name),
+                AscendMLAAttentionSpec,
+            )
+        ]
+        mamba_layers = [
+            layer_name
+            for layer_name in tensor_config.shared_by
+            if isinstance(layer_kv_cache_spec.get(layer_name), MambaSpec)
+        ]
+        for mla_layer_name in mla_layers:
+            mla_cache = kv_caches.get(mla_layer_name)
+            if not isinstance(mla_cache, (list, tuple)) or not mla_cache:
+                continue
+            mla_k_cache = mla_cache[0]
+            if not isinstance(mla_k_cache, torch.Tensor):
+                continue
+            for mamba_layer_name in mamba_layers:
+                mamba_cache = kv_caches.get(mamba_layer_name)
+                if not isinstance(mamba_cache, (list, tuple)) or not mamba_cache:
+                    continue
+                mamba_states = [
+                    state for state in mamba_cache
+                    if isinstance(state, torch.Tensor) and state.ndim > 1
+                ]
+                if not mamba_states:
+                    continue
+                # Hybrid alignment uses the largest Mamba state page. For KDA
+                # this is the recurrent state, not the short-convolution state.
+                mamba_state = max(
+                    mamba_states,
+                    key=lambda state: state[0].numel() * state.element_size(),
+                )
+                overlap = _first_cross_group_block_overlap(
+                    mla_k_cache,
+                    mamba_state,
+                )
+                if overlap is None:
+                    continue
+                (
+                    mla_block_id,
+                    mamba_block_id,
+                    overlap_bytes,
+                    mla_stride,
+                    mamba_stride,
+                ) = overlap
+                conflicts.append(
+                    _HybridMLAMambaAliasConflict(
+                        mla_layer_name=mla_layer_name,
+                        mamba_layer_name=mamba_layer_name,
+                        mla_block_id=mla_block_id,
+                        mamba_block_id=mamba_block_id,
+                        overlap_bytes=overlap_bytes,
+                        mla_k_base_addr=mla_k_cache.data_ptr(),
+                        mamba_state_base_addr=mamba_state.data_ptr(),
+                        mla_k_block_stride_bytes=mla_stride,
+                        mamba_state_block_stride_bytes=mamba_stride,
+                    )
+                )
+    return conflicts
+
+
 @dataclass
 class GraphCaptureContext:
     stream: torch.npu.Stream
@@ -3813,6 +3946,33 @@ class NPUModelRunner(GPUModelRunner):
         kv_cache_raw_tensors = self._allocate_kv_cache_tensors(kv_cache_config)
         # Change the memory buffer to the desired shape
         kv_caches = self._reshape_kv_cache_tensors(kv_cache_config, kv_cache_raw_tensors)
+
+        layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
+        self.hybrid_mla_mamba_alias_conflicts = (
+            _find_hybrid_mla_mamba_alias_conflicts(
+                kv_cache_config,
+                kv_caches,
+                layer_kv_cache_spec,
+            )
+        )
+        for conflict in self.hybrid_mla_mamba_alias_conflicts[:1]:
+            logger.error(
+                "HYBRID_MLA_MAMBA_ALIAS_CONFLICT: mla_layer=%s "
+                "mamba_layer=%s mla_block_id=%d mamba_block_id=%d "
+                "overlap_bytes=%d total_conflicts=%d mla_k_base_addr=%d "
+                "mamba_state_base_addr=%d mla_k_block_stride_bytes=%d "
+                "mamba_state_block_stride_bytes=%d",
+                conflict.mla_layer_name,
+                conflict.mamba_layer_name,
+                conflict.mla_block_id,
+                conflict.mamba_block_id,
+                conflict.overlap_bytes,
+                len(self.hybrid_mla_mamba_alias_conflicts),
+                conflict.mla_k_base_addr,
+                conflict.mamba_state_base_addr,
+                conflict.mla_k_block_stride_bytes,
+                conflict.mamba_state_block_stride_bytes,
+            )
 
         # Set up cross-layer KV cache sharing
         for layer_name, target_layer_name in self.shared_kv_cache_layers.items():


### PR DESCRIPTION
### What this PR does / why we need it?

Backports the validation-only hybrid KV-cache alias diagnostic from https://github.com/Yaphets24/vllm-ascend/pull/1 to the v0.26.0 release branch. It detects unsafe physical aliasing between MLA latent-K and Mamba/KDA state blocks without changing cache allocation or inference behavior.

### Does this PR introduce any user-facing change?

No inference behavior changes. A one-time error log is emitted only if unsafe cross-group physical aliasing is detected during KV-cache initialization.

### How was this patch tested?

- python -m py_compile vllm_ascend/worker/model_runner_v1.py tests/ut/worker/a2/test_model_runner_v1.py
- git diff --check
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
