### PR TITLE
[v0.26.0rc][BugFix][P/D] Backport async KV-delivery preemption fixes

### DIFF
--- a/tests/ut/patch/platform/test_kv_delivery_preemption.py
+++ b/tests/ut/patch/platform/test_kv_delivery_preemption.py
@@ -5,13 +5,20 @@ shipped in its wheel. These tests cover the same compatibility-boundary state
 transitions without requiring an NPU model runner.
 """
 
+import ast
 import inspect
+import subprocess
+import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from vllm_ascend.patch.platform import patch_async_scheduler as async_backport
-from vllm_ascend.patch.platform import patch_balance_schedule as backport
+from vllm_ascend.patch.platform import patch_balance_schedule as balance_backport
+from vllm_ascend.patch.platform import patch_kv_delivery_preemption as backport
+
+_VLLM_BASE_COMMIT = "d02df748bf9efd99022f1a062597dc3cb3808485"
 
 
 class _Queue:
@@ -51,7 +58,7 @@ def _request(
 
 
 def _scheduler():
-    scheduler = backport.BalanceScheduler.__new__(backport.BalanceScheduler)
+    scheduler = backport.KVDeliveryScheduler.__new__(backport.KVDeliveryScheduler)
     scheduler._free_request_blocks = lambda _request: None
     scheduler.encoder_cache_manager = SimpleNamespace(free=lambda _request: None)
     scheduler._inflight_prefills = set()
@@ -95,8 +102,24 @@ def test_request_stale_output_state_has_neutral_defaults():
     assert backport.Request.drop_stale_output is False
 
 
-def test_async_scheduler_inherits_existing_balance_patch():
-    assert issubclass(async_backport.AsyncScheduler, backport.BalanceScheduler)
+def test_async_scheduler_inherits_kv_delivery_patch():
+    assert issubclass(async_backport.AsyncScheduler, balance_backport.BalanceScheduler)
+    assert issubclass(balance_backport.BalanceScheduler, backport.KVDeliveryScheduler)
+    assert issubclass(async_backport.AsyncScheduler, backport.KVDeliveryScheduler)
+
+
+def test_all_sync_scheduler_backports_live_in_kv_delivery_patch():
+    moved_methods = {
+        "_preempt_request",
+        "update_from_output",
+        "_update_request_with_output",
+        "reset_prefix_cache",
+    }
+
+    assert moved_methods <= set(backport.KVDeliveryScheduler.__dict__)
+    assert moved_methods.isdisjoint(balance_backport.BalanceScheduler.__dict__)
+    assert "schedule" in backport.KVDeliveryScheduler.__dict__
+    assert "schedule" in balance_backport.BalanceScheduler.__dict__
 
 
 @pytest.mark.parametrize("drop_stale_output", [False, True])
@@ -105,7 +128,7 @@ def test_preempt_marks_all_inflight_output_stale(drop_stale_output):
     request = _request(in_flight=12, placeholders=4)
     scheduler = _scheduler()
 
-    backport.BalanceScheduler._preempt_request(
+    backport.KVDeliveryScheduler._preempt_request(
         scheduler,
         request,
         0.0,
@@ -123,7 +146,7 @@ def test_repreempt_keeps_an_undrained_drop_share_dropped():
     request = _request(in_flight=8, stale=4, drop_stale=True)
     scheduler = _scheduler()
 
-    backport.BalanceScheduler._preempt_request(scheduler, request, 0.0)
+    backport.KVDeliveryScheduler._preempt_request(scheduler, request, 0.0)
 
     assert request.num_stale_output_tokens == 8
     assert request.drop_stale_output is True
@@ -138,7 +161,7 @@ def test_reset_prefix_cache_uses_drop_mode_for_same_step_resume():
     scheduler.kv_cache_manager = SimpleNamespace(reset_prefix_cache=lambda: True)
     scheduler.connector = None
 
-    assert backport.BalanceScheduler.reset_prefix_cache(scheduler, reset_running_requests=True) is True
+    assert backport.KVDeliveryScheduler.reset_prefix_cache(scheduler, reset_running_requests=True) is True
 
     assert request.num_stale_output_tokens == 8
     assert request.num_output_placeholders == 0
@@ -159,7 +182,7 @@ def test_async_placeholder_update_skips_stale_delivery(monkeypatch, is_stale, ex
     def update_original(_scheduler, _request, new_token_ids, is_stale=False):
         return new_token_ids, False
 
-    monkeypatch.setattr(backport.BalanceScheduler, "_update_request_with_output", update_original)
+    monkeypatch.setattr(backport.KVDeliveryScheduler, "_update_request_with_output", update_original)
     if is_stale:
         request.num_output_placeholders = 0
 
@@ -177,20 +200,31 @@ def test_async_placeholder_update_skips_stale_delivery(monkeypatch, is_stale, ex
 
 def test_50297_pressure_preemption_uses_connector_delivery_requirement():
     """The existing schedule copy carries #50297 at the original call site."""
-    source = inspect.getsource(backport.BalanceScheduler.schedule)
+    source = inspect.getsource(backport.KVDeliveryScheduler.schedule)
 
     assert "drop_stale_output=self.requires_kv_delivery" in source
 
 
+def test_kv_delivery_schedule_has_no_balance_dependency():
+    source = inspect.getsource(backport.KVDeliveryScheduler.schedule)
+
+    assert "_should_defer_waiting_admission" not in source
+    assert "_balance_enabled" not in source
+    assert "balance_queue" not in source
+    assert "_use_consumer_partial_group_hits" not in source
+    assert "get_computed_blocks_for_connector" in source
+    assert "assert request_queue is not None" in source
+
+
 def test_48245_waits_for_deliverable_stale_output_before_resume():
-    source = inspect.getsource(backport.BalanceScheduler.schedule)
+    source = inspect.getsource(backport.KVDeliveryScheduler.schedule)
 
     assert "request.num_stale_output_tokens > 0" in source
     assert "not request.drop_stale_output" in source
 
 
 def test_48245_preemption_keeps_upstream_operation_order():
