### PR TITLE
[Test][Feature] Add managed KV pool support for E2E test frameworks

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -343,6 +343,9 @@ a3:
       - name: Minimax_M2.7_w8a8_A3
         os: linux-aarch64-a3-16
         config_file_path: Minimax_M2.7_w8a8_A3.yaml
+      - name: Qwen3.5-397B-Memcache-perf
+        os: linux-aarch64-a3-16
+        config_file_path: Qwen3.5-397B-Memcache-perf.yaml
 310p:
   single_node:
     test_config:
@@ -371,6 +374,9 @@ a3-560t:
       - name: test_qwen3_grid_exceed_65536
         os: linux-aarch64-a3-2-cn12-001
         tests: tests/e2e/weekly/single_node/features/test_qwen3_grid_exceed_65536.py
+      - name: Qwen3.5-397B-Memcache-perf
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Qwen3.5-397B-Memcache-perf.yaml
   multi_card:
     test_config:
       # pytest-driven tests

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -270,7 +270,10 @@ a3:
         config_file_path: Qwen3.5-397B-w4a8-PD-no-mtp.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
-
+      - name: Qwen2.5-7B-Instruct-mooncake-PD
+        config_file_path: Qwen2.5-7B-Instruct-mooncake-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
   single_node:
     test_config:
       # pytest-driven tests

--- a/tests/e2e/common/kv_pool/__init__.py
+++ b/tests/e2e/common/kv_pool/__init__.py
@@ -1,0 +1,1 @@
+"""Shared KV pool support for E2E test frameworks."""

--- a/tests/e2e/common/kv_pool/config.py
+++ b/tests/e2e/common/kv_pool/config.py
@@ -1,0 +1,95 @@
+from dataclasses import dataclass
+from typing import Any
+
+SUPPORTED_KV_POOL_TYPES = {"memcache", "mooncake"}
+
+
+@dataclass(frozen=True)
+class KVPoolConfig:
+    """Base configuration shared by managed KV pool backends."""
+
+    config: dict[str, Any]
+
+    @property
+    def type(self) -> str:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class MooncakeKVPoolConfig(KVPoolConfig):
+    """Mooncake master configuration."""
+
+    master_port: int
+    metrics_port: int
+
+    @property
+    def type(self) -> str:
+        return "mooncake"
+
+
+@dataclass(frozen=True)
+class MemcacheKVPoolConfig(KVPoolConfig):
+    """Memcache MetaService configuration."""
+
+    meta_service_port: int
+    config_store_port: int
+
+    @property
+    def type(self) -> str:
+        return "memcache"
+
+
+def parse_kv_pool_config(raw_kv_pool: Any) -> KVPoolConfig | None:
+    if raw_kv_pool is None:
+        return None
+    if not isinstance(raw_kv_pool, dict):
+        raise TypeError("kv_pool must be a mapping")
+
+    pool_type = str(raw_kv_pool.get("type", "")).lower()
+    if pool_type not in SUPPORTED_KV_POOL_TYPES:
+        raise ValueError(f"Unsupported kv_pool.type: {pool_type!r}")
+
+    pool_config = raw_kv_pool.get("config")
+    if not isinstance(pool_config, dict):
+        raise TypeError("kv_pool.config must be a mapping")
+    kv_pool: KVPoolConfig
+    if pool_type == "mooncake":
+        kv_pool = MooncakeKVPoolConfig(
+            config=dict(pool_config),
+            master_port=int(raw_kv_pool["master_port"]),
+            metrics_port=int(raw_kv_pool["metrics_port"]),
+        )
+    else:
+        kv_pool = MemcacheKVPoolConfig(
+            config=dict(pool_config),
+            meta_service_port=int(raw_kv_pool["meta_service_port"]),
+            config_store_port=int(raw_kv_pool["config_store_port"]),
+        )
+    validate_kv_pool_config(kv_pool)
+    return kv_pool
+
+
+def validate_kv_pool_config(kv_pool: KVPoolConfig) -> None:
+    if isinstance(kv_pool, MooncakeKVPoolConfig):
+        ports = (
+            ("master_port", kv_pool.master_port),
+            ("metrics_port", kv_pool.metrics_port),
+        )
+    elif isinstance(kv_pool, MemcacheKVPoolConfig):
+        ports = (
+            ("meta_service_port", kv_pool.meta_service_port),
+            ("config_store_port", kv_pool.config_store_port),
+        )
+    else:
+        raise TypeError(f"Unsupported KV pool config: {type(kv_pool).__name__}")
+
+    for field_name, port in ports:
+        if port < 1 or port > 65535:
+            raise ValueError(f"kv_pool.{field_name} must be between 1 and 65535")
+    if ports[0][1] == ports[1][1]:
+        raise ValueError(f"kv_pool.{ports[0][0]} and kv_pool.{ports[1][0]} must be different")
+
+    if isinstance(kv_pool, MemcacheKVPoolConfig):
+        for section in ("meta", "local"):
+            if not isinstance(kv_pool.config.get(section), dict):
+                raise TypeError(f"kv_pool.config.{section} must be a mapping for memcache")

--- a/tests/e2e/nightly/multi_node/external_dp/config/template.md
+++ b/tests/e2e/nightly/multi_node/external_dp/config/template.md
@@ -34,6 +34,21 @@ routing:
     prefiller: [0]
     decoder: [1]
 
+# Optional. Select one managed KV pool backend and configure its ports. The
+# framework starts the backend service on node 0 and writes the backend config
+# used by every vLLM rank.
+kv_pool:
+  type: mooncake
+  master_port: 50088
+  metrics_port: 50089
+  config:
+    metadata_server: "P2PHANDSHAKE"
+    protocol: "ascend"
+    device_name: ""
+    global_segment_size: "1GB"
+    preferred_segment: false
+    prefer_alloc_in_same_node: true
+
 config:
   - node_index: 0
     port_start: 7100
@@ -56,10 +71,17 @@ config:
 env_common: &env_common
   HCCL_OP_
   VLLM_USE_MODELSCOPE: "true"
+  LD_LIBRARY_PATH: "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH"
+  PYTHONHASHSEED: "0"
   OMP_PROC_BIND: "false"
   OMP_NUM_THREADS: "10"
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
   ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  ASCEND_ENABLE_USE_FABRIC_MEM: "1"
