### PR TITLE
[v0.26.0][Feature] dspark: always replicate the Markov head via ReplicatedGroup

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -534,8 +534,10 @@
   base: spec_decode_base
   source_file_dependencies:
     - vllm_ascend/spec_decode/dspark_proposer.py
+    - vllm_ascend/ops/vocab_parallel_embedding.py
   tests:
     - tests/e2e/pull_request/one_card/spec_decode/test_dspark.py
+    - tests/e2e/pull_request/four_card/spec_decode/test_dspark_qwen3.py
 
 - name: spec_decode_extract_hidden_states
   optional: false
@@ -809,6 +811,7 @@ estimated_times:
   tests/e2e/pull_request/four_card/context_parallel/test_prefix_caching_cp.py: 210
   tests/e2e/pull_request/four_card/spec_decode/test_mtp_qwen3_next.py: 450
   tests/e2e/pull_request/four_card/spec_decode/test_dspark_deepseekv4.py: 0
+  tests/e2e/pull_request/four_card/spec_decode/test_dspark_qwen3.py: 360
   tests/e2e/pull_request/four_card/spec_decode/test_mtp_step3p5.py: 30
   tests/e2e/pull_request/eight_card/test_glm5_2.py: 3600
   tests/e2e/pull_request/four_card/test_data_parallel_tp2.py: 20

--- a/tests/e2e/pull_request/four_card/spec_decode/test_dspark_qwen3.py
+++ b/tests/e2e/pull_request/four_card/spec_decode/test_dspark_qwen3.py
@@ -1,0 +1,126 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+"""DSpark draft acceptance on TP4.
+
+The DSpark markov head (markov_w1 VocabParallelEmbedding + markov_w2
+ParallelLMHead) is replicated on every TP rank via the ReplicatedGroup
+instead of being TP-sharded, so the per-draft-step TP all-reduce and
+all-gather disappear. The one-card TP1 case
+(tests/e2e/pull_request/one_card/spec_decode/test_dspark.py) already
+exercises the routing at tp_size==1; this TP4 case pins that holding the
+full markov tables on all four ranks keeps draft acceptance at the TP1
+level.
+
+Run `pytest tests/e2e/pull_request/four_card/spec_decode/test_dspark_qwen3.py`.
+"""
+
+import os
+from typing import Any
+
+import pytest
+from transformers import AutoTokenizer
+from vllm import SamplingParams
+from vllm.config import CompilationConfig
+from vllm.v1.metrics.reader import Counter, Vector
+
+from tests.e2e.conftest import VllmRunner, cleanup_dist_env_and_memory
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+MODELS = ["Qwen/Qwen3-8B"]
+# Same models as the one-card TP1 dspark case
+# (tests/e2e/pull_request/one_card/spec_decode/utils.py).
+DRAFT_MODEL = "deepseek-ai/dspark_qwen3_8b_block7"
+NUM_SPECULATIVE_TOKENS = 7
+# Same acceptance baseline as the one-card TP1 dspark case.
+GOLDEN = [1.0, 0.8, 0.6, 0.6, 0.6, 0.6, 0.6]
+
+
+def acceptance_per_pos(metrics: list[Any], num_speculative_tokens: int) -> list[float]:
+    num_drafts = 0
+    num_accepted_tokens_per_pos = [0] * num_speculative_tokens
+    for metric in metrics:
+        if metric.name == "vllm:spec_decode_num_drafts":
+            assert isinstance(metric, Counter)
+            num_drafts += metric.value
+        elif metric.name == "vllm:spec_decode_num_accepted_tokens_per_pos":
+            assert isinstance(metric, Vector)
+            for pos in range(len(metric.values)):
+                num_accepted_tokens_per_pos[pos] += metric.values[pos]
+    return [num_accepted / num_drafts for num_accepted in num_accepted_tokens_per_pos]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_dspark_acceptance_tp4(model_name: str):
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_name,
+        trust_remote_code=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        ignore_eos=False,
+        max_tokens=256,
+    )
+
+    prompts = [{"role": "user", "content": "Hello, your name is"}]
+    prompts = [
+        tokenizer.apply_chat_template(
+            [prompt],
+            tokenize=False,
+            add_generation_prompt=True,
+            enable_thinking=False,
+        )
+        for prompt in prompts
+    ]
+
+    speculative_config = {
+        "method": "dspark",
+        "model": DRAFT_MODEL,
+        "num_speculative_tokens": NUM_SPECULATIVE_TOKENS,
+    }
+
+    compilation_config = CompilationConfig(cudagraph_mode="PIECEWISE", cudagraph_capture_sizes=[7, 8])
+
+    with VllmRunner(
+        model_name,
+        max_model_len=4096,
+        disable_log_stats=False,
+        tensor_parallel_size=4,
+        max_num_seqs=256,
+        distributed_executor_backend="mp",
+        gpu_memory_utilization=0.8,
+        speculative_config=speculative_config,
+        compilation_config=compilation_config,
+        enable_prefix_caching=False,
+    ) as llm:
+        outputs = llm.model.generate(prompts, sampling_params)
+        metrics = llm.model.get_metrics()
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        output_tokens = output.outputs[0].token_ids
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")
+        print(f"Output tokens: {output_tokens}")
+
+    acceptance = acceptance_per_pos(metrics, NUM_SPECULATIVE_TOKENS)
+
+    match = all(abs(a - b) < 0.1 for a, b in zip(acceptance, GOLDEN))
+    assert match, f"acceptance_per_pos {acceptance} does not match golden {GOLDEN}"
+    cleanup_dist_env_and_memory()