-    source = inspect.getsource(backport.BalanceScheduler._preempt_request)
+    source = inspect.getsource(backport.KVDeliveryScheduler._preempt_request)
     markers = [
         "self._free_request_blocks(request)",
         "request.num_computed_tokens = 0",
@@ -204,7 +238,7 @@ def test_48245_preemption_keeps_upstream_operation_order():
 
 
 def test_48245_output_update_keeps_stale_checks_in_original_flow():
-    source = inspect.getsource(inspect.unwrap(backport.BalanceScheduler.update_from_output))
+    source = inspect.getsource(inspect.unwrap(backport.KVDeliveryScheduler.update_from_output))
     markers = [
         "request.num_in_flight_tokens -= num_tokens_scheduled",
         "request.num_stale_output_tokens -= num_tokens_scheduled",
@@ -215,3 +249,55 @@ def test_48245_output_update_keeps_stale_checks_in_original_flow():
     ]
 
     assert [source.index(marker) for marker in markers] == sorted(source.index(marker) for marker in markers)
+
+
+def _kv_schedule_body_ast(source: str) -> str:
+    """Strip only the two PR scheduler deltas from a schedule body."""
+    tree = ast.parse(textwrap.dedent(source))
+    func = next(node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "schedule")
+
+    class _KVDeltaStripper(ast.NodeTransformer):
+        def visit_Call(self, node: ast.Call):  # noqa: N802
+            self.generic_visit(node)
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "_preempt_request":
+                node.keywords = [kw for kw in node.keywords if kw.arg != "drop_stale_output"]
+            return node
+
+        def visit_If(self, node: ast.If):  # noqa: N802
+            if "num_stale_output_tokens" in ast.dump(node.test) and "drop_stale_output" in ast.dump(node.test):
+                return None
+            return self.generic_visit(node)
+
+    stripped = _KVDeltaStripper().visit(func)
+    assert isinstance(stripped, ast.FunctionDef)
+    return ast.dump(ast.Module(body=stripped.body, type_ignores=[]))
+
+
+def _target_schedule_source() -> str | None:
+    scheduler_file = Path(inspect.getsourcefile(backport.KVDeliveryScheduler.__bases__[0]) or "").resolve()
+    if len(scheduler_file.parents) < 5:
+        return None
+    vllm_repo = scheduler_file.parents[4]
+    try:
+        relative_file = scheduler_file.relative_to(vllm_repo).as_posix()
+        result = subprocess.run(
+            ["git", "-C", str(vllm_repo), "show", f"{_VLLM_BASE_COMMIT}:{relative_file}"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError):
+        return None
+    return result.stdout
+
+
+def test_kv_delivery_schedule_body_matches_target_vllm_commit():
+    target_source = _target_schedule_source()
+    if target_source is None:
+        pytest.skip(f"target vLLM commit {_VLLM_BASE_COMMIT} is unavailable")
+
+    ours = _kv_schedule_body_ast(inspect.getsource(backport.KVDeliveryScheduler.schedule))
+    upstream = _kv_schedule_body_ast(target_source)
+
+    assert ours == upstream

--- a/tests/ut/patch/platform/test_kv_delivery_preemption.py
+++ b/tests/ut/patch/platform/test_kv_delivery_preemption.py
@@ -23,7 +23,10 @@ class _Queue:
 
 
 class _Request(SimpleNamespace):
-    __hash__ = object.__hash__
+    # Request instances are identity-hashable and are stored in scheduler sets.
+    # typeshed marks SimpleNamespace.__hash__ as None, so this intentional test
+    # double override needs a narrow assignment suppression.
+    __hash__ = object.__hash__  # type: ignore[assignment]
 
 
 def _request(

--- a/tests/ut/patch/platform/test_kv_delivery_preemption.py
+++ b/tests/ut/patch/platform/test_kv_delivery_preemption.py
@@ -212,7 +212,6 @@ def test_kv_delivery_schedule_has_no_balance_dependency():
     assert "_balance_enabled" not in source
     assert "balance_queue" not in source
     assert "_use_consumer_partial_group_hits" not in source
-    assert "get_computed_blocks_for_connector" in source
     assert "assert request_queue is not None" in source
 
 

--- a/tests/ut/patch/platform/test_kv_delivery_preemption.py
+++ b/tests/ut/patch/platform/test_kv_delivery_preemption.py
@@ -1,0 +1,214 @@
+"""CPU regression tests adapted from vLLM PRs #48245 and #50297.
+
+The upstream tests use vLLM's in-tree ``tests/v1/core`` helpers, which are not
+shipped in its wheel. These tests cover the same compatibility-boundary state
+transitions without requiring an NPU model runner.
+"""
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend.patch.platform import patch_async_scheduler as async_backport
+from vllm_ascend.patch.platform import patch_balance_schedule as backport
+
+
+class _Queue:
+    def __init__(self):
+        self.requests = []
+
+    def prepend_request(self, request):
+        self.requests.insert(0, request)
+
+
+class _Request(SimpleNamespace):
+    __hash__ = object.__hash__
+
+
+def _request(
+    request_id="handoff",
+    *,
+    in_flight=4,
+    placeholders=4,
+    stale=0,
+    drop_stale=False,
+):
+    return _Request(
+        request_id=request_id,
+        status=backport.RequestStatus.RUNNING,
+        num_in_flight_tokens=in_flight,
+        num_output_placeholders=placeholders,
+        num_stale_output_tokens=stale,
+        drop_stale_output=drop_stale,
+        spec_token_ids=[],
+        num_computed_tokens=32,
+        num_preemptions=0,
+    )
+
+
+def _scheduler():
+    scheduler = backport.BalanceScheduler.__new__(backport.BalanceScheduler)
+    scheduler._free_request_blocks = lambda _request: None
+    scheduler.encoder_cache_manager = SimpleNamespace(free=lambda _request: None)
+    scheduler._inflight_prefills = set()
+    scheduler.log_stats = False
+    scheduler.waiting = _Queue()
+    scheduler.reset_preempted_req_ids = set()
+    return scheduler
+
+
+@pytest.mark.parametrize(
+    ("is_producer", "expected"),
+    [(True, True), (False, False)],
+)
+def test_requires_kv_delivery_defaults_to_producer_role(is_producer, expected):
+    connector = SimpleNamespace(_kv_transfer_config=SimpleNamespace(is_kv_producer=is_producer))
+
+    assert backport._requires_kv_delivery(connector) is expected
+
+
+@pytest.mark.parametrize(
+    ("children", "expected"),
+    [
+        ([False, False], False),
+        ([False, True], True),
+        ([True, False], True),
+        ([], False),
+    ],
+)
+def test_multi_connector_aggregates_child_delivery_requirements(children, expected):
+    connector = SimpleNamespace(_connectors=[SimpleNamespace(requires_kv_delivery=value) for value in children])
+
+    assert backport._multi_requires_kv_delivery(connector) is expected
+
+
+def test_best_effort_offload_cache_does_not_require_delivery():
+    assert backport._best_effort_cache_requires_kv_delivery(SimpleNamespace()) is False
+
+
+def test_request_stale_output_state_has_neutral_defaults():
+    assert backport.Request.num_stale_output_tokens == 0
+    assert backport.Request.drop_stale_output is False
+
+
+def test_async_scheduler_inherits_existing_balance_patch():
+    assert issubclass(async_backport.AsyncScheduler, backport.BalanceScheduler)
+
+
+@pytest.mark.parametrize("drop_stale_output", [False, True])
+def test_preempt_marks_all_inflight_output_stale(drop_stale_output):
+    """#48245 records the complete in-flight token share, not one frame."""
+    request = _request(in_flight=12, placeholders=4)
+    scheduler = _scheduler()
+
+    backport.BalanceScheduler._preempt_request(
+        scheduler,
+        request,
+        0.0,
+        drop_stale_output=drop_stale_output,
+    )
+
+    assert request.status == backport.RequestStatus.PREEMPTED
+    assert request.num_stale_output_tokens == 12
+    assert request.num_output_placeholders == 0
+    assert request.drop_stale_output is drop_stale_output
+    assert scheduler.waiting.requests == [request]
+
+
+def test_repreempt_keeps_an_undrained_drop_share_dropped():
+    request = _request(in_flight=8, stale=4, drop_stale=True)
+    scheduler = _scheduler()
+
+    backport.BalanceScheduler._preempt_request(scheduler, request, 0.0)
+
+    assert request.num_stale_output_tokens == 8
+    assert request.drop_stale_output is True
+
+
+def test_reset_prefix_cache_uses_drop_mode_for_same_step_resume():
+    """#48245 replaces v0.26's placeholder-count discard bookkeeping."""
+    request = _request(in_flight=8, placeholders=4)
+    scheduler = _scheduler()
+    scheduler.running = [request]
+    scheduler.prev_step_scheduled_req_ids = {request.request_id}
+    scheduler.kv_cache_manager = SimpleNamespace(reset_prefix_cache=lambda: True)
+    scheduler.connector = None
+
+    assert backport.BalanceScheduler.reset_prefix_cache(scheduler, reset_running_requests=True) is True
+
+    assert request.num_stale_output_tokens == 8
+    assert request.num_output_placeholders == 0
+    assert request.drop_stale_output is True
+    assert scheduler.prev_step_scheduled_req_ids == set()
+
+
+@pytest.mark.parametrize(
+    ("is_stale", "expected_placeholders"),
+    [(True, 0), (False, 2)],
+)
+def test_async_placeholder_update_skips_stale_delivery(monkeypatch, is_stale, expected_placeholders):
+    """#48245 stale output is delivered without decrementing reset counters."""
+    request = _request(placeholders=4)
+    scheduler = async_backport.AsyncScheduler.__new__(async_backport.AsyncScheduler)
+    scheduler.kv_cache_manager = SimpleNamespace(cache_blocks=lambda *_args: None)
+
+    def update_original(_scheduler, _request, new_token_ids, is_stale=False):
+        return new_token_ids, False
+
+    monkeypatch.setattr(backport.BalanceScheduler, "_update_request_with_output", update_original)
+    if is_stale:
+        request.num_output_placeholders = 0
+
+    new_token_ids, stopped = async_backport._update_request_with_output(
+        scheduler,
+        request,
+        [10, 11],
+        is_stale=is_stale,
+    )
+
+    assert new_token_ids == [10, 11]
+    assert stopped is False
+    assert request.num_output_placeholders == expected_placeholders
+
+
+def test_50297_pressure_preemption_uses_connector_delivery_requirement():
+    """The existing schedule copy carries #50297 at the original call site."""
+    source = inspect.getsource(backport.BalanceScheduler.schedule)
+
+    assert "drop_stale_output=self.requires_kv_delivery" in source
+
+
+def test_48245_waits_for_deliverable_stale_output_before_resume():
+    source = inspect.getsource(backport.BalanceScheduler.schedule)
+
+    assert "request.num_stale_output_tokens > 0" in source
+    assert "not request.drop_stale_output" in source
+
+
+def test_48245_preemption_keeps_upstream_operation_order():
+    source = inspect.getsource(backport.BalanceScheduler._preempt_request)
+    markers = [
+        "self._free_request_blocks(request)",
+        "request.num_computed_tokens = 0",
+        "request.drop_stale_output =",
+        "request.num_stale_output_tokens = request.num_in_flight_tokens",
+        "request.num_preemptions += 1",
+        "self.waiting.prepend_request(request)",
+    ]
+
+    assert [source.index(marker) for marker in markers] == sorted(source.index(marker) for marker in markers)
+
+
+def test_48245_output_update_keeps_stale_checks_in_original_flow():
+    source = inspect.getsource(inspect.unwrap(backport.BalanceScheduler.update_from_output))
+    markers = [
+        "request.num_in_flight_tokens -= num_tokens_scheduled",
+        "request.num_stale_output_tokens -= num_tokens_scheduled",
+        "if failed_kv_load_req_ids",
+        "if request is None or request.is_finished()",
+        "if output_is_stale and request.drop_stale_output",
+        "req_index = model_runner_output.req_id_to_index[req_id]",
+    ]
+
+    assert [source.index(marker) for marker in markers] == sorted(source.index(marker) for marker in markers)

--- a/tests/ut/patch/platform/test_kv_delivery_preemption.py
+++ b/tests/ut/patch/platform/test_kv_delivery_preemption.py
@@ -296,6 +296,7 @@ def test_kv_delivery_schedule_body_matches_target_vllm_commit():
     target_source = _target_schedule_source()
     if target_source is None:
         pytest.skip(f"target vLLM commit {_VLLM_BASE_COMMIT} is unavailable")
+    assert target_source is not None
 
     ours = _kv_schedule_body_ast(inspect.getsource(backport.KVDeliveryScheduler.schedule))
     upstream = _kv_schedule_body_ast(target_source)

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -20,11 +20,11 @@ What is guarded here (everything reachable from CPU UT):
 * the module-level class swaps actually took effect;
 * the upstream Scheduler/DPEngineCoreProc methods the patch calls/super-calls
   still exist;
-* the 4 platform deltas remain present in ``schedule()`` (intent lock);
+* the 5 platform deltas remain present in ``schedule()`` (intent lock);
 * the copied ``schedule()`` body stays a verbatim copy of the ``schedule()``
   at vllm-ascend's pinned vLLM release tag (read from
   ``.github/vllm-release-tag.commit`` -- the same file CI uses), modulo exactly
-  those 4 deltas. Reading the tag from the pin file means a pin advance
+  those 5 deltas. Reading the tag from the pin file means a pin advance
   auto-flips this guard to the new tag until the copy is re-synced.
 
 What is NOT guarded here (structurally unreachable without a real engine):
@@ -249,13 +249,13 @@ def test_balance_scheduler_does_not_import_sfr_when_disabled(monkeypatch):
 
 
 def _schedule_body_ast(source: str) -> str:
-    """Canonical AST dump of a ``schedule`` method body with the 4 platform
+    """Canonical AST dump of a ``schedule`` method body with the 5 platform
     deltas stripped, so the remainder can be compared verbatim against the
     pinned release tag's ``schedule()``. AST-based on purpose: it is blind to
     comments and whitespace, so the only differences that surface are real code
     drift (not the escape-quoting of a comment or reformatting).
 
-    The 3 deltas removed:
+    The 5 deltas removed:
       * delta 1 -- the disabled-path early return (``if not
         self._balance_enabled: ... super().schedule(...)``);
       * delta 2 -- the ``balance_flag`` gate (``max(t.item() for t in
@@ -265,6 +265,8 @@ def _schedule_body_ast(source: str) -> str:
         ``assert request_queue is not None``. Both are stripped so the two
         bodies align.
       * delta 4 -- the consumer-only partial-group cache lookup gate.
+      * delta 5 -- the #48245/#50297 stale-output admission gate and
+        reliable-delivery preemption flag.
     """
     tree = ast.parse(textwrap.dedent(source))
     func = next(
@@ -274,6 +276,12 @@ def _schedule_body_ast(source: str) -> str:
     assert func is not None, "no schedule() in source"
 
     class _BalanceDeltaStripper(ast.NodeTransformer):
+        def visit_Call(self, node: ast.Call):  # noqa: N802
+            self.generic_visit(node)
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "_preempt_request":
+                node.keywords = [kw for kw in node.keywords if kw.arg != "drop_stale_output"]
+            return node
+
         def visit_BoolOp(self, node: ast.BoolOp):  # noqa: N802
             self.generic_visit(node)
             node.values = [value for value in node.values if "_use_consumer_partial_group_hits" not in ast.dump(value)]
@@ -289,6 +297,9 @@ def _schedule_body_ast(source: str) -> str:
                 return None
             # delta 3 (ours): if request_queue is None: break.
             if "request_queue" in test and "None" in test and "Is" in test:
+                return None
+            # delta 5: wait for deliverable stale output before resuming.
+            if "num_stale_output_tokens" in test and "drop_stale_output" in test:
                 return None
             return self.generic_visit(node)
 
@@ -366,13 +377,13 @@ def test_schedule_signature_matches_installed_vllm():
 
 
 # ---------------------------------------------------------------------------
-# 1b. the 3 balance deltas remain present in schedule() (intent lock)
+# 1b. the platform deltas remain present in schedule() (intent lock)
 # ---------------------------------------------------------------------------
 
 
 def test_balance_deltas_present_in_schedule():
     """The whole point of copying schedule() is to inject the balance logic.
-    If a future re-sync against the pinned tag drops any of the 3 deltas,
+    If a future re-sync against the pinned tag drops any of the 5 deltas,
     balance silently stops working -- this locks their presence in the source."""
     src = inspect.getsource(BalanceScheduler.schedule)
 
@@ -390,6 +401,10 @@ def test_balance_deltas_present_in_schedule():
     # delta 4: producer schedulers never use the consumer-only per-group lookup.
     assert "self._use_consumer_partial_group_hits" in src
 
+    # delta 5: stale output is drained or dropped according to connector need.
+    assert "request.num_stale_output_tokens" in src
+    assert "drop_stale_output=self.requires_kv_delivery" in src
+
 
 # ---------------------------------------------------------------------------
 # 1c. copied schedule() body stays verbatim with the pinned release tag
@@ -399,7 +414,7 @@ def test_balance_deltas_present_in_schedule():
 def test_schedule_body_matches_pinned_release_tag():
     """The copied ``schedule()`` body must stay a verbatim copy of the
     ``schedule()`` at vllm-ascend's pinned vLLM release tag, modulo exactly the
-    3 balance deltas.
+    5 platform deltas.
 
     The tag is read dynamically from ``.github/vllm-release-tag.commit`` -- the
     same file CI uses to pick the tag, NOT a hardcoded string or a design doc
@@ -422,9 +437,10 @@ def test_schedule_body_matches_pinned_release_tag():
     theirs = _schedule_body_ast(pinned_src)
     assert ours == theirs, (
         f"BalanceScheduler.schedule body drifted from the pinned release tag "
-        f"({tag}) beyond the 3 balance deltas. Re-sync the copy against "
+        f"({tag}) beyond the 5 platform deltas. Re-sync the copy against "
         f"{tag} and re-apply only: (1) disabled-path early return, "
-        f"(2) balance_flag gate, (3) if request_queue is None: break."
+        f"(2) balance_flag gate, (3) if request_queue is None: break, "
+        f"(4) producer partial-group lookup gate, (5) stale-output handling."
     )
 
 
@@ -513,6 +529,8 @@ def test_module_level_swaps_take_effect():
 _SCHEDULER_METHOD_SEAMS = [
     "schedule",  # super().schedule() on the disabled path
     "_preempt_request",
+    "update_from_output",
+    "reset_prefix_cache",
     "_try_schedule_encoder_inputs",
     "_mamba_block_aligned_split",
     "_select_waiting_queue_for_scheduling",

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -154,6 +154,7 @@ def test_pinned_release_schedule_reads_mamba_flag_only_for_partial_group_lookup(
     ref = _pinned_release_schedule_source()
     if ref is None:
         pytest.skip("pinned vLLM release schedule is not retrievable")
+    assert ref is not None
     _, src = ref
     tree = ast.parse(src)
     scheduler = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Scheduler")

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -21,8 +21,8 @@ What is guarded here (everything reachable from CPU UT):
 * the upstream Scheduler/DPEngineCoreProc methods the patch calls/super-calls
   still exist;
 * the 2 balance deltas remain present in ``schedule()`` (intent lock);
-* the copied ``schedule()`` body stays a verbatim copy of the target vLLM
-  commit's ``schedule()``, modulo exactly those 2 deltas.
+* the copied ``schedule()`` body stays aligned with the pinned release tag,
+  modulo the 2 balance deltas and explicit main/release compatibility deltas.
 
 What is NOT guarded here (structurally unreachable without a real engine):
 
@@ -150,11 +150,19 @@ def test_disabled_balance_hides_mamba_only_from_producer_lookup(
     assert scheduler.has_mamba_layers is True
 
 
-def test_upstream_schedule_reads_mamba_flag_only_for_partial_group_lookup():
-    src = inspect.getsource(BalanceScheduler.__bases__[0].schedule)
+def test_pinned_release_schedule_reads_mamba_flag_only_for_partial_group_lookup():
+    ref = _pinned_release_schedule_source()
+    if ref is None:
+        pytest.skip("pinned vLLM release schedule is not retrievable")
+    _, src = ref
+    tree = ast.parse(src)
+    scheduler = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "Scheduler")
+    schedule = next(node for node in scheduler.body if isinstance(node, ast.FunctionDef) and node.name == "schedule")
+    schedule_src = ast.get_source_segment(src, schedule)
+    assert schedule_src is not None
 
-    assert src.count("self.has_mamba_layers") == 1
-    assert "find_longest_cache_hit_per_group" in src
+    assert schedule_src.count("self.has_mamba_layers") == 1
+    assert "find_longest_cache_hit_per_group" in schedule_src
 
 
 @pytest.mark.parametrize("balance_enabled", [False, True])
@@ -246,17 +254,12 @@ def test_balance_scheduler_does_not_import_sfr_when_disabled(monkeypatch):
 
 
 def _schedule_body_ast(source: str) -> str:
-    """Canonical AST dump of a ``schedule`` method body with the 5 platform
-    deltas stripped, so the remainder can be compared verbatim against the
-    pinned release tag's ``schedule()``. AST-based on purpose: it is blind to
-    comments and whitespace, so the only differences that surface are real code
-    drift (not the escape-quoting of a comment or reformatting).
+    """Return a canonical AST for comparison with the pinned release tag.
 
-    The 2 deltas removed:
-      * delta 1 -- the disabled-path early return (``if not
-        self._balance_enabled: ... super().schedule(...)``);
-      * delta 2 -- the ``balance_flag`` gate (``max(t.item() for t in
-        self.balance_queue) == self.max_num_running_reqs``);
+    This strips the 2 balance deltas and normalizes the known API differences
+    between the release tag and the main-verified vLLM commit: connector-aware
+    prefix-cache lookup/stat accounting, the equivalent ``prefill_stats``
+    truthiness check, and encoder-cache connector metadata.
     """
     tree = ast.parse(textwrap.dedent(source))
     func = next(
@@ -265,16 +268,16 @@ def _schedule_body_ast(source: str) -> str:
     )
     assert func is not None, "no schedule() in source"
 
-    class _BalanceDeltaStripper(ast.NodeTransformer):
+    class _ScheduleCompatibilityNormalizer(ast.NodeTransformer):
+        def visit_Assign(self, node: ast.Assign):  # noqa: N802
+            if any(isinstance(target, ast.Name) and target.id == "did_prefix_cache_lookup" for target in node.targets):
+                return None
+            return self.generic_visit(node)
+
         def visit_Call(self, node: ast.Call):  # noqa: N802
             self.generic_visit(node)
-            if isinstance(node.func, ast.Attribute) and node.func.attr == "_preempt_request":
-                node.keywords = [kw for kw in node.keywords if kw.arg != "drop_stale_output"]
-            return node
-
-        def visit_BoolOp(self, node: ast.BoolOp):  # noqa: N802
-            self.generic_visit(node)
-            node.values = [value for value in node.values if "_use_consumer_partial_group_hits" not in ast.dump(value)]
+            if isinstance(node.func, ast.Name) and node.func.id == "SchedulerOutput":
+                node.keywords = [kw for kw in node.keywords if kw.arg != "ec_manager_metadata"]
             return node
 
         def visit_If(self, node: ast.If):  # noqa: N802
@@ -285,9 +288,26 @@ def _schedule_body_ast(source: str) -> str:
             # delta 2: the balance admission gate inside the WAITING loop.
             if "balance_queue" in test and "max_num_running_reqs" in test:
                 return None
+            # Main uses a connector-aware local cache lookup while the release
+            # tag has a Mamba-specific lookup. Their common external-cache and
+            # scheduling logic begins at get_num_new_matched_tokens.
+            if "num_computed_tokens" in test and "Constant(value=0)" in test:
+                for index, statement in enumerate(node.body):
+                    if "get_num_new_matched_tokens" in ast.dump(statement):
+                        node.body = node.body[index:]
+                        break
+            # Main-only fallback when connector group hits diverge.
+            if "hit_diverged" in test:
+                return None
+            # Main records prefix-cache stats after successful admission.
+            if "did_prefix_cache_lookup" in test:
+                return None
+            # ``x`` and ``x is not None`` are equivalent for PrefillStats.
+            if "prefill_stats" in test and "num_preemptions" in test:
+                node.test = ast.Name(id="prefill_stats_guard", ctx=ast.Load())
             return self.generic_visit(node)
 
-    stripped = _BalanceDeltaStripper().visit(func)
+    stripped = _ScheduleCompatibilityNormalizer().visit(func)
     assert isinstance(stripped, ast.FunctionDef)
     return ast.dump(ast.Module(body=stripped.body, type_ignores=[]))
 
@@ -360,7 +380,7 @@ def test_schedule_signature_matches_installed_vllm():
 
 def test_balance_deltas_present_in_schedule():
     """The whole point of copying schedule() is to inject the balance logic.
-    If a future re-sync against the pinned tag drops any of the 5 deltas,
+    If a future re-sync against the pinned tag drops either balance delta,
     balance silently stops working -- this locks their presence in the source."""
     src = inspect.getsource(BalanceScheduler.schedule)
 
@@ -381,9 +401,7 @@ def test_balance_deltas_present_in_schedule():
 
 
 def test_schedule_body_matches_pinned_release_tag():
-    """The copied ``schedule()`` body must stay a verbatim copy of the
-    ``schedule()`` at vllm-ascend's pinned vLLM release tag, modulo exactly the
-    2 balance deltas.
+    """The copied ``schedule()`` body must stay aligned with the pinned tag.
 
     The tag is read dynamically from ``.github/vllm-release-tag.commit`` -- the
     same file CI uses to pick the tag, NOT a hardcoded string or a design doc
@@ -406,9 +424,7 @@ def test_schedule_body_matches_pinned_release_tag():
     theirs = _schedule_body_ast(pinned_src)
     assert ours == theirs, (
         f"BalanceScheduler.schedule body drifted from the pinned release tag "
-        f"({tag}) beyond the 2 balance deltas. Re-sync the copy against "
-        f"{tag} and re-apply only: (1) disabled-path early return, "
-        f"(2) balance_flag gate."
+        f"({tag}) beyond the documented balance and compatibility deltas."
     )
 
 

--- a/tests/ut/patch/platform/test_patch_balance_schedule.py
+++ b/tests/ut/patch/platform/test_patch_balance_schedule.py
@@ -20,12 +20,9 @@ What is guarded here (everything reachable from CPU UT):
 * the module-level class swaps actually took effect;
 * the upstream Scheduler/DPEngineCoreProc methods the patch calls/super-calls
   still exist;
-* the 5 platform deltas remain present in ``schedule()`` (intent lock);
-* the copied ``schedule()`` body stays a verbatim copy of the ``schedule()``
-  at vllm-ascend's pinned vLLM release tag (read from
-  ``.github/vllm-release-tag.commit`` -- the same file CI uses), modulo exactly
-  those 5 deltas. Reading the tag from the pin file means a pin advance
-  auto-flips this guard to the new tag until the copy is re-synced.
+* the 2 balance deltas remain present in ``schedule()`` (intent lock);
+* the copied ``schedule()`` body stays a verbatim copy of the target vLLM
+  commit's ``schedule()``, modulo exactly those 2 deltas.
 
 What is NOT guarded here (structurally unreachable without a real engine):
 
@@ -255,18 +252,11 @@ def _schedule_body_ast(source: str) -> str:
     comments and whitespace, so the only differences that surface are real code
     drift (not the escape-quoting of a comment or reformatting).
 
-    The 5 deltas removed:
+    The 2 deltas removed:
       * delta 1 -- the disabled-path early return (``if not
         self._balance_enabled: ... super().schedule(...)``);
       * delta 2 -- the ``balance_flag`` gate (``max(t.item() for t in
         self.balance_queue) == self.max_num_running_reqs``);
-      * delta 3 -- the ``request_queue is None`` check, which exists in our
-        copy as ``if request_queue is None: break`` and in upstream as
-        ``assert request_queue is not None``. Both are stripped so the two
-        bodies align.
-      * delta 4 -- the consumer-only partial-group cache lookup gate.
-      * delta 5 -- the #48245/#50297 stale-output admission gate and
-        reliable-delivery preemption flag.
     """
     tree = ast.parse(textwrap.dedent(source))
     func = next(
@@ -294,19 +284,6 @@ def _schedule_body_ast(source: str) -> str:
                 return None
             # delta 2: the balance admission gate inside the WAITING loop.
             if "balance_queue" in test and "max_num_running_reqs" in test:
-                return None
-            # delta 3 (ours): if request_queue is None: break.
-            if "request_queue" in test and "None" in test and "Is" in test:
-                return None
-            # delta 5: wait for deliverable stale output before resuming.
-            if "num_stale_output_tokens" in test and "drop_stale_output" in test:
-                return None
-            return self.generic_visit(node)
-
-        def visit_Assert(self, node: ast.Assert):  # noqa: N802
-            test = ast.dump(node.test)
-            # delta 3 (upstream): assert request_queue is not None.
-            if "request_queue" in test and "None" in test and "IsNot" in test:
                 return None
             return self.generic_visit(node)
 
@@ -395,15 +372,7 @@ def test_balance_deltas_present_in_schedule():
     assert "max(t.item() for t in self.balance_queue)" in src
     assert "self.max_num_running_reqs" in src
 
-    # delta 3: `if request_queue is None: break` replaces upstream's assert.
-    assert "if request_queue is None:" in src
-
-    # delta 4: producer schedulers never use the consumer-only per-group lookup.
-    assert "self._use_consumer_partial_group_hits" in src
-
-    # delta 5: stale output is drained or dropped according to connector need.
-    assert "request.num_stale_output_tokens" in src
-    assert "drop_stale_output=self.requires_kv_delivery" in src
+    assert "assert request_queue is not None" in src
 
 
 # ---------------------------------------------------------------------------
@@ -414,7 +383,7 @@ def test_balance_deltas_present_in_schedule():
 def test_schedule_body_matches_pinned_release_tag():
     """The copied ``schedule()`` body must stay a verbatim copy of the
     ``schedule()`` at vllm-ascend's pinned vLLM release tag, modulo exactly the
-    5 platform deltas.
+    2 balance deltas.
 
     The tag is read dynamically from ``.github/vllm-release-tag.commit`` -- the
     same file CI uses to pick the tag, NOT a hardcoded string or a design doc
@@ -437,10 +406,9 @@ def test_schedule_body_matches_pinned_release_tag():
     theirs = _schedule_body_ast(pinned_src)
     assert ours == theirs, (
         f"BalanceScheduler.schedule body drifted from the pinned release tag "
-        f"({tag}) beyond the 5 platform deltas. Re-sync the copy against "
+        f"({tag}) beyond the 2 balance deltas. Re-sync the copy against "
         f"{tag} and re-apply only: (1) disabled-path early return, "
-        f"(2) balance_flag gate, (3) if request_queue is None: break, "
-        f"(4) producer partial-group lookup gate, (5) stale-output handling."
+        f"(2) balance_flag gate."
     )
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1497,6 +1497,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
 class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def __init__(self, vllm_config: VllmConfig, role: KVConnectorRole, kv_cache_config: KVCacheConfig | None = None):
         assert vllm_config.kv_transfer_config is not None
+        self._kv_transfer_config = vllm_config.kv_transfer_config
         self.engine_id = vllm_config.kv_transfer_config.engine_id
         self._connector_metadata = MooncakeConnectorMetadata()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1081,6 +1081,7 @@ class MooncakeConnectorMetadata(KVConnectorMetadata):
 class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
     def __init__(self, vllm_config: VllmConfig, role: KVConnectorRole, kv_cache_config: KVCacheConfig | None = None):
         assert vllm_config.kv_transfer_config is not None
+        self._kv_transfer_config = vllm_config.kv_transfer_config
         self.engine_id = vllm_config.kv_transfer_config.engine_id
         self._connector_metadata = MooncakeConnectorMetadata()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -78,6 +78,11 @@ class AscendStoreKVEvents(KVConnectorKVEvents):
 
 
 class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
+    @property
+    def requires_kv_delivery(self) -> bool:
+        # AscendStore is a best-effort cache: a dropped save is a future miss.
+        return False
+
     @classmethod
     def requires_piecewise_for_cudagraph(cls, extra_config: dict[str, Any]) -> bool:
         """

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -32,7 +32,8 @@
 # =================
 # Entries are listed in alphabetical order by file name.
 #
-# ** 1. Files: platform/patch_async_scheduler.py, platform/patch_balance_schedule.py**
+# ** 1. Files: platform/patch_async_scheduler.py, platform/patch_balance_schedule.py,
+#              platform/patch_kv_delivery_preemption.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
 #      `vllm.v1.core.sched.scheduler.Scheduler`
@@ -59,6 +60,27 @@
 #       https://github.com/vllm-project/vllm/pull/48245
 #    Future Plan:
 #       Remove this patch when the supported vLLM version includes PR #48245.
+#
+#   3. `vllm.v1.core.sched.scheduler.Scheduler`
+#      `vllm.v1.request.Request`
+#      `vllm.distributed.kv_transfer.kv_connector.v1.*`
+#    Why:
+#       vLLM #48245/#50297 prevent preemption from losing or reordering
+#       in-flight output while a producer connector still requires reliable KV
+#       delivery. This correctness requirement is independent of balance
+#       scheduling.
+#    How:
+#       Install `KVDeliveryScheduler` first with all affected scheduler methods
+#       and request/connector contracts. `BalanceScheduler` derives from it and
+#       keeps its own `d02df748bf9efd99022f1a062597dc3cb3808485`-based
+#       balance `schedule()`. When balance is disabled,
+#       that method delegates to `KVDeliveryScheduler.schedule()`; when enabled,
+#       it runs only the original balance scheduling logic.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/48245
+#       https://github.com/vllm-project/vllm/pull/50297
+#    Future Plan:
+#       Remove this patch when the supported vLLM version includes both PRs.
 #
 # ** 2. File: platform/patch_camem_allocator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -32,7 +32,7 @@
 # =================
 # Entries are listed in alphabetical order by file name.
 #
-# ** 1. File: platform/patch_balance_schedule.py**
+# ** 1. Files: platform/patch_async_scheduler.py, platform/patch_balance_schedule.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.engine.core.EngineCoreProc.run_engine_core`
 #      `vllm.v1.core.sched.scheduler.Scheduler`
@@ -47,6 +47,18 @@
 #       https://github.com/vllm-project/vllm/pull/29721
 #    Future Plan:
 #       Remove this patch when vLLM merge the PR.
+#
+#   2. `vllm.v1.core.sched.async_scheduler.AsyncScheduler._update_request_with_output`
+#    Why:
+#       vLLM #48245 adds lossless stale-output handling for async scheduling.
+#       AsyncScheduler owns placeholder accounting, so this method cannot
+#       inherit the implementation from the scheduler patch.
+#    How:
+#       Replace only `_update_request_with_output` with the #48245 version.
+#    Related PR (if no, explain why):
+#       https://github.com/vllm-project/vllm/pull/48245
+#    Future Plan:
+#       Remove this patch when the supported vLLM version includes PR #48245.
 #
 # ** 2. File: platform/patch_camem_allocator.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -72,8 +72,8 @@
 #    How:
 #       Install `KVDeliveryScheduler` first with all affected scheduler methods
 #       and request/connector contracts. `BalanceScheduler` derives from it and
-#       keeps its own `d02df748bf9efd99022f1a062597dc3cb3808485`-based
-#       balance `schedule()`. When balance is disabled,
+#       keeps its own vLLM `v0.26.0`-based balance `schedule()`. When balance
+#       is disabled,
 #       that method delegates to `KVDeliveryScheduler.schedule()`; when enabled,
 #       it runs only the original balance scheduling logic.
 #    Related PR (if no, explain why):

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -45,6 +45,9 @@ if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXP
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
+# Must follow the Scheduler class swap so AsyncScheduler inherits it.
+import vllm_ascend.patch.platform.patch_async_scheduler  # noqa
+
 import vllm_ascend.patch.platform.patch_kv_cache_coordinator  # noqa
 import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -43,6 +43,8 @@ import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
 if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
 
+# Install the base KV-delivery scheduler before balance derives from it.
+import vllm_ascend.patch.platform.patch_kv_delivery_preemption  # noqa
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 
 # Must follow the Scheduler class swap so AsyncScheduler inherits it.

--- a/vllm_ascend/patch/platform/patch_async_scheduler.py
+++ b/vllm_ascend/patch/platform/patch_async_scheduler.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Backport vLLM #48245's AsyncScheduler stale-output handling."""
+
+from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+from vllm.v1.request import Request, RequestStatus
+
+
+def _update_request_with_output(
+    self: AsyncScheduler,
+    request: Request,
+    new_token_ids: list[int],
+    is_stale: bool = False,
+) -> tuple[list[int], bool]:
+    status_before_update = request.status
+    new_token_ids, stopped = super(AsyncScheduler, self)._update_request_with_output(request, new_token_ids)
+
+    # Placeholders were zeroed at preemption; a stale delivery must not
+    # decrement them (it would underflow).
+    if not is_stale:
+        request.num_output_placeholders -= len(new_token_ids)
+        assert request.num_output_placeholders >= 0
+
+    # Cache the new tokens. Preempted requests should be skipped.
+    if status_before_update == RequestStatus.RUNNING:
+        self.kv_cache_manager.cache_blocks(
+            request,
+            request.num_computed_tokens - request.num_output_placeholders,
+        )
+    return new_token_ids, stopped
+
+
+AsyncScheduler._update_request_with_output = _update_request_with_output

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -10,11 +10,10 @@ rank reaches that decision independently from the same gathered snapshot --
 there is no leader. See ``docs/.../balance_schedule_refactor.md`` for the
 design.
 
-The ``schedule()`` body is a verbatim copy of vLLM commit
-``d02df748bf9efd99022f1a062597dc3cb3808485``, plus exactly two balance
-deltas: (1) the disabled path delegates to the independent KV-delivery
-scheduler, and (2) the ``balance_queue`` admission gate inside the WAITING
-loop. It deliberately contains none of the Mooncake/producer lookup or
+The ``schedule()`` body is a verbatim copy of the vLLM ``v0.26.0`` tag, plus
+exactly two balance deltas: (1) the disabled path delegates to the independent
+KV-delivery scheduler, and (2) the ``balance_queue`` admission gate inside the
+WAITING loop. It deliberately contains none of the Mooncake/producer lookup or
 reliable-delivery preemption changes; those live in
 ``patch_kv_delivery_preemption.py`` and are selected by the disabled path.
 
@@ -63,6 +62,7 @@ import vllm.v1.engine.core as _engine_core_mod
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
 from vllm.logger import logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
@@ -454,27 +454,50 @@ class BalanceScheduler(KVDeliveryScheduler):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
-                did_prefix_cache_lookup = False
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
-                    did_prefix_cache_lookup = True
-                    hit_diverged = False
                     # Get locally-cached tokens.
-                    if self.connector is not None:
-                        # A KV connector transfers the missing suffix, which needs a
-                        # hybrid-aware lookup that can diverge across groups.
-                        (
-                            new_computed_blocks,
-                            num_new_local_computed_tokens,
-                            request.shared_prefix_boundary,
-                            hit_diverged,
-                        ) = self.kv_cache_manager.get_computed_blocks_for_connector(request)
+                    if (
+                        self.connector is not None
+                        and self.has_mamba_layers
+                        and isinstance(
+                            self.kv_cache_manager.coordinator,
+                            HybridKVCacheCoordinator,
+                        )
+                    ):
+                        computed, per_group_hits = self.kv_cache_manager.coordinator.find_longest_cache_hit_per_group(
+                            request.block_hashes, request.num_tokens - 1
+                        )
+                        new_computed_blocks = self.kv_cache_manager.create_kv_cache_blocks(computed)
+                        # NOTE(ZhanqiuHu): For Mamba hybrid models,
+                        # num_new_local_computed_tokens should be the FA hit
+                        # length. This value is passed to the connector's
+                        # get_num_new_matched_tokens which computes:
+                        # external = total - local_computed.
+                        # Using the FA hit skips re-transferring FA blocks
+                        # already cached on D-side. The Mamba state (always
+                        # the last block) is transferred unconditionally by
+                        # _apply_prefix_caching in nixl/worker.py.
+                        num_new_local_computed_tokens = max(per_group_hits)
+                        # The per-group lookup does not detect an uncached shared
+                        # prefix, so there is no junction to pin in this path.
+                        request.shared_prefix_boundary = 0
+                        if self.kv_cache_manager.log_stats:
+                            assert self.kv_cache_manager.prefix_cache_stats is not None
+                            self.kv_cache_manager.prefix_cache_stats.record(
+                                num_tokens=request.num_tokens,
+                                num_hits=num_new_local_computed_tokens,
+                                preempted=request.num_preemptions > 0,
+                            )
                     else:
                         (
                             new_computed_blocks,
                             num_new_local_computed_tokens,
-                            # Marconi shared-prefix junction to pin; 0 if none.
+                            # Junction to pin (Marconi-style APC) so its
+                            # sparse-retention state (Mamba block / sliding-window
+                            # tail) survives retention and serves a later hit; 0
+                            # if no uncached shared prefix was detected.
                             request.shared_prefix_boundary,
                         ) = self.kv_cache_manager.get_computed_blocks(request)
 
@@ -494,16 +517,6 @@ class BalanceScheduler(KVDeliveryScheduler):
 
                         num_external_computed_tokens = ext_tokens
 
-                        if hit_diverged and num_external_computed_tokens == 0:
-                            # No external tokens back the deeper local hit, so its
-                            # resume boundary would have no valid Mamba state.
-                            # Reconcile to the boundary every group agrees on.
-                            (
-                                new_computed_blocks,
-                                num_new_local_computed_tokens,
-                                request.shared_prefix_boundary,
-                            ) = self.kv_cache_manager.get_computed_blocks(request)
-
                         connector_prefix_cache_queries = request.num_tokens - num_new_local_computed_tokens
                         connector_prefix_cache_hits = num_external_computed_tokens
 
@@ -522,7 +535,7 @@ class BalanceScheduler(KVDeliveryScheduler):
                         continue
 
                     # Track first scheduled prefill, not post-preemption repeat prefills
-                    if request.prefill_stats and request.num_preemptions <= 0:
+                    if request.prefill_stats is not None and request.num_preemptions <= 0:
                         assert num_computed_tokens <= request.num_prompt_tokens
                         request.prefill_stats.set(
                             num_prompt_tokens=request.num_prompt_tokens,
@@ -672,10 +685,6 @@ class BalanceScheduler(KVDeliveryScheduler):
                             num_hits=connector_prefix_cache_hits,
                             preempted=request.num_preemptions > 0,
                         )
-
-                # Record at admission so unscheduled lookups are not counted.
-                if did_prefix_cache_lookup:
-                    self.kv_cache_manager.record_prefix_cache_stats(request, num_new_local_computed_tokens)
 
                 request = request_queue.pop_request()
                 if load_kv_async:
@@ -845,7 +854,6 @@ class BalanceScheduler(KVDeliveryScheduler):
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             kv_cache_block_copies=pending_kv_cache_block_copies,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
-            ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -11,12 +11,14 @@ there is no leader. See ``docs/.../balance_schedule_refactor.md`` for the
 design.
 
 The ``schedule()`` body is a verbatim copy of the **v0.24.0** release tag's
-``Scheduler.schedule()`` (the production pin), plus exactly three balance
+``Scheduler.schedule()`` (the production pin), plus the balance and KV-delivery
 deltas: (1) the disabled-path early return that delegates to ``super()``,
 (2) the ``balance_flag`` break inside the WAITING loop
 (``any-rank-at-cap => global freeze``), and (3) ``if request_queue is None:
 break`` in place of upstream's ``assert request_queue is not None`` (so a
-drained-rank schedule does not assert when balance defers admission). Both
+drained-rank schedule does not assert when balance defers admission), (4) the
+producer partial-group lookup gate, and (5) the vLLM #48245/#50297 output
+stale-output admission gate and reliable-delivery preemption flag. Both
 supported vLLM refs expose ``schedule(throttle_prefills=False)``, so the
 disabled fast path forwards that argument directly.
 
@@ -57,12 +59,21 @@ touch configs that don't use it, e.g. PD-disaggregated recompute).
 """
 
 import time
+from collections import defaultdict
 
 import torch
 import torch.distributed as dist
 import vllm.v1.core.sched.scheduler as _sched_mod
 import vllm.v1.engine.core as _engine_core_mod
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
+from vllm.distributed.kv_events import KVEventBatch
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import MultiConnector
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import OffloadingConnector
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    SimpleCPUOffloadConnector,
+)
 from vllm.logger import logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
@@ -71,14 +82,32 @@ from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
 from vllm.v1.core.sched.scheduler import Scheduler
-from vllm.v1.engine import EngineCoreEventType
+from vllm.v1.core.sched.utils import check_stop, remove_all
+from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
 from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.metrics.perf import PerfStats
+from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.spec_decode.metrics import SpecDecodingStats
+from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
 from vllm_ascend.ascend_config import init_ascend_config
+
+
+def _requires_kv_delivery(connector: KVConnectorBase_V1) -> bool:
+    """Match the producer-role default introduced by vLLM #50297."""
+    return connector._kv_transfer_config.is_kv_producer
+
+
+def _multi_requires_kv_delivery(connector: MultiConnector) -> bool:
+    """A MultiConnector must preserve every reliable child hand-off."""
+    return any(child.requires_kv_delivery for child in connector._connectors)
+
+
+def _best_effort_cache_requires_kv_delivery(_: KVConnectorBase_V1) -> bool:
+    return False
 
 
 def _balance_scheduling_enabled(vllm_config) -> bool:
@@ -127,6 +156,7 @@ class BalanceScheduler(Scheduler):
         self._use_consumer_partial_group_hits = not bool(
             kv_transfer_config is not None and kv_transfer_config.is_kv_producer
         )
+        self.requires_kv_delivery = bool(self.connector is not None and self.connector.requires_kv_delivery)
         short_request_first_config = init_ascend_config(vllm_config).scheduler_config.short_request_first_config
         if short_request_first_config.enabled:
             from vllm_ascend.core.short_request_first_scheduler import install_short_request_first_waiting_queue
@@ -345,7 +375,11 @@ class BalanceScheduler(Scheduler):
                     else:
                         preempted_req = self.running.pop()
 
-                    self._preempt_request(preempted_req, scheduled_timestamp)
+                    self._preempt_request(
+                        preempted_req,
+                        scheduled_timestamp,
+                        drop_stale_output=self.requires_kv_delivery,
+                    )
                     preempted_reqs.append(preempted_req)
                     if preempted_req == request:
                         # No more request to preempt. Cannot schedule this request.
@@ -433,6 +467,14 @@ class BalanceScheduler(Scheduler):
                             "%s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                if request.num_stale_output_tokens > 0 and not request.drop_stale_output:
+                    # Deliverable stale output still in flight: resuming now
+                    # could resample a position that output later delivers.
+                    # It drains within the pipeline depth.
                     request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
@@ -847,6 +889,454 @@ class BalanceScheduler(Scheduler):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
 
+    def _preempt_request(
+        self,
+        request: Request,
+        timestamp: float,
+        drop_stale_output: bool = False,
+    ) -> None:
+        """Preempt a request and put it back to the waiting queue.
+
+        NOTE: The request should be popped from the running queue outside of this
+        method.
+
+        drop_stale_output: drop (rather than deliver) any in-flight output; used
+        by reset_prefix_cache, whose same-step resume would otherwise deliver
+        tokens out of order, and for connectors with a pending KV hand-off,
+        which the preemption's block free would leave without valid KV.
+        """
+        assert request.status == RequestStatus.RUNNING, "Only running requests can be preempted"
+        self._free_request_blocks(request)
+        self.encoder_cache_manager.free(request)
+        self._inflight_prefills.discard(request)
+        request.status = RequestStatus.PREEMPTED
+        request.num_computed_tokens = 0
+        if request.spec_token_ids:
+            request.spec_token_ids = []
+        # Async scheduling: mark all in-flight output as stale. Its tokens are
+        # still delivered on return (dropping them would perturb spec-decode
+        # acceptance) but must not mutate the reset counters; each step drains
+        # its share in update_from_output. num_in_flight_tokens already
+        # includes any undrained stale share, so assign rather than accumulate.
+        # An undrained drop-mode share stays dropped: its positions have
+        # already been resampled.
+        request.drop_stale_output = drop_stale_output or (
+            request.drop_stale_output and request.num_stale_output_tokens > 0
+        )
+        request.num_stale_output_tokens = request.num_in_flight_tokens
+        request.num_output_placeholders = 0
+        request.num_preemptions += 1
+        if self.log_stats:
+            request.record_event(EngineCoreEventType.PREEMPTED, timestamp)
+
+        # Put the request back to the waiting queue.
+        self.waiting.prepend_request(request)
+        self.reset_preempted_req_ids.add(request.request_id)
+
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        sampled_token_ids = model_runner_output.sampled_token_ids
+        logprobs = model_runner_output.logprobs
+        prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        pooler_outputs = model_runner_output.pooler_output
+        num_nans_in_logits = model_runner_output.num_nans_in_logits
+        kv_connector_output = model_runner_output.kv_connector_output
+        cudagraph_stats = model_runner_output.cudagraph_stats
+
+        # Every GPU write enqueued by this and earlier steps has completed, so it is
+        # safe to return deferred-free blocks to the pool.
+        if self.defer_block_free and scheduler_output.total_num_scheduled_tokens > 0:
+            self.processed_step_seq += 1
+            self._drain_deferred_frees()
+
+        perf_stats: PerfStats | None = None
+        if self.perf_metrics and self.perf_metrics.is_enabled():
+            perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
+
+        outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        spec_decoding_stats: SpecDecodingStats | None = None
+
+        failed_kv_load_req_ids = None
+        if kv_connector_output and kv_connector_output.invalid_block_ids:
+            # These blocks contain externally computed tokens that failed to
+            # load. Identify affected requests and adjust their computed token
+            # count to trigger recomputation of the invalid blocks.
+            failed_kv_load_req_ids = self._handle_invalid_blocks(
+                kv_connector_output.invalid_block_ids,
+                num_scheduled_tokens,
+            )
+
+        # Persist per-step routed experts into the scheduler-side slot
+        # buffer (CPU->CPU fancy-index assign; ~few MB per step).
+        # MUST precede the per-request routing reads below: stopped
+        # requests may terminate on tokens generated in this very step,
+        # whose routing was just D2H'd into model_runner_output.
+        routing_data = None
+        routing_offsets: dict[str, int] = {}
+        if model_runner_output.routed_experts is not None:
+            re = model_runner_output.routed_experts
+            self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
+            routing_data = re.routing_data.astype(
+                self.routed_experts_mgr.routed_experts_by_slot.dtype,
+                copy=False,
+            )
+            # Build offset map using model runner's request order
+            # (input_batch ordering), NOT scheduler dict order.
+            offset = 0
+            for rid in model_runner_output.req_ids:
+                routing_offsets[rid] = offset
+                offset += num_scheduled_tokens[rid]
+
+        # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
+        # the below loop can be a performance bottleneck. We should do our best
+        # to avoid expensive operations inside the loop.
+        stopped_running_reqs: set[Request] = set()
+        stopped_preempted_reqs: set[Request] = set()
+        for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
+            assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            output_is_stale = False
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
+                # Drain any stale share (see _preempt_request) in lockstep.
+                if request.num_stale_output_tokens > 0:
+                    output_is_stale = True
+                    request.num_stale_output_tokens -= num_tokens_scheduled
+                    assert request.num_stale_output_tokens >= 0
+            if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
+                # skip failed or rescheduled requests from KV load failure
+                continue
+            if request is None or request.is_finished():
+                # The request is already finished. This can happen if the
+                # request is aborted while the model is executing it (e.g.,
+                # in pipeline parallelism or in async scheduling).
+                # NOTE(Kuntai): When delay_free_blocks=True (for async KV
+                # cache transfer in KV connector), the aborted request will not
+                # be set to None (in order to finish async KV transfer).
+                # In this case, we use is_finished() to check.
+                continue
+
+            # Drop-mode stale output (same-step resume) is discarded entirely.
+            if output_is_stale and request.drop_stale_output:
+                continue
+
+            req_index = model_runner_output.req_id_to_index[req_id]
+            generated_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
+
+            scheduled_spec_token_ids = scheduler_output.scheduled_spec_decode_tokens.get(req_id)
+            if scheduled_spec_token_ids and (generated_token_ids or self.num_sampled_tokens_per_step == 0):
+                num_draft_tokens = len(scheduled_spec_token_ids)
+                num_sampled = self.num_sampled_tokens_per_step
+                num_accepted = max(len(generated_token_ids) - num_sampled, 0)
+                num_rejected = num_draft_tokens - num_accepted
+                # Rejections roll back num_computed_tokens (and, under async
+                # scheduling, num_output_placeholders, which covers the spec
+                # tokens). A stale rejection count predates the preemption
+                # rollback and must not apply.
+                if not output_is_stale:
+                    if request.num_computed_tokens > 0:
+                        request.num_computed_tokens -= num_rejected
+                    if request.num_output_placeholders > 0:
+                        request.num_output_placeholders -= num_rejected
+                spec_decoding_stats = self.make_spec_decoding_stats(
+                    spec_decoding_stats,
+                    num_draft_tokens=num_draft_tokens,
+                    num_accepted_tokens=num_accepted,
+                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
+                    request_id=req_id,
+                )
+
+            # Free encoder inputs only after the step has actually executed.
+            if request.has_encoder_inputs:
+                self._free_encoder_inputs(request)
+
+            stopped = False
+            new_logprobs = None
+            new_token_ids = generated_token_ids
+            pooler_output = pooler_outputs[req_index] if pooler_outputs else None
+            kv_transfer_params = None
+            ec_transfer_params = None
+            prefill_stats = None
+            status_before_stop = request.status
+            num_output_tokens_before = len(request._output_token_ids)
+
+            # Check for stop and update request status.
+            if new_token_ids:
+                new_token_ids, stopped = self._update_request_with_output(
+                    request, new_token_ids, is_stale=output_is_stale
+                )
+            elif request.pooling_params and pooler_output is not None:
+                # Pooling stops as soon as there is output.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+
+            if new_token_ids and self.structured_output_manager.should_advance(request):
+                struct_output_request = request.structured_output_request
+                assert struct_output_request is not None
+                grammar = struct_output_request.grammar
+                assert isinstance(grammar, StructuredOutputGrammar)
+                # new_token_ids can be a mixed block of reasoning content, then
+                # the reasoning end marker, then the start of the grammar content.
+                # Trim the reasoning content so the grammar only sees grammar content.
+                advance_token_ids = self.structured_output_manager.trim_reasoning_for_advance(request, new_token_ids)
+                if advance_token_ids and not grammar.accept_tokens(req_id, advance_token_ids):
+                    logger.error(
+                        "Unexpected: grammar rejected tokens %s for request %s. Terminating request.",
+                        advance_token_ids,
+                        req_id,
+                    )
+                    request.status = RequestStatus.FINISHED_ERROR
+                    request.resumable = False
+                    stopped = True
+
+            routed_experts = None
+            if self.enable_return_routed_experts and routing_data is not None and new_token_ids:
+                req_offset = routing_offsets[req_id]
+                end = req_offset + num_tokens_scheduled
+                block_ids = self._re_block_ids.pop(req_id, [])
+                if num_output_tokens_before == 0:
+                    # Prefill completed: read full prompt routing from
+                    # slot buffer using the block-ID snapshot taken at
+                    # schedule time (immune to async preemption).
+                    if (
+                        request.sampling_params is not None
+                        and request.sampling_params.routed_experts_prompt_start is not None
+                    ):
+                        prompt_start = request.sampling_params.routed_experts_prompt_start
+                        assert prompt_start < request.num_prompt_tokens
+                    else:
+                        prompt_start = 0
+                    routed_experts = self.routed_experts_mgr.get(
+                        block_ids,
+                        request.num_prompt_tokens,
+                        token_start=prompt_start,
+                    )
+                else:
+                    if scheduled_spec_token_ids:
+                        # Spec decode: accepted tokens at the START of
+                        # the scheduled range, rejected at the end.
+                        routed_experts = routing_data[req_offset : req_offset + len(new_token_ids)]
+                    else:
+                        # Normal decode / re-prefill: token(s) at the END.
+                        routed_experts = routing_data[end - len(new_token_ids) : end]
+
+            should_emit_output = bool(new_token_ids or pooler_output is not None or stopped)
+            if should_emit_output:
+                prefill_stats = request.take_prefill_stats()
+                if prefill_stats is not None:
+                    prefill_stats.finalize(self.kv_cache_manager.estimate_cached_tokens(request))
+
+            finish_reason = None
+            if stopped:
+                # Capture finish_reason BEFORE _handle_stopped_request, which may
+                # reset the status to WAITING for streaming requests that continue.
+                finish_reason = request.get_finished_reason()
+                finished = self._handle_stopped_request(request)
+                if finished:
+                    kv_transfer_params, ec_transfer_params = self._free_request(request)
+
+                if status_before_stop == RequestStatus.RUNNING:
+                    stopped_running_reqs.add(request)
+                else:
+                    stopped_preempted_reqs.add(request)
+
+            # Extract sample logprobs if needed.
+            if request.sampling_params is not None and request.sampling_params.num_logprobs is not None and logprobs:
+                new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
+
+            if num_nans_in_logits is not None and req_id in num_nans_in_logits:
+                request.num_nans_in_logits = num_nans_in_logits[req_id]
+
+            # Get prompt logprobs for this request.
+            prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+            if should_emit_output:
+                # Add EngineCoreOutput for this Request.
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=new_token_ids,
+                        finish_reason=finish_reason,
+                        new_logprobs=new_logprobs,
+                        new_prompt_logprobs_tensors=prompt_logprobs_tensors,
+                        pooling_output=pooler_output,
+                        stop_reason=request.stop_reason,
+                        events=request.take_events(),
+                        prefill_stats=prefill_stats,
+                        kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
+                        trace_headers=request.trace_headers,
+                        routed_experts=routed_experts,
+                        num_nans_in_logits=request.num_nans_in_logits,
+                    )
+                )
+            else:
+                # Invariant: EngineCore returns no partial prefill outputs.
+                assert not prompt_logprobs_tensors
+
+        # Remove the stopped requests from the running and waiting queues.
+        if stopped_running_reqs:
+            self.running = remove_all(self.running, stopped_running_reqs)
+        if stopped_preempted_reqs:
+            # This is a rare case and unlikely to impact performance.
+            self.waiting.remove_requests(stopped_preempted_reqs)
+            self.skipped_waiting.remove_requests(stopped_preempted_reqs)
+
+        error_req_ids = set(self.grammar_compile_error_reqs)
+        self.grammar_compile_error_reqs.clear()
+        if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
+            error_req_ids.update(failed_kv_load_req_ids)
+
+        if error_req_ids:
+            error_reqs = self.finish_requests(error_req_ids, RequestStatus.FINISHED_ERROR)
+            for request in error_reqs:
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=request.request_id,
+                        new_token_ids=[],
+                        finish_reason=request.get_finished_reason(),
+                        events=request.take_events(),
+                        trace_headers=request.trace_headers,
+                    )
+                )
+
+        # KV Connector: update state for finished KV Transfers.
+        if kv_connector_output:
+            self._update_from_kv_xfer_finished(kv_connector_output)
+
+        # Worker-side KV connector stats from the model runner output.
+        kv_connector_stats: KVConnectorStats | None = (
+            kv_connector_output.kv_connector_stats if kv_connector_output else None
+        )
+        if self.connector:
+            # Scheduler-side KV connector stats collected after connector update.
+            scheduler_kv_connector_stats = self.connector.get_kv_connector_stats()
+            if scheduler_kv_connector_stats is not None and not scheduler_kv_connector_stats.is_empty():
+                kv_connector_stats = (
+                    kv_connector_stats.aggregate(scheduler_kv_connector_stats)
+                    if kv_connector_stats is not None
+                    else scheduler_kv_connector_stats
+                )
+
+        # collect KV cache events from KV cache manager
+        events = self.kv_cache_manager.take_events()
+
+        # collect KV cache events from connector
+        if self.connector is not None:
+            connector_events = self.connector.take_events()
+            if connector_events:
+                if events is None:
+                    events = list(connector_events)
+                else:
+                    events.extend(connector_events)
+
+        # publish collected KV cache events
+        if events:
+            batch = KVEventBatch(ts=time.time(), events=events)
+            self.kv_event_publisher.publish(batch)
+
+        # Create EngineCoreOutputs for all clients that have requests with
+        # outputs in this step.
+        engine_core_outputs = {client_index: EngineCoreOutputs(outputs=outs) for client_index, outs in outputs.items()}
+
+        finished_req_ids = self.finished_req_ids_dict
+        if finished_req_ids:
+            # Include ids of requests that finished since last outputs
+            # were sent.
+            for client_index, finished_set in finished_req_ids.items():
+                # Set finished request set in EngineCoreOutputs for this client.
+                if (eco := engine_core_outputs.get(client_index)) is not None:
+                    eco.finished_requests = finished_set
+                else:
+                    engine_core_outputs[client_index] = EngineCoreOutputs(finished_requests=finished_set)
+            finished_req_ids.clear()
+
+        if (
+            stats := self.make_stats(
+                spec_decoding_stats,
+                kv_connector_stats,
+                cudagraph_stats,
+                perf_stats,
+            )
+        ) is not None:
+            # Return stats to only one of the front-ends.
+            if (eco := next(iter(engine_core_outputs.values()), None)) is None:
+                # We must return the stats even if there are no request
+                # outputs this step.
+                engine_core_outputs[0] = eco = EngineCoreOutputs()
+            eco.scheduler_stats = stats
+
+        return engine_core_outputs
+
+    def _update_request_with_output(
+        self,
+        request: Request,
+        new_token_ids: list[int],
+        is_stale: bool = False,
+    ) -> tuple[list[int], bool]:
+        # is_stale is only used by the AsyncScheduler override.
+        # Append generated tokens and check for stop. Note that if
+        # a request is still being prefilled, we expect the model runner
+        # to return empty token ids for the request.
+        stopped = False
+        for num_new, output_token_id in enumerate(new_token_ids, 1):
+            request.append_output_token_ids(output_token_id)
+
+            # Check for stop and update request state.
+            # This must be called before we make the EngineCoreOutput.
+            stopped = check_stop(request, self.max_model_len)
+            if stopped:
+                del new_token_ids[num_new:]  # Trim new tokens if needed.
+                break
+        return new_token_ids, stopped
+
+    def reset_prefix_cache(self, reset_running_requests: bool = False, reset_connector: bool = False) -> bool:
+        """Reset the KV prefix cache.
+
+        If reset_running_requests is True, all the running requests will be
+        preempted and moved to the waiting queue.
+        Otherwise, this method will only reset the KV prefix cache when there
+        is no running requests taking KV cache.
+        """
+        if reset_running_requests:
+            # For logging.
+            timestamp = time.monotonic()
+            # Invalidate all the current running requests KV's by pushing them to
+            # the waiting queue. In this case, we can reduce the ref count of all
+            # the kv blocks to 0 and thus we can make sure the reset is successful.
+            # Preempt in reverse order so the requests will be added back to the
+            # running queue in FIFO order.
+            while self.running:
+                request = self.running.pop()
+                self._preempt_request(
+                    request,
+                    timestamp,
+                    drop_stale_output=True,
+                )
+
+            # Clear scheduled request ids cache. Since we are forcing preemption
+            # + resumption in the same step, we must act as if these requests were
+            # not scheduled in the prior step. They will be flushed from the
+            # persistent batch in the model runner.
+            self.prev_step_scheduled_req_ids.clear()
+
+        reset_successful = self.kv_cache_manager.reset_prefix_cache()
+        if reset_running_requests and not reset_successful:
+            raise RuntimeError(
+                "Failed to reset KV cache even when all the running requests are "
+                "preempted and moved to the waiting queue. This is likely due to "
+                "the presence of running requests waiting for remote KV transfer, "
+                "which is not supported yet."
+            )
+
+        if reset_connector:
+            reset_successful = self.reset_connector_cache() and reset_successful
+
+        return reset_successful
+
 
 class BalanceDPEngineCoreProc(DPEngineCoreProc):
     """Minimal DP engine core hook for balance scheduling.
@@ -897,12 +1387,33 @@ class BalanceDPEngineCoreProc(DPEngineCoreProc):
         return result
 
 
+# Backport the connector contract from vLLM #50297. Ascend-specific
+# connectors override this property on their classes where needed.
+KVConnectorBase_V1.requires_kv_delivery = property(_requires_kv_delivery)
+MultiConnector.requires_kv_delivery = property(_multi_requires_kv_delivery)
+OffloadingConnector.requires_kv_delivery = property(_best_effort_cache_requires_kv_delivery)
+SimpleCPUOffloadConnector.requires_kv_delivery = property(_best_effort_cache_requires_kv_delivery)
+
+# Backport the request state introduced by vLLM #48245 without replacing
+# Request.__init__. Preempted requests get instance values in _preempt_request;
+# all other requests read these neutral class defaults.
+Request.num_stale_output_tokens = 0
+Request.drop_stale_output = False
+
+
 # The scheduler is constructed as ``Scheduler(...)`` from
 # ``vllm.v1.core.sched.scheduler``. This takes effect when scheduler_cls is
 # unset, covering ordinary synchronous, PD-prefill, and PD-mixed paths.
 # vLLM-Ascend's recompute, dynamic-batch, and profiling schedulers set
 # scheduler_cls and correctly bypass this name.
 _sched_mod.Scheduler = BalanceScheduler
+
+# patch_pp_mtp wrapped the upstream Scheduler before this class swap. Reapply
+# its idempotent wrapper to the replacement update_from_output implementation.
+from vllm_ascend.patch.platform.patch_pp_mtp import _patch_scheduler_update_from_output  # noqa: E402, I001
+
+
+_patch_scheduler_update_from_output()
 
 # Activate BalanceDPEngineCoreProc ONLY when balance scheduling is enabled.
 # Upstream ``run_engine_core`` resolves ``DPEngineCoreProc`` via the

--- a/vllm_ascend/patch/platform/patch_balance_schedule.py
+++ b/vllm_ascend/patch/platform/patch_balance_schedule.py
@@ -120,6 +120,10 @@ class BalanceScheduler(KVDeliveryScheduler):
             include_finished_set,
             log_stats,
         )
+        kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
+        self._use_consumer_partial_group_hits = not bool(
+            kv_transfer_config is not None and kv_transfer_config.is_kv_producer
+        )
         short_request_first_config = init_ascend_config(vllm_config).scheduler_config.short_request_first_config
         if short_request_first_config.enabled:
             from vllm_ascend.core.short_request_first_scheduler import install_short_request_first_waiting_queue

--- a/vllm_ascend/patch/platform/patch_kv_delivery_preemption.py
+++ b/vllm_ascend/patch/platform/patch_kv_delivery_preemption.py
@@ -1,104 +1,61 @@
 # mypy: ignore-errors
-"""Balance scheduling patch.
+"""Backport lossless stale-output and reliable KV-delivery scheduling.
 
-Keeps running-request counts even across DP ranks: every step an all-gather
-of each rank's ``len(running)`` runs once via ``BalanceScheduler.balance_gather``
-(invoked from the engine core, NOT from inside ``schedule()``); if any rank
-was at the running cap at the end of the previous step, every rank stops
-admitting new WAITING requests (``any-rank-at-cap => global freeze``). Each
-rank reaches that decision independently from the same gathered snapshot --
-there is no leader. See ``docs/.../balance_schedule_refactor.md`` for the
-design.
-
-The ``schedule()`` body is a verbatim copy of vLLM commit
-``d02df748bf9efd99022f1a062597dc3cb3808485``, plus exactly two balance
-deltas: (1) the disabled path delegates to the independent KV-delivery
-scheduler, and (2) the ``balance_queue`` admission gate inside the WAITING
-loop. It deliberately contains none of the Mooncake/producer lookup or
-reliable-delivery preemption changes; those live in
-``patch_kv_delivery_preemption.py`` and are selected by the disabled path.
-
-The engine-core side is NOT copied: ``BalanceDPEngineCoreProc`` hooks
-``_has_global_unfinished_reqs`` (called every iteration by upstream's
-``run_busy_loop`` on every non-idle path) to inject the DP group and run
-``balance_gather`` once per step. The gather lives in the engine core, NOT
-inside ``schedule()``: a rank that has drained its local requests never enters
-``schedule()`` (it runs a dummy batch instead), so an ``all_gather`` in
-``schedule()`` would be skipped by that rank while busy ranks call it -- a
-collective mismatch that deadlocks.
-
-The gather is hooked IMMEDIATELY AFTER ``super()._has_global_unfinished_reqs()``
-(not inside ``_process_engine_step``). ``_has_global_unfinished_reqs`` is
-itself a cross-rank collective (an all-reduce every 32 steps internally) and is
-the only point in the busy loop that re-synchronizes ranks on wave/idle state.
-Hooking gather right after it keeps the every-step all-gather in the same
-lock-stepped region, so ranks enter the gather having just agreed on
-``engines_running``. Hooking it earlier -- inside ``_process_engine_step``,
-before that sync and before the idle ``continue`` gate -- decouples the gather
-from the synchronization: at wave boundaries one rank can reach the gather
-while another is still blocked in ``_process_input_queue`` or
-``future.result()``, deadlocking the all-gather. The stuck EngineCore then
-can't drain its worker shm channel, the worker's ``sample_tokens`` response
-has nowhere to land, and after 60s the engine dies with
-``RPC call to sample_tokens timed out``. ``_has_global_unfinished_reqs`` is
-only called on iterations that did NOT take the idle ``continue``, so gather
-is skipped consistently by every rank when all are idle -- no rank does an
-extra gather.
-
-The engine core class is swapped via the module-level ``DPEngineCoreProc``
-reference. This works ONLY because upstream's ``run_engine_core`` resolves
-that name at call time rather than binding it at import -- if upstream ever
-switches to an import-time binding the swap silently stops taking effect, so
-the call-time lookup is a load-bearing assumption. The swap is done ONLY when
-balance scheduling is enabled (conditional activation, so balance does not
-touch configs that don't use it, e.g. PD-disaggregated recompute).
+This module owns the vLLM #48245/#50297 scheduler changes independently of
+Ascend balance scheduling. ``KVDeliveryScheduler.schedule`` is copied from
+vLLM commit ``d02df748bf9efd99022f1a062597dc3cb3808485`` and carries only
+the two scheduler deltas from those PRs: stale-output admission and
+reliable-delivery pressure preemption. Balance admission is intentionally not
+handled here. The request/connector contracts and every scheduler method
+changed by those PRs live here as well.
 """
 
 import time
+from collections import defaultdict
 
-import torch
-import torch.distributed as dist
 import vllm.v1.core.sched.scheduler as _sched_mod
-import vllm.v1.engine.core as _engine_core_mod
 from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorMetadata
+from vllm.distributed.kv_events import KVEventBatch
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import MultiConnector
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import OffloadingConnector
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    SimpleCPUOffloadConnector,
+)
 from vllm.logger import logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
 from vllm.v1.core.sched.request_queue import SchedulingPolicy, create_request_queue
