### PR TITLE
[BugFix][KV Cache] Align A5 C8 MLA cache blocks with Mamba

### DIFF
--- a/tests/ut/patch/platform/test_patch_mamba_config.py
+++ b/tests/ut/patch/platform/test_patch_mamba_config.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.patch.platform import patch_mamba_config
+from vllm_ascend.utils import AscendDeviceType
+
+
+class _MambaModel:
+    @staticmethod
+    def get_mamba_state_shape_from_config(_vllm_config):
+        return [(786432,), (1,)]
+
+    @staticmethod
+    def get_mamba_state_dtype_from_config(_vllm_config):
+        return [torch.uint8, torch.uint8]
+
+
+@pytest.mark.parametrize(
+    ("fa_quant_enabled", "expected_block_size", "expected_page_size"),
+    [
+        (False, 768, 884737),
+        (True, 1536, 983041),
+    ],
+)
+def test_mamba_alignment_uses_a5_c8_latent_k_storage_bytes(
+    monkeypatch,
+    fa_quant_enabled,
+    expected_block_size,
+    expected_page_size,
+):
+    monkeypatch.setattr(
+        patch_mamba_config.MambaModelConfig,
+        "verify_and_update_config",
+        lambda _vllm_config: None,
+    )
+    monkeypatch.setattr(
+        patch_mamba_config.ModelRegistry,
+        "resolve_model_cls",
+        lambda *_args, **_kwargs: (_MambaModel, None),
+    )
+    monkeypatch.setattr(
+        patch_mamba_config,
+        "get_ascend_device_type",
+        lambda: AscendDeviceType.A5,
+    )
+    monkeypatch.setattr(
+        patch_mamba_config,
+        "enable_fa_quant",
+        lambda _vllm_config: fa_quant_enabled,
+    )
+
+    cache_config = SimpleNamespace(
+        cache_dtype="auto",
+        block_size=None,
+        mamba_page_size_padded=None,
+        mamba_cache_mode="align",
+        enable_prefix_caching=True,
+        mamba_block_size=None,
+    )
+    model_config = SimpleNamespace(
+        use_mla=True,
+        dtype=torch.bfloat16,
+        architecture="KimiK3ForConditionalGeneration",
+        hf_text_config=SimpleNamespace(
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+        ),
+        get_num_kv_heads=lambda _parallel_config: 1,
+        max_model_len=200000,
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=cache_config,
+        model_config=model_config,
+        parallel_config=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        kv_transfer_config=None,
+        speculative_config=None,
+    )
+
+    patch_mamba_config.verify_and_update_config(None, vllm_config)
+
+    assert cache_config.block_size == expected_block_size
+    assert cache_config.mamba_block_size == expected_block_size
+    assert cache_config.mamba_page_size_padded == expected_page_size

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -1,4 +1,5 @@
 import importlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,12 +10,37 @@ from vllm.v1.attention.selector import AttentionSelectorConfig  # type: ignore
 
 from tests.ut.base import TestBase
 from vllm_ascend.ascend_forward_context import MoECommType, override_mrv2_in_profile_run
-from vllm_ascend.platform import NPUPlatform
+from vllm_ascend.platform import NPUPlatform, _refresh_hybrid_mamba_cache_config
 from vllm_ascend.utils import (
     ASCEND_QUANTIZATION_METHOD,
     COMPRESSED_TENSORS_METHOD,
     AscendDeviceType,
 )
+
+
+@pytest.mark.parametrize("is_hybrid", [False, True])
+def test_refresh_hybrid_mamba_cache_config_after_quantization(
+    monkeypatch,
+    is_hybrid,
+):
+    from vllm.model_executor.models.config import HybridAttentionMambaModelConfig
+
+    refresh_config = MagicMock()
+    monkeypatch.setattr(
+        HybridAttentionMambaModelConfig,
+        "verify_and_update_config",
+        refresh_config,
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(is_hybrid=is_hybrid),
+    )
+
+    _refresh_hybrid_mamba_cache_config(vllm_config)
+
+    if is_hybrid:
+        refresh_config.assert_called_once_with(vllm_config)
+    else:
+        refresh_config.assert_not_called()
 
 
 class TestNPUPlatform(TestBase):

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -1,12 +1,16 @@
 # mypy: ignore-errors
 import math
 
