### PR TITLE
[Refactor][Config] Remove balance scheduling environment variable

### DIFF
--- a/docs/source/developer_guide/Design_Documents/balance_schedule_refactor.md
+++ b/docs/source/developer_guide/Design_Documents/balance_schedule_refactor.md
@@ -37,8 +37,9 @@ growing. It is **not** "make the lagging ranks catch up to the leader" (that
 semantic is **explicitly rejected** here — see
 [Behavior-preservation contract](#behavior-preservation-contract), item 1).
 
-The feature is enabled via `additional_config.enable_balance_scheduling = true`
-(the environment variable `VLLM_ASCEND_BALANCE_SCHEDULING` is deprecated). It
+The feature is enabled via
+`additional_config.scheduler_config.enable_balance_scheduling = true`. The
+legacy environment variable is no longer supported. It
 supports PD-mixed mode only; validation lives in `vllm_ascend/platform.py` and
 `vllm_ascend/ascend_config.py`.
 
@@ -168,10 +169,9 @@ drafting assumptions did not hold; both are corrected here:
 Accordingly the Phase 1 description and the "post-refactor file shape" below are
 both rewritten to match the actual implementation. Phase 3 collapses config
 probing to two fallbacks (AscendConfig → additional_config) and **removes the
-direct environment-variable read** — `VLLM_ASCEND_BALANCE_SCHEDULING` is still
-parsed centrally by `AscendConfig` (as a deprecated fallback for
-`additional_config`), but `_balance_scheduling_enabled` no longer reads it
-itself, bypassing `AscendConfig`. Details in [Phased rollout](#phased-rollout).
+direct environment-variable read**. Balance scheduling is now configured only
+through `additional_config`; `_balance_scheduling_enabled` no longer bypasses
+`AscendConfig`. Details in [Phased rollout](#phased-rollout).
 
 ### Step 1 — Hook gather onto `_has_global_unfinished_reqs` and delete the EngineCore copies
 
@@ -356,12 +356,9 @@ moment still cannot be guaranteed (the origin of the old top-of-file TODO), so
 returns `False` otherwise. This round tightens one thing relative to the old
 implementation:
 
-- **The direct environment-variable read is removed.** The old implementation
-  fell back to a bare `os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING")`, violating
-  AGENTS.md's "no scattered `os.getenv`". This function no longer reads the
-  environment itself — `VLLM_ASCEND_BALANCE_SCHEDULING` is parsed centrally by
-  `AscendConfig` (as a deprecated fallback for `additional_config`) and takes
-  effect via the main `get_ascend_config().enable_balance_scheduling` path,
+- **The environment-variable path is removed.** The old implementation read
+  the setting from the environment. Balance scheduling now takes effect only
+  through the main `get_ascend_config().enable_balance_scheduling` path,
   avoiding multiple entry points.
 - The top-of-file TODO is updated to "once AscendConfig initialization is moved
   earlier, this can collapse to a single
@@ -428,7 +425,7 @@ def _balance_scheduling_enabled(vllm_config) -> bool:
     additional_config = getattr(vllm_config, "additional_config", None) or {}
     if "enable_balance_scheduling" in additional_config:
         return bool(additional_config["enable_balance_scheduling"])
-    return False  # no longer reads the env var itself; VLLM_ASCEND_BALANCE_SCHEDULING is parsed by AscendConfig
+    return False  # no environment-variable fallback
 
 
 class BalanceScheduler(Scheduler):

--- a/docs/source/developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.md
+++ b/docs/source/developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.md
@@ -147,7 +147,8 @@ After each batch, feature vectors `[Σ(C+H)·C, Σ(C+H), N]` and actual executio
 
 - **Pipeline Parallelism Required**: Must set `--pipeline-parallel-size > 1`
 - **Chunked Prefill Required**: Must enable `--enable-chunked-prefill`
-- **Incompatible with Balance Scheduling**: Cannot enable `VLLM_ASCEND_BALANCE_SCHEDULING`
+- **Incompatible with Balance Scheduling**: Cannot enable
+  `additional_config.scheduler_config.enable_balance_scheduling`
 - **Startup Overhead**: Profiling phase adds tens of seconds to initialization
 - **Memory**: No additional runtime memory overhead; profiling reuses existing dummy_run mechanism
 

--- a/docs/source/tutorials/models/DeepSeek-R1.md
+++ b/docs/source/tutorials/models/DeepSeek-R1.md
@@ -140,10 +140,9 @@ export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
 export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_ASCEND_BALANCE_SCHEDULING=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-vllm serve vllm-ascend/DeepSeek-R1-W8A8 \
+vllm serve vllm-ascend/DeepSeek-R1-W8A8 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
   --host 0.0.0.0 \
   --port 8000 \
   --data-parallel-size 4 \
@@ -163,7 +162,7 @@ vllm serve vllm-ascend/DeepSeek-R1-W8A8 \
 
 Key Parameter Descriptions:
 
-- Setting the environment variable `VLLM_ASCEND_BALANCE_SCHEDULING=1` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
+- Setting `additional_config.scheduler_config.enable_balance_scheduling=true` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
 - For single-node deployment, we recommend using `dp4tp4` instead of `dp2tp8`.
 - `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. For performance testing with an input length of 3.5k and output length of 1.5k, a value of `16384` is sufficient, however, for precision testing, please set it to at least `35000`.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
@@ -243,11 +242,10 @@ Run the following scripts on two nodes respectively.
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export HCCL_INTRA_PCIE_ENABLE=1
     export HCCL_INTRA_ROCE_ENABLE=0
 
-    vllm serve vllm-ascend/DeepSeek-R1-W8A8 \
+    vllm serve vllm-ascend/DeepSeek-R1-W8A8 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8000 \
     --data-parallel-size 4 \
@@ -289,11 +287,10 @@ Run the following scripts on two nodes respectively.
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export HCCL_INTRA_PCIE_ENABLE=1
     export HCCL_INTRA_ROCE_ENABLE=0
 
-    vllm serve vllm-ascend/DeepSeek-R1-W8A8 \
+    vllm serve vllm-ascend/DeepSeek-R1-W8A8 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8000 \
     --headless \

--- a/docs/source/tutorials/models/DeepSeek-V3.1.md
+++ b/docs/source/tutorials/models/DeepSeek-V3.1.md
@@ -227,7 +227,6 @@ Single-node deployment completes both Prefill and Decode within the same node. T
     export GLOO_SOCKET_IFNAME=$nic_name
     export TP_SOCKET_IFNAME=$nic_name
     export HCCL_SOCKET_IFNAME=$nic_name
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
@@ -246,12 +245,13 @@ Single-node deployment completes both Prefill and Decode within the same node. T
     --no-enable-prefix-caching \
     --gpu-memory-utilization 0.92 \
     --speculative-config '{"num_speculative_tokens": 3, "method": "mtp"}' \
-    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+    --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
+    --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}'
     ```
 
 Key Parameter Descriptions:
 
-- Setting the environment variable `VLLM_ASCEND_BALANCE_SCHEDULING=1` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
+- Setting `additional_config.scheduler_config.enable_balance_scheduling=true` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
 - For single-node deployment, we recommend using `dp4tp4` instead of `dp2tp8`.
 - `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. For performance testing with an input length of 3.5k and output length of 1.5k, a value of `16384` is sufficient, however, for precision testing, please set it at least `35000`.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
@@ -340,11 +340,10 @@ Run the following scripts on two nodes respectively.
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export HCCL_INTRA_PCIE_ENABLE=1
     export HCCL_INTRA_ROCE_ENABLE=0
 
-    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
+    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8004 \
     --data-parallel-size 4 \
@@ -393,11 +392,10 @@ Run the following scripts on two nodes respectively.
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export HCCL_INTRA_PCIE_ENABLE=1
     export HCCL_INTRA_ROCE_ENABLE=0
 
-    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot \
+    vllm serve /weights/DeepSeek-V3.1-w8a8-mtp-QuaRot --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8004 \
     --headless \

--- a/docs/source/tutorials/models/GLM4.x.md
+++ b/docs/source/tutorials/models/GLM4.x.md
@@ -130,7 +130,6 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 export HCCL_OP_EXPANSION_MODE=AIV
-export VLLM_ASCEND_BALANCE_SCHEDULING=1
 export VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE=1
 
 vllm serve Eco-Tech/GLM-4.7-W8A8-floatmtp \
@@ -147,7 +146,7 @@ vllm serve Eco-Tech/GLM-4.7-W8A8-floatmtp \
   --gpu-memory-utilization 0.9 \
   --speculative-config '{"num_speculative_tokens": 3, "method":"mtp", "enforce_eager":true}' \
   --compilation-config '{"cudagraph_capture_sizes": [1,2,4,8,16,32,64,128,256,512], "cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}'
+  --additional-config '{"enable_shared_expert_dp":true,"ascend_fusion_config":{"fusion_ops_gmmswigluquant":false},"scheduler_config":{"enable_balance_scheduling":true}}'
 ```
 
 **Notice:**
@@ -179,7 +178,6 @@ While the previous documentation advises against multi-node deployment on the At
     export OMP_NUM_THREADS=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
     export HCCL_OP_EXPANSION_MODE=AIV
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE=1
 
     vllm serve Eco-Tech/GLM-4.7-W8A8-floatmtp \
@@ -205,7 +203,7 @@ While the previous documentation advises against multi-node deployment on the At
     --served-model-name glm47 \
     --speculative-config '{"num_speculative_tokens": 3, "method":"mtp", "enforce_eager":true}' \
     --compilation-config '{"cudagraph_capture_sizes": [1,2,4,8,16,32,64,128,256,512], "cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}'
+    --additional-config '{"enable_shared_expert_dp":true,"ascend_fusion_config":{"fusion_ops_gmmswigluquant":false},"scheduler_config":{"enable_balance_scheduling":true}}'
     ```
 
 === "Node 1"
@@ -229,7 +227,6 @@ While the previous documentation advises against multi-node deployment on the At
     export OMP_NUM_THREADS=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
     export HCCL_OP_EXPANSION_MODE=AIV
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE=1
 
     vllm serve Eco-Tech/GLM-4.7-W8A8-floatmtp \
@@ -256,7 +253,7 @@ While the previous documentation advises against multi-node deployment on the At
     --served-model-name glm47 \
     --speculative-config '{"num_speculative_tokens": 3, "method":"mtp", "enforce_eager":true}' \
     --compilation-config '{"cudagraph_capture_sizes": [1,2,4,8,16,32,64,128,256,512], "cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}'
+    --additional-config '{"enable_shared_expert_dp":true,"ascend_fusion_config":{"fusion_ops_gmmswigluquant":false},"scheduler_config":{"enable_balance_scheduling":true}}'
     ```
 
 ### 5.3 Prefill-Decode Disaggregation

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -184,7 +184,7 @@ Only the key parameters specific to this model/scenario are described below. `ma
 
 - `"enable_dsa_cp": true`: Enables DSA context parallelism to accelerate long-context prefill. With DSA-CP enabled, `layer_sharding` cannot include `o_proj`.
 - `"enable_sparse_li_c8": true`: Sparse attention optimizations of the C8 quantized model. `enable_sparse_li_c8` accelerates the layer-index (LI) sparse attention and is recommended to keep `true`; If the GPU memory is insufficient due to a long sequence length, you are advised to enable `enable_sparse_sfa_c8`.
-- `"enable_balance_scheduling": true`: Balance scheduling improves output throughput and reduces TPOT in the v1 scheduler. It replaces the deprecated environment variable `VLLM_ASCEND_BALANCE_SCHEDULING`; TTFT may degrade in some scenarios, and it is not recommended when Prefill-Decode is separated.
+- `"enable_balance_scheduling": true`: Balance scheduling improves output throughput and reduces TPOT in the v1 scheduler. This config field replaces the removed environment setting; TTFT may degrade in some scenarios, and it is not recommended when Prefill-Decode is separated.
 - `"multistream_overlap_shared_expert": true`: Overlaps shared-expert computation on an additional stream, improving decode efficiency.
 
 ##### 5.1.1.2 Multi-Node Co-Located Deployment

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -148,7 +148,6 @@ If you want to deploy multi-node environment, you need to set up environment on 
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
     --host 0.0.0.0 \
@@ -166,7 +165,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --quantization ascend \
     --enable-chunked-prefill \
     --enable-prefix-caching \
-    --additional-config '{"multistream_overlap_shared_expert": true}' \
+    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
@@ -181,7 +180,6 @@ If you want to deploy multi-node environment, you need to set up environment on 
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export VLLM_ASCEND_ENABLE_MLAPO=1
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
@@ -200,7 +198,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --quantization ascend \
     --enable-chunked-prefill \
     --enable-prefix-caching \
-    --additional-config '{"multistream_overlap_shared_expert": true}' \
+    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
@@ -219,7 +217,6 @@ If you want to deploy multi-node environment, you need to set up environment on 
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
     --host 0.0.0.0 \
@@ -238,7 +235,7 @@ If you want to deploy multi-node environment, you need to set up environment on 
     --enable-chunked-prefill \
     --enable-prefix-caching \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"multistream_overlap_shared_expert": true}' \
+    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
@@ -259,7 +256,7 @@ Only the key parameters specific to this model/scenario are described below. `ma
 **Key environment variables:**
 
 - `VLLM_ASCEND_ENABLE_MLAPO=1`: Enables the MLA preprocess fusion operator (MlaPreprocessOperation). Enabled by default for w8a8 models — significantly improves Decode performance but consumes more NPU memory; set `VLLM_ASCEND_ENABLE_MLAPO=0` if memory is a priority. Recommended for w8a8; w4a8 may not benefit.
-- `VLLM_ASCEND_BALANCE_SCHEDULING=1`: Enables balance scheduling to improve output throughput and reduce TPOT in the v1 scheduler.
+- `additional_config.scheduler_config.enable_balance_scheduling=true`: Enables balance scheduling to improve output throughput and reduce TPOT in the v1 scheduler.
 
 **Performance tuning notes for single-node:**
 
@@ -299,10 +296,9 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
     export OMP_PROC_BIND=false
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8077 \
     --data-parallel-size 2 \
@@ -341,10 +337,9 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
     export OMP_PROC_BIND=false
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-bf16 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8077 \
     --headless \
@@ -389,7 +384,6 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
     export OMP_PROC_BIND=false
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
@@ -410,7 +404,7 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"multistream_overlap_shared_expert": true}' \
+    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
@@ -433,7 +427,6 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
     export OMP_PROC_BIND=false
     export OMP_NUM_THREADS=1
     export HCCL_BUFFSIZE=200
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
@@ -456,7 +449,7 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
     --trust-remote-code \
     --gpu-memory-utilization 0.95 \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"multistream_overlap_shared_expert": true}' \
+    --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
     --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
     ```
 
@@ -543,7 +536,6 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export HCCL_BUFFSIZE=200
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_ASCEND_BALANCE_SCHEDULING=1
 export VLLM_ASCEND_ENABLE_MLAPO=1
 
 vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
@@ -566,7 +558,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
 --enable-chunked-prefill \
 --enable-prefix-caching \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
 ```
 
@@ -591,7 +583,6 @@ export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=1
 export HCCL_BUFFSIZE=200
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_ASCEND_BALANCE_SCHEDULING=1
 export VLLM_ASCEND_ENABLE_MLAPO=1
 
 vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
@@ -616,7 +607,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
 --enable-chunked-prefill \
 --enable-prefix-caching \
 --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---additional-config '{"multistream_overlap_shared_expert": true}' \
+--additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}' \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
 ```
 

--- a/docs/source/tutorials/models/Kimi-K2.5.md
+++ b/docs/source/tutorials/models/Kimi-K2.5.md
@@ -143,9 +143,8 @@ export TASK_QUEUE_ENABLE=1
 
 export HCCL_BUFFSIZE=800
 export VLLM_ASCEND_ENABLE_MLAPO=1
-export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
-vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
+vllm serve Eco-Tech/Kimi-K2.5-w4a8 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
   --host 0.0.0.0 \
   --port 8088 \
   --quantization ascend \
@@ -171,7 +170,7 @@ vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
 
 Key Parameter Descriptions:
 
-- Setting the environment variable `VLLM_ASCEND_BALANCE_SCHEDULING=1` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
+- Setting `additional_config.scheduler_config.enable_balance_scheduling=true` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
 - For single-node deployment, we recommend using `dp4 tp4` instead of `dp2 tp8`.
 - `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. For performance testing with an input length of 3.5K and output length of 1.5K, a value of `16384` is sufficient, however, for precision testing, please set it at least `35000`.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
@@ -272,9 +271,8 @@ Run the following scripts on two nodes respectively.
 
     export HCCL_BUFFSIZE=1024
     export VLLM_ASCEND_ENABLE_MLAPO=1
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
-    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8088 \
     --quantization ascend \
@@ -339,9 +337,8 @@ Run the following scripts on two nodes respectively.
 
     export HCCL_BUFFSIZE=1024
     export VLLM_ASCEND_ENABLE_MLAPO=1
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
 
-    vllm serve Eco-Tech/Kimi-K2.5-w4a8 \
+    vllm serve Eco-Tech/Kimi-K2.5-w4a8 --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
     --host 0.0.0.0 \
     --port 8088 \
     --quantization ascend \

--- a/docs/source/tutorials/models/Kimi-K2.6.md
+++ b/docs/source/tutorials/models/Kimi-K2.6.md
@@ -146,7 +146,6 @@ sysctl -w kernel.numa_balancing=0
 sysctl -w kernel.sched_migration_cost_ns=50000
 
 export HCCL_BUFFSIZE=600
-export VLLM_ASCEND_BALANCE_SCHEDULING=0
 
 vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
     --quantization ascend \
@@ -169,13 +168,13 @@ vllm serve Eco-Tech/Kimi-K2.6-W4A8 \
     --profiler-config '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}' \
     --mm-processor-cache-gb 0 \
     --mm-encoder-tp-mode data \
-    --additional-config '{"enable_balance_scheduling": true}' \
+    --additional-config '{"scheduler_config":{"enable_balance_scheduling":false}}' \
     --speculative-config '{"method": "dflash","model": "z-lab/Kimi-K2.5-DFlash", "num_speculative_tokens": 15}'
 ```
 
 Key Parameter Descriptions:
 
-- Setting the environment variable `VLLM_ASCEND_BALANCE_SCHEDULING=1` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
+- Setting `additional_config.scheduler_config.enable_balance_scheduling=true` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios. Furthermore, enabling this feature is not recommended in scenarios where PD is separated.
 - `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. For performance testing with an input length of 3.5K and output length of 1.5K, a value of `16384` is sufficient, however, for precision testing, please set it at least `35000`.
 - `--no-enable-prefix-caching` indicates that prefix caching is disabled. To enable it, remove this option.
 - `--mm-encoder-tp-mode` indicates how to optimize multi-modal encoder inference using tensor parallelism (TP). If you want to test the multimodal inputs, we recommend using `data`.

--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -178,7 +178,6 @@ sysctl kernel.sched_migration_cost_ns=50000
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 export TASK_QUEUE_ENABLE=1
 
-export VLLM_ASCEND_BALANCE_SCHEDULING=0
 
 vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --served-model-name "MiniMax-M2.7" \
@@ -187,7 +186,8 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --trust-remote-code \
     --quantization ascend \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-    --additional-config '{"enable_cpu_binding":true,
+    --additional-config '{"scheduler_config":{"enable_balance_scheduling":false},
+                          "enable_cpu_binding":true,
                           "enable_fused_mc2":true,
                           "weight_nz_mode":true}' \
     --enable-expert-parallel \
@@ -600,7 +600,7 @@ The following optimizations are enabled by default and require no additional con
 | Optimization Technique | Applicable Scenarios | Enablement Method | Technical Principle | Precautions |
 | ---------------------- | -------------------- | ----------------- | ------------------- | ----------- |
 | Fused MC2 | TP ≥ 4 scenarios | `--additional-config '{"enable_fused_mc2": true}'` | Fuses multiple communication and computation operations | Recommended for A3; not applicable for A2 |
