### PR TITLE
[Refactor](kv_pool): simplify backend and model-specific paths

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_scheduler.py
+++ b/tests/ut/distributed/ascend_store/test_pool_scheduler.py
@@ -585,7 +585,7 @@ class TestKVPoolSchedulerGetStoreLookupHitTokens(unittest.TestCase):
         for hash_count, exists, computed_tokens, expected in cases:
             with self.subTest(hash_count=hash_count, exists=exists, computed_tokens=computed_tokens):
                 scheduler = self._make_scheduler()
-                scheduler.store_scheduler.batch_is_exist.return_value = exists
+                scheduler.store_scheduler.exists.return_value = exists
                 request = MagicMock()
                 request.block_hashes = [b"\xaa"] * hash_count
                 result = scheduler._get_store_lookup_hit_tokens(request, 64, computed_tokens)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/memcache_backend.py
@@ -104,14 +104,6 @@ class MemcacheBackend(Backend):
         # keep the old device_id=0/init_bm=False behavior here.
         return cls(parallel_config, local_rank=0, init_bm=False)
 
-    def init_store(self, init_bm: bool = True):
-        if self.store is not None:
-            return
-        self._init_bm = init_bm
-        self.store = self._setup_store()
-        self._store_initialized = True
-        self._register_buffers_if_needed()
-
     def set_device(self):
         device = torch.device(f"npu:{self.local_rank}")
         torch.npu.set_device(device)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -158,26 +158,20 @@ class KVPoolScheduler:
         )
         self.tp_mismatch = tp_mismatch_info.enabled
 
-        backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake")
-        self.backend_name = backend_name.lower()
-        self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
-        backend = backend_map.get(self.backend_name)
+        backend_name = vllm_config.kv_transfer_config.kv_connector_extra_config.get("backend", "mooncake").lower()
+        self.use_gva_layerwise = self.use_layerwise and backend_name == "memcache"
+        backend = backend_map.get(backend_name)
         if backend is None:
             raise ValueError(f"Unsupported KV pool backend: {backend_name}")
-        backend_path = backend.get("path")
-        backend_class_name = backend.get("name")
-        assert backend_path is not None and backend_class_name is not None
-        backend_module = importlib.import_module(backend_path)
-        backend_class = getattr(backend_module, backend_class_name)
+        backend_module = importlib.import_module(backend["path"])
+        backend_class = getattr(backend_module, backend["name"])
         self.store_scheduler = backend_class.create_scheduler_client(vllm_config.parallel_config)
 
         model_config = vllm_config.model_config
         self.tp_size = vllm_config.parallel_config.tensor_parallel_size
         self.pp_size = vllm_config.parallel_config.pipeline_parallel_size
         self.pp_rank = (vllm_config.parallel_config.rank // self.tp_size) % self.pp_size
-        self.use_mla = False
-        if hasattr(model_config, "use_mla") and isinstance(model_config.use_mla, bool) and model_config.use_mla:
-            self.use_mla = True
+        self.use_mla = getattr(model_config, "use_mla", False) is True
         if self.use_mla:
             self.num_kv_head = 1
         else:
@@ -280,7 +274,7 @@ class KVPoolScheduler:
             include_layers=include_layers,
         )
         query_keys = [key for block_keys in query_keys_by_block for key in block_keys]
-        exists_states = self.store_scheduler.batch_is_exist(query_keys)
+        exists_states = self.store_scheduler.exists(query_keys)
         if len(exists_states) != len(query_keys):
             raise RuntimeError(
                 "KV pool exists check returned unexpected number of "

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -114,23 +114,17 @@ class KVPoolWorker:
         if self.compress_ratios is None:
             self.compress_ratios = getattr(hf_config, "compress_ratios", None)
         self.use_compress = self.compress_ratios is not None
-        self.dp_rank = parallel_config.data_parallel_rank
-
         self._init_parallelism_info(model_config, parallel_config)
         self._init_kv_transfer_config(vllm_config, extra_config, use_layerwise, kv_cache_config)
         self._init_key_head_config(model_config, parallel_config)
         self._init_metadata(model_config, vllm_config, extra_config)
-        self._init_backend(parallel_config, extra_config)
+        self._init_backend(parallel_config)
         self._init_kv_events(vllm_config)
         self._init_state_vars()
         self._init_layerwise_config()
 
     def _init_parallelism_info(self, model_config, parallel_config) -> None:
-        self.local_rank = envs.LOCAL_RANK
-
-        self.use_mla = False
-        if hasattr(model_config, "use_mla") and isinstance(model_config.use_mla, bool) and model_config.use_mla:
-            self.use_mla = True
+        self.use_mla = getattr(model_config, "use_mla", False) is True
         self.use_sparse = hasattr(model_config.hf_text_config, "index_topk")
 
         self.tp_rank = get_tensor_model_parallel_rank()
@@ -152,8 +146,7 @@ class KVPoolWorker:
         self._invalid_block_ids: set[int] = set()
         self._invalid_block_ids_lock = threading.Lock()
         self.consumer_is_to_put = extra_config.get("consumer_is_to_put", False)
-        self.backend = extra_config.get("backend", "mooncake")
-        self.backend_name = self.backend.lower()
+        self.backend_name = extra_config.get("backend", "mooncake").lower()
         self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
         kv_cache_groups = kv_cache_config.kv_cache_groups if kv_cache_config is not None else None
         self.use_hybrid = uses_hybrid_kv_cache(vllm_config.scheduler_config, kv_cache_groups)
@@ -308,23 +301,19 @@ class KVPoolWorker:
         self.cache_coordinator = self._build_cache_coordinator(vllm_config)
         self.token_database.cache_coordinator = self.cache_coordinator
 
-    def _init_backend(self, parallel_config, extra_config) -> None:
-        backend = backend_map.get(self.backend.lower())
-        assert backend is not None
-        backend_path = backend.get("path")
-        backend_name = backend.get("name")
-        assert backend_path is not None and backend_name is not None
-        backend_module = importlib.import_module(backend_path)
-        real_backend = getattr(backend_module, backend_name)
+    def _init_backend(self, parallel_config) -> None:
+        backend = backend_map.get(self.backend_name)
+        if backend is None:
+            raise ValueError(f"Unsupported KV pool backend: {self.backend_name}")
+        backend_module = importlib.import_module(backend["path"])
+        real_backend = getattr(backend_module, backend["name"])
 
-        backend_kwargs = {}
         # lazy_init is enabled only for DSV4 compress models. The backend further
         # gates this based on hardware: Mooncake requires ASCEND_ENABLE_FABRIC_MEM=1
         # (A3 fabric memory), and Memcache requires device_sdma protocol.
-        backend_kwargs["lazy_init"] = self.use_compress
         self.m_store = real_backend(  # type: ignore[misc]
             parallel_config,
-            **backend_kwargs,
+            lazy_init=self.use_compress,
         )
 
     def _init_kv_events(self, vllm_config) -> None:


### PR DESCRIPTION
## What this PR does / why we need it?

Follow-up of #14465. Simplify KV pool backend init and model-specific paths:
- Remove `MemcacheBackend.init_store()` (handled by constructor)
- Unify `batch_is_exist` → `exists`
- Simplify backend loading, MLA detection, and `_init_backend` signature

## Does this PR introduce any user-facing change?

No. Internal refactoring only.

## How was this patch tested?

- compileall syntax check
- UT updated for `exists()` rename
- #13242 block-size contract and #14046 waiter logic preserved

- vLLM version: v0.27.1
- vLLM main: vllm-project/vllm@58d3918
