### PR TITLE
[Test][Feature] Add GLM-5.2 with DCP E2E test configuration

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -189,6 +189,10 @@ a3:
         config_file_path: Qwen3.5-397B-w4a8_986k-function-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
+      - name: GLM-5.2-W4A8C8-1M-PD-DCP
+        config_file_path: GLM-5.2-W4A8C8-1M-PD-DCP.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
   double_node:
     test_config:
       - name: DeepSeek-V3_2-W8A8-EP_weekly

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W4A8C8-1M-PD-DCP.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W4A8C8-1M-PD-DCP.yaml
@@ -1,0 +1,356 @@
+test_name: "GLM-5.2-W4A8C8-1M-PD-DCP"
+model: "Eco-Tech/GLM-5.2-w4a8c8"
+num_nodes: 4
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0, 1 ]
+    decoder: [ 2, 3 ]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 16591
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 16591
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 2
+    tp_size: 8
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 2
+    port_start: 7100
+    dp_rpc_port: 16600
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 8
+    dp_address: "${NODE_2_IP}"
+
+  - node_index: 3
+    port_start: 7100
+    dp_rpc_port: 16600
+    dp_size: 4
+    dp_size_local: 2
+    dp_rank_start: 2
+    tp_size: 8
+    dp_address: "${NODE_2_IP}"
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  VLLM_ASCEND_ENABLE_NZ: "1"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "20"
+  HCCL_BUFFSIZE: "768"
+  HCCL_TRANSFER_TIMEOUT: "600"
+  HCCL_EXEC_TIMEOUT: "3600"
+  HCCL_CONNECT_TIMEOUT: "3600"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  VLLM_WORKER_MULTIPROC_METHOD: "spawn"
+  TASK_QUEUE_ENABLE: "1"
+  VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT: "480"
+  ASCEND_A3_ENABLE: "1"
+
+env_prefill: &env_prefill
+  <<: *env_common
+
+env_decode: &env_decode
+  <<: *env_common
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --seed
+      - "1024"
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --max-model-len
+      - "1024000"
+      - --max-num-batched-tokens
+      - "16384"
+      - --gpu-memory-utilization
+      - "0.75"
+      - --max-num-seqs
+      - "8"
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --pipeline-parallel-size
+      - "1"
+      - --prefill-context-parallel-size
+      - "1"
+      - --decode-context-parallel-size
+      - "8"
+      - --cp-kv-cache-interleave-size
+      - "128"
+      - --enforce-eager
+      - --additional-config
+      - '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}'
+      - --speculative-config
+      - '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}'
+      - --quantization
+      - "ascend"
+      - --enable-expert-parallel
+      - --safetensors-load-strategy
+      - "prefetch"
+      - --trust-remote-code
+      - --no-enable-prefix-caching
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - "glm47"
+      - --reasoning-parser
+      - "glm45"
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30000", "engine_id": "0", "kv_connector_extra_config": {"use_ascend_direct": true, "prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 4, "tp_size": 8}}}'
+
+  - node_index: 1
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --seed
+      - "1024"
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --max-model-len
+      - "1024000"
+      - --max-num-batched-tokens
+      - "16384"
+      - --gpu-memory-utilization
+      - "0.75"
+      - --max-num-seqs
+      - "8"
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --pipeline-parallel-size
+      - "1"
+      - --prefill-context-parallel-size
+      - "1"
+      - --decode-context-parallel-size
+      - "8"
+      - --cp-kv-cache-interleave-size
+      - "128"
+      - --enforce-eager
+      - --additional-config
+      - '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}'
+      - --speculative-config
+      - '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}'
+      - --quantization
+      - "ascend"
+      - --enable-expert-parallel
+      - --safetensors-load-strategy
+      - "prefetch"
+      - --trust-remote-code
+      - --no-enable-prefix-caching
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - "glm47"
+      - --reasoning-parser
+      - "glm45"
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30000", "engine_id": "1", "kv_connector_extra_config": {"use_ascend_direct": true, "prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 4, "tp_size": 8}}}'
+
+  - node_index: 2
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --seed
+      - "1024"
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --max-model-len
+      - "1024000"
+      - --max-num-batched-tokens
+      - "128"
+      - --gpu-memory-utilization
+      - "0.93"
+      - --max-num-seqs
+      - "32"
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --pipeline-parallel-size
+      - "1"
+      - --prefill-context-parallel-size
+      - "1"
+      - --decode-context-parallel-size
+      - "8"
+      - --cp-kv-cache-interleave-size
+      - "128"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --additional-config
+      - '{"ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}'
+      - --speculative-config
+      - '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+      - --quantization
+      - "ascend"
+      - --enable-expert-parallel
+      - --safetensors-load-strategy
+      - "prefetch"
+      - --trust-remote-code
+      - --no-enable-prefix-caching
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - "glm47"
+      - --reasoning-parser
+      - "glm45"
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30100", "engine_id": "2", "kv_connector_extra_config": {"use_ascend_direct": true, "prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 4, "tp_size": 8}}}'
+
+  - node_index: 3
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --seed
+      - "1024"
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --max-model-len
+      - "1024000"
+      - --max-num-batched-tokens
+      - "128"
+      - --gpu-memory-utilization
+      - "0.93"
+      - --max-num-seqs
+      - "32"
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --pipeline-parallel-size
+      - "1"
+      - --prefill-context-parallel-size
+      - "1"
+      - --decode-context-parallel-size
+      - "8"
+      - --cp-kv-cache-interleave-size
+      - "128"
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --additional-config
+      - '{"ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}'
+      - --speculative-config
+      - '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}'
+      - --quantization
+      - "ascend"
+      - --enable-expert-parallel
+      - --safetensors-load-strategy
+      - "prefetch"
+      - --trust-remote-code
+      - --no-enable-prefix-caching
+      - --enable-auto-tool-choice
+      - --tool-call-parser
+      - "glm47"
+      - --reasoning-parser
+      - "glm45"
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30100", "engine_id": "3", "kv_connector_extra_config": {"use_ascend_direct": true, "prefill": {"dp_size": 4, "tp_size": 8}, "decode": {"dp_size": 4, "tp_size": 8}}}'
+
+benchmarks:
+  perf_in3500_bs1:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in3500-bs2800
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 4
+    max_out_len: 1500
+    batch_size: 1
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97
+  perf_in3500_bs4:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in3500-bs2800
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 64
+    max_out_len: 1500
+    batch_size: 16
+    request_rate: 0
+    baseline: 1
+    threshold: 0.97
+  perf_in3500_bs64:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in3500-bs2800
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 256
+    max_out_len: 1500
+    batch_size: 64
+    request_rate: 0
+    baseline: 100
+    threshold: 0.97
+  perf_1m:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in1007616-bs16-prefix0-qwen
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    trust_remote_code: true
+    num_prompts: 4
+    max_out_len: 1024
+    batch_size: 1
+    request_rate: 0
+    baseline: 0
+    threshold: 0.97
+  acc_aime2025:
+    case_type: accuracy
+    dataset_path: vllm-ascend/aime2025
+    request_conf: vllm_api_general_chat
+    dataset_conf: aime2025/aime2025_gen_0_shot_chat_prompt
+    max_out_len: 65536
+    temperature: 1.0
+    top_p: 0.95
+    batch_size: 32
+    baseline: 93.33
+    threshold: 10

