### PR TITLE
[BugFix][SpecDecode] Align block_table rows with query_start_loc for drafter slot mapping

### DIFF
--- a/tests/ut/spec_decode/test_slot_mapping_bt_qsl_alignment.py
+++ b/tests/ut/spec_decode/test_slot_mapping_bt_qsl_alignment.py
@@ -1,0 +1,136 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Regression tests: drafter slot mapping with padded block_table rows.
+
+Reproduces the draft_model + FULL-graph batch-shrink crash: the cad handed
+to the drafter comes from AscendCommonAttentionMetadata.unpadded(), which
+slices query_start_loc to the real request count while intentionally
+keeping the FULL-graph-padded block_table (phantom rows included). Upstream
+compute_new_slot_mapping derives batch_size from block_table rows, so the
+disagreement crashes torch.repeat_interleave.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+from vllm.v1.spec_decode.utils import compute_new_slot_mapping
+
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, align_block_table_for_slot_mapping
+
+BLOCK_SIZE = 128
+NUM_REAL_REQS = 5  # batch shrunk to 5 running requests
+TOKENS_PER_REQ = 6  # K+1 = 6 verify tokens per request
+PHANTOM_ROWS = 1  # 5*(K+1)=30 fell between buckets 24 and 36 -> pad to 36
+NUM_NEW_TOKENS = 1  # net_num_new_slots_per_request for draft_model (K+2 accounting)
+N_BLOCKS_PER_REQ = 32
+BASE_POS_PER_REQ = 1000  # distinct position ranges make slot attribution checkable
+
+
+def _build_padded_cad() -> AscendCommonAttentionMetadata:
+    """Mimic the cad the drafter receives after unpadded(30, 5).
+
+    qsl describes 5 requests x 6 tokens; block_table carries 6 rows
+    (5 real + 1 zero-filled phantom row) because unpadded() keeps it padded.
+    """
+    total_reqs = NUM_REAL_REQS + PHANTOM_ROWS
+    qsl = torch.arange(0, (NUM_REAL_REQS + 1) * TOKENS_PER_REQ, TOKENS_PER_REQ, dtype=torch.int32)
+    bt = torch.arange(1, total_reqs * N_BLOCKS_PER_REQ + 1, dtype=torch.int32).reshape(total_reqs, N_BLOCKS_PER_REQ)
+    bt[NUM_REAL_REQS:].fill_(0)  # phantom rows are zero-filled at padding time
+    return AscendCommonAttentionMetadata(
+        query_start_loc=qsl,
+        query_start_loc_cpu=qsl.clone(),
+        seq_lens=torch.full((NUM_REAL_REQS,), 64, dtype=torch.int64),
+        num_reqs=NUM_REAL_REQS,
+        num_actual_tokens=NUM_REAL_REQS * TOKENS_PER_REQ,
+        max_query_len=TOKENS_PER_REQ,
+        max_seq_len=BASE_POS_PER_REQ * NUM_REAL_REQS + TOKENS_PER_REQ + NUM_NEW_TOKENS,
+        block_table_tensor=bt,
+        slot_mapping=torch.zeros(NUM_REAL_REQS * TOKENS_PER_REQ, dtype=torch.int64),
+    )
+
+
+def _new_positions() -> torch.Tensor:
+    # R*(K+2) = 35 positions: 7 contiguous positions per real request
+    # (6 verify slots + 1 extra seed slot, matching drafter accounting).
+    return torch.cat(
+        [
+            torch.arange(
+                BASE_POS_PER_REQ * r,
+                BASE_POS_PER_REQ * r + TOKENS_PER_REQ + NUM_NEW_TOKENS,
+                dtype=torch.int64,
+            )
+            for r in range(NUM_REAL_REQS)
+        ]
+    )
+
+
+def _expected_slots() -> list[int]:
+    pos = _new_positions()
+    bt = _build_padded_cad().block_table_tensor
+    slots = []
+    for i, p in enumerate(pos.tolist()):
+        r = i // (TOKENS_PER_REQ + NUM_NEW_TOKENS)
+        slots.append(int(bt[r, p // BLOCK_SIZE]) * BLOCK_SIZE + p % BLOCK_SIZE)
+    return slots
+
+
+def _rejected_mask() -> torch.Tensor:
+    return torch.zeros(len(_new_positions()), dtype=torch.bool)
+
+
+class TestBlockTableQslAlignment:
+    def test_raw_padded_cad_reproduces_upstream_crash(self):
+        """Anchor: the pre-fix shapes crash inside upstream's function."""
+        cad = _build_padded_cad()
+        with pytest.raises(RuntimeError, match="repeats must have the same size as input along dim"):
+            compute_new_slot_mapping(
+                cad=cad,
+                new_positions=_new_positions(),
+                is_rejected_token_mask=_rejected_mask(),
+                block_size=BLOCK_SIZE,
+                num_new_tokens=NUM_NEW_TOKENS,
+                max_model_len=BASE_POS_PER_REQ * NUM_REAL_REQS * 2,
+            )
+
+    def test_aligned_cad_slots_correctly_attributed(self):
+        cad = _build_padded_cad()
+        aligned = align_block_table_for_slot_mapping(cad)
+        assert aligned.block_table_tensor.shape[0] == NUM_REAL_REQS
+        slots = compute_new_slot_mapping(
+            cad=aligned,
+            new_positions=_new_positions(),
+            is_rejected_token_mask=_rejected_mask(),
+            block_size=BLOCK_SIZE,
+            num_new_tokens=NUM_NEW_TOKENS,
+            max_model_len=BASE_POS_PER_REQ * NUM_REAL_REQS * 2,
+        )
+        expected = _expected_slots()
+        assert slots.tolist() == expected  # request idx / block id / offset all correct
+
+    def test_alignment_does_not_mutate_original_cad(self):
+        cad = _build_padded_cad()
+        original_rows = cad.block_table_tensor.shape[0]
+        aligned = align_block_table_for_slot_mapping(cad)
+        assert aligned is not cad
+        assert cad.block_table_tensor.shape[0] == original_rows  # still padded
+
+    def test_noop_when_block_table_already_consistent(self):
+        cad = _build_padded_cad()
+        consistent = cad.replace(block_table_tensor=cad.block_table_tensor[:NUM_REAL_REQS])
+        assert align_block_table_for_slot_mapping(consistent) is consistent

--- a/vllm_ascend/attention/utils.py
+++ b/vllm_ascend/attention/utils.py
@@ -318,6 +318,30 @@ class AscendCommonAttentionMetadata(CommonAttentionMetadata):
         )
 
 
+def align_block_table_for_slot_mapping(
+    cad: "AscendCommonAttentionMetadata",
+) -> "AscendCommonAttentionMetadata":
+    """Return a cad whose block_table row count matches the qsl request count.
+
+    The spec-decode cad handed to the drafter comes from
+    AscendCommonAttentionMetadata.unpadded(), which slices query_start_loc
+    to the real request count but intentionally keeps the FULL-graph-padded
+    block_table (slicing it there breaks reshape_and_cache). When a
+    shrinking batch falls between FULL-graph capture buckets (e.g. 5 reqs x
+    (K+1)=6 tokens = 30, no bucket 30 -> padded to 36), the padded
+    block_table carries phantom request rows while qsl does not. Upstream
+    compute_new_slot_mapping derives batch_size from block_table rows, so
+    the disagreement crashes repeat_interleave. Slice the block table for
+    this computation only; downstream metadata keeps the padded block
+    table for graph replay.
+    """
+    qsl_num_reqs = cad.query_start_loc.numel() - 1
+    bt_num_rows = cad.block_table_tensor.shape[0]
+    if bt_num_rows > qsl_num_reqs:
+        return cad.replace(block_table_tensor=cad.block_table_tensor[:qsl_num_reqs])
+    return cad
+
+
 def filter_chunked_req_indices(
     seq_len: torch.Tensor,
     mask_for_non_zero_chunk: list[bool] | None,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -43,7 +43,7 @@ from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, align_block_table_for_slot_mapping
 from vllm_ascend.compilation.acl_graph import ACLGraphWrapper, update_full_graph_params
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
@@ -1485,7 +1485,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             block_size = self.draft_attn_groups[0].kv_cache_spec.block_size
 
             new_slot_mapping = compute_new_slot_mapping(
-                cad=cad,
+                cad=align_block_table_for_slot_mapping(cad),
                 new_positions=self.positions[:total_num_output_tokens],
                 is_rejected_token_mask=self.is_rejected_token_mask[:total_num_output_tokens],
                 block_size=block_size,


### PR DESCRIPTION
### What this PR does / why we need it?
`method=draft_model` with FULL graphs crashes when the running batch shrinks between FULL-graph capture buckets:

```
RuntimeError: repeats must have the same size as input along dim
  (upstream compute_new_slot_mapping, called from set_inputs_first_pass)
```

Repro shape: 8 concurrent requests draining; at 5 running requests with K=5, 5×(K+1)=30 tokens has no bucket in the default capture list (…24, 36…), so FULL-uniform dispatch pads to 36 by appending a phantom request row. The spec-decode cad then goes through `AscendCommonAttentionMetadata.unpadded()`, which slices `query_start_loc` to the real request count but intentionally keeps the padded `block_table` (slicing it there breaks `reshape_and_cache`). Attention kernels are qsl-driven and ignore the extra rows, but upstream `compute_new_slot_mapping` derives `batch_size` from `block_table` rows: `arange(6)` vs 5 query lens → `repeat_interleave` crashes.

The hole positions are a function of K and max_num_seqs (K=5 → holes at 30/54/78…; K=7 → none; K=3 → shifted), so which batch sizes crash looks like a lottery — the bug stayed latent until a benchmark drained a batch through R=5.

Fix: new `align_block_table_for_slot_mapping()` helper in `vllm_ascend/attention/utils.py` (next to `unpadded()`, whose padding behavior it compensates for); `set_inputs_first_pass` computes the slot mapping against a cad whose `block_table` is sliced to the qsl request count (`cad.replace(...)` — a temporary view; downstream metadata keeps the padded block table for graph replay, `unpadded()` semantics unchanged).

Ordering note: reaching this crash at runtime requires draft_model + FULL to get past #14508 (MRO), #14509 (pattern scoping) and #14510 (drafter sizing) — verified stacked on v0.23.0. The change itself is one self-contained hunk plus the helper.

### Does this PR introduce _any_ user-facing change?
No config/API changes. Previously-crashing workloads (batch shrink through a capture-table hole) now complete; numerics untouched.
### How was this patch tested?
- Unit tests added: `tests/ut/spec_decode/test_slot_mapping_bt_qsl_alignment.py` — anchors the crash (raw padded cad reproduces the upstream error through the real upstream `compute_new_slot_mapping`), verifies the aligned cad yields correctly attributed slots (request index, block id, in-block offset) for all R×(K+2) tokens, checks the original cad is not mutated and the helper is a no-op when rows already agree. 4/4 pass locally (torch_npu stub + `--noconftest` driver; conftest's `adapt_patch()` needs the pinned vllm version, CI runs it normally).
- CPU check against the upstream implementation: raw shapes reproduce the exact server error text; sliced form yields 35/35 correctly attributed slots.
- Verified on Ascend 910B3 (v0.23.0 + #14508/#14509/#14510 + this fix), Qwen3-8B + Qwen3-0.6B, K=5, FULL: 4K/16K/32K × concurrency 1/4/16 all pass (9/9 cells; the crash previously killed the engine mid-cell at 4K/c16). Accept length 2.80–3.02, consistent with the unaffected cells before the fix.

> Note: developed with AI assistance (GLM-5.3); human-reviewed, human-validated on hardware.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