--- a/tests/ut/ops/test_vocab_parallel_embedding.py
+++ b/tests/ut/ops/test_vocab_parallel_embedding.py
@@ -139,8 +139,9 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
         layer.quant_method.embedding.assert_called_once_with(layer, input_.long())
         self.assertEqual(output.shape, (3, layer.embedding_dim))
 
-        # Verify all_reduce was called once
-        mock_reduce_tp1.assert_called_once()
+        # A tp_size==1 layer already holds the full output locally (e.g. the
+        # replicated DSpark Markov head), so the reduce must be skipped.
+        mock_reduce_tp1.assert_not_called()
 
     def test_forward_with_tp(self):
         layer = self._create_layer()
@@ -201,6 +202,55 @@ class TestCustomVocabParallelEmbedding(unittest.TestCase):
                     output = layer.forward(input_)
                 self.assertEqual(output.shape, expected_shape)
 
+    def test_markov_prefix_always_replicated(self):
+        """The DSpark Markov head is replicated on every rank (vllm#49731).
+
+        The markov prefix must win over the lmhead prefix match ("markov_head"
+        contains "head") even when lmhead_tp is enabled — setUp makes
+        lmhead_tp_enable() return True — and pin the layer to the
+        world_size=1 ReplicatedGroup so every rank holds the full table and
+        forward skips all communication.
+        """
+        markov_group = MagicMock()
+        markov_group.world_size = 1
+        markov_group.rank_in_group = 0
+        with (
+            patch("vllm_ascend.ops.vocab_parallel_embedding.get_markov_tp_group", return_value=markov_group),
+            patch("vllm_ascend.ops.vocab_parallel_embedding.get_tp_group", return_value=MagicMock()),
+            patch(
+                "vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            patch(
+                "vllm.model_executor.layers.vocab_parallel_embedding.get_tensor_model_parallel_world_size",
+                return_value=2,
+            ),
+            patch(
+                "vllm.model_executor.layers.vocab_parallel_embedding.pad_vocab_size",
+                side_effect=lambda x, y: x + y,
+            ),
+            patch("vllm.model_executor.layers.vocab_parallel_embedding.divide", side_effect=lambda x, y: x // y),
+        ):
+            layer = AscendVocabParallelEmbedding(
+                num_embeddings=self.num_embeddings,
+                embedding_dim=self.embedding_dim,
+                org_num_embeddings=self.org_num_embeddings,
+                padding_size=self.padding_size,
+                quant_config=None,
+                prefix="markov_head.markov_w2",
+            )
+
+        self.assertIs(layer.comm_group, markov_group)
+        self.assertEqual(layer.tp_size, 1)
+        self.assertEqual(layer.tp_rank, 0)
+        self.assertIsNone(layer.forward_type)
+
+        # tp_size==1: shard indices cover the full padded vocab, so each rank
+        # holds the entire markov table (no padding rows reserved for peers).
+        self.assertEqual(layer.num_embeddings_per_partition, layer.num_embeddings_padded)
+        self.assertEqual(layer.num_org_embeddings_per_partition, layer.org_vocab_size_padded)
+        self.assertEqual(layer.num_added_embeddings_per_partition, layer.num_added_embeddings)
+
 
 class TestAscendLogitsProcessor(unittest.TestCase):
     def setUp(self):
@@ -260,3 +310,38 @@ class TestAscendLogitsProcessor(unittest.TestCase):
         hidden_state = torch.randn(1, self.org_num_embeddings)
         processor._get_logits(hidden_state, lmhead)
         self.mock_quant_method.apply.assert_called_once()
+
+    def test_get_logits_replicated_head_takes_normal_path(self):
+        """A replicated head (tp_size==1, e.g. the DSpark Markov w2) must not
+        join the lmhead_tp logits exchange even when lmhead_tp is enabled:
+        it holds the full table locally, so gathering/scattering across the
+        finegrained group would be wrong."""
+        hidden_states = torch.randn(1, 4)
+        replicated_head = MagicMock()
+        replicated_head.tp_size = 1
+        processor = AscendLogitsProcessor(vocab_size=self.vocab_size)
+        with (
+            patch.object(processor, "_get_logits_normal", return_value="normal") as mock_normal,
+            patch.object(processor, "_get_logits_lmheadtp") as mock_lmheadtp,
+        ):
+            result = processor._get_logits(hidden_states, replicated_head, None)
+
+        self.assertEqual(result, "normal")
+        mock_normal.assert_called_once_with(hidden_states, replicated_head, None)
+        mock_lmheadtp.assert_not_called()
+
+    def test_get_logits_sharded_head_takes_lmheadtp_path(self):
+        """A tp_size>1 lm_head keeps the lmhead_tp path (guard precision)."""
+        hidden_states = torch.randn(1, 4)
+        sharded_head = MagicMock()
+        sharded_head.tp_size = 2
+        processor = AscendLogitsProcessor(vocab_size=self.vocab_size)
+        with (
+            patch.object(processor, "_get_logits_normal") as mock_normal,
+            patch.object(processor, "_get_logits_lmheadtp", return_value="lmheadtp") as mock_lmheadtp,
+        ):
+            result = processor._get_logits(hidden_states, sharded_head, None)
+
+        self.assertEqual(result, "lmheadtp")
+        mock_lmheadtp.assert_called_once_with(hidden_states, sharded_head, None)
+        mock_normal.assert_not_called()

--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -18,6 +18,36 @@ _P_TP: GroupCoordinator | None = None
 _DYNAMIC_EPLB: GroupCoordinator | None = None
 
 
+class ReplicatedGroup:
+    """A no-communication stand-in for a TP group of world_size 1.
+
+    Used to replicate a parameter across ranks (e.g. the DSpark Markov head,
+    which is always replicated): every rank holds the full weight, so there is
+    nothing to all-reduce / all-gather. Unlike a real ``GroupCoordinator``,
+    constructing this does **not** call ``hcclCommInitRootInfoConfig`` — it is
+    a pure logical object exposing just the attributes
+    ``AscendVocabParallelEmbedding`` reads (``world_size``, ``rank_in_group``)
+    plus no-op comm methods for safety.
+    """
+
+    world_size = 1
+    rank_in_group = 0
+    device_group = None
+
+    def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
+        return input_
+
+    def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        return input_
+
+    def destroy(self) -> None:
+        pass
+
+
+# Singleton: identical on every rank, no HCCL comm created.
+_MARKOV_TP = ReplicatedGroup()
+
+
 def init_ascend_model_parallel(
     parallel_config: ParallelConfig,
 ):
@@ -161,6 +191,10 @@ def get_lmhead_tp_group() -> GroupCoordinator:
 def get_embed_tp_group() -> GroupCoordinator:
     assert _EMBED_TP is not None, "emtp group is not initialized"
     return _EMBED_TP
+
+
+def get_markov_tp_group() -> ReplicatedGroup:
+    return _MARKOV_TP
 
 
 def get_p_tp_group() -> GroupCoordinator:

--- a/vllm_ascend/ops/vocab_parallel_embedding.py
+++ b/vllm_ascend/ops/vocab_parallel_embedding.py
@@ -38,7 +38,7 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.utils import set_weight_attrs
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.distributed.parallel_state import get_embed_tp_group, get_lmhead_tp_group
+from vllm_ascend.distributed.parallel_state import get_embed_tp_group, get_lmhead_tp_group, get_markov_tp_group
 from vllm_ascend.utils import embedding_tp_enable, get_potential_max_tokens, lmhead_tp_enable
 
 
@@ -61,7 +61,19 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
     ):
         nn.Module.__init__(self)
         self.forward_type = None
