### PR TITLE
[CI]Update the test case regex to handle rename scenarios. Restrict rename handling and precision testing to product code only (Python files).

### DIFF
--- a/.github/workflows/scripts/test_selector.py
+++ b/.github/workflows/scripts/test_selector.py
@@ -59,10 +59,13 @@ def _get_test_files_from_pr_diff(diff_file: str) -> list[str]:
         return test_files_found
 
     # Pattern to match test file paths: tests/e2e/pull_request/ or tests/ut/ directory
-    # In diff output: +++ b/tests/ut/core/test_xxx.py
+    # In diff output:
+    #   - +++ b/tests/ut/core/test_xxx.py (new/modified test file)
+    #   - rename to tests/ut/attention/test_xxx.py (renamed test file)
     # Test files must be in tests/e2e/pull_request/ or tests/ut/ directory and start with test_
     test_file_pattern = re.compile(
-        r"^\+\+\+ [ab]/(tests/e2e/pull_request(?:/.+)?/test_\w+\.py|tests/ut(?:/.+)?/test_\w+\.py)", re.MULTILINE
+        r"^(?:\+\+\+ [ab]/|rename to )((?:tests/e2e/pull_request(?:/.+)?/test_\w+\.py|tests/ut(?:/.+)?/test_\w+\.py))",
+        re.MULTILINE,
     )
 
     changed_test_files = set()
@@ -434,7 +437,7 @@ class CodeChangeDetector:
 
     def detect_renames(self, diff_output: str) -> dict[str, str]:
         """
-        Detect file renames in git diff output.
+        Detect file renames in git diff output (product code only, vllm_ascend/).
 
         Args:
             diff_output: diff content
@@ -459,7 +462,9 @@ class CodeChangeDetector:
                     # Remove a/ or b/ prefix if present
                     old_path = current_old_path[2:] if current_old_path.startswith("a/") else current_old_path
                     new_path = current_new_path[2:] if current_new_path.startswith("b/") else current_new_path
-                    renames[old_path] = new_path
+                    # Only record product code renames (vllm_ascend/)
+                    if old_path.startswith(f"{REPO_NAME}/"):
+                        renames[old_path] = new_path
                     current_old_path = None
                     current_new_path = None
 
@@ -1221,8 +1226,10 @@ def main():
             print(f"Parsed {len(changed_files_with_lines)} changed files:")
             for file_path, line_set in changed_files_with_lines.items():
                 print(f"  {file_path}")
+
+            # detect_renames already filters to vllm_ascend/ prefix only (product code renames)
             if renames:
-                print(f"\n=== Detected {len(renames)} Renamed File(s) - Using File-Level Matching ===")
+                print(f"\n=== Detected {len(renames)} Product Code Renamed File(s) - Using File-Level Matching ===")
                 for old_path, new_path in renames.items():
                     print(f"  {old_path} -> {new_path}")
 


### PR DESCRIPTION
Updates the test case matching regex to properly handle file rename scenarios. Restricts the rename detection and handling logic to Python product code files only.

### What this PR does / why we need it?
This PR makes the following changes:
Updates the test case matching regex to properly handle file rename scenarios.
*Restricts the rename detection and handling logic to Python product code files only (e.g., .py). Non-Python files are excluded from rename processing.
### Does this PR introduce _any_ user-facing change?
No. This PR does not introduce any user-facing changes.
### How was this patch tested?
This patch was tested through the following approaches:
Test the rename scenario for test cases, as well as other scenarios.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