-from vllm.v1.engine import EngineCoreEventType
-from vllm.v1.engine.core import DPEngineCoreProc, EngineCoreProc
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.sched.utils import check_stop, remove_all
+from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutputs
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.metrics.perf import PerfStats
+from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
-from vllm.v1.structured_output import StructuredOutputManager
+from vllm.v1.spec_decode.metrics import SpecDecodingStats
+from vllm.v1.structured_output import StructuredOutputGrammar, StructuredOutputManager
 from vllm.v1.utils import record_function_or_nullcontext
 
-from vllm_ascend.ascend_config import init_ascend_config
-from vllm_ascend.patch.platform.patch_kv_delivery_preemption import KVDeliveryScheduler
+
+def _requires_kv_delivery(connector: KVConnectorBase_V1) -> bool:
+    """Match the producer-role default introduced by vLLM #50297."""
+    return connector._kv_transfer_config.is_kv_producer
 
 
-def _balance_scheduling_enabled(vllm_config) -> bool:
-    # Primary source of truth is AscendConfig. The additional_config fallback
-    # covers the startup window where AscendConfig may not yet be initialized
-    # (see the TODO that used to live here); once AscendConfig init is moved
-    # earlier it can go away.
-    try:
-        from vllm_ascend.ascend_config import get_ascend_config
+def _multi_requires_kv_delivery(connector: MultiConnector) -> bool:
+    """A MultiConnector must preserve every reliable child hand-off."""
+    return any(child.requires_kv_delivery for child in connector._connectors)
 