-        if lmhead_tp_enable() and "head" in prefix:
+        # markov must be checked before lmhead: the DSpark Markov head prefix
+        # ("markov_head.markov_w1/w2") contains "head", so it would otherwise
+        # be routed to the lmhead_tp group. The Markov head is always
+        # replicated (matching upstream vllm#49731): the causal-correction
+        # loop runs serially per draft position, so sharding markov_w1 /
+        # markov_w2 would add a per-step TP all-reduce and all-gather, while
+        # each rank holding the full V x r / r x V table computes the same
+        # result locally at ~150 MB extra HBM. The ReplicatedGroup is a pure
+        # world_size=1 stand-in (no hcclCommInitRootInfoConfig); tp_size=1
+        # makes shard_indices cover the full vocab and forward skip all comm.
+        if "markov" in prefix:
+            self.comm_group = get_markov_tp_group()
+        elif lmhead_tp_enable() and "head" in prefix:
             self.comm_group = get_lmhead_tp_group()
         elif embedding_tp_enable() and "embed_tokens" in prefix:
             self.comm_group = get_embed_tp_group()
@@ -244,8 +256,14 @@ class AscendVocabParallelEmbedding(VocabParallelEmbedding):
         # Mask the output embedding.
         if self.tp_size > 1:
             output_parallel.masked_fill_(input_mask.unsqueeze(-1), 0)
