### PR TITLE
[Doc][Misc] Update GLM-5 and GLM-5.2 deployment guides with HCCL timeouts and per-node decode configs

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -19,7 +19,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (128GB × 16) node or 4 Atlas 800 A2 (64GB × 32) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
 - `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 16) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
 - `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
-- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios; use `GLM-5.2-w8a8c8` for PD deployment instead. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
+- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios;
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
@@ -233,7 +233,7 @@ Run the following scripts on two nodes respectively.
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-    vllm serve <MODEL_PATH> \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
     --host 0.0.0.0 \
     --port 8077 \
     --api-server-count 1 \
@@ -289,7 +289,7 @@ Run the following scripts on two nodes respectively.
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-    vllm serve <MODEL_PATH> \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
     --host 0.0.0.0 \
     --port 8077 \
     --headless \
@@ -470,7 +470,7 @@ Before you start, please
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-        vllm serve <MODEL_PATH> \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
             --host 0.0.0.0 \
             --port 9081 \
             --pipeline-parallel-size 2 \
@@ -543,7 +543,7 @@ Before you start, please
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-        vllm serve <MODEL_PATH> \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
             --host 0.0.0.0 \
             --port 9082 \
             --pipeline-parallel-size 2 \
@@ -583,7 +583,7 @@ Before you start, please
         }'
 ```
 
-**Decode nodes** (`run_dp_template.sh`): launch one instance per DP rank on each decode node. Positional parameters: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size. Decode node 0 hosts ranks 0–3, decode node 1 hosts ranks 4–7.
+**Decode node 0** (`run_dp_template.sh`): hosts DP ranks 0–3. The template launches one instance per DP rank on the node; positional parameters: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size. Prepare `run_dp_template.sh` on decode node 0 with the content below.
 
 ```shell
         nic_name="xxxx" # change to your own nic name
@@ -615,7 +615,77 @@ Before you start, please
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-        vllm serve <MODEL_PATH> \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 164 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}' \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
+            --trust-remote-code \
+            --max-num-seqs 32 \
+            --gpu-memory-utilization 0.92 \
+            --async-scheduling \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "2",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
+```
+
+**Decode node 1** (`run_dp_template.sh`): hosts DP ranks 4–7. Prepare `run_dp_template.sh` on decode node 1 with the content below.
+
+```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        export HCCL_OP_EXPANSION_MODE="AIV"
+
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
+
+        #Mooncake
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=256
+
+        export ACL_OP_INIT_MODE=1
+        export ASCEND_A3_ENABLE=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+        export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
@@ -1218,7 +1288,7 @@ export VLLM_ASCEND_ENABLE_MLAPO=1
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-vllm serve <MODEL_PATH> \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
 --host 0.0.0.0 \
 --port 8077 \
 --api-server-count 1 \
@@ -1276,7 +1346,7 @@ export VLLM_ASCEND_ENABLE_MLAPO=1
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-vllm serve <MODEL_PATH> \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
 --host 0.0.0.0 \
 --port 8077 \
 --headless \
@@ -1350,7 +1420,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-vllm serve <MODEL_PATH> \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
     --host 0.0.0.0 \
     --port 9081 \
     --data-parallel-size 2 \
@@ -1420,7 +1490,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-vllm serve <MODEL_PATH> \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
     --host 0.0.0.0 \
     --port 9082 \
     --data-parallel-size 2 \
@@ -1460,7 +1530,7 @@ vllm serve <MODEL_PATH> \
 }'
 ```
 
-**Decode nodes** (`run_dp_template.sh`): prepare the script `launch_online_dp.py` on each node (see [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)) and launch one instance per DP rank. Decode node 0 hosts ranks 0–3, decode node 1 hosts ranks 4–7.
+**Decode node 0** (`run_dp_template.sh`): hosts DP ranks 0–3. Prepare `run_dp_template.sh` and `launch_online_dp.py` (see [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)) on decode node 0 with the content below.
 
 ```shell
 nic_name="xxxx" # change to your own nic name
