### PR TITLE
[v0.23.0][Doc] Remove the w8a8c8-not-available-on-A2 note in GLM-5.2

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -892,7 +892,7 @@ The A2 series uses a different optimization stack than A3: FlashComm1 and DSA-CP
 
 On Atlas 800 A2, where each node exposes 8 cards, the same global P/D topology (Prefill `DP4 TP8`, Decode `DP8 TP4`) is split across 8 nodes: 4 prefill nodes hosting 1 DP rank each (8 cards per rank), and 4 decode nodes hosting 2 DP ranks each (4 cards per rank). The `launch_online_dp.py` above is reused as-is. The prefill side enables FlashComm1 and DSA CP; the decode side enables MLAPO and `DYNAMIC_EPLB` with a `FULL_DECODE_ONLY` graph. Both sides enable prefix caching and MTP (`num_speculative_tokens=1` on prefill, `3` on decode). All IPs, NIC names, ports and weight paths below are placeholders.
 
-**Note:** `GLM-5.2-w4a8c8` is an experimental feature with known accuracy issues in Prefill-Decode (PD) disaggregation scenarios (see [Model Weight](#31-model-weight)). The `GLM-5.2-w8a8c8` weights are not available for the A2 series; verify accuracy before production use in this scenario.
+**Note:** `GLM-5.2-w4a8c8` is an experimental feature with known accuracy issues in Prefill-Decode (PD) disaggregation scenarios (see [Model Weight](#31-model-weight)).
 
 Please refer to the [KV Cache Pool (Ascend Store) Deployment Guide](https://docs.vllm.ai/projects/ascend/zh-cn/latest/user_guide/feature_guide/kv_pool.html) for the KV Cache Pool startup method and the Mooncake configuration file.
 


### PR DESCRIPTION
The GLM-5.2-w8a8c8 weights are supported on the A2 series; remove the incorrect statement from the A2 PD scenario note.

### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