-| Balanced Scheduling | High DP scenarios | `export VLLM_ASCEND_BALANCE_SCHEDULING=1` | Enhances scheduling capacity between prefill and decode | Currently disabled by default (`0`). Set to `1` only when concurrency ≈ DP × max-num-seqs. Disable for long-context scenarios |
+| Balanced Scheduling | High DP scenarios | `--additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}'` | Enhances scheduling capacity between prefill and decode | Currently disabled by default (`0`). Set to `1` only when concurrency ≈ DP × max-num-seqs. Disable for long-context scenarios |
 | EAGLE3 Speculative Decoding | All scenarios | `--speculative_config '{"method": "eagle3", "model": "/path/to/Eagle3/", "num_speculative_tokens": 3}'` | Uses a draft model to predict future tokens | 1–3 tokens for long context; 3 tokens for short context |
 | jemalloc Preload | All scenarios | `export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2` | Replaces default memory allocator to reduce fragmentation | Ensure jemalloc is installed in the container |
 

--- a/docs/source/tutorials/models/Mixtral-8x7B-Instruct-v0.1.md
+++ b/docs/source/tutorials/models/Mixtral-8x7B-Instruct-v0.1.md
@@ -95,7 +95,7 @@ vllm serve "mistralai/Mixtral-8x7B-Instruct-v0.1" \
 **Notice:**
 The parameters are explained as follows:
 
