### PR TITLE
[BugFix][Performance] Skip identity d2t mapping for full-vocab drafts

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -259,6 +259,15 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "disable_padded_drafter_batch in the speculative_config."
             )
 
+    def _maybe_remove_d2t(self, draft_model: nn.Module) -> None:
+        """Drop the identity d2t mapping of a full-vocab EAGLE3 draft."""
+        if self.method != "eagle3":
+            return
+        target_vocab_size = self.speculative_config.draft_model_config.get_vocab_size()
+        draft_vocab_size = draft_model.config.draft_vocab_size
+        if draft_vocab_size == target_vocab_size:
+            draft_model.draft_id_to_target_id = None
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which
@@ -280,6 +289,8 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 model_config=self.speculative_config.draft_model_config,
                 load_config=self.speculative_config.draft_load_config,
             )
+            self._maybe_remove_d2t(model)
+
         return model
 
     def load_model(self, model: nn.Module) -> None:


### PR DESCRIPTION
### What this PR does / why we need it?

When the draft model uses the full target vocabulary (`draft_vocab_size == vocab_size`), the `draft_id_to_target_id` mapping is the identity. The draft's `compute_logits` still builds a full-vocab `-inf` buffer and scatters logits through this identity mapping on every call, which is pure overhead: measured ~1.4 ms per call at (112, 151936) bf16 — ~55x the cost of a plain copy, and comparable to the lm_head matmul itself.

This drops the mapping right after the draft model loads when the vocab sizes are equal, so `compute_logits` takes the fast path and returns logits unchanged.

### Does this PR introduce any user-facing change?

No.

### How was this patch tested?

1. Verified with a Qwen3-8B target and the EAGLE3 draft `Qwen3-8B-speculator-eagle3`: the live `draft_id_to_target_id` table dumped from a real run equals `arange` (identity), and the scatter output is bit-identical to its input for real tensors, so skipping it is a no-op transform.
2. A micro-benchmark of the removed op shows `logits_new[:, targets] = logits` at (112, 151936) bf16 takes ~1.42 ms/op, vs 0.019 ms for a plain `copy_`.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