+import torch
 import vllm.model_executor.models.config
 from vllm.logger import logger
 from vllm.model_executor.models import ModelRegistry
 from vllm.model_executor.models.config import MambaModelConfig
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size
+
+from vllm_ascend.quantization.utils import enable_fa_quant
+from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
 
 def _using_kv_store(vllm_config) -> bool:
@@ -82,7 +86,15 @@ def verify_and_update_config(cls, vllm_config) -> None:
         attn_num_kv_heads = model_config.get_num_kv_heads(parallel_config)
         kv_lora_rank = model_config.hf_text_config.kv_lora_rank
         qk_rope_head_dim = model_config.hf_text_config.qk_rope_head_dim
-        attn_single_token_k_page_size = kv_lora_rank * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
+        # A5 C8 stores the MLA latent-K in FP8 while retaining the positional
+        # cache in the configured KV-cache dtype. Use the actual latent-K
+        # storage dtype when deriving the hybrid MLA/Mamba manager block size.
+        latent_k_dtype = kv_cache_dtype
+        if get_ascend_device_type() == AscendDeviceType.A5 and enable_fa_quant(vllm_config):
+            latent_k_dtype = torch.float8_e4m3fn
+        attn_single_token_k_page_size = (
+            kv_lora_rank * attn_num_kv_heads * get_dtype_size(latent_k_dtype)
+        )
         attn_rope_token_page_size = qk_rope_head_dim * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
         attn_token_page_size = attn_single_token_k_page_size + attn_rope_token_page_size
     else:

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -105,6 +105,16 @@ def config_deprecated_logging():
     warnings_logger.propagate = False
 
 
+def _refresh_hybrid_mamba_cache_config(vllm_config: VllmConfig) -> None:
+    """Recompute hybrid MLA/Mamba cache alignment after quant config loads."""
+    if not getattr(vllm_config.model_config, "is_hybrid", False):
+        return
+
+    from vllm.model_executor.models.config import HybridAttentionMambaModelConfig
+
+    HybridAttentionMambaModelConfig.verify_and_update_config(vllm_config)
+
+
 def prune_capture_sizes_for_950(vllm_config):
     original_sizes = vllm_config.compilation_config.cudagraph_capture_sizes
     if not original_sizes:
@@ -421,6 +431,7 @@ class NPUPlatform(Platform):
             return
 
         maybe_auto_detect_quantization(vllm_config)
+        _refresh_hybrid_mamba_cache_config(vllm_config)
 
         cls._validate_draft_decode_context_parallel_config(vllm_config)
         cls._validate_parallel_config(vllm_config)


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes the hybrid MLA/Mamba KV-cache block alignment used by A5 C8 Kimi K3. The Mamba configuration originally derives the attention block size before automatic quantization has loaded the ModelSlim C8 settings. It therefore sees BF16 latent-K bytes instead of the actual FP8 storage size, leaving the MLA manager-block stride at half the Mamba state stride and allowing cross-ID physical aliasing.

This PR uses the real FP8 latent-K byte size while retaining the positional cache in the configured KV-cache dtype. It also reruns the hybrid MLA/Mamba configuration immediately after `maybe_auto_detect_quantization(vllm_config)` and before KV-cache planning. At that point the C8 configuration is available, so the final MLA and Mamba manager-block strides agree before cache allocation. It complements #13286 and is validated by the diagnostic introduced in #14693.

### Does this PR introduce any user-facing change?

Yes. A5 C8 Kimi K3 hybrid cache initialization now uses a safe MLA/Mamba block layout instead of one that can alias distinct logical blocks.

### How was this patch tested?

- `python -m py_compile vllm_ascend/platform.py tests/ut/test_platform.py vllm_ascend/patch/platform/patch_mamba_config.py tests/ut/patch/platform/test_patch_mamba_config.py`
- `git diff --check`
- Added unit regression coverage for BF16/C8 block alignment and for refreshing only hybrid model configurations after quantization detection.

The local Windows environment does not include pytest or ruff, so the targeted test requires CI/NPU validation.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