+  ACL_OP_INIT_MODE: "1"
+  HCCL_RDMA_TIMEOUT: "17"
+  ASCEND_CONNECT_TIMEOUT: "10000"
+  ASCEND_TRANSFER_TIMEOUT: "10000"
   HCCL_BUFFSIZE: "256"
   SERVER_PORT: "${PORT}"
   VLLM_ASCEND_ENABLE_FLASHCOMM1: "0"
@@ -184,6 +206,72 @@ benchmarks:
   address for prefiller nodes and the decoder master address for decoder nodes.
 - `templates`: One template per config entry. The framework expands one command
   per local DP rank.
+- `kv_pool`: Optional managed KV pool. `type` is either `mooncake` or
+  `memcache`. Mooncake requires `master_port` and `metrics_port`; Memcache
+  requires `meta_service_port` and `config_store_port`. All configured ports
+  must be available on node 0. The framework starts the selected service on
+  node 0 before any vLLM rank starts.
+- `kv_pool.config`: Backend-specific config. For Mooncake, it is written to
+  each node's generated `mooncake.json`; the framework derives and overwrites
+  `master_server_address`. For Memcache, it contains `meta` and `local`
+  mappings written to `mmc-meta.conf` and `mmc-local.conf`; the framework
+  derives and overwrites the MetaService and Config Store URLs.
+
+For KV pooling, use `MultiConnector` in each server template. The prefiller
+uses `kv_producer` for both child connectors:
+
+```yaml
+- --kv-transfer-config
+- >-
+  {
+    "kv_connector": "MultiConnector",
+    "kv_role": "kv_producer",
+    "kv_load_failure_policy": "recompute",
+    "kv_connector_extra_config": {
+      "connectors": [
+        {
+          "kv_connector": "MooncakeConnectorV1",
+          "kv_role": "kv_producer",
+          "kv_port": "30000",
+          "kv_connector_extra_config": {
+            "prefill": {"dp_size": 2, "tp_size": 1},
+            "decode": {"dp_size": 2, "tp_size": 1}
+          }
+        },
+        {
+          "kv_connector": "AscendStoreConnector",
+          "kv_role": "kv_producer",
+          "kv_connector_extra_config": {
+            "lookup_rpc_port": "0",
+            "backend": "mooncake"
+          }
+        }
+      ]
+    }
+  }
+```
+
+The decoder uses the same structure with `kv_role: kv_consumer` on the outer
+connector and both child connectors. The framework passes this argument
+through unchanged. When selecting Memcache, write `"backend": "memcache"`
+in the YAML command yourself.
+
+To use Memcache instead, replace the `kv_pool` block with:
+
+```yaml
+kv_pool:
+  type: memcache
+  meta_service_port: 5000
+  config_store_port: 6000
+  config:
+    meta:
+      ock.mmc.log_level: error
+    local:
+      ock.mmc.log_level: error
+      ock.mmc.local_service.world_size: 256
+      ock.mmc.local_service.protocol: device_sdma
+      ock.mmc.local_service.dram.size: 1GB
+```
 
 The framework injects distributed network envs at startup:
 
@@ -195,6 +283,29 @@ TP_SOCKET_IFNAME
 LOCAL_IP
 NIC_NAME
 MASTER_IP
