### PR TITLE
[CI] update schedule image build config

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -170,6 +170,8 @@ jobs:
       contents: read
 
     strategy:
+      max-parallel: 2
+      fail-fast: false
       matrix:
         runner_info:
           - {runner: linux-aarch64-cpu-4, tag: arm64}

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -105,7 +105,7 @@ jobs:
     if: ${{ !((github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'image-build')))
         && !(github.event_name == 'workflow_dispatch' && inputs.vllm_commit != '' && inputs.vllm_ascend_commit != '') }}
     strategy:
-      max-parallel: 6
+      fail-fast: false
       matrix:
         build_meta:
           - name: A2 Ubuntu
@@ -179,7 +179,7 @@ jobs:
         && inputs.tag == 'none'
         && inputs.branch == 'none' }}
     strategy:
-      max-parallel: 6
+      fail-fast: false
       matrix:
         build_meta:
           - name: A2 Ubuntu


### PR DESCRIPTION
1、Adjust concurrency settings to avoid exhausting parallel execution capacity, which may lead to image build failures.
2、Refine the workflow logic so that a single task failure does not abort other running tasks.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