-        return bool(get_ascend_config().scheduler_config.enable_balance_scheduling)
-    except Exception:
-        pass
-    additional_config = getattr(vllm_config, "additional_config", None) or {}
-    scheduler_config = additional_config.get("scheduler_config")
-    if isinstance(scheduler_config, dict) and "enable_balance_scheduling" in scheduler_config:
-        return bool(scheduler_config["enable_balance_scheduling"])
-    if "enable_balance_scheduling" in additional_config:
-        return bool(additional_config["enable_balance_scheduling"])
+
+def _best_effort_cache_requires_kv_delivery(_: KVConnectorBase_V1) -> bool:
     return False
 
 
-class BalanceScheduler(KVDeliveryScheduler):
+class KVDeliveryScheduler(Scheduler):
     def __init__(
         self,
         vllm_config,
@@ -120,58 +77,9 @@ class BalanceScheduler(KVDeliveryScheduler):
             include_finished_set,
             log_stats,
         )
-        short_request_first_config = init_ascend_config(vllm_config).scheduler_config.short_request_first_config
-        if short_request_first_config.enabled:
-            from vllm_ascend.core.short_request_first_scheduler import install_short_request_first_waiting_queue
-
-            install_short_request_first_waiting_queue(
-                self,
-                threshold=short_request_first_config.threshold,
-                long_max_wait_ms=short_request_first_config.long_max_wait_ms,
-            )
-        self._balance_enabled = _balance_scheduling_enabled(vllm_config)
-        # Injected by BalanceDPEngineCoreProc._has_global_unfinished_reqs
-        # before the first gather. Only used on the enabled path (balance
-        # requires DP > 1).
-        self.dp_group = None
-        if self._balance_enabled:
-            self.balance_queue = [
-                torch.tensor([0], dtype=torch.int, device="cpu")
-                for _ in range(self.vllm_config.parallel_config.data_parallel_size)
-            ]
-
-    def balance_gather(self):
-        """All-gather per-rank running counts into ``self.balance_queue``.
-
-        Called once per busy-loop iteration from
-        ``BalanceDPEngineCoreProc._has_global_unfinished_reqs`` (immediately
-        after the cross-rank all-reduce, which runs after ``schedule()`` +
-        execute + ``update_from_output()``). This MUST be invoked on every
-        rank every non-idle iteration, including dummy-batch iterations where
-        a drained rank never enters ``schedule()`` --
-        ``all_gather`` is a collective, so any rank skipping it deadlocks
-        the busy ranks. Returns early when balance is disabled or the DP
-        group has not been injected yet.
-        """
-        if not self._balance_enabled or self.dp_group is None:
-            return
-        running_tensor = torch.tensor([len(self.running)], dtype=torch.int, device="cpu")
-        dist.all_gather(self.balance_queue, running_tensor, group=self.dp_group)
+        self.requires_kv_delivery = bool(self.connector is not None and self.connector.requires_kv_delivery)
 
     def schedule(self, throttle_prefills: bool = False) -> SchedulerOutput:
-        if not self._balance_enabled:
-            if not self._use_consumer_partial_group_hits and self.has_mamba_layers:
-                # Upstream's per-group lookup is a remote-prefill consumer
-                # optimization that intentionally omits Mamba state. Producer
-                # requests must use the normal all-group lookup instead. The
-                # current upstream schedule reads has_mamba_layers only when
-                # selecting between these two lookup paths.
-                self.has_mamba_layers = False
-                try:
-                    return super().schedule(throttle_prefills)
-                finally:
-                    self.has_mamba_layers = True
-            return super().schedule(throttle_prefills)
         self.current_step += 1
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
@@ -340,7 +248,11 @@ class BalanceScheduler(KVDeliveryScheduler):
                     else:
                         preempted_req = self.running.pop()
 
-                    self._preempt_request(preempted_req, scheduled_timestamp)
+                    self._preempt_request(
+                        preempted_req,
+                        scheduled_timestamp,
+                        drop_stale_output=self.requires_kv_delivery,
+                    )
                     preempted_reqs.append(preempted_req)
                     if preempted_req == request:
                         # No more request to preempt. Cannot schedule this request.
@@ -410,9 +322,6 @@ class BalanceScheduler(KVDeliveryScheduler):
                 if num_running >= self.max_num_running_reqs:
                     break
 