+```
+
+When `kv_pool.type` is `mooncake`, it additionally injects:
+
+```text
+MOONCAKE_CONFIG_PATH
+MOONCAKE_MASTER
+```
+
+When `kv_pool.type` is `memcache`, it injects:
+
+```text
+MMC_LOCAL_CONFIG_PATH
+```
+
+The generated configs and service logs are archived with the node logs:
+
+```text
+<external-dp-log-root>/node-<index>/runtime/mooncake.json
+<external-dp-log-root>/node-0/mooncake-master.log
+<external-dp-log-root>/node-<index>/runtime/mmc-meta.conf
+<external-dp-log-root>/node-<index>/runtime/mmc-local.conf
+<external-dp-log-root>/node-0/memcache-meta-service.log
 ```
 
 The framework also derives proxy metadata from `routing.type`:

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/external_dp_config.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/external_dp_config.py
@@ -5,6 +5,11 @@ from typing import Any
 
 import regex as re
 
+from tests.e2e.common.kv_pool.config import (
+    KVPoolConfig,
+    parse_kv_pool_config,
+    validate_kv_pool_config,
+)
 from tests.e2e.nightly.multi_node.scripts.utils import (
     load_yaml_mapping,
     resolve_cluster_ips,
@@ -105,6 +110,7 @@ class ExternalDPConfig:
     launch_templates: list[NodeTemplate]
     benchmark_cases: list[dict[str, Any]] = field(default_factory=list)
     special_dependencies: dict[str, str] = field(default_factory=dict)
+    kv_pool: KVPoolConfig | None = None
 
     @property
     def is_disaggregated_prefill(self) -> bool:
@@ -189,6 +195,7 @@ class ExternalDPConfigLoader:
         nodes = cls._parse_nodes(raw_config, resolved_cluster_ips)
         launch_templates = cls._parse_templates(raw_config)
         benchmark_cases = cls._parse_benchmarks(raw_config)
+        kv_pool = cls._parse_kv_pool(raw_config)
 
         config = ExternalDPConfig(
             test_name=str(raw_config.get("test_name", "external_dp_test")),
@@ -202,6 +209,7 @@ class ExternalDPConfigLoader:
             launch_templates=launch_templates,
             benchmark_cases=benchmark_cases,
             special_dependencies=dict(raw_config.get("special_dependencies", {})),
+            kv_pool=kv_pool,
         )
         cls._validate_config(config)
         return config
@@ -324,11 +332,16 @@ class ExternalDPConfigLoader:
             benchmark_cases.append(case_with_name)
         return benchmark_cases
 
+    @staticmethod
+    def _parse_kv_pool(raw_config: dict[str, Any]) -> KVPoolConfig | None:
+        return parse_kv_pool_config(raw_config.get("kv_pool"))
+
     @classmethod
     def _validate_config(cls, config: ExternalDPConfig) -> None:
         cls._validate_config_sizes(config)
         cls._validate_routing(config)
         cls._validate_node_parallel_config(config)
+        cls._validate_kv_pool(config)
 
     @staticmethod
     def _validate_config_sizes(config: ExternalDPConfig) -> None:
@@ -384,6 +397,13 @@ class ExternalDPConfigLoader:
                 )
             if node.dp_rank_start + node.dp_size_local > node.dp_size:
                 raise ValueError(f"node {node_index} dp rank range exceeds dp_size")
+
+    @staticmethod
+    def _validate_kv_pool(config: ExternalDPConfig) -> None:
+        kv_pool = config.kv_pool
+        if kv_pool is None:
+            return
+        validate_kv_pool_config(kv_pool)
 
 
 class RankResolver:

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/runtime.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/runtime.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import os
+import socket
 import subprocess
 import sys
 import time
@@ -10,6 +12,10 @@ from typing import Any
 
 import regex as re
 
+from tests.e2e.common.kv_pool.config import (
+    MemcacheKVPoolConfig,
+    MooncakeKVPoolConfig,
+)
 from tests.e2e.nightly.multi_node.external_dp.scripts.external_dp_config import (
     ROUTING_DISAGGREGATED_PREFILL,
     ExternalDPConfig,
@@ -30,6 +36,15 @@ from tests.e2e.nightly.multi_node.scripts.utils import get_net_interface
 logger = logging.getLogger(__name__)
 
 SERVER_READY_TIMEOUT_SECONDS = 3600
+KV_POOL_READY_TIMEOUT_SECONDS = 300
+MOONCAKE_EVICTION_HIGH_WATERMARK_RATIO = 0.9
+MOONCAKE_EVICTION_RATIO = 0.1
+MOONCAKE_DEFAULT_KV_LEASE_TTL = 11000
+MOONCAKE_LIBRARY_PATHS = (
+    "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake",
+    "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages",
+)
+PRIMARY_NODE_INDEX = 0
 TEMPLATE_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 ENV_VAR_RE = re.compile(r"(?<!\$)\$([A-Za-z_][A-Za-z0-9_]*)")
 
@@ -44,6 +59,266 @@ class ServerCommand:
 
 
 RankProcess = tuple[subprocess.Popen, RankInfo, Path]
+
+
+class ExternalDPKVPoolManager:
+    """Common lifecycle for a KV pool service running on node 0."""
+
+    def __init__(
+        self,
+        *,
+        config: ExternalDPConfig,
+        current_node_index: int,
+        log_root: Path,
+    ):
+        self.config = config
+        self.current_node_index = current_node_index
+        self.log_root = log_root
+        self.process: subprocess.Popen | None = None
+        self.server_envs: dict[str, str] = {}
+
+    @property
+    def pool_type(self) -> str:
+        if self.config.kv_pool is None:
+            raise RuntimeError("KV pool is not configured")
+        return self.config.kv_pool.type
+
+    @property
+    def pool_config(self) -> dict[str, Any]:
+        if self.config.kv_pool is None:
+            raise RuntimeError("KV pool is not configured")
+        return self.config.kv_pool.config
+
+    @property
+    def service_host(self) -> str:
+        return self.config.cluster_ips[PRIMARY_NODE_INDEX]
+
+    def start(self) -> None:
+        self._write_config()
+        if self.current_node_index == PRIMARY_NODE_INDEX:
+            self._start_service()
+        self._wait_ready()
+
+    def _write_config(self) -> None:
+        raise NotImplementedError
+
+    def _start_service(self) -> None:
+        raise NotImplementedError
+
+    def _ready_ports(self) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    def _wait_ready(self, timeout: int = KV_POOL_READY_TIMEOUT_SECONDS) -> None:
+        pending_ports = set(self._ready_ports())
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.process is not None and self.process.poll() is not None:
+                raise RuntimeError(
+                    f"{self.pool_type} service exited before becoming ready with code {self.process.returncode}"
+                )
+            for port in tuple(pending_ports):
+                try:
+                    with socket.create_connection((self.service_host, port), timeout=2):
+                        pending_ports.remove(port)
+                except OSError:
+                    pass
+            if not pending_ports:
+                logger.info("%s KV pool ready on node 0", self.pool_type)
+                return
+            time.sleep(1)
+        raise TimeoutError(
+            f"Timed out waiting for {self.pool_type} KV pool at {self.service_host}; ports={sorted(pending_ports)}"
+        )
+
+    @staticmethod
+    def _write_text_atomic(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+        temporary_path.write_text(content, encoding="utf-8")
+        temporary_path.replace(path)
+
+    def cleanup(self) -> None:
+        if self.process is None:
+            return
+        logger.info("Stopping %s KV pool service pid=%d", self.pool_type, self.process.pid)
+        terminate_process_tree(self.process.pid)
+        self.process = None
+
+    def __enter__(self):
+        try:
+            self.start()
+        except Exception:
+            self.cleanup()
+            raise
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.cleanup()
+
+
+class ExternalDPMooncakeManager(ExternalDPKVPoolManager):
+    """Materialize Mooncake config and manage one cluster-wide master."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.config_path = (self.log_root / f"node-{self.current_node_index}" / "runtime" / "mooncake.json").resolve()
+
+    @property
+    def mooncake_config(self) -> MooncakeKVPoolConfig:
+        kv_pool = self.config.kv_pool
+        if not isinstance(kv_pool, MooncakeKVPoolConfig):
+            raise TypeError("Mooncake manager requires MooncakeKVPoolConfig")
+        return kv_pool
+
+    @property
+    def master_address(self) -> str:
+        return f"{self.service_host}:{self.mooncake_config.master_port}"
+
+    def _write_config(self) -> None:
+        local_ip = self.config.cluster_ips[self.current_node_index]
+        store_config = replace_cluster_placeholders(
+            self.pool_config,
+            cluster_ips=self.config.cluster_ips,
+            local_ip=local_ip,
+            current_node_index=self.current_node_index,
+        )
+        store_config["master_server_address"] = self.master_address
+        self._write_text_atomic(
+            self.config_path,
+            json.dumps(store_config, indent=2, ensure_ascii=False),
+        )
+        self.server_envs = {
+            "MOONCAKE_CONFIG_PATH": str(self.config_path),
+            "MOONCAKE_MASTER": self.master_address,
+        }
+        logger.info(
+            "Generated Mooncake config for node %d: %s",
+            self.current_node_index,
+            self.config_path,
+        )
+
+    def _start_service(self) -> None:
+        cmd = [
+            "mooncake_master",
+            "--port",
+            str(self.mooncake_config.master_port),
+            "--metrics_port",
+            str(self.mooncake_config.metrics_port),
+            "--eviction_high_watermark_ratio",
+            str(MOONCAKE_EVICTION_HIGH_WATERMARK_RATIO),
+            "--eviction_ratio",
+            str(MOONCAKE_EVICTION_RATIO),
+            "--default_kv_lease_ttl",
+            str(MOONCAKE_DEFAULT_KV_LEASE_TTL),
+        ]
+        inherited_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+        library_path_parts = [*MOONCAKE_LIBRARY_PATHS]
+        if inherited_library_path:
+            library_path_parts.append(inherited_library_path)
+        env = {"LD_LIBRARY_PATH": os.pathsep.join(library_path_parts)}
+        log_file = self.log_root / f"node-{self.current_node_index}" / "mooncake-master.log"
+        self.process = start_logged_process(cmd, env, log_file)
+        logger.info("Mooncake master launched at %s", self.master_address)
+
+    def _ready_ports(self) -> tuple[int, ...]:
+        return (self.mooncake_config.master_port,)
+
+
+class ExternalDPMemcacheManager(ExternalDPKVPoolManager):
+    """Materialize Memcache configs and manage one cluster-wide MetaService."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        runtime_dir = self.log_root / f"node-{self.current_node_index}" / "runtime"
+        self.meta_config_path = (runtime_dir / "mmc-meta.conf").resolve()
+        self.local_config_path = (runtime_dir / "mmc-local.conf").resolve()
+
+    @property
+    def memcache_config(self) -> MemcacheKVPoolConfig:
+        kv_pool = self.config.kv_pool
+        if not isinstance(kv_pool, MemcacheKVPoolConfig):
+            raise TypeError("Memcache manager requires MemcacheKVPoolConfig")
+        return kv_pool
+
+    @staticmethod
+    def _format_config(config: dict[str, Any]) -> str:
+        def format_value(value: Any) -> str:
+            if isinstance(value, bool):
+                return str(value).lower()
+            return str(value)
+
+        return "".join(f"{key} = {format_value(value)}\n" for key, value in config.items())
+
+    def _write_config(self) -> None:
+        local_ip = self.config.cluster_ips[self.current_node_index]
+        rendered_config = replace_cluster_placeholders(
+            self.pool_config,
+            cluster_ips=self.config.cluster_ips,
+            local_ip=local_ip,
+            current_node_index=self.current_node_index,
+        )
+        meta_config = dict(rendered_config["meta"])
+        local_config = dict(rendered_config["local"])
+        meta_service_url = f"tcp://{self.service_host}:{self.memcache_config.meta_service_port}"
+        config_store_url = f"tcp://{self.service_host}:{self.memcache_config.config_store_port}"
+        meta_config["ock.mmc.meta_service_url"] = meta_service_url
+        meta_config["ock.mmc.meta_service.config_store_url"] = config_store_url
+        local_config["ock.mmc.meta_service_url"] = meta_service_url
+        local_config["ock.mmc.local_service.config_store_url"] = config_store_url
+        self._write_text_atomic(self.meta_config_path, self._format_config(meta_config))
+        self._write_text_atomic(self.local_config_path, self._format_config(local_config))
+        self.server_envs = {"MMC_LOCAL_CONFIG_PATH": str(self.local_config_path)}
+        logger.info("Generated Memcache configs for node %d", self.current_node_index)
+
+    def _start_service(self) -> None:
+        cmd = [
+            sys.executable,
+            "-c",
+            "from memcache_hybrid import MetaService; MetaService.main()",
+        ]
+        env = {"MMC_META_CONFIG_PATH": str(self.meta_config_path)}
+        log_file = self.log_root / f"node-{self.current_node_index}" / "memcache-meta-service.log"
+        self.process = start_logged_process(cmd, env, log_file)
+        logger.info("Memcache MetaService launched on node 0")
+
+    def _ready_ports(self) -> tuple[int, ...]:
+        return (
+            self.memcache_config.meta_service_port,
+            self.memcache_config.config_store_port,
+        )
+
+
+class NullKVPoolManager:
+    """No-op context manager used when kv_pool is not configured."""
+
+    def __init__(self):
+        self.server_envs: dict[str, str] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+
+def create_kv_pool_manager(
+    *,
+    config: ExternalDPConfig,
+    current_node_index: int,
+    log_root: Path,
+) -> ExternalDPKVPoolManager | NullKVPoolManager:
+    kwargs = {
+        "config": config,
+        "current_node_index": current_node_index,
+        "log_root": log_root,
+    }
+    if config.kv_pool is None:
+        return NullKVPoolManager()
+    if isinstance(config.kv_pool, MooncakeKVPoolConfig):
+        return ExternalDPMooncakeManager(**kwargs)
+    if isinstance(config.kv_pool, MemcacheKVPoolConfig):
+        return ExternalDPMemcacheManager(**kwargs)
+    raise TypeError(f"Unsupported KV pool config: {type(config.kv_pool).__name__}")
 
 
 class ServerCommandBuilder:
@@ -177,11 +452,13 @@ class ExternalDPServerManager:
         ranks: list[RankInfo],
         current_node_index: int,
         log_root: Path,
+        extra_envs: dict[str, str] | None = None,
     ):
         self.config = config
         self.ranks = ranks
         self.current_node_index = current_node_index
         self.log_root = log_root
+        self.extra_envs = dict(extra_envs or {})
         self.command_builder = ServerCommandBuilder(config)
         self.dist_envs = build_dist_envs(
             config.cluster_ips[current_node_index],
@@ -196,7 +473,7 @@ class ExternalDPServerManager:
             for rank in local_ranks:
                 template = self.config.launch_templates[rank.node_index]
                 template = type(template)(
-                    envs={**template.envs, **self.dist_envs},
+                    envs={**template.envs, **self.dist_envs, **self.extra_envs},
                     server_cmd_template=template.server_cmd_template,
                 )
                 server_cmd = self.command_builder.build(rank, template)

--- a/tests/e2e/nightly/multi_node/external_dp/scripts/test_external_dp.py
+++ b/tests/e2e/nightly/multi_node/external_dp/scripts/test_external_dp.py
@@ -18,6 +18,7 @@ from tests.e2e.nightly.multi_node.external_dp.scripts.runtime import (
     ExternalDPProxyLauncher,
     ExternalDPServerManager,
     build_all_server_commands,
+    create_kv_pool_manager,
     format_http_status,
     master_rank_health_url,
     proxy_server_health_url,
@@ -108,9 +109,8 @@ def test_external_dp() -> None:
     max_wait_seconds = int(os.environ.get("EXTERNAL_DP_MAX_WAIT_SECONDS", "3600"))
     is_master = current_node_index == 0
 
-    server_manager = ExternalDPServerManager(
+    kv_pool_manager = create_kv_pool_manager(
         config=config,
-        ranks=ranks,
         current_node_index=current_node_index,
         log_root=log_root,
     )
@@ -122,7 +122,17 @@ def test_external_dp() -> None:
     )
 
     try:
-        with server_manager, proxy_launcher:
+        with (
+            kv_pool_manager,
+            ExternalDPServerManager(
+                config=config,
+                ranks=ranks,
+                current_node_index=current_node_index,
+                log_root=log_root,
+                extra_envs=kv_pool_manager.server_envs,
+            ),
+            proxy_launcher,
+        ):
             if is_master:
                 wait_ranks_ready(ranks, timeout=max_wait_seconds)
                 proxy_launcher.wait_ready()

--- a/tests/e2e/nightly/single_node/models/scripts/GUIDE_AND_TEMPLATE.md
+++ b/tests/e2e/nightly/single_node/models/scripts/GUIDE_AND_TEMPLATE.md
@@ -146,6 +146,7 @@ pytest -sv tests/e2e/nightly/single_node/models/scripts/test_single_node.py
 | `benchmarks`     | map        | No      | `{}`             | Configuration for `aisbench` performance verification               |
 | `epd_server_cmds`| list[list] | Cond.   | `[]`             | (EPD Only) Command arrays for starting dual Encode/Decode processes |
 | `epd_proxy_args` | list       | Cond.   | `[]`             | (EPD Only) Startup arguments for the EPD routing gateway            |
+| `kv_pool`        | map        | No      | -                | Managed `mooncake` or `memcache` KV pool service                    |
 
 **Notes / Behaviors**
 
@@ -164,6 +165,13 @@ pytest -sv tests/e2e/nightly/single_node/models/scripts/test_single_node.py
 * Extra fields:
     * Any non-standard fields in a case are stored in `config.extra_config`.
     * This is how extension configs are passed through without changing the dataclass.
+
+* `kv_pool`:
+    * The framework starts the pool before vLLM and stops it after all vLLM
+      and proxy processes exit.
+    * Pool ports are user-configured and must be available on the local host.
+    * `--kv-transfer-config` remains in `server_cmd` or `epd_server_cmds`; the
+      framework does not parse or modify it.
 
 ### 3.3 YAML Examples
 
@@ -272,6 +280,41 @@ test_cases:
 
     test_content:
       - "chat_completion"
+```
+
+#### Managed KV Pool
+
+Mooncake:
+
+```yaml
+kv_pool:
+  type: mooncake
+  master_port: 50088
+  metrics_port: 50089
+  config:
+    metadata_server: P2PHANDSHAKE
+    protocol: ascend
+    device_name: ""
+    global_segment_size: 1GB
+    preferred_segment: false
+    prefer_alloc_in_same_node: true
+```
+
+Memcache:
+
+```yaml
+kv_pool:
+  type: memcache
+  meta_service_port: 5000
+  config_store_port: 6000
+  config:
+    meta:
+      ock.mmc.log_level: error
+    local:
+      ock.mmc.log_level: error
+      ock.mmc.local_service.world_size: 256
+      ock.mmc.local_service.protocol: device_sdma
+      ock.mmc.local_service.dram.size: 1GB
 ```
 
 ## 4. How to Add Custom Tests (Extension)

