### PR TITLE
[Feature][MRV2] Support DSA decode ACLGraph

### DIFF
--- a/tests/ut/attention/test_dsa_v1.py
+++ b/tests/ut/attention/test_dsa_v1.py
@@ -424,7 +424,7 @@ def test_build_req_metadata_preserves_zero_max_sequence_lengths():
     metadata = builder.build_req_metadata(
         common_attn_metadata=common_attn_metadata,
         seq_lens_cpu=torch.zeros(2, dtype=torch.int32),
-        num_reqs_actual=None,
+        num_actual_reqs=None,
         cos=torch.empty(0),
         sin=torch.empty(0),
     )
@@ -462,12 +462,12 @@ def test_build_req_metadata_clears_graph_padding_rows():
     metadata = builder.build_req_metadata(
         common_attn_metadata=common_attn_metadata,
         seq_lens_cpu=torch.tensor([8, 6, 7], dtype=torch.int32),
-        num_reqs_actual=1,
+        num_actual_reqs=1,
         cos=torch.ones(2),
         sin=torch.zeros(2),
     )
 
-    assert metadata.num_reqs_actual == 1
+    assert metadata.num_actual_reqs == 1
     assert torch.equal(
         metadata.start_pos,
         torch.tensor([6, 0, 0], dtype=torch.int32),
@@ -1191,7 +1191,7 @@ def test_pcp_metadata_builds_from_manager_global_view():
             pcp_context=pcp_context,
             pcp_cache_group_idx=1,
             common_ratio_to_sas_metadata={"local": True},
-            num_reqs_actual=7,
+            num_actual_reqs=7,
         )
 
     assert isinstance(actual, AscendDSAPCPMetadata)
@@ -1213,10 +1213,10 @@ def test_pcp_metadata_builds_from_manager_global_view():
     assert global_common.block_table_tensor is global_block_table
     assert torch.equal(global_common.slot_mapping, global_slot_mapping)
     assert global_common.attn_state is global_batch.attn_state
-    assert global_call.kwargs["num_reqs_actual"] == global_batch.num_reqs
+    assert global_call.kwargs["num_actual_reqs"] == global_batch.num_reqs
     assert global_call.kwargs["common_ratio_to_sas_metadata"] == {}
     assert build_local.call_args.args[2] is local_common
-    assert build_local.call_args.kwargs["num_reqs_actual"] == 7
+    assert build_local.call_args.kwargs["num_actual_reqs"] == 7
 
 
 @pytest.mark.parametrize("local_num_actual_tokens", [2, 0], ids=["local_tokens", "empty_rank"])

--- a/tests/ut/attention/test_dsv4_block_geometry.py
+++ b/tests/ut/attention/test_dsv4_block_geometry.py
@@ -35,7 +35,7 @@ def test_compressor_metadata_uses_physical_storage_geometry(
         block_table=logical_block_table,
         storage_block_size=128,
         num_compressed_tokens=2,
-        num_reqs_actual=1,
+        num_actual_reqs=1,
     )
     captured = {}
     expected = (

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -33,7 +33,7 @@ class TestCompressorMetadata:
             block_table=block_table,
             storage_block_size=128,
             num_compressed_tokens=3,
-            num_reqs_actual=2,
+            num_actual_reqs=2,
         )
         result_cos = torch.ones((3, 4))
         result_sin = torch.zeros((3, 4))

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -109,7 +109,7 @@ class AscendDSAReqMetadata:
     full_compress_sin: torch.Tensor = None
     full_compress_cos: torch.Tensor = None
     start_pos: torch.Tensor = None
-    num_reqs_actual: int | None = None
+    num_actual_reqs: int | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
     cu_cmp_seqlen_list: torch.Tensor = None
@@ -294,7 +294,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
     ) -> AscendDSAMetadata:
         num_reqs = common_attn_metadata.num_reqs
         query_start_loc = common_attn_metadata.query_start_loc
-        num_reqs_actual = kwargs.get("num_reqs_actual")
+        num_actual_reqs = kwargs.get("num_actual_reqs")
         common_ratio_to_sas_metadata = kwargs.get("common_ratio_to_sas_metadata")
         assert common_ratio_to_sas_metadata is not None
         self.common_ratio_to_sas_metadata = common_ratio_to_sas_metadata