-- Setting the environment variable `VLLM_ASCEND_BALANCE_SCHEDULING=1` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios.
+- Setting `additional_config.scheduler_config.enable_balance_scheduling=true` enables balance scheduling. This may help increase output throughput and reduce TPOT in v1 scheduler. However, TTFT may degrade in some scenarios.
 - `--max-model-len` specifies the maximum context length - that is, the sum of input and output tokens for a single request. For testing purposes, a value of `4096` is used here.
 - `--dtype float16` specifies the data type for model weights and computations.
 - `--trust-remote-code` allows loading models with custom code.

--- a/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
+++ b/docs/source/tutorials/models/Qwen3-VL-235B-A22B-Instruct.md
@@ -261,9 +261,7 @@ Single-node deployment runs both Prefill and Decode on the same node. The W8A8 v
     export OMP_PROC_BIND=false
     export TASK_QUEUE_ENABLE=1
     export VLLM_ASCEND_ENABLE_FUSED_MC2=1
-    export VLLM_ASCEND_BALANCE_SCHEDULING=1
-
-    vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot \
+    vllm serve Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot --additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}' \
       --host 0.0.0.0 \
       --port 8000 \
       --served-model-name qwen3-vl-235b \

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -138,7 +138,7 @@ The legacy top-level `enable_balance_scheduling`, `recompute_scheduler_enable`, 
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| `enable_balance_scheduling` | bool | `False` | Whether to enable balance scheduling. Can also be configured via the `VLLM_ASCEND_BALANCE_SCHEDULING` environment variable during the migration period. |
+| `enable_balance_scheduling` | bool | `False` | Whether to enable balance scheduling. The legacy `VLLM_ASCEND_BALANCE_SCHEDULING` environment variable is no longer supported. |
 | `recompute_scheduler_enable` | bool | `False` | Whether to enable the recompute scheduler. **Only valid on PD-disaggregated D nodes** (`kv_role` is `kv_consumer`). **Do not enable on P nodes or in PD-mixed mode** (no `kv_transfer_config`, `kv_role` is `kv_producer`, or `kv_role` is `kv_both`); startup will fail with a clear error. |
 | `profiling_chunk_config` | dict | `{}` | Configuration options for dynamic chunked pipeline parallel. See [Dynamic Chunked Pipeline Parallel](../feature_guide/dynamic_chunk_pipeline_parallel.md) for details. |
 | `short_request_first_config` | dict | `{}` | Configuration options for ShortRequestFirst prefill scheduling on FCFS synchronous or asynchronous, PD-prefill (P), or PD-mixed nodes. |