-                if max(t.item() for t in self.balance_queue) == self.max_num_running_reqs:
-                    break
-
                 request_queue = self._select_waiting_queue_for_scheduling()
                 assert request_queue is not None
 
@@ -428,6 +337,14 @@ class BalanceScheduler(KVDeliveryScheduler):
                             "%s is still in WAITING_FOR_REMOTE_KVS state.",
                             request_id,
                         )
+                    request_queue.pop_request()
+                    step_skipped_waiting.prepend_request(request)
+                    continue
+
+                if request.num_stale_output_tokens > 0 and not request.drop_stale_output:
+                    # Deliverable stale output still in flight: resuming now
+                    # could resample a position that output later delivers.
+                    # It drains within the pipeline depth.
                     request_queue.pop_request()
                     step_skipped_waiting.prepend_request(request)
                     continue
@@ -866,82 +783,463 @@ class BalanceScheduler(KVDeliveryScheduler):
             self._update_after_schedule(scheduler_output)
         return scheduler_output
 
+    def _preempt_request(self, request: Request, timestamp: float, drop_stale_output: bool = False) -> None:
+        """Preempt a request and put it back to the waiting queue.
 
-class BalanceDPEngineCoreProc(DPEngineCoreProc):
-    """Minimal DP engine core hook for balance scheduling.
+        NOTE: The request should be popped from the running queue outside of this
+        method.
 
-    The only thing balance scheduling needs from the engine core is the DP
-    process group, which the scheduler uses for its per-step all-gather. The
-    group is created in ``_init_data_parallel`` (during ``__init__``, before
-    the scheduler exists) and the scheduler is created in ``EngineCore.__init__``,
-    so both are present by the time the busy loop runs.
+        drop_stale_output: drop (rather than deliver) any in-flight output; used
+        by reset_prefix_cache, whose same-step resume would otherwise deliver
+        tokens out of order, and for connectors with a pending KV hand-off,
+        which the preemption's block free would leave without valid KV.
+        """
+        assert request.status == RequestStatus.RUNNING, "Only running requests can be preempted"
+        self._free_request_blocks(request)
+        self.encoder_cache_manager.free(request)
+        self._inflight_prefills.discard(request)
+        request.status = RequestStatus.PREEMPTED
+        request.num_computed_tokens = 0
+        if request.spec_token_ids:
+            request.spec_token_ids = []
+        # Async scheduling: mark all in-flight output as stale. Its tokens are
+        # still delivered on return (dropping them would perturb spec-decode
+        # acceptance) but must not mutate the reset counters; each step drains
+        # its share in update_from_output. num_in_flight_tokens already
+        # includes any undrained stale share, so assign rather than accumulate.
+        # An undrained drop-mode share stays dropped: its positions have
+        # already been resampled.
+        request.drop_stale_output = drop_stale_output or (
+            request.drop_stale_output and request.num_stale_output_tokens > 0
+        )
+        request.num_stale_output_tokens = request.num_in_flight_tokens
+        request.num_output_placeholders = 0
+        request.num_preemptions += 1
+        if self.log_stats:
+            request.record_event(EngineCoreEventType.PREEMPTED, timestamp)
 
-    The per-step gather is hooked via ``_has_global_unfinished_reqs`` (called
-    every iteration by upstream's ``run_busy_loop`` on every non-idle path),
-    NOT from inside ``schedule()``: a rank that has drained its local requests
-    never enters ``schedule()`` (it runs a dummy batch instead), so an
-    ``all_gather`` living in ``schedule()`` would be skipped by that rank while
-    busy ranks call it -- a collective mismatch that deadlocks.
+        # Put the request back to the waiting queue.
+        self.waiting.prepend_request(request)
+        self.reset_preempted_req_ids.add(request.request_id)
 
-    Why ``_has_global_unfinished_reqs`` and not ``_process_engine_step``:
-    ``_has_global_unfinished_reqs`` is itself a cross-rank collective (an
-    all-reduce every 32 steps internally) and is the only point in the busy
-    loop that re-synchronizes ranks on wave/idle state. Hooking the gather
-    immediately after ``super()._has_global_unfinished_reqs()`` keeps the
-    every-step all-gather in the same lock-stepped region, so ranks enter the
-    gather having just agreed on ``engines_running``. Hooking it earlier --
-    inside ``_process_engine_step``, before that sync and before the idle
-    ``continue`` gate -- decouples the gather from the synchronization: at
-    wave boundaries one rank can reach the gather while another is still
-    blocked in ``_process_input_queue`` or ``future.result()``, deadlocking
-    the all-gather. The stuck EngineCore then can't drain its worker shm
-    channel, the worker's ``sample_tokens`` response has nowhere to land, and
-    after 60s the engine dies with ``RPC call to sample_tokens timed out``.
-    Because ``_has_global_unfinished_reqs`` is only called on iterations that
-    did NOT take the idle ``continue``, gather is skipped consistently by
-    every rank when all are idle -- no rank does an extra gather. This matches
-    the pre-refactor copied ``run_busy_loop``, where gather sat right after
-    the all-reduce (after schedule + execute + update_from_output).
-    """
+    def update_from_output(
+        self,
+        scheduler_output: SchedulerOutput,
+        model_runner_output: ModelRunnerOutput,
+    ) -> dict[int, EngineCoreOutputs]:
+        sampled_token_ids = model_runner_output.sampled_token_ids
+        logprobs = model_runner_output.logprobs
+        prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
+        num_scheduled_tokens = scheduler_output.num_scheduled_tokens
+        pooler_outputs = model_runner_output.pooler_output
+        num_nans_in_logits = model_runner_output.num_nans_in_logits
+        kv_connector_output = model_runner_output.kv_connector_output
+        cudagraph_stats = model_runner_output.cudagraph_stats
 