@@ -1492,7 +1562,79 @@ export ASCEND_RT_VISIBLE_DEVICES=$1
 export VLLM_ASCEND_ENABLE_MLAPO=1
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-vllm serve <MODEL_PATH> \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+    --host 0.0.0.0 \
+    --port $2 \
+    --data-parallel-size $3 \
+    --data-parallel-rank $4 \
+    --data-parallel-address $5 \
+    --data-parallel-rpc-port $6 \
+    --tensor-parallel-size $7 \
+    --enable-expert-parallel \
+    --prefill-context-parallel-size 1 \
+    --decode-context-parallel-size 4 \
+    --cp-kv-cache-interleave-size 128 \
+    --speculative-config '{"num_speculative_tokens": 5,  "method":"deepseek_mtp","enforce_eager":true}' \
+    --seed 1024 \
+    --served-model-name glm-5 \
+    --max-model-len 1048576 \
+    --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
+    --max-num-batched-tokens 192 \
+    --trust-remote-code \
+    --max-num-seqs 32 \
+    --quantization ascend \
+    --gpu-memory-utilization 0.92 \
+    --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+    --async-scheduling \
+    --enable-auto-tool-choice \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --kv-transfer-config \
+    '{"kv_connector": "MooncakeConnectorV1",
+    "kv_role": "kv_consumer",
+    "kv_port": "30200",
+    "engine_id": "2",
+    "kv_connector_extra_config": {
+        "use_ascend_direct": true,
+        "prefill": {"dp_size": 2, "tp_size": 16},
+        "decode": {"dp_size": 8, "tp_size": 4}
+    }
+}'
+```
+
+**Decode node 1** (`run_dp_template.sh`): hosts DP ranks 4–7. Prepare `run_dp_template.sh` and `launch_online_dp.py` (see [Prefill-Decode Disaggregation](#5113-prefill-decode-disaggregation)) on decode node 1 with the content below.
+
+```shell
+nic_name="xxxx" # change to your own nic name
+local_ip="xxxx" # change to your own ip
+
+export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+export HCCL_OP_EXPANSION_MODE="AIV"
+
+export HCCL_IF_IP=$local_ip
+export GLOO_SOCKET_IFNAME=$nic_name
+export TP_SOCKET_IFNAME=$nic_name
+export HCCL_SOCKET_IFNAME=$nic_name
+export HCCL_TRANSFER_TIMEOUT=600
+export HCCL_EXEC_TIMEOUT=3600
+export HCCL_CONNECT_TIMEOUT=3600
+
+#Mooncake
+export OMP_PROC_BIND=false
+export OMP_NUM_THREADS=1
+
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export HCCL_BUFFSIZE=400
+
+export ACL_OP_INIT_MODE=1
+export ASCEND_A3_ENABLE=1
+export TASK_QUEUE_ENABLE=1
+export ASCEND_RT_VISIBLE_DEVICES=$1
+
+export VLLM_ASCEND_ENABLE_MLAPO=1
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
     --host 0.0.0.0 \
     --port $2 \
     --data-parallel-size $3 \

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -18,7 +18,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 - `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (128GB × 16) node or 4 Atlas 800 A2 (64GB × 32) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
 - `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 16) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
-- `GLM-5.2-w8a8c8`(Quantized version for Atlas 800 A3): requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+- `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 - `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios; use `GLM-5.2-w8a8c8` for PD deployment instead. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -202,7 +202,7 @@ Only the key parameters specific to this model/scenario are described below. `ma
 
 **GLM-5.2-w8a8c8 (198K context, dual-node co-located):**
 
-`GLM-5.2-w8a8c8` can be deployed on 2 Atlas 800 A3 (128GB × 8) for the 198K high-throughput scenario (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` can be deployed on 2 Atlas 800 A3 (128GB × 8) for the 198K high-throughput scenario (`DP8 TP4`, 4 DP ranks per node).
 
 Run the following scripts on two nodes respectively.
 