--- a/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
+++ b/docs/source/user_guide/feature_guide/dynamic_chunk_pipeline_parallel.md
@@ -300,5 +300,5 @@ To evaluate the effectiveness of Dynamic Chunked Pipeline Parallel in long seque
 
 - **Pipeline Parallelism Required**: `--pipeline-parallel-size > 1`
 - **Chunked Prefill Required**: `--enable-chunked-prefill`
-- **Incompatible with Balance Scheduling**: Cannot enable `VLLM_ASCEND_BALANCE_SCHEDULING`
+- **Incompatible with Balance Scheduling**: Cannot enable `additional_config.scheduler_config.enable_balance_scheduling`
 - **Startup Overhead**: Profiling adds ~64 forward passes (tens of seconds)

--- a/docs/source/user_guide/feature_guide/short_request_first.md
+++ b/docs/source/user_guide/feature_guide/short_request_first.md
@@ -104,7 +104,7 @@ ShortRequestFirst also emits an aggregate stats log every 5s so queue behavior i
 
 ShortRequestFirst changes only the waiting-queue policy. It requires FCFS scheduling and supports both synchronous and asynchronous scheduling. It is not supported with batch-job-aware scheduling, profiling-chunk scheduling, or on PD-disaggregated D nodes (`kv_role='kv_consumer'`).
 