--- a/tests/e2e/weekly/multi_node/external_dp/config/Minimax_m2.7_in3_5_tpot20.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Minimax_m2.7_in3_5_tpot20.yaml
@@ -224,7 +224,7 @@ templates:
 benchmarks:
   perf_1:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K-in3500-bs2800
+    dataset_path: vllm-ascend/GSM8K_in3500_bs4000_minimax
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     num_prompts: 800

--- a/tests/e2e/weekly/multi_node/external_dp/config/Minimax_m2.7_in3_5_tpot50.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Minimax_m2.7_in3_5_tpot50.yaml
@@ -225,7 +225,7 @@ templates:
 benchmarks:
   perf_1:
     case_type: performance
-    dataset_path: vllm-ascend/GSM8K-in3500-bs2800
+    dataset_path: vllm-ascend/GSM8K_in3500_bs4000_minimax
     request_conf: vllm_api_stream_chat
     dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
     num_prompts: 3440


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a new weekly multi-node end-to-end test configuration file `GLM-5.2-W4A8C8-1M-PD-DCP.yaml` for the GLM-5.2 model with Disaggregated Prefill (PD) and Context Parallel (DCP) enabled on Ascend NPUs.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

This is a test configuration file to be run in the weekly multi-node E2E test pipeline.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
