### PR TITLE
[Ops][Feature] Add prefill abort side-channel support for disaggregated prefill

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -152,6 +152,12 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 
 logger = logging.getLogger(__name__)
 
+
+class UpstreamHTTPError(Exception):
+    def __init__(self, response: httpx.Response):
+        self.response = response
+        super().__init__(f"upstream returned HTTP {response.status_code}")
+
 try:
     import uvloop  # type: ignore[import-not-found]
 
@@ -900,6 +906,8 @@ async def send_request_to_service(
     for attempt in range(1, max_retries + 1):
         try:
             response = await client.post(endpoint, json=req_data, headers=headers)
+            if 400 <= response.status_code < 500:
+                raise UpstreamHTTPError(response)
             response.raise_for_status()
             return response
         except (httpx.RequestError, httpx.HTTPStatusError) as exc:
@@ -1167,6 +1175,16 @@ async def handle_completions_impl(api: str, request: Request):
 
         media_type = "text/event-stream; charset=utf-8" if stream_flag else "application/json"
         return StreamingResponse(generate_stream(), media_type=media_type)
+    except UpstreamHTTPError as exc:
+        if not request_released and "instance_info" in locals():
+            await _finish_instance(runtime, instance_info, release_prefill_kv=True)
+            request_released = True
+        upstream = exc.response
+        return Response(
+            content=upstream.content,
+            status_code=upstream.status_code,
+            media_type=upstream.headers.get("content-type"),
+        )
     except Exception:
         import traceback
 

--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -867,9 +867,11 @@ def auth_headers(request_id: str) -> dict[str, str]:
 
 def build_prefill_request(req_data: dict) -> dict:
     payload = req_data.copy()
+    original_max_tokens = payload.get("max_tokens", payload.get("max_completion_tokens", 16))
     payload["kv_transfer_params"] = {
         "do_remote_decode": True,
         "do_remote_prefill": False,
+        "original_max_tokens": original_max_tokens,
         "remote_engine_id": None,
         "remote_block_ids": None,
         "remote_host": None,

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -255,6 +255,16 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
         t._handle_request(req)
         self.assertEqual(len(store.put_calls), 0)
 
+    def test_put_request_limit_reserves_unique_requests(self):
+        t, _ = self._make_thread()
+        t.max_put_requests = 2
+
+        self.assertTrue(t.add_stored_request("r1"))
+        self.assertTrue(t.add_stored_request("r1"))
+        self.assertTrue(t.add_stored_request("r2"))
+        self.assertFalse(t.add_stored_request("r3"))
+        self.assertEqual(t.put_request_count, 2)
+
     def test_handle_request_with_kv_event(self):
         t, store = self._make_thread([0], enable_kv_event=True)
         req = ReqMeta(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -1,3 +1,4 @@
+import os
 import queue
 import threading
 from collections import defaultdict
@@ -24,6 +25,17 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.config_data import
 # isort: on
 
 
+def _get_max_put_requests() -> int:
+    try:
+        from vllm_ascend import envs as ascend_envs
+
+        value = ascend_envs.VLLM_ASCEND_KV_POOL_PUT_REQUESTS
+    except ImportError:
+        # Keep lightweight unit-test dependency shims compatible with this module.
+        value = os.getenv("VLLM_ASCEND_KV_POOL_PUT_REQUESTS", "10")
+    return max(int(value), 0)
+
+
 class KVTransferThread(threading.Thread):
     def __init__(
         self,
@@ -48,6 +60,9 @@ class KVTransferThread(threading.Thread):
         self.executor = ThreadPoolExecutor(max_workers=32)
         self.finished_requests: set[str] = set()
         self.kv_event_lock = threading.Lock()
+        self.max_put_requests = _get_max_put_requests()
+        self.put_request_count = 0
+        self.put_request_ids: set[str] = set()
         self.kv_events: list[BlockStored] = []
 
     def _get_block_size(self, kv_cache_group_id: int = 0) -> int:
@@ -56,6 +71,17 @@ class KVTransferThread(threading.Thread):
                 return self.block_size[0]
             return self.block_size[kv_cache_group_id]
         return self.block_size
+
+    def _reserve_stored_request(self, req_id: str) -> bool:
+        """Reserve one of the configured request slots for KV-store writes."""
+        with self.done_task_lock:
+            if req_id in self.put_request_ids:
+                return True
+            if self.put_request_count >= self.max_put_requests:
+                return False
+            self.put_request_ids.add(req_id)
+            self.put_request_count += 1
+            return True
 
     def add_request(
         self,
@@ -345,9 +371,13 @@ class KVCacheStoreSendingThread(KVTransferThread):
         self.completed_events_lock = threading.Lock()
         self.completed_events: dict[int, int] = {}
 
-    def add_stored_request(self, req_id: str):
+    def add_stored_request(self, req_id: str) -> bool:
+        if not self._reserve_stored_request(req_id):
+            logger.debug("KV store put request limit reached; skipping request %s", req_id)
+            return False
         with self.done_task_lock:
             self.stored_requests[req_id] += 1
+        return True
 
     def dec_stored_request(self, req_id: str):
         with self.done_task_lock:
@@ -777,9 +807,13 @@ class KVCacheStoreLayerSendingThread(KVTransferThread):
         self.done_task_lock = threading.Lock()
         self.layerwise_event_lock = threading.Lock()
 
-    def add_stored_request(self, req_id: str):
+    def add_stored_request(self, req_id: str) -> bool:
+        if not self._reserve_stored_request(req_id):
+            logger.debug("KV store put request limit reached; skipping request %s", req_id)
+            return False
         with self.done_task_lock:
             self.stored_requests[req_id] += 1
+        return True
 
     def dec_stored_request(self, req_id: str):
         with self.done_task_lock:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -949,9 +949,8 @@ class KVPoolWorker:
                     continue
 
                 request.current_event = current_event
-                self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
-                    request.req_id
-                )
+                if not self.kv_send_thread.add_stored_request(request.req_id):  # type: ignore[union-attr]
+                    continue
                 layerwise_storer = self.store_layer(request, current_event)
                 self.layerwise_storers.append(layerwise_storer)
         for layerwise_storer in self.layerwise_storers:
@@ -979,9 +978,8 @@ class KVPoolWorker:
 
             request.skip_null_blocks_by_group = self.group_uses_align_state
             request.current_event = current_event
-            self.kv_send_thread.add_stored_request(  # type: ignore[union-attr]
-                request.req_id
-            )
+            if not self.kv_send_thread.add_stored_request(request.req_id):  # type: ignore[union-attr]
+                continue
             self.kv_send_thread.add_request(  # type: ignore[union-attr]
                 request,
             )
@@ -1477,7 +1475,7 @@ class KVPoolWorker:
                     return 0
                 max_hit_position = min(max_hit_position, group_hits[-1])
                 hits.append(group_hits)
-                logger.debug(
+                logger.info(
                     "KV pool scheduler lookup group=%d keys=%d hit=%d token_len=%d",
                     group_id,
                     len(keys),

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -130,6 +130,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Maximum number of requests whose KV cache is written to the external KV store.
+    # The default is 10; valid values are non-negative integers, and 0 disables request writes.
+    "VLLM_ASCEND_KV_POOL_PUT_REQUESTS": lambda: int(os.getenv("VLLM_ASCEND_KV_POOL_PUT_REQUESTS", "5")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -45,6 +45,7 @@ import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_tool_choice_none_content  # noqa
 import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
+import vllm_ascend.patch.platform.patch_prefill_length_validation  # noqa
 
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa

--- a/vllm_ascend/patch/platform/patch_prefill_length_validation.py
+++ b/vllm_ascend/patch/platform/patch_prefill_length_validation.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from typing import Any
 
 from vllm.logger import logger
-from vllm.v1.engine.core import EngineCore
+from vllm.v1.engine.async_llm import AsyncLLM
 
 
-_ORIGINAL_PREPROCESS_ADD_REQUEST = EngineCore.preprocess_add_request
+_ORIGINAL_ADD_REQUEST = AsyncLLM._add_request
 
 
-def _is_target_model(engine: EngineCore) -> bool:
+def _is_target_model(engine: AsyncLLM) -> bool:
     model_config = engine.vllm_config.model_config
     hf_config = getattr(model_config, "hf_config", None)
     model_type = str(getattr(hf_config, "model_type", "")).lower()
@@ -21,42 +21,61 @@ def _is_target_model(engine: EngineCore) -> bool:
 
 def _prefill_max_tokens(request: Any) -> int:
     params = getattr(request, "kv_transfer_params", None) or {}
-    value = params.get("original_max_tokens", request.max_tokens)
+    if not params:
+        sampling_params = getattr(request, "sampling_params", None)
+        extra_args = getattr(sampling_params, "extra_args", None) or {}
+        params = extra_args.get("kv_transfer_params", {}) or {}
+    default_value = getattr(request, "max_tokens", None)
+    if default_value is None:
+        sampling_params = getattr(request, "sampling_params", None)
+        default_value = getattr(sampling_params, "max_tokens", 0)
+    value = params.get("original_max_tokens", default_value)
     try:
         return max(int(value), 0)
     except (TypeError, ValueError):
-        return request.max_tokens
+        return max(int(default_value or 0), 0)
 
-
-def _validate_prefill_request(engine: EngineCore, request: Any) -> None:
+def _validate_prefill_request(engine: AsyncLLM, request: Any) -> None:
     kv_config = getattr(engine.vllm_config, "kv_transfer_config", None)
     if kv_config is None or getattr(kv_config, "kv_role", None) != "kv_producer":
         return
     if not _is_target_model(engine):
         return
     max_tokens = _prefill_max_tokens(request)
-    total_tokens = request.num_prompt_tokens + max_tokens
-    max_model_len = engine.scheduler.max_model_len
+    prompt_tokens = getattr(request, "num_prompt_tokens", None)
+    if prompt_tokens is None:
+        prompt_token_ids = getattr(request, "prompt_token_ids", None)
+        if prompt_token_ids is None:
+            return
+        prompt_tokens = len(prompt_token_ids)
+    total_tokens = prompt_tokens + max_tokens
+    max_model_len = engine.vllm_config.model_config.max_model_len
     if total_tokens > max_model_len:
         raise ValueError(
             "Request exceeds model-len before prefill: "
-            f"prompt tokens ({request.num_prompt_tokens}) + max_tokens ({max_tokens}) "
+            f"prompt tokens ({prompt_tokens}) + max_tokens ({max_tokens}) "
             f"= {total_tokens} > model-len ({max_model_len})."
         )
     logger.debug(
         "Prefill length validation passed: request_id=%s prompt_tokens=%d max_tokens=%d model_len=%d",
         request.request_id,
-        request.num_prompt_tokens,
+        prompt_tokens,
         max_tokens,
         max_model_len,
     )
 
 
-def _patched_preprocess_add_request(self: EngineCore, request: Any) -> Any:
-    # Request.from_engine_core_request has already tokenized the prompt here.
-    processed_request = _ORIGINAL_PREPROCESS_ADD_REQUEST(self, request)
-    _validate_prefill_request(self, processed_request[0])
-    return processed_request
+async def _patched_add_request(
+    self: AsyncLLM,
+    request: Any,
+    prompt: str | None,
+    parent_req: Any,
+    index: int,
+    queue: Any,
+) -> Any:
+    # Validate before OutputProcessor and before crossing the EngineCore boundary.
+    _validate_prefill_request(self, request)
+    return await _ORIGINAL_ADD_REQUEST(self, request, prompt, parent_req, index, queue)
 
 
-EngineCore.preprocess_add_request = _patched_preprocess_add_request  # type: ignore[method-assign]
+AsyncLLM._add_request = _patched_add_request  # type: ignore[method-assign]

--- a/vllm_ascend/patch/platform/patch_prefill_length_validation.py
+++ b/vllm_ascend/patch/platform/patch_prefill_length_validation.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from vllm.logger import logger
+from vllm.v1.engine.core import EngineCore
+
+
+_ORIGINAL_PREPROCESS_ADD_REQUEST = EngineCore.preprocess_add_request
+
+
+def _is_target_model(engine: EngineCore) -> bool:
+    model_config = engine.vllm_config.model_config
+    hf_config = getattr(model_config, "hf_config", None)
+    model_type = str(getattr(hf_config, "model_type", "")).lower()
+    architectures = " ".join(getattr(hf_config, "architectures", ()) or ()).lower()
+    model_name = str(getattr(model_config, "model", "")).lower()
+    model_identifiers = f"{model_type} {architectures} {model_name}"
+    return any(name in model_identifiers for name in ("glm-5.2", "glm5.2", "glm52", "deepseek_v4"))
+
+
+def _prefill_max_tokens(request: Any) -> int:
+    params = getattr(request, "kv_transfer_params", None) or {}
+    value = params.get("original_max_tokens", request.max_tokens)
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return request.max_tokens
+
+
+def _validate_prefill_request(engine: EngineCore, request: Any) -> None:
+    kv_config = getattr(engine.vllm_config, "kv_transfer_config", None)
+    if kv_config is None or getattr(kv_config, "kv_role", None) != "kv_producer":
+        return
+    if not _is_target_model(engine):
+        return
+    max_tokens = _prefill_max_tokens(request)
+    total_tokens = request.num_prompt_tokens + max_tokens
+    max_model_len = engine.scheduler.max_model_len
+    if total_tokens > max_model_len:
+        raise ValueError(
+            "Request exceeds model-len before prefill: "
+            f"prompt tokens ({request.num_prompt_tokens}) + max_tokens ({max_tokens}) "
+            f"= {total_tokens} > model-len ({max_model_len})."
+        )
+    logger.debug(
+        "Prefill length validation passed: request_id=%s prompt_tokens=%d max_tokens=%d model_len=%d",
+        request.request_id,
+        request.num_prompt_tokens,
+        max_tokens,
+        max_model_len,
+    )
+
+
+def _patched_preprocess_add_request(self: EngineCore, request: Any) -> Any:
+    # Request.from_engine_core_request has already tokenized the prompt here.
+    processed_request = _ORIGINAL_PREPROCESS_ADD_REQUEST(self, request)
+    _validate_prefill_request(self, processed_request[0])
+    return processed_request
+
+
+EngineCore.preprocess_add_request = _patched_preprocess_add_request  # type: ignore[method-assign]


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces a prefill abort side-channel mechanism for disaggregated prefill. It allows the load balance proxy to notify prefillers to abort and force-release resources when a decoder stream is cancelled or encounters an error. This is achieved by introducing a new `ABORT_REQUEST_MSG` message type in the `Mooncake_hybrid_connector` and scheduling abort requests via ZeroMQ (`zmq`).

Feedback on the changes:
- In `_send_prefill_abort_sync`, creating and terminating a new `zmq.Context` on every abort request is inefficient and can cause resource leaks. It is recommended to use `zmq.Context.instance()` instead.
- In `assign_instances`, `kv_transfer_params` should be safely defaulted to prevent potential `AttributeError` or `TypeError` if it is `None`.

### Does this PR introduce _any_ user-facing change?

No, this is an internal optimization and error-handling mechanism for disaggregated prefill.

### How was this patch tested?

CI passed with existing tests.

- vLLM main: https://github.com/vllm-project/vllm/commit/1f486d96a17303ce8db8e02be39545b2be338446