-        # Reduce across all the model parallel GPUs.
-        output = torch.ops.vllm.maybe_pad_and_reduce(output_parallel)
+            # Reduce across all the model parallel GPUs.
+            # maybe_pad_and_reduce uses the global TP group, so only call it
+            # when this layer is actually TP-sharded. A replicated layer (e.g.
+            # the DSpark Markov head) has tp_size==1 and already holds the
+            # full output locally.
+            output = torch.ops.vllm.maybe_pad_and_reduce(output_parallel)
+        else:
+            output = output_parallel
         return output
 
 
@@ -302,7 +320,11 @@ class AscendLogitsProcessor(LogitsProcessor):
         lm_head: AscendParallelLMHead,
         embedding_bias: torch.Tensor | None = None,
     ) -> torch.Tensor | None:
-        if lmhead_tp_enable():
+        # A replicated head (tp_size==1, e.g. the DSpark Markov w2) must take
+        # the normal path: the lmhead_tp path gathers hidden states / scatters
+        # logits across the finegrained group, which a replicated head must
+        # not participate in.
+        if lmhead_tp_enable() and lm_head.tp_size > 1:
             return self._get_logits_lmheadtp(hidden_states, lm_head, embedding_bias)
         else:
             return self._get_logits_normal(hidden_states, lm_head, embedding_bias)