-The `VLLM_ASCEND_BALANCE_SCHEDULING` setting keeps its existing behavior: it controls balance scheduling's cross-DP admission logic. ShortRequestFirst is installed independently of whether balance scheduling is enabled, so the balance-disabled path continues to delegate scheduling to vLLM while using the ShortRequestFirst waiting queue.
+The `additional_config.scheduler_config.enable_balance_scheduling` setting keeps its existing behavior: it controls balance scheduling's cross-DP admission logic. ShortRequestFirst is installed independently of whether balance scheduling is enabled, so the balance-disabled path continues to delegate scheduling to vLLM while using the ShortRequestFirst waiting queue.
 
 ## Minimal examples
 

--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3.1-BF16.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-V3.1-BF16.yaml
@@ -10,7 +10,6 @@ env_common: &env_common
   PYTORCH_NPU_ALLOC_CONF: expandable_segments:True
   OMP_NUM_THREADS: 1
   VLLM_ASCEND_ENABLE_MLAPO: 1
-  VLLM_ASCEND_BALANCE_SCHEDULING: 1
   HCCL_INTRA_PCIE_ENABLE: 1
   HCCL_INTRA_ROCE_ENABLE: 0
   VLLM_ENGINE_READY_TIMEOUT_S: "3000"
@@ -37,7 +36,7 @@ deployment:
       --gpu-memory-utilization 0.95
       --speculative-config '{"num_speculative_tokens": 1, "method":"mtp"}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[2, 4, 8, 16, 32]}'
-      --additional_config '{"multistream_overlap_shared_expert": true}'
+      --additional_config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}'
 
   -
     envs:
@@ -60,7 +59,7 @@ deployment:
       --gpu-memory-utilization 0.95
       --speculative-config '{"num_speculative_tokens": 1, "method":"mtp"}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[2, 4, 8, 16, 32]}'
-      --additional_config '{"multistream_overlap_shared_expert": true}'
+      --additional_config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}'
 benchmarks:
   perf:
     case_type: performance

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A2-dual-nodes.yaml
@@ -8,7 +8,6 @@ env_common: &env_common
   OMP_NUM_THREADS: 1
   HCCL_BUFFSIZE: 200
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-  VLLM_ASCEND_BALANCE_SCHEDULING: 0
   VLLM_ASCEND_ENABLE_MLAPO: 1
   VLLM_USE_MODELSCOPE: true
   VLLM_ENGINE_READY_TIMEOUT_S: 3000
