### PR TITLE
[Test][Triton] Add RMS norm kernel e2e tests

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rms_norm.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rms_norm.py
@@ -1,0 +1,58 @@
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.rms_norm import triton_q_rms
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+DEVICE = "npu"
+TOLERANCES = {
+    torch.float16: (2e-3, 2e-2),
+    torch.bfloat16: (2e-2, 5e-2),
+    torch.float32: (1e-4, 1e-4),
+}
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_triton_device_properties():
+    init_device_properties_triton()
+
+
+def rms_norm_ref(x: torch.Tensor, eps: float) -> torch.Tensor:
+    x_fp32 = x.cpu().float()
+    out = x_fp32 * torch.rsqrt(x_fp32.square().mean(dim=-1, keepdim=True) + eps)
+    return out.to(x.dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize(
+    ("shape", "eps"),
+    [
+        pytest.param((1, 1, 128), 1e-6, id="single-row"),
+        pytest.param((2, 8, 512), 1e-5, id="multi-head"),
+        pytest.param((1, 17, 2048), 1e-5, id="max-hidden-size"),
+    ],
+)
+@torch.inference_mode()
+def test_triton_q_rms_correctness(dtype, shape, eps):
+    torch.manual_seed(42)
+    q = (torch.randn(shape, dtype=torch.float32) * 0.5).to(dtype=dtype, device=DEVICE)
+
+    actual = triton_q_rms(q, eps)
+    expected = rms_norm_ref(q, eps)
+    rtol, atol = TOLERANCES[dtype]
+
+    assert actual.shape == expected.shape
+    assert actual.dtype == expected.dtype
+    torch.testing.assert_close(
+        actual.float().cpu(),
+        expected.float().cpu(),
+        rtol=rtol,
+        atol=atol,
+    )
+
+
+def test_triton_q_rms_rejects_unsupported_dim():
+    q = torch.empty((1, 1, 2049), dtype=torch.float16, device=DEVICE)
+
+    with pytest.raises(NotImplementedError, match="dim > 2048 not supported"):
+        triton_q_rms(q, 1e-5)


### PR DESCRIPTION
### What this PR does / why we need it?

Adds single-card Triton operator test coverage for `triton_q_rms` / `triton_rms_kernel`, following the existing tests under `tests/e2e/nightly/single_node/ops/singlecard_ops/triton`.

The new test verifies `triton_q_rms` against an FP32 PyTorch RMSNorm baseline across representative dtype and shape cases, including the maximum supported hidden size. It also checks that hidden dimensions greater than 2048 are rejected.

`triton_q_rms` is used by the DSA Q RMS norm paths through `DeviceOperator.apply_dsa_q_rms`, and is also warmed up by `rms_triton_warmup`.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Added e2e test: `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rms_norm.py`
- Ran syntax check locally:
  `python -m py_compile tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rms_norm.py`
- Ran format/lint checks locally:
  `uvx ruff format --check tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rms_norm.py`
  `uvx ruff check tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rms_norm.py`

Could not run the NPU e2e test locally on this Windows PC.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