@@ -335,8 +357,11 @@ class AscendLogitsProcessor(LogitsProcessor):
         embedding_bias: torch.Tensor | None,
     ) -> torch.Tensor | None:
         logits = self._apply_head(lm_head, hidden_states, embedding_bias)
-        # Gather logits for tensor parallel
-        if not get_ascend_config().enable_reduce_sample:
+        # Gather logits for tensor parallel. _gather_logits uses the global TP
+        # group, so skip it for a replicated head (e.g. the DSpark Markov w2):
+        # each rank already holds the full vocab logits locally and no
+        # all-gather is needed.
+        if not get_ascend_config().enable_reduce_sample and lm_head.tp_size > 1:
             logits = self._gather_logits(logits)
 
         # Remove paddings in vocab (if any)


### PR DESCRIPTION

### What this PR does / why we need it?

The DSpark Markov head (`markov_w1` VocabParallelEmbedding + `markov_w2` ParallelLMHead) serves the draft-decoding causal-correction loop, which runs serially per draft position. Under TP sharding every step pays a TP all-reduce (w1) and all-gather (w2), and these collectives are latency-bound: measured on a TP16 Kimi-K3 DSpark deployment, each costs ~240 us regardless of payload, which dominates the markov loop.

This PR replicates the Markov head on every rank instead of sharding it: any `AscendVocabParallelEmbedding` whose prefix contains "markov" is routed to a `ReplicatedGroup` — a pure world_size=1 stand-in (no `hcclCommInitRootInfoConfig`) — so each rank holds the full V x r / r x V table (~150 MB extra HBM per rank) and the per-step collectives disappear. This matches upstream vLLM, where the markov head is replicated unconditionally (vllm#49731; deepseek_v4_dspark in #15496 likewise replicates it), so **no new config option is introduced**: the prefix routing itself is the switch, and it is checked before the lmhead prefix match because "markov_head" contains "head".

- before
<img width="1009" height="629" alt="image-20260826144751584" src="https://github.com/user-attachments/assets/b76b3142-a842-4df8-b40a-0abc770f4d00" />

- after
<img width="1171" height="595" alt="image-20260826144547733" src="https://github.com/user-attachments/assets/eb3fce46-700f-4a8b-9a29-68d7e4466cca" />

### Does this PR introduce _any_ user-facing change?

No new config or API. For DSpark models under TP > 1, the Markov head is now replicated on every rank instead of TP-sharded, matching upstream vLLM behavior: draft outputs are numerically equivalent (any difference is limited to floating-point reduction order), while the per-draft-step TP collectives are removed at the cost of ~150 MB extra HBM per rank.

### How was this patch tested?

End-to-end PD-separated deployment — kimi-k3, 8P+8D (16×Ascend910A3/node), `markov_tensor_parallel_size=1` (P+D), dspark num_spec=7 greedy.

- random 40k/700

| percentile | metric | markov=1 | markov=0 | diff |
| --- | --- | --- | --- | --- |
| P50 | ITL | 98.71ms | 101.19ms | -2.5% |
| P90 | ITL | 102.03ms | 105.07ms | -2.9% |

- online_20k_40k

| percentile | metric | markov=1 | markov=0 | diff |
| --- | --- | --- | --- | --- |
| P50 | ITL | 98.19ms | 100.60ms | -2.4% |
| P99 | ITL | 123.65ms | 126.39ms | -2.2% |


- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