@@ -359,7 +359,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             common_attn_metadata,
             input_positions,
             num_input_tokens,
-            num_reqs_actual,
+            num_actual_reqs,
             attn_state,
             cos=cos,
             sin=sin,
@@ -675,7 +675,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         common_attn_metadata: AscendCommonAttentionMetadata,
         input_positions: torch.Tensor | None,
         num_input_tokens: int,
-        num_reqs_actual: int | None,
+        num_actual_reqs: int | None,
         attn_state: AscendAttentionState,
         cos: RopeDataProxy,
         sin: RopeDataProxy,
@@ -738,13 +738,13 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         max_local_query_len = max(1, int(local_seq_lens_q_cpu.max().item()))
         max_local_seq_lens = max(1, int(local_seq_lens_cpu.max().item()))
 
-        if num_reqs_actual is None:
-            num_reqs_actual = num_reqs
+        if num_actual_reqs is None:
+            num_actual_reqs = num_reqs
         else:
-            num_reqs_actual = min(num_reqs_actual, num_reqs)
-            if num_reqs_actual < num_reqs:
-                self.start_pos_prefill[num_reqs_actual:].fill_(0)
-                self.block_table[num_reqs_actual:num_reqs, ...].fill_(0)
+            num_actual_reqs = min(num_actual_reqs, num_reqs)
+            if num_actual_reqs < num_reqs:
+                self.start_pos_prefill[num_actual_reqs:].fill_(0)
+                self.block_table[num_actual_reqs:num_reqs, ...].fill_(0)
 
         # --- Compressed positions ---
         full_compress_cos, full_compress_sin = None, None
@@ -811,7 +811,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             full_compress_cos=full_compress_cos,
             start_pos=self.start_pos_prefill[:num_reqs],
             num_compressed_tokens=num_compressed_tokens,
-            num_reqs_actual=num_reqs_actual,
+            num_actual_reqs=num_actual_reqs,
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
             cu_cmp_seqlen_list=cu_cmp_seqlens,
@@ -1189,7 +1189,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         assert metadata.full_compress_sin is not None
         assert metadata.num_compressed_tokens is not None
         assert metadata.start_pos is not None