--- a/tests/e2e/nightly/single_node/models/scripts/kv_pool_runtime.py
+++ b/tests/e2e/nightly/single_node/models/scripts/kv_pool_runtime.py
@@ -1,0 +1,261 @@
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+import regex as re
+
+from tests.e2e.common.kv_pool.config import (
+    KVPoolConfig,
+    MemcacheKVPoolConfig,
+    MooncakeKVPoolConfig,
+)
+
+KV_POOL_READY_TIMEOUT_SECONDS = 300
+KV_POOL_STOP_TIMEOUT_SECONDS = 10
+MOONCAKE_EVICTION_HIGH_WATERMARK_RATIO = 0.9
+MOONCAKE_EVICTION_RATIO = 0.1
+MOONCAKE_DEFAULT_KV_LEASE_TTL = 11000
+MOONCAKE_LIBRARY_PATHS = (
+    "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake",
+    "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages",
+)
+SINGLE_NODE_POOL_HOST = "127.0.0.1"
+
+
+def _replace_localhost(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _replace_localhost(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_replace_localhost(item) for item in value]
+    if isinstance(value, str):
+        return value.replace("${LOCAL_IP}", SINGLE_NODE_POOL_HOST)
+    return value
+
+
+class SingleNodeKVPoolManager:
+    """Manage one KV pool service for a single-node YAML test case."""
+
+    def __init__(self, config: KVPoolConfig, case_name: str):
+        self.config = config
+        safe_case_name = re.sub(r"[^A-Za-z0-9_.-]+", "-", case_name)
+        self.runtime_dir = (Path(tempfile.gettempdir()) / "vllm_ascend_single_node_kv_pool" / safe_case_name).resolve()
+        self.process: subprocess.Popen | None = None
+        self.server_envs: dict[str, str] = {}
+
+    def start(self) -> None:
+        self._write_config()
+        self._start_service()
+        self._wait_ready()
+
+    def _write_config(self) -> None:
+        raise NotImplementedError
+
+    def _start_service(self) -> None:
+        raise NotImplementedError
+
+    def _ready_ports(self) -> tuple[int, ...]:
+        raise NotImplementedError
+
+    def _start_process(self, cmd: list[str], extra_env: dict[str, str]) -> None:
+        env = {**os.environ, **extra_env}
+        print(f"Starting {self.config.type} KV pool: {' '.join(cmd)}")
+        self.process = subprocess.Popen(cmd, env=env, start_new_session=True)
+
+    def _wait_ready(self, timeout: int = KV_POOL_READY_TIMEOUT_SECONDS) -> None:
+        pending_ports = set(self._ready_ports())
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.process is not None and self.process.poll() is not None:
+                raise RuntimeError(
+                    f"{self.config.type} service exited before becoming ready with code {self.process.returncode}"
+                )
+            for port in tuple(pending_ports):
+                try:
+                    with socket.create_connection((SINGLE_NODE_POOL_HOST, port), timeout=2):
+                        pending_ports.remove(port)
+                except OSError:
+                    pass
+            if not pending_ports:
+                print(f"{self.config.type} KV pool is ready")
+                return
+            time.sleep(1)
+        raise TimeoutError(f"Timed out waiting for {self.config.type} KV pool; ports={sorted(pending_ports)}")
+
+    @staticmethod
+    def _write_text_atomic(path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = path.with_suffix(f"{path.suffix}.tmp")
+        temporary_path.write_text(content, encoding="utf-8")
+        temporary_path.replace(path)
+
+    def cleanup(self) -> None:
+        if self.process is None or self.process.poll() is not None:
+            self.process = None
+            return
+        try:
+            if os.name == "posix":
+                os.killpg(os.getpgid(self.process.pid), signal.SIGTERM)
+            else:
+                self.process.terminate()
+            self.process.wait(timeout=KV_POOL_STOP_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            try:
+                if os.name == "posix":
+                    os.killpg(os.getpgid(self.process.pid), signal.SIGKILL)
+                else:
+                    self.process.kill()
+                self.process.wait(timeout=KV_POOL_STOP_TIMEOUT_SECONDS)
+            except ProcessLookupError:
+                pass
+        except ProcessLookupError:
+            pass
+        finally:
+            self.process = None
+
+    def __enter__(self):
+        try:
+            self.start()
+        except Exception:
+            self.cleanup()
+            raise
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.cleanup()
+
+
+class SingleNodeMooncakeManager(SingleNodeKVPoolManager):
+    def __init__(self, config: MooncakeKVPoolConfig, case_name: str):
+        super().__init__(config, case_name)
+        self.config = config
+        self.config_path = self.runtime_dir / "mooncake.json"
+
+    @property
+    def mooncake_config(self) -> MooncakeKVPoolConfig:
+        if not isinstance(self.config, MooncakeKVPoolConfig):
+            raise TypeError("Mooncake manager requires MooncakeKVPoolConfig")
+        return self.config
+
+    @property
+    def master_address(self) -> str:
+        return f"{SINGLE_NODE_POOL_HOST}:{self.mooncake_config.master_port}"
+
+    def _write_config(self) -> None:
+        store_config = _replace_localhost(self.config.config)
+        store_config["master_server_address"] = self.master_address
+        self._write_text_atomic(
+            self.config_path,
+            json.dumps(store_config, indent=2, ensure_ascii=False),
+        )
+        self.server_envs = {
+            "MOONCAKE_CONFIG_PATH": str(self.config_path),
+            "MOONCAKE_MASTER": self.master_address,
+        }
+
+    def _start_service(self) -> None:
+        cmd = [
+            "mooncake_master",
+            "--port",
+            str(self.mooncake_config.master_port),
+            "--metrics_port",
+            str(self.mooncake_config.metrics_port),
+            "--eviction_high_watermark_ratio",
+            str(MOONCAKE_EVICTION_HIGH_WATERMARK_RATIO),
+            "--eviction_ratio",
+            str(MOONCAKE_EVICTION_RATIO),
+            "--default_kv_lease_ttl",
+            str(MOONCAKE_DEFAULT_KV_LEASE_TTL),
+        ]
+        inherited_library_path = os.environ.get("LD_LIBRARY_PATH", "")
+        library_paths = [*MOONCAKE_LIBRARY_PATHS]
+        if inherited_library_path:
+            library_paths.append(inherited_library_path)
+        self._start_process(
+            cmd,
+            {"LD_LIBRARY_PATH": os.pathsep.join(library_paths)},
+        )
+
+    def _ready_ports(self) -> tuple[int, ...]:
+        return (self.mooncake_config.master_port,)
+
+
+class SingleNodeMemcacheManager(SingleNodeKVPoolManager):
+    def __init__(self, config: MemcacheKVPoolConfig, case_name: str):
+        super().__init__(config, case_name)
+        self.config = config
+        self.meta_config_path = self.runtime_dir / "mmc-meta.conf"
+        self.local_config_path = self.runtime_dir / "mmc-local.conf"
+
+    @property
+    def memcache_config(self) -> MemcacheKVPoolConfig:
+        if not isinstance(self.config, MemcacheKVPoolConfig):
+            raise TypeError("Memcache manager requires MemcacheKVPoolConfig")
+        return self.config
+
+    @staticmethod
+    def _format_config(config: dict[str, Any]) -> str:
+        def format_value(value: Any) -> str:
+            return str(value).lower() if isinstance(value, bool) else str(value)
+
+        return "".join(f"{key} = {format_value(value)}\n" for key, value in config.items())
+
+    def _write_config(self) -> None:
+        rendered_config = _replace_localhost(self.config.config)
+        meta_config = dict(rendered_config["meta"])
+        local_config = dict(rendered_config["local"])
+        meta_service_url = f"tcp://{SINGLE_NODE_POOL_HOST}:{self.memcache_config.meta_service_port}"
+        config_store_url = f"tcp://{SINGLE_NODE_POOL_HOST}:{self.memcache_config.config_store_port}"
+        meta_config["ock.mmc.meta_service_url"] = meta_service_url
+        meta_config["ock.mmc.meta_service.config_store_url"] = config_store_url
+        local_config["ock.mmc.meta_service_url"] = meta_service_url
+        local_config["ock.mmc.local_service.config_store_url"] = config_store_url
+        self._write_text_atomic(self.meta_config_path, self._format_config(meta_config))
+        self._write_text_atomic(self.local_config_path, self._format_config(local_config))
+        self.server_envs = {"MMC_LOCAL_CONFIG_PATH": str(self.local_config_path)}
+
+    def _start_service(self) -> None:
+        self._start_process(
+            [
+                sys.executable,
+                "-c",
+                "from memcache_hybrid import MetaService; MetaService.main()",
+            ],
+            {"MMC_META_CONFIG_PATH": str(self.meta_config_path)},
+        )
+
+    def _ready_ports(self) -> tuple[int, ...]:
+        return (
+            self.memcache_config.meta_service_port,
+            self.memcache_config.config_store_port,
+        )
+
+
+class NullSingleNodeKVPoolManager:
+    def __init__(self):
+        self.server_envs: dict[str, str] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return None
+
+
+def create_single_node_kv_pool_manager(
+    config: KVPoolConfig | None,
+    case_name: str,
+) -> SingleNodeKVPoolManager | NullSingleNodeKVPoolManager:
+    if config is None:
+        return NullSingleNodeKVPoolManager()
+    if isinstance(config, MooncakeKVPoolConfig):
+        return SingleNodeMooncakeManager(config, case_name)
+    if isinstance(config, MemcacheKVPoolConfig):
+        return SingleNodeMemcacheManager(config, case_name)
+    raise TypeError(f"Unsupported KV pool config: {type(config).__name__}")

--- a/tests/e2e/nightly/single_node/models/scripts/single_node_config.py
+++ b/tests/e2e/nightly/single_node/models/scripts/single_node_config.py
@@ -7,6 +7,8 @@ import regex as re
 import yaml
 from vllm.utils.network_utils import get_open_port
 
+from tests.e2e.common.kv_pool.config import KVPoolConfig, parse_kv_pool_config
+
 CONFIG_BASE_PATH = os.getenv("CONFIG_BASE_PATH") or "tests/e2e/nightly/single_node/models/configs"
 
 logger = logging.getLogger(__name__)
@@ -37,6 +39,7 @@ class SingleNodeConfig:
     epd_proxy_args: list[str] = field(default_factory=list)
     mm_request: dict[str, Any] = field(default_factory=dict)
     expected_response: dict[str, Any] = field(default_factory=dict)
+    kv_pool: KVPoolConfig | None = None
     extra_config: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -120,6 +123,7 @@ class SingleNodeConfigLoader:
         "epd_proxy_args",
         "expected_response",
         "mm_request",
+        "kv_pool",
     }
 
     @classmethod
@@ -192,6 +196,7 @@ class SingleNodeConfigLoader:
                     extra_config=extra_case_fields,
                     expected_response=case.get("expected_response", {}),
                     mm_request=case.get("mm_request", {}),
+                    kv_pool=parse_kv_pool_config(case.get("kv_pool")),
                 )
             )
         return result

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -14,6 +14,9 @@ import vllm
 
 from tests.e2e.conftest import DisaggEpdProxy, RemoteEPDServer, RemoteOpenAIServer
 from tests.e2e.nightly.scripts.result_postprocess import postprocess_benchmark_results
