### PR TITLE
[BugFix][v0.26.0rc] Fix MegaMoe hang when main and draft models have inconsistent MoE quantization

### DIFF
--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -9,6 +9,7 @@ from vllm_ascend.ascend_forward_context import MoECommType
 @pytest.fixture(autouse=True)
 def reset_mc2_tokens_capacity(monkeypatch):
     monkeypatch.setattr(afc, "_mc2_tokens_capacity", None)
+    monkeypatch.setattr(afc, "_moe_quant_mismatch", None)
     monkeypatch.setattr(
         afc,
         "get_ascend_config",
@@ -379,3 +380,34 @@ def test_select_moe_comm_method_310p_uses_allgather(monkeypatch):
     )
 
     assert afc.select_moe_comm_method(128, _make_vllm_config()) == MoECommType.ALLGATHER
+
+
+@pytest.mark.parametrize(
+    ("is_draft_model", "moe_quant_mismatch", "num_tokens", "expected"),
+    [
+        (True, True, 128, MoECommType.MC2),
+        (True, True, 129, MoECommType.ALLTOALL),
+        (False, True, 128, MoECommType.FUSED_MC2),
+        (True, False, 128, MoECommType.FUSED_MC2),
+    ],
+)
+def test_select_a3_draft_quant_mismatch(
+    monkeypatch,
+    is_draft_model,
+    moe_quant_mismatch,
+    num_tokens,
+    expected,
+):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=256,
+        ep_world_size=8,
+        enable_fused_mc2=1,
+    )
+    monkeypatch.setattr(afc, "get_dispatch_v2_tokens_capacity", lambda: 128)
+    monkeypatch.setattr(afc, "_moe_quant_mismatch", moe_quant_mismatch)
+
+    vllm_config = _make_vllm_config()
+
+    assert afc.select_moe_comm_method(num_tokens, vllm_config, is_draft_model=is_draft_model) == expected

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -161,6 +161,7 @@ def set_ascend_forward_context(
         moe_comm_type = select_moe_comm_method(
             max_num_tokens,
             vllm_config,
+            is_draft_model=is_draft_model,
         )
 
         forward_context.moe_comm_type = moe_comm_type
@@ -262,6 +263,10 @@ def set_ascend_forward_context(
 
 _mc2_tokens_capacity: int | None = None
 _reserved_mc2_mask: torch.Tensor | None = None
+# TODO: Remove the following variables and related methods once the megamoe operator supports mixed weight formats
+#  (e.g., main model quantized, draft model in floating point)
+_moe_quant_mismatch: bool | None = None
+_dispatch_v2_tokens_capacity: int | None = None
 
 
 def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len):
@@ -288,6 +293,8 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
             num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _MEGA_MOE_TOKENS_PER_RANK_LIMIT)
         else:
             num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT)
+        global _dispatch_v2_tokens_capacity
+        _dispatch_v2_tokens_capacity = min(num_tokens_per_tp_rank, _MC2_TOKENS_PER_RANK_LIMIT) * tp_size
 
     # keep the num_tokens_per_tp_rank less than mc2 tokens per rank limit
     else:
@@ -297,6 +304,10 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
 
 def get_mc2_tokens_capacity():
     return _mc2_tokens_capacity
+
+
+def get_dispatch_v2_tokens_capacity():
+    return _dispatch_v2_tokens_capacity
 
 
 def set_mc2_mask(vllm_config, device):
