### PR TITLE
[Misc] Add concurrent-log-handler to Dockerfiles- #14645

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -71,6 +71,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -67,6 +67,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -63,6 +63,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -59,6 +59,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -67,6 +67,7 @@ RUN export PIP_EXTRA_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pyp
     python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index https://download.pytorch.org/whl/cpu/ && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url https://mirrors.huaweicloud.com/ascend/repos/pypi && \
+    python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek_V4_Flash_A5.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek_V4_Flash_A5.yaml
@@ -66,7 +66,7 @@ _benchmarks_per2: &benchmarks_per
 # ACTUAL TEST CASES
 # ==========================================
 test_cases:
-  - name: "DeepSeekV4_Flash_A5_Signle_GPQA_Accurancy_Test_01"
+  - name: "DeepSeekV4_Flash_A5_Signal_GPQA_Accuracy_Test_01"
     model: "/root/.cache/modelscope/hub/models/models--deepseek-ai--DeepSeek-V4-Flash"
     envs:
       <<: *envs

--- a/tests/e2e/weekly/single_node/configs/DeepSeek_V4_Flash_A5.yaml
+++ b/tests/e2e/weekly/single_node/configs/DeepSeek_V4_Flash_A5.yaml
@@ -66,7 +66,7 @@ _benchmarks_per2: &benchmarks_per
 # ACTUAL TEST CASES
 # ==========================================
 test_cases:
-  - name: "DeepSeekV4_Flash_A5_Signle_GPQA_Accurancy_Test_01"
+  - name: "DeepSeekV4_Flash_A5_Signal_GPQA_Accuracy_Test_01"
     model: "/root/.cache/modelscope/hub/models/models--deepseek-ai--DeepSeek-V4-Flash"
     envs:
       <<: *envs


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds `concurrent-log-handler` to the Dockerfiles to support concurrent logging.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Base image:

- Test step:
```
export VLLM_CONFIGURE_LOGGING=1
export VLLM_LOGGING_CONFIG_PATH=/mnt/share/vllm_log_rotate.json
```
vllm_log_rotate.json:
```
{
    "version": 1,
    "disable_existing_loggers": false,
    "formatters": {
        "standard": {
            "format": "%(asctime)s [%(levelname)s] %(name)s:%(lineno)d - %(message)s",
            "datefmt": "%Y-%m-%d %H:%M:%S"
        }
    },
    "handlers": {
        "console": {
            "class": "logging.StreamHandler",
            "level": "INFO",
            "formatter": "standard",
            "stream": "ext://sys.stdout"
        },
        "concurrent_rotating_file": {
            "class": "concurrent_log_handler.ConcurrentRotatingFileHandler",
            "level": "INFO",
            "formatter": "standard",
            "filename": "/mnt/share/test.log",
            "maxBytes": 20,
            "backupCount": 10,
            "encoding": "utf-8"
        }
    },
    "loggers": {
        "vllm": {
            "level": "INFO",
            "handlers": ["console", "concurrent_rotating_file"],
            "propagate": false
        }
    },
    "root": {
        "level": "INFO",
        "handlers": ["console", "concurrent_rotating_file"]
    }
}
```
- Test results:
<img width="812" height="348" alt="image" src="https://github.com/user-attachments/assets/e27592bc-bfb1-46de-b4db-989965e1372c" />
<img width="443" height="185" alt="image" src="https://github.com/user-attachments/assets/04969ac0-a071-4366-aee4-58688bc52337" />


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
