### PR TITLE
[BugFix][MiniMax M3] Fix MXFP8 RMSNorm and sparse index bounds

### DIFF
--- a/tests/e2e/pull_request/one_card/test_minimax_m3_sparse_attn.py
+++ b/tests/e2e/pull_request/one_card/test_minimax_m3_sparse_attn.py
@@ -391,7 +391,12 @@ def test_prefill_index_topk_correctness(
 
     cu_seqlens = torch.zeros(batch + 1, device=DEVICE, dtype=torch.int32)
     cu_seqlens[1:] = q_lens.cumsum(0)
-    block_table = torch.randperm(num_pages, device=DEVICE, dtype=torch.int32).reshape(batch, max_blocks)
+    # Keep an invalid page directly before the view so a block_id=-1 access is
+    # deterministic instead of silently reading neighboring allocator memory.
+    block_table_storage = torch.empty(num_pages + 1, device=DEVICE, dtype=torch.int32)
+    block_table_storage[0] = torch.iinfo(torch.int32).max
+    block_table_storage[1:] = torch.randperm(num_pages, device=DEVICE, dtype=torch.int32)
+    block_table = block_table_storage[1:].reshape(batch, max_blocks)
     idx_q = torch.ones(q_lens.sum().item(), num_idx_heads, head_dim, device=DEVICE)
     index_kv_cache = _allocate_index_kv_cache(num_pages, head_dim, index_layout)
     for req_id in range(batch):

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -64,6 +64,25 @@ def test_RMSNorm_forward(
         assert torch.allclose(out_x, expected_out_x)
 
 
+def test_RMSNorm_supports_quant_config_without_quant_description(default_vllm_config):
+    default_vllm_config.quant_config = object()
+
+    layer = RMSNorm(hidden_size=8, eps=1e-05)
+
+    assert layer.bias is None
+
+
+def test_RMSNorm_creates_bias_from_quant_description(default_vllm_config):
+    quant_config = MagicMock()
+    quant_config.quant_description = {"model.layers.0.input_layernorm.bias": "W8A8"}
+    default_vllm_config.quant_config = quant_config
+
+    layer = RMSNorm(hidden_size=8, eps=1e-05)
+
+    assert layer.bias is not None
+    assert not layer.bias.requires_grad
+
+
 @pytest.mark.skipif(not is_310p_hw(), reason="310P device unittest case.")
 @pytest.mark.parametrize("residual", [None, torch.randn(4, 8, dtype=torch.float16)])
 @patch("torch_npu.npu_rms_norm", side_effect=mock_rms_norm)

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
@@ -192,7 +192,10 @@ def _index_block_score_kernel(
     bt_row = block_table_ptr + pid_b * stride_bt_b
     hi = tl.minimum(seq_len, prefix_len + (pid_q + 1) * BLOCK_SIZE_Q)
 
-    middle = (q_start - BLOCK_SIZE_K) // BLOCK_SIZE_K * BLOCK_SIZE_K
+    middle = tl.maximum(
+        0,
+        (q_start - BLOCK_SIZE_K) // BLOCK_SIZE_K * BLOCK_SIZE_K,
+    )
 
     for key_start in tl.range(0, middle, BLOCK_SIZE_K):
         block_id = key_start // BLOCK_SIZE_K

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -40,9 +40,8 @@ class AscendRMSNorm(RMSNorm):
         self.bias_loaded = False
 
         # quantization with anti_method m4 will generate none-zero norm bias
-        if vllm_config.quant_config is not None and any(
-            "norm.bias" in name for name in vllm_config.quant_config.quant_description
-        ):
+        quant_description = getattr(vllm_config.quant_config, "quant_description", None) or {}
+        if any("norm.bias" in name for name in quant_description):
             self.bias = torch.nn.Parameter(torch.zeros(hidden_size), requires_grad=False)
             self.bias.weight_loader = self._bias_weight_loader
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR carries the remaining MiniMax M3 MXFP8 follow-up fixes after #14412:

- tolerate quantization configs without `quant_description` in RMSNorm;
- clamp the A5 zero-prefix index-score range to avoid negative block-table access;
- add focused unit and E2E regression coverage.

The previous `SequenceRowParallelOp` / `matmul_and_reduce*` changes have been removed from this PR. FlashComm v1 and those paths were removed from `main` by #13946. The upstream SP path communicates after the quantization method returns a tensor, so the tuple-reduction compatibility code is no longer applicable.

This PR intentionally excludes `sparse_attention_score_950`, which is handled separately by #14642.

### Does this PR introduce _any_ user-facing change?

Yes. MiniMax M3 MXFP8 configurations without `quant_description` no longer fail during RMSNorm construction, and short/zero-prefix A5 index-score cases avoid negative block-table access. There is no new API, CLI option, or configuration format.

### How was this patch tested?

The following checks passed locally:

```bash
git diff --check upstream/main...HEAD
git diff --name-only -z --diff-filter=ACMR upstream/main...HEAD -- '*.py' | xargs -0 python3 -m compileall -q
```

NPU unit/E2E tests were not run locally because `torch`, `torch_npu`, `vllm`, and `pytest` are unavailable in this environment.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
