### PR TITLE
[BugFix] Guard dp device ids patch for missing vLLM API

### DIFF
--- a/vllm_ascend/patch/platform/patch_dp_device_ids.py
+++ b/vllm_ascend/patch/platform/patch_dp_device_ids.py
@@ -37,8 +37,6 @@ if not vllm_version_is("0.23.0"):
     from vllm.platforms import current_platform
     from vllm.v1.engine import utils as _engine_utils
 
-    _original_get_physical_gpu_ids = _engine_utils.get_physical_gpu_ids_for_local_dp_rank
-
     def _patched_get_physical_gpu_ids_for_local_dp_rank(
         device_control_env_var,
         local_dp_rank,
@@ -69,4 +67,6 @@ if not vllm_version_is("0.23.0"):
             user_assigned_gpu_ids,
         )
 
-    _engine_utils.get_physical_gpu_ids_for_local_dp_rank = _patched_get_physical_gpu_ids_for_local_dp_rank
+    if hasattr(_engine_utils, "get_physical_gpu_ids_for_local_dp_rank"):
+        _original_get_physical_gpu_ids = _engine_utils.get_physical_gpu_ids_for_local_dp_rank
+        _engine_utils.get_physical_gpu_ids_for_local_dp_rank = _patched_get_physical_gpu_ids_for_local_dp_rank


### PR DESCRIPTION
## Summary

Guard access to `get_physical_gpu_ids_for_local_dp_rank` in
`patch_dp_device_ids.py` for compatibility with vLLM versions where
the API is unavailable.
get_physical_gpu_ids_for_local_dp_rank is an internal vLLM helper and is not guaranteed to exist across vLLM revisions. The current patch accesses it unconditionally, which can make vLLM-Ascend fail during module import when the helper is absent. This change guards the whole monkey-patch installation with hasattr, preserving the existing behavior when the helper exists and safely skipping the patch otherwise.
## Testing

Verified on `releases/v0.23.0`.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