-        assert metadata.num_reqs_actual is not None
+        assert metadata.num_actual_reqs is not None
         full_compress_cos = metadata.full_compress_cos.view(
             metadata.full_compress_cos.shape[0],
             metadata.full_compress_cos.shape[-1],
@@ -1208,7 +1208,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             DeviceOperator.get_dsa_compressor_slot_mapping_format(),
             self.compress_ratio,
             metadata.num_compressed_tokens,
-            metadata.num_reqs_actual,
+            metadata.num_actual_reqs,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
@@ -2085,7 +2085,7 @@ class AscendDSAPCPMetadataBuilder(dsa_v1.AscendDSAMetadataBuilder):
         global_build_kwargs = {
             **kwargs,
             "common_ratio_to_sas_metadata": {},
-            "num_reqs_actual": global_common_attn_metadata.num_reqs,
+            "num_actual_reqs": global_common_attn_metadata.num_reqs,
         }
         return self._global_metadata_builder.build(
             common_prefix_len,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -214,7 +214,7 @@ class AscendDSAReqMetadata:
     full_compress_sin: torch.Tensor = None
     full_compress_cos: torch.Tensor = None
     start_pos: torch.Tensor | None = None
-    num_reqs_actual: int | None = None
+    num_actual_reqs: int | None = None
     sas_metadata: torch.Tensor = None
     qli_metadata: torch.Tensor = None
     attn_mask: torch.Tensor | None = None
@@ -507,6 +507,15 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         num_tokens = self.num_actual_tokens
         return min(num_tokens, num_tokens // self.compressor_ratio + num_reqs)
 
+    def build_for_cudagraph_capture(self, common_attn_metadata: AscendCommonAttentionMetadata) -> AscendDSAMetadata:
+        """Delegate to build() because DSA needs shared request metadata."""
+        return self.build(
+            common_prefix_len=0,
+            common_attn_metadata=common_attn_metadata,
+            num_actual_reqs=common_attn_metadata.num_reqs,
+            common_ratio_to_sas_metadata={},
+        )
+
     def build(
         self,
         common_prefix_len: int,
@@ -515,7 +524,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         **kwargs,
     ) -> AscendDSAMetadata:
         num_reqs = common_attn_metadata.num_reqs
-        num_reqs_actual = kwargs.get("num_reqs_actual")
+        num_actual_reqs = kwargs.get("num_actual_reqs")
         self.common_ratio_to_sas_metadata = kwargs.get("common_ratio_to_sas_metadata")
         assert self.common_ratio_to_sas_metadata is not None
         self.set_num_actual_tokens(common_attn_metadata)
@@ -577,7 +586,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         req_metadata = self.build_req_metadata(
             common_attn_metadata=common_attn_metadata,
             seq_lens_cpu=seq_lens_cpu,
-            num_reqs_actual=num_reqs_actual,
+            num_actual_reqs=num_actual_reqs,
             cos=cos,
             sin=sin,
         )
@@ -680,7 +689,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self,
         common_attn_metadata: AscendCommonAttentionMetadata,
         seq_lens_cpu: torch.Tensor,
-        num_reqs_actual: int | None,
+        num_actual_reqs: int | None,
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> AscendDSAReqMetadata:
@@ -697,13 +706,13 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
 
         self.start_pos_prefill.fill_(0)
         self.start_pos_prefill[:num_reqs] = seq_lens - seq_lens_q
-        if num_reqs_actual is None:
-            num_reqs_actual = num_reqs
+        if num_actual_reqs is None:
+            num_actual_reqs = num_reqs
         else:
-            num_reqs_actual = min(num_reqs_actual, num_reqs)
-            if num_reqs_actual < num_reqs:
-                self.start_pos_prefill[num_reqs_actual:num_reqs].fill_(0)
-                self.block_table[num_reqs_actual:num_reqs, ...].fill_(0)
+            num_actual_reqs = min(num_actual_reqs, num_reqs)
+            if num_actual_reqs < num_reqs:
+                self.start_pos_prefill[num_actual_reqs:num_reqs].fill_(0)
+                self.block_table[num_actual_reqs:num_reqs, ...].fill_(0)
 
         layer_name = f"c{self.compressor_ratio}"
         cu_seqlens_ori_kv = None
@@ -780,7 +789,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             full_compress_sin=full_compress_sin,
             full_compress_cos=full_compress_cos,
             start_pos=self.start_pos_prefill[:num_reqs],
-            num_reqs_actual=num_reqs_actual,
+            num_actual_reqs=num_actual_reqs,
             sas_metadata=sas_metadata,
             qli_metadata=qli_metadata,
             attn_mask=None,
@@ -938,7 +947,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             sin=sin,
             cos=cos,
             start_pos=self.seq_lens[:num_reqs] - seq_lens_q,
-            num_reqs_actual=num_reqs,
+            num_actual_reqs=num_reqs,
             sas_metadata=sas_metadata,
             qli_metadata=None,
             attn_mask=None,

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -176,7 +176,7 @@ class Compressor(nn.Module):
         assert metadata.full_compress_sin is not None
         assert metadata.num_compressed_tokens is not None
         assert metadata.start_pos is not None
-        assert metadata.num_reqs_actual is not None
+        assert metadata.num_actual_reqs is not None
         full_compress_cos = metadata.full_compress_cos.view(
             metadata.full_compress_cos.shape[0],
             metadata.full_compress_cos.shape[-1],
@@ -195,7 +195,7 @@ class Compressor(nn.Module):
             DeviceOperator.get_dsa_compressor_slot_mapping_format(),
             self.compress_ratio,
             metadata.num_compressed_tokens,
-            metadata.num_reqs_actual,
+            metadata.num_actual_reqs,
         )
 
     def forward(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3013,7 +3013,7 @@ class NPUModelRunner(GPUModelRunner):
                 if for_cudagraph_capture:
                     common_ratio_to_sas_metadata = {}
                 extra_attn_metadata_args = dict(
-                    num_reqs_actual=num_reqs,
+                    num_actual_reqs=num_reqs,
                     common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                 )
 

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -167,6 +167,7 @@ def build_attn_metadata(
     *,
     attn_groups: list[list[AttentionGroup]],
     num_reqs: int,
+    num_actual_reqs: int | None = None,
     num_tokens: int,
     query_start_loc_gpu: torch.Tensor,
     query_start_loc_cpu: torch.Tensor,
@@ -211,6 +212,8 @@ def build_attn_metadata(
         num_actual_tokens = num_tokens
     if num_input_tokens is None:
         num_input_tokens = num_tokens
+    if num_actual_reqs is None:
+        num_actual_reqs = num_reqs
 
     attn_metadata: dict[str, Any] = {}
     # Share request-level DSA metadata across cache groups in one execution.
@@ -251,8 +254,10 @@ def build_attn_metadata(
         for attn_group in attn_groups[i]:
             attn_metadata_builder = attn_group.get_metadata_builder(0)
             if for_cudagraph_capture:
+                # All backends use the capture wrapper; DSA overrides it internally.
                 metadata = attn_metadata_builder.build_for_cudagraph_capture(common_attn_metadata)
             else:
+                is_dsa_builder = isinstance(attn_metadata_builder, AscendDSAMetadataBuilder)
                 attn_metadata_extra_kwargs = (
                     model_specific_attn_metadata.get_extra_attn_kwargs(
                         attn_metadata_builder,
@@ -261,9 +266,10 @@ def build_attn_metadata(
                     if model_specific_attn_metadata is not None
                     else {}
                 )
-                if isinstance(attn_metadata_builder, AscendDSAMetadataBuilder):
+                if is_dsa_builder:
+                    # DSA cache groups share request-level metadata during replay.
                     attn_metadata_extra_kwargs.update(
-                        num_reqs_actual=num_reqs,
+                        num_actual_reqs=num_actual_reqs,
                         common_ratio_to_sas_metadata=common_ratio_to_sas_metadata,
                     )
                     if pcp_context is not None:
@@ -276,7 +282,7 @@ def build_attn_metadata(
                     common_attn_metadata=common_attn_metadata,
                     **attn_metadata_extra_kwargs,
                 )
-                if isinstance(attn_metadata_builder, AscendDSAMetadataBuilder):
+                if is_dsa_builder:
                     # Preserve sharing even if a builder replaces one of the
                     # dictionaries while constructing its metadata.
                     common_ratio_to_sas_metadata = attn_metadata_builder.common_ratio_to_sas_metadata  # type: ignore[assignment]

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -57,6 +57,7 @@ class AscendModelState(DefaultModelState):
             num_reqs = input_batch.num_reqs
             num_input_tokens = input_batch.num_tokens
 
+        num_actual_reqs = input_batch.num_reqs
         num_actual_tokens = input_batch.num_tokens
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)
@@ -75,6 +76,7 @@ class AscendModelState(DefaultModelState):
         self.attn_metadata = build_attn_metadata(
             attn_groups=attn_groups,
             num_reqs=num_reqs,
+            num_actual_reqs=num_actual_reqs,
             num_tokens=num_input_tokens,
             num_actual_tokens=num_actual_tokens,
             num_input_tokens=num_input_tokens,


### PR DESCRIPTION
## What this PR does

This PR adds DSA decode ACLGraph support in ModelRunner V2 (FULL_DECODE_ONLY mode).

The generic build_for_cudagraph_capture() does not populate DSA-specific request-level metadata during graph capture, causing incomplete attention metadata. Changes:
1. Override build_for_cudagraph_capture() in AscendDSAMetadataBuilder, delegating to build() with capture-appropriate defaults.
2. Unify all backends to call build_for_cudagraph_capture() during capture; DSA uses its override via polymorphism, no special-casing.
3. Global rename num_reqs_actual → num_actual_reqs for consistency with num_actual_tokens, across all related files.

## Does this PR introduce user-facing change?

No. 

## How was this patch tested

- Unit tests pass (DSA attention tests).
- A3 TP4 runtime validation in FULL_DECODE_ONLY mode: graph capture and inference verified.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
