### PR TITLE
[BugFix][releases/v0.23.0] fix spelling errors of 'get_rotataion_maxtrix'

### DIFF
--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -53,7 +53,7 @@ def get_rotation_path(target_vllm_config):
     return Path(target_model_path) / rotation_relative_path
 
 
-def get_rotataion_matrix(rotation_path):
+def get_rotation_matrix(rotation_path):
     """
     Anti-rotate maxtrix.
     """
@@ -90,7 +90,7 @@ def patch_load_weights(target_vllm_config):
 
 def make_load_weights(target_model_path, rotation_path):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-        Q = get_rotataion_matrix(rotation_path)
+        Q = get_rotation_matrix(rotation_path)
         Q3 = compute_rotataion_matrix3(Q)
         if isinstance(self.config.dtype, str):
             embed_dtype = getattr(torch, self.config.dtype)


### PR DESCRIPTION
### What this PR does / why we need it?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