-    def _has_global_unfinished_reqs(self, local_unfinished: bool) -> bool:
-        result = super()._has_global_unfinished_reqs(local_unfinished)
-        # Inject the DP group (idempotent) and refresh the cross-rank running
-        # snapshot once per non-idle iteration. balance_gather is a no-op when
-        # balance is disabled or dp_group is unset, so this is safe on every
-        # path. MUST run immediately after the sync collective so ranks enter
-        # the all-gather already aligned -- see class docstring.
-        self.scheduler.dp_group = self.dp_group
-        self.scheduler.balance_gather()
-        return result
+        # Every GPU write enqueued by this and earlier steps has completed, so it is
+        # safe to return deferred-free blocks to the pool.
+        if self.defer_block_free and scheduler_output.total_num_scheduled_tokens > 0:
+            self.processed_step_seq += 1
+            self._drain_deferred_frees()
+
+        perf_stats: PerfStats | None = None
+        if self.perf_metrics and self.perf_metrics.is_enabled():
+            perf_stats = self.perf_metrics.get_step_perf_stats_per_gpu(scheduler_output)
+
+        outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
+        spec_decoding_stats: SpecDecodingStats | None = None
+
+        failed_kv_load_req_ids = None
+        if kv_connector_output and kv_connector_output.invalid_block_ids:
+            # These blocks contain externally computed tokens that failed to
+            # load. Identify affected requests and adjust their computed token
+            # count to trigger recomputation of the invalid blocks.
+            failed_kv_load_req_ids = self._handle_invalid_blocks(
+                kv_connector_output.invalid_block_ids,
+                num_scheduled_tokens,
+            )
+
+        # Persist per-step routed experts into the scheduler-side slot
+        # buffer (CPU->CPU fancy-index assign; ~few MB per step).
+        # MUST precede the per-request routing reads below: stopped
+        # requests may terminate on tokens generated in this very step,
+        # whose routing was just D2H'd into model_runner_output.
+        routing_data = None
+        routing_offsets: dict[str, int] = {}
+        if model_runner_output.routed_experts is not None:
+            re = model_runner_output.routed_experts
+            self.routed_experts_mgr.store_batch(re.routing_data, re.slot_mapping)
+            routing_data = re.routing_data.astype(
+                self.routed_experts_mgr.routed_experts_by_slot.dtype,
+                copy=False,
+            )
+            # Build offset map using model runner's request order
+            # (input_batch ordering), NOT scheduler dict order.
+            offset = 0
+            for rid in model_runner_output.req_ids:
+                routing_offsets[rid] = offset
+                offset += num_scheduled_tokens[rid]
+
+        # NOTE(woosuk): As len(num_scheduled_tokens) can be up to 1K or more,
+        # the below loop can be a performance bottleneck. We should do our best
+        # to avoid expensive operations inside the loop.
+        stopped_running_reqs: set[Request] = set()
+        stopped_preempted_reqs: set[Request] = set()
+        for req_id, num_tokens_scheduled in num_scheduled_tokens.items():
+            assert num_tokens_scheduled > 0
+            request = self.requests.get(req_id)
+            output_is_stale = False
+            if request is not None:
+                request.num_in_flight_tokens -= num_tokens_scheduled
+                # Drain any stale share (see _preempt_request) in lockstep.
+                if request.num_stale_output_tokens > 0:
+                    output_is_stale = True
+                    request.num_stale_output_tokens -= num_tokens_scheduled
+                    assert request.num_stale_output_tokens >= 0
+            if failed_kv_load_req_ids and req_id in failed_kv_load_req_ids:
+                # skip failed or rescheduled requests from KV load failure
+                continue
+            if request is None or request.is_finished():
+                # The request is already finished. This can happen if the
+                # request is aborted while the model is executing it (e.g.,
+                # in pipeline parallelism or in async scheduling).
+                # NOTE(Kuntai): When delay_free_blocks=True (for async KV
+                # cache transfer in KV connector), the aborted request will not
+                # be set to None (in order to finish async KV transfer).
+                # In this case, we use is_finished() to check.
+                continue
+
+            # Drop-mode stale output (same-step resume) is discarded entirely.
+            if output_is_stale and request.drop_stale_output:
+                continue
+
+            req_index = model_runner_output.req_id_to_index[req_id]
+            generated_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
+
+            scheduled_spec_token_ids = scheduler_output.scheduled_spec_decode_tokens.get(req_id)
+            if scheduled_spec_token_ids and (generated_token_ids or self.num_sampled_tokens_per_step == 0):
+                num_draft_tokens = len(scheduled_spec_token_ids)
+                num_sampled = self.num_sampled_tokens_per_step
+                num_accepted = max(len(generated_token_ids) - num_sampled, 0)
+                num_rejected = num_draft_tokens - num_accepted
+                # Rejections roll back num_computed_tokens (and, under async
+                # scheduling, num_output_placeholders, which covers the spec
+                # tokens). A stale rejection count predates the preemption
+                # rollback and must not apply.
+                if not output_is_stale:
+                    if request.num_computed_tokens > 0:
+                        request.num_computed_tokens -= num_rejected
+                    if request.num_output_placeholders > 0:
+                        request.num_output_placeholders -= num_rejected
+                spec_decoding_stats = self.make_spec_decoding_stats(
+                    spec_decoding_stats,
+                    num_draft_tokens=num_draft_tokens,
+                    num_accepted_tokens=num_accepted,
+                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
+                    request_id=req_id,
+                )
+
+            # Free encoder inputs only after the step has actually executed.
+            if request.has_encoder_inputs:
+                self._free_encoder_inputs(request)
+
+            stopped = False
+            new_logprobs = None
+            new_token_ids = generated_token_ids
+            pooler_output = pooler_outputs[req_index] if pooler_outputs else None
+            kv_transfer_params = None
+            ec_transfer_params = None
+            prefill_stats = None
+            status_before_stop = request.status
+            num_output_tokens_before = len(request._output_token_ids)
+
+            # Check for stop and update request status.
+            if new_token_ids:
+                new_token_ids, stopped = self._update_request_with_output(
+                    request, new_token_ids, is_stale=output_is_stale
+                )
+            elif request.pooling_params and pooler_output is not None:
+                # Pooling stops as soon as there is output.
+                request.status = RequestStatus.FINISHED_STOPPED
+                stopped = True
+
+            if new_token_ids and self.structured_output_manager.should_advance(request, new_token_ids=new_token_ids):
+                struct_output_request = request.structured_output_request
+                assert struct_output_request is not None
+                grammar = struct_output_request.grammar
+                assert isinstance(grammar, StructuredOutputGrammar)
+                # new_token_ids can be a mixed block of reasoning content, then
+                # the reasoning end marker, then the start of the grammar content.
+                # Trim the reasoning content so the grammar only sees grammar content.
+                advance_token_ids = self.structured_output_manager.trim_reasoning_for_advance(request, new_token_ids)
+                if advance_token_ids and not grammar.accept_tokens(req_id, advance_token_ids):
+                    logger.error(
+                        "Unexpected: grammar rejected tokens %s for request %s. Terminating request.",
+                        advance_token_ids,
+                        req_id,
+                    )
+                    request.status = RequestStatus.FINISHED_ERROR
+                    request.resumable = False
+                    stopped = True
+
+            routed_experts = None
+            if self.enable_return_routed_experts and routing_data is not None and new_token_ids:
+                req_offset = routing_offsets[req_id]
+                end = req_offset + num_tokens_scheduled
+                block_ids = self._re_block_ids.pop(req_id, [])
+                if num_output_tokens_before == 0:
+                    # Prefill completed: read full prompt routing from
+                    # slot buffer using the block-ID snapshot taken at
+                    # schedule time (immune to async preemption).
+                    if (
+                        request.sampling_params is not None
+                        and request.sampling_params.routed_experts_prompt_start is not None
+                    ):
+                        prompt_start = request.sampling_params.routed_experts_prompt_start
+                        assert prompt_start < request.num_prompt_tokens
+                    else:
+                        prompt_start = 0
+                    routed_experts = self.routed_experts_mgr.get(
+                        block_ids,
+                        request.num_prompt_tokens,
+                        token_start=prompt_start,
+                    )
+                else:
+                    if scheduled_spec_token_ids:
+                        # Spec decode: accepted tokens at the START of
+                        # the scheduled range, rejected at the end.
+                        routed_experts = routing_data[req_offset : req_offset + len(new_token_ids)]
+                    else:
+                        # Normal decode / re-prefill: token(s) at the END.
+                        routed_experts = routing_data[end - len(new_token_ids) : end]
+
+            should_emit_output = bool(new_token_ids or pooler_output is not None or stopped)
+            if should_emit_output:
+                prefill_stats = request.take_prefill_stats()
+                if prefill_stats is not None:
+                    prefill_stats.finalize(self.kv_cache_manager.estimate_cached_tokens(request))
+
+            finish_reason = None
+            if stopped:
+                # Capture finish_reason BEFORE _handle_stopped_request, which may
+                # reset the status to WAITING for streaming requests that continue.
+                finish_reason = request.get_finished_reason()
+                finished = self._handle_stopped_request(request)
+                if finished:
+                    kv_transfer_params, ec_transfer_params = self._free_request(request)
+
+                if status_before_stop == RequestStatus.RUNNING:
+                    stopped_running_reqs.add(request)
+                else:
+                    stopped_preempted_reqs.add(request)
+
+            # Extract sample logprobs if needed.
+            if request.sampling_params is not None and request.sampling_params.num_logprobs is not None and logprobs:
+                new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
+
+            if num_nans_in_logits is not None and req_id in num_nans_in_logits:
+                request.num_nans_in_logits = num_nans_in_logits[req_id]
+
+            # Get prompt logprobs for this request.
+            prompt_logprobs_tensors = prompt_logprobs_dict.get(req_id)
+            if should_emit_output:
+                # Add EngineCoreOutput for this Request.
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=req_id,
+                        new_token_ids=new_token_ids,
+                        finish_reason=finish_reason,
+                        new_logprobs=new_logprobs,
+                        new_prompt_logprobs_tensors=prompt_logprobs_tensors,
+                        pooling_output=pooler_output,
+                        stop_reason=request.stop_reason,
+                        events=request.take_events(),
+                        prefill_stats=prefill_stats,
+                        kv_transfer_params=kv_transfer_params,
+                        ec_transfer_params=ec_transfer_params,
+                        trace_headers=request.trace_headers,
+                        routed_experts=routed_experts,
+                        num_nans_in_logits=request.num_nans_in_logits,
+                    )
+                )
+            else:
+                # Invariant: EngineCore returns no partial prefill outputs.
+                assert not prompt_logprobs_tensors
+
+        # Remove the stopped requests from the running and waiting queues.
+        if stopped_running_reqs:
+            self.running = remove_all(self.running, stopped_running_reqs)
+        if stopped_preempted_reqs:
+            # This is a rare case and unlikely to impact performance.
+            self.waiting.remove_requests(stopped_preempted_reqs)
+            self.skipped_waiting.remove_requests(stopped_preempted_reqs)
+
+        error_req_ids = set(self.grammar_compile_error_reqs)
+        self.grammar_compile_error_reqs.clear()
+        if failed_kv_load_req_ids and not self.recompute_kv_load_failures:
+            error_req_ids.update(failed_kv_load_req_ids)
+
+        if error_req_ids:
+            error_reqs = self.finish_requests(error_req_ids, RequestStatus.FINISHED_ERROR)
+            for request in error_reqs:
+                outputs[request.client_index].append(
+                    EngineCoreOutput(
+                        request_id=request.request_id,
+                        new_token_ids=[],
+                        finish_reason=request.get_finished_reason(),
+                        events=request.take_events(),
+                        trace_headers=request.trace_headers,
+                    )
+                )
+
+        # KV Connector: update state for finished KV Transfers.
+        if kv_connector_output:
+            self._update_from_kv_xfer_finished(kv_connector_output)
+
+        # Worker-side KV connector stats from the model runner output.
+        kv_connector_stats: KVConnectorStats | None = (
+            kv_connector_output.kv_connector_stats if kv_connector_output else None
+        )
+        if self.connector:
+            # Scheduler-side KV connector stats collected after connector update.
+            scheduler_kv_connector_stats = self.connector.get_kv_connector_stats()
+            if scheduler_kv_connector_stats is not None and not scheduler_kv_connector_stats.is_empty():
+                kv_connector_stats = (
+                    kv_connector_stats.aggregate(scheduler_kv_connector_stats)
+                    if kv_connector_stats is not None
+                    else scheduler_kv_connector_stats
+                )
+
+        # collect KV cache events from KV cache manager
+        events = self.kv_cache_manager.take_events()
+
+        # collect KV cache events from connector
+        if self.connector is not None:
+            connector_events = self.connector.take_events()
+            if connector_events:
+                if events is None:
+                    events = list(connector_events)
+                else:
+                    events.extend(connector_events)
+
+        # publish collected KV cache events
+        if events:
+            batch = KVEventBatch(ts=time.time(), events=events)
+            self.kv_event_publisher.publish(batch)
+
+        # Create EngineCoreOutputs for all clients that have requests with
+        # outputs in this step.
+        engine_core_outputs = {client_index: EngineCoreOutputs(outputs=outs) for client_index, outs in outputs.items()}
+
+        finished_req_ids = self.finished_req_ids_dict
+        if finished_req_ids:
+            # Include ids of requests that finished since last outputs
+            # were sent.
+            for client_index, finished_set in finished_req_ids.items():
+                # Set finished request set in EngineCoreOutputs for this client.
+                if (eco := engine_core_outputs.get(client_index)) is not None:
+                    eco.finished_requests = finished_set
+                else:
+                    engine_core_outputs[client_index] = EngineCoreOutputs(finished_requests=finished_set)
+            finished_req_ids.clear()
+
+        if (
+            stats := self.make_stats(
+                spec_decoding_stats,
+                kv_connector_stats,
+                cudagraph_stats,
+                perf_stats,
+            )
+        ) is not None:
+            # Return stats to only one of the front-ends.
+            if (eco := next(iter(engine_core_outputs.values()), None)) is None:
+                # We must return the stats even if there are no request
+                # outputs this step.
+                engine_core_outputs[0] = eco = EngineCoreOutputs()
+            eco.scheduler_stats = stats
+
+        return engine_core_outputs
+
+    def _update_request_with_output(
+        self, request: Request, new_token_ids: list[int], is_stale: bool = False
+    ) -> tuple[list[int], bool]:
+        # is_stale is only used by the AsyncScheduler override.
+        # Append generated tokens and check for stop. Note that if
+        # a request is still being prefilled, we expect the model runner
+        # to return empty token ids for the request.
+        stopped = False
+        for num_new, output_token_id in enumerate(new_token_ids, 1):
+            request.append_output_token_ids(output_token_id)
+
+            # Check for stop and update request state.
+            # This must be called before we make the EngineCoreOutput.
+            stopped = check_stop(request, self.max_model_len)
+            if stopped:
+                del new_token_ids[num_new:]  # Trim new tokens if needed.
+                break
+        return new_token_ids, stopped
+
+    def reset_prefix_cache(self, reset_running_requests: bool = False, reset_connector: bool = False) -> bool:
+        """Reset the KV prefix cache.
+
+        If reset_running_requests is True, all the running requests will be
+        preempted and moved to the waiting queue.
+        Otherwise, this method will only reset the KV prefix cache when there
+        is no running requests taking KV cache.
+        """
+        if reset_running_requests:
+            # For logging.
+            timestamp = time.monotonic()
+            # Invalidate all the current running requests KV's by pushing them to
+            # the waiting queue. In this case, we can reduce the ref count of all
+            # the kv blocks to 0 and thus we can make sure the reset is successful.
+            # Preempt in reverse order so the requests will be added back to the
+            # running queue in FIFO order.
+            while self.running:
+                request = self.running.pop()
+                self._preempt_request(request, timestamp, drop_stale_output=True)
+
+            # Clear scheduled request ids cache. Since we are forcing preemption
+            # + resumption in the same step, we must act as if these requests were
+            # not scheduled in the prior step. They will be flushed from the
+            # persistent batch in the model runner.
+            self.prev_step_scheduled_req_ids.clear()
+
+        reset_successful = self.kv_cache_manager.reset_prefix_cache()
+        if reset_running_requests and not reset_successful:
+            raise RuntimeError(
+                "Failed to reset KV cache even when all the running requests are "
+                "preempted and moved to the waiting queue. This is likely due to "
+                "the presence of running requests waiting for remote KV transfer, "
+                "which is not supported yet."
+            )
+
+        if reset_connector:
+            reset_successful = self.reset_connector_cache() and reset_successful
+
+        return reset_successful
 
 
-# The scheduler is constructed as ``Scheduler(...)`` from
-# ``vllm.v1.core.sched.scheduler``. This takes effect when scheduler_cls is
-# unset, covering ordinary synchronous, PD-prefill, and PD-mixed paths.
-# vLLM-Ascend's recompute, dynamic-batch, and profiling schedulers set
-# scheduler_cls and correctly bypass this name.
-_sched_mod.Scheduler = BalanceScheduler
+# Backport the connector contract from vLLM #50297. Ascend-specific
+# connectors override this property on their classes where needed.
+KVConnectorBase_V1.requires_kv_delivery = property(_requires_kv_delivery)
+MultiConnector.requires_kv_delivery = property(_multi_requires_kv_delivery)
+OffloadingConnector.requires_kv_delivery = property(_best_effort_cache_requires_kv_delivery)
+SimpleCPUOffloadConnector.requires_kv_delivery = property(_best_effort_cache_requires_kv_delivery)
 