@@ -434,7 +434,7 @@ Before you start, please
 
 **GLM-5.2-w8a8c8 (198K context, PD disaggregation with PP2):**
 
-`GLM-5.2-w8a8c8` PD disaggregation can be deployed on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` PD disaggregation can be deployed on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node).
 
 **Prefill node 0** (`run_dp_template.sh`): `node_rank=0`, engine port `9081`. The value of `node_p0_ip` must be consistent with the `local_ip` set on prefill node 0 (PP master node).
 
@@ -1258,7 +1258,7 @@ DCP and Sparse Flash Attention C8 (`enable_sparse_sfa_c8`, also referred to as `
 
 **GLM-5.2-w8a8c8 (1M context, dual-node co-located):**
 
-`GLM-5.2-w8a8c8` 1M co-located deployment on 2 Atlas 800 A3 (128GB × 8) (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` 1M co-located deployment on 2 Atlas 800 A3 (128GB × 8) (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4).
 
 Run the following scripts on two nodes respectively.
 
@@ -1387,7 +1387,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
 
 **GLM-5.2-w8a8c8 (1M context, PD disaggregation):**
 
-`GLM-5.2-w8a8c8` 1M PD disaggregation can be deployed on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`DP2 TP16`, 1 DP rank per node, decode context parallelism 16) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` 1M PD disaggregation can be deployed on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`DP2 TP16`, 1 DP rank per node, decode context parallelism 16) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4).
 
 **Prefill node 0** (`run_dp_template.sh`): DP rank 0, engine port `9081`. The value of `node_p0_ip` must be consistent with the `local_ip` set on prefill node 0 (DP master node).
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -16,10 +16,10 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (128GB × 16) node or 4 Atlas 800 A2 (64GB × 32) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
-- `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 16) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
+- `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (64GB × 16) node or 4 Atlas 800 A2 (64GB × 32) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
+- `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 16) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
 - `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
-- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios;
+- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios;
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -19,7 +19,7 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 - `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (64GB × 16) node or 4 Atlas 800 A2 (64GB × 32) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
 - `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 16) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
 - `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
-- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios;
+- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
@@ -203,7 +203,7 @@ Only the key parameters specific to this model/scenario are described below. `ma
 
 **GLM-5.2-w8a8c8 (198K context, dual-node co-located):**
 
-`GLM-5.2-w8a8c8` can be deployed on 2 Atlas 800 A3 (64GB × 16) for the 198K high-throughput scenario (`DP8 TP4`, 4 DP ranks per node).
+`GLM-5.2-w8a8c8` can be deployed on 2 Atlas 800 A3 (64GB × 16) for the 198K high-throughput scenario (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 Run the following scripts on two nodes respectively.
 
@@ -435,7 +435,7 @@ Before you start, please
 
 **GLM-5.2-w8a8c8 (198K context, PD disaggregation with PP2):**
 
-`GLM-5.2-w8a8c8` PD disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 16): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node).
+`GLM-5.2-w8a8c8` PD disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 16): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 **Prefill node 0** (`run_dp_template.sh`): `node_rank=0`, engine port `9081`. The value of `node_p0_ip` must be consistent with the `local_ip` set on prefill node 0 (PP master node).
 