@@ -39,7 +38,7 @@ deployment:
       --gpu-memory-utilization 0.95
       --quantization ascend
       --no-enable-prefix-caching
-      --additional-config '{"multistream_overlap_shared_expert": true, "ascend_compilation_config": {"fuse_qknorm_rope": false}}'
+      --additional-config '{"multistream_overlap_shared_expert":true,"ascend_compilation_config":{"fuse_qknorm_rope":false},"scheduler_config":{"enable_balance_scheduling":false}}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes": [1,4,8,12,16,20,24,28,32,36,48,60,72]}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
   -
@@ -65,7 +64,7 @@ deployment:
       --gpu-memory-utilization 0.95
       --quantization ascend
       --no-enable-prefix-caching
-      --additional-config '{"multistream_overlap_shared_expert": true, "ascend_compilation_config": {"fuse_qknorm_rope": false}}'
+      --additional-config '{"multistream_overlap_shared_expert":true,"ascend_compilation_config":{"fuse_qknorm_rope":false},"scheduler_config":{"enable_balance_scheduling":false}}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes": [1,4,8,12,16,20,24,28,32,36,48,60,72]}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 benchmarks:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM5_1-W8A8-A3-dual-nodes.yaml
@@ -9,7 +9,6 @@ env_common: &env_common
   OMP_NUM_THREADS: 1
   HCCL_BUFFSIZE: 200
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-  VLLM_ASCEND_BALANCE_SCHEDULING: 0
   VLLM_ASCEND_ENABLE_MLAPO: 1
   VLLM_ENGINE_READY_TIMEOUT_S: "3000"
   VLLM_RPC_TIMEOUT: "600"
@@ -41,7 +40,7 @@ deployment:
       --enable-chunked-prefill
       --enable-prefix-caching
       --async-scheduling
-      --additional-config '{"multistream_overlap_shared_expert":true}'
+      --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":false}}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
   -
@@ -69,7 +68,7 @@ deployment:
       --enable-chunked-prefill
       --enable-prefix-caching
       --async-scheduling
-      --additional-config '{"multistream_overlap_shared_expert":true}'
+      --additional-config '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":false}}'
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 benchmarks:

--- a/tests/e2e/nightly/single_node/models/configs/GLM-4.7.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/GLM-4.7.yaml
@@ -9,7 +9,6 @@ _envs: &envs
   OMP_NUM_THREADS: "1"
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
   HCCL_OP_EXPANSION_MODE: "AIV"
-  VLLM_ASCEND_BALANCE_SCHEDULING: "1"
   VLLM_ASCEND_ENABLE_TOPK_OPTIMIZE: "1"
   VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
 
@@ -35,7 +34,7 @@ _server_cmd: &server_cmd
   - "--speculative-config"
   - '{"num_speculative_tokens": 3, "method":"mtp"}'
   - "--additional-config"
-  - '{"enable_shared_expert_dp": true, "ascend_fusion_config": {"fusion_ops_gmmswigluquant": false}}'
+  - '{"enable_shared_expert_dp":true,"ascend_fusion_config":{"fusion_ops_gmmswigluquant":false},"scheduler_config":{"enable_balance_scheduling":true}}'
 
 _benchmarks: &benchmarks
   acc:

--- a/tests/e2e/nightly/single_node/models/configs/Kimi-K2.6-w4a8-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Kimi-K2.6-w4a8-A3.yaml
@@ -13,7 +13,6 @@ test_cases:
       HCCL_BUFFSIZE: "800"
       VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       DYNAMIC_EPLB: "true"
       SERVER_PORT: "DEFAULT_PORT"
@@ -47,7 +46,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": true},"ascend_compilation_config": {"enable_static_kernel": false}}'
+      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}'
       - "--mm-processor-cache-gb"

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
@@ -11,7 +11,6 @@ _envs: &envs
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
   VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
   VLLM_ASCEND_ENABLE_NZ: "2"
-  VLLM_ASCEND_BALANCE_SCHEDULING: "1"
   SERVER_PORT: "DEFAULT_PORT"
 
 _server_cmd: &server_cmd
@@ -65,5 +64,7 @@ test_cases:
     server_cmd_extra:
       - "--compilation_config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,24,32]}'
+      - --additional-config
+      - '{"scheduler_config":{"enable_balance_scheduling":true}}'
     benchmarks:
       <<: *benchmarks

--- a/tests/e2e/weekly/single_node/configs/GLM-5.yaml
+++ b/tests/e2e/weekly/single_node/configs/GLM-5.yaml
@@ -9,7 +9,6 @@ _envs: &envs
   OMP_PROC_BIND: "false"
   OMP_NUM_THREADS: "1"
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-  VLLM_ASCEND_BALANCE_SCHEDULING: "0"
 _server_cmd: &server_cmd
   - "--enable-expert-parallel"
   - "--tensor-parallel-size"
@@ -30,7 +29,7 @@ _server_cmd: &server_cmd
   - "--quantization"
   - "ascend"
   - "--additional-config"
-  - '{"multistream_overlap_shared_expert": false, "ascend_compilation_config": {"enable_npugraph_ex": true}}'
+  - '{"multistream_overlap_shared_expert":false,"ascend_compilation_config":{"enable_npugraph_ex":true},"scheduler_config":{"enable_balance_scheduling":false}}'
   - "--speculative-config"
   - '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
 

--- a/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
+++ b/tests/e2e/weekly/single_node/configs/GLM-5_1-W8A8_A3_weekly.yaml
@@ -8,7 +8,6 @@ _envs: &envs
   OMP_NUM_THREADS: "1"
   HCCL_BUFFSIZE: "200"
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-  VLLM_ASCEND_BALANCE_SCHEDULING: "1"
   VLLM_ASCEND_ENABLE_MLAPO: "1"
   SERVER_PORT: "DEFAULT_PORT"
 