@@ -332,16 +343,88 @@ def _select_a2_moe_comm_method(
     return MoECommType.ALLGATHER
 
 
+def _is_moe_quantized(model_instance: torch.nn.Module) -> bool | None:
+    """Check if the model's MoE layers use a quantized method.
+
+    Scans the model for the first ``routed_experts.quant_method`` and checks
+    whether it is an unquantized (float) or quantized MoE method instance.
+    modelslim quantization cannot be reliably detected from config, so the
+    actual runtime instance type is used instead.
+
+    Returns ``True`` if quantized, ``False`` if unquantized, ``None`` if no MoE
+    layers are found (e.g. dense model or ``model_instance`` is ``None``).
+    """
+    if model_instance is None:
+        return None
+    for module in model_instance.modules():
+        routed_experts = getattr(module, "routed_experts", None)
+        if routed_experts is None:
+            continue
+        quant_method = getattr(routed_experts, "quant_method", None)
+        if quant_method is None:
+            continue
+        from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import (
+            UnquantizedFusedMoEMethod,
+        )
+
+        return not isinstance(quant_method, UnquantizedFusedMoEMethod)
+    return None
+
+
+def set_moe_quant_mismatch(
+    main_model: torch.nn.Module | None,
+    draft_model: torch.nn.Module | None,
+) -> None:
+    """Cache whether the main and draft models have inconsistent MoE quantization.
+
+    MegaMoe is configured from the MoE-part weight format. When the main model
+    and the draft model use different MoE quantization (e.g. main is quantized
+    while the draft is floating-point), the MegaMoe kernel cannot handle the
+    mixed weight formats and hangs.
+
+    Should be called once after both models are loaded. The weight format is
+    fixed for the lifetime of the process, so the result is cached. Only the MoE
+    part is compared; a model without MoE layers (or a ``None`` draft model)
+    never exercises the MegaMoe path, so its quantization is irrelevant.
+    """
+    global _moe_quant_mismatch
+    if _moe_quant_mismatch is not None:
+        return
+
+    _moe_quant_mismatch = False
+    main_quantized = _is_moe_quantized(main_model)
+    if main_quantized is None:
+        return
+
+    draft_quantized = _is_moe_quantized(draft_model)
+    if draft_quantized is None:
+        return
+
+    if main_quantized != draft_quantized:
+        _moe_quant_mismatch = True
+        logger.warning_once(
+            "FUSED_MC2 disabled on draft model path due to inconsistent MoE "
+            "quantization between main model (quantized=%s) and draft model "
+            "(quantized=%s). Main model still uses FUSED_MC2; draft model falls "
+            "back to MC2/ALLTOALL.",
+            main_quantized,
+            draft_quantized,
+        )
+
+
 def _select_a3_moe_comm_method(
     num_tokens: int,
     mc2_tokens_capacity: int,
     vllm_config: VllmConfig,
+    is_draft_model: bool = False,
 ) -> MoECommType:
-    if use_cann_megamoe(vllm_config):
+    skip_fused_mc2 = is_draft_model and _moe_quant_mismatch
+    if not skip_fused_mc2 and use_cann_megamoe(vllm_config):
         return MoECommType.FUSED_MC2
-    if get_ascend_config().enable_fused_mc2 == 1 and get_ep_group().world_size <= 32:
+    if not skip_fused_mc2 and get_ascend_config().enable_fused_mc2 == 1 and get_ep_group().world_size <= 32:
         return MoECommType.FUSED_MC2
 
+    mc2_tokens_capacity = get_dispatch_v2_tokens_capacity() or mc2_tokens_capacity
     if num_tokens <= mc2_tokens_capacity:
         return MoECommType.MC2
 
@@ -366,7 +449,11 @@ def _select_a5_moe_comm_method(
     return MoECommType.ALLTOALL
 
 
-def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommType | None:
+def select_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    is_draft_model: bool = False,
+) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, and token count.
 
@@ -414,6 +501,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
             num_tokens,
             mc2_tokens_capacity,
             vllm_config,
+            is_draft_model=is_draft_model,
         )
     elif soc_version == AscendDeviceType.A5:
         moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -296,7 +296,7 @@ class FusedMC2CommImpl(MoECommMethod):
         return self.prepare_finalize.pad_and_split_input_ids(input_ids)  # type: ignore[attr-defined]
 
     def _get_token_dispatcher(self):