@@ -1259,7 +1259,7 @@ DCP and Sparse Flash Attention C8 (`enable_sparse_sfa_c8`, also referred to as `
 
 **GLM-5.2-w8a8c8 (1M context, dual-node co-located):**
 
-`GLM-5.2-w8a8c8` 1M co-located deployment on 2 Atlas 800 A3 (64GB × 16) (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4):
+`GLM-5.2-w8a8c8` 1M co-located deployment on 2 Atlas 800 A3 (64GB × 16) (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 Run the following scripts on two nodes respectively.
 
@@ -1388,7 +1388,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808
 
 **GLM-5.2-w8a8c8 (1M context, PD disaggregation):**
 
-`GLM-5.2-w8a8c8` 1M PD disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 16): 2 prefill nodes (`DP2 TP16`, 1 DP rank per node, decode context parallelism 16) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4).
+`GLM-5.2-w8a8c8` 1M PD disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 16): 2 prefill nodes (`DP2 TP16`, 1 DP rank per node, decode context parallelism 16) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 **Prefill node 0** (`run_dp_template.sh`): DP rank 0, engine port `9081`. The value of `node_p0_ip` must be consistent with the `local_ip` set on prefill node 0 (DP master node).
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -233,7 +233,7 @@ Run the following scripts on two nodes respectively.
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port 8077 \
     --api-server-count 1 \
@@ -289,7 +289,7 @@ Run the following scripts on two nodes respectively.
     export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
     export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+    vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port 8077 \
     --headless \
@@ -470,7 +470,7 @@ Before you start, please
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
             --host 0.0.0.0 \
             --port 9081 \
             --pipeline-parallel-size 2 \
@@ -543,7 +543,7 @@ Before you start, please
 
         export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
             --host 0.0.0.0 \
             --port 9082 \
             --pipeline-parallel-size 2 \
@@ -615,7 +615,7 @@ Before you start, please
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
@@ -685,7 +685,7 @@ Before you start, please
         export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
         export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
             --host 0.0.0.0 \
             --port $2 \
             --data-parallel-size $3 \
@@ -1288,7 +1288,7 @@ export VLLM_ASCEND_ENABLE_MLAPO=1
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
 --host 0.0.0.0 \
 --port 8077 \
 --api-server-count 1 \
@@ -1346,7 +1346,7 @@ export VLLM_ASCEND_ENABLE_MLAPO=1
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 export VLLM_ASCEND_ENABLE_FUSED_MC2=1
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
 --host 0.0.0.0 \
 --port 8077 \
 --headless \
@@ -1420,7 +1420,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port 9081 \
     --data-parallel-size 2 \
@@ -1490,7 +1490,7 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
 export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port 9082 \
     --data-parallel-size 2 \
@@ -1562,7 +1562,7 @@ export ASCEND_RT_VISIBLE_DEVICES=$1
 export VLLM_ASCEND_ENABLE_MLAPO=1
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port $2 \
     --data-parallel-size $3 \
@@ -1634,7 +1634,7 @@ export ASCEND_RT_VISIBLE_DEVICES=$1
 export VLLM_ASCEND_ENABLE_MLAPO=1
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808 \
+vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
     --host 0.0.0.0 \
     --port $2 \
     --data-parallel-size $3 \

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -16,10 +16,9 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `GLM-5.2`(BF16 version): requires 2 Atlas 800 A3 (64GB × 16) node or 4 Atlas 800 A2 (64GB × 32) node.[Download model weight](https://www.modelscope.cn/models/ZhipuAI/GLM-5.2).
-- `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 16) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
-- `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (64GB × 16) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
-- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (64GB × 16) node or 2 Atlas 800 A2 (64GB × 16) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
+- `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
+- `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (128GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+- `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.
 
 It is recommended to download the model weight to the shared directory of multiple nodes, such as `/root/.cache/`
@@ -137,7 +136,7 @@ The deployment scenarios validated for this release are organized by context win
 
 ##### 5.1.1.1 Single-Node Deployment
 