+from tests.e2e.nightly.single_node.models.scripts.kv_pool_runtime import (
+    create_single_node_kv_pool_manager,
+)
 from tests.e2e.nightly.single_node.models.scripts.single_node_config import (
     SingleNodeConfig,
     SingleNodeConfigLoader,
@@ -493,9 +496,14 @@ async def test_single_node(config: SingleNodeConfig) -> None:
                 f"{k}=={v}",
             ]
             subprocess.call(command)
+    kv_pool_manager = create_single_node_kv_pool_manager(config.kv_pool, config.name)
     if config.service_mode == "epd":
         with (
-            RemoteEPDServer(vllm_serve_args=config.epd_server_cmds, env_dict=config.envs) as _,
+            kv_pool_manager,
+            RemoteEPDServer(
+                vllm_serve_args=config.epd_server_cmds,
+                env_dict={**config.envs, **kv_pool_manager.server_envs},
+            ) as _,
             DisaggEpdProxy(proxy_args=config.epd_proxy_args, env_dict=config.envs) as proxy,
         ):
             await _dispatch_tests(config, proxy)
@@ -503,12 +511,15 @@ async def test_single_node(config: SingleNodeConfig) -> None:
         return
 
     # Standard OpenAI service mode
-    with RemoteOpenAIServer(
-        model=config.model,
-        vllm_serve_args=config.server_cmd,
-        server_port=config.server_port,
-        env_dict=config.envs,
-        auto_port=False,
-    ) as server:
+    with (
+        kv_pool_manager,
+        RemoteOpenAIServer(
+            model=config.model,
+            vllm_serve_args=config.server_cmd,
+            server_port=config.server_port,
+            env_dict={**config.envs, **kv_pool_manager.server_envs},
+            auto_port=False,
+        ) as server,
+    ):
         await _dispatch_tests(config, server)
         _run_benchmarks(config, config.server_port)