-# Activate BalanceDPEngineCoreProc ONLY when balance scheduling is enabled.
-# Upstream ``run_engine_core`` resolves ``DPEngineCoreProc`` via the
-# ``vllm.v1.engine.core`` module-global name whenever DP>1 + MoE, so an
-# unconditional swap would inject balance machinery into configs that don't use
-# it -- e.g. PD-disaggregated recompute, whose scheduler is AsyncRecomputeScheduler
-# and must not be touched by balance. A conditional swap at run_engine_core
-# entry (where vllm_config is available) restores the pre-refactor "balance off
-# => no involvement" invariant without copying run_engine_core's body.
-_OriginalDPEngineCoreProc = _engine_core_mod.DPEngineCoreProc
-_OriginalRunEngineCore = EngineCoreProc.run_engine_core
+# Backport the request state introduced by vLLM #48245 without replacing
+# Request.__init__. Preempted requests get instance values in _preempt_request;
+# all other requests read these neutral class defaults.
+Request.num_stale_output_tokens = 0
+Request.drop_stale_output = False
 
+# Install the KV-delivery scheduler before balance and async scheduler patches
+# derive their subclasses from the module-level Scheduler symbol.
+_sched_mod.Scheduler = KVDeliveryScheduler
 
-def _balance_run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
-    vllm_config = kwargs.get("vllm_config")
-    if _balance_scheduling_enabled(vllm_config):
-        _engine_core_mod.DPEngineCoreProc = BalanceDPEngineCoreProc
-    else:
-        _engine_core_mod.DPEngineCoreProc = _OriginalDPEngineCoreProc
-    return _OriginalRunEngineCore(*args, dp_rank=dp_rank, local_dp_rank=local_dp_rank, **kwargs)
+# patch_pp_mtp wrapped the upstream Scheduler before this class swap. Reapply
+# its idempotent wrapper to this replacement update_from_output implementation.
+from vllm_ascend.patch.platform.patch_pp_mtp import _patch_scheduler_update_from_output  # noqa: E402, I001
 
 
-EngineCoreProc.run_engine_core = staticmethod(_balance_run_engine_core)
+_patch_scheduler_update_from_output()

--- a/vllm_ascend/patch/platform/patch_kv_delivery_preemption.py
+++ b/vllm_ascend/patch/platform/patch_kv_delivery_preemption.py
@@ -2,12 +2,11 @@
 """Backport lossless stale-output and reliable KV-delivery scheduling.
 
 This module owns the vLLM #48245/#50297 scheduler changes independently of
-Ascend balance scheduling. ``KVDeliveryScheduler.schedule`` is copied from
-vLLM commit ``d02df748bf9efd99022f1a062597dc3cb3808485`` and carries only
-the two scheduler deltas from those PRs: stale-output admission and
-reliable-delivery pressure preemption. Balance admission is intentionally not
-handled here. The request/connector contracts and every scheduler method
-changed by those PRs live here as well.
+Ascend balance scheduling. ``KVDeliveryScheduler.schedule`` is copied from the
+vLLM ``v0.26.0`` tag and carries only the two scheduler deltas from those PRs:
+stale-output admission and reliable-delivery pressure preemption. Balance
+admission is intentionally not handled here. The request/connector contracts
+and every scheduler method changed by those PRs live here as well.
 """
 
 import time
@@ -25,6 +24,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector i
 )
 from vllm.logger import logger
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.v1.core.kv_cache_coordinator import HybridKVCacheCoordinator
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import NewRequestData, SchedulerOutput
@@ -367,27 +367,50 @@ class KVDeliveryScheduler(Scheduler):
                 num_external_computed_tokens = 0
                 load_kv_async = False
                 connector_prefix_cache_queries, connector_prefix_cache_hits = 0, 0
-                did_prefix_cache_lookup = False
 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
-                    did_prefix_cache_lookup = True
-                    hit_diverged = False
                     # Get locally-cached tokens.
-                    if self.connector is not None:
-                        # A KV connector transfers the missing suffix, which needs a
-                        # hybrid-aware lookup that can diverge across groups.
-                        (
-                            new_computed_blocks,
-                            num_new_local_computed_tokens,
-                            request.shared_prefix_boundary,
-                            hit_diverged,
-                        ) = self.kv_cache_manager.get_computed_blocks_for_connector(request)
+                    if (
+                        self.connector is not None
+                        and self.has_mamba_layers
+                        and isinstance(
+                            self.kv_cache_manager.coordinator,
+                            HybridKVCacheCoordinator,
+                        )
+                    ):
+                        computed, per_group_hits = self.kv_cache_manager.coordinator.find_longest_cache_hit_per_group(
+                            request.block_hashes, request.num_tokens - 1
+                        )
+                        new_computed_blocks = self.kv_cache_manager.create_kv_cache_blocks(computed)
+                        # NOTE(ZhanqiuHu): For Mamba hybrid models,
+                        # num_new_local_computed_tokens should be the FA hit
+                        # length. This value is passed to the connector's
+                        # get_num_new_matched_tokens which computes:
+                        # external = total - local_computed.
+                        # Using the FA hit skips re-transferring FA blocks
+                        # already cached on D-side. The Mamba state (always
+                        # the last block) is transferred unconditionally by
+                        # _apply_prefix_caching in nixl/worker.py.
+                        num_new_local_computed_tokens = max(per_group_hits)
+                        # The per-group lookup does not detect an uncached shared
+                        # prefix, so there is no junction to pin in this path.
+                        request.shared_prefix_boundary = 0
+                        if self.kv_cache_manager.log_stats:
+                            assert self.kv_cache_manager.prefix_cache_stats is not None
+                            self.kv_cache_manager.prefix_cache_stats.record(
+                                num_tokens=request.num_tokens,
+                                num_hits=num_new_local_computed_tokens,
+                                preempted=request.num_preemptions > 0,
+                            )
                     else:
                         (
                             new_computed_blocks,
                             num_new_local_computed_tokens,
-                            # Marconi shared-prefix junction to pin; 0 if none.
+                            # Junction to pin (Marconi-style APC) so its
+                            # sparse-retention state (Mamba block / sliding-window
+                            # tail) survives retention and serves a later hit; 0
+                            # if no uncached shared prefix was detected.
                             request.shared_prefix_boundary,
                         ) = self.kv_cache_manager.get_computed_blocks(request)
 
@@ -407,16 +430,6 @@ class KVDeliveryScheduler(Scheduler):
 
                         num_external_computed_tokens = ext_tokens
 
-                        if hit_diverged and num_external_computed_tokens == 0:
-                            # No external tokens back the deeper local hit, so its
-                            # resume boundary would have no valid Mamba state.
-                            # Reconcile to the boundary every group agrees on.
-                            (
-                                new_computed_blocks,
-                                num_new_local_computed_tokens,
-                                request.shared_prefix_boundary,
-                            ) = self.kv_cache_manager.get_computed_blocks(request)
-
                         connector_prefix_cache_queries = request.num_tokens - num_new_local_computed_tokens
                         connector_prefix_cache_hits = num_external_computed_tokens
 
@@ -435,7 +448,7 @@ class KVDeliveryScheduler(Scheduler):
                         continue
 
                     # Track first scheduled prefill, not post-preemption repeat prefills
-                    if request.prefill_stats and request.num_preemptions <= 0:
+                    if request.prefill_stats is not None and request.num_preemptions <= 0:
                         assert num_computed_tokens <= request.num_prompt_tokens
                         request.prefill_stats.set(
                             num_prompt_tokens=request.num_prompt_tokens,
@@ -585,10 +598,6 @@ class KVDeliveryScheduler(Scheduler):
                             num_hits=connector_prefix_cache_hits,
                             preempted=request.num_preemptions > 0,
                         )
-
-                # Record at admission so unscheduled lookups are not counted.
-                if did_prefix_cache_lookup:
-                    self.kv_cache_manager.record_prefix_cache_stats(request, num_new_local_computed_tokens)
 
                 request = request_queue.pop_request()
                 if load_kv_async:
@@ -758,7 +767,6 @@ class KVDeliveryScheduler(Scheduler):
             new_block_ids_to_zero=self._get_new_block_ids_to_zero(),
             kv_cache_block_copies=pending_kv_cache_block_copies,
             num_spec_tokens_to_schedule=num_spec_tokens_to_schedule,
-            ec_manager_metadata=self.encoder_cache_manager.get_manager_metadata(),
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -963,7 +971,7 @@ class KVDeliveryScheduler(Scheduler):
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
 
-            if new_token_ids and self.structured_output_manager.should_advance(request, new_token_ids=new_token_ids):
+            if new_token_ids and self.structured_output_manager.should_advance(request):
                 struct_output_request = request.structured_output_request
                 assert struct_output_request is not None
                 grammar = struct_output_request.grammar


### PR DESCRIPTION
## Purpose

Backport the async-preemption correctness fixes from upstream vLLM [#48245](https://github.com/vllm-project/vllm/pull/48245) and [#50297](https://github.com/vllm-project/vllm/pull/50297) to the v0.26 RC branch.

This fixes stale in-flight output accounting after preemption and prevents P/D producers from delivering outputs whose KV blocks have already been released under memory pressure. The change is needed for Mooncake KV transfer configurations using async scheduling.

## Changes

- track stale in-flight outputs across preemption without underflowing output placeholders;
- drain ordinary stale outputs losslessly, while dropping/recomputing them when the connector requires reliable KV delivery;
- add the `requires_kv_delivery` contract for KV connectors and aggregate it through `MultiConnector`;
- mark Mooncake producer connectors and AscendStore as requiring KV delivery;
- keep the AsyncScheduler-specific override in a dedicated patch module;
- preserve the existing balance-scheduler deltas and add regression guards;
- add CPU unit tests adapted from both upstream PRs.

## Validation

- `git diff --check origin/releases/v0.26.0rc...HEAD` — passed.
- Targeted unit tests were attempted:
  `python -m pytest -q tests/ut/patch/platform/test_kv_delivery_preemption.py tests/ut/patch/platform/test_patch_balance_schedule.py`
  - the default environment stopped during collection because `vllm` is not installed;
  - using the local vLLM checkout via `PYTHONPATH` also stopped during collection because the installed Torch does not expose `torch.library.infer_schema`.
  - No test assertion was reached; CI should run these tests with the branch's supported vLLM/Torch environment.

## Upstream

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