-- Quantized model `GLM-5.2-w4a8c8` (experimental, see [Model Weight](#31-model-weight)) can be deployed on 1 Atlas 800 A3 (64GB × 16) .
+- Quantized model `GLM-5.2-w4a8c8` (experimental, see [Model Weight](#31-model-weight)) can be deployed on 1 Atlas 800 A3 (128GB × 8) .
 
 Run the following script to execute online inference.
 
@@ -203,7 +202,7 @@ Only the key parameters specific to this model/scenario are described below. `ma
 
 **GLM-5.2-w8a8c8 (198K context, dual-node co-located):**
 
-`GLM-5.2-w8a8c8` can be deployed on 2 Atlas 800 A3 (64GB × 16) for the 198K high-throughput scenario (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` can be deployed on 2 Atlas 800 A3 (128GB × 8) for the 198K high-throughput scenario (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 Run the following scripts on two nodes respectively.
 
@@ -435,7 +434,7 @@ Before you start, please
 
 **GLM-5.2-w8a8c8 (198K context, PD disaggregation with PP2):**
 
-`GLM-5.2-w8a8c8` PD disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 16): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` PD disaggregation can be deployed on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 **Prefill node 0** (`run_dp_template.sh`): `node_rank=0`, engine port `9081`. The value of `node_p0_ip` must be consistent with the `local_ip` set on prefill node 0 (PP master node).
 
@@ -1259,7 +1258,7 @@ DCP and Sparse Flash Attention C8 (`enable_sparse_sfa_c8`, also referred to as `
 
 **GLM-5.2-w8a8c8 (1M context, dual-node co-located):**
 
-`GLM-5.2-w8a8c8` 1M co-located deployment on 2 Atlas 800 A3 (64GB × 16) (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` 1M co-located deployment on 2 Atlas 800 A3 (128GB × 8) (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 Run the following scripts on two nodes respectively.
 
@@ -1388,7 +1387,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
 
 **GLM-5.2-w8a8c8 (1M context, PD disaggregation):**
 
-`GLM-5.2-w8a8c8` 1M PD disaggregation can be deployed on 4 Atlas 800 A3 (64GB × 16): 2 prefill nodes (`DP2 TP16`, 1 DP rank per node, decode context parallelism 16) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
+`GLM-5.2-w8a8c8` 1M PD disaggregation can be deployed on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`DP2 TP16`, 1 DP rank per node, decode context parallelism 16) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node, decode context parallelism 4). [Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 
 **Prefill node 0** (`run_dp_template.sh`): DP rank 0, engine port `9081`. The value of `node_p0_ip` must be consistent with the `local_ip` set on prefill node 0 (DP master node).
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -16,7 +16,6 @@ Refer to [feature guide](../../user_guide/feature_guide/index.md) to get the fea
 
 ### 3.1 Model Weight
 
-- `GLM-5.2-w8a8`: requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node.[Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w8a8).
 - `GLM-5.2-w8a8c8`: requires 2 Atlas 800 A3 (128GB × 8) node.[Download model weight](https://modelers.cn/models/Eco-Tech/GLM-5.2-w8a8c8).
 - `GLM-5.2-w4a8c8` (experimental): requires 1 Atlas 800 A3 (128GB × 8) node or 2 Atlas 800 A2 (64GB × 8) node. This experimental feature has known accuracy issues in Prefill-Decode (PD) disaggregation scenarios. [Download model weight](https://www.modelscope.cn/models/Eco-Tech/GLM-5.2-w4a8c8).
 - You can use [msmodelslim](https://gitcode.com/Ascend/msmodelslim) to quantize the model directly.

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -254,7 +254,7 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a4 \
 ::::{tab-item} A3 series
 :sync: A3
 
-- Quantized model `glm-5-w4a8` and `glm-5.1-w4a8` can be deployed on 1 Atlas 800 A3 (64GB × 16) .
+- Quantized model `glm-5-w4a8` and `glm-5.1-w4a8` can be deployed on 1 Atlas 800 A3 (128GB × 8) .
 
 Run the following script to execute online inference.
 
@@ -381,7 +381,7 @@ Common Issues Tip: If you encounter issues, Refer to [FAQs](../../faqs.md).
 
 **High-Throughput Scenario (DP8 TP4)**
 
-- `glm-5.1-w8a8c8`: can be deployed on 2 Atlas 800 A3 (64GB × 16) for high-throughput scenarios.
+- `glm-5.1-w8a8c8`: can be deployed on 2 Atlas 800 A3 (128GB × 8) for high-throughput scenarios.
 
 Run the following scripts on two nodes respectively.
 
@@ -1053,7 +1053,7 @@ Once the preparation is done, you can start the server with the following comman
 
 #### 5.3.2 Prefill-Decode Disaggregation (A3 series)
 
-The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (64GB × 16): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). The same scripts serve both the high-throughput and low-latency cases.
+The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). The same scripts serve both the high-throughput and low-latency cases.
 
 1. prepare the script `run_dp_template.sh` on each node.
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -295,43 +295,6 @@ vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w4a8 \
 --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
 ```
 
-- Quantized model `glm-5-w8a8` and `glm-5.1-w8a8` can be deployed on 1 Atlas 800 A3 (64GB × 16) .
-
-Run the following script to execute online inference.
-
-```{code-block} bash
-   :substitutions:
-export HCCL_OP_EXPANSION_MODE="AIV"
-export OMP_PROC_BIND=false
-export OMP_NUM_THREADS=1
-export HCCL_BUFFSIZE=200
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export VLLM_ASCEND_BALANCE_SCHEDULING=1
-export VLLM_ASCEND_ENABLE_MLAPO=1
-export VLLM_ASCEND_ENABLE_FLASHCOMM1=1
-
-vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM5-w8a8 \
---host 0.0.0.0 \
---port 8077 \
---data-parallel-size 1 \
---tensor-parallel-size 16 \
---enable-expert-parallel \
---seed 1024 \
---served-model-name glm-5 \
---max-num-seqs 16 \
---max-model-len 40960 \
---max-num-batched-tokens 4096 \
---trust-remote-code \
---gpu-memory-utilization 0.95 \
---quantization ascend \
---enable-chunked-prefill \
---enable-prefix-caching \
---additional-config '{"multistream_overlap_shared_expert": true}' \
---compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
---hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
---speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
-```
-
 ::::
 ::::{tab-item} A2 series
 :sync: A2

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -394,6 +394,9 @@ Run the following scripts on two nodes respectively.
 nic_name="xxx"
 local_ip="xxx"
 export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_TRANSFER_TIMEOUT=600
+export HCCL_EXEC_TIMEOUT=3600
+export HCCL_CONNECT_TIMEOUT=3600
 export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
 export TP_SOCKET_IFNAME=$nic_name
@@ -443,6 +446,9 @@ local_ip="xxx"
 node0_ip="xxxx"
 
 export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_TRANSFER_TIMEOUT=600
+export HCCL_EXEC_TIMEOUT=3600
+export HCCL_CONNECT_TIMEOUT=3600
 export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
 export TP_SOCKET_IFNAME=$nic_name
@@ -1064,6 +1070,9 @@ The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (64GB
         node_rank=0
 
         export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
 
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name
@@ -1135,6 +1144,9 @@ The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (64GB
         node_rank=1
 
         export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
 
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name
@@ -1193,15 +1205,90 @@ The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (64GB
         }'
         ```
 
-    3. Decode node 0 / decode node 1
+    3. Decode node 0 (ranks 0–3)
 
-        Launch one instance per DP rank via positional parameters: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size. Decode node 0 hosts ranks 0–3, decode node 1 hosts ranks 4–7.
+        Launch one instance per DP rank via positional parameters: `$1` = visible devices, `$2` = engine port, `$3` = data-parallel-size, `$4` = data-parallel-rank, `$5` = data-parallel-address, `$6` = data-parallel-rpc-port, `$7` = tensor-parallel-size. Prepare `run_dp_template.sh` on decode node 0 with the content below.
 
         ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
         export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
+
+        export HCCL_IF_IP=$local_ip
+        export GLOO_SOCKET_IFNAME=$nic_name
+        export TP_SOCKET_IFNAME=$nic_name
+        export HCCL_SOCKET_IFNAME=$nic_name
+
+        #Mooncake
+        export OMP_PROC_BIND=false
+        export OMP_NUM_THREADS=1
+
+        export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+        export HCCL_BUFFSIZE=256
+
+        export ACL_OP_INIT_MODE=1
+        export ASCEND_A3_ENABLE=1
+        export TASK_QUEUE_ENABLE=1
+        export ASCEND_RT_VISIBLE_DEVICES=$1
+
+        export VLLM_ASCEND_ENABLE_FUSED_MC2=1
+        export VLLM_ASCEND_ENABLE_MLAPO=1
+        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+        vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
+            --host 0.0.0.0 \
+            --port $2 \
+            --data-parallel-size $3 \
+            --data-parallel-rank $4 \
+            --data-parallel-address $5 \
+            --data-parallel-rpc-port $6 \
+            --tensor-parallel-size $7 \
+            --enable-expert-parallel \
+            --speculative-config '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}' \
+            --seed 1024 \
+            --served-model-name glm-5 \
+            --max-model-len 202752 \
+            --max-num-batched-tokens 164 \
+            --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}' \
+            --additional-config '{"fuse_muls_add":true, "recompute_scheduler_enable":true, "multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}' \
+            --trust-remote-code \
+            --max-num-seqs 32 \
+            --gpu-memory-utilization 0.92 \
+            --hf-overrides '{"use_index_cache": true, "index_topk_freq": 4}' \
+            --async-scheduling \
+            --quantization ascend \
+            --enable-auto-tool-choice \
+            --tool-call-parser glm47 \
+            --reasoning-parser glm45 \
+            --kv-transfer-config \
+            '{"kv_connector": "MooncakeConnectorV1",
+            "kv_role": "kv_consumer",
+            "kv_port": "30200",
+            "engine_id": "2",
+            "kv_connector_extra_config": {
+                "use_ascend_direct": true,
+                "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
+                "decode": {"dp_size": 8, "tp_size": 4}
+            }
+        }'
+        ```
+
+    4. Decode node 1 (ranks 4–7)
+
+        Prepare `run_dp_template.sh` on decode node 1 with the content below.
+
+        ```shell
+        nic_name="xxxx" # change to your own nic name
+        local_ip="xxxx" # change to your own ip
+
+        export HCCL_OP_EXPANSION_MODE="AIV"
+        export HCCL_TRANSFER_TIMEOUT=600
+        export HCCL_EXEC_TIMEOUT=3600
+        export HCCL_CONNECT_TIMEOUT=3600
 
         export HCCL_IF_IP=$local_ip
         export GLOO_SOCKET_IFNAME=$nic_name


### PR DESCRIPTION
### What this PR does / why we need it?
 - **GLM-5.2**: replace the `vllm serve <MODEL_PATH>` placeholders with the
    concrete weight path `/root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-W8A8C8-A3-0808`;
    split the PD decode nodes (198K and 1M) into separate `Decode node 0`
    (ranks 0–3) and `Decode node 1` (ranks 4–7) configurations, each with its                                                                                                                                                                                                               own `run_dp_template.sh`, keeping the per-node `launch_online_dp.py`                                                                                                                                                                                                                    commands (`--dp-rank-start 0/4`) in the start list; align the `w8a8c8`                                                                                                                                                                                                                  weight entry format in chapter 3 with the other weight entries.                                                                                                                                                                                                                       - **GLM-5**: add `HCCL_TRANSFER_TIMEOUT`/`HCCL_EXEC_TIMEOUT`/                                                                                                                                                                                                                             `HCCL_CONNECT_TIMEOUT` to the A3 multi-node co-located and A3 PD
    disaggregation scripts; split the A3 PD decode nodes into separate
    `Decode node 0` (ranks 0–3) and `Decode node 1` (ranks 4–7)                                                                                                                                                                                                                             configurations; remove the stale `glm-5-w8a8` A3 single-node deployment                                                                                                                                                                                                                 script.                          

### Does this PR introduce _any_ user-facing change?
  No, documentation-only update.

### How was this patch tested?
  - Built the docs locally with Sphinx (`build succeeded`) and previewed the
    rendered GLM-5/GLM-5.2 pages.
  - No code changes; no tests required.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