--- a/tests/e2e/weekly/multi_node/external_dp/config/Qwen2.5-7B-Instruct-mooncake-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Qwen2.5-7B-Instruct-mooncake-PD.yaml
@@ -1,0 +1,176 @@
+test_name: "Qwen2.5-7B-Instruct Mooncake KV pool PD"
+model: "Qwen/Qwen2.5-7B-Instruct"
+num_nodes: 2
+npu_per_node: 2
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0 ]
+    decoder: [ 1 ]
+
+kv_pool:
+  type: mooncake
+  master_port: 50088
+  metrics_port: 50089
+  config:
+    metadata_server: "P2PHANDSHAKE"
+    protocol: "ascend"
+    device_name: ""
+    global_segment_size: "1GB"
+    preferred_segment: false
+    prefer_alloc_in_same_node: true
+
+config:
+  - node_index: 0
+    port_start: 8100
+    dp_rpc_port: 12321
+    dp_size: 2
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 1
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 8200
+    dp_rpc_port: 12321
+    dp_size: 2
+    dp_size_local: 2
+    dp_rank_start: 0
+    tp_size: 1
+    dp_address: "${NODE_1_IP}"
+
+env_common: &env_common
+  LD_LIBRARY_PATH: "/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH"
+  PYTHONHASHSEED: "0"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  ACL_OP_INIT_MODE: "1"
+  ASCEND_ENABLE_USE_FABRIC_MEM: "1"
+  HCCL_RDMA_TIMEOUT: "17"
+  ASCEND_CONNECT_TIMEOUT: "10000"
+  ASCEND_TRANSFER_TIMEOUT: "10000"
+  SERVER_PORT: "${PORT}"
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_common
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --trust-remote-code
+      - --enforce-eager
+      - --no-enable-prefix-caching
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --max-model-len
+      - "32768"
+      - --block-size
+      - "128"
+      - --max-num-batched-tokens
+      - "16384"
+      - --kv-transfer-config
+      - >-
+        {
+          "kv_connector": "MultiConnector",
+          "kv_role": "kv_producer",
+          "kv_load_failure_policy": "fail",
+          "kv_connector_extra_config": {
+            "connectors": [
+              {
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_producer",
+                "kv_port": "20001",
+                "kv_connector_extra_config": {
+                  "prefill": {"dp_size": 2, "tp_size": 1},
+                  "decode": {"dp_size": 2, "tp_size": 1}
+                }
+              },
+              {
+                "kv_connector": "AscendStoreConnector",
+                "kv_role": "kv_producer",
+                "kv_connector_extra_config": {
+                  "lookup_rpc_port": "0",
+                  "backend": "mooncake"
+                }
+              }
+            ]
+          }
+        }
+
+  - node_index: 1
+    envs:
+      <<: *env_common
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --trust-remote-code
+      - --enforce-eager
+      - --no-enable-prefix-caching
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --max-model-len
+      - "32768"
+      - --block-size
+      - "128"
+      - --max-num-batched-tokens
+      - "16384"
+      - --kv-transfer-config
+      - >-
+        {
+          "kv_connector": "MultiConnector",
+          "kv_role": "kv_consumer",
+          "kv_load_failure_policy": "fail",
+          "kv_connector_extra_config": {
+            "connectors": [
+              {
+                "kv_connector": "MooncakeConnectorV1",
+                "kv_role": "kv_consumer",
+                "kv_port": "20002",
+                "kv_connector_extra_config": {
+                  "prefill": {"dp_size": 2, "tp_size": 1},
+                  "decode": {"dp_size": 2, "tp_size": 1}
+                }
+              },
+              {
+                "kv_connector": "AscendStoreConnector",
+                "kv_role": "kv_consumer",
+                "kv_connector_extra_config": {
+                  "lookup_rpc_port": "0",
+                  "backend": "mooncake"
+                }
+              }
+            ]
+          }
+        }
+
+benchmarks:
+  smoke:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gsm8k
+    request_conf: vllm_api_general_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+    max_out_len: 48
+    batch_size: 4
+    baseline: 0
+    threshold: 100

