### PR TITLE
[CI] simplify rerun strategy to use run-level API instead of per-job rerun

### DIFF
--- a/.github/workflows/pr_rerun_command.yml
+++ b/.github/workflows/pr_rerun_command.yml
@@ -119,8 +119,8 @@ jobs:
             map(max_by(.id)) |
             .[] | "\(.id)|\(.name)|\(.status)|\(.conclusion // "null")|\(.event)"')
 
-          RERUNNED=""
-          RERUNNED_JOBS=""
+          RERUNNED_FAILED=""
+          RERUNNED_FULL=""
           FAILED=""
           RERUN_COUNT=0
 
@@ -138,8 +138,6 @@ jobs:
               continue
             fi
 
-            # Reusable workflow runs are re-run through their caller job to
-            # avoid executing the tests twice.
             if [ "$EVENT" = "workflow_call" ]; then
               echo "Skipping $RUN_NAME (ID: $RUN_ID) - reusable workflow run, rerun handled via caller job."
               continue
@@ -154,138 +152,56 @@ jobs:
                 ;;
             esac
 
-            # Collect jobs that did not complete successfully. Only these are
-            # re-run so that already successful jobs are not executed again.
-            JOBS=""
-            JOB_PAGE=1
-            while :; do
-              JOB_RESP=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
-                "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/jobs?per_page=100&page=$JOB_PAGE" \
-                | tr -d '\000-\010\013\014\016-\037')
-              JOB_BATCH=$(echo "$JOB_RESP" | jq -r '.jobs[]? | "\(.id)|\(.conclusion // "null")"')
-              [ -z "$JOB_BATCH" ] && break
-              JOBS="${JOBS}${JOB_BATCH}"$'\n'
-              JOB_TOTAL=$(echo "$JOB_RESP" | jq '.total_count // 0')
-              if [ "$JOB_PAGE" -ge $(( (JOB_TOTAL + 99) / 100 )) ] || [ "$JOB_TOTAL" = "0" ]; then
-                break
-              fi
-              JOB_PAGE=$((JOB_PAGE + 1))
-            done
+            echo "Attempting to re-run failed jobs in $RUN_NAME (ID: $RUN_ID)..."
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+              -H "Authorization: Bearer $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs")
 
-            TARGET_IDS=$(echo "$JOBS" | awk -F'|' '$2 != "success" && $2 != "neutral" && $2 != "skipped" && $2 != "null" && $2 != "" {print $1}' | sort -u)
-            TARGET_COUNT=$(echo "$TARGET_IDS" | sed '/^$/d' | wc -l)
-            HAS_CANCELLED=$(echo "$JOBS" | awk -F'|' '$2 == "cancelled" {found = 1} END {print found + 0}')
-
-            # A startup failure usually leaves no jobs to re-run individually;
-            # fall back to re-running the whole workflow run.
-            if [ "$TARGET_COUNT" = "0" ] && [ "$CONCLUSION" = "startup_failure" ]; then
-              echo "Re-running $RUN_NAME (ID: $RUN_ID) - no jobs available, full rerun..."
+            if [ "$HTTP_CODE" = "201" ]; then
+              echo "  -> Re-run failed jobs accepted."
+              RERUNNED_FAILED="${RERUNNED_FAILED}"$'\n'"- $RUN_NAME"
+              RERUN_COUNT=$((RERUN_COUNT + 1))
+            else
+              echo "  -> Re-run failed jobs returned HTTP $HTTP_CODE, falling back to full rerun..."
               HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
                 -H "Authorization: Bearer $GITHUB_TOKEN" \
                 "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/rerun")
+
               if [ "$HTTP_CODE" = "201" ]; then
-                echo "  -> Success."
-                RERUNNED="${RERUNNED}"$'\n'"- $RUN_NAME"
+                echo "  -> Full rerun accepted."
+                RERUNNED_FULL="${RERUNNED_FULL}"$'\n'"- $RUN_NAME"
                 RERUN_COUNT=$((RERUN_COUNT + 1))
               else
-                echo "  -> Failed (HTTP $HTTP_CODE)."
+                echo "  -> Full rerun failed (HTTP $HTTP_CODE)."
                 FAILED="${FAILED}"$'\n'"- $RUN_NAME: API returned HTTP $HTTP_CODE"
               fi