@@ -29,7 +28,7 @@ _server_cmd: &server_cmd
   - "ascend"
   - "--enable-chunked-prefill"
   - "--additional-config"
-  - '{"multistream_overlap_shared_expert":true}'
+  - '{"multistream_overlap_shared_expert":true,"scheduler_config":{"enable_balance_scheduling":true}}'
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--speculative-config"

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.6-w4a8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.6-w4a8-A3.yaml
@@ -13,7 +13,6 @@ test_cases:
       HCCL_BUFFSIZE: "800"
       VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       DYNAMIC_EPLB: "true"
       SERVER_PORT: "DEFAULT_PORT"
@@ -47,7 +46,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": true},"ascend_compilation_config": {"enable_static_kernel": false}}'
+      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}'
       - "--mm-processor-cache-gb"
@@ -79,7 +78,6 @@ test_cases:
       HCCL_BUFFSIZE: "1300"
       VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       DYNAMIC_EPLB: "true"
       SERVER_PORT: "DEFAULT_PORT"
@@ -113,7 +111,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": true},"ascend_compilation_config": {"enable_static_kernel": false}}'
+      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}'
       - "--mm-processor-cache-gb"
@@ -145,7 +143,6 @@ test_cases:
       VLLM_ASCEND_ENABLE_MLAPO: "1"
       HCCL_BUFFSIZE: "1500"
       VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "0"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -182,6 +179,8 @@ test_cases:
       - "data"
       - "--speculative-config"
       - '{"method": "dflash","model": "z-lab/Kimi-K2.5-DFlash", "num_speculative_tokens": 15}'
+      - --additional-config
+      - '{"scheduler_config":{"enable_balance_scheduling":false}}'
     benchmarks:
       acc:
         case_type: accuracy
@@ -215,7 +214,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
       HCCL_BUFFSIZE: "300"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--quantization"
@@ -250,6 +248,8 @@ test_cases:
       - "0"
       - "--mm-encoder-tp-mode"
       - "data"
+      - --additional-config
+      - '{"scheduler_config":{"enable_balance_scheduling":true}}'
     benchmarks:
       perf:
         case_type: performance

--- a/tests/e2e/weekly/single_node/configs/Kimi-K2.7-w4a8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Kimi-K2.7-w4a8-A3.yaml
@@ -12,7 +12,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "800"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       DYNAMIC_EPLB: "true"
       SERVER_PORT: "DEFAULT_PORT"
@@ -46,7 +45,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": true},"ascend_compilation_config": {"enable_static_kernel": false}}'
+      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}'
       - "--mm-processor-cache-gb"
@@ -77,7 +76,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "800"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       DYNAMIC_EPLB: "true"
       SERVER_PORT: "DEFAULT_PORT"
@@ -111,7 +109,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": true},"ascend_compilation_config": {"enable_static_kernel": false}}'
+      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}'
       - "--mm-processor-cache-gb"
@@ -142,7 +140,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "1300"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       DYNAMIC_EPLB: "true"
       SERVER_PORT: "DEFAULT_PORT"
@@ -176,7 +173,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"eplb_config": {"dynamic_eplb": true},"ascend_compilation_config": {"enable_static_kernel": false}}'
+      - '{"eplb_config":{"dynamic_eplb":true},"ascend_compilation_config":{"enable_static_kernel":false},"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch", "torch_profiler_dir": "./vllm_profile", "torch_profiler_with_stack": true}'
       - "--mm-processor-cache-gb"
@@ -207,7 +204,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
       HCCL_BUFFSIZE: "1500"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "0"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -244,6 +240,8 @@ test_cases:
       - "data"
       - "--speculative-config"
       - '{"method": "dflash","model": "z-lab/Kimi-K2.5-DFlash", "num_speculative_tokens": 15}'
+      - --additional-config
+      - '{"scheduler_config":{"enable_balance_scheduling":false}}'
     benchmarks:
       acc:
         case_type: accuracy
@@ -277,7 +275,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       VLLM_ASCEND_ENABLE_MLAPO: "1"
       HCCL_BUFFSIZE: "300"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--quantization"
@@ -312,6 +309,8 @@ test_cases:
       - "0"
       - "--mm-encoder-tp-mode"
       - "data"
+      - --additional-config
+      - '{"scheduler_config":{"enable_balance_scheduling":true}}'
     benchmarks:
       perf:
         case_type: performance

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-122B-A10B-w4a8-A3-accuracy.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-122B-A10B-w4a8-A3-accuracy.yaml
@@ -11,7 +11,6 @@ test_cases:
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "1024"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "0"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -44,7 +43,7 @@ test_cases:
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch","torch_profiler_dir": "./profiling","torch_profiler_with_stack": false}'
       - "--mm-processor-cache-gb"

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-122B-A10B-w4a8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-122B-A10B-w4a8-A3.yaml
@@ -6,7 +6,6 @@ test_cases:
     model: "Eco-Tech/Qwen3.5-122B-A10B-w4a8"
     envs:
       HCCL_BUFFSIZE: "2048"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "0"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -37,7 +36,7 @@ test_cases:
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch","torch_profiler_dir": "./profiling","torch_profiler_with_stack": false}'
       - "--mm-processor-cache-gb"
@@ -60,7 +59,6 @@ test_cases:
     model: "Eco-Tech/Qwen3.5-122B-A10B-w4a8"
     envs:
       HCCL_BUFFSIZE: "2048"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "0"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -91,7 +89,7 @@ test_cases:
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch","torch_profiler_dir": "./profiling","torch_profiler_with_stack": false}'
       - "--mm-processor-cache-gb"