-        return TokenDispatcherWithMC2()
+        return TokenDispatcherWithMC2(is_fused_mc2=True)
 
     def _get_prepare_finalize(self):
         return PrepareAndFinalizeWithMC2(self.moe_config)

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -29,7 +29,7 @@ from vllm.config import get_current_vllm_config
 from vllm.distributed.parallel_state import get_ep_group
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
+from vllm_ascend.ascend_forward_context import get_dispatch_v2_tokens_capacity, get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.lora.fused_moe import (
@@ -132,6 +132,8 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         vllm_config = get_current_vllm_config()
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         mc2_tokens_capacity = get_mc2_tokens_capacity()
+        if not kwargs.get("is_fused_mc2", False):
+            mc2_tokens_capacity = get_dispatch_v2_tokens_capacity() or mc2_tokens_capacity
         num_tokens_per_tp_rank = mc2_tokens_capacity // tp_size
         # Surface the per-rank capacity for CANN MegaMoe's get_symm_buffer
         # sizing (used by FusedMC2CommImpl._get_cann_symm_buffer). Without

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -1211,9 +1211,11 @@ def should_skip_allreduce_across_dp_group(vllm_config: VllmConfig, is_draft_mode
 
     scheduler_config = vllm_config.scheduler_config
     # potential_max_tokens is read from the set/get global (computed once in init).
-    decode_comm_method = select_moe_comm_method(get_potential_max_tokens(), vllm_config)
+    decode_comm_method = select_moe_comm_method(get_potential_max_tokens(), vllm_config, is_draft_model=is_draft_model)
     # For prefill, use the scheduler's max_num_batched_tokens for a single batch.
-    prefill_comm_method = select_moe_comm_method(scheduler_config.max_num_batched_tokens, vllm_config)
+    prefill_comm_method = select_moe_comm_method(
+        scheduler_config.max_num_batched_tokens, vllm_config, is_draft_model=is_draft_model
+    )
 
     if use_cann_megamoe(vllm_config):
         return False

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -198,6 +198,7 @@ from vllm_ascend.ascend_forward_context import (  # isort: skip
     set_ascend_forward_context,
     set_mc2_mask,
     set_mc2_tokens_capacity,
+    set_moe_quant_mismatch,
 )
 
 from vllm.model_executor.models.interfaces import supports_multimodal_pruning
@@ -3613,6 +3614,11 @@ class NPUModelRunner(GPUModelRunner):
                     patch_load_weights(self.vllm_config)
                 with get_tp_context(self.drafter):
                     self.drafter.load_model(self.model)
+
+            set_moe_quant_mismatch(
+                self.model,
+                getattr(self.drafter, "model", None) if self.drafter else None,
+            )
 
             pp_group = get_pp_group()
             should_configure_aux_hidden_states = (


### PR DESCRIPTION

### What this PR does / why we need it?
If the quantization modes of the main model and draft model are inconsistent, for example, the main model is a quantized model and the draft model is a floating-point model, the MEGAMOE operator reports an error, indicating that this format is not supported.
The error message is as follows:
```
RuntimeError: call aclnnMegaMoe failed, detail:[PID: 2799] 2026-08-20-22:15:59.473.813 Execution_Error(EZ1008): Failed to execute operator MegaMoe_6081. Reason: Failed to execute tiling function.
        Solution: 1.If the tiling function does not exist, check whether the tiling function is registered successfully. 2.If the tiling function fails to be executed, check the implementation logic of the tiling function.
TraceBack (most recent call last):
        weight1[0] must be 2-dimension, but got 3 dim.[FUNC:CheckWeight1Input][FILE:mega_moe_tiling_arch22.cpp][LINE:648]
        CheckWeight1Input failed.[FUNC:MegaMoeA2A3CheckShapeAndSetTiling][FILE:mega_moe_tiling_arch22.cpp][LINE:860]
        MegaMoeA2A3 CheckShapeAndSetTiling Failed[FUNC:MegaMoeA2A3TilingFuncImpl][FILE:mega_moe_tiling_arch22.cpp][LINE:1139]
        Failed to execute operator MegaMoe_6081. Reason: Failed to execute tiling function.
        Check NnopbaseExecutorDoTiling(executor) failed
        Check NnopbaseExecutorTilingAndUpdateBinInfo(executor) failed
        Check NnopbaseExecutorMatchCache(executor) failed
        Check NnopbaseRunForWorkspace(*executor, workspaceSize) failed
```

**Modification plan:**
When it is identified that the current weight is in this hybrid format, the draft model will be rolled back to the small operator path.

This PR is only a workaround for version 0.26.0rc. The main branch will address this issue through the megamoe operator.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
nightly test case: `glm-4.7-w8a8`


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
