### PR TITLE
[CI]Fix  job cancle 

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -292,13 +292,13 @@ jobs:
     needs:
       - recommend-tests-from-coverage
     # select-tests is the single producer of test_groups / base_sha / has_tests.
-    # always() is required so this job still runs when recommend-tests-from-coverage
-    # is skipped under ready-all. Modes:
+    # !cancelled() is required so this job still runs when recommend-tests-from-coverage
+    # is skipped under ready-all, but not when the workflow itself is cancelled. Modes:
     #   recommended - recommend job succeeded with coverage paths
     #   all         - ready-all forced (full selected suite)
     #   none        - recommend job succeeded but produced no paths (no tests)
     # Recommend job failure does not fall back to all; this job fails instead.
-    if: ${{ always() && !cancelled() }}
+    if: ${{ !cancelled() }}
     runs-on: linux-amd64-cpu-8-hk
     container:
       image: quay.io/ascend-ci/vllm-ascend:lint
@@ -487,12 +487,12 @@ jobs:
   ensure-csrc-cache:
     needs:
       - select-tests
-    # always() is required: select-tests depends on recommend-tests-from-coverage,
-    # which is skipped under ready-all. Without always(), the skipped need
-    # propagates transitively and skips this job even when select-tests succeeded.
+    # !cancelled() is required: select-tests depends on recommend-tests-from-coverage,
+    # which is skipped under ready-all. Without a status check function, the skipped
+    # need propagates transitively and skips this job even when select-tests succeeded.
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.select-tests.result == 'success' &&
         (
           contains(github.event.pull_request.labels.*.name, 'ready-precise') ||
@@ -512,11 +512,11 @@ jobs:
       - pre-commit
       - select-tests
       - ensure-csrc-cache
-    # always() overrides transitive skip-propagation from recommend-tests-from-coverage
-    # (skipped under ready-all) through select-tests.
+    # !cancelled() overrides transitive skip-propagation from recommend-tests-from-coverage
+    # (skipped under ready-all) through select-tests, without running after workflow cancel.
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.pre-commit.result == 'success' &&
         needs.ensure-csrc-cache.result == 'success' &&
         (
@@ -544,11 +544,11 @@ jobs:
       - pre-commit
       - select-tests
       - ensure-csrc-cache
-    # always() overrides transitive skip-propagation from recommend-tests-from-coverage
-    # (skipped under ready-all) through select-tests.
+    # !cancelled() overrides transitive skip-propagation from recommend-tests-from-coverage
+    # (skipped under ready-all) through select-tests, without running after workflow cancel.
     if: >-
       ${{
-        always() &&
+        !cancelled() &&
         needs.pre-commit.result == 'success' &&
         needs.ensure-csrc-cache.result == 'success' &&
         contains(github.event.pull_request.labels.*.name, 'ready-precise') &&

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -2016,7 +2016,7 @@ def ensure_zmq_send(
 def ensure_zmq_recv(
     socket: zmq.Socket,  # type: ignore
     path: str,
-    max_retries: int = 3,
+    max_retries: int = 2,
 ) -> bytes:
     retries_left = max_retries
     while True:

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -2016,7 +2016,7 @@ def ensure_zmq_send(
 def ensure_zmq_recv(
     socket: zmq.Socket,  # type: ignore
     path: str,
-    max_retries: int = 2,
+    max_retries: int = 3,
 ) -> bytes:
     retries_left = max_retries
     while True:


### PR DESCRIPTION
### What this PR does / why we need it?

Tasks cannot be canceled during a re-push; fix re-push cancellation.

### Does this PR introduce _any_ user-facing change?
 no  
### How was this patch tested?
The code re-pushing can be canceled normally.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