@@ -115,7 +113,6 @@ test_cases:
     envs:
       HCCL_BUFFSIZE: "2048"
       VLLM_ALLOW_LONG_MAX_MODEL_LEN: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -146,7 +143,7 @@ test_cases:
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch","torch_profiler_dir": "./profiling","torch_profiler_with_stack": false}'
       - "--mm-processor-cache-gb"

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-w8a8-64k-1k-90-50-single.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-A17B-w8a8-64k-1k-90-50-single.yaml
@@ -13,7 +13,6 @@ test_cases:
       TASK_QUEUE_ENABLE: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "0"
       VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--port"
@@ -43,7 +42,7 @@ test_cases:
       - --speculative_config
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - --additional-config
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - --trust-remote-code
       - --async-scheduling
       - --mm-processor-cache-gb

--- a/tests/e2e/weekly/single_node/configs/Qwen3.6-35B-A3B-w4a8-A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.6-35B-A3B-w4a8-A3.yaml
@@ -12,7 +12,6 @@ test_cases:
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "1024"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
@@ -43,7 +42,7 @@ test_cases:
       - "--speculative-config"
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch","torch_profiler_dir": "./profiling","torch_profiler_with_stack": false}'
       - "--mm-processor-cache-gb"
@@ -128,7 +127,6 @@ test_cases:
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "1024"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       VLLM_DISABLE_COMPILE_CACHE: "1"
       VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
       SERVER_PORT: "DEFAULT_PORT"
@@ -160,7 +158,7 @@ test_cases:
       - "--speculative-config"
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch","torch_profiler_dir": "./profiling","torch_profiler_with_stack": false}'
       - "--mm-processor-cache-gb"

--- a/tests/e2e/weekly/single_node/configs/Qwen3.6-35B-A3B-w8a8-A3-accuracy.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.6-35B-A3B-w8a8-A3-accuracy.yaml
@@ -11,7 +11,6 @@ test_cases:
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
       HCCL_BUFFSIZE: "1024"
-      VLLM_ASCEND_BALANCE_SCHEDULING: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--quantization"
@@ -41,7 +40,7 @@ test_cases:
       - "--speculative-config"
       - '{"method": "qwen3_5_mtp","num_speculative_tokens": 3}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true}'
+      - '{"enable_cpu_binding":true,"scheduler_config":{"enable_balance_scheduling":true}}'
       - "--profiler-config"
       - '{"profiler": "torch","torch_profiler_dir": "./profiling","torch_profiler_with_stack": false}'
       - "--mm-processor-cache-gb"

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1046,8 +1046,8 @@ class SchedulerConfig:
             return default
 
         resolved = {
-            # VLLM_ASCEND_BALANCE_SCHEDULING is being sunset; do not carry its
-            # environment fallback into the new construction path.
+            # Balance scheduling is configured only through additional_config;
+            # the legacy environment fallback has been removed.
             "enable_balance_scheduling": _resolve("enable_balance_scheduling", False),
             "recompute_scheduler_enable": _resolve("recompute_scheduler_enable", False),
             # Let pydantic coerce the resolved dicts into typed sub-configs.

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -90,9 +90,6 @@ env_variables: dict[str, Callable[[], Any]] = {
     # `mega_moe` can be used only for moe layer with W8A8/W4A8/bf16(none quant), EP<=64, non-dynamic-eplb.
     # DEPRECATED: use additional_config.enable_fused_mc2 instead.
     "VLLM_ASCEND_ENABLE_FUSED_MC2": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_FUSED_MC2", "0")),
-    # DEPRECATED: VLLM_ASCEND_BALANCE_SCHEDULING env var will be removed in a future release.
-    # Use --additional-config '{"enable_balance_scheduling": true}' instead.
-    "VLLM_ASCEND_BALANCE_SCHEDULING": lambda: bool(int(os.getenv("VLLM_ASCEND_BALANCE_SCHEDULING", "0"))),
     # use fused op transpose_kv_cache_by_block, default is True
     "VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK": lambda: bool(
         int(os.getenv("VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK", "1"))

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -41,8 +41,8 @@
 #       requests simultaneously in a single scheduling session. This can impact the overall system throughput
 #       and performance in some scenarios.
 #    How：
-#       Set --additional-config '{"enable_balance_scheduling": true}' or
-#       set environmental variable VLLM_ASCEND_BALANCE_SCHEDULING=1 (deprecated).
+#       Set --additional-config
+#       '{"scheduler_config": {"enable_balance_scheduling": true}}'.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/29721
 #    Future Plan:


### PR DESCRIPTION
### What this PR does / why we need it?

Removes the legacy `VLLM_ASCEND_BALANCE_SCHEDULING` environment variable after its behavior was migrated to `additional_config.scheduler_config.enable_balance_scheduling`. Runtime code, deployment examples, test configurations, and documentation are migrated to the config field where applicable.

This is one independently reviewable part of the seven-variable split of #14637.

### Does this PR introduce _any_ user-facing change?

Yes. `VLLM_ASCEND_BALANCE_SCHEDULING` is no longer read. Users must configure the behavior with `--additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}'`.

### How was this patch tested?

- `ruff check` and `ruff format --check` on changed Python files
- Python byte-compilation of changed Python files
- YAML parsing of changed YAML files
- JSON parsing of concrete `additional-config` payloads
- Scan confirming no active references to `VLLM_ASCEND_BALANCE_SCHEDULING` remain outside migration documentation and the ignored-variable unit test
- NPU end-to-end tests were not run in this Windows environment

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