-              continue
-            fi
-
-            if [ "$TARGET_COUNT" = "0" ]; then
-              echo "Skipping $RUN_NAME (ID: $RUN_ID) - no failed or cancelled jobs found."
-              continue
-            fi
-
-            # Pure failure without any cancelled jobs: keep the single
-            # rerun-failed-jobs call so only failed jobs are re-run.
-            if [ "$CONCLUSION" = "failure" ] && [ "$HAS_CANCELLED" = "0" ]; then
-              echo "Re-running failed jobs in $RUN_NAME (ID: $RUN_ID)..."
-              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-                -H "Authorization: Bearer $GITHUB_TOKEN" \
-                "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs")
-              if [ "$HTTP_CODE" = "201" ]; then
-                echo "  -> Success."
-                RERUNNED="${RERUNNED}"$'\n'"- $RUN_NAME"
-                RERUN_COUNT=$((RERUN_COUNT + 1))
-              else
-                echo "  -> Failed (HTTP $HTTP_CODE)."
-                FAILED="${FAILED}"$'\n'"- $RUN_NAME: API returned HTTP $HTTP_CODE"
-              fi
-              continue
-            fi
-
-            # Cancelled / timed-out / startup-failure runs, or failure runs
-            # containing cancelled jobs: re-run the remaining jobs one by one.
-            # A per-job rerun can return 409 while its upstream needs are not
-            # re-run yet, so retry the leftovers a few times.
-            echo "Re-running remaining jobs in $RUN_NAME (ID: $RUN_ID)..."
-            REMAINING="$TARGET_IDS"
-            JOB_FAILED=""
-            ATTEMPT=0
-            while [ -n "$REMAINING" ] && [ "$ATTEMPT" -lt 3 ]; do
-              RETRY=""
-              while IFS= read -r JOB_ID; do
-                [ -z "$JOB_ID" ] && continue
-                HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-                  -H "Authorization: Bearer $GITHUB_TOKEN" \
-                  "https://api.github.com/repos/$REPO/actions/jobs/$JOB_ID/rerun")
-                if [ "$HTTP_CODE" = "201" ]; then
-                  echo "  -> Job $JOB_ID re-run accepted."
-                elif [ "$HTTP_CODE" = "409" ] && [ "$ATTEMPT" -lt 2 ]; then
-                  echo "  -> Job $JOB_ID not ready (409), will retry."
-                  RETRY="${RETRY}"$'\n'"$JOB_ID"
-                else
-                  echo "  -> Job $JOB_ID failed (HTTP $HTTP_CODE)."
-                  JOB_FAILED="${JOB_FAILED}"$'\n'"$JOB_ID"
-                fi
-              done <<< "$REMAINING"
-              REMAINING=$(echo "$RETRY" | sed '/^$/d')
-              if [ -n "$REMAINING" ]; then
-                ATTEMPT=$((ATTEMPT + 1))
-                if [ "$ATTEMPT" -lt 3 ]; then
-                  echo "Waiting 15s before retrying leftover jobs..."
-                  sleep 15
-                fi
-              fi
-            done
-
-            if [ -z "$REMAINING" ] && [ -z "$JOB_FAILED" ]; then
-              echo "  -> Success."
-              RERUNNED_JOBS="${RERUNNED_JOBS}"$'\n'"- $RUN_NAME"
-              RERUN_COUNT=$((RERUN_COUNT + 1))
-            else
-              echo "  -> Some jobs could not be re-run."
-              FAILED="${FAILED}"$'\n'"- $RUN_NAME: some jobs could not be re-run (still waiting on dependencies)"
             fi
           done <<< "$CANDIDATE_RUNS"
 
           # Build comment body
           {
             echo "comment_body<<CMTEOF"
-            if [ -n "$RERUNNED" ] || [ -n "$RERUNNED_JOBS" ]; then
+            if [ -n "$RERUNNED_FAILED" ] || [ -n "$RERUNNED_FULL" ]; then
               echo "[Bot]: rerun completed."
               echo ""
-              if [ -n "$RERUNNED" ]; then
-                echo "**Rerun:**$RERUNNED"
+              if [ -n "$RERUNNED_FAILED" ]; then
+                echo "**Rerun (failed jobs only):**$RERUNNED_FAILED"
                 echo ""
               fi
-              if [ -n "$RERUNNED_JOBS" ]; then
-                echo "**Rerun (remaining cancelled/failed jobs):**$RERUNNED_JOBS"
+              if [ -n "$RERUNNED_FULL" ]; then
+                echo "**Rerun (full workflow):**$RERUNNED_FULL"
                 echo ""
               fi
             fi
             if [ -n "$FAILED" ]; then
-              if [ -z "$RERUNNED" ] && [ -z "$RERUNNED_JOBS" ]; then
+              if [ -z "$RERUNNED_FAILED" ] && [ -z "$RERUNNED_FULL" ]; then
                 echo "[Bot]: rerun completed."
                 echo ""
               fi
               echo "**Failed:**$FAILED"
               echo ""
             fi
-            if [ -z "$RERUNNED" ] && [ -z "$RERUNNED_JOBS" ] && [ -z "$FAILED" ]; then
+            if [ -z "$RERUNNED_FAILED" ] && [ -z "$RERUNNED_FULL" ] && [ -z "$FAILED" ]; then
               echo "[Bot]: rerun completed. No failed jobs found."
             fi
             echo "CMTEOF"


### PR DESCRIPTION

### What this PR does / why we need it?

Per-job rerun API (POST /jobs/{job_id}/rerun) returns HTTP 403 for reusable workflow caller jobs (matrix jobs using uses:), causing failed/cancelled test jobs to be silently skipped. Only inline jobs like ci-gate were successfully re-run, leading to inconsistent state.

Replace the per-job collection and retry logic with a unified strategy:
1. Try rerun-failed-jobs (run-level) first — covers both failed and cancelled jobs including reusable workflow callers
2. Fallback to full rerun if rerun-failed-jobs is not accepted

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/58d3918e3ea0a544ffedadad2ba84559e9c51d8f