--- a/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-Memcache-perf.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3.5-397B-Memcache-perf.yaml
@@ -1,0 +1,67 @@
+# Memcache Pooling + Qwen3.5-397B Performance Testing
+test_cases:
+  - name: "Qwen3.5-397B-Memcache-perf"
+    model: "Eco-Tech/Qwen3.5-397B-A17B-w8a8-mtp"
+    envs:
+      PYTHONHASHSEED: "0"
+      PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      HCCL_BUFFSIZE: "1024"
+      OMP_NUM_THREADS: "1"
+      TASK_QUEUE_ENABLE: "1"
+      LD_PRELOAD: "/usr/lib64/libjemalloc.so.2"
+      SERVER_PORT: "DEFAULT_PORT"
+    kv_pool:
+      type: "memcache"
+      meta_service_port: 5000
+      config_store_port: 6000
+      config:
+        meta:
+          ock.mmc.log_level: "info"
+        local:
+          ock.mmc.log_level: "info"
+          ock.mmc.local_service.world_size: 256
+          ock.mmc.local_service.protocol: "device_sdma"
+          ock.mmc.local_service.dram.size: "10GB"
+    server_cmd:
+      - "--data-parallel-size"
+      - "1"
+      - "--tensor-parallel-size"
+      - "16"
+      - "--enable-expert-parallel"
+      - "--seed"
+      - "1024"
+      - "--quantization"
+      - "ascend"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-num-seqs"
+      - "128"
+      - "--max-model-len"
+      - "133000"
+      - "--max-num-batched-tokens"
+      - "16384"
+      - "--trust-remote-code"
+      - "--gpu-memory-utilization"
+      - "0.90"
+      - "--enable-prefix-caching"
+      - "--speculative-config"
+      - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3, "enforce_eager": true}'
+      - "--compilation-config"
+      - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+      - "--additional-config"
+      - '{"enable_cpu_binding":true, "enable_fused_mc2":1, "enable_flashcomm1":true}'
+      - "--kv-transfer-config"
+      - '{"kv_connector": "AscendStoreConnector", "kv_role": "kv_both", "kv_connector_extra_config": {"backend": "memcache", "lookup_rpc_port": "0"}}'
+    benchmarks:
+      perf:
+        case_type: performance
+        dataset_path: vllm-ascend/GSM8K-in32768-bs400
+        request_conf: vllm_api_stream_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+        num_prompts: 64
+        max_out_len: 1500
+        batch_size: 32
+        request_rate: 0
+        baseline: 1
+        threshold: 0.97


### PR DESCRIPTION
### What this PR does / why we need it?
This pull request introduces a shared KV pool management system for E2E test frameworks, supporting both Mooncake and Memcache backends. It includes configuration parsing, validation, and runtime managers for both single-node and multi-node environments.

### Does this PR introduce _any_ user-facing change?
No, these changes are internal to the E2E testing framework.

### How was this patch tested?
Integrated into the E2E nightly and weekly test pipelines, with a new performance test case added for Qwen3.5-397B using Memcache.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
