### PR TITLE
[BugFix] Fix Kimi K3 C8 DSpark and MiniMax M3 follow-up issues

### DIFF
--- a/tests/e2e/pull_request/one_card/test_minimax_m3_sparse_attn.py
+++ b/tests/e2e/pull_request/one_card/test_minimax_m3_sparse_attn.py
@@ -391,7 +391,12 @@ def test_prefill_index_topk_correctness(
 
     cu_seqlens = torch.zeros(batch + 1, device=DEVICE, dtype=torch.int32)
     cu_seqlens[1:] = q_lens.cumsum(0)
-    block_table = torch.randperm(num_pages, device=DEVICE, dtype=torch.int32).reshape(batch, max_blocks)
+    # Keep an invalid page directly before the view so a block_id=-1 access is
+    # deterministic instead of silently reading neighboring allocator memory.
+    block_table_storage = torch.empty(num_pages + 1, device=DEVICE, dtype=torch.int32)
+    block_table_storage[0] = torch.iinfo(torch.int32).max
+    block_table_storage[1:] = torch.randperm(num_pages, device=DEVICE, dtype=torch.int32)
+    block_table = block_table_storage[1:].reshape(batch, max_blocks)
     idx_q = torch.ones(q_lens.sum().item(), num_idx_heads, head_dim, device=DEVICE)
     index_kv_cache = _allocate_index_kv_cache(num_pages, head_dim, index_layout)
     for req_id in range(batch):

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import torch

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -21,6 +21,7 @@ from vllm_ascend.attention.mla_v1 import (
     PrefillMLAPreprocessResult,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.utils import AscendDeviceType
 
 
 class TestAscendMLABackend(TestBase):
@@ -1018,6 +1019,329 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(self.impl.num_heads_padded, 256)
         self.assertEqual(self.impl.head_padding, 0)
 
+    @patch("vllm_ascend.attention.mla_v1.enable_fa_quant", return_value=True)
+    @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    def test_kimi_k3_no_rope_keeps_a5_fused_preprocess(
+        self,
+        mock_get_current_vllm_config,
+        mock_enabling_mlapo,
+        mock_enable_fa_quant,
+    ):
+        mock_get_current_vllm_config.return_value = self.impl.vllm_config
+        kwargs = {
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": None,
+            "use_mla_rope": False,
+        }
+
+        from vllm_ascend.attention.mla_v1 import AscendDeviceType
+
+        with patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_device_type",
+            return_value=AscendDeviceType.A5,
+        ):
+            impl = AscendMLAImpl(
+                num_heads=12,
+                head_size=96,
+                scale=0.1,
+                num_kv_heads=1,
+                alibi_slopes=None,
+                sliding_window=None,
+                kv_cache_dtype="auto",
+                blocksparse_params=None,
+                logits_soft_cap=None,
+                attn_type=None,
+                kv_sharing_target_layer_name=None,
+                **kwargs,
+            )
+
+        self.assertTrue(impl.fa_quant_layer)
+        self.assertTrue(impl.enable_mlapo)
+
+    @patch("vllm_ascend.attention.mla_v1.enable_fa_quant", return_value=True)
+    @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=True)
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type", return_value=AscendDeviceType.A2)
+    def test_kimi_k3_no_rope_disables_c8_and_mlapo_on_a2(
+        self,
+        mock_get_device_type,
+        mock_get_current_vllm_config,
+        mock_enabling_mlapo,
+        mock_enable_fa_quant,
+    ):
+        mock_get_current_vllm_config.return_value = self.impl.vllm_config
+        kwargs = {
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": None,
+            "use_mla_rope": False,
+        }
+        impl = AscendMLAImpl(
+            num_heads=12,
+            head_size=96,
+            scale=0.1,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+        self.assertFalse(impl.fa_quant_layer)
+        self.assertFalse(impl.enable_mlapo)
+        self.assertEqual(impl.dtype, self.impl.vllm_config.model_config.dtype)
+
+    @patch("vllm_ascend.attention.mla_v1.enable_fa_quant", return_value=False)
+    @patch("vllm_ascend.attention.mla_v1.enabling_mlapo", return_value=False)
+    @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    def test_kimi_k3_no_rope_enables_a3_c8_without_kv_consumer(
+        self,
+        mock_get_device_type,
+        mock_get_current_vllm_config,
+        mock_enabling_mlapo,
+        mock_enable_fa_quant,
+    ):
+        quant_config = SimpleNamespace(
+            enable_fa_quant=True,
+            is_fa_quant_layer=MagicMock(return_value=True),
+        )
+        self.impl.vllm_config.quant_config = quant_config
+        mock_get_current_vllm_config.return_value = self.impl.vllm_config
+        kwargs = {
+            "kv_lora_rank": 32,
+            "qk_nope_head_dim": 64,
+            "qk_rope_head_dim": 32,
+            "qk_head_dim": 96,
+            "v_head_dim": 128,
+            "q_lora_rank": 64,
+            "q_proj": MagicMock(),
+            "q_b_proj": MagicMock(),
+            "kv_b_proj": MagicMock(),
+            "o_proj": MagicMock(),
+            "kv_a_proj_with_mqa": MagicMock(),
+            "fused_qkv_a_proj": MagicMock(),
+            "kv_a_layernorm": MagicMock(),
+            "rotary_emb": None,
+            "use_mla_rope": False,
+            "layer_name": "model.layers.3.self_attn.attn",
+        }
+        impl = AscendMLAImpl(
+            num_heads=12,
+            head_size=96,
+            scale=0.1,
+            num_kv_heads=1,
+            alibi_slopes=None,
+            sliding_window=None,
+            kv_cache_dtype="auto",
+            blocksparse_params=None,
+            logits_soft_cap=None,
+            attn_type=None,
+            kv_sharing_target_layer_name=None,
+            **kwargs,
+        )
+        self.assertTrue(impl.fa_quant_layer)
+        self.assertEqual(impl.dtype, torch.int8)
+        quant_config.is_fa_quant_layer.assert_called_once_with(kwargs["layer_name"])
+
+    @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
+    @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad", side_effect=lambda value, enabled: value)
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator")
+    def test_no_rope_bypasses_fused_decode_preprocess(
+        self,
+        mock_device_operator,
+        mock_gather_unpad,
+        mock_save_kv,
+    ):
+        num_tokens = 2
+        self.impl.enable_mlapo = True
+        self.impl.fa_quant_layer = False
+        self.impl.use_mla_rope = False
+        self.impl.num_heads = 2
+        self.impl.v_head_dim = 4
+        hidden_states = torch.randn(num_tokens, 16)
+        attention_output = torch.randn(num_tokens, self.impl.num_heads * self.impl.v_head_dim)
+        projected = torch.randn_like(hidden_states)
+        decode_result = DecodeMLAPreprocessResult(
+            ql_nope=MagicMock(),
+            q_pe=MagicMock(),
+            k_nope=MagicMock(),
+            k_pe=MagicMock(),
+        )
+        self.impl._mla_preprocess = MagicMock(return_value=(decode_result, None))
+        self.impl._forward_decode = MagicMock(return_value=attention_output)
+        self.impl.o_proj = MagicMock(return_value=(projected,))
+        attn_metadata = SimpleNamespace(
+            num_actual_tokens=num_tokens,
+            num_decodes=num_tokens,
+            num_prefills=0,
+            num_decode_tokens=num_tokens,
+        )
+        kv_cache = (torch.empty(1, 4), torch.empty(1, 4))
+        output = torch.empty_like(projected)
+
+        with patch("vllm_ascend.attention.mla_v1._EXTRA_CTX", SimpleNamespace(num_tokens=num_tokens)):
+            self.impl.forward(
+                "model.layers.3.self_attn.attn",
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                output=output,
+            )
+
+        mock_device_operator.mla_preprocess_only_decode.assert_not_called()
+        self.impl._mla_preprocess.assert_called_once_with(
+            "model.layers.3.self_attn.attn",
+            hidden_states,
+            kv_cache,
+            attn_metadata,
+            False,
+        )
+        torch.testing.assert_close(output, projected)
+
+    @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
+    @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad")
+    def test_kimi_k3_gate_gathers_tokens_before_local_head_projection(
+        self,
+        mock_gather_unpad,
+        mock_save_kv,
+    ):
+        num_tokens = 2
+        hidden_states = torch.randn(num_tokens, 16)
+        self.impl.num_heads = 12
+        self.impl.num_kv_heads = 12
+        self.impl.v_head_dim = 128
+        self.impl.use_output_gate = True
+        self.impl.enable_mlapo = False
+        self.impl.layer_sharding_kwargs = []
+        gate_logits = torch.randn(num_tokens, 12 * 128)
+        self.impl.g_proj = MagicMock(return_value=(gate_logits,))
+        qkv_lora = torch.randn(
+            num_tokens,
+            self.impl.q_lora_rank + self.impl.kv_lora_rank + self.impl.qk_rope_head_dim,
+        )
+        self.impl.fused_qkv_a_proj = MagicMock(return_value=(qkv_lora,))
+        self.impl.q_a_layernorm = MagicMock(side_effect=lambda value: value)
+        projected = torch.randn(num_tokens, 16)
+        self.impl.o_proj = MagicMock(return_value=(projected,))
+        self.impl.o_proj.weight = MagicMock()
+        attn_metadata = MagicMock(
+            num_actual_tokens=num_tokens,
+            num_decodes=0,
+            num_prefills=0,
+            num_decode_tokens=0,
+        )
+        output = torch.empty_like(projected)
+        kv_cache = (torch.empty(1, 4), torch.empty(1, 4))
+        mock_gather_unpad.side_effect = lambda value, enabled: value.flip(0) if enabled else value
+
+        with (
+            patch("vllm_ascend.attention.mla_v1._EXTRA_CTX", SimpleNamespace(num_tokens=num_tokens)),
+            patch("vllm_ascend.attention.mla_v1.notify_kv_cache_written"),
+        ):
+            self.impl.forward(
+                "model.layers.3.self_attn.attn",
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                need_gather_q_kv=True,
+                output=output,
+            )
+
+        self.impl.g_proj.assert_called_once()
+        torch.testing.assert_close(self.impl.g_proj.call_args.args[0], hidden_states.flip(0))
+        gathered_widths = [call.args[0].shape[-1] for call in mock_gather_unpad.call_args_list]
+        gathered_flags = [call.args[1] for call in mock_gather_unpad.call_args_list]
+        self.assertEqual(gathered_widths, [16, self.impl.q_lora_rank, 64])
+        self.assertEqual(gathered_flags, [True, True, True])
+
+    @patch("vllm_ascend.attention.mla_v1.maybe_save_kv_layer_to_connector")
+    @patch("torch.ops.vllm.maybe_all_gather_and_maybe_unpad", side_effect=lambda value, enabled: value)
+    def test_kimi_k3_gate_is_local_head_shaped_and_applied_before_o_proj(
+        self,
+        mock_gather_unpad,
+        mock_save_kv,
+    ):
+        num_tokens = 2
+        local_heads = 12
+        self.impl.num_heads = local_heads
+        self.impl.num_kv_heads = local_heads
+        self.impl.v_head_dim = 128
+        self.impl.use_output_gate = True
+        self.impl.enable_mlapo = False
+        hidden_states = torch.randn(num_tokens, 16)
+        gate_logits = torch.randn(num_tokens, local_heads * self.impl.v_head_dim)
+        attention_output = torch.randn_like(gate_logits)
+        self.impl.g_proj = MagicMock(return_value=(gate_logits,))
+        prefill_result = PrefillMLAPreprocessResult(
+            q_nope=MagicMock(),
+            q_pe=MagicMock(),
+            k_nope=MagicMock(),
+            k_pe=MagicMock(),
+            value=MagicMock(),
+        )
+        self.impl._mla_preprocess = MagicMock(return_value=(None, prefill_result))
+        self.impl._forward_prefill = MagicMock(return_value=attention_output)
+        projected = torch.randn(num_tokens, 16)
+        self.impl.o_proj = MagicMock(return_value=(projected,))
+        self.impl.o_proj.weight = MagicMock()
+        attn_metadata = MagicMock(
+            num_actual_tokens=num_tokens,
+            num_decodes=0,
+            num_prefills=1,
+            num_decode_tokens=0,
+        )
+        output = torch.empty_like(projected)
+        kv_cache = (torch.empty(1, 4), torch.empty(1, 4))
+
+        with patch("vllm_ascend.attention.mla_v1._EXTRA_CTX", SimpleNamespace(num_tokens=num_tokens)):
+            self.impl.forward(
+                "model.layers.3.self_attn.attn",
+                hidden_states,
+                kv_cache,
+                attn_metadata,
+                need_gather_q_kv=True,
+                output=output,
+            )
+
+        o_proj_input = self.impl.o_proj.call_args.args[0]
+        expected = attention_output * torch.sigmoid(gate_logits)
+        self.assertEqual(o_proj_input.shape, (num_tokens, local_heads * 128))
+        torch.testing.assert_close(o_proj_input, expected)
+        torch.testing.assert_close(output, projected)
+        mock_gather_unpad.assert_called_once()
+        torch.testing.assert_close(mock_gather_unpad.call_args.args[0], hidden_states)
+        self.assertTrue(mock_gather_unpad.call_args.args[1])
+        self.impl.g_proj.assert_called_once()
+        torch.testing.assert_close(self.impl.g_proj.call_args.args[0], hidden_states)
+
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     def test_init_head_padding_for_non_power_of_two(self, mock_get_current_vllm_config):
         """Test head padding computation for num_heads that are not power of 2 (e.g. GLM-4.7-Flash with 20 heads)."""
@@ -1327,6 +1651,7 @@ class TestAscendMLAImpl(TestBase):
         mock_layer = MagicMock()
         mock_layer.quant_kscale = torch.randn(128)
         mock_layer.fak_descale_float = torch.randn(1)
+        mock_layer.fak_descale_reciprocal = torch.randn(1)
         self.impl.vllm_config = MagicMock()
         self.impl.vllm_config.compilation_config = MagicMock()
         self.impl.vllm_config.compilation_config.static_forward_context = {"layer_0": mock_layer}
@@ -1338,6 +1663,7 @@ class TestAscendMLAImpl(TestBase):
         self.assertTrue(hasattr(self.impl, "wu_q"))
         self.assertTrue(hasattr(self.impl, "wd_q"))
         self.assertTrue(hasattr(self.impl, "wd_kv"))
+        self.assertIs(self.impl.fak_descale_reciprocal, mock_layer.fak_descale_reciprocal)
 
     @patch("vllm_ascend.attention.mla_v1.trans_rope_weight")
     @patch("vllm_ascend.attention.mla_v1.transdata")
@@ -1817,6 +2143,92 @@ class TestAscendMLAImpl(TestBase):
 
         self.assertEqual(out.shape, prefix_out.shape)
 
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.attention.mla_v1.torch_npu.npu_format_cast", side_effect=lambda cache, *_: cache)
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator.kv_cache_load")
+    @patch("torch_npu.npu_attention_update")
+    @patch("torch_npu.npu_fused_infer_attention_score")
+    def test_compute_prefill_context_dequantizes_a3_c8_latent_cache(
+        self,
+        mock_fia,
+        mock_update,
+        mock_cache_load,
+        _mock_format_cast,
+        mock_get_device_type,
+    ):
+        self.impl.fa_quant_layer = True
+        self.impl.use_mla_rope = False
+        self.impl.num_heads = 2
+        self.impl.num_kv_heads = 1
+        self.impl.kv_lora_rank = 32
+        self.impl.qk_nope_head_dim = 32
+        self.impl.qk_rope_head_dim = 16
+        self.impl.v_head_dim = 3
+        self.impl.vllm_config.model_config.dtype = torch.bfloat16
+        self.impl.fak_descale_float = torch.tensor([0.25])
+
+        quantized_kv = torch.arange(32, dtype=torch.int8).view(1, 32)
+        loaded_k_pe = torch.ones(1, self.impl.qk_rope_head_dim, dtype=torch.bfloat16)
+
+        def load_cache(*args, key, value, **_):
+            if key.dtype == torch.int8:
+                key.copy_(quantized_kv.view_as(key))
+                value.copy_(quantized_kv.view_as(value))
+            else:
+                key.copy_(loaded_k_pe.view_as(key))
+                value.copy_(loaded_k_pe.view_as(value))
+
+        mock_cache_load.side_effect = load_cache
+        captured_kv_b_inputs = []
+
+        def kv_b_proj(value):
+            captured_kv_b_inputs.append(value)
+            return (torch.zeros(1, self.impl.num_heads, self.impl.qk_nope_head_dim + self.impl.v_head_dim),)
+
+        self.impl.kv_b_proj = MagicMock(side_effect=kv_b_proj)
+        mock_fia.return_value = (
+            torch.zeros(1, self.impl.num_heads, self.impl.v_head_dim),
+            torch.zeros(self.impl.num_heads, 1),
+        )
+        mock_update.return_value = (torch.zeros(self.impl.num_heads, self.impl.v_head_dim), None)
+
+        chunked_context = MagicMock()
+        chunked_context.seq_tot = [1]
+        chunked_context.starts = [torch.tensor([0])]
+        chunked_context.chunk_seq_lens_npu = [torch.tensor([1])]
+        chunked_context.chunk_actual_seq_lengths_kv_list = [[1]]
+        prefill_metadata = MagicMock(
+            actual_seq_lengths_q=[1],
+            block_table=torch.tensor([[0]]),
+            chunked_context=chunked_context,
+        )
+        attn_metadata = MagicMock(prefill=prefill_metadata)
+        kv_cache = (
+            torch.empty(1, 1, 1, self.impl.kv_lora_rank, dtype=torch.int8),
+            torch.empty(1, 1, 1, self.impl.qk_rope_head_dim, dtype=torch.bfloat16),
+        )
+        q_nope = torch.zeros(1, self.impl.num_heads, self.impl.qk_nope_head_dim, dtype=torch.bfloat16)
+        q_pe = torch.zeros(1, self.impl.num_heads, self.impl.qk_rope_head_dim, dtype=torch.bfloat16)
+        prefix_output = torch.zeros(1, self.impl.num_heads, self.impl.v_head_dim)
+        prefix_lse = torch.zeros(self.impl.num_heads, 1)
+
+        self.impl._compute_prefill_context(
+            q_nope,
+            q_pe,
+            kv_cache,
+            self.impl.qk_rope_head_dim,
+            attn_metadata,
+            prefix_output,
+            prefix_lse,
+        )
+
+        self.assertEqual(mock_cache_load.call_count, 2)
+        latent_call, rope_call = mock_cache_load.call_args_list
+        self.assertEqual(latent_call.args[0].shape, (1, 1, 1, 32))
+        self.assertEqual(rope_call.args[0].shape, (1, 1, 1, 16))
+        expected = (quantized_kv.squeeze().to(torch.float32) * self.impl.fak_descale_float).to(torch.bfloat16)
+        torch.testing.assert_close(captured_kv_b_inputs[0], expected)
+
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
     @patch("torch_npu.npu_gather_pa_kv_cache")
     @patch("torch_npu.npu_attention_update")
@@ -1857,6 +2269,7 @@ class TestAscendMLAImpl(TestBase):
             kv_sharing_target_layer_name=None,
             **kwargs,
         )
+        impl.fa_quant_layer = False
         S, N, D, VD = 2, num_heads, impl.qk_head_dim, impl.v_head_dim
         latent_kv_dim = impl.kv_lora_rank
         num_blocks, block_size = 100, 20
@@ -2010,6 +2423,184 @@ class TestAscendMLAImpl(TestBase):
 
         self.assertEqual(k_pe.shape[-1], self.impl.qk_rope_head_dim)
         self.assertEqual(k_nope.shape[-1], self.impl.kv_lora_rank)
+
+    @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator.reshape_and_cache")
+    def test_kimi_k3_exec_kv_prefill_caches_raw_position_slice(
+        self,
+        mock_reshape_and_cache,
+        mock_kv_rmsnorm_rope_cache,
+    ):
+        self.impl.use_mla_rope = False
+        self.impl.num_kv_heads = 2
+        self.impl.kv_lora_rank = 4
+        self.impl.qk_rope_head_dim = 2
+        kv_no_split = torch.arange(24, dtype=torch.float32).view(2, 2, 6)
+        kv_c = kv_no_split[..., :4]
+        raw_k_pe = kv_no_split[..., 4:]
+        kv_c_normed = kv_c + 100
+        self.impl.kv_a_layernorm = MagicMock(return_value=kv_c_normed)
+        kv_cache = (MagicMock(name="latent_cache"), MagicMock(name="position_cache"))
+        slots = torch.tensor([3, 7])
+
+        k_pe, k_nope = self.impl.exec_kv_prefill(
+            kv_no_split,
+            MagicMock(),
+            MagicMock(),
+            kv_cache,
+            slots,
+        )
+
+        torch.testing.assert_close(k_pe, raw_k_pe)
+        torch.testing.assert_close(k_nope, kv_c_normed)
+        mock_kv_rmsnorm_rope_cache.assert_not_called()
+        cache_call = mock_reshape_and_cache.call_args.kwargs
+        torch.testing.assert_close(cache_call["key"], kv_c_normed)
+        torch.testing.assert_close(cache_call["value"], raw_k_pe)
+        self.assertIs(cache_call["key_cache"], kv_cache[0])
+        self.assertIs(cache_call["value_cache"], kv_cache[1])
+        self.assertIs(cache_call["slot_mapping"], slots)
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.attention.mla_v1.torch_npu.npu_scatter_pa_kv_cache")
+    @patch("vllm_ascend.attention.mla_v1.torch_npu.npu_quantize")
+    def test_kimi_k3_exec_kv_prefill_quantizes_and_writes_a3_nz_cache(
+        self,
+        mock_npu_quantize,
+        mock_scatter_pa_kv_cache,
+        mock_get_device_type,
+    ):
+        self.impl.use_mla_rope = False
+        self.impl.fa_quant_layer = True
+        self.impl.num_kv_heads = 1
+        self.impl.kv_lora_rank = 32
+        self.impl.qk_rope_head_dim = 16
+        self.impl.fak_descale_reciprocal = torch.tensor([4.0])
+        self.impl.dtype = torch.int8
+        kv_no_split = torch.arange(96, dtype=torch.bfloat16).view(2, 1, 48)
+        kv_c_normed = kv_no_split[..., :32] + 100
+        raw_k_pe = kv_no_split[..., 32:]
+        quantized_kv_c = torch.zeros(kv_c_normed.shape, dtype=torch.int8)
+        self.impl.kv_a_layernorm = MagicMock(return_value=kv_c_normed)
+        mock_npu_quantize.return_value = quantized_kv_c
+        kv_cache = (
+            torch.empty(2, 4, 1, 32, dtype=torch.int8),
+            torch.empty(2, 4, 1, 16, dtype=torch.bfloat16),
+        )
+        slots = torch.tensor([3, 7])
+
+        k_pe, k_nope = self.impl.exec_kv_prefill(
+            kv_no_split,
+            MagicMock(),
+            MagicMock(),
+            kv_cache,
+            slots,
+        )
+
+        torch.testing.assert_close(k_pe, raw_k_pe)
+        torch.testing.assert_close(k_nope, kv_c_normed)
+        mock_npu_quantize.assert_called_once()
+        quantize_args = mock_npu_quantize.call_args.args
+        torch.testing.assert_close(quantize_args[0], kv_c_normed)
+        self.assertIs(quantize_args[1], self.impl.fak_descale_reciprocal)
+        self.assertIsNone(quantize_args[2])
+        self.assertIs(quantize_args[3], torch.qint8)
+        self.assertEqual(quantize_args[4:], (-1, False))
+        self.assertEqual(mock_scatter_pa_kv_cache.call_count, 2)
+        latent_call, position_call = mock_scatter_pa_kv_cache.call_args_list
+        latent_call = latent_call.kwargs
+        position_call = position_call.kwargs
+
+        torch.testing.assert_close(latent_call["key"], quantized_kv_c)
+        torch.testing.assert_close(latent_call["value"], quantized_kv_c)
+        self.assertEqual(latent_call["key_cache"].shape, (2, 1, 1, 4, 32))
+        self.assertIs(latent_call["key_cache"]._base, kv_cache[0])
+        self.assertIs(latent_call["value_cache"]._base, kv_cache[0])
+        torch.testing.assert_close(latent_call["slot_mapping"], slots)
+        self.assertEqual(latent_call["key"].dtype, latent_call["value"].dtype)
+        self.assertEqual(latent_call["cache_mode"], "PA_NZ")
+
+        torch.testing.assert_close(position_call["key"], raw_k_pe)
+        torch.testing.assert_close(position_call["value"], raw_k_pe)
+        self.assertEqual(position_call["key_cache"].shape, (2, 1, 1, 4, 16))
+        self.assertIs(position_call["key_cache"]._base, kv_cache[1])
+        self.assertIs(position_call["value_cache"]._base, kv_cache[1])
+        torch.testing.assert_close(position_call["slot_mapping"], slots)
+        self.assertEqual(position_call["key"].dtype, position_call["value"].dtype)
+        self.assertEqual(position_call["cache_mode"], "PA_NZ")
+
+    @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator.reshape_and_cache")
+    def test_kimi_k3_exec_kv_decode_returns_full_raw_position_cache(
+        self,
+        mock_reshape_and_cache,
+        mock_kv_rmsnorm_rope_cache,
+    ):
+        self.impl.use_mla_rope = False
+        self.impl.num_kv_heads = 1
+        self.impl.kv_lora_rank = 4
+        self.impl.qk_rope_head_dim = 2
+        kv_no_split = torch.arange(12, dtype=torch.float32).view(2, 1, 6)
+        kv_c_normed = kv_no_split[..., :4] + 100
+        raw_k_pe = kv_no_split[..., 4:]
+        self.impl.kv_a_layernorm = MagicMock(return_value=kv_c_normed)
+        kv_cache = (MagicMock(name="latent_cache"), MagicMock(name="position_cache"))
+        slots = torch.tensor([3, 7])
+
+        k_pe_cache, k_nope_cache = self.impl.exec_kv_decode(
+            kv_no_split,
+            MagicMock(),
+            MagicMock(),
+            kv_cache,
+            slots,
+        )
+
+        self.assertIs(k_pe_cache, kv_cache[1])
+        self.assertIs(k_nope_cache, kv_cache[0])
+        mock_kv_rmsnorm_rope_cache.assert_not_called()
+        cache_call = mock_reshape_and_cache.call_args.kwargs
+        torch.testing.assert_close(cache_call["key"], kv_c_normed)
+        torch.testing.assert_close(cache_call["value"], raw_k_pe)
+        self.assertIs(cache_call["slot_mapping"], slots)
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.attention.mla_v1.torch_npu.npu_dynamic_quant")
+    def test_kimi_k3_decode_a3_c8_quantizes_latent_query_to_int8(
+        self,
+        mock_dynamic_quant,
+        mock_get_device_type,
+    ):
+        num_tokens = 2
+        self.impl.use_mla_rope = False
+        self.impl.fa_quant_layer = True
+        self.impl.dtype = torch.int8
+        self.impl.fak_descale_float = torch.tensor([0.25])
+        q_c = torch.randn(num_tokens, self.impl.q_lora_rank)
+        kv_no_split = torch.randn(num_tokens, self.impl.kv_lora_rank + self.impl.qk_rope_head_dim)
+        ql_nope = torch.randn(num_tokens, self.impl.num_heads, self.impl.kv_lora_rank)
+        raw_q_pe = torch.randn(num_tokens, self.impl.num_heads, self.impl.qk_rope_head_dim)
+        quantized_ql_nope = torch.zeros(ql_nope.shape, dtype=torch.int8)
+        query_scale = torch.full((num_tokens, self.impl.num_heads), 0.5)
+        self.impl._q_proj_and_k_up_proj = MagicMock(return_value=(ql_nope, raw_q_pe))
+        self.impl.rope_single = MagicMock(side_effect=lambda value, cos, sin: value)
+        mock_dynamic_quant.return_value = (quantized_ql_nope, query_scale)
+        k_pe_cache = MagicMock(name="k_pe_cache")
+        k_nope_cache = MagicMock(name="k_nope_cache")
+        self.impl.exec_kv_decode = MagicMock(return_value=(k_pe_cache, k_nope_cache))
+        attn_metadata = MagicMock(
+            num_decode_tokens=num_tokens,
+            slot_mapping=torch.tensor([3, 7]),
+        )
+
+        result = self.impl.mla_preprocess_decode(q_c, kv_no_split, MagicMock(), attn_metadata)
+
+        self.assertIs(result.ql_nope, quantized_ql_nope)
+        expected_q_pe = (raw_q_pe / query_scale.unsqueeze(-1) / self.impl.fak_descale_float).to(torch.bfloat16)
+        torch.testing.assert_close(result.q_pe, expected_q_pe)
+        self.assertIs(result.k_nope, k_nope_cache)
+        self.assertIs(result.k_pe, k_pe_cache)
+        self.assertIs(result.dequant_scale_q_nope, query_scale)
+        mock_dynamic_quant.assert_called_once_with(ql_nope, dst_type=torch.int8)
 
     @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
     def test_exec_kv_prefill_with_fa_quant(self, mock_kv_rmsnorm_rope_cache):
@@ -2283,3 +2874,67 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(result.shape[0], B)
         self.assertEqual(result.shape[1], self.impl.num_kv_heads)
         self.assertEqual(result.shape[2], HD)
+
+    @patch("vllm_ascend.attention.mla_v1.get_ascend_device_type", return_value=AscendDeviceType.A3)
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("torch_npu.npu_fused_infer_attention_score_v2")
+    def test_forward_decode_a3_fa_quant_pads_query_descale_with_heads(
+        self,
+        mock_npu_fused_infer_attention_score_v2,
+        mock_get_forward_context,
+        _mock_get_device_type,
+    ):
+        """FIA's per-token-per-head query descale must match padded Q heads."""
+        num_heads = 6
+        padded_heads = 8
+        block_size = 128
+        self.impl.num_heads = num_heads
+        self.impl.num_heads_padded = padded_heads
+        self.impl.head_padding = padded_heads - num_heads
+        self.impl.num_kv_heads = 1
+        self.impl.kv_lora_rank = 512
+        self.impl.qk_nope_head_dim = 512
+        self.impl.qk_rope_head_dim = 64
+        self.impl.enable_kv_nz = False
+        self.impl.enable_mla_fia_split = False
+        self.impl.fa_quant_layer = True
+        self.impl.use_mla_rope = False
+        self.impl.speculative_config = None
+        self.impl.fak_descale_float = torch.ones(1)
+        self.impl._v_up_proj = MagicMock(return_value=torch.empty(1, num_heads, self.impl.v_head_dim))
+
+        q_nope = torch.randn(1, num_heads, self.impl.qk_nope_head_dim)
+        q_pe = torch.randn(1, num_heads, self.impl.qk_rope_head_dim)
+        k_nope = torch.randint(
+            -128,
+            127,
+            (block_size, self.impl.num_kv_heads, self.impl.kv_lora_rank),
+            dtype=torch.int8,
+        )
+        k_pe = torch.randn(block_size, self.impl.num_kv_heads, self.impl.qk_rope_head_dim)
+        descale = torch.ones(1, num_heads)
+        attn_metadata = MagicMock()
+        attn_metadata.attn_state = AscendAttentionState.DecodeOnly
+        attn_metadata.decode = MagicMock()
+        attn_metadata.decode.block_table = torch.zeros((1, 1), dtype=torch.int32)
+        attn_metadata.decode.seq_lens_list = [block_size]
+
+        mock_get_forward_context.return_value = MagicMock(capturing=False)
+        mock_npu_fused_infer_attention_score_v2.return_value = [
+            torch.empty(padded_heads, 1, 1, self.impl.kv_lora_rank),
+            None,
+        ]
+
+        self.impl._forward_decode(q_nope, q_pe, k_nope, k_pe, block_size, attn_metadata, descale)
+
+        call_args = mock_npu_fused_infer_attention_score_v2.call_args
+        self.assertEqual(call_args.args[0].shape, (1, 1, padded_heads, self.impl.qk_nope_head_dim))
+        self.assertEqual(call_args.args[1].shape, (1, 1, 16, block_size, 32))
+        self.assertEqual(call_args.kwargs["key_rope"].shape, (1, 1, 4, block_size, 16))
+        expected_descale = torch.nn.functional.pad(
+            descale.view(1, 1, num_heads),
+            (0, padded_heads - num_heads),
+            "constant",
+            0,
+        )
+        torch.testing.assert_close(call_args.kwargs["dequant_scale_query"], expected_descale)

--- a/tests/ut/models/minimax_m3/test_msa_m3.py
+++ b/tests/ut/models/minimax_m3/test_msa_m3.py
@@ -392,6 +392,7 @@ def test_a5_index_decode_uses_a5_triton_without_tp_block_sharding() -> None:
     import_branches = module_source[a5_branch_start:a5_branch_end]
 
     assert import_branches.count("minimax_m3_index_decode") == 2
+    assert import_branches.count("minimax_m3_sparse_attn_decode") == 2
     assert "msa_m3_triton_a5" in import_branches
     with patch(
         "vllm_ascend.models.minimax_m3.msa_m3.get_ascend_device_type",

--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -7,6 +7,10 @@ import pytest
 import torch
 from torch import nn
 from vllm.model_executor.models.utils import StageMissingLayer
+from vllm_ascend.transformers_utils.configs.kimi_k3 import (
+    KimiK3Config,
+    KimiK3VisionConfig,
+)
 
 from vllm_ascend.models import kimi_k3
 from vllm_ascend.models.kimi_k3 import (
@@ -23,10 +27,6 @@ from vllm_ascend.models.kimi_k3 import (
     get_spec_layer_idx_from_weight_name,
 )
 from vllm_ascend.ops.activation import AscendSituAndMul, SituActivationConfig
-from vllm_ascend.transformers_utils.configs.kimi_k3 import (
-    KimiK3Config,
-    KimiK3VisionConfig,
-)
 
 
 def test_kimi_k3_model_declares_checkpoint_packing_contract():
@@ -139,9 +139,7 @@ def test_kimi_k3_enables_projector_rotation_only_when_weight_is_loaded(
             return loaded_weights
 
     monkeypatch.setattr(kimi_k3, "AutoWeightsLoader", StubLoader)
-    wrapper = AscendKimiK3ForConditionalGeneration.__new__(
-        AscendKimiK3ForConditionalGeneration
-    )
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(AscendKimiK3ForConditionalGeneration)
     nn.Module.__init__(wrapper)
     wrapper.mm_projector = nn.Module()
     wrapper.mm_projector.rot_proj = nn.Linear(1, 1, bias=False)
@@ -167,9 +165,7 @@ def test_kimi_k3_skips_forwarded_projector_rotation_on_non_vision_pp_stage(
             return set()
 
     monkeypatch.setattr(kimi_k3, "AutoWeightsLoader", StubLoader)
-    wrapper = AscendKimiK3ForConditionalGeneration.__new__(
-        AscendKimiK3ForConditionalGeneration
-    )
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(AscendKimiK3ForConditionalGeneration)
     nn.Module.__init__(wrapper)
     wrapped_projector = nn.Module()
     wrapped_projector.rot_proj = nn.Linear(1, 1, bias=False)

--- a/tests/ut/models/test_kimi_k3.py
+++ b/tests/ut/models/test_kimi_k3.py
@@ -1,0 +1,625 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from torch import nn
+from vllm.model_executor.models.utils import StageMissingLayer
+
+from vllm_ascend.models import kimi_k3
+from vllm_ascend.models.kimi_k3 import (
+    AscendKimiK3ForCausalLM,
+    AscendKimiK3ForConditionalGeneration,
+    KimiK3MLP,
+    KimiK3MoE,
+    KimiK3MultiModalProjector,
+    KimiK3TextModel,
+    KimiK3VisionEncoderLayer,
+    _move_module_to_device,
+    _resolve_packed_expert_weight_name,
+    _routed_latent_quant_config,
+    get_spec_layer_idx_from_weight_name,
+)
+from vllm_ascend.ops.activation import AscendSituAndMul, SituActivationConfig
+from vllm_ascend.transformers_utils.configs.kimi_k3 import (
+    KimiK3Config,
+    KimiK3VisionConfig,
+)
+
+
+def test_kimi_k3_model_declares_checkpoint_packing_contract():
+    assert AscendKimiK3ForCausalLM.packed_modules_mapping["fused_qkv"] == [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+    ]
+    assert AscendKimiK3ForCausalLM.packed_modules_mapping["experts"] == [
+        "experts.0.w1",
+        "experts.0.w3",
+        "experts.0.w2",
+    ]
+
+
+def test_kimi_k3_loads_qkv_checkpoint_shards_into_fused_linear():
+    model = KimiK3TextModel.__new__(KimiK3TextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(num_experts=0)
+    model.layers = nn.ModuleList([nn.Module()])
+    model.layers[0].self_attn = nn.Module()
+    model.layers[0].self_attn.fused_qkv = nn.Module()
+
+    fused_weight = nn.Parameter(torch.empty(1))
+    fused_weight.weight_loader = MagicMock()
+    model.layers[0].self_attn.fused_qkv.register_parameter("weight", fused_weight)
+    weights = [(f"layers.0.self_attn.{name}.weight", torch.empty(1)) for name in ("q_proj", "k_proj", "v_proj")]
+
+    with (
+        patch("vllm_ascend.models.kimi_k3.get_spec_layer_idx_from_weight_name", return_value=None),
+        patch("vllm_ascend.models.kimi_k3.fused_moe_make_expert_params_mapping", return_value=[]),
+        patch("vllm_ascend.models.kimi_k3.is_pp_missing_parameter", return_value=False),
+    ):
+        loaded = model.load_weights(weights)
+
+    assert [call.args[2] for call in fused_weight.weight_loader.call_args_list] == ["q", "k", "v"]
+    assert loaded == {"layers.0.self_attn.fused_qkv.weight"}
+
+
+@pytest.mark.parametrize(
+    ("quant_name", "uses_quantized_latent_projections"),
+    [
+        ("ascend", True),
+        ("compressed-tensors", False),
+        ("other", False),
+    ],
+)
+def test_kimi_k3_quantizes_latent_projections_only_for_modelslim(
+    quant_name: str,
+    uses_quantized_latent_projections: bool,
+):
+    quant_config = MagicMock()
+    quant_config.get_name.return_value = quant_name
+
+    actual = _routed_latent_quant_config(quant_config)
+
+    if uses_quantized_latent_projections:
+        assert actual is quant_config
+    else:
+        assert actual is None
+
+
+def test_kimi_k3_unquantized_model_keeps_latent_projections_unquantized():
+    assert _routed_latent_quant_config(None) is None
+
+
+def test_kimi_k3_projector_registers_rotation_for_weight_loading(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class StubReplicatedLinear(nn.Module):
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+
+        def forward(self, hidden_states):
+            return hidden_states, None
+
+    monkeypatch.setattr(kimi_k3, "ReplicatedLinear", StubReplicatedLinear)
+    monkeypatch.setattr(kimi_k3, "RMSNorm", lambda *args, **kwargs: nn.Identity())
+    monkeypatch.setattr(kimi_k3, "get_act_fn", lambda *args, **kwargs: nn.Identity())
+    config = KimiK3VisionConfig(
+        mm_hidden_size=2,
+        text_hidden_size=8,
+        merge_kernel_size=(2, 2),
+    )
+    projector = KimiK3MultiModalProjector(config)
+
+    assert projector.rot_proj is not None
+
+
+@pytest.mark.parametrize(
+    ("loaded_weights", "has_rot_proj"),
+    [
+        ({"mm_projector.rot_proj.weight"}, True),
+        ({"mm_projector.linear_1.weight"}, False),
+    ],
+)
+def test_kimi_k3_enables_projector_rotation_only_when_weight_is_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+    loaded_weights: set[str],
+    has_rot_proj: bool,
+):
+    class StubLoader:
+        def __init__(self, model, *, skip_prefixes):
+            assert model is wrapper
+            assert skip_prefixes == []
+
+        def load_weights(self, weights, *, mapper):
+            assert list(weights) == []
+            assert mapper is wrapper.hf_to_vllm_mapper
+            return loaded_weights
+
+    monkeypatch.setattr(kimi_k3, "AutoWeightsLoader", StubLoader)
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(
+        AscendKimiK3ForConditionalGeneration
+    )
+    nn.Module.__init__(wrapper)
+    wrapper.mm_projector = nn.Module()
+    wrapper.mm_projector.rot_proj = nn.Linear(1, 1, bias=False)
+
+    actual = wrapper.load_weights(iter(()))
+
+    assert actual == loaded_weights
+    assert hasattr(wrapper.mm_projector, "rot_proj") is has_rot_proj
+    assert ("mm_projector.rot_proj.weight" in dict(wrapper.named_parameters())) is has_rot_proj
+
+
+def test_kimi_k3_skips_forwarded_projector_rotation_on_non_vision_pp_stage(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class StubLoader:
+        def __init__(self, model, *, skip_prefixes):
+            assert model is wrapper
+            assert skip_prefixes == ["mm_projector.rot_proj."]
+
+        def load_weights(self, weights, *, mapper):
+            assert list(weights) == []
+            assert mapper is wrapper.hf_to_vllm_mapper
+            return set()
+
+    monkeypatch.setattr(kimi_k3, "AutoWeightsLoader", StubLoader)
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(
+        AscendKimiK3ForConditionalGeneration
+    )
+    nn.Module.__init__(wrapper)
+    wrapped_projector = nn.Module()
+    wrapped_projector.rot_proj = nn.Linear(1, 1, bias=False)
+    wrapper.mm_projector = StageMissingLayer("vision_tower", wrapped_projector)
+
+    assert wrapper.load_weights(iter(())) == set()
+
+
+def test_kimi_k3_projector_applies_rotation_only_after_weight_load():
+    class PassthroughLinear(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states, None
+
+    class ScaleLinear(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states * 2, None
+
+    projector = KimiK3MultiModalProjector.__new__(KimiK3MultiModalProjector)
+    nn.Module.__init__(projector)
+    projector.input_size = 2
+    projector.linear_1 = PassthroughLinear()
+    projector.linear_2 = PassthroughLinear()
+    projector.act = nn.Identity()
+    projector.post_norm = nn.Identity()
+    image_features = torch.tensor([[1.0, 2.0]])
+
+    projector.rot_proj = ScaleLinear()
+    del projector.rot_proj
+    assert not hasattr(projector, "rot_proj")
+    torch.testing.assert_close(projector(image_features), image_features)
+
+    projector.rot_proj = ScaleLinear()
+    torch.testing.assert_close(projector(image_features), image_features * 2)
+
+
+@pytest.mark.parametrize(
+    ("name", "params", "expected"),
+    [
+        (
+            "layers.1.experts.w13_weight",
+            {"layers.1.experts.w13_weight": object()},
+            "layers.1.experts.w13_weight",
+        ),
+        (
+            "layers.1.experts.w13_weight",
+            {"layers.1.experts.w13_weight_packed": object()},
+            "layers.1.experts.w13_weight_packed",
+        ),
+        (
+            "layers.1.experts.w2_weight",
+            {"layers.1.experts.w2_weight_packed": object()},
+            "layers.1.experts.w2_weight_packed",
+        ),
+        (
+            "layers.1.experts.w13_weight_scale",
+            {"layers.1.experts.w13_weight_packed": object()},
+            "layers.1.experts.w13_weight_scale",
+        ),
+    ],
+)
+def test_kimi_k3_resolves_packed_expert_checkpoint_names(
+    name: str,
+    params: dict[str, object],
+    expected: str,
+):
+    assert _resolve_packed_expert_weight_name(name, params) == expected
+
+
+def test_kimi_k3_config_normalizes_checkpoint_schema_for_vllm():
+    """Cover only the non-pass-through checkpoint-to-vLLM adaptations."""
+    config = KimiK3Config(
+        text_config={"hidden_size": 4096},
+        vision_config={
+            "vt_num_attention_heads": 12,
+            "vt_num_hidden_layers": 7,
+            "vt_hidden_size": 1024,
+            "vt_intermediate_size": 3584,
+            "text_hidden_size": 1024,
+        },
+        use_unified_vision_chunk=True,
+    )
+
+    # Old plugin checkpoints used vision_chunk, while vLLM consumes image.
+    assert not hasattr(config, "use_unified_vision_chunk")
+    # MoonViT consumers use canonical names instead of checkpoint vt_* names.
+    assert config.vision_config.num_attention_heads == 12
+    assert config.vision_config.hidden_size == 1024
+    # The projector output must follow the text model, not stale vision config.
+    assert config.vision_config.text_hidden_size == config.text_config.hidden_size
+
+
+def test_kimi_k3_model_uses_image_placeholder_from_upstream_contract():
+    assert AscendKimiK3ForConditionalGeneration.get_placeholder_str("image", 0) == "<|kimi_image_placeholder|>"
+    with pytest.raises(ValueError, match="does not support modality"):
+        AscendKimiK3ForConditionalGeneration.get_placeholder_str(
+            "vision_chunk",
+            0,
+        )
+
+
+def test_kimi_k3_weight_mapper_adds_inner_language_model_prefix():
+    mapper = AscendKimiK3ForConditionalGeneration.hf_to_vllm_mapper
+
+    assert (
+        mapper._map_name("language_model.layers.12.self_attn.q_proj.weight")
+        == "language_model.model.layers.12.self_attn.q_proj.weight"
+    )
+    assert (
+        mapper._map_name("language_model.model.layers.12.self_attn.q_proj.weight")
+        == "language_model.model.layers.12.self_attn.q_proj.weight"
+    )
+    assert mapper._map_name("mm_projector.proj.0.weight") == "mm_projector.linear_1.weight"
+
+
+@pytest.mark.parametrize(
+    ("weight_name", "expected_layer"),
+    [
+        ("model.layers.93.self_attn.q_proj.weight", 93),
+        ("layers.94.self_attn.q_proj.weight", 94),
+        ("language_model.layers.93.mlp.gate_proj.weight", 93),
+        ("language_model.model.layers.94.mlp.up_proj.weight", 94),
+        ("model.layers.92.self_attn.q_proj.weight", None),
+        ("model.layers.95.self_attn.q_proj.weight", None),
+    ],
+)
+def test_kimi_k3_spec_layer_detection_accepts_loader_prefixes(
+    weight_name: str,
+    expected_layer: int | None,
+):
+    config = SimpleNamespace(
+        num_hidden_layers=93,
+        num_nextn_predict_layers=2,
+    )
+
+    assert get_spec_layer_idx_from_weight_name(config, weight_name) == expected_layer
+
+
+def test_kimi_k3_spec_layer_detection_allows_missing_nextn_config():
+    config = SimpleNamespace(num_hidden_layers=93)
+
+    assert (
+        get_spec_layer_idx_from_weight_name(
+            config,
+            "model.layers.93.self_attn.q_proj.weight",
+        )
+        is None
+    )
+
+
+def test_kimi_k3_vision_tp16_falls_back_to_data_parallel(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.model_executor.models import vision as vision_utils
+
+    class StubModule(nn.Module):
+        pass
+
+    qkv_kwargs: dict[str, object] = {}
+    output_kwargs: dict[str, object] = {}
+
+    def fake_qkv(*args, **kwargs):
+        del args
+        qkv_kwargs.update(kwargs)
+        return StubModule()
+
+    def fake_output(*args, **kwargs):
+        del args
+        output_kwargs.update(kwargs)
+        return StubModule()
+
+    monkeypatch.setattr(
+        vision_utils,
+        "get_tensor_model_parallel_world_size",
+        lambda: 16,
+    )
+    monkeypatch.setattr(
+        kimi_k3,
+        "get_tensor_model_parallel_world_size",
+        lambda: 16,
+    )
+    monkeypatch.setattr(
+        kimi_k3,
+        "KimiK3VisionMLP",
+        lambda *args, **kwargs: StubModule(),
+    )
+    monkeypatch.setattr(kimi_k3, "get_act_fn", lambda name: nn.Identity())
+    monkeypatch.setattr(kimi_k3, "QKVParallelLinear", fake_qkv)
+    monkeypatch.setattr(kimi_k3, "RowParallelLinear", fake_output)
+    monkeypatch.setattr(
+        kimi_k3,
+        "MMEncoderAttention",
+        lambda *args, **kwargs: StubModule(),
+    )
+
+    layer = KimiK3VisionEncoderLayer(
+        KimiK3VisionConfig(vt_num_attention_heads=12),
+        quant_config=None,
+        prefix="vision_tower.encoder.blocks.0",
+    )
+
+    assert layer.use_data_parallel is True
+    assert layer.tp_size == 1
+    assert layer.num_local_heads == 12
+    assert qkv_kwargs["disable_tp"] is True
+    assert output_kwargs["disable_tp"] is True
+
+
+def test_kimi_k3_vit_dp_compat_calls_release_helper_without_num_heads(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls: list[None] = []
+
+    def release_helper():
+        calls.append(None)
+        return False
+
+    monkeypatch.setattr(kimi_k3, "vllm_version_is", lambda version: version == "0.25.1")
+    monkeypatch.setattr(kimi_k3, "get_tensor_model_parallel_world_size", lambda: 4)
+    monkeypatch.setattr(kimi_k3, "is_vit_use_data_parallel", release_helper)
+
+    assert kimi_k3._is_vit_use_data_parallel(8) is False
+    assert calls == [None]
+
+
+def test_kimi_k3_vit_dp_compat_recreates_release_tp_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    def unexpected_release_helper():
+        pytest.fail("The release helper must not run after the TP fallback")
+
+    monkeypatch.setattr(kimi_k3, "vllm_version_is", lambda version: version == "0.25.1")
+    monkeypatch.setattr(kimi_k3, "get_tensor_model_parallel_world_size", lambda: 16)
+    monkeypatch.setattr(kimi_k3, "is_vit_use_data_parallel", unexpected_release_helper)
+
+    assert kimi_k3._is_vit_use_data_parallel(12) is True
+
+
+def test_kimi_k3_vit_dp_compat_passes_num_heads_to_main_helper(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    calls = []
+
+    def main_helper(num_heads):
+        calls.append(num_heads)
+        return True
+
+    monkeypatch.setattr(kimi_k3, "vllm_version_is", lambda version: False)
+    monkeypatch.setattr(kimi_k3, "is_vit_use_data_parallel", main_helper)
+
+    assert kimi_k3._is_vit_use_data_parallel(12) is True
+    assert calls == [12]
+
+
+def test_kimi_k3_skips_explicit_move_for_meta_modules():
+    module = nn.Linear(4, 4, device="meta")
+
+    actual = _move_module_to_device(
+        module,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+
+    assert actual is module
+    assert all(parameter.is_meta for parameter in module.parameters())
+
+
+def test_kimi_k3_moves_non_meta_modules():
+    module = nn.Linear(4, 4)
+
+    actual = _move_module_to_device(
+        module,
+        device=torch.device("cpu"),
+        dtype=torch.bfloat16,
+    )
+
+    assert actual is module
+    assert all(parameter.device.type == "cpu" for parameter in module.parameters())
+    assert all(parameter.dtype == torch.bfloat16 for parameter in module.parameters())
+
+
+def test_kimi_k3_passes_situ_parameters_through_activation_config(monkeypatch):
+    class StubModule(nn.Module):
+        pass
+
+    fused_moe_kwargs = {}
+
+    def fake_replicated_linear(*args, **kwargs):
+        return StubModule()
+
+    def fake_fused_moe(**kwargs):
+        fused_moe_kwargs.update(kwargs)
+        return StubModule()
+
+    monkeypatch.setattr(kimi_k3, "ReplicatedLinear", fake_replicated_linear)
+    monkeypatch.setattr(kimi_k3, "FusedMoE", fake_fused_moe)
+    config = SimpleNamespace(
+        hidden_act="situ",
+        hidden_size=32,
+        routed_expert_hidden_size=16,
+        num_shared_experts=0,
+        num_experts=8,
+        rms_norm_eps=1e-6,
+        latent_moe_use_norm=False,
+        moe_intermediate_size=12,
+        num_experts_per_token=2,
+        moe_renormalize=True,
+        use_grouped_topk=True,
+        num_expert_group=4,
+        topk_group=2,
+        moe_router_activation_func="sigmoid",
+        routed_scaling_factor=2.5,
+        activation_situ_beta=4.0,
+        activation_situ_linear_beta=25.0,
+    )
+
+    KimiK3MoE(config, prefix="model.layers.1.block_sparse_moe")
+
+    activation = fused_moe_kwargs["activation"]
+    assert isinstance(activation, SituActivationConfig)
+    assert activation.beta == 4.0
+    assert activation.linear_beta == 25.0
+
+
+def test_kimi_k3_dense_mlp_uses_callable_situ(monkeypatch):
+    class StubLinear(nn.Module):
+        def forward(self, hidden_states):
+            return hidden_states, None
+
+    monkeypatch.setattr(kimi_k3, "MergedColumnParallelLinear", lambda *args, **kwargs: StubLinear())
+    monkeypatch.setattr(kimi_k3, "RowParallelLinear", lambda *args, **kwargs: StubLinear())
+    config = SimpleNamespace(
+        hidden_act="situ",
+        activation_situ_beta=4.0,
+        activation_situ_linear_beta=25.0,
+    )
+
+    mlp = KimiK3MLP(config, hidden_size=4, intermediate_size=2)
+    hidden_states = torch.tensor([[1.0, -2.0, 3.0, -4.0]])
+    output = mlp(hidden_states)
+
+    assert isinstance(mlp.act_fn, AscendSituAndMul)
+    assert output.shape == (1, 2)
+
+
+def test_text_model_captures_materialized_dspark_aux_stream(monkeypatch: pytest.MonkeyPatch):
+    residual_calls: list[tuple[int, torch.Tensor]] = []
+    consumed_inputs: list[torch.Tensor] = []
+
+    class Marker(nn.Module):
+        def __init__(self, value: int) -> None:
+            super().__init__()
+            self.value = value
+
+    class FakeLayer(nn.Module):
+        def __init__(self, layer_idx: int) -> None:
+            super().__init__()
+            self.layer_idx = layer_idx
+            self.self_attention_res_proj = Marker(layer_idx)
+            self.self_attention_res_norm = nn.Identity()
+
+        def forward(
+            self,
+            positions: torch.Tensor,
+            hidden_states: torch.Tensor,
+            block_residual: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            del positions
+            if block_residual.shape[1] > 0:
+                hidden_states = kimi_k3._apply_attention_residual(
+                    hidden_states,
+                    block_residual,
+                    self.self_attention_res_proj,
+                    self.self_attention_res_norm,
+                )
+            consumed_inputs.append(hidden_states.clone())
+            if block_residual.shape[1] == 0:
+                block_residual = hidden_states.unsqueeze(1)
+            return hidden_states + 10, block_residual
+
+    def fake_attention_residual(
+        hidden_states: torch.Tensor,
+        block_residual: torch.Tensor,
+        projection: Marker,
+        norm: nn.Module,
+    ) -> torch.Tensor:
+        del block_residual, norm
+        residual_calls.append((projection.value, hidden_states.clone()))
+        return hidden_states + projection.value * 100
+
+    monkeypatch.setattr(kimi_k3, "_apply_attention_residual", fake_attention_residual)
+    monkeypatch.setattr(
+        kimi_k3,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_first_rank=True, is_last_rank=True),
+    )
+
+    model = KimiK3TextModel.__new__(KimiK3TextModel)
+    nn.Module.__init__(model)
+    model.do_not_compile = True
+    model.start_layer = 0
+    model.end_layer = 2
+    model.layers = nn.ModuleList([FakeLayer(0), FakeLayer(1)])
+    model.embed_input_ids = MagicMock(return_value=torch.tensor([[1.0]]))
+    model.output_attn_res_proj = Marker(0)
+    model.output_attn_res_norm = nn.Identity()
+    model.norm = nn.Identity()
+    model.dspark_aux_capture_materialized = True
+    model._set_aux_hidden_state_layers((0, 1))
+
+    hidden_states, aux_hidden_states = model(
+        torch.tensor([1]),
+        torch.tensor([0]),
+        None,
+    )
+
+    torch.testing.assert_close(aux_hidden_states[0], consumed_inputs[0])
+    torch.testing.assert_close(aux_hidden_states[1], consumed_inputs[1])
+    torch.testing.assert_close(aux_hidden_states[0], torch.tensor([[1.0]]))
+    torch.testing.assert_close(aux_hidden_states[1], torch.tensor([[111.0]]))
+    torch.testing.assert_close(hidden_states, torch.tensor([[121.0]]))
+    assert [layer_idx for layer_idx, _ in residual_calls] == [1, 1, 0]
+
+    residual_calls.clear()
+    consumed_inputs.clear()
+    model.dspark_aux_capture_materialized = False
+    model._set_aux_hidden_state_layers((1,))
+
+    _, raw_aux_hidden_states = model(
+        torch.tensor([1]),
+        torch.tensor([0]),
+        None,
+    )
+
+    torch.testing.assert_close(raw_aux_hidden_states[0], torch.tensor([[11.0]]))
+    assert [layer_idx for layer_idx, _ in residual_calls] == [1, 0]
+
+
+def test_kimi_k3_dspark_aux_capture_mode_is_forwarded():
+    causal_model = AscendKimiK3ForCausalLM.__new__(AscendKimiK3ForCausalLM)
+    nn.Module.__init__(causal_model)
+    causal_model.model = SimpleNamespace(dspark_aux_capture_materialized=False)
+
+    causal_model.set_dspark_aux_capture_materialized(True)
+
+    assert causal_model.model.dspark_aux_capture_materialized is True
+
+    wrapper = AscendKimiK3ForConditionalGeneration.__new__(AscendKimiK3ForConditionalGeneration)
+    nn.Module.__init__(wrapper)
+    wrapper.language_model = MagicMock()
+
+    wrapper.set_dspark_aux_capture_materialized(True)
+
+    wrapper.language_model.set_dspark_aux_capture_materialized.assert_called_once_with(True)

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -9,6 +9,7 @@ from torch import nn
 from torch.nn import functional as F
 
 from vllm_ascend.ascend_forward_context import MoECommType
+from vllm_ascend.ops.activation import AscendSituAndMul
 from vllm_ascend.ops.fused_moe import fused_moe as fused_moe_module
 from vllm_ascend.ops.fused_moe import routed_experts as routed_experts_module
 from vllm_ascend.ops.fused_moe import shared_experts as shared_experts_module
@@ -27,6 +28,8 @@ from vllm_ascend.ops.fused_moe.shared_experts import (
     FusedMoEEvents,
     SharedExpertParallelMode,
 )
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.quant_type import QuantType
 
 
@@ -921,6 +924,138 @@ def test_local_shared_expert_dp_pads_splits_gathers_and_unpads(num_tokens):
     )
     torch.testing.assert_close(result, hidden_states)
     tp_group.all_gather.assert_called_once_with(local_hidden_states, dim=0)
+
+
+def _build_quantized_shared_experts(layer, quant_type):
+    shared_experts = AscendSharedExperts.__new__(AscendSharedExperts)
+    shared_experts.layer = layer
+    shared_experts.multistream_overlap = False
+    shared_experts.quant_type = quant_type
+    shared_experts.lora_context = None
+    shared_experts.swiglu_limit = 0.0
+    shared_experts.swiglu_alpha = 1.0
+    shared_experts.swiglu_beta = 0.0
+    shared_experts.parallel_mode = MagicMock(return_value=SharedExpertParallelMode.SEQUENCE_PARALLEL_SEDP)
+    return shared_experts
+
+
+def _patch_shared_expert_runtime(monkeypatch, custom_ops):
+    stream = MagicMock()
+    monkeypatch.setattr(shared_experts_module, "npu_stream_switch", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(shared_experts_module, "shared_experts_calculation_stream", MagicMock())
+    monkeypatch.setattr(shared_experts_module.torch.npu, "current_stream", MagicMock(return_value=stream))
+    monkeypatch.setattr(shared_experts_module.torch.ops, "_C_ascend", custom_ops)
+
+
+@pytest.mark.parametrize("routed_quant_type", [QuantType.W8A8, QuantType.W4A8])
+def test_per_channel_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch, routed_quant_type):
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.ones(2, 4, dtype=torch.int32)
+    quantized_input = torch.ones(2, 4, dtype=torch.int8)
+    input_scale = torch.ones(2, dtype=torch.float32)
+    quantized_situ = torch.ones(2, 2, dtype=torch.int8)
+    situ_scale = torch.ones(2, dtype=torch.float32)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up_proj = MagicMock()
+    gate_up_proj.weight = torch.ones(4, 4, dtype=torch.int8)
+    gate_up_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
+    gate_up_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
+    gate_up_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod))
+    down_proj = MagicMock()
+    down_proj.weight = torch.ones(2, 4, dtype=torch.int8)
+    down_proj.weight_scale = torch.ones(4, dtype=torch.bfloat16)
+    down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
+    down_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW8A8DynamicLinearMethod))
+    layer = SimpleNamespace(
+        gate_up_proj=gate_up_proj,
+        down_proj=down_proj,
+        act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
+    )
+    shared_experts = _build_quantized_shared_experts(layer, routed_quant_type)
+    events = FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        after_routed_experts=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    fast_dynamic_quant = MagicMock(return_value=(quantized_input, input_scale))
+    fast_quant_matmul = MagicMock(side_effect=[gate_up, down_out])
+    custom_ops = SimpleNamespace(dequant_situ_quant=MagicMock(return_value=(quantized_situ, situ_scale)))
+
+    _patch_shared_expert_runtime(monkeypatch, custom_ops)
+    monkeypatch.setattr(shared_experts_module.torch_npu, "npu_dynamic_quant", fast_dynamic_quant, raising=False)
+    monkeypatch.setattr(shared_experts_module.torch_npu, "npu_quant_matmul", fast_quant_matmul)
+
+    output = shared_experts.forward(hidden_states, events)
+
+    torch.testing.assert_close(output, down_out)
+    gate_up_proj.assert_not_called()
+    down_proj.assert_not_called()
+    fast_dynamic_quant.assert_called_once_with(hidden_states)
+    assert fast_quant_matmul.call_count == 2
+    situ_call = custom_ops.dequant_situ_quant.call_args.kwargs
+    assert situ_call["x"] is gate_up
+    assert situ_call["weight_scale"] is gate_up_proj.weight_scale_fp32
+    assert situ_call["activation_scale"] is input_scale
+    assert situ_call["beta"] == 4.0
+    assert situ_call["linear_beta"] == 25.0
+    assert fast_quant_matmul.call_args_list[1].kwargs["pertoken_scale"] is situ_scale
+
+
+def test_per_channel_w4a8_shared_situ_uses_single_expert_gmm_fusion(monkeypatch):
+    hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up = torch.randn(2, 8, dtype=torch.bfloat16)
+    quantized_input = torch.ones(2, 4, dtype=torch.int8)
+    input_scale = torch.ones(2, dtype=torch.float32)
+    quantized_situ = torch.ones(2, 4, dtype=torch.int8)
+    situ_scale = torch.ones(2, dtype=torch.float32)
+    down_out = torch.randn(2, 4, dtype=torch.bfloat16)
+    gate_up_proj = MagicMock(return_value=(gate_up, None))
+    gate_up_proj.weight_scale = torch.ones(8, dtype=torch.int64)
+    gate_up_proj.weight_scale_fp32 = torch.ones(8, dtype=torch.float32)
+    gate_up_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod))
+    down_proj = MagicMock(return_value=(down_out, None))
+    down_proj.weight_scale = torch.ones(4, dtype=torch.int64)
+    down_proj.weight_scale_fp32 = torch.ones(4, dtype=torch.float32)
+    down_proj.quant_method = SimpleNamespace(quant_method=MagicMock(spec=AscendW4A8DynamicLinearMethod))
+    layer = SimpleNamespace(
+        gate_up_proj=gate_up_proj,
+        down_proj=down_proj,
+        act_fn=AscendSituAndMul(beta=4.0, linear_beta=25.0),
+    )
+    shared_experts = _build_quantized_shared_experts(layer, QuantType.W4A8)
+    shared_experts.part1 = MagicMock()
+    shared_experts.part2 = MagicMock()
+    events = FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        after_routed_experts=MagicMock(),
+        before_gmm2=MagicMock(),
+        before_combine=MagicMock(),
+    )
+    dynamic_quant = MagicMock(return_value=(quantized_input, input_scale))
+    quant_matmul = MagicMock()
+    custom_ops = SimpleNamespace(dequant_situ_quant=MagicMock(return_value=(quantized_situ, situ_scale)))
+
+    _patch_shared_expert_runtime(monkeypatch, custom_ops)
+    monkeypatch.setattr(shared_experts_module.torch_npu, "npu_dynamic_quant", dynamic_quant, raising=False)
+    monkeypatch.setattr(shared_experts_module.torch_npu, "npu_quant_matmul", quant_matmul)
+
+    output = shared_experts.forward(hidden_states, events)
+
+    assert output is down_out
+    gate_quantized, gate_scale = gate_up_proj.call_args.args[0]
+    assert gate_quantized is quantized_input
+    assert gate_scale is input_scale
+    situ_call = custom_ops.dequant_situ_quant.call_args.kwargs
+    assert situ_call["x"] is gate_up
+    assert situ_call["weight_scale"] is None
+    assert situ_call["activation_scale"] is None
+    down_quantized, down_scale = down_proj.call_args.args[0]
+    assert down_quantized is quantized_situ
+    assert down_scale is situ_scale
+    shared_experts.part1.assert_not_called()
+    shared_experts.part2.assert_not_called()
+    quant_matmul.assert_not_called()
 
 
 @pytest.mark.parametrize("num_tokens", [4, 5])

--- a/tests/ut/ops/test_layernorm.py
+++ b/tests/ut/ops/test_layernorm.py
@@ -64,6 +64,25 @@ def test_RMSNorm_forward(
         assert torch.allclose(out_x, expected_out_x)
 
 
+def test_RMSNorm_supports_quant_config_without_quant_description(default_vllm_config):
+    default_vllm_config.quant_config = object()
+
+    layer = RMSNorm(hidden_size=8, eps=1e-05)
+
+    assert layer.bias is None
+
+
+def test_RMSNorm_creates_bias_from_quant_description(default_vllm_config):
+    quant_config = MagicMock()
+    quant_config.quant_description = {"model.layers.0.input_layernorm.bias": "W8A8"}
+    default_vllm_config.quant_config = quant_config
+
+    layer = RMSNorm(hidden_size=8, eps=1e-05)
+
+    assert layer.bias is not None
+    assert not layer.bias.requires_grad
+
+
 @pytest.mark.skipif(not is_310p_hw(), reason="310P device unittest case.")
 @pytest.mark.parametrize("residual", [None, torch.randn(4, 8, dtype=torch.float16)])
 @patch("torch_npu.npu_rms_norm", side_effect=mock_rms_norm)

--- a/tests/ut/patch/platform/test_patch_kv_cache_utils.py
+++ b/tests/ut/patch/platform/test_patch_kv_cache_utils.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+import vllm.v1.core.kv_cache_utils as upstream_kv_cache_utils
+import vllm.v1.engine.core as engine_core
+from vllm.utils.torch_utils import get_dtype_size
+from vllm.v1.kv_cache_interface import MambaSpec, UniformTypeKVCacheSpecs
+
+import vllm_ascend.patch.platform.patch_kv_cache_utils as kv_cache_utils_patch
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+
+BLOCK_SIZE = 768
+MAIN_PAGE_SIZE = 537_600
+DRAFT_PAGE_SIZE = BLOCK_SIZE * 576 * get_dtype_size(torch.bfloat16)
+MAX_MODEL_LEN = BLOCK_SIZE * 2
+NUM_SPECULATIVE_BLOCKS = 7
+NUM_BLOCKS_PER_REQUEST = 2 + 2 * (2 + NUM_SPECULATIVE_BLOCKS)
+PROFILED_NUM_BLOCKS = 12
+EXPECTED_CONCURRENCY = PROFILED_NUM_BLOCKS / NUM_BLOCKS_PER_REQUEST
+EXPECTED_TOKEN_CAPACITY = int(EXPECTED_CONCURRENCY * MAX_MODEL_LEN)
+
+
+def _make_vllm_config(
+    *,
+    num_gpu_blocks_override: int | None = None,
+    method: str = "dspark",
+    draft_model_type: str = "k3_dspark",
+    use_v2_model_runner: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        use_v2_model_runner=use_v2_model_runner,
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(model_type="wrapped_multimodal_model"),
+            hf_text_config=SimpleNamespace(
+                model_type="kimi_linear",
+                attn_res_block_size=3,
+            ),
+            max_model_len=MAX_MODEL_LEN,
+            original_max_model_len=MAX_MODEL_LEN,
+        ),
+        speculative_config=SimpleNamespace(
+            method=method,
+            draft_model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(model_type=draft_model_type),
+            ),
+        ),
+        scheduler_config=SimpleNamespace(
+            disable_hybrid_kv_cache_manager=False,
+        ),
+        cache_config=SimpleNamespace(
+            mamba_cache_mode="align",
+            num_gpu_blocks_override=num_gpu_blocks_override,
+        ),
+        parallel_config=SimpleNamespace(
+            decode_context_parallel_size=1,
+        ),
+        kv_transfer_config=None,
+    )
+
+
+def _make_kimi_k3_kv_cache_specs() -> dict[str, AscendMLAAttentionSpec | MambaSpec]:
+    target_spec = AscendMLAAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=1,
+        head_size=640,
+        dtype=torch.int8,
+        page_size_padded=MAIN_PAGE_SIZE,
+    )
+    draft_spec = AscendMLAAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+    )
+    mamba_spec = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((1,),),
+        dtypes=(torch.bfloat16,),
+        page_size_padded=MAIN_PAGE_SIZE,
+        mamba_cache_mode="align",
+        num_speculative_blocks=NUM_SPECULATIVE_BLOCKS,
+    )
+    assert target_spec.page_size_bytes == MAIN_PAGE_SIZE
+    assert target_spec.unpadded_page_size_bytes < MAIN_PAGE_SIZE
+    assert target_spec.compress_ratio == draft_spec.compress_ratio == 1
+    assert draft_spec.page_size_bytes == DRAFT_PAGE_SIZE
+    assert mamba_spec.num_speculative_blocks == NUM_SPECULATIVE_BLOCKS
+    return {
+        "target.0": target_spec,
+        "target.1": target_spec,
+        "draft.0": draft_spec,
+        "mamba.0": mamba_spec,
+        "mamba.1": mamba_spec,
+        "mamba.2": mamba_spec,
+        "mamba.3": mamba_spec,
+    }
+
+
+def _make_groups():
+    vllm_config = _make_vllm_config()
+    specs = _make_kimi_k3_kv_cache_specs()
+    groups = kv_cache_utils_patch.get_kv_cache_groups(vllm_config, specs)
+    return vllm_config, specs, groups
+
+
+def test_kimi_k3_dspark_draft_shares_target_logical_group_only() -> None:
+    _, specs, groups = _make_groups()
+
+    assert len(groups) == 3
+    target_draft_group = groups[0]
+    assert target_draft_group.layer_names == ["target.0", "target.1", "draft.0"]
+    assert target_draft_group.is_eagle_group
+    assert isinstance(target_draft_group.kv_cache_spec, UniformTypeKVCacheSpecs)
+    assert target_draft_group.kv_cache_spec.kv_cache_specs == {
+        "target.0": specs["target.0"],
+        "target.1": specs["target.1"],
+        "draft.0": specs["draft.0"],
+    }
+
+    assert [group.layer_names for group in groups[1:]] == [
+        ["mamba.0", "mamba.2"],
+        ["mamba.1", "mamba.3"],
+    ]
+    assert all(not group.is_eagle_group for group in groups[1:])
+    assert all(group.kv_cache_spec.page_size_bytes == MAIN_PAGE_SIZE for group in groups[1:])
+
+
+def test_kimi_k3_dspark_uses_main_hybrid_tensors_then_contiguous_draft_tensor() -> None:
+    vllm_config, _, groups = _make_groups()
+    bytes_per_global_block = 2 * MAIN_PAGE_SIZE + DRAFT_PAGE_SIZE
+    kv_cache_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=bytes_per_global_block * 11,
+    )
+
+    assert kv_cache_config.num_blocks == 11
+    assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
+        ["target.0", "mamba.0", "mamba.1"],
+        ["target.1", "mamba.2", "mamba.3"],
+        ["draft.0"],
+    ]
+    assert [tensor.size for tensor in kv_cache_config.kv_cache_tensors] == [
+        MAIN_PAGE_SIZE * 11,
+        MAIN_PAGE_SIZE * 11,
+        DRAFT_PAGE_SIZE * 11,
+    ]
+    assert all(tensor.offset == 0 for tensor in kv_cache_config.kv_cache_tensors)
+    assert all(tensor.block_stride == 0 for tensor in kv_cache_config.kv_cache_tensors)
+
+
+def test_kimi_k3_dspark_pool_memory_and_concurrency_use_global_block_ids() -> None:
+    vllm_config, _, groups = _make_groups()
+    bytes_per_global_block = 2 * MAIN_PAGE_SIZE + DRAFT_PAGE_SIZE
+
+    assert kv_cache_utils_patch._pool_bytes_per_block(vllm_config, groups) == bytes_per_global_block
+    assert (
+        kv_cache_utils_patch._max_memory_usage_bytes_from_groups(vllm_config, groups)
+        == bytes_per_global_block * NUM_BLOCKS_PER_REQUEST
+    )
+
+    kv_cache_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=bytes_per_global_block * PROFILED_NUM_BLOCKS,
+    )
+    concurrency = kv_cache_utils_patch.get_max_concurrency_for_kv_cache_config(vllm_config, kv_cache_config)
+    assert concurrency == pytest.approx(EXPECTED_CONCURRENCY)
+    token_capacity, concurrency = upstream_kv_cache_utils.get_kv_cache_capacity(vllm_config, kv_cache_config)
+    assert token_capacity == EXPECTED_TOKEN_CAPACITY
+    assert concurrency == pytest.approx(EXPECTED_CONCURRENCY)
+
+
+def test_kimi_k3_dspark_num_blocks_override_uses_bucketed_pool_size() -> None:
+    vllm_config, _, groups = _make_groups()
+    vllm_config.cache_config.num_gpu_blocks_override = 7
+    bytes_per_global_block = 2 * MAIN_PAGE_SIZE + DRAFT_PAGE_SIZE
+
+    kv_cache_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=bytes_per_global_block * PROFILED_NUM_BLOCKS,
+    )
+
+    assert kv_cache_config.num_blocks == 7
+    assert [tensor.size for tensor in kv_cache_config.kv_cache_tensors] == [
+        MAIN_PAGE_SIZE * 7,
+        MAIN_PAGE_SIZE * 7,
+        DRAFT_PAGE_SIZE * 7,
+    ]
+
+
+def test_kimi_k3_dspark_scheduler_uses_target_spec_for_uniform_group(monkeypatch) -> None:
+    vllm_config, _, groups = _make_groups()
+    bytes_per_global_block = 2 * MAIN_PAGE_SIZE + DRAFT_PAGE_SIZE
+    worker_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        groups,
+        available_memory=bytes_per_global_block * PROFILED_NUM_BLOCKS,
+    )
+
+    scheduler_config = upstream_kv_cache_utils.generate_scheduler_kv_cache_config([worker_config])
+
+    scheduler_target_spec = scheduler_config.kv_cache_groups[0].kv_cache_spec
+    assert isinstance(scheduler_target_spec, AscendMLAAttentionSpec)
+    assert scheduler_target_spec.dtype == torch.int8
+    assert scheduler_target_spec.page_size_bytes == MAIN_PAGE_SIZE
+    assert scheduler_config.kv_cache_groups[0].is_eagle_group
+    monkeypatch.setattr(
+        kv_cache_utils_patch,
+        "_orig_get_max_concurrency_for_kv_cache_config",
+        lambda *_: pytest.fail("K3 scheduler layout should use group-aware concurrency"),
+    )
+    token_capacity, concurrency = upstream_kv_cache_utils.get_kv_cache_capacity(vllm_config, scheduler_config)
+    assert token_capacity == EXPECTED_TOKEN_CAPACITY
+    assert concurrency == pytest.approx(EXPECTED_CONCURRENCY)
+
+
+def test_kimi_k3_dspark_pp_projection_handles_draft_only_worker_and_empty_groups(monkeypatch) -> None:
+    vllm_config, specs, global_groups = _make_groups()
+    projected_groups = upstream_kv_cache_utils._project_kv_cache_groups_to_worker(
+        global_groups,
+        {"draft.0": specs["draft.0"]},
+    )
+
+    assert projected_groups[0].layer_names == ["draft.0"]
+    assert all(not group.layer_names for group in projected_groups[1:])
+    assert kv_cache_utils_patch._pool_bytes_per_block(vllm_config, projected_groups) == DRAFT_PAGE_SIZE
+    assert (
+        kv_cache_utils_patch._max_memory_usage_bytes_from_groups(vllm_config, projected_groups)
+        == DRAFT_PAGE_SIZE * NUM_BLOCKS_PER_REQUEST
+    )
+
+    kv_cache_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        projected_groups,
+        available_memory=DRAFT_PAGE_SIZE * PROFILED_NUM_BLOCKS,
+    )
+    assert kv_cache_config.num_blocks == PROFILED_NUM_BLOCKS
+    assert len(kv_cache_config.kv_cache_tensors) == 1
+    assert kv_cache_config.kv_cache_tensors[0].shared_by == ["draft.0"]
+    assert kv_cache_config.kv_cache_tensors[0].size == DRAFT_PAGE_SIZE * PROFILED_NUM_BLOCKS
+    assert kv_cache_utils_patch.get_max_concurrency_for_kv_cache_config(vllm_config, kv_cache_config) == pytest.approx(
+        EXPECTED_CONCURRENCY
+    )
+
+    scheduler_config = upstream_kv_cache_utils.generate_scheduler_kv_cache_config([kv_cache_config])
+    assert scheduler_config.kv_cache_groups[0].kv_cache_spec.dtype == torch.bfloat16
+    monkeypatch.setattr(
+        kv_cache_utils_patch,
+        "_orig_get_max_concurrency_for_kv_cache_config",
+        lambda *_: pytest.fail("draft-only K3 scheduler layout should use group-aware concurrency"),
+    )
+    token_capacity, concurrency = upstream_kv_cache_utils.get_kv_cache_capacity(vllm_config, scheduler_config)
+    assert token_capacity == EXPECTED_TOKEN_CAPACITY
+    assert concurrency == pytest.approx(EXPECTED_CONCURRENCY)
+
+
+def test_kimi_k3_dspark_pp_projection_handles_mamba_only_worker() -> None:
+    vllm_config, specs, global_groups = _make_groups()
+    projected_groups = upstream_kv_cache_utils._project_kv_cache_groups_to_worker(
+        global_groups,
+        {"mamba.0": specs["mamba.0"]},
+    )
+
+    assert not projected_groups[0].layer_names
+    assert kv_cache_utils_patch._pool_bytes_per_block(vllm_config, projected_groups) == MAIN_PAGE_SIZE
+    assert (
+        kv_cache_utils_patch._max_memory_usage_bytes_from_groups(vllm_config, projected_groups)
+        == MAIN_PAGE_SIZE * NUM_BLOCKS_PER_REQUEST
+    )
+
+    kv_cache_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        projected_groups,
+        available_memory=MAIN_PAGE_SIZE * PROFILED_NUM_BLOCKS,
+    )
+    assert kv_cache_config.num_blocks == PROFILED_NUM_BLOCKS
+    assert len(kv_cache_config.kv_cache_tensors) == 1
+    assert kv_cache_config.kv_cache_tensors[0].shared_by == ["mamba.0"]
+
+
+def test_scheduler_eagle_flag_is_or_reduced_across_pp_workers() -> None:
+    vllm_config, specs, global_groups = _make_groups()
+    mamba_only_groups = upstream_kv_cache_utils._project_kv_cache_groups_to_worker(
+        global_groups,
+        {"mamba.0": specs["mamba.0"]},
+    )
+    target_draft_groups = upstream_kv_cache_utils._project_kv_cache_groups_to_worker(
+        global_groups,
+        {
+            "target.0": specs["target.0"],
+            "target.1": specs["target.1"],
+            "draft.0": specs["draft.0"],
+        },
+    )
+    mamba_only_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        mamba_only_groups,
+        available_memory=MAIN_PAGE_SIZE * PROFILED_NUM_BLOCKS,
+    )
+    target_draft_bytes_per_block = 2 * MAIN_PAGE_SIZE + DRAFT_PAGE_SIZE
+    target_draft_config = kv_cache_utils_patch.get_kv_cache_config_from_groups(
+        vllm_config,
+        target_draft_groups,
+        available_memory=target_draft_bytes_per_block * PROFILED_NUM_BLOCKS,
+    )
+
+    assert [group.is_eagle_group for group in mamba_only_config.kv_cache_groups] == [False, False, False]
+    assert [group.is_eagle_group for group in target_draft_config.kv_cache_groups] == [True, False, False]
+    assert (
+        upstream_kv_cache_utils.generate_scheduler_kv_cache_config
+        is kv_cache_utils_patch.generate_scheduler_kv_cache_config
+    )
+    assert engine_core.generate_scheduler_kv_cache_config is kv_cache_utils_patch.generate_scheduler_kv_cache_config
+
+    scheduler_config = engine_core.generate_scheduler_kv_cache_config([mamba_only_config, target_draft_config])
+
+    assert [group.is_eagle_group for group in scheduler_config.kv_cache_groups] == [True, False, False]
+    token_capacity, concurrency = upstream_kv_cache_utils.get_kv_cache_capacity(vllm_config, scheduler_config)
+    assert token_capacity == EXPECTED_TOKEN_CAPACITY
+    assert concurrency == pytest.approx(EXPECTED_CONCURRENCY)
+
+
+@pytest.mark.parametrize(
+    ("config_overrides"),
+    [
+        pytest.param({"method": "mtp"}, id="not-dspark"),
+        pytest.param({"draft_model_type": "deepseek_mtp"}, id="not-k3-draft"),
+        pytest.param({"use_v2_model_runner": True}, id="v2-fails-closed"),
+    ],
+)
+def test_kimi_k3_special_layout_is_narrow(config_overrides: dict[str, object]) -> None:
+    vllm_config = _make_vllm_config(**config_overrides)
+
+    assert (
+        kv_cache_utils_patch._get_kimi_k3_c8_dspark_spec_partition(
+            vllm_config,
+            _make_kimi_k3_kv_cache_specs(),
+        )
+        is None
+    )
+
+
+def test_non_kimi_grouping_delegates_to_existing_dsv4_mtp_path(monkeypatch) -> None:
+    sentinel = [object()]
+    vllm_config = _make_vllm_config(draft_model_type="deepseek_mtp")
+    monkeypatch.setattr(kv_cache_utils_patch, "_orig_get_kv_cache_groups", lambda *_: sentinel)
+
+    assert kv_cache_utils_patch.get_kv_cache_groups(vllm_config, _make_kimi_k3_kv_cache_specs()) is sentinel

--- a/tests/ut/patch/platform/test_patch_mamba_config.py
+++ b/tests/ut/patch/platform/test_patch_mamba_config.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.patch.platform.patch_mamba_config import (
+    _uses_mla_fa_quant_cache,
+    verify_and_update_config,
+)
+
+
+def test_non_modelslim_quantization_does_not_enable_mla_fa_quant_cache():
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            use_mla=True,
+            quantization="compressed-tensors",
+            model="/weights/other-model",
+            revision=None,
+        ),
+        quant_config=None,
+    )
+
+    with patch(
+        "vllm_ascend.patch.platform.patch_mamba_config."
+        "model_uses_fa_quantization",
+        return_value=True,
+    ) as detect_fa_quant:
+        assert not _uses_mla_fa_quant_cache(vllm_config)
+
+    detect_fa_quant.assert_not_called()
+
+
+def test_mla_fa_quant_metadata_doubles_attention_block_size_before_quant_config_init():
+    cache_config = SimpleNamespace(
+        cache_dtype="auto",
+        block_size=None,
+        mamba_page_size_padded=None,
+        enable_prefix_caching=True,
+        mamba_cache_mode="align",
+        mamba_block_size=None,
+    )
+    text_config = SimpleNamespace(
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+    )
+    model_config = SimpleNamespace(
+        use_mla=True,
+        dtype=torch.bfloat16,
+        architecture="AnyHybridMLAModel",
+        model="/weights/any-mla-model",
+        revision=None,
+        hf_text_config=text_config,
+        max_model_len=32768,
+        get_num_kv_heads=MagicMock(return_value=1),
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=cache_config,
+        model_config=model_config,
+        parallel_config=SimpleNamespace(),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        kv_transfer_config=None,
+        speculative_config=None,
+        # Match the real initialization order: ModelSlim quant_config is
+        # populated only after hybrid cache verification.
+        quant_config=None,
+    )
+    model_cls = SimpleNamespace(
+        get_mamba_state_shape_from_config=MagicMock(
+            return_value=((2304, 3), (6, 128, 128))
+        ),
+        get_mamba_state_dtype_from_config=MagicMock(
+            return_value=(torch.bfloat16, torch.float32)
+        ),
+    )
+
+    with (
+        patch(
+            "vllm_ascend.patch.platform.patch_mamba_config."
+            "MambaModelConfig.verify_and_update_config"
+        ),
+        patch(
+            "vllm_ascend.patch.platform.patch_mamba_config."
+            "ModelRegistry.resolve_model_cls",
+            return_value=(model_cls, None),
+        ),
+        patch(
+            "vllm_ascend.patch.platform.patch_mamba_config."
+            "model_uses_fa_quantization",
+            return_value=True,
+        ) as detect_fa_quant,
+    ):
+        verify_and_update_config.__func__(None, vllm_config)
+
+    assert cache_config.block_size == 768
+    assert cache_config.mamba_page_size_padded == 505344
+    assert cache_config.mamba_block_size == 768
+    detect_fa_quant.assert_called_once_with(
+        "/weights/any-mla-model",
+        revision=None,
+    )

--- a/tests/ut/patch/platform/test_patch_mamba_config.py
+++ b/tests/ut/patch/platform/test_patch_mamba_config.py
@@ -21,8 +21,7 @@ def test_non_modelslim_quantization_does_not_enable_mla_fa_quant_cache():
     )
 
     with patch(
-        "vllm_ascend.patch.platform.patch_mamba_config."
-        "model_uses_fa_quantization",
+        "vllm_ascend.patch.platform.patch_mamba_config.model_uses_fa_quantization",
         return_value=True,
     ) as detect_fa_quant:
         assert not _uses_mla_fa_quant_cache(vllm_config)
@@ -65,27 +64,18 @@ def test_mla_fa_quant_metadata_doubles_attention_block_size_before_quant_config_
         quant_config=None,
     )
     model_cls = SimpleNamespace(
-        get_mamba_state_shape_from_config=MagicMock(
-            return_value=((2304, 3), (6, 128, 128))
-        ),
-        get_mamba_state_dtype_from_config=MagicMock(
-            return_value=(torch.bfloat16, torch.float32)
-        ),
+        get_mamba_state_shape_from_config=MagicMock(return_value=((2304, 3), (6, 128, 128))),
+        get_mamba_state_dtype_from_config=MagicMock(return_value=(torch.bfloat16, torch.float32)),
     )
 
     with (
+        patch("vllm_ascend.patch.platform.patch_mamba_config.MambaModelConfig.verify_and_update_config"),
         patch(
-            "vllm_ascend.patch.platform.patch_mamba_config."
-            "MambaModelConfig.verify_and_update_config"
-        ),
-        patch(
-            "vllm_ascend.patch.platform.patch_mamba_config."
-            "ModelRegistry.resolve_model_cls",
+            "vllm_ascend.patch.platform.patch_mamba_config.ModelRegistry.resolve_model_cls",
             return_value=(model_cls, None),
         ),
         patch(
-            "vllm_ascend.patch.platform.patch_mamba_config."
-            "model_uses_fa_quantization",
+            "vllm_ascend.patch.platform.patch_mamba_config.model_uses_fa_quantization",
             return_value=True,
         ) as detect_fa_quant,
     ):

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -1,0 +1,712 @@
+from unittest.mock import MagicMock, Mock, patch
+
+import regex as re
+import torch
+
+from tests.ut.base import TestBase
+from tests.ut.quantization.conftest_quantization import identity
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicFusedMoEMethod, AscendW4A8DynamicLinearMethod
+from vllm_ascend.utils import COMPRESSED_TENSORS_METHOD
+
+
+class TestAscendW4A8DynamicLinearMethod(TestBase):
+    @patch("vllm_ascend.quantization.methods.w4a8.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
+    def setUp(self, mock_get_current_vllm_config, mock_get_tp_world_size):
+        mock_get_tp_world_size.return_value = 1
+        mock_vllm_config = Mock()
+        mock_vllm_config.quant_config = Mock(quant_description={"group_size": 256})
+        mock_vllm_config.scheduler_config = Mock(
+            max_num_batched_tokens=2048, max_model_len=2048, enable_chunked_prefill=False
+        )
+        mock_get_current_vllm_config.return_value = mock_vllm_config
+        self.method = AscendW4A8DynamicLinearMethod()
+        self.method.group_size = 8
+
+    def test_get_weight(self):
+        weight = self.method.get_weight(8, 32, torch.bfloat16)
+        self.assertEqual(weight["weight"].dtype, torch.int8)
+        self.assertEqual(weight["weight"].shape, (32, 8))
+        # new quant version weight
+        self.method.new_quant_version = True
+        weight = self.method.get_weight(8, 32, torch.bfloat16)
+        self.assertEqual(weight["weight"].dtype, torch.int8)
+        self.assertEqual(weight["weight"].shape, (16, 8))
+        self.assertEqual(weight["_packed_dim"], 0)
+        self.assertEqual(weight["_packed_factor"], 2)
+
+    def test_get_pergroup_param(self):
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16)
+        self.assertEqual(params["weight_scale"].dtype, torch.bfloat16)
+        self.assertEqual(params["weight_scale"].shape, (32, 1))
+        self.assertEqual(params["weight_offset"].dtype, torch.bfloat16)
+        self.assertEqual(params["weight_offset"].shape, (32, 1))
+        self.assertEqual(params["weight_scale_second"].dtype, torch.bfloat16)
+        self.assertEqual(params["weight_scale_second"].shape, (32, 1))
+        self.assertEqual(params["weight_offset_second"].dtype, torch.bfloat16)
+        self.assertEqual(params["weight_offset_second"].shape, (32, 1))
+        # new quant version weight
+        self.method.new_quant_version = True
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16, layer_type="column")
+        self.assertEqual(params["scale_bias"].dtype, torch.float32)
+        self.assertEqual(params["scale_bias"].shape, (32, 1))
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16, layer_type="row")
+        self.assertEqual(params["scale_bias"].dtype, torch.float32)
+        self.assertEqual(params["scale_bias"].shape, (32, 16))
+
+    def test_per_channel_weight_uses_only_first_level_scale(self):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+
+        params = self.method.get_pergroup_param(8, 32, torch.bfloat16)
+
+        self.assertEqual(params["weight_scale"].shape, (32, 1))
+        self.assertEqual(params["weight_offset"].shape, (32, 1))
+        self.assertNotIn("weight_scale_second", params)
+        self.assertNotIn("weight_offset_second", params)
+        self.assertEqual(params["scale_bias"].shape, (32, 1))
+
+    @patch("torch_npu.npu_quant_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_weight_uses_per_token_activation_scale(self, mock_dynamic_quant, mock_matmul):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(8, 4, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.bfloat16), requires_grad=False)
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        mock_dynamic_quant.return_value = (quantized_x, pertoken_scale)
+        mock_matmul.return_value = torch.empty(2, 8, dtype=torch.bfloat16)
+
+        self.method.apply(layer, x)
+
+        mock_dynamic_quant.assert_called_once_with(x)
+        self.assertEqual(mock_matmul.call_args.args, (quantized_x, layer.weight, layer.weight_scale))
+        self.assertIs(mock_matmul.call_args.kwargs["pertoken_scale"], pertoken_scale)
+        self.assertEqual(mock_matmul.call_args.kwargs["output_dtype"], x.dtype)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_shared_expert_uses_w4a8_grouped_matmul(
+        self, mock_dynamic_quant, mock_grouped_matmul
+    ):
+        self.method.enable_per_channel_shared_expert()
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.arange(8, dtype=torch.float32), requires_grad=False)
+        x = torch.randn(2, 1, 4, dtype=torch.bfloat16)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        expected_2d = torch.empty(2, 8, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (quantized_x, pertoken_scale)
+        mock_grouped_matmul.return_value = [expected_2d]
+
+        # A host-backed ``torch.tensor(..., device="npu")`` is illegal during
+        # ACL Graph capture. Keep this unit test sensitive to that regression;
+        # the implementation should create group_list with a device fill op.
+        with patch(
+            "torch.tensor",
+            side_effect=AssertionError("host tensor construction is not graph-safe"),
+        ):
+            output = self.method.apply(layer, x)
+
+        self.assertEqual(output.shape, (2, 1, 8))
+        mock_dynamic_quant.assert_called_once()
+        torch.testing.assert_close(mock_dynamic_quant.call_args.args[0], x.reshape(2, 4))
+        mock_grouped_matmul.assert_called_once()
+        call = mock_grouped_matmul.call_args.kwargs
+        self.assertIs(call["x"][0], quantized_x)
+        self.assertIs(call["weight"][0], layer.weight)
+        torch.testing.assert_close(call["scale"][0], layer.weight_scale.reshape(1, 1, -1))
+        torch.testing.assert_close(call["bias"][0], layer.scale_bias.reshape(1, -1))
+        self.assertIs(call["per_token_scale"][0], pertoken_scale)
+        torch.testing.assert_close(call["group_list"], torch.tensor([2]))
+        self.assertEqual(call["split_item"], 2)
+        self.assertEqual(call["group_type"], 0)
+        self.assertEqual(call["group_list_type"], 1)
+        self.assertEqual(call["output_dtype"], x.dtype)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_shared_expert_reuses_quantized_input(
+        self, mock_dynamic_quant, mock_grouped_matmul
+    ):
+        self.method.enable_per_channel_shared_expert()
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.arange(8, dtype=torch.float32), requires_grad=False)
+        quantized_x = torch.ones(2, 4, dtype=torch.int8)
+        pertoken_scale = torch.ones(2, dtype=torch.float32)
+        expected = torch.empty(2, 8, dtype=torch.bfloat16)
+        mock_grouped_matmul.return_value = [expected]
+
+        output = self.method.apply(layer, (quantized_x, pertoken_scale))
+
+        self.assertEqual(output.shape, expected.shape)
+        torch.testing.assert_close(output, expected)
+        mock_dynamic_quant.assert_not_called()
+        call = mock_grouped_matmul.call_args.kwargs
+        self.assertIs(call["x"][0], quantized_x)
+        self.assertIs(call["per_token_scale"][0], pertoken_scale)
+        self.assertEqual(call["output_dtype"], torch.bfloat16)
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_shared_expert_sums_owned_tp_scale_bias(
+        self, mock_dynamic_quant, mock_grouped_matmul
+    ):
+        self.method.enable_per_channel_shared_expert()
+        layer = torch.nn.Module()
+        layer.tp_size = 4
+        layer.tp_rank = 3
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(
+            torch.arange(8 * 16, dtype=torch.float32).reshape(8, 16),
+            requires_grad=False,
+        )
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (
+            torch.ones(2, 4, dtype=torch.int8),
+            torch.ones(2, dtype=torch.float32),
+        )
+        mock_grouped_matmul.return_value = [torch.empty(2, 8)]
+
+        self.method.apply(layer, x, tp_rank=3)
+
+        grouped_bias = mock_grouped_matmul.call_args.kwargs["bias"][0]
+        torch.testing.assert_close(grouped_bias, layer.scale_bias[:, 12:16].sum(dim=1).reshape(1, -1))
+
+    @patch("torch_npu.npu_grouped_matmul")
+    @patch("torch_npu.npu_dynamic_quant")
+    def test_apply_per_channel_shared_expert_tp1_sums_all_scale_bias(
+        self, mock_dynamic_quant, mock_grouped_matmul
+    ):
+        self.method.enable_per_channel_shared_expert()
+        layer = torch.nn.Module()
+        layer.tp_size = 1
+        layer.tp_rank = 0
+        layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones(8, dtype=torch.int64), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(
+            torch.arange(8 * 16, dtype=torch.float32).reshape(8, 16),
+            requires_grad=False,
+        )
+        x = torch.randn(2, 4, dtype=torch.bfloat16)
+        mock_dynamic_quant.return_value = (
+            torch.ones(2, 4, dtype=torch.int8),
+            torch.ones(2, dtype=torch.float32),
+        )
+        mock_grouped_matmul.return_value = [torch.empty(2, 8)]
+
+        self.method.apply(layer, x)
+
+        grouped_bias = mock_grouped_matmul.call_args.kwargs["bias"][0]
+        torch.testing.assert_close(grouped_bias, layer.scale_bias.sum(dim=1).reshape(1, -1))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
+    def test_process_per_channel_weight_without_second_level_scale(self, _mock_maybe_trans_nz):
+        self.method.group_size = 0
+        self.method.is_per_channel_weight = True
+        self.method.new_quant_version = True
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.empty((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        self.assertEqual(layer.weight.data.shape, (8, 4))
+        self.assertEqual(layer.weight_scale.data.shape, (32,))
+        self.assertEqual(layer.weight_scale.dtype, torch.bfloat16)
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        torch.testing.assert_close(layer.weight_scale_fp32, layer.weight_scale.data.float())
+        self.assertFalse(hasattr(layer, "weight_scale_second"))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    @patch("torch_npu.npu_convert_weight_to_int4pack")
+    @patch("torch.Tensor.npu")
+    @patch("torch_npu.npu_format_cast")
+    def test_process_weights_after_loading(
+        self, mock_format_cast, mock_npu, mock_npu_convert_weight, mock_maybe_trans_nz
+    ):
+        mock_npu.side_effect = lambda: torch.zeros((1, 32), dtype=torch.float32)
+        mock_npu_convert_weight.return_value = torch.zeros((32, 4), dtype=torch.int32)
+        mock_maybe_trans_nz.side_effect = identity
+        # old quant version weight
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((32, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.empty_like(layer.weight_scale.data), requires_grad=False)
+        layer.weight_scale_second = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset_second = torch.nn.Parameter(
+            torch.empty_like(layer.weight_scale_second.data), requires_grad=False
+        )
+        mock_format_cast.return_value = layer.weight.data.transpose(0, 1).contiguous()
+        self.method.process_weights_after_loading(layer)
+        self.assertTrue(hasattr(layer, "weight_scale_bias"))
+        self.assertEqual(layer.weight_scale_bias.data.shape, (32,))
+        self.assertEqual(layer.weight_scale_bias.data.dtype, torch.float32)
+        # new quant version weight
+        self.method.new_quant_version = True
+        new_layer = torch.nn.Module()
+        new_layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        new_layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        new_layer.weight_offset = torch.nn.Parameter(torch.empty_like(new_layer.weight_scale.data), requires_grad=False)
+        new_layer.weight_scale_second = torch.nn.Parameter(
+            torch.ones((32, 1), dtype=torch.float32), requires_grad=False
+        )
+        new_layer.weight_offset_second = torch.nn.Parameter(
+            torch.empty_like(new_layer.weight_scale_second.data), requires_grad=False
+        )
+        new_layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+        mock_format_cast.return_value = new_layer.weight.data.transpose(0, 1).contiguous()
+        self.method.process_weights_after_loading(new_layer)
+        self.assertEqual(new_layer.scale_bias.data.shape, (32,))
+        self.assertTrue(hasattr(new_layer, "weight_scale_second"))
+        self.assertEqual(new_layer.weight_scale_second.data.shape, (1, 32))
+
+    @patch("torch_npu.npu_weight_quant_batchmatmul")
+    def test_apply_basic(self, mock_matmul):
+        layer = MagicMock()
+        layer.weight = MagicMock(data=torch.randint(-8, 8, (256, 512), dtype=torch.int8))
+        layer.weight_scale_second = MagicMock(data=torch.randn(1, 512, dtype=torch.float32))
+        mock_matmul.return_value = torch.randn(32, 512)
+        x = torch.randn(32, 256)
+        self.method.apply(layer, x)
+        mock_matmul.assert_called_once()
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    def test_process_weights_after_loading_asserts_new_quant_packed_dim(self, mock_maybe_trans_nz):
+        self.method.new_quant_version = True
+        mock_maybe_trans_nz.side_effect = identity
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((10, 16), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((20, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.empty_like(layer.weight_scale.data), requires_grad=False)
+        layer.weight_scale_second = torch.nn.Parameter(torch.ones((20, 2), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset_second = torch.nn.Parameter(
+            torch.empty_like(layer.weight_scale_second.data), requires_grad=False
+        )
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((20, 1), dtype=torch.float32), requires_grad=False)
+        expected_message = "the last dim of weight needs to be divided by 4 but got shape torch.Size([16, 10])"
+
+        with (
+            patch.object(self.method, "process_scale_second", return_value=(torch.ones((2, 20)), None)),
+            self.assertRaisesRegex(AssertionError, re.escape(expected_message)),
+        ):
+            self.method.process_weights_after_loading(layer)
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    @patch("torch_npu.npu_convert_weight_to_int4pack")
+    def test_process_per_channel_shared_expert_prepares_grouped_nz_weight(
+        self, mock_int4pack, mock_maybe_trans_nz
+    ):
+        self.method.enable_per_channel_shared_expert()
+        self.method.new_quant_version = True
+        mock_maybe_trans_nz.side_effect = identity
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(
+            torch.tensor([[1.0], [2.0]] + [[1.0]] * 30, dtype=torch.float32),
+            requires_grad=False,
+        )
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        layer.scale_bias = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        mock_int4pack.assert_not_called()
+        mock_maybe_trans_nz.assert_called_once()
+        nz_input = mock_maybe_trans_nz.call_args.args[0]
+        self.assertEqual(nz_input.shape, torch.Size([1, 8, 16]))
+        self.assertEqual(nz_input.dtype, torch.int8)
+        self.assertEqual(layer.weight.shape, torch.Size([1, 8, 4]))
+        self.assertEqual(layer.weight.dtype, torch.int32)
+        self.assertEqual(layer.weight_scale_fp32.dtype, torch.float32)
+        self.assertEqual(layer.weight_scale_fp32.shape, torch.Size([32]))
+        self.assertEqual(layer.weight_scale.dtype, torch.int64)
+        expected_scale_bits = layer.weight_scale_fp32.numpy().view("uint32").astype("int64")
+        torch.testing.assert_close(layer.weight_scale, torch.from_numpy(expected_scale_bits))
+        self.assertEqual(layer.scale_bias.shape, torch.Size([32]))
+
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
+    def test_process_per_channel_shared_expert_tp1_sums_down_scale_bias(
+        self, _mock_maybe_trans_nz
+    ):
+        self.method.enable_per_channel_shared_expert()
+        self.method.new_quant_version = True
+        layer = torch.nn.Module()
+        layer.tp_size = 1
+        layer.tp_rank = 0
+        layer.weight = torch.nn.Parameter(torch.zeros((16, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.bfloat16), requires_grad=False)
+        original_bias = torch.arange(32 * 16, dtype=torch.float32).reshape(32, 16)
+        layer.scale_bias = torch.nn.Parameter(original_bias.clone(), requires_grad=False)
+
+        self.method.process_weights_after_loading(layer)
+
+        torch.testing.assert_close(layer.scale_bias, original_bias.sum(dim=1))
+
+    def test_process_per_channel_shared_expert_rejects_old_quant_version(self):
+        self.method.enable_per_channel_shared_expert()
+        self.method.new_quant_version = False
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(torch.zeros((32, 8), dtype=torch.int8), requires_grad=False)
+        layer.weight_scale = torch.nn.Parameter(torch.ones((32, 1), dtype=torch.float32), requires_grad=False)
+        layer.weight_offset = torch.nn.Parameter(torch.zeros((32, 1), dtype=torch.float32), requires_grad=False)
+
+        with self.assertRaisesRegex(ValueError, "requires quantization version 1.0.0"):
+            self.method.process_weights_after_loading(layer)
+
+
+class TestAscendW4A8DynamicLinearMethodWithNpu(TestBase):
+    @patch("vllm_ascend.quantization.methods.w4a8.get_tensor_model_parallel_world_size")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
+    def setUp(self, mock_get_current_vllm_config, mock_get_tp_world_size):
+        mock_get_tp_world_size.return_value = 1
+        mock_vllm_config = Mock()
+        mock_vllm_config.quant_config = Mock(quant_description={"group_size": 64})
+        mock_get_current_vllm_config.return_value = mock_vllm_config
+        self.method = AscendW4A8DynamicLinearMethod()
+
+    def test_apply_with_npu(self):
+        layer = torch.nn.Module()
+        layer.weight = torch.nn.Parameter(
+            torch.randint(-128, 127, (128, 32), dtype=torch.int32).npu(), requires_grad=False
+        )
+        layer.weight_scale_second = torch.nn.Parameter(
+            torch.randn(2, 256, dtype=torch.bfloat16).npu(), requires_grad=False
+        )
+
+        x = torch.randn(32, 128, dtype=torch.bfloat16).npu()
+        output = self.method.apply(layer, x)
+        self.assertEqual(output.shape, (32, 256))
+
+
+class TestAscendW4A8DynamicFusedMoEMethod(TestBase):
+    experts = 8
+    input_size = 16
+    output_size = 56
+    group_size = 2
+
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_current_vllm_config")
+    @patch("vllm_ascend.quantization.methods.w4a8.get_mc2_group")
+    @patch("torch.distributed.get_rank", return_value=0)
+    def setUp(self, mock_get_rank, mock_get_mc2_group, get_current_vllm_config, mock_get_ascend_config):
+        # Mock ascend config
+        mock_ascend_config = Mock()
+        mock_ascend_config.eplb_config.dynamic_eplb = False
+        mock_get_ascend_config.return_value = mock_ascend_config
+
+        mock_vllm_config = Mock()
+        mock_vllm_config.quant_config = Mock(quant_description={"group_size": self.group_size, "version": "0.0.0"})
+        mock_vllm_config.parallel_config = Mock(enable_expert_parallel=True)
+        mock_vllm_config.scheduler_config = Mock(
+            max_num_batched_tokens=2048, max_model_len=2048, enable_chunked_prefill=False
+        )
+        get_current_vllm_config.return_value = mock_vllm_config
+        self.quant_method = AscendW4A8DynamicFusedMoEMethod()
+
+    def test_get_weight(self):
+        # old quant version w4a8 weight
+        param_dict = self.quant_method.get_weight(self.experts, self.input_size, self.output_size, torch.bfloat16)
+        self.assertEqual(param_dict["w13_weight"].dtype, torch.int8)
+        self.assertEqual(param_dict["w13_weight"].shape, (self.experts, 2 * self.input_size, self.output_size))
+        # new quant version weight
+        self.quant_method.new_quant_version = True
+        param_dict = self.quant_method.get_weight(self.experts, self.input_size, self.output_size, torch.bfloat16)
+        self.assertEqual(param_dict["w13_weight"].dtype, torch.int8)
+        self.assertEqual(param_dict["w13_weight"].shape, (self.experts, self.input_size, self.output_size))
+
+    def test_get_dynamic_quant_param(self):
+        # old quant version weight
+        param_dict = self.quant_method.get_dynamic_quant_param(
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
+        self.assertEqual(param_dict["w13_weight_scale"].dtype, torch.float32)
+        self.assertEqual(param_dict["w13_weight_scale"].shape, (self.experts, 2 * self.input_size, 1))
+        self.assertEqual(param_dict["w13_weight_scale_second"].dtype, torch.float32)
+        self.assertEqual(
+            param_dict["w13_weight_scale_second"].shape,
+            (self.experts, 2 * self.input_size, self.output_size // self.group_size),
+        )
+        self.assertEqual(param_dict["w2_weight_scale"].dtype, torch.float32)
+        self.assertEqual(param_dict["w2_weight_scale"].shape, (self.experts, self.output_size, 1))
+        self.assertEqual(param_dict["w2_weight_scale_second"].dtype, torch.float32)
+        self.assertEqual(
+            param_dict["w2_weight_scale_second"].shape,
+            (self.experts, self.output_size, self.input_size // self.group_size),
+        )
+        # new quant version weight
+        self.quant_method.new_quant_version = True
+        param_dict = self.quant_method.get_dynamic_quant_param(
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
+        self.assertEqual(param_dict["w2_scale_bias"].dtype, torch.float32)
+        self.assertEqual(
+            param_dict["w2_scale_bias"].shape, (self.experts, self.output_size, 16 // self.quant_method.tp_size)
+        )
+        # per-channel weight
+        self.quant_method.is_per_channel_weight = True
+        param_dict = self.quant_method.get_dynamic_quant_param(
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
+        pergroup_param = [
+            "w13_weight_scale_second",
+            "w13_weight_offset_second",
+            "w2_weight_scale_second",
+            "w2_weight_offset_second",
+        ]
+        is_contains = any(key in param_dict for key in pergroup_param)
+        self.assertFalse(is_contains)
+
+    def build_layer(self, is_new_quant_version=True, is_per_channel_weight=False):
+        layer = torch.nn.Module()
+        if is_new_quant_version:
+            layer.w13_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, self.input_size, self.output_size), dtype=torch.int8), requires_grad=False
+            )
+            layer.w2_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, self.output_size // 2, self.input_size), dtype=torch.int8),
+                requires_grad=False,
+            )
+            w13_scale_bias = torch.zeros((self.experts, 2 * self.input_size, 1), dtype=torch.float32)
+            layer.w13_scale_bias = torch.nn.Parameter(w13_scale_bias, requires_grad=False)
+            w2_scale_bias = torch.zeros(
+                (self.experts, self.output_size, 16 // self.quant_method.tp_size), dtype=torch.float32
+            )
+            layer.w2_scale_bias = torch.nn.Parameter(w2_scale_bias, requires_grad=False)
+        else:
+            layer.w13_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, 2 * self.input_size, self.output_size), dtype=torch.int8),
+                requires_grad=False,
+            )
+            layer.w2_weight = torch.nn.Parameter(
+                torch.zeros((self.experts, self.output_size, self.input_size), dtype=torch.int8), requires_grad=False
+            )
+        layer.w13_weight_scale = torch.nn.Parameter(
+            torch.ones((self.experts, 2 * self.input_size, 1), dtype=torch.float32), requires_grad=False
+        )
+        layer.w2_weight_scale = torch.nn.Parameter(
+            torch.ones((self.experts, self.output_size, 1), dtype=torch.float32), requires_grad=False
+        )
+        if not is_per_channel_weight:
+            layer.w13_weight_scale_second = torch.nn.Parameter(
+                torch.ones(
+                    (self.experts, 2 * self.input_size, self.output_size // self.group_size), dtype=torch.float32
+                ),
+                requires_grad=False,
+            )
+            layer.w13_weight_offset_second = torch.nn.Parameter(
+                torch.empty_like(layer.w13_weight_scale_second.data), requires_grad=False
+            )
+            layer.w2_weight_scale_second = torch.nn.Parameter(
+                torch.ones((self.experts, self.output_size, self.input_size // self.group_size), dtype=torch.float32),
+                requires_grad=False,
+            )
+            layer.w2_weight_offset_second = torch.nn.Parameter(
+                torch.empty_like(layer.w2_weight_scale_second.data), requires_grad=False
+            )
+        return layer
+
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    @patch("torch_npu.npu_format_cast")
+    @patch("torch_npu.npu_quantize")
+    @patch("torch.Tensor.npu", new=lambda self: self)
+    def test_process_weights_after_loading(
+        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz, mock_get_ascend_config
+    ):
+        mock_npu_quantize.return_value = torch.Tensor()
+        mock_npu_format_cast.side_effect = identity
+        mock_maybe_trans_nz.side_effect = identity
+        mock_get_ascend_config.return_value.enable_fused_mc2 = 0
+        # old quant version weight
+        layer = self.build_layer(is_new_quant_version=False)
+        self.quant_method.process_weights_after_loading(layer)
+        self.assertTrue(hasattr(layer, "w13_scale_bias"))
+        self.assertEqual(layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(layer.w13_scale_bias.data.dtype, torch.float32)
+        self.assertTrue(hasattr(layer, "w2_scale_bias"))
+        self.assertEqual(layer.w2_scale_bias.data.shape, (self.experts, self.output_size))
+        self.assertEqual(layer.w2_scale_bias.data.dtype, torch.float32)
+        # new quant version weight
+        self.quant_method.new_quant_version = True
+        new_layer = self.build_layer(is_new_quant_version=True)
+        self.quant_method.process_weights_after_loading(new_layer)
+        self.assertEqual(new_layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(new_layer.w2_scale_bias.data.shape, (self.experts, self.output_size))
+        self.assertFalse(hasattr(new_layer, "w13_weight_scale_second"))
+        # per-channel weight
+        self.quant_method.is_per_channel_weight = True
+        per_channel_layer = self.build_layer(is_new_quant_version=True, is_per_channel_weight=True)
+        self.quant_method.process_weights_after_loading(per_channel_layer)
+        self.assertEqual(new_layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(per_channel_layer.w13_weight_scale.data.shape, (self.experts, 2 * self.input_size))
+
+    def test_pack_to_int32_asserts_new_quant_packed_dim(self):
+        self.quant_method.new_quant_version = True
+        weight = torch.zeros((self.experts, self.output_size, 10), dtype=torch.int8)
+        expected_message = f"the last dim of weight needs to be divided by 4 but got shape {weight.shape}"
+
+        with self.assertRaisesRegex(AssertionError, re.escape(expected_message)):
+            self.quant_method.pack_to_int32(weight)
+
+    def test_pack_to_int32_preserves_prepacked_int4_bytes(self):
+        self.quant_method.new_quant_version = True
+        # Each int8 byte already contains two int4 values. The ABI conversion
+        # must only reinterpret four adjacent bytes as int32, not repack them.
+        weight = torch.tensor([[[0x21, 0x43, 0x65, 0x07]]], dtype=torch.int8)
+
+        packed = self.quant_method.pack_to_int32(weight)
+
+        self.assertEqual(packed.dtype, torch.int32)
+        self.assertEqual(packed.shape, torch.Size([1, 1, 1]))
+        torch.testing.assert_close(packed.view(torch.int8), weight)
+
+    def test_get_weight_compressed_tensors(self):
+        self.quant_method.quant_method = COMPRESSED_TENSORS_METHOD
+        result = self.quant_method.get_weight(self.experts, self.input_size, self.output_size, torch.bfloat16)
+        self.assertEqual(result["w13_weight"].dtype, torch.int8)
+
+    def test_get_dynamic_quant_param_compressed_tensors(self):
+        self.quant_method.quant_method = COMPRESSED_TENSORS_METHOD
+        result = self.quant_method.get_dynamic_quant_param(
+            self.experts, self.input_size, self.output_size, torch.bfloat16
+        )
+        self.assertIn("w13_weight_scale", result)
+        self.assertIn("w2_weight_scale", result)
+        self.assertEqual(result["w13_weight_scale"].dtype, torch.bfloat16)
+        self.assertEqual(result["w2_weight_scale"].dtype, torch.bfloat16)
+
+    @patch("vllm_ascend.quantization.methods.w4a8.get_ascend_config")
+    @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
+    @patch("torch_npu.npu_format_cast")
+    @patch("torch_npu.npu_quantize")
+    @patch("torch.Tensor.npu", new=lambda self: self)
+    def test_process_weights_after_loading_compressed_tensors(
+        self, mock_npu_quantize, mock_npu_format_cast, mock_maybe_trans_nz, mock_get_ascend_config
+    ):
+        mock_npu_quantize.return_value = torch.Tensor()
+        mock_npu_format_cast.side_effect = identity
+        mock_maybe_trans_nz.side_effect = identity
+        mock_get_ascend_config.return_value.enable_fused_mc2 = 0
+
+        layer = self.build_layer(is_new_quant_version=False)
+        self.quant_method.quant_method = COMPRESSED_TENSORS_METHOD
+        self.quant_method.weight_strategy = "group"
+        self.quant_method.process_weights_after_loading(layer)
+        self.assertTrue(hasattr(layer, "w13_scale_bias"))
+        self.assertEqual(layer.w13_scale_bias.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(layer.w13_scale_bias.data.dtype, torch.float32)
+
+        self.quant_method.is_per_channel_weight = True
+        self.quant_method.weight_strategy = "channel"
+        per_channel_layer = self.build_layer(is_new_quant_version=False)
+        self.quant_method.process_weights_after_loading(per_channel_layer)
+        self.assertEqual(per_channel_layer.w13_weight_scale.data.shape, (self.experts, 2 * self.input_size))
+        self.assertEqual(per_channel_layer.w2_weight_scale.data.shape, (self.experts, 1, self.output_size))
+
+    @patch("vllm_ascend.quantization.methods.w4a8._EXTRA_CTX")
+    @patch("vllm_ascend.quantization.methods.w4a8.select_experts")
+    @patch("vllm_ascend.quantization.methods.w4a8.build_fused_experts_input")
+    def test_apply_comprehensive(self, mock_build_input, mock_select, mock_ctx):
+        tokens = 4
+        num_experts = self.experts
+        hidden_size = self.output_size
+        top_k = 2
+
+        layer = self.build_layer(is_new_quant_version=True, is_per_channel_weight=True)
+        self.quant_method.is_per_channel_weight = True
+        layer.swiglu_limit = 1000000
+        x = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
+        router_logits = torch.randn(tokens, num_experts, dtype=torch.float32)
+        topk_weights = torch.randn(tokens, top_k, dtype=torch.float32)
+        topk_ids = torch.randint(0, num_experts, (tokens, top_k), dtype=torch.int64)
+        expert_map = torch.randint(0, num_experts, (num_experts,), dtype=torch.int64)
+        mc2_mask = torch.tensor([1, 0, 1, 0], dtype=torch.bool)
+        pertoken_scale = torch.randn(tokens, dtype=torch.float32)
+        log2phy = torch.randint(0, num_experts, (num_experts,), dtype=torch.int64)
+        e_score_correction_bias = torch.randn(num_experts, dtype=torch.float32)
+
+        mock_select.return_value = (topk_weights, topk_ids)
+
+        mock_fused_input = Mock()
+        mock_fused_input.hidden_states = x
+        mock_fused_input.topk_weights = topk_weights
+        mock_fused_input.topk_ids = topk_ids
+        mock_fused_input.activation = "silu"
+        mock_build_input.return_value = mock_fused_input
+
+        mock_comm = Mock()
+        expected_output = torch.randn(tokens, hidden_size, dtype=torch.bfloat16)
+        mock_comm.fused_experts.return_value = expected_output
+        mock_ctx.moe_comm_method = mock_comm
+
+        output = self.quant_method.apply(
+            layer=layer,
+            x=x,
+            router_logits=router_logits,
+            top_k=top_k,
+            renormalize=True,
+            use_grouped_topk=False,
+            num_experts=num_experts,
+            expert_map=expert_map,
+            scoring_func="softmax",
+            routed_scaling_factor=1.0,
+            e_score_correction_bias=e_score_correction_bias,
+            is_prefill=True,
+            enable_force_load_balance=False,
+            log2phy=log2phy,
+            global_redundant_expert_num=0,
+            pertoken_scale=pertoken_scale,
+            activation="silu",
+            apply_router_weight_on_input=False,
+            mc2_mask=mc2_mask,
+        )
+
+        mock_select.assert_called_once()
+        select_call_args = mock_select.call_args
+        self.assertTrue(torch.equal(select_call_args.kwargs["hidden_states"], x))
+        self.assertEqual(select_call_args.kwargs["top_k"], top_k)
+        self.assertEqual(select_call_args.kwargs["num_experts"], num_experts)
+
+        mock_build_input.assert_called_once()
+        build_kwargs = mock_build_input.call_args.kwargs
+        self.assertTrue(torch.equal(build_kwargs["hidden_states"], x))
+        self.assertEqual(build_kwargs["quant_type"], self.quant_method.quant_type)
+        self.assertTrue(build_kwargs["is_per_channel_weight"])
+        self.assertEqual(build_kwargs["activation"], "silu")
+        self.assertEqual(build_kwargs["apply_router_weight_on_input"], False)
+
+        mock_comm.fused_experts.assert_called_once()
+        self.assertEqual(mock_comm.fused_experts.call_args.kwargs["fused_experts_input"], mock_fused_input)
+        self.assertTrue(torch.equal(output, expected_output))
+
+    def test_apply_asserts_router_logits_expert_mismatch(self):
+        layer = self.build_layer(is_new_quant_version=True, is_per_channel_weight=True)
+        x = torch.randn(4, self.output_size, dtype=torch.bfloat16)
+        router_logits = torch.randn(4, self.experts - 1, dtype=torch.float32)
+        expected_message = (
+            "Number of global experts mismatch (excluding redundancy): "
+            f"router_logits.shape[1]={self.experts - 1}, num_logical_experts={self.experts}"
+        )
+
+        with self.assertRaisesRegex(AssertionError, re.escape(expected_message)):
+            self.quant_method.apply(
+                layer=layer,
+                x=x,
+                router_logits=router_logits,
+                top_k=2,
+                renormalize=True,
+                num_experts=self.experts,
+            )

--- a/tests/ut/quantization/methods/a2/test_w4a8.py
+++ b/tests/ut/quantization/methods/a2/test_w4a8.py
@@ -90,9 +90,7 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
 
     @patch("torch_npu.npu_grouped_matmul")
     @patch("torch_npu.npu_dynamic_quant")
-    def test_apply_per_channel_shared_expert_uses_w4a8_grouped_matmul(
-        self, mock_dynamic_quant, mock_grouped_matmul
-    ):
+    def test_apply_per_channel_shared_expert_uses_w4a8_grouped_matmul(self, mock_dynamic_quant, mock_grouped_matmul):
         self.method.enable_per_channel_shared_expert()
         layer = torch.nn.Module()
         layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
@@ -132,9 +130,7 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
 
     @patch("torch_npu.npu_grouped_matmul")
     @patch("torch_npu.npu_dynamic_quant")
-    def test_apply_per_channel_shared_expert_reuses_quantized_input(
-        self, mock_dynamic_quant, mock_grouped_matmul
-    ):
+    def test_apply_per_channel_shared_expert_reuses_quantized_input(self, mock_dynamic_quant, mock_grouped_matmul):
         self.method.enable_per_channel_shared_expert()
         layer = torch.nn.Module()
         layer.weight = torch.nn.Parameter(torch.empty(1, 4, 1, dtype=torch.int32), requires_grad=False)
@@ -157,9 +153,7 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
 
     @patch("torch_npu.npu_grouped_matmul")
     @patch("torch_npu.npu_dynamic_quant")
-    def test_apply_per_channel_shared_expert_sums_owned_tp_scale_bias(
-        self, mock_dynamic_quant, mock_grouped_matmul
-    ):
+    def test_apply_per_channel_shared_expert_sums_owned_tp_scale_bias(self, mock_dynamic_quant, mock_grouped_matmul):
         self.method.enable_per_channel_shared_expert()
         layer = torch.nn.Module()
         layer.tp_size = 4
@@ -184,9 +178,7 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
 
     @patch("torch_npu.npu_grouped_matmul")
     @patch("torch_npu.npu_dynamic_quant")
-    def test_apply_per_channel_shared_expert_tp1_sums_all_scale_bias(
-        self, mock_dynamic_quant, mock_grouped_matmul
-    ):
+    def test_apply_per_channel_shared_expert_tp1_sums_all_scale_bias(self, mock_dynamic_quant, mock_grouped_matmul):
         self.method.enable_per_channel_shared_expert()
         layer = torch.nn.Module()
         layer.tp_size = 1
@@ -305,9 +297,7 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
 
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz")
     @patch("torch_npu.npu_convert_weight_to_int4pack")
-    def test_process_per_channel_shared_expert_prepares_grouped_nz_weight(
-        self, mock_int4pack, mock_maybe_trans_nz
-    ):
+    def test_process_per_channel_shared_expert_prepares_grouped_nz_weight(self, mock_int4pack, mock_maybe_trans_nz):
         self.method.enable_per_channel_shared_expert()
         self.method.new_quant_version = True
         mock_maybe_trans_nz.side_effect = identity
@@ -337,9 +327,7 @@ class TestAscendW4A8DynamicLinearMethod(TestBase):
         self.assertEqual(layer.scale_bias.shape, torch.Size([32]))
 
     @patch("vllm_ascend.quantization.methods.w4a8.maybe_trans_nz", side_effect=identity)
-    def test_process_per_channel_shared_expert_tp1_sums_down_scale_bias(
-        self, _mock_maybe_trans_nz
-    ):
+    def test_process_per_channel_shared_expert_tp1_sums_down_scale_bias(self, _mock_maybe_trans_nz):
         self.method.enable_per_channel_shared_expert()
         self.method.new_quant_version = True
         layer = torch.nn.Module()

--- a/tests/ut/quantization/methods/test_kv_c8.py
+++ b/tests/ut/quantization/methods/test_kv_c8.py
@@ -151,7 +151,7 @@ class TestAscendFAQuantAttentionMethodInit(unittest.TestCase):
         self.mock_hf_config = Mock()
         self.mock_hf_config.kv_lora_rank = 128
         self.mock_hf_config.qk_rope_head_dim = 64
-        self.mock_config.model_config.hf_config = self.mock_hf_config
+        self.mock_config.model_config.hf_text_config = self.mock_hf_config
         self.mock_get_config.return_value = self.mock_config
 
         # Import the class after patching
@@ -192,7 +192,7 @@ class TestAscendFAQuantAttentionMethodCreateWeights(unittest.TestCase):
         self.mock_hf_config = Mock()
         self.mock_hf_config.kv_lora_rank = 128
         self.mock_hf_config.qk_rope_head_dim = 64
-        self.mock_config.model_config.hf_config = self.mock_hf_config
+        self.mock_config.model_config.hf_text_config = self.mock_hf_config
         self.mock_get_config.return_value = self.mock_config
 
         # Import the class
@@ -308,7 +308,7 @@ class TestAscendFAQuantAttentionMethodProcessWeights(unittest.TestCase):
         self.mock_hf_config = Mock()
         self.mock_hf_config.kv_lora_rank = 64
         self.mock_hf_config.qk_rope_head_dim = 32
-        self.mock_config.model_config.hf_config = self.mock_hf_config
+        self.mock_config.model_config.hf_text_config = self.mock_hf_config
         self.mock_get_config.return_value = self.mock_config
 
         # Import the class
@@ -363,7 +363,7 @@ class TestIntegration(unittest.TestCase):
         self.mock_hf_config = Mock()
         self.mock_hf_config.kv_lora_rank = 64
         self.mock_hf_config.qk_rope_head_dim = 32
-        self.mock_config.model_config.hf_config = self.mock_hf_config
+        self.mock_config.model_config.hf_text_config = self.mock_hf_config
         self.mock_get_config.return_value = self.mock_config
 
         # Mock distributed functions

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -18,6 +18,7 @@ from vllm_ascend.quantization.modelslim_config import (
     get_linear_quant_type,
     get_packed_modules_mapping,
 )
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD
 
 
@@ -64,6 +65,277 @@ class TestAscendModelSlimConfig(TestBase):
         config = AscendModelSlimConfig.from_config(self.sample_config)
         self.assertIsInstance(config, AscendModelSlimConfig)
         self.assertEqual(config.quant_description, self.sample_config)
+
+    def test_model_mapping_packed_module_quant_types(self):
+        mapping = {
+            "gate_up_proj": ["gate_proj", "up_proj"],
+            "experts": ["experts.0.w1", "experts.0.w3", "experts.0.w2"],
+            "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        }
+        description = {
+            "language_model.model.layers.0.mlp.gate_proj.weight": "FLOAT",
+            "language_model.model.layers.0.mlp.up_proj.weight": "FLOAT",
+            "language_model.model.layers.1.block_sparse_moe.experts.0.w1.weight": "W4A8_DYNAMIC",
+            "language_model.model.layers.1.block_sparse_moe.experts.0.w2.weight": "W4A8_DYNAMIC",
+            "language_model.model.layers.1.block_sparse_moe.experts.0.w3.weight": "W4A8_DYNAMIC",
+            "language_model.model.layers.3.self_attn.q_a_proj.weight": "FLOAT",
+            "language_model.model.layers.3.self_attn.kv_a_proj_with_mqa.weight": "FLOAT",
+        }
+
+        assert (
+            get_linear_quant_type(
+                description,
+                "language_model.model.layers.0.mlp.gate_up_proj",
+                mapping,
+            )
+            == "FLOAT"
+        )
+        assert (
+            get_linear_quant_type(
+                description,
+                "language_model.model.layers.1.block_sparse_moe.experts",
+                mapping,
+            )
+            == "W4A8_DYNAMIC"
+        )
+        assert (
+            get_linear_quant_type(
+                description,
+                "language_model.model.layers.3.self_attn.fused_qkv_a_proj",
+                mapping,
+            )
+            == "FLOAT"
+        )
+
+    def test_get_quant_method_uses_model_mapping_and_gate_capability(self):
+        description = {
+            "model.layers.0.mlp.gate_proj.weight": "W8A8_DYNAMIC",
+            "model.layers.0.mlp.up_proj.weight": "W8A8_DYNAMIC",
+            "model.layers.1.block_sparse_moe.experts.0.w1.weight": "W4A8_DYNAMIC",
+            "model.layers.1.block_sparse_moe.experts.0.w2.weight": "W4A8_DYNAMIC",
+            "model.layers.1.block_sparse_moe.experts.0.w3.weight": "W4A8_DYNAMIC",
+            "model.layers.3.self_attn.q_a_proj.weight": "W8A8_DYNAMIC",
+            "model.layers.3.self_attn.kv_a_proj_with_mqa.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(description)
+        model_mapping = {
+            "gate_up_proj": ["gate_proj", "up_proj"],
+            "experts": ["experts.0.w1", "experts.0.w3", "experts.0.w2"],
+            "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+        }
+        config.packed_modules_mapping = model_mapping
+        vllm_config = MagicMock()
+        text_config = KimiLinearConfig(
+            linear_attn_config={
+                "kda_layers": [1],
+                "full_attn_layers": [2],
+                "use_full_rank_gate": True,
+            }
+        )
+        vllm_config.model_config.hf_config = text_config
+        vllm_config.model_config.hf_text_config = text_config
+        linear = MagicMock(spec=LinearBase)
+        fused_moe = RoutedExperts.__new__(RoutedExperts)
+        torch.nn.Module.__init__(fused_moe)
+        fused_moe.moe_config = MagicMock(spec=FusedMoEConfig)
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=MagicMock(),
+            ) as create_scheme,
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendLinearMethod",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendFusedMoEMethod",
+                return_value=MagicMock(),
+            ),
+        ):
+            temporary_g_a = config.get_quant_method(
+                linear,
+                "model.layers.0.self_attn.g_a_proj",
+            )
+            temporary_g_b = config.get_quant_method(
+                linear,
+                "model.layers.0.self_attn.g_b_proj",
+            )
+            config.get_quant_method(linear, "model.layers.0.mlp.gate_up_proj")
+            config.get_quant_method(
+                linear,
+                "model.layers.3.self_attn.fused_qkv_a_proj",
+            )
+            config.get_quant_method(
+                fused_moe,
+                "model.layers.1.block_sparse_moe.experts",
+            )
+
+        assert isinstance(temporary_g_a, AscendUnquantizedLinearMethod)
+        assert isinstance(temporary_g_b, AscendUnquantizedLinearMethod)
+        assert config.packed_modules_mapping is model_mapping
+        assert [call.args[2] for call in create_scheme.call_args_list] == [
+            "linear",
+            "linear",
+            "moe",
+        ]
+
+    def test_plain_kimi_linear_has_no_modelslim_override(self):
+        assert get_packed_modules_mapping(KimiLinearConfig.model_type) == {}
+        assert get_packed_modules_mapping("kimi_k2")["experts"] == [
+            "experts.0.gate_proj",
+            "experts.0.up_proj",
+            "experts.0.down_proj",
+        ]
+
+    def test_per_channel_shared_expert_w4a8_uses_grouped_matmul_scheme(self):
+        prefix = "model.layers.0.mlp.shared_experts.gate_up_proj"
+        config = AscendModelSlimConfig(
+            {
+                "group_size": 0,
+                f"{prefix}.weight": "W4A8_DYNAMIC",
+            }
+        )
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "future_hybrid_moe"
+        vllm_config.model_config.hf_text_config = MagicMock()
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+        scheme.is_per_channel_weight = True
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_per_channel_shared_expert.assert_called_once_with()
+
+    def test_per_group_shared_expert_does_not_use_grouped_matmul_scheme(self):
+        prefix = "model.layers.0.block_sparse_moe.shared_experts.gate_up_proj"
+        config = AscendModelSlimConfig(
+            {
+                "group_size": 256,
+                f"{prefix}.weight": "W4A8_DYNAMIC",
+            }
+        )
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "future_hybrid_moe"
+        vllm_config.model_config.hf_text_config = MagicMock()
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock(spec=AscendW4A8DynamicLinearMethod)
+        scheme.is_per_channel_weight = False
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ),
+            patch("vllm_ascend.quantization.method_adapters.AscendLinearMethod", return_value=MagicMock()),
+        ):
+            config.get_quant_method(linear, prefix)
+
+        scheme.enable_per_channel_shared_expert.assert_not_called()
+
+    def test_missing_linear_weight_without_gate_capability_does_not_fall_back(self):
+        config = AscendModelSlimConfig({})
+        config.packed_modules_mapping = {}
+        text_config = KimiLinearConfig(
+            linear_attn_config={
+                "kda_layers": [1],
+                "full_attn_layers": [2],
+                "use_full_rank_gate": False,
+            }
+        )
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config = text_config
+        vllm_config.model_config.hf_text_config = text_config
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock()
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ) as create_scheme,
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendLinearMethod",
+                return_value=MagicMock(),
+            ),
+        ):
+            method = config.get_quant_method(
+                linear,
+                "model.layers.0.self_attn.g_a_proj",
+            )
+
+        assert not isinstance(method, AscendUnquantizedLinearMethod)
+        create_scheme.assert_called_once_with(
+            {},
+            "model.layers.0.self_attn.g_a_proj",
+            "linear",
+            {},
+        )
+
+    def test_unknown_model_type_preserves_existing_packed_mapping(self):
+        description = {
+            "model.layers.0.mlp.gate_proj.weight": "W8A8_DYNAMIC",
+            "model.layers.0.mlp.up_proj.weight": "W8A8_DYNAMIC",
+        }
+        config = AscendModelSlimConfig(description)
+        packed_mapping = {
+            "gate_up_proj": ["gate_proj", "up_proj"],
+        }
+        config.packed_modules_mapping = packed_mapping
+        vllm_config = MagicMock()
+        vllm_config.model_config.hf_config.model_type = "qwen3"
+        linear = MagicMock(spec=LinearBase)
+        scheme = MagicMock()
+
+        with (
+            patch(
+                "vllm_ascend.quantization.modelslim_config.get_current_vllm_config",
+                return_value=vllm_config,
+            ),
+            patch(
+                "vllm_ascend.quantization.modelslim_config.create_scheme_for_layer",
+                return_value=scheme,
+            ) as create_scheme,
+            patch(
+                "vllm_ascend.quantization.method_adapters.AscendLinearMethod",
+                return_value=MagicMock(),
+            ),
+        ):
+            config.get_quant_method(
+                linear,
+                "model.layers.0.mlp.gate_up_proj",
+            )
+
+        assert config.packed_modules_mapping is packed_mapping
+        create_scheme.assert_called_once_with(
+            description,
+            "model.layers.0.mlp.gate_up_proj",
+            "linear",
+            packed_mapping,
+        )
 
     @patch("torch.npu.is_available")
     def test_override_quantization_method(self, mock_is_available):
@@ -453,6 +725,15 @@ class TestGetCacheScaleMapper(TestBase):
             mapper._map_name("model.layers.1.fa_v.offset"),
             "model.layers.1.mla_attn.mla_attn.fa_v.offset",
         )
+        # Kimi K3 multimodal loading invokes AutoWeightsLoader for both the
+        # outer model and language_model. A second application must preserve
+        # the parameter name registered on the inner MLAAttention module.
+        checkpoint_name = "language_model.model.layers.23.self_attn.fa_q.offset"
+        mapped_name = mapper._map_name(checkpoint_name)
+        self.assertEqual(
+            mapper._map_name(mapped_name),
+            "language_model.model.layers.23.self_attn.mla_attn.mla_attn.fa_q.offset",
+        )
 
     def test_indexer_quant_returns_mapper(self):
         config = AscendModelSlimConfig(
@@ -470,6 +751,11 @@ class TestGetCacheScaleMapper(TestBase):
         self.assertEqual(
             mapper._map_name("model.layers.1.indexer.k_rot"),
             "model.layers.1.mla_attn.mla_attn.indexer.k_rot",
+        )
+        mapped_name = mapper._map_name("model.layers.1.indexer.q_rot")
+        self.assertEqual(
+            mapper._map_name(mapped_name),
+            "model.layers.1.mla_attn.mla_attn.indexer.q_rot",
         )
 
 

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -7,10 +7,13 @@ import torch
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.layers.fused_moe import RoutedExperts
+from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.linear import LinearBase
+from vllm.transformers_utils.configs.kimi_linear import KimiLinearConfig
 
 from tests.ut.base import TestBase
 from vllm_ascend.ops.linear import AscendUnquantizedLinearMethod
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.quantization.modelslim_config import (
     MODELSLIM_CONFIG_FILENAME,
     AscendModelSlimConfig,
@@ -18,7 +21,6 @@ from vllm_ascend.quantization.modelslim_config import (
     get_linear_quant_type,
     get_packed_modules_mapping,
 )
-from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD
 
 

--- a/tests/ut/quantization/test_utils.py
+++ b/tests/ut/quantization/test_utils.py
@@ -15,6 +15,7 @@ from vllm_ascend.quantization.utils import (
     enable_fa_quant,
     get_dynamic_mx_quant_scale_alg,
     maybe_auto_detect_quantization,
+    model_uses_fa_quantization,
 )
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD, AscendDeviceType
 
@@ -63,6 +64,22 @@ class TestDetectQuantizationMethod(TestBase):
 
             result = detect_quantization_method(tmpdir)
             self.assertEqual(result, ASCEND_QUANTIZATION_METHOD)
+
+    def test_detects_fa_quantization_from_modelslim_metadata(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, MODELSLIM_CONFIG_FILENAME)
+            with open(config_path, "w") as f:
+                json.dump({"fa_quant_type": "FAKQuant"}, f)
+
+            self.assertTrue(model_uses_fa_quantization(tmpdir))
+
+    def test_fa_quantization_detection_is_model_agnostic(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = os.path.join(tmpdir, MODELSLIM_CONFIG_FILENAME)
+            with open(config_path, "w") as f:
+                json.dump({"model.layers.0.weight": "W8A8_DYNAMIC"}, f)
+
+            self.assertFalse(model_uses_fa_quantization(tmpdir))
 
     def test_detects_compressed_tensors(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -26,6 +26,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
@@ -723,4 +725,184 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
         kv_cache_config = SimpleNamespace(kv_cache_groups=[non_overlapping_group])
         with pytest.raises(RuntimeError, match="registered draft attention groups"):
             proposer.initialize_attn_backend(kv_cache_config)
+
+    def test_initialization_tracks_logical_block_size_per_gid(self, monkeypatch):
+        manager_specs = [MagicMock(), MagicMock()]
+        for spec in manager_specs:
+            spec.block_size = 384
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.backend"
+        layers = {}
+        for gid in range(2):
+            layer = MagicMock()
+            layer.get_attn_backend.return_value = backend
+            layers[f"L{gid}"] = layer
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *a, **k: layers,
+        )
+
+        proposer = self._make_proposer_for_init()
+        proposer.model = SimpleNamespace(
+            get_draft_kv_cache_layer_names=lambda: {"L0", "L1"}
+        )
+        assert not isinstance(
+            proposer.draft_model_config.hf_config,
+            dspark_proposer_module.K3DSparkConfig,
+        )
+        proposer.max_query_tokens = 8
+        proposer.max_num_tokens = 16
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=[f"L{gid}"],
+                    kv_cache_spec=manager_specs[gid],
+                )
+                for gid in range(2)
+            ],
+        )
+
+        with patch.object(AttentionGroup, "create_metadata_builders") as create_builders:
+            proposer.initialize_attn_backend(
+                kv_cache_config,
+                kernel_block_sizes=[128, 64],
+            )
+
+        assert [spec.block_size for spec in manager_specs] == [384, 384]
+        assert proposer._per_group_kernel_block_sizes == {0: 128, 1: 64}
+        assert [g.kv_cache_group_id for g in proposer.draft_attn_groups] == [0, 1]
+        assert set(proposer._per_group_query_slot_mapping_buffers) == {0, 1}
+        assert set(proposer._per_group_context_slot_mapping_buffers) == {0, 1}
+        assert proposer.kernel_block_size == 128
+        assert [
+            call.kwargs["kernel_block_size"]
+            for call in create_builders.call_args_list
+        ] == [128, 64]
+
+    def test_initialization_selects_draft_from_shared_uniform_group(self, monkeypatch):
+        target_spec = MagicMock()
+        target_spec.block_size = 768
+        draft_spec = MagicMock()
+        draft_spec.block_size = 768
+        uniform_spec = UniformTypeKVCacheSpecs(
+            block_size=768,
+            kv_cache_specs={
+                "target.0": target_spec,
+                "draft.0": draft_spec,
+            },
+        )
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.mla.backend"
+        draft_layer = MagicMock()
+        draft_layer.get_attn_backend.return_value = backend
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *a, **k: {"draft.0": draft_layer},
+        )
+
+        proposer = self._make_proposer_for_init()
+        proposer.model = SimpleNamespace(
+            get_draft_kv_cache_layer_names=lambda: {"draft.0"}
+        )
+        proposer.max_query_tokens = 8
+        proposer.max_num_tokens = 16
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=["target.0", "draft.0"],
+                    kv_cache_spec=uniform_spec,
+                )
+            ],
+        )
+
+        with patch.object(AttentionGroup, "create_metadata_builders") as create_builders:
+            proposer.initialize_attn_backend(
+                kv_cache_config,
+                kernel_block_sizes=[128],
+            )
+
+        assert len(proposer.draft_attn_groups) == 1
+        draft_group = proposer.draft_attn_groups[0]
+        assert draft_group.layer_names == ["draft.0"]
+        assert draft_group.kv_cache_spec is draft_spec
+        assert draft_group.kv_cache_group_id == 0
+        assert proposer._layer_group_idx == [0]
+        assert proposer.kv_cache_gid == 0
+        assert proposer.kernel_block_size == 128
+        create_builders.assert_called_once_with(
+            proposer.vllm_config,
+            proposer.device,
+            kernel_block_size=128,
+        )
+
+    def test_k3_initialization_enables_rope_on_mla_builders(self, monkeypatch):
+        class FakeK3Config:
+            pass
+
+        class FakeMLABuilder:
+            def __init__(self):
+                self.use_mla_rope = False
+
+        fake_builder = FakeMLABuilder()
+
+        def create_metadata_builders(group, *args, **kwargs):
+            del args, kwargs
+            group.metadata_builders = [fake_builder]
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.backend"
+        layer = MagicMock()
+        layer.get_attn_backend.return_value = backend
+        monkeypatch.setattr(
+            dspark_proposer_module,
+            "get_layers_from_vllm_config",
+            lambda *args, **kwargs: {"L0": layer},
+        )
+        monkeypatch.setattr(dspark_proposer_module, "K3DSparkConfig", FakeK3Config)
+        monkeypatch.setattr(
+            dspark_proposer_module,
+            "AscendMLAMetadataBuilder",
+            FakeMLABuilder,
+        )
+        monkeypatch.setattr(
+            AttentionGroup,
+            "create_metadata_builders",
+            create_metadata_builders,
+        )
+
+        proposer = self._make_proposer_for_init()
+        proposer.draft_model_config = SimpleNamespace(hf_config=FakeK3Config())
+        proposer.model = SimpleNamespace(
+            get_draft_kv_cache_layer_names=lambda: {"L0"}
+        )
+        proposer.max_query_tokens = 8
+        proposer.max_num_tokens = 16
+        manager_spec = MagicMock()
+        manager_spec.block_size = 128
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=["L0"],
+                    kv_cache_spec=manager_spec,
+                )
+            ]
+        )
+
+        proposer.initialize_attn_backend(kv_cache_config)
+
+        assert fake_builder.use_mla_rope is dspark_proposer_module.K3_DSPARK_USE_MLA_ROPE
+
+    def test_kernel_block_size_falls_back_to_cache_spec(self):
+        proposer = self._make_proposer_for_init()
+
+        assert (
+            proposer._resolve_kernel_block_size(
+                0,
+                SimpleNamespace(block_size=384),
+                None,
+            )
+            == 384
+        )
 # fmt: on

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -29,6 +29,7 @@ import torch
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
 
+import vllm_ascend.spec_decode.dspark_proposer as dspark_proposer_module
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -11,6 +11,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
     UniformTypeKVCacheSpecs,
 )
 
@@ -138,6 +139,196 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(k_cache.shape, (2, 16, 8, 64))
         self.assertEqual(v_cache.shape, (2, 16, 8, 64))
+
+    def test_hybrid_c8_double_token_block_is_contiguous_and_slot_aligned(self):
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        runner.hybrid_with_attn_and_mamba = True
+        runner.model_config.dtype = torch.bfloat16
+
+        num_blocks = 4
+        # 768-token INT8 K + 768-token BF16 V + one conv-state block.
+        common_page_size = 393216 + 98304 + 13824
+        attn_layer = "model.layers.3.self_attn.attn"
+        mamba_layer = "model.layers.2.self_attn"
+        attn_spec = AscendMLAAttentionSpec(
+            block_size=768,
+            num_kv_heads=1,
+            head_size=640,
+            dtype=torch.int8,
+            page_size_padded=common_page_size,
+        )
+        mamba_spec = MambaSpec(
+            block_size=768,
+            shapes=((2304, 3), (6, 128, 128)),
+            dtypes=(torch.bfloat16, torch.float32),
+            page_size_padded=common_page_size,
+            mamba_cache_mode="align",
+        )
+        raw = torch.zeros(num_blocks * common_page_size, dtype=torch.int8)
+        raw_caches = {attn_layer: raw, mamba_layer: raw}
+        kv_cache_config = SimpleNamespace(num_blocks=num_blocks)
+        runner._get_layer_kv_cache_specs = lambda _config: {
+            attn_layer: attn_spec,
+            mamba_layer: mamba_spec,
+        }
+        backend = MagicMock()
+        backend.get_supported_kernel_block_sizes.return_value = [128]
+        backend.get_kv_cache_shape.side_effect = (
+            lambda blocks, block_size, heads, head_size: (
+                blocks,
+                block_size,
+                heads,
+                head_size,
+            )
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=attn_spec,
+                backend=backend,
+                layer_names=[attn_layer],
+            ),
+            SimpleNamespace(
+                kv_cache_spec=mamba_spec,
+                backend=backend,
+                layer_names=[mamba_layer],
+            ),
+        ]
+        runner._get_attention_kv_cache_dims = lambda _name, _spec: (512, 64)
+        runner._get_mla_fa_quant_cache_dtypes = lambda _name, _spec: (
+            torch.int8,
+            torch.bfloat16,
+        )
+
+        caches = runner._reshape_kv_cache_tensors(kv_cache_config, raw_caches)
+        k_cache, v_cache = caches[attn_layer]
+        conv_state, recurrent_state = caches[mamba_layer]
+
+        self.assertEqual(k_cache.shape, (num_blocks * 6, 128, 1, 512))
+        self.assertEqual(v_cache.shape, (num_blocks * 6, 128, 1, 64))
+        self.assertTrue(k_cache.is_contiguous())
+        self.assertTrue(v_cache.is_contiguous())
+        self.assertEqual(conv_state.shape, (num_blocks, 2304, 3))
+        self.assertEqual(recurrent_state.shape, (num_blocks, 6, 128, 128))
+
+        # Six 128-token chunks form one 768-token K block. Its byte span is
+        # exactly one recurrent-state slot, so both caches share block IDs.
+        for block_id in range(num_blocks):
+            self.assertEqual(
+                k_cache[block_id * 6].data_ptr(),
+                recurrent_state[block_id].data_ptr(),
+            )
+        self.assertEqual(
+            k_cache[6].data_ptr() - k_cache[0].data_ptr(),
+            recurrent_state[1].data_ptr() - recurrent_state[0].data_ptr(),
+        )
+        self.assertEqual(
+            v_cache.numel() * v_cache.element_size(),
+            num_blocks * 98304,
+        )
+
+    @patch("vllm_ascend.worker.model_runner_v1.enable_fa_quant", return_value=True)
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_a3_fa_quant_mla_cache_accounts_for_mixed_dtype_bytes(
+        self,
+        mock_get_layers,
+        _mock_has_ec_transfer,
+        _mock_enable_fa_quant,
+    ):
+        runner = self._build_runner()
+        runner.block_size = 16
+        runner.shared_kv_cache_layers = {}
+        runner.model_config.dtype = torch.bfloat16
+        runner.attn_backend.get_kv_cache_shape.side_effect = (
+            lambda num_blocks, block_size, num_kv_heads, head_size: (
+                num_blocks,
+                block_size,
+                num_kv_heads,
+                head_size,
+            )
+        )
+
+        layer_name = "model.layers.5.self_attn.attn"
+        attn_module = MLAAttention.__new__(MLAAttention)
+        torch.nn.Module.__init__(attn_module)
+        attn_module.head_size = 576
+        attn_module.kv_lora_rank = 512
+        attn_module.qk_rope_head_dim = 64
+        attn_module.impl = SimpleNamespace(
+            fa_quant_layer=True,
+            dtype=torch.int8,
+        )
+        attn_module.get_kv_cache_spec = MagicMock(
+            return_value=AscendMLAAttentionSpec(
+                block_size=runner.block_size,
+                num_kv_heads=1,
+                head_size=576,
+                dtype=torch.bfloat16,
+                cache_dtype_str="auto",
+            )
+        )
+        mock_get_layers.return_value = {layer_name: attn_module}
+        layer_spec = runner.get_kv_cache_spec()[layer_name]
+        spec = AscendMLAAttentionSpec.merge([layer_spec])
+        expected_bytes_per_token = 512 + 64 * 2
+        self.assertEqual(spec.dtype, torch.int8)
+        self.assertEqual(spec.head_size, expected_bytes_per_token)
+        self.assertEqual(spec.page_size_bytes, runner.block_size * expected_bytes_per_token)
+
+        num_blocks = 2
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=spec.page_size_bytes * num_blocks,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=spec,
+                )
+            ],
+        )
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        raw_k_cache, raw_v_cache = raw_caches[layer_name]
+        runner.vllm_config.quant_config.get_kv_quant_split_factor.assert_not_called()
+        self.assertEqual(raw_k_cache.numel(), num_blocks * runner.block_size * 512)
+        self.assertEqual(raw_v_cache.numel(), num_blocks * runner.block_size * 64 * 2)
+
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=spec,
+                backend=runner.attn_backend,
+                layer_names=[layer_name],
+            )
+        ]
+        k_cache, v_cache = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            raw_caches,
+        )[layer_name]
+        runner.vllm_config.quant_config.get_kv_quant_dtype.assert_not_called()
+        self.assertEqual(k_cache.dtype, torch.int8)
+        self.assertEqual(k_cache.shape, (num_blocks, runner.block_size, 1, 512))
+        self.assertEqual(v_cache.dtype, torch.bfloat16)
+        self.assertEqual(v_cache.shape, (num_blocks, runner.block_size, 1, 64))
+        runner.use_hybrid_blocks = True
+        runner.hybrid_with_attn_and_mamba = True
+        runner.attn_backend.get_supported_kernel_block_sizes.return_value = [runner.block_size]
+        hybrid_raw_cache = torch.zeros(
+            spec.page_size_bytes * num_blocks,
+            dtype=torch.int8,
+        )
+        hybrid_k_cache, hybrid_v_cache = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            {layer_name: hybrid_raw_cache},
+        )[layer_name]
+        self.assertEqual(hybrid_k_cache.dtype, torch.int8)
+        self.assertEqual(hybrid_k_cache.shape, (num_blocks, runner.block_size, 1, 512))
+        self.assertEqual(hybrid_v_cache.dtype, torch.bfloat16)
+        self.assertEqual(hybrid_v_cache.shape, (num_blocks, runner.block_size, 1, 64))
 
     @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
     @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
@@ -335,6 +526,7 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.c8_k_cache_dtype = torch.int8
         runner.c8_k_scale_cache_dtype = torch.float16
         runner._get_attention_kv_cache_dims = lambda _layer_name, _spec: (512, 64)
+        runner._get_mla_fa_quant_cache_dtypes = MagicMock(return_value=None)
         runner.sparse_kv_offload_enabled = False
 
         attn_layer_name = "model.layers.1.self_attn.attn"

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -174,13 +174,11 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         }
         backend = MagicMock()
         backend.get_supported_kernel_block_sizes.return_value = [128]
-        backend.get_kv_cache_shape.side_effect = (
-            lambda blocks, block_size, heads, head_size: (
-                blocks,
-                block_size,
-                heads,
-                head_size,
-            )
+        backend.get_kv_cache_shape.side_effect = lambda blocks, block_size, heads, head_size: (
+            blocks,
+            block_size,
+            heads,
+            head_size,
         )
         runner._kv_cache_spec_attn_group_iterator = lambda: [
             SimpleNamespace(
@@ -227,6 +225,284 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
             num_blocks * 98304,
         )
 
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.enable_fa_quant",
+        return_value=True,
+    )
+    def test_k3_hybrid_layout_keeps_standalone_draft_contiguous_for_any_tensor_order(
+        self,
+        _mock_enable_fa_quant,
+    ):
+        num_blocks = 2
+        target_page_size = 537600
+        draft_page_size = 884736
+        target_layer = "model.layers.3.self_attn.attn"
+        mamba_layer = "model.layers.2.linear_attn"
+        draft_layer = "draft_model.layers.0.self_attn.attn"
+
+        target_spec = AscendMLAAttentionSpec(
+            block_size=768,
+            num_kv_heads=1,
+            head_size=640,
+            dtype=torch.int8,
+            page_size_padded=target_page_size,
+        )
+        draft_spec = AscendMLAAttentionSpec(
+            block_size=768,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+        )
+        self.assertEqual(draft_spec.page_size_bytes, draft_page_size)
+        mamba_spec = MambaSpec(
+            block_size=768,
+            shapes=((7680, 3), (6, 128, 128)),
+            dtypes=(torch.bfloat16, torch.float32),
+            page_size_padded=target_page_size,
+            mamba_cache_mode="align",
+        )
+        attention_group_spec = UniformTypeKVCacheSpecs(
+            block_size=768,
+            kv_cache_specs={
+                target_layer: target_spec,
+                draft_layer: draft_spec,
+            },
+        )
+
+        hybrid_tensor = KVCacheTensor(
+            size=num_blocks * target_page_size,
+            shared_by=[target_layer, mamba_layer],
+        )
+        draft_tensor = KVCacheTensor(
+            size=num_blocks * draft_page_size,
+            shared_by=[draft_layer],
+        )
+
+        for reverse_tensor_order in (False, True):
+            with self.subTest(reverse_tensor_order=reverse_tensor_order):
+                runner = self._build_runner()
+                runner.use_hybrid_blocks = True
+                runner.model_config.dtype = torch.bfloat16
+                backend = MagicMock()
+                backend.get_supported_kernel_block_sizes.return_value = [128]
+                backend.get_kv_cache_shape.side_effect = lambda blocks, block_size, heads, head_size: (
+                    blocks,
+                    block_size,
+                    heads,
+                    head_size,
+                )
+                tensors = [hybrid_tensor, draft_tensor]
+                if reverse_tensor_order:
+                    tensors.reverse()
+                kv_cache_config = KVCacheConfig(
+                    num_blocks=num_blocks,
+                    kv_cache_tensors=tensors,
+                    kv_cache_groups=[
+                        KVCacheGroupSpec(
+                            layer_names=[target_layer, draft_layer],
+                            kv_cache_spec=attention_group_spec,
+                            is_eagle_group=True,
+                        ),
+                        KVCacheGroupSpec(
+                            layer_names=[mamba_layer],
+                            kv_cache_spec=mamba_spec,
+                        ),
+                    ],
+                )
+                runner._get_attention_kv_cache_dims = lambda _name, _spec: (512, 64)
+                runner._get_mla_fa_quant_cache_dtypes = lambda name, _spec: (
+                    (torch.int8, torch.bfloat16) if name == target_layer else None
+                )
+
+                raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+
+                target_raw = raw_caches[target_layer]
+                self.assertIsInstance(target_raw, torch.Tensor)
+                self.assertIs(target_raw, raw_caches[mamba_layer])
+                self.assertIsInstance(raw_caches[draft_layer], tuple)
+                draft_k_raw, draft_v_raw = raw_caches[draft_layer]
+                self.assertTrue(draft_k_raw.is_contiguous())
+                self.assertTrue(draft_v_raw.is_contiguous())
+                self.assertEqual(draft_k_raw.numel(), num_blocks * 786432)
+                self.assertEqual(draft_v_raw.numel(), num_blocks * 98304)
+                self.assertNotEqual(
+                    target_raw.untyped_storage().data_ptr(),
+                    draft_k_raw.untyped_storage().data_ptr(),
+                )
+                self.assertNotEqual(
+                    target_raw.untyped_storage().data_ptr(),
+                    draft_v_raw.untyped_storage().data_ptr(),
+                )
+                self.assertEqual(
+                    runner._hybrid_attn_mamba_layout_layers,
+                    {target_layer, mamba_layer},
+                )
+                runner.vllm_config.quant_config.get_kv_quant_split_factor.assert_not_called()
+
+                runner._kv_cache_spec_attn_group_iterator = lambda backend=backend: [
+                    SimpleNamespace(
+                        kv_cache_spec=target_spec,
+                        backend=backend,
+                        layer_names=[target_layer],
+                    ),
+                    SimpleNamespace(
+                        kv_cache_spec=draft_spec,
+                        backend=backend,
+                        layer_names=[draft_layer],
+                    ),
+                    SimpleNamespace(
+                        kv_cache_spec=mamba_spec,
+                        backend=backend,
+                        layer_names=[mamba_layer],
+                    ),
+                ]
+                caches = runner._reshape_kv_cache_tensors(
+                    kv_cache_config,
+                    raw_caches,
+                )
+                target_k, target_v = caches[target_layer]
+                draft_k, draft_v = caches[draft_layer]
+                _, recurrent_state = caches[mamba_layer]
+
+                self.assertEqual(
+                    target_k.shape,
+                    (num_blocks * 6, 128, 1, 512),
+                )
+                self.assertEqual(
+                    target_v.shape,
+                    (num_blocks * 6, 128, 1, 64),
+                )
+                self.assertEqual(
+                    draft_k.shape,
+                    (num_blocks * 6, 128, 1, 512),
+                )
+                self.assertEqual(
+                    draft_v.shape,
+                    (num_blocks * 6, 128, 1, 64),
+                )
+                self.assertTrue(draft_k.is_contiguous())
+                self.assertTrue(draft_v.is_contiguous())
+                self.assertEqual(draft_k.dtype, torch.bfloat16)
+                self.assertEqual(draft_v.dtype, torch.bfloat16)
+                self.assertEqual(
+                    draft_k[6].data_ptr() - draft_k[0].data_ptr(),
+                    786432,
+                )
+                self.assertEqual(
+                    draft_v[6].data_ptr() - draft_v[0].data_ptr(),
+                    98304,
+                )
+                for block_id in range(num_blocks):
+                    self.assertEqual(
+                        target_k[block_id * 6].data_ptr(),
+                        recurrent_state[block_id].data_ptr(),
+                    )
+                self.assertNotEqual(
+                    target_k.untyped_storage().data_ptr(),
+                    draft_k.untyped_storage().data_ptr(),
+                )
+                self.assertNotEqual(
+                    target_k.untyped_storage().data_ptr(),
+                    draft_v.untyped_storage().data_ptr(),
+                )
+                runner.vllm_config.quant_config.get_kv_quant_dtype.assert_not_called()
+
+    @patch(
+        "vllm_ascend.worker.model_runner_v1.enable_fa_quant",
+        return_value=True,
+    )
+    def test_pp_target_only_tensor_uses_planar_layout_from_empty_mamba_group(
+        self,
+        _mock_enable_fa_quant,
+    ):
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        runner.model_config.dtype = torch.bfloat16
+        num_blocks = 2
+        common_page_size = 537600
+        target_layer = "model.layers.3.self_attn.attn"
+        target_spec = AscendMLAAttentionSpec(
+            block_size=768,
+            num_kv_heads=1,
+            head_size=640,
+            dtype=torch.int8,
+            page_size_padded=common_page_size,
+        )
+        mamba_spec = MambaSpec(
+            block_size=768,
+            shapes=((7680, 3), (6, 128, 128)),
+            dtypes=(torch.bfloat16, torch.float32),
+            page_size_padded=common_page_size,
+            mamba_cache_mode="align",
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=num_blocks * common_page_size,
+                    shared_by=[target_layer],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[target_layer],
+                    kv_cache_spec=target_spec,
+                ),
+                KVCacheGroupSpec(
+                    layer_names=[],
+                    kv_cache_spec=mamba_spec,
+                ),
+            ],
+        )
+        backend = MagicMock()
+        backend.get_supported_kernel_block_sizes.return_value = [128]
+        backend.get_kv_cache_shape.side_effect = lambda blocks, block_size, heads, head_size: (
+            blocks,
+            block_size,
+            heads,
+            head_size,
+        )
+        runner._get_attention_kv_cache_dims = lambda _name, _spec: (512, 64)
+        runner._get_mla_fa_quant_cache_dtypes = lambda _name, _spec: (
+            torch.int8,
+            torch.bfloat16,
+        )
+
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+
+        target_raw = raw_caches[target_layer]
+        self.assertIsInstance(target_raw, torch.Tensor)
+        self.assertEqual(
+            runner._hybrid_attn_mamba_layout_layers,
+            {target_layer},
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=target_spec,
+                backend=backend,
+                layer_names=[target_layer],
+            )
+        ]
+        target_k, target_v = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            raw_caches,
+        )[target_layer]
+
+        self.assertTrue(target_k.is_contiguous())
+        self.assertTrue(target_v.is_contiguous())
+        self.assertEqual(
+            target_k.shape,
+            (num_blocks * 6, 128, 1, 512),
+        )
+        self.assertEqual(
+            target_v.shape,
+            (num_blocks * 6, 128, 1, 64),
+        )
+        self.assertEqual(
+            target_k.data_ptr() - target_raw.data_ptr(),
+            num_blocks * 46080,
+        )
+
     @patch("vllm_ascend.worker.model_runner_v1.enable_fa_quant", return_value=True)
     @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
     @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
@@ -240,13 +516,11 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.block_size = 16
         runner.shared_kv_cache_layers = {}
         runner.model_config.dtype = torch.bfloat16
-        runner.attn_backend.get_kv_cache_shape.side_effect = (
-            lambda num_blocks, block_size, num_kv_heads, head_size: (
-                num_blocks,
-                block_size,
-                num_kv_heads,
-                head_size,
-            )
+        runner.attn_backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
         )
 
         layer_name = "model.layers.5.self_attn.attn"

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -759,10 +759,15 @@ class AscendMLAImpl(MLAAttentionImpl):
         if not self.use_mla_rope and self.enable_mlapo and device_type != AscendDeviceType.A5:
             logger.warning_once("MLAPO is disabled for MLA layers with RoPE disabled outside A5.")
             self.enable_mlapo = False
-        if not self.use_mla_rope and self.fa_quant_layer and device_type not in {
-            AscendDeviceType.A3,
-            AscendDeviceType.A5,
-        }:
+        if (
+            not self.use_mla_rope
+            and self.fa_quant_layer
+            and device_type
+            not in {
+                AscendDeviceType.A3,
+                AscendDeviceType.A5,
+            }
+        ):
             logger.warning_once("FA quant for no-RoPE MLA layers is supported only on A3/A5; falling back to BF16.")
             self.fa_quant_layer = False
         if self.fa_quant_layer:
@@ -1138,11 +1143,7 @@ class AscendMLAImpl(MLAAttentionImpl):
 
     def _uses_a3_mla_fa_quant_cache(self) -> bool:
         """Whether A3 MLA uses separate 8-bit latent and model-dtype caches."""
-        return (
-            bool(self.fa_quant_layer)
-            and not self.use_mla_rope
-            and get_ascend_device_type() == AscendDeviceType.A3
-        )
+        return bool(self.fa_quant_layer) and not self.use_mla_rope and get_ascend_device_type() == AscendDeviceType.A3
 
     @staticmethod
     def _compact_block_table_for_nz_gather(

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -742,8 +742,31 @@ class AscendMLAImpl(MLAAttentionImpl):
 
         self.layer_name = kwargs.get("layer_name")
         self.fa_quant_layer = enable_fa_quant(self.vllm_config, self.layer_name)
+        device_type = get_ascend_device_type()
+        # A3's generic FA-quant gate is restricted to KV consumers because it
+        # normally takes the fused MLA-prolog path. No-RoPE MLA layers bypass
+        # that prolog because their positional slice must not be reordered.
+        if (
+            not self.fa_quant_layer
+            and not self.use_mla_rope
+            and device_type == AscendDeviceType.A3
+            and self.vllm_config.quant_config is not None
+            and getattr(self.vllm_config.quant_config, "enable_fa_quant", False)
+        ):
+            self.fa_quant_layer = self.vllm_config.quant_config.is_fa_quant_layer(self.layer_name)
+        # A5 supports its no-RoPE MLAPO path. Other devices must retain the
+        # explicit no-RoPE layout to avoid fused rotary reordering.
+        if not self.use_mla_rope and self.enable_mlapo and device_type != AscendDeviceType.A5:
+            logger.warning_once("MLAPO is disabled for MLA layers with RoPE disabled outside A5.")
+            self.enable_mlapo = False
+        if not self.use_mla_rope and self.fa_quant_layer and device_type not in {
+            AscendDeviceType.A3,
+            AscendDeviceType.A5,
+        }:
+            logger.warning_once("FA quant for no-RoPE MLA layers is supported only on A3/A5; falling back to BF16.")
+            self.fa_quant_layer = False
         if self.fa_quant_layer:
-            self.dtype = torch.float8_e4m3fn if get_ascend_device_type() == AscendDeviceType.A5 else torch.int8
+            self.dtype = torch.float8_e4m3fn if device_type == AscendDeviceType.A5 else torch.int8
         else:
             self.dtype = self.vllm_config.model_config.dtype
         # For models whose num_heads is not a power of 2 (e.g., GLM-4.7-Flash
@@ -993,6 +1016,7 @@ class AscendMLAImpl(MLAAttentionImpl):
             layer = self.vllm_config.compilation_config.static_forward_context[self.layer_name]
             self.quant_kscale = layer.quant_kscale
             self.fak_descale_float = layer.fak_descale_float
+            self.fak_descale_reciprocal = layer.fak_descale_reciprocal
 
     def _process_weights_for_fused_mlapo(self, act_dtype: torch.dtype):
         assert self.fused_qkv_a_proj is not None
@@ -1112,6 +1136,74 @@ class AscendMLAImpl(MLAAttentionImpl):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return kv_c_normed, k_pe
 
+    def _uses_a3_mla_fa_quant_cache(self) -> bool:
+        """Whether A3 MLA uses separate 8-bit latent and model-dtype caches."""
+        return (
+            bool(self.fa_quant_layer)
+            and not self.use_mla_rope
+            and get_ascend_device_type() == AscendDeviceType.A3
+        )
+
+    @staticmethod
+    def _compact_block_table_for_nz_gather(
+        cache: torch.Tensor,
+        block_table: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return referenced cache blocks and a block table indexed into them.
+
+        A3 MLA FA quant writes PA-NZ bytes into the regular vLLM cache pool. The
+        Gather wrapper determines PA-NZ from the source tensor's format, so
+        chunked prefill works on a temporary compact cache segment rather than
+        format-casting the complete layer cache.
+        """
+        table_long = block_table.to(torch.long)
+        block_ids = torch.unique(table_long[table_long >= 0], sorted=True)
+        if block_ids.numel() == 0:
+            raise ValueError("Chunked-context block table does not reference any KV cache block.")
+        if int(block_ids[-1]) >= cache.shape[0]:
+            raise ValueError(
+                f"Block table references block {int(block_ids[-1])}, but cache has only {cache.shape[0]} blocks."
+            )
+
+        remap = torch.full((cache.shape[0],), -1, dtype=torch.long, device=cache.device)
+        remap[block_ids] = torch.arange(block_ids.numel(), dtype=torch.long, device=cache.device)
+        safe_table = table_long.clamp_min(0)
+        compact_table = remap[safe_table]
+        compact_table = torch.where(table_long >= 0, compact_table, table_long)
+        return block_ids, compact_table.to(dtype=block_table.dtype)
+
+    @staticmethod
+    def _format_compact_a3_mla_c8_cache_for_gather(
+        cache: torch.Tensor,
+        block_ids: torch.Tensor,
+        *,
+        num_kv_heads: int,
+        head_dim: int,
+        nz_width: int,
+    ) -> torch.Tensor:
+        """Convert referenced PA-NZ cache blocks back to logical ND for Gather.
+
+        A3 C8 Scatter writes PA-NZ bytes through a 5-D view of the shared ND
+        cache allocation.  Selecting from the registered 4-D tensor directly
+        therefore treats physical PA-NZ bytes as logical ND values.  Reinterpret
+        the storage with the same PA-NZ view used by Scatter before compacting,
+        then transpose it back to the Normal-cache layout expected by Gather.
+        """
+        block_size = cache.shape[1]
+        physical_pa_nz = cache.view(
+            cache.shape[0],
+            num_kv_heads,
+            head_dim // nz_width,
+            block_size,
+            nz_width,
+        )
+        compact_pa_nz = physical_pa_nz.index_select(0, block_ids)
+        return (
+            compact_pa_nz.permute(0, 3, 1, 2, 4)
+            .contiguous()
+            .view(block_ids.numel(), block_size, num_kv_heads, head_dim)
+        )
+
     def _compute_prefill_context(
         self,
         q_nope: torch.Tensor,
@@ -1130,8 +1222,32 @@ class AscendMLAImpl(MLAAttentionImpl):
         iters = len(prefill_metadata.chunked_context.seq_tot)
         cache_kv_c = kv_c_and_k_pe_cache[0]
         cache_k_pe = kv_c_and_k_pe_cache[1]
-        num_heads = cache_k_pe.size(2)
-        latent_kv_dim = kv_c_and_k_pe_cache[0].size(-1)
+        is_a3_c8_cache = self._uses_a3_mla_fa_quant_cache()
+        if is_a3_c8_cache:
+            num_heads = self.num_kv_heads
+            latent_kv_dim = self.kv_lora_rank
+            block_ids, gather_block_table = self._compact_block_table_for_nz_gather(
+                cache_kv_c,
+                prefill_metadata.block_table,
+            )
+            cache_kv_c_for_load = self._format_compact_a3_mla_c8_cache_for_gather(
+                cache_kv_c,
+                block_ids,
+                num_kv_heads=num_heads,
+                head_dim=latent_kv_dim,
+                nz_width=32,
+            )
+            cache_k_pe_for_load = self._format_compact_a3_mla_c8_cache_for_gather(
+                cache_k_pe,
+                block_ids,
+                num_kv_heads=num_heads,
+                head_dim=rope_dim,
+                nz_width=16,
+            )
+        else:
+            num_heads = cache_k_pe.size(2)
+            latent_kv_dim = cache_kv_c.size(-1)
+            gather_block_table = prefill_metadata.block_table
 
         actual_seq_lengths_q = prefill_metadata.actual_seq_lengths_q
 
@@ -1168,18 +1284,72 @@ class AscendMLAImpl(MLAAttentionImpl):
         for i in range(iters):
             toks = prefill_metadata.chunked_context.seq_tot[i]
             context_seq_len_npu = self.get_context_seq_len_npu(i, attn_metadata)
-            kv_c_normed = torch.empty(toks, num_heads, latent_kv_dim, dtype=cache_kv_c.dtype, device=cache_kv_c.device)
-            k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device)
+            if is_a3_c8_cache:
+                # The compact caches were converted back to Normal layout, so
+                # Gather uses the standard 3-D [tokens, heads, dim] outputs.
+                # Load the two caches separately because their dtypes differ.
+                kv_c_normed = torch.empty(
+                    toks,
+                    num_heads,
+                    latent_kv_dim,
+                    dtype=cache_kv_c.dtype,
+                    device=cache_kv_c.device,
+                )
+                k_pe = torch.empty(
+                    toks,
+                    num_heads,
+                    rope_dim,
+                    dtype=q_pe.dtype,
+                    device=q_pe.device,
+                )
+            else:
+                cache_kv_c_for_load = cache_kv_c
+                cache_k_pe_for_load = cache_k_pe
+                kv_c_normed = torch.empty(
+                    toks,
+                    num_heads,
+                    latent_kv_dim,
+                    dtype=cache_kv_c.dtype,
+                    device=cache_kv_c.device,
+                )
+                k_pe = torch.empty(toks, num_heads, rope_dim, dtype=q_pe.dtype, device=q_pe.device)
 
-            DeviceOperator.kv_cache_load(
-                cache_kv_c,
-                cache_k_pe,
-                prefill_metadata.block_table,
-                context_seq_len_npu,
-                prefill_metadata.chunked_context.starts[i],
-                key=kv_c_normed,
-                value=k_pe,
-            )
+            if is_a3_c8_cache:
+                # npu_gather_pa_kv_cache requires matching dtypes for the
+                # key/value cache pair. A3 C8 stores latent cache in INT8 and
+                # RoPE cache in BF16, so gather the two Normal compact caches
+                # separately. Normal Gather consumes the token offset directly.
+                chunk_token_offset = prefill_metadata.chunked_context.starts[i]
+                kv_c_unused = torch.empty_like(kv_c_normed)
+                k_pe_unused = torch.empty_like(k_pe)
+                DeviceOperator.kv_cache_load(
+                    cache_kv_c_for_load,
+                    cache_kv_c_for_load,
+                    gather_block_table,
+                    context_seq_len_npu,
+                    chunk_token_offset,
+                    key=kv_c_normed,
+                    value=kv_c_unused,
+                )
+                DeviceOperator.kv_cache_load(
+                    cache_k_pe_for_load,
+                    cache_k_pe_for_load,
+                    gather_block_table,
+                    context_seq_len_npu,
+                    chunk_token_offset,
+                    key=k_pe,
+                    value=k_pe_unused,
+                )
+            else:
+                DeviceOperator.kv_cache_load(
+                    cache_kv_c_for_load,
+                    cache_k_pe_for_load,
+                    prefill_metadata.block_table,
+                    context_seq_len_npu,
+                    prefill_metadata.chunked_context.starts[i],
+                    key=kv_c_normed,
+                    value=k_pe,
+                )
             kv_c_normed, k_pe = self._reorg_kvcache(
                 kv_c_normed,
                 k_pe,
@@ -1188,9 +1358,14 @@ class AscendMLAImpl(MLAAttentionImpl):
                 toks=toks,
             )
             kv_c_normed = kv_c_normed.squeeze()
-            if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
-                kv_c_normed = torch.mul(kv_c_normed.to(self.fak_descale_float.dtype), self.fak_descale_float).to(
+            if self.fa_quant_layer:
+                target_dtype = (
                     torch.bfloat16
+                    if get_ascend_device_type() == AscendDeviceType.A5
+                    else self.vllm_config.model_config.dtype
+                )
+                kv_c_normed = torch.mul(kv_c_normed.to(self.fak_descale_float.dtype), self.fak_descale_float).to(
+                    target_dtype
                 )
             kv_nope = self.kv_b_proj(kv_c_normed)[0].view(-1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim)
             k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
@@ -1293,6 +1468,109 @@ class AscendMLAImpl(MLAAttentionImpl):
 
         return attn_output
 
+    def _exec_kv_no_rope(
+        self,
+        kv_no_split: torch.Tensor,
+        kv_cache: tuple,
+        slots: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Normalize and cache MLA KV while preserving a no-RoPE q/k slice."""
+        assert self.kv_a_layernorm is not None
+        assert len(kv_cache) > 1, "MLA requires separate latent and positional KV caches"
+        num_tokens = kv_no_split.shape[0]
+        kv_no_split = kv_no_split.view(
+            num_tokens,
+            self.num_kv_heads,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+        )
+        kv_c, k_pe = kv_no_split.split(
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
+        )
+        kv_c_normed = self.kv_a_layernorm(kv_c.contiguous())
+        kv_c_normed = kv_c_normed.view(num_tokens, self.num_kv_heads, self.kv_lora_rank)
+        k_pe = k_pe.view(num_tokens, self.num_kv_heads, self.qk_rope_head_dim)
+        cache_kv_c = kv_c_normed
+        if self.fa_quant_layer:
+            device_type = get_ascend_device_type()
+            assert device_type in {AscendDeviceType.A3, AscendDeviceType.A5}
+            quant_scale = self.fak_descale_reciprocal
+            quant_dtype = torch.qint8
+            if device_type == AscendDeviceType.A5:
+                quant_scale = quant_scale.to(torch.bfloat16)
+                quant_dtype = torch.float8_e4m3fn
+            # Keep the A3 cache format identical to npu_mla_prolog_v2's
+            # symmetric FAK cache mode: FIA receives only descales, so no
+            # per-channel zero point is consumed by the decode kernel.
+            cache_kv_c = torch_npu.npu_quantize(
+                kv_c_normed,
+                quant_scale,
+                None,
+                quant_dtype,
+                -1,
+                False,
+            )
+            if device_type == AscendDeviceType.A3:
+                # Decode FIA's INT8 MLA path requires PA-NZ KV layout.  The
+                # registered vLLM pool remains ND; expose matching 5D views
+                # while Scatter writes PA-NZ bytes into it.
+                block_size = kv_cache[0].shape[1]
+                latent_cache_nz = kv_cache[0].view(
+                    -1,
+                    self.num_kv_heads,
+                    self.kv_lora_rank // 32,
+                    block_size,
+                    32,
+                )
+                rope_cache_nz = kv_cache[1].view(
+                    -1,
+                    self.num_kv_heads,
+                    self.qk_rope_head_dim // 16,
+                    block_size,
+                    16,
+                )
+                torch_npu.npu_scatter_pa_kv_cache(
+                    key=cache_kv_c.contiguous(),
+                    value=cache_kv_c.contiguous(),
+                    key_cache=latent_cache_nz,
+                    value_cache=latent_cache_nz,
+                    slot_mapping=slots.contiguous(),
+                    cache_mode="PA_NZ",
+                )
+                torch_npu.npu_scatter_pa_kv_cache(
+                    key=k_pe.contiguous(),
+                    value=k_pe.contiguous(),
+                    key_cache=rope_cache_nz,
+                    value_cache=rope_cache_nz,
+                    slot_mapping=slots.contiguous(),
+                    cache_mode="PA_NZ",
+                )
+            else:
+                # reshape_and_cache requires key and value to have the same dtype.
+                DeviceOperator.reshape_and_cache(
+                    key=cache_kv_c,
+                    value=cache_kv_c,
+                    key_cache=kv_cache[0],
+                    value_cache=kv_cache[0],
+                    slot_mapping=slots,
+                )
+                DeviceOperator.reshape_and_cache(
+                    key=k_pe,
+                    value=k_pe,
+                    key_cache=kv_cache[1],
+                    value_cache=kv_cache[1],
+                    slot_mapping=slots,
+                )
+        else:
+            DeviceOperator.reshape_and_cache(
+                key=cache_kv_c,
+                value=k_pe,
+                key_cache=kv_cache[0],
+                value_cache=kv_cache[1],
+                slot_mapping=slots,
+            )
+        return k_pe, kv_c_normed
+
     def exec_kv_decode(
         self,
         kv_no_split: torch.Tensor,
@@ -1364,6 +1642,11 @@ class AscendMLAImpl(MLAAttentionImpl):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
+        if not self.use_mla_rope:
+            # npu_interleave_rope with cos=1/sin=0 still reorders dimensions
+            # from [0, 1, 2, 3, ...] to [0, 2, ..., 1, 3, ...]. A no-RoPE
+            # layer has no rotary transform, so its positional slice bypasses it.
+            return x
         B, N, D = x.shape
         S = 1
         x = x.view(B, N, S, D)
@@ -1438,6 +1721,12 @@ class AscendMLAImpl(MLAAttentionImpl):
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
             if self.fa_quant_layer:
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads)
+                if self.head_padding > 0:
+                    # query_quant_mode=3 is per-token, per-head. FIA sees the
+                    # padded query heads, so its scale must have the identical
+                    # head axis. A zero scale keeps the synthetic zero query
+                    # heads zero after dequantization.
+                    dequant_scale_q_nope = F.pad(dequant_scale_q_nope, (0, self.head_padding), "constant", 0)
         elif self.fa_quant_layer:
             attn_mask = None
             sparse_mode = 0
@@ -1450,6 +1739,13 @@ class AscendMLAImpl(MLAAttentionImpl):
                     q_pe = F.pad(q_pe, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                     q_nope = F.pad(q_nope, (0, 0, 0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads, 1)
+                if self.head_padding > 0:
+                    dequant_scale_q_nope = F.pad(
+                        dequant_scale_q_nope,
+                        (0, 0, 0, self.head_padding),
+                        "constant",
+                        0,
+                    )
                 attn_output_shape = (num_tokens, self.num_heads_padded, 1, self.kv_lora_rank)
             else:
                 input_layout = "BSND_NBSD"
@@ -1459,6 +1755,8 @@ class AscendMLAImpl(MLAAttentionImpl):
                     q_pe = F.pad(q_pe, (0, 0, 0, self.head_padding), "constant", 0)
                     q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, 1, self.num_heads)
+                if self.head_padding > 0:
+                    dequant_scale_q_nope = F.pad(dequant_scale_q_nope, (0, self.head_padding), "constant", 0)
                 attn_output_shape = (self.num_heads_padded, num_tokens, 1, self.kv_lora_rank)
         else:
             # The output layout is set to NBSD to eliminate the need for a
@@ -1613,9 +1911,10 @@ class AscendMLAImpl(MLAAttentionImpl):
         )
         decode_q_pe = self.rope_single(decode_q_pe, cos, sin)
         dequant_scale_q_nope = None
-        if self.fa_quant_layer and get_ascend_device_type() == AscendDeviceType.A5:
+        if self.fa_quant_layer and get_ascend_device_type() in {AscendDeviceType.A3, AscendDeviceType.A5}:
             decode_ql_nope, dequant_scale_q_nope = torch_npu.npu_dynamic_quant(
-                decode_ql_nope, dst_type=torch.float8_e4m3fn
+                decode_ql_nope,
+                dst_type=self.dtype,
             )
             decode_q_pe = (decode_q_pe / dequant_scale_q_nope.unsqueeze(-1) / self.fak_descale_float).to(torch.bfloat16)
         decode_slots = attn_metadata.slot_mapping[:num_decode_tokens:1]
@@ -1715,8 +2014,10 @@ class AscendMLAImpl(MLAAttentionImpl):
         o_proj_input = torch.zeros(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
         # MLA Preprocess
-        if (self.fa_quant_layer or self.enable_mlapo) and (
-            attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS and attn_metadata.num_prefills == 0
+        if (
+            self.use_mla_rope
+            and (self.fa_quant_layer or self.enable_mlapo)
+            and (attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS and attn_metadata.num_prefills == 0)
         ):
             decode_preprocess_res, prefill_preprocess_res = DeviceOperator.mla_preprocess_only_decode(
                 self, hidden_states, kv_cache, attn_metadata

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -291,7 +291,15 @@ class BaseDeviceAdaptor:
         )[0]
 
     @staticmethod
-    def kv_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_starts, key, value):
+    def kv_cache_load(
+        cache_kv_c,
+        cache_k_pe,
+        block_table,
+        context_seq_len_npu,
+        seq_starts,
+        key,
+        value,
+    ):
         torch_npu.npu_gather_pa_kv_cache(
             cache_kv_c,
             cache_k_pe,
@@ -1385,7 +1393,15 @@ class A5DeviceAdaptor(BaseDeviceAdaptor):
         )[0]
 
     @staticmethod
-    def kv_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_offset, key, value):
+    def kv_cache_load(
+        cache_kv_c,
+        cache_k_pe,
+        block_table,
+        context_seq_len_npu,
+        seq_offset,
+        key,
+        value,
+    ):
         torch_npu.npu_gather_pa_kv_cache(
             cache_kv_c,
             cache_k_pe,

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -1,0 +1,1751 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+"""Native multimodal Kimi K3 model for vLLM-Ascend."""
+
+import math
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from copy import deepcopy
+from typing import Annotated, Any, Literal, cast
+
+import numpy as np
+import torch
+import torch_npu
+from torch import nn
+from transformers import BatchFeature
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import CacheConfig, VllmConfig
+from vllm.config.multimodal import BaseDummyOptions, ImageDummyOptions
+from vllm.distributed import divide, get_pp_group, get_tensor_model_parallel_world_size
+from vllm.inputs import MultiModalDataDict
+from vllm.logger import logger
+from vllm.model_executor.layers.activation import SiluAndMul, get_act_fn
+from vllm.model_executor.layers.attention.mm_encoder_attention import MMEncoderAttention
+from vllm.model_executor.layers.fused_moe import FusedMoE, fused_moe_make_expert_params_mapping
+from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import KimiGatedDeltaNetAttention
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateDtypeCalculator,
+)
+from vllm.model_executor.layers.mla import MLAModules, MultiHeadLatentAttentionWrapper
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.compressed_tensors import compressed_tensors
+from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead, VocabParallelEmbedding
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader, maybe_remap_kv_scale_name
+from vllm.model_executor.models.deepseek_v2 import DeepSeekV2FusedQkvAProjLinear
+from vllm.model_executor.models.interfaces import (
+    EagleModelMixin,
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    SupportsEagle3,
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsQuant,
+)
+from vllm.model_executor.models.kimi_k25_vit import (
+    Learnable2DInterpPosEmbDivided_fixed,
+    Rope2DPosEmbRepeated,
+    apply_rope,
+    tpool_patch_merger,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    WeightsMapper,
+    init_vllm_registered_model,
+    is_pp_missing_parameter,
+    make_layers,
+    maybe_prefix,
+)
+from vllm.model_executor.models.vision import is_vit_use_data_parallel, run_dp_sharded_mrope_vision_model
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import (
+    MultiModalFieldConfig,
+    MultiModalKwargsItems,
+    NestedTensors,
+)
+from vllm.multimodal.parse import ImageProcessorItems, ImageSize, MultiModalDataItems
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    InputProcessingContext,
+    PromptReplacement,
+    PromptUpdate,
+    PromptUpdateDetails,
+)
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.processor import cached_get_image_processor
+from vllm.triton_utils import HAS_TRITON
+from vllm.utils.tensor_schema import TensorSchema, TensorShape
+
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
+from vllm_ascend.ops.activation import AscendSituAndMul, SituActivationConfig
+from vllm_ascend.ops.kimi_kda import uses_kimi_k3_global_inputs_embeds
+from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
+from vllm_ascend.transformers_utils.configs.kimi_k3 import KimiK3Config, KimiK3TextConfig, KimiK3VisionConfig
+from vllm_ascend.transformers_utils.processors.kimi_k3 import KimiK3Processor
+from vllm_ascend.utils import vllm_version_is
+
+apply_attn_res: (
+    Callable[
+        [torch.Tensor, torch.Tensor, nn.Module, nn.Module],
+        torch.Tensor,
+    ]
+    | None
+) = None
+if HAS_TRITON:
+    from vllm_ascend.ops.triton.kimi_k3.attention_residual import apply_attn_res as triton_apply_attn_res
+
+    apply_attn_res = triton_apply_attn_res
+
+
+def _routed_latent_quant_config(
+    quant_config: QuantizationConfig | None,
+) -> QuantizationConfig | None:
+    """Quantize latent MoE projections only for native ModelSlim weights."""
+    if quant_config is not None and quant_config.get_name() == "ascend":
+        return quant_config
+    return None
+
+
+def _resolve_packed_expert_weight_name(
+    name: str,
+    params_dict: Mapping[str, object],
+) -> str:
+    """Map packed checkpoint weights to the parameter name used by the scheme."""
+    if name in params_dict or not name.endswith("_weight"):
+        return name
+    packed_name = f"{name}_packed"
+    return packed_name if packed_name in params_dict else name
+
+
+def _is_vit_use_data_parallel(num_heads: int) -> bool:
+    """Keep vision TP fallback compatible with the vLLM release branch."""
+    if not vllm_version_is("0.25.1"):
+        return is_vit_use_data_parallel(num_heads)
+
+    # TODO: Remove this branch when vLLM 0.25.1 support is dropped.
+    if num_heads % get_tensor_model_parallel_world_size() != 0:
+        logger.warning_once(
+            "The number of vision attention heads is not divisible by "
+            "the tensor parallel size. Falling back to data parallelism "
+            "for the vision encoder."
+        )
+        return True
+    return is_vit_use_data_parallel()
+
+
+def _move_module_to_device(
+    module: nn.Module,
+    *,
+    device: torch.device,
+    dtype: torch.dtype | None,
+) -> nn.Module:
+    """Move materialized modules while preserving lazy meta parameters.
+
+    Some quantization methods deliberately create parameters on the meta
+    device. The model loader records and materializes those parameters after
+    model construction, so calling ``Module.to`` here would fail before the
+    loader gets that opportunity. Non-meta modules retain the explicit move
+    used by the upstream Kimi multimodal implementation.
+    """
+    tensors = (*module.parameters(), *module.buffers())
+    if any(tensor.is_meta for tensor in tensors):
+        return module
+    return module.to(device=device, dtype=dtype)
+
+
+def navit_resize_image(
+    width: int,
+    height: int,
+    patch_size: int,
+    merge_kernel_size: int,
+    in_patch_limit: int,
+    patch_limit_on_one_side: int,
+    fixed_output_tokens: int | None,
+) -> dict[str, int]:
+    """Mirror the checkpoint's NaViT resize and media-token calculation."""
+
+    scale_by_total = math.sqrt(in_patch_limit / (max(1.0, width // patch_size) * max(1.0, height // patch_size)))
+    scale_by_width = patch_limit_on_one_side * patch_size / width
+    scale_by_height = patch_limit_on_one_side * patch_size / height
+    scale = min(1.0, scale_by_total, scale_by_width, scale_by_height)
+    new_width = max(1, int(width * scale))
+    new_height = max(1, int(height * scale))
+    max_side = patch_limit_on_one_side * patch_size
+    new_width = min(new_width, max_side)
+    new_height = min(new_height, max_side)
+
+    factor = merge_kernel_size * patch_size
+    pad_height = (factor - new_height % factor) % factor
+    pad_width = (factor - new_width % factor) % factor
+
+    if fixed_output_tokens is not None:
+        num_tokens = fixed_output_tokens
+    else:
+        token_height = (new_height + pad_height) // factor
+        token_width = (new_width + pad_width) // factor
+        if token_height * merge_kernel_size > patch_limit_on_one_side:
+            raise ValueError("Kimi K3 resized image exceeds the height patch limit")
+        if token_width * merge_kernel_size > patch_limit_on_one_side:
+            raise ValueError("Kimi K3 resized image exceeds the width patch limit")
+        num_tokens = token_height * token_width
+
+    return {
+        "num_tokens": num_tokens,
+        "new_width": new_width,
+        "new_height": new_height,
+        "pad_width": pad_width,
+        "pad_height": pad_height,
+        "sampled_nframes": 1,
+    }
+
+
+class KimiK3MediaPixelInputs(TensorSchema):
+    type: Literal["pixel_values"] = "pixel_values"
+    pixel_values: Annotated[
+        torch.Tensor | list[torch.Tensor],
+        TensorShape("np", 3, "ps", "ps"),
+    ]
+    grid_thws: Annotated[torch.Tensor, TensorShape("nm", 3)]
+
+
+class KimiK3ProcessingInfo(BaseProcessingInfo):
+    def __init__(self, ctx: InputProcessingContext) -> None:
+        super().__init__(ctx)
+        self.hf_config = self.get_hf_config()
+        tokenizer = self.get_tokenizer()
+        image_processor = cached_get_image_processor(
+            self.ctx.model_config.model,
+            revision=self.ctx.model_config.revision,
+            trust_remote_code=self.ctx.model_config.trust_remote_code,
+        )
+        config_token_id = self.hf_config.media_placeholder_token_id
+        resolved_token_id = tokenizer.convert_tokens_to_ids("<|media_pad|>")
+        unk_token_id = getattr(tokenizer, "unk_token_id", None)
+        valid_resolved_id = isinstance(resolved_token_id, int) and (
+            unk_token_id is None or resolved_token_id != unk_token_id
+        )
+        if valid_resolved_id and resolved_token_id != config_token_id:
+            logger.warning_once(
+                "Kimi-K3 config.media_placeholder_token_id (%d) disagrees "
+                "with tokenizer mapping for <|media_pad|> (%d). "
+                "Using tokenizer value.",
+                config_token_id,
+                resolved_token_id,
+            )
+            self.hf_config.media_placeholder_token_id = resolved_token_id
+            self.media_token_id = resolved_token_id
+        else:
+            self.media_token_id = config_token_id
+        self.hf_config.media_placeholder_token_id = self.media_token_id
+        self.media_token = tokenizer.decode(self.media_token_id)
+        self.image_processor = image_processor
+        self.hf_processor = KimiK3Processor(image_processor, tokenizer)
+        self.media_tokens_calculator = image_processor.media_tokens_calculator
+
+    def get_hf_processor(self, **kwargs: object) -> KimiK3Processor:
+        del kwargs
+        return self.hf_processor
+
+    def get_hf_config(self) -> KimiK3Config:
+        return self.ctx.get_hf_config(KimiK3Config)
+
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        return {"image": None}
+
+    @classmethod
+    def get_max_image_size(
+        cls,
+        patch_size: int,
+        merge_kernel_size: int,
+        in_patch_limit: int,
+        patch_limit_on_one_side: int,
+        fixed_output_tokens: int | None,
+    ) -> ImageSize:
+        max_side = patch_limit_on_one_side * patch_size
+        best_score = (-1, -1)
+        best_size = (max_side, max_side)
+
+        for width_patches in range(patch_limit_on_one_side + 1):
+            width = min((width_patches + 1) * patch_size - 1, max_side)
+            for height_patches in range(
+                width_patches,
+                patch_limit_on_one_side + 1,
+            ):
+                height = min((height_patches + 1) * patch_size - 1, max_side)
+                resize_config = navit_resize_image(
+                    width,
+                    height,
+                    patch_size,
+                    merge_kernel_size,
+                    in_patch_limit,
+                    patch_limit_on_one_side,
+                    fixed_output_tokens,
+                )
+                padded_width = resize_config["new_width"] + resize_config["pad_width"]
+                padded_height = resize_config["new_height"] + resize_config["pad_height"]
+                num_patches = padded_width // patch_size * (padded_height // patch_size)
+                score = (resize_config["num_tokens"], num_patches)
+                if score > best_score:
+                    best_score = score
+                    best_size = (width, height)
+
+        return ImageSize(width=best_size[0], height=best_size[1])
+
+
+class KimiK3DummyInputsBuilder(BaseDummyInputsBuilder[KimiK3ProcessingInfo]):
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        return self.info.get_hf_config().image_placeholder * mm_counts.get(
+            "image",
+            0,
+        )
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions],
+    ) -> MultiModalDataDict:
+        del seq_len
+        media_proc_cfg = self.info.image_processor.media_proc_cfg
+        max_size = self.info.get_max_image_size(
+            media_proc_cfg["patch_size"],
+            media_proc_cfg["merge_kernel_size"],
+            media_proc_cfg["in_patch_limit"],
+            media_proc_cfg["patch_limit_on_one_side"],
+            media_proc_cfg["fixed_output_tokens"],
+        )
+        image_overrides = cast(
+            ImageDummyOptions | None,
+            mm_options.get("image"),
+        )
+        return {
+            "image": self._get_dummy_images(
+                height=max_size.height,
+                width=max_size.width,
+                num_images=mm_counts.get("image", 0),
+                overrides=image_overrides,
+            ),
+        }
+
+
+class KimiK3MultiModalProcessor(BaseMultiModalProcessor[KimiK3ProcessingInfo]):
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        del hf_processor_mm_kwargs
+        grid_thws = hf_inputs.get("grid_thws", torch.empty((0, 3)))
+        grid_sizes = grid_thws.prod(-1)
+        return {
+            "pixel_values": MultiModalFieldConfig.flat_from_sizes(
+                "image",
+                grid_sizes,
+            ),
+            "grid_thws": MultiModalFieldConfig.batched(
+                "image",
+                keep_on_cpu=True,
+            ),
+        }
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        # Always route through KimiK3Processor, which wraps bare images into
+        # the media dictionaries expected by the checkpoint processor.
+        return super()._call_hf_processor(prompt, mm_data, mm_kwargs, tok_kwargs)
+
+    def _hf_processor_applies_updates(
+        self,
+        prompt_text: str,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+    ) -> bool:
+        del (
+            prompt_text,
+            mm_items,
+            hf_processor_mm_kwargs,
+            tokenization_kwargs,
+        )
+        return False
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, Any],
+        out_mm_kwargs: MultiModalKwargsItems,
+    ) -> Sequence[PromptUpdate]:
+        del hf_processor_mm_kwargs, out_mm_kwargs
+        media_token_id = self.info.media_token_id
+        media_token = self.info.media_token
+        image_placeholder = self.info.get_hf_config().image_placeholder
+
+        def replacement(item_idx: int) -> PromptUpdateDetails[str]:
+            images = mm_items.get_items("image", (ImageProcessorItems,))
+            image = images.get(item_idx)
+            if image is None:
+                raise ValueError(f"Missing Kimi K3 image at index {item_idx}")
+            num_media_tokens = self.info.media_tokens_calculator({"type": "image", "image": image})
+            width, height = images.get_image_size(item_idx)
+            full = (
+                f"<|media_begin|>image {width}x{height}<|media_content|>{media_token * num_media_tokens}<|media_end|>"
+            )
+            return PromptUpdateDetails.select_token_id(full, media_token_id)
+
+        return [
+            PromptReplacement(
+                modality="image",
+                target=image_placeholder,
+                replacement=replacement,
+            )
+        ]
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    KimiK3MultiModalProcessor,
+    info=KimiK3ProcessingInfo,
+    dummy_inputs=KimiK3DummyInputsBuilder,
+)
+class AscendKimiK3ForConditionalGeneration(
+    nn.Module,
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsQuant,
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    SupportsEagle3,
+):
+    supports_encoder_tp_data = True
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "language_model.layers.": "language_model.model.layers.",
+            "mm_projector.proj.0": "mm_projector.linear_1",
+            "mm_projector.proj.2": "mm_projector.linear_2",
+        }
+    )
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        del i
+        if modality == "image":
+            return "<|kimi_image_placeholder|>"
+        raise ValueError(f"Kimi K3 does not support modality: {modality}")
+
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        model_config = vllm_config.model_config
+        config: KimiK3Config = model_config.hf_config
+        self.config = config
+        self.model_config = model_config
+        self.quant_config = vllm_config.quant_config
+        self.hidden_size = config.text_config.hidden_size
+        self.device = current_platform.current_device()
+        self.use_data_parallel = _is_vit_use_data_parallel(config.vision_config.num_attention_heads)
+        vision_quant = self._maybe_ignore_quant_config(self.quant_config)
+
+        with self._mark_tower_model(vllm_config, "image"):
+            self.vision_tower = KimiK3VisionTower(
+                config.vision_config,
+                quant_config=vision_quant,
+                prefix=maybe_prefix(prefix, "vision_tower"),
+            )
+            tower_dtype = model_config.dtype if vision_quant is None else None
+            self.vision_tower = _move_module_to_device(
+                self.vision_tower,
+                device=self.device,
+                dtype=tower_dtype,
+            )
+            self.mm_projector = KimiK3MultiModalProjector(
+                config.vision_config,
+                quant_config=vision_quant,
+                prefix=maybe_prefix(prefix, "mm_projector"),
+            )
+            self.mm_projector = _move_module_to_device(
+                self.mm_projector,
+                device=self.device,
+                dtype=model_config.dtype,
+            )
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                hf_config=config.text_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+                architectures=["KimiK3ForCausalLM"],
+            )
+        self.make_empty_intermediate_tensors = self.language_model.make_empty_intermediate_tensors
+        self.media_placeholder = config.media_placeholder_token_id
+
+    @staticmethod
+    def _maybe_ignore_quant_config(
+        quant_config: QuantizationConfig | None,
+    ) -> QuantizationConfig | None:
+        if quant_config is not None and (
+            isinstance(quant_config, compressed_tensors.CompressedTensorsConfig)
+            or quant_config.get_name() == "compressed-tensors"
+        ):
+            return None
+        return quant_config
+
+    def _parse_and_validate_media_input(self, **kwargs: object) -> KimiK3MediaPixelInputs | None:
+        pixel_values = kwargs.pop("pixel_values", None)
+        grid_thws = kwargs.pop("grid_thws", None)
+        if pixel_values is None:
+            return None
+        if isinstance(pixel_values, list):
+            pixel_tensors: list[torch.Tensor] = []
+            for pixel_value in pixel_values:
+                if not isinstance(pixel_value, torch.Tensor):
+                    raise TypeError(f"pixel_values entries must be tensors, got {type(pixel_value)}")
+                pixel_tensors.append(pixel_value)
+            pixel_values = torch.cat(pixel_tensors, dim=0)
+        elif not isinstance(pixel_values, torch.Tensor):
+            raise TypeError(f"pixel_values must be a tensor or list of tensors, got {type(pixel_values)}")
+        if pixel_values.ndim in (3, 5):
+            pixel_values = pixel_values.reshape(
+                pixel_values.shape[0] * pixel_values.shape[1],
+                *pixel_values.shape[2:],
+            )
+        target_dtype = next(self.vision_tower.parameters()).dtype
+        pixel_values = pixel_values.to(target_dtype)
+        if not isinstance(grid_thws, torch.Tensor):
+            raise TypeError(f"grid_thws must be a tensor, got {type(grid_thws)}")
+        grid_thws_tensor: torch.Tensor = grid_thws.reshape(-1, grid_thws.shape[-1])
+        if grid_thws_tensor.ndim != 2 or grid_thws_tensor.shape[1] != 3:
+            raise ValueError(f"Unexpected Kimi K3 grid_thws shape: {grid_thws_tensor.shape}")
+        return KimiK3MediaPixelInputs(
+            type="pixel_values",
+            pixel_values=pixel_values,
+            grid_thws=grid_thws_tensor,
+        )
+
+    def embed_multimodal(self, **kwargs: object) -> NestedTensors | None:
+        media_input = self._parse_and_validate_media_input(**kwargs)
+        if media_input is None:
+            return None
+        return vision_tower_forward(
+            self.vision_tower,
+            media_input["pixel_values"],
+            media_input["grid_thws"],
+            self.mm_projector,
+            self.use_data_parallel,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        del kwargs
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        return self.language_model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+
+    def compute_logits(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor | None:
+        del kwargs
+        return self.language_model.compute_logits(hidden_states)
+
+    def set_dspark_aux_capture_materialized(self, enabled: bool) -> None:
+        self.language_model.set_dspark_aux_capture_materialized(enabled)
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(cls, vllm_config: VllmConfig):
+        return AscendKimiK3ForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(cls, vllm_config: VllmConfig):
+        return AscendKimiK3ForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(cls):
+        return AscendKimiK3ForCausalLM.get_mamba_state_copy_func()
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        # ModelSlim checkpoints may include an explicit projector rotation.
+        # Build the optional layer before loading so streaming checkpoint
+        # iterators can populate it, then release it when the weight is absent.
+        # A StageMissingLayer forwards attribute access to the wrapped module,
+        # so a plain getattr can make ``rot_proj`` look locally registered on
+        # pipeline stages that do not own the vision tower. Use vLLM's common
+        # PP ownership helper before inspecting or mutating the projector.
+        projector_is_missing = is_pp_missing_parameter("mm_projector.rot_proj", self)
+        rot_proj = (
+            None if projector_is_missing else getattr(self.mm_projector, "rot_proj", None)
+        )
+        skip_prefixes = [] if rot_proj is not None else ["mm_projector.rot_proj."]
+        loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes)
+        rot_proj_weight_names = (
+            {name for name, _ in rot_proj.named_parameters(prefix="mm_projector.rot_proj")}
+            if rot_proj is not None
+            else set()
+        )
+        loaded_weights = loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+        if rot_proj is not None and rot_proj_weight_names.isdisjoint(loaded_weights):
+            del self.mm_projector.rot_proj
+        return loaded_weights
+
+
+class KimiK3MLP(nn.Module):
+    def __init__(
+        self,
+        config: KimiK3TextConfig,
+        hidden_size: int,
+        intermediate_size: int,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.gate_up_proj = MergedColumnParallelLinear(
+            hidden_size,
+            [intermediate_size, intermediate_size],
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.gate_up_proj",
+        )
+        self.down_proj = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            reduce_results=reduce_results,
+            prefix=f"{prefix}.down_proj",
+        )
+        if config.hidden_act == "situ":
+            self.act_fn = AscendSituAndMul(
+                beta=config.activation_situ_beta or 1.0,
+                linear_beta=config.activation_situ_linear_beta,
+            )
+        elif config.hidden_act == "silu":
+            self.act_fn = SiluAndMul()
+        else:
+            raise ValueError(f"Unsupported Kimi K3 activation: {config.hidden_act}")
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        gate_up, _ = self.gate_up_proj(hidden_states)
+        hidden_states = self.act_fn(gate_up)
+        hidden_states, _ = self.down_proj(hidden_states)
+        return hidden_states
+
+
+class _KimiRoutedOutputTransform(nn.Module):
+    """Non-owning callable used by MoERunner after routed expert combine."""
+
+    _norm: nn.Module | None
+    _up_proj: nn.Module
+
+    def __init__(self, norm: nn.Module | None, up_proj: nn.Module) -> None:
+        super().__init__()
+        self._norm = norm
+        self._up_proj = up_proj
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        # Dynamo fullgraph can trace normal attribute access, but not an
+        # explicit call to object.__getattribute__.
+        norm = self._norm
+        up_proj = self._up_proj
+        if norm is not None:
+            hidden_states = norm(hidden_states)
+        return up_proj(hidden_states)[0]
+
+
+class KimiK3MoE(nn.Module):
+    def __init__(
+        self,
+        config: KimiK3TextConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if config.hidden_act != "situ":
+            raise ValueError("Kimi K3 routed experts require the SiTU activation")
+        if config.routed_expert_hidden_size is None:
+            raise ValueError("Kimi K3 requires routed_expert_hidden_size")
+
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.moe_hidden_size = config.routed_expert_hidden_size
+        self.num_shared_experts = config.num_shared_experts
+        latent_quant_config = _routed_latent_quant_config(quant_config)
+        # Routing always uses the original full-width hidden state.
+        self.gate = ReplicatedLinear(
+            self.hidden_size,
+            config.num_experts,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.gate",
+        )
+        self.gate.e_score_correction_bias = nn.Parameter(torch.empty(config.num_experts))
+
+        self.routed_expert_down_proj = ReplicatedLinear(
+            self.hidden_size,
+            self.moe_hidden_size,
+            bias=False,
+            quant_config=latent_quant_config,
+            prefix=f"{prefix}.routed_expert_down_proj",
+        )
+        self.routed_expert_norm = (
+            RMSNorm(self.moe_hidden_size, eps=config.rms_norm_eps) if config.latent_moe_use_norm else None
+        )
+        self.routed_expert_up_proj = ReplicatedLinear(
+            self.moe_hidden_size,
+            self.hidden_size,
+            bias=False,
+            quant_config=latent_quant_config,
+            prefix=f"{prefix}.routed_expert_up_proj",
+        )
+        routed_output_transform = _KimiRoutedOutputTransform(
+            self.routed_expert_norm,
+            self.routed_expert_up_proj,
+        )
+
+        self.shared_experts: KimiK3MLP | None
+        if self.num_shared_experts:
+            self.shared_experts = KimiK3MLP(
+                config,
+                hidden_size=self.hidden_size,
+                intermediate_size=config.moe_intermediate_size * self.num_shared_experts,
+                quant_config=quant_config,
+                reduce_results=False,
+                prefix=f"{prefix}.shared_experts",
+            )
+        else:
+            self.shared_experts = None
+
+        self.experts = FusedMoE(
+            shared_experts=self.shared_experts,
+            num_experts=config.num_experts,
+            top_k=config.num_experts_per_token,
+            hidden_size=self.moe_hidden_size,
+            intermediate_size=config.moe_intermediate_size,
+            renormalize=config.moe_renormalize,
+            quant_config=quant_config,
+            use_grouped_topk=config.use_grouped_topk,
+            num_expert_group=config.num_expert_group,
+            topk_group=config.topk_group,
+            prefix=f"{prefix}.experts",
+            scoring_func=config.moe_router_activation_func,
+            e_score_correction_bias=self.gate.e_score_correction_bias,
+            routed_scaling_factor=config.routed_scaling_factor,
+            n_shared_experts=self.num_shared_experts,
+            routed_input_transform=self.routed_expert_down_proj,
+            routed_output_transform=routed_output_transform,
+            activation=SituActivationConfig(
+                beta=config.activation_situ_beta or 1.0,
+                linear_beta=config.activation_situ_linear_beta,
+            ),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        num_tokens, hidden_size = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_size)
+        router_logits, _ = self.gate(hidden_states)
+        output = self.experts(hidden_states=hidden_states, router_logits=router_logits)
+        return output.view(num_tokens, hidden_size)
+
+
+class KimiK3MLAAttention(nn.Module):
+    """Q-LoRA MLA with a position-independent q/k slice and output gate."""
+
+    def __init__(
+        self,
+        config: KimiK3TextConfig,
+        hidden_size: int,
+        num_heads: int,
+        qk_nope_head_dim: int,
+        qk_rope_head_dim: int,
+        v_head_dim: int,
+        q_lora_rank: int,
+        kv_lora_rank: int,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+        **kwargs,
+    ) -> None:
+        super().__init__()
+        del kwargs
+        if not config.mla_use_nope or config.mla_use_rope:
+            raise ValueError("Kimi K3 MLA must use the explicit no-RoPE path")
+        if not config.mla_use_output_gate:
+            raise ValueError("Kimi K3 MLA requires its output gate")
+
+        self.hidden_size = hidden_size
+        self.qk_nope_head_dim = qk_nope_head_dim
+        self.qk_rope_head_dim = qk_rope_head_dim
+        self.qk_head_dim = qk_nope_head_dim + qk_rope_head_dim
+        self.v_head_dim = v_head_dim
+        self.q_lora_rank = q_lora_rank
+        self.kv_lora_rank = kv_lora_rank
+        self.num_heads = num_heads
+        tp_size = get_tensor_model_parallel_world_size()
+        if num_heads % tp_size:
+            raise ValueError("num_attention_heads must be divisible by tensor parallel size")
+        self.num_local_heads = num_heads // tp_size
+        self.scaling = self.qk_head_dim**-0.5
+
+        self.fused_qkv_a_proj = DeepSeekV2FusedQkvAProjLinear(
+            hidden_size,
+            [q_lora_rank, kv_lora_rank + qk_rope_head_dim],
+            quant_config=quant_config,
+            prefix=f"{prefix}.fused_qkv_a_proj",
+        )
+        self.q_a_layernorm = RMSNorm(q_lora_rank, eps=config.rms_norm_eps)
+        self.q_b_proj = ColumnParallelLinear(
+            q_lora_rank,
+            num_heads * self.qk_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_b_proj",
+        )
+        self.kv_a_layernorm = RMSNorm(kv_lora_rank, eps=config.rms_norm_eps)
+        self.kv_b_proj = ColumnParallelLinear(
+            kv_lora_rank,
+            num_heads * (qk_nope_head_dim + v_head_dim),
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.kv_b_proj",
+        )
+        self.g_proj = ColumnParallelLinear(
+            hidden_size,
+            num_heads * v_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.g_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            num_heads * v_head_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        mla_modules = MLAModules(
+            kv_a_layernorm=self.kv_a_layernorm,
+            kv_b_proj=self.kv_b_proj,
+            rotary_emb=None,
+            o_proj=self.o_proj,
+            fused_qkv_a_proj=self.fused_qkv_a_proj,
+            kv_a_proj_with_mqa=None,
+            q_a_layernorm=self.q_a_layernorm,
+            q_b_proj=self.q_b_proj,
+            q_proj=None,
+            indexer=None,
+            is_sparse=False,
+            topk_indices_buffer=None,
+        )
+        # MLAModules is an upstream dataclass without K3 fields.  Dynamic
+        # attributes preserve compatibility while the Ascend OOT wrapper
+        # consumes the model-specific modules.
+        mla_modules.g_proj = self.g_proj
+        mla_modules.use_output_gate = True
+        mla_modules.use_mla_rope = False
+        self.mla_attn = MultiHeadLatentAttentionWrapper(
+            hidden_size,
+            self.num_local_heads,
+            self.scaling,
+            qk_nope_head_dim,
+            qk_rope_head_dim,
+            v_head_dim,
+            q_lora_rank,
+            kv_lora_rank,
+            mla_modules,
+            cache_config,
+            quant_config,
+            prefix,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        output[:] = self.mla_attn(positions, hidden_states)
+
+
+def _apply_attention_residual(
+    prefix_sum: torch.Tensor,
+    block_residual: torch.Tensor,
+    projection: nn.Module,
+    norm: RMSNorm,
+) -> torch.Tensor:
+    """Apply K3's learned normalized mixture over residual block starts."""
+    if apply_attn_res is not None and prefix_sum.device.type == "npu" and prefix_sum.numel() > 0:
+        mixed = apply_attn_res(prefix_sum, block_residual, projection, norm)
+    else:
+        values = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
+        values_fp32 = values.float()
+        normalized, _ = torch_npu.npu_rms_norm(
+            values_fp32,
+            norm.weight.float(),
+            norm.variance_epsilon,
+        )
+        scores = torch.matmul(normalized, projection.weight.t().float()).squeeze(-1)
+        probabilities = scores.softmax(-1).unsqueeze(1)
+        mixed = torch.matmul(probabilities, values_fp32).squeeze(1).to(values.dtype)
+    if _EXTRA_CTX.flash_comm_v1_enabled:
+        # FlashComm changes the first decoder layer from the global token
+        # layout to a TP-local layout.  The learned-residual arithmetic above
+        # can specialize that derived token dimension to the compile example
+        # size.  Re-anchor it to prefix_sum through the existing no-op residual
+        # helper so later KDA/MLA layers keep the TP-local SymInt dynamic.
+        mixed = torch.ops.vllm.maybe_chunk_residual(prefix_sum, mixed)
+    return mixed
+
+
+class KimiK3DecoderLayer(nn.Module):
+    def __init__(self, config: KimiK3TextConfig, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.layer_idx = int(prefix.rsplit(".", 1)[1])
+        self.is_vl_first_layer = bool(uses_kimi_k3_global_inputs_embeds(vllm_config) and self.layer_idx == 0)
+        quant_config = vllm_config.quant_config
+
+        if config.is_kda_layer(self.layer_idx):
+            # Instantiate by the upstream registered class name so vLLM's
+            # PluggableLayer mechanism selects the Ascend OOT implementation.
+            self.self_attn = KimiGatedDeltaNetAttention(
+                config,
+                vllm_config,
+                prefix=f"{prefix}.self_attn",
+            )
+        else:
+            self.self_attn = KimiK3MLAAttention(
+                config=config,
+                hidden_size=config.hidden_size,
+                num_heads=config.num_attention_heads,
+                qk_nope_head_dim=config.qk_nope_head_dim,
+                qk_rope_head_dim=config.qk_rope_head_dim,
+                v_head_dim=config.v_head_dim,
+                q_lora_rank=config.q_lora_rank,
+                kv_lora_rank=config.kv_lora_rank,
+                cache_config=vllm_config.cache_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.self_attn",
+            )
+
+        if (
+            config.num_experts is not None
+            and self.layer_idx >= config.first_k_dense_replace
+            and self.layer_idx % config.moe_layer_freq == 0
+        ):
+            # Keep the registered module name identical to the checkpoint.
+            # A local ``self.mlp`` alias would move every MoE parameter under
+            # ``layers.N.mlp`` and make AutoWeightsLoader miss
+            # ``layers.N.block_sparse_moe`` weights.
+            self.block_sparse_moe = KimiK3MoE(
+                config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.block_sparse_moe",
+            )
+        else:
+            self.mlp = KimiK3MLP(
+                config,
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        attn_res_block_size = config.attn_res_block_size
+        if attn_res_block_size is None:
+            raise ValueError("Kimi K3 requires attn_res_block_size")
+        self.attn_res_block_size = attn_res_block_size
+        self.self_attention_res_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.mlp_res_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.self_attention_res_proj = ReplicatedLinear(
+            config.hidden_size,
+            1,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.self_attention_res_proj",
+        )
+        self.mlp_res_proj = ReplicatedLinear(
+            config.hidden_size,
+            1,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.mlp_res_proj",
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        block_residual: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        prefix_sum: torch.Tensor | None = hidden_states
+        if block_residual.shape[1] > 0:
+            hidden_states = _apply_attention_residual(
+                prefix_sum,
+                block_residual,
+                self.self_attention_res_proj,
+                self.self_attention_res_norm,
+            )
+
+        if self.layer_idx % self.attn_res_block_size == 0:
+            assert prefix_sum is not None
+            block_residual = torch.cat((block_residual, prefix_sum.unsqueeze(1)), dim=1)
+            prefix_sum = None
+
+        hidden_states = self.input_layernorm(hidden_states)
+        if self.is_vl_first_layer and _EXTRA_CTX.flash_comm_v1_enabled:
+            tp_size = get_tensor_model_parallel_world_size()
+            num_local_tokens = hidden_states.shape[0] // tp_size
+            attention_output = torch.empty(
+                (num_local_tokens, hidden_states.shape[-1]),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+        else:
+            attention_output = torch.empty_like(hidden_states)
+        self.self_attn(positions=positions, hidden_states=hidden_states, output=attention_output)
+
+        # The multimodal first layer transitions from full inputs_embeds to a
+        # FlashComm token shard.  The token axis is dim 0 for both tensors, so
+        # reuse the framework residual sharding op directly.  The singleton
+        # block axis on the output anchor keeps fake/meta and runtime 3-D.
+        if self.is_vl_first_layer and _EXTRA_CTX.flash_comm_v1_enabled:
+            block_residual = torch.ops.vllm.maybe_chunk_residual(
+                attention_output.unsqueeze(1),
+                block_residual,
+            )
+        prefix_sum = attention_output if prefix_sum is None else prefix_sum + attention_output
+
+        hidden_states = _apply_attention_residual(
+            prefix_sum,
+            block_residual,
+            self.mlp_res_proj,
+            self.mlp_res_norm,
+        )
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        if hasattr(self, "block_sparse_moe"):
+            hidden_states = self.block_sparse_moe(hidden_states)
+        else:
+            hidden_states = self.mlp(hidden_states)
+        return prefix_sum + hidden_states, block_residual
+
+
+@support_torch_compile
+class KimiK3TextModel(nn.Module, EagleModelMixin):
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: KimiK3TextConfig = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        if get_pp_group().is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=f"{prefix}.embed_tokens",
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        def get_layer(prefix: str):
+            return KimiK3DecoderLayer(config, vllm_config, prefix)
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            get_layer,
+            prefix=f"{prefix}.layers",
+        )
+        if get_pp_group().is_last_rank:
+            self.output_attn_res_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.output_attn_res_proj = ReplicatedLinear(
+                config.hidden_size,
+                1,
+                bias=False,
+                quant_config=None,
+                prefix=f"{prefix}.output_attn_res_proj",
+            )
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.output_attn_res_norm = PPMissingLayer()
+            self.output_attn_res_proj = PPMissingLayer()
+            self.norm = PPMissingLayer()
+        # Legacy Qwen3/GQA DSpark checkpoints were trained from the
+        # materialized Kimi residual stream. Keep the PR #13071 raw-boundary
+        # behavior as the default for MLA-style draft checkpoints.
+        self.dspark_aux_capture_materialized = False
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def initial_block_count(self) -> int:
+        block_size = self.config.attn_res_block_size
+        if block_size is None:
+            raise ValueError("Kimi K3 requires attn_res_block_size")
+        return sum(layer_idx % block_size == 0 for layer_idx in range(self.start_layer))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor | IntermediateTensors:
+        del kwargs
+        if get_pp_group().is_first_rank:
+            hidden_states = inputs_embeds if inputs_embeds is not None else self.embed_input_ids(input_ids)
+            block_residual = hidden_states.new_zeros((hidden_states.shape[0], 0, hidden_states.shape[-1]))
+        else:
+            if intermediate_tensors is None:
+                raise ValueError("intermediate_tensors are required on non-first PP ranks")
+            hidden_states = intermediate_tensors["hidden_states"]
+            block_residual = intermediate_tensors["block_residual"]
+
+        aux_hidden_states: list[torch.Tensor] = []
+        for layer_idx, layer in enumerate(
+            self.layers[self.start_layer : self.end_layer],
+            start=self.start_layer,
+        ):
+            # The GQA drafter consumes the materialized input to the next
+            # target layer. Kimi K3 stores part of that stream separately in
+            # block_residual, so fold it through that layer's projection.
+            if self.dspark_aux_capture_materialized and layer_idx in self.aux_hidden_state_layers:
+                if block_residual.shape[1] == 0:
+                    aux_hidden_states.append(hidden_states)
+                else:
+                    aux_hidden_states.append(
+                        _apply_attention_residual(
+                            hidden_states,
+                            block_residual,
+                            layer.self_attention_res_proj,
+                            layer.self_attention_res_norm,
+                        )
+                    )
+            hidden_states, block_residual = layer(positions, hidden_states, block_residual)
+            if not self.dspark_aux_capture_materialized and (layer_idx + 1) in self.aux_hidden_state_layers:
+                aux_hidden_states.append(hidden_states)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors({"hidden_states": hidden_states, "block_residual": block_residual})
+
+        hidden_states = _apply_attention_residual(
+            hidden_states,
+            block_residual,
+            self.output_attn_res_proj,
+            self.output_attn_res_norm,
+        )
+        hidden_states = self.norm(hidden_states)
+        if aux_hidden_states:
+            return hidden_states, aux_hidden_states
+        return hidden_states
+
+    def load_weights(
+        self,
+        weights: Iterable[tuple[str, torch.Tensor] | tuple[str, torch.Tensor, dict[str, Any]]],
+    ) -> set[str]:
+        stacked_params_mapping = [
+            (".fused_qkv", ".q_proj", "q"),
+            (".fused_qkv", ".k_proj", "k"),
+            (".fused_qkv", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+            (".fused_qkv_a_proj", ".q_a_proj", 0),
+            (".fused_qkv_a_proj", ".kv_a_proj_with_mqa", 1),
+        ]
+        expert_params_mapping = fused_moe_make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="w1",
+            ckpt_down_proj_name="w2",
+            ckpt_up_proj_name="w3",
+            num_experts=self.config.num_experts,
+        )
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+
+        for args in weights:
+            name, loaded_weight = args[:2]
+            loader_kwargs: dict[str, Any] = args[2] if len(args) == 3 else {}
+            if "rotary_emb" in name:
+                continue
+            spec_layer = get_spec_layer_idx_from_weight_name(self.config, name)
+            if spec_layer is not None:
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if ".experts." in name and name not in params_dict:
+                    continue
+                name = name.replace(weight_name, param_name)
+                if name.endswith(".bias") and name not in params_dict:
+                    continue
+                if is_pp_missing_parameter(name, self):
+                    break
+                param = params_dict[name]
+                param.weight_loader(param, loaded_weight, shard_id)
+                break
+            else:
+                for param_name, weight_name, expert_id, shard_id in expert_params_mapping:
+                    if weight_name not in name:
+                        continue
+                    name = name.replace(weight_name, param_name)
+                    name = _resolve_packed_expert_weight_name(name, params_dict)
+                    if is_pp_missing_parameter(name, self):
+                        break
+                    param = params_dict[name]
+                    param.weight_loader(
+                        param,
+                        loaded_weight,
+                        name,
+                        expert_id=expert_id,
+                        shard_id=shard_id,
+                    )
+                    break
+                else:
+                    if name.endswith(".bias") and name not in params_dict:
+                        continue
+                    name = maybe_remap_kv_scale_name(name, params_dict)
+                    if name is None or is_pp_missing_parameter(name, self):
+                        continue
+                    param = params_dict[name]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight, **loader_kwargs)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class AscendKimiK3ForCausalLM(nn.Module, HasInnerState, SupportsPP, MixtureOfExperts, IsHybrid):
+    packed_modules_mapping = {
+        "fused_qkv": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "experts": ["experts.0.w1", "experts.0.w3", "experts.0.w2"],
+        "fused_qkv_a_proj": ["q_a_proj", "kv_a_proj_with_mqa"],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        self.model_config = vllm_config.model_config
+        self.vllm_config = vllm_config
+        self.config: KimiK3TextConfig = self.model_config.hf_text_config
+        self.quant_config = vllm_config.quant_config
+        self.model = KimiK3TextModel(vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model"))
+        if get_pp_group().is_last_rank:
+            self.lm_head = ParallelLMHead(
+                self.config.vocab_size,
+                self.config.hidden_size,
+                quant_config=self.quant_config,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+        else:
+            self.lm_head = PPMissingLayer()
+        self.logits_processor = LogitsProcessor(
+            self.config.vocab_size,
+            scale=getattr(self.config, "logit_scale", 1.0),
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def set_dspark_aux_capture_materialized(self, enabled: bool) -> None:
+        self.model.dspark_aux_capture_materialized = enabled
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds, **kwargs)
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def make_empty_intermediate_tensors(
+        self,
+        batch_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> IntermediateTensors:
+        return IntermediateTensors(
+            {
+                "hidden_states": torch.zeros((batch_size, self.config.hidden_size), dtype=dtype, device=device),
+                "block_residual": torch.zeros(
+                    (batch_size, self.model.initial_block_count(), self.config.hidden_size),
+                    dtype=dtype,
+                    device=device,
+                ),
+            }
+        )
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.kda_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        parallel_config = vllm_config.parallel_config
+        config = vllm_config.model_config.hf_text_config
+        num_spec = vllm_config.speculative_config.num_speculative_tokens if vllm_config.speculative_config else 0
+        return kimi_kda_state_shape(
+            parallel_config.tensor_parallel_size,
+            config.linear_attn_config["num_heads"],
+            config.linear_attn_config["head_dim"],
+            config.linear_attn_config["short_conv_kernel_size"],
+            num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.kda_state_copy_func()
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+        )
+        return loader.load_weights(weights)
+
+
+def get_spec_layer_idx_from_weight_name(config: KimiK3TextConfig, weight_name: str) -> int | None:
+    num_nextn_predict_layers = getattr(
+        config,
+        "num_nextn_predict_layers",
+        0,
+    )
+    for index in range(num_nextn_predict_layers):
+        layer_idx = config.num_hidden_layers + index
+        if f"layers.{layer_idx}." in weight_name:
+            return layer_idx
+    return None
+
+
+class KimiK3VisionPatchEmbed(nn.Module):
+    def __init__(self, config: KimiK3VisionConfig) -> None:
+        super().__init__()
+        configured_patch_size: int | Sequence[int] = config.patch_size
+        if isinstance(configured_patch_size, int):
+            self.patch_size = (configured_patch_size, configured_patch_size)
+        elif isinstance(configured_patch_size, Sequence) and len(configured_patch_size) == 2:
+            self.patch_size = (configured_patch_size[0], configured_patch_size[1])
+        else:
+            raise ValueError(f"Invalid Kimi K3 patch size: {configured_patch_size}")
+        self.proj = nn.Conv2d(
+            3,
+            config.hidden_size,
+            kernel_size=self.patch_size,
+            stride=self.patch_size,
+            bias=config.patch_embed_proj_bias,
+        )
+        self.pos_emb = Learnable2DInterpPosEmbDivided_fixed(
+            height=config.init_pos_emb_height,
+            width=config.init_pos_emb_width,
+            num_frames=config.init_pos_emb_time,
+            dim=config.hidden_size,
+            # The released K3 reference constructor leaves this at the
+            # LearnablePosEmbInterp default, which is bicubic. Its config.json
+            # contains a bilinear field but the reference model never consumes
+            # it, so honoring that field here would change non-64x64 grids.
+            interpolation_mode="bicubic",
+        )
+
+    def forward(self, pixels: torch.Tensor, grid_thws: torch.Tensor | list[list[int]]) -> torch.Tensor:
+        hidden_states = self.proj(pixels).view(pixels.shape[0], -1)
+        return self.pos_emb(hidden_states, grid_thws)
+
+
+class KimiK3VisionMLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        activation: nn.Module,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+        use_data_parallel: bool,
+        bias: bool,
+    ) -> None:
+        super().__init__()
+        self.fc0 = ColumnParallelLinear(
+            hidden_size,
+            intermediate_size,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc0",
+            disable_tp=use_data_parallel,
+        )
+        self.fc1 = RowParallelLinear(
+            intermediate_size,
+            hidden_size,
+            bias=bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.fc1",
+            disable_tp=use_data_parallel,
+        )
+        self.activation = activation
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states, _ = self.fc0(hidden_states)
+        hidden_states = self.activation(hidden_states)
+        return self.fc1(hidden_states)[0]
+
+
+class KimiK3VisionEncoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: KimiK3VisionConfig,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.use_data_parallel = _is_vit_use_data_parallel(config.num_attention_heads)
+        self.hidden_dim = config.hidden_size
+        self.qkv_hidden_size = config.qkv_hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.qkv_hidden_size // self.num_heads
+        if self.qkv_hidden_size % self.num_heads:
+            raise ValueError("K3 qkv_hidden_size must be divisible by vision heads")
+        self.tp_size = 1 if self.use_data_parallel else get_tensor_model_parallel_world_size()
+        self.num_local_heads = divide(self.num_heads, self.tp_size)
+
+        if config.norm_type != "rmsnorm":
+            raise ValueError(f"K3 vision requires RMSNorm, got {config.norm_type}")
+        # The released K3 implementation intentionally leaves encoder eps at
+        # torch.nn.RMSNorm's dtype-dependent default.  Projector RMSNorm below
+        # is the only vision norm with an explicit 1e-5 checkpoint contract.
+        self.norm0 = nn.RMSNorm(self.hidden_dim)
+        self.norm1 = nn.RMSNorm(self.hidden_dim)
+        self.mlp = KimiK3VisionMLP(
+            self.hidden_dim,
+            config.intermediate_size,
+            get_act_fn(config.activation_func),
+            quant_config,
+            f"{prefix}.mlp",
+            self.use_data_parallel,
+            config.linear_bias,
+        )
+        self.wqkv = QKVParallelLinear(
+            hidden_size=self.hidden_dim,
+            head_size=self.head_dim,
+            total_num_heads=self.num_heads,
+            total_num_kv_heads=self.num_heads,
+            bias=config.attn_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wqkv",
+            disable_tp=self.use_data_parallel,
+        )
+        self.wo = RowParallelLinear(
+            self.qkv_hidden_size,
+            self.hidden_dim,
+            bias=config.attn_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.wo",
+            disable_tp=self.use_data_parallel,
+        )
+        self.attn = MMEncoderAttention(
+            num_heads=self.num_local_heads,
+            head_size=self.head_dim,
+            scale=self.head_dim**-0.5,
+            prefix=f"{prefix}.attn",
+        )
+
+    def attention(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rope_freqs_cis: torch.Tensor,
+        max_seqlen: torch.Tensor,
+        sequence_lengths: torch.Tensor | None,
+    ) -> torch.Tensor:
+        num_tokens = hidden_states.shape[0]
+        qkv = self.wqkv(hidden_states)[0].view(
+            num_tokens,
+            3,
+            self.num_local_heads,
+            self.head_dim,
+        )
+        query, key, value = qkv.unbind(dim=1)
+        # QKVParallelLinear shards heads, while the shared RoPE table is head
+        # independent and therefore needs no TP slicing.
+        query, key = apply_rope(query, key, rope_freqs_cis)
+        output = self.attn(
+            query.unsqueeze(0),
+            key.unsqueeze(0),
+            value.unsqueeze(0),
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
+        )
+        output = output.reshape(num_tokens, self.num_local_heads * self.head_dim)
+        return self.wo(output)[0]
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rope_freqs_cis: torch.Tensor,
+        max_seqlen: torch.Tensor,
+        sequence_lengths: torch.Tensor | None,
+    ) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.norm0(hidden_states)
+        hidden_states = residual + self.attention(
+            hidden_states,
+            cu_seqlens,
+            rope_freqs_cis,
+            max_seqlen,
+            sequence_lengths,
+        )
+        residual = hidden_states
+        hidden_states = self.norm1(hidden_states)
+        return residual + self.mlp(hidden_states)
+
+
+class KimiK3VisionEncoder(nn.Module):
+    def __init__(
+        self,
+        config: KimiK3VisionConfig,
+        quant_config: QuantizationConfig | None,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.rope_2d = Rope2DPosEmbRepeated(
+            config.qkv_hidden_size // config.num_attention_heads,
+            512,
+            512,
+        )
+        self.blocks = nn.ModuleList(
+            [
+                KimiK3VisionEncoderLayer(config, quant_config, f"{prefix}.blocks.{layer_idx}")
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.final_layernorm = nn.RMSNorm(config.hidden_size)
+
+    def prepare_encoder_metadata(
+        self,
+        grid_thw_list: list[list[int]],
+        device: torch.device,
+    ) -> dict[str, torch.Tensor | None]:
+        rope_freqs_cis = self.rope_2d.get_freqs_cis(grid_thw_list, device=device)
+        grid = np.asarray(grid_thw_list, dtype=np.int32)
+        lengths = grid[:, 0] * grid[:, 1] * grid[:, 2]
+        cu_seqlens_np = np.concatenate((np.zeros(1, dtype=np.int32), lengths.cumsum(dtype=np.int32)))
+        backend = self.blocks[0].attn.attn_backend
+        sequence_lengths = MMEncoderAttention.maybe_compute_seq_lens(backend, cu_seqlens_np, device)
+        max_seqlen = torch.tensor(
+            MMEncoderAttention.compute_max_seqlen(backend, cu_seqlens_np),
+            dtype=torch.int32,
+        )
+        cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+            backend,
+            cu_seqlens_np,
+            self.blocks[0].hidden_dim,
+            self.blocks[0].tp_size,
+            device,
+        )
+        return {
+            "rope_freqs_cis": rope_freqs_cis,
+            "sequence_lengths": sequence_lengths,
+            "max_seqlen": max_seqlen,
+            "cu_seqlens": cu_seqlens,
+        }
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thws: torch.Tensor | list[list[int]],
+        encoder_metadata: dict[str, torch.Tensor | None] | None = None,
+    ) -> torch.Tensor:
+        grid_thw_list = grid_thws if isinstance(grid_thws, list) else grid_thws.tolist()
+        if encoder_metadata is None:
+            encoder_metadata = self.prepare_encoder_metadata(grid_thw_list, hidden_states.device)
+        rope_freqs_cis = encoder_metadata["rope_freqs_cis"]
+        cu_seqlens = encoder_metadata["cu_seqlens"]
+        max_seqlen = encoder_metadata["max_seqlen"]
+        if rope_freqs_cis is None or cu_seqlens is None or max_seqlen is None:
+            raise RuntimeError("Incomplete Kimi K3 vision attention metadata")
+        for block in self.blocks:
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens,
+                rope_freqs_cis,
+                max_seqlen,
+                encoder_metadata["sequence_lengths"],
+            )
+        return self.final_layernorm(hidden_states)
+
+
+class KimiK3VisionTower(nn.Module):
+    def __init__(
+        self,
+        config: KimiK3VisionConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = deepcopy(config)
+        self.patch_size = config.patch_size
+        self.merge_kernel_size = config.merge_kernel_size
+        self.merge_type = config.merge_type
+        self.patch_embed = KimiK3VisionPatchEmbed(config)
+        self.encoder = KimiK3VisionEncoder(config, quant_config, maybe_prefix(prefix, "encoder"))
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        grid_thws: torch.Tensor | list[list[int]],
+        encoder_metadata: dict[str, torch.Tensor | None] | None = None,
+    ) -> list[torch.Tensor]:
+        grid_thw_list = grid_thws if isinstance(grid_thws, list) else grid_thws.tolist()
+        if encoder_metadata is None:
+            encoder_metadata = self.encoder.prepare_encoder_metadata(grid_thw_list, pixel_values.device)
+        hidden_states = self.patch_embed(pixel_values, grid_thw_list)
+        hidden_states = self.encoder(hidden_states, grid_thw_list, encoder_metadata)
+        if self.merge_type != "sd2_tpool":
+            raise ValueError(f"Unsupported Kimi K3 merge type: {self.merge_type}")
+        return tpool_patch_merger(hidden_states, grid_thw_list, self.merge_kernel_size)
+
+
+class KimiK3MultiModalProjector(nn.Module):
+    def __init__(
+        self,
+        config: KimiK3VisionConfig,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        merge_size = config.merge_kernel_size[0] * config.merge_kernel_size[1]
+        self.input_size = config.mm_hidden_size * merge_size
+        if config.mm_projector_type != "patchmergerv2":
+            raise ValueError(f"Unsupported Kimi K3 projector: {config.mm_projector_type}")
+        self.linear_1 = ReplicatedLinear(
+            self.input_size,
+            self.input_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_1",
+        )
+        self.linear_2 = ReplicatedLinear(
+            self.input_size,
+            config.text_hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.linear_2",
+        )
+        self.act = get_act_fn(config.projector_hidden_act)
+        self.post_norm = RMSNorm(config.text_hidden_size, eps=config.projector_ln_eps)
+        # ModelSlim rotates K3's FP4 activations before INT4 inference. Text
+        # embeddings fold this matrix into their input projection, but the
+        # vision path ends in RMSNorm, so the rotation must remain explicit.
+        self.rot_proj: ReplicatedLinear | None = ReplicatedLinear(
+            config.text_hidden_size,
+            config.text_hidden_size,
+            bias=False,
+            quant_config=None,
+            prefix=f"{prefix}.rot_proj",
+        )
+
+    def forward(self, image_features: torch.Tensor) -> torch.Tensor:
+        hidden_states = image_features.reshape(-1, self.input_size)
+        hidden_states = self.linear_1(hidden_states)[0]
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.linear_2(hidden_states)[0]
+        hidden_states = self.post_norm(hidden_states)
+        rot_proj = getattr(self, "rot_proj", None)
+        if rot_proj is not None:
+            hidden_states = rot_proj(hidden_states)[0]
+        return hidden_states
+
+
+@torch.inference_mode()
+def vision_tower_forward(
+    vision_tower: KimiK3VisionTower,
+    pixel_values: torch.Tensor,
+    grid_thws: torch.Tensor,
+    mm_projector: KimiK3MultiModalProjector,
+    use_data_parallel: bool,
+) -> list[torch.Tensor]:
+    grid_thw_list = grid_thws.tolist()
+    if use_data_parallel:
+        tower_outputs = run_dp_sharded_mrope_vision_model(
+            vision_model=vision_tower,
+            pixel_values=pixel_values,
+            grid_thw_list=grid_thw_list,
+            rope_type="rope_2d",
+        )
+    else:
+        metadata = vision_tower.encoder.prepare_encoder_metadata(grid_thw_list, pixel_values.device)
+        tower_outputs = vision_tower(pixel_values, grid_thw_list, metadata)
+
+    lengths = [item.shape[0] for item in tower_outputs]
+    batched = torch.cat(list(tower_outputs), dim=0)
+    projected = mm_projector(batched)
+    return list(projected.split(lengths, dim=0))
+
+
+__all__ = [
+    "AscendKimiK3ForCausalLM",
+    "AscendKimiK3ForConditionalGeneration",
+    "KimiK3DecoderLayer",
+    "KimiK3MLAAttention",
+    "KimiK3MLP",
+    "KimiK3MoE",
+    "KimiK3MultiModalProjector",
+    "KimiK3TextModel",
+    "KimiK3VisionEncoderLayer",
+    "KimiK3VisionTower",
+    "vision_tower_forward",
+]

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -611,9 +611,7 @@ class AscendKimiK3ForConditionalGeneration(
         # pipeline stages that do not own the vision tower. Use vLLM's common
         # PP ownership helper before inspecting or mutating the projector.
         projector_is_missing = is_pp_missing_parameter("mm_projector.rot_proj", self)
-        rot_proj = (
-            None if projector_is_missing else getattr(self.mm_projector, "rot_proj", None)
-        )
+        rot_proj = None if projector_is_missing else getattr(self.mm_projector, "rot_proj", None)
         skip_prefixes = [] if rot_proj is not None else ["mm_projector.rot_proj."]
         loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes)
         rot_proj_weight_names = (

--- a/vllm_ascend/models/minimax_m3/msa_m3.py
+++ b/vllm_ascend/models/minimax_m3/msa_m3.py
@@ -38,10 +38,7 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
-from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
-    minimax_m3_sparse_attn,
-    minimax_m3_sparse_attn_decode,
-)
+from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import minimax_m3_sparse_attn
 from vllm_ascend.ops.linear import AscendColumnParallelLinear
 from vllm_ascend.ops.linear_op import get_parallel_op
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
@@ -51,8 +48,12 @@ if get_ascend_device_type() == AscendDeviceType.A5:
         minimax_m3_index_decode,
         minimax_m3_index_score,
         minimax_m3_index_topk,
+        minimax_m3_sparse_attn_decode,
     )
 else:
+    from vllm_ascend.models.minimax_m3.ops.msa_m3_npu import (
+        minimax_m3_sparse_attn_decode,
+    )
     from vllm_ascend.models.minimax_m3.ops.msa_m3_triton import (
         minimax_m3_index_decode,
         minimax_m3_index_score,

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
@@ -192,7 +192,10 @@ def _index_block_score_kernel(
     bt_row = block_table_ptr + pid_b * stride_bt_b
     hi = tl.minimum(seq_len, prefix_len + (pid_q + 1) * BLOCK_SIZE_Q)
 
-    middle = (q_start - BLOCK_SIZE_K) // BLOCK_SIZE_K * BLOCK_SIZE_K
+    middle = tl.maximum(
+        0,
+        (q_start - BLOCK_SIZE_K) // BLOCK_SIZE_K * BLOCK_SIZE_K,
+    )
 
     for key_start in tl.range(0, middle, BLOCK_SIZE_K):
         block_id = key_start // BLOCK_SIZE_K

--- a/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
+++ b/vllm_ascend/models/minimax_m3/ops/msa_m3_triton_a5.py
@@ -1334,8 +1334,11 @@ def minimax_m3_sparse_attn_decode(
     sm_scale: float,
     output: torch.Tensor,  # [total_q, num_heads, head_dim]
     decode_query_len: int,
+    block_size: int = SPARSE_BLOCK_SIZE,
 ) -> None:
     """GQA block-sparse attention for decode (split-K over the top-k blocks)."""
+    if block_size != SPARSE_BLOCK_SIZE:
+        raise ValueError(f"A5 sparse decode requires block_size={SPARSE_BLOCK_SIZE}, got {block_size}")
     kv_cache = _as_triton_main_kv_cache(kv_cache)
     total_q, num_heads, head_dim = q.shape
     assert total_q == seq_lens.shape[0] * decode_query_len

--- a/vllm_ascend/ops/activation.py
+++ b/vllm_ascend/ops/activation.py
@@ -15,8 +15,11 @@
 # This file is a part of the vllm-ascend project.
 #
 
+from dataclasses import dataclass
+
 import torch
 import torch_npu
+from torch import nn
 from vllm.model_executor.layers.activation import (
     QuickGELU,
     SiluAndMul,
@@ -24,6 +27,60 @@ from vllm.model_executor.layers.activation import (
     SwigluOAIAndMul,
     SwigluStepAndMul,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class SituActivationConfig:
+    """Runtime parameters for Kimi's SiTU gated activation."""
+
+    beta: float = 1.0
+    linear_beta: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.beta <= 0:
+            raise ValueError(f"SiTU beta must be positive, got {self.beta}.")
+        if self.linear_beta is not None and self.linear_beta <= 0:
+            raise ValueError(f"SiTU linear_beta must be positive, got {self.linear_beta}.")
+
+
+def situ_and_mul(
+    x: torch.Tensor,
+    *,
+    beta: float = 1.0,
+    linear_beta: float | None = None,
+) -> torch.Tensor:
+    """Apply Kimi SiTU with FP32 intermediates and restore the input dtype."""
+    config = SituActivationConfig(beta=beta, linear_beta=linear_beta)
+    if x.shape[-1] % 2 != 0:
+        raise ValueError(f"SiTU expects an even last dimension, got {x.shape[-1]}.")
+
+    gate, up = x.to(torch.float32).chunk(2, dim=-1)
+    gate = config.beta * torch.tanh(gate / config.beta) * torch.sigmoid(gate)
+    if config.linear_beta is not None:
+        up = config.linear_beta * torch.tanh(up / config.linear_beta)
+    return (gate * up).to(x.dtype)
+
+
+class AscendSituAndMul(nn.Module):
+    """Module form of Kimi SiTU used by dense and shared-expert MLPs."""
+
+    def __init__(self, beta: float = 1.0, linear_beta: float | None = None) -> None:
+        super().__init__()
+        self.config = SituActivationConfig(beta=beta, linear_beta=linear_beta)
+
+    @property
+    def beta(self) -> float:
+        return self.config.beta
+
+    @property
+    def linear_beta(self) -> float | None:
+        return self.config.linear_beta
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return situ_and_mul(x, beta=self.beta, linear_beta=self.linear_beta)
+
+    def extra_repr(self) -> str:
+        return f"beta={self.beta}, linear_beta={self.linear_beta}"
 
 
 class AscendQuickGELU(QuickGELU):

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -16,7 +16,7 @@
 #
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from functools import wraps
+from functools import cache, wraps
 
 import torch
 import torch.nn.functional as F
@@ -29,8 +29,6 @@ from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.lora.fused_moe import has_lora
 from vllm_ascend.ops.activation import AscendSituAndMul
-from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
-from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     AscendDeviceType,
@@ -38,6 +36,15 @@ from vllm_ascend.utils import (
     npu_stream_switch,
     shared_experts_calculation_stream,
 )
+
+
+@cache
+def _get_dynamic_linear_method_types() -> tuple[type, type]:
+    # Defer quantization package initialization until routed_experts has loaded.
+    from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
+    from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
+
+    return AscendW4A8DynamicLinearMethod, AscendW8A8DynamicLinearMethod
 
 
 def _linear_uses_quant_method(linear: torch.nn.Module, method_type: type) -> bool:
@@ -262,12 +269,13 @@ class AscendSharedExperts:
                 and hasattr(self.layer.down_proj, "weight_scale")
             )
             shared_uses_situ = isinstance(self.layer.act_fn, AscendSituAndMul)
+            w4a8_linear_method, w8a8_linear_method = _get_dynamic_linear_method_types()
             shared_is_w4a8 = all(
-                _linear_uses_quant_method(proj, AscendW4A8DynamicLinearMethod)
+                _linear_uses_quant_method(proj, w4a8_linear_method)
                 for proj in (self.layer.gate_up_proj, self.layer.down_proj)
             )
             shared_is_w8a8 = all(
-                _linear_uses_quant_method(proj, AscendW8A8DynamicLinearMethod)
+                _linear_uses_quant_method(proj, w8a8_linear_method)
                 for proj in (self.layer.gate_up_proj, self.layer.down_proj)
             )
             has_per_channel_w4a8_situ_shared = (

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -273,10 +273,7 @@ class AscendSharedExperts:
             has_per_channel_w4a8_situ_shared = (
                 shared_is_w4a8
                 and shared_uses_situ
-                and all(
-                    hasattr(proj, "weight_scale_fp32")
-                    for proj in (self.layer.gate_up_proj, self.layer.down_proj)
-                )
+                and all(hasattr(proj, "weight_scale_fp32") for proj in (self.layer.gate_up_proj, self.layer.down_proj))
             )
             if has_quantized_shared_without_lora and (shared_is_w8a8 or has_per_channel_w4a8_situ_shared):
                 original_dtype = hidden_states.dtype
@@ -304,9 +301,7 @@ class AscendSharedExperts:
                     quantized_x, swiglu_out_scale = torch.ops._C_ascend.dequant_situ_quant(
                         x=hidden_states,
                         weight_scale=(
-                            None
-                            if has_per_channel_w4a8_situ_shared
-                            else self.layer.gate_up_proj.weight_scale_fp32
+                            None if has_per_channel_w4a8_situ_shared else self.layer.gate_up_proj.weight_scale_fp32
                         ),
                         activation_scale=None if has_per_channel_w4a8_situ_shared else pertoken_scale,
                         bias=None,

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -28,6 +28,9 @@ from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoEMethodB
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.lora.fused_moe import has_lora
+from vllm_ascend.ops.activation import AscendSituAndMul
+from vllm_ascend.quantization.methods.w4a8 import AscendW4A8DynamicLinearMethod
+from vllm_ascend.quantization.methods.w8a8_dynamic import AscendW8A8DynamicLinearMethod
 from vllm_ascend.quantization.quant_type import QuantType
 from vllm_ascend.utils import (
     AscendDeviceType,
@@ -35,6 +38,13 @@ from vllm_ascend.utils import (
     npu_stream_switch,
     shared_experts_calculation_stream,
 )
+
+
+def _linear_uses_quant_method(linear: torch.nn.Module, method_type: type) -> bool:
+    """Check a linear's concrete scheme, unwrapping AscendLinearMethod."""
+    quant_method = getattr(linear, "quant_method", None)
+    quant_method = getattr(quant_method, "quant_method", quant_method)
+    return isinstance(quant_method, method_type)
 
 
 @dataclass
@@ -251,7 +261,24 @@ class AscendSharedExperts:
                 and hasattr(self.layer.gate_up_proj, "weight_scale")
                 and hasattr(self.layer.down_proj, "weight_scale")
             )
-            if has_quantized_shared_without_lora and self.quant_type in (QuantType.W8A8, QuantType.W4A8):
+            shared_uses_situ = isinstance(self.layer.act_fn, AscendSituAndMul)
+            shared_is_w4a8 = all(
+                _linear_uses_quant_method(proj, AscendW4A8DynamicLinearMethod)
+                for proj in (self.layer.gate_up_proj, self.layer.down_proj)
+            )
+            shared_is_w8a8 = all(
+                _linear_uses_quant_method(proj, AscendW8A8DynamicLinearMethod)
+                for proj in (self.layer.gate_up_proj, self.layer.down_proj)
+            )
+            has_per_channel_w4a8_situ_shared = (
+                shared_is_w4a8
+                and shared_uses_situ
+                and all(
+                    hasattr(proj, "weight_scale_fp32")
+                    for proj in (self.layer.gate_up_proj, self.layer.down_proj)
+                )
+            )
+            if has_quantized_shared_without_lora and (shared_is_w8a8 or has_per_channel_w4a8_situ_shared):
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
@@ -259,46 +286,71 @@ class AscendSharedExperts:
                 # Execute the gate projection and activation concurrently with the
                 # dispatch communication.
                 maybe_wait_event(fused_moe_evts.after_routed_experts)
-                hidden_states = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self.layer.gate_up_proj.weight,
-                    self.layer.gate_up_proj.weight_scale,
-                    pertoken_scale=None,
-                    bias=None,
-                    output_dtype=torch.int32,
-                )
+                if has_per_channel_w4a8_situ_shared:
+                    hidden_states = self.layer.gate_up_proj((quantized_x, pertoken_scale))[0]
+                else:
+                    hidden_states = torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        self.layer.gate_up_proj.weight,
+                        self.layer.gate_up_proj.weight_scale,
+                        pertoken_scale=None,
+                        bias=None,
+                        output_dtype=torch.int32,
+                    )
                 # Execute activation concurrently with gmm2.
 
                 maybe_wait_event(fused_moe_evts.before_gmm2)
-                quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
-                    x=hidden_states,
-                    weight_scale=self.layer.gate_up_proj.weight_scale_fp32,
-                    activation_scale=pertoken_scale,
-                    bias=None,
-                    quant_scale=None,
-                    quant_offset=None,
-                    group_index=None,
-                    activate_left=True,
-                    quant_mode=1,
-                    swiglu_mode=1,
-                    clamp_limit=self.swiglu_limit,
-                    **(
-                        {}
-                        if get_ascend_device_type() == AscendDeviceType.A5
-                        else {"glu_alpha": self.swiglu_alpha, "glu_bias": self.swiglu_beta}
-                    ),
-                )
+                if shared_uses_situ:
+                    quantized_x, swiglu_out_scale = torch.ops._C_ascend.dequant_situ_quant(
+                        x=hidden_states,
+                        weight_scale=(
+                            None
+                            if has_per_channel_w4a8_situ_shared
+                            else self.layer.gate_up_proj.weight_scale_fp32
+                        ),
+                        activation_scale=None if has_per_channel_w4a8_situ_shared else pertoken_scale,
+                        bias=None,
+                        quant_scale=None,
+                        quant_offset=None,
+                        group_index=None,
+                        beta=self.layer.act_fn.beta,
+                        linear_beta=self.layer.act_fn.linear_beta,
+                        activate_left=True,
+                        quant_mode="dynamic",
+                    )
+                else:
+                    quantized_x, swiglu_out_scale = torch.ops._C_ascend.npu_dequant_swiglu_quant(
+                        x=hidden_states,
+                        weight_scale=self.layer.gate_up_proj.weight_scale_fp32,
+                        activation_scale=pertoken_scale,
+                        bias=None,
+                        quant_scale=None,
+                        quant_offset=None,
+                        group_index=None,
+                        activate_left=True,
+                        quant_mode=1,
+                        swiglu_mode=1,
+                        clamp_limit=self.swiglu_limit,
+                        **(
+                            {}
+                            if get_ascend_device_type() == AscendDeviceType.A5
+                            else {"glu_alpha": self.swiglu_alpha, "glu_bias": self.swiglu_beta}
+                        ),
+                    )
                 # Execute the down projection concurrently with the combine
                 # communication.
                 maybe_wait_event(fused_moe_evts.before_combine)
-                shared_out = torch_npu.npu_quant_matmul(
-                    quantized_x,
-                    self.layer.down_proj.weight,
-                    self.layer.down_proj.weight_scale,
-                    pertoken_scale=swiglu_out_scale,
-                    bias=None,
-                    output_dtype=original_dtype,
-                )
+                if has_per_channel_w4a8_situ_shared:
+                    shared_out = self.layer.down_proj((quantized_x, swiglu_out_scale))[0]
+                else:
+                    shared_out = torch_npu.npu_quant_matmul(
+                        quantized_x,
+                        self.layer.down_proj.weight,
+                        self.layer.down_proj.weight_scale,
+                        pertoken_scale=swiglu_out_scale,
+                        bias=None,
+                        output_dtype=original_dtype,
+                    )
             elif has_quantized_shared_without_lora and self.quant_type == QuantType.W4A8MXFP:
                 original_dtype = hidden_states.dtype
                 # Execute dynamic quant concurrently with MoE gate.
@@ -325,6 +377,8 @@ class AscendSharedExperts:
                 maybe_wait_event(fused_moe_evts.before_combine)
                 shared_out = self.layer.down_proj((quantized_x, swiglu_out_scale))[0]
             else:
+                # Per-group W4A8 shared experts use this path. Per-channel
+                # W4A8 shared experts take the fused branch above.
                 # Ensure the shared experts wait for hidden_states to be ready.
                 torch.npu.current_stream().wait_event(fused_moe_evts.before_routed_experts)
                 # Execute the gate projection and activation concurrently with the

--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -1,0 +1,721 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+"""Ascend implementation of Kimi's gated delta attention.
+
+The vLLM implementation provides the projections, cache specification, and
+opaque ``kda_attention`` custom op.  This OOT replacement keeps that public
+surface while routing prefill through the Kimi AscendC kernels and decode
+through the recurrent KDA AscendC kernel.
+"""
+
+from collections.abc import Callable
+from functools import partial, wraps
+
+import torch
+from einops import rearrange
+from vllm.config import VllmConfig
+from vllm.distributed import get_pcp_group, get_tensor_model_parallel_rank
+from vllm.forward_context import get_forward_context
+
+try:
+    from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd  # type: ignore[import-not-found]
+except ModuleNotFoundError:
+    from vllm.third_party.flash_linear_attention.ops.l2norm import l2norm_fwd
+from vllm.model_executor.layers.linear import ColumnParallelLinear, QKVParallelLinear
+from vllm.model_executor.layers.mamba.gdn.kimi_gdn_linear_attn import (
+    KimiGatedDeltaNetAttention,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.utils import replace_parameter
+from vllm.triton_utils import HAS_TRITON
+from vllm.v1.attention.backend import AttentionBackend, AttentionMetadata
+from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+
+from vllm_ascend.ops.gdn_attn_builder import AscendGDNAttentionBackend
+from vllm_ascend.ops.kimi_kda_state import kimi_kda_state_shape
+from vllm_ascend.ops.triton.fla.utils import clear_ssm_states
+from vllm_ascend.ops.triton.kda.kda import fused_kda_gate
+from vllm_ascend.utils import is_vl_model, parse_layer_idx
+
+apply_kda_rms_norm_sigmoid_gate: (
+    Callable[
+        [torch.Tensor, torch.Tensor, torch.Tensor, float],
+        torch.Tensor,
+    ]
+    | None
+) = None
+if HAS_TRITON:
+    from vllm_ascend.ops.triton.kda.fused_norm_gate import (
+        apply_kda_rms_norm_sigmoid_gate as triton_apply_kda_rms_norm_sigmoid_gate,
+    )
+
+    apply_kda_rms_norm_sigmoid_gate = triton_apply_kda_rms_norm_sigmoid_gate
+
+_KDA_CHUNK_SIZE = 64
+_PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
+_FUSED_QKV_NAME = "fused_qkv"
+
+
+def _zero_padded_spec_output(
+    output: torch.Tensor,
+    query_start_loc: torch.Tensor,
+) -> torch.Tensor:
+    """Zero graph-padding rows skipped by the recurrent KDA kernel.
+
+    ``recurrent_kda`` leaves the output for zero-length sequences
+    uninitialized. FULL graph replay keeps those rows in the static output
+    shape, so explicitly clear the uncovered tail before it reaches the
+    residual and MoE layers.
+    """
+    token_indices = torch.arange(
+        output.shape[1],
+        dtype=query_start_loc.dtype,
+        device=output.device,
+    )
+    valid_tokens = token_indices < query_start_loc[-1]
+    return torch.where(
+        valid_tokens.view(1, -1, 1, 1),
+        output,
+        0.0,
+    )
+
+
+def uses_kimi_k3_global_inputs_embeds(vllm_config: VllmConfig) -> bool:
+    model_config = vllm_config.model_config
+    if model_config.enable_prompt_embeds:
+        return True
+    if not is_vl_model(vllm_config) or model_config.multimodal_config is None:
+        return False
+    multimodal_config = model_config.multimodal_config
+    return bool(multimodal_config.enable_mm_embeds or multimodal_config.get_limit_per_prompt("image") > 0)
+
+
+def _load_a_log(
+    param: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *,
+    num_heads: int,
+) -> None:
+    """Normalize supported A_log layouts and then TP-shard heads."""
+    if loaded_weight.ndim == 1:
+        if loaded_weight.shape[0] < num_heads:
+            raise ValueError(f"A_log has fewer checkpoint heads than the model: {loaded_weight.shape[0]} < {num_heads}")
+        # Some checkpoints pad the logical heads in a one-dimensional tensor.
+        loaded_weight = loaded_weight[:num_heads].reshape(1, 1, num_heads, 1)
+    elif loaded_weight.ndim == 4:
+        if loaded_weight.shape[0] != 1 or loaded_weight.shape[1] != 1 or loaded_weight.shape[3] != 1:
+            raise ValueError(f"A_log 4-D checkpoint must have shape [1, 1, H, 1], got {tuple(loaded_weight.shape)}")
+        if tuple(loaded_weight.shape) == tuple(param.shape):
+            default_weight_loader(param, loaded_weight)
+            return
+        if loaded_weight.shape[2] < num_heads:
+            raise ValueError(f"A_log has fewer checkpoint heads than the model: {loaded_weight.shape[2]} < {num_heads}")
+        loaded_weight = loaded_weight[:, :, :num_heads, :]
+    else:
+        raise ValueError(f"A_log checkpoint must be 1-D or 4-D, got {loaded_weight.ndim}-D")
+
+    local_heads = param.shape[2]
+    if local_heads <= 0 or num_heads % local_heads != 0:
+        raise ValueError(
+            "A_log parameter shape is incompatible with logical heads: "
+            f"param={tuple(param.shape)}, num_heads={num_heads}"
+        )
+    tp_rank = get_tensor_model_parallel_rank()
+    start = tp_rank * local_heads
+    if start + local_heads > num_heads:
+        raise ValueError(f"A_log TP rank {tp_rank} exceeds {num_heads} logical heads")
+    default_weight_loader(
+        param,
+        loaded_weight.narrow(2, start, local_heads),
+    )
+
+
+def _require_ascendc_prefill_ops() -> None:
+    required_ops = ("kda_gate_cumsum", "chunk_kda_fwd")
+    missing_ops = [name for name in required_ops if not hasattr(torch.ops._C_ascend, name)]
+    if missing_ops:
+        qualified_ops = ", ".join(f"torch.ops._C_ascend.{name}" for name in missing_ops)
+        raise RuntimeError(
+            "Kimi KDA prefill requires the PR141 AscendC operators, but the "
+            f"following schemas are missing: {qualified_ops}. Rebuild and install "
+            "the vllm-ascend custom operators with KDA support."
+        )
+
+
+class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
+    """Kimi KDA with Ascend prefill/decode kernels.
+
+    Kimi K3 adds two details that are absent from vLLM 0.23's base layer:
+    a full-rank output gate (``g_proj``) and a bounded sigmoid decay gate.
+    """
+
+    def __init__(self, config, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__(config, vllm_config, prefix)
+
+        kda_config = config.linear_attn_config
+        assert kda_config is not None, "linear_attn_config must be set"
+        self.use_full_rank_gate = bool(kda_config.get("use_full_rank_gate", False))
+        gate_lower_bound = kda_config.get("gate_lower_bound")
+        self.gate_lower_bound = float(gate_lower_bound) if gate_lower_bound is not None else None
+
+        # KDA uses the same hidden states and TP head layout for Q, K, and V.
+        # Pack their checkpoint shards into one standard QKV linear so MXFP8
+        # performs one dynamic quantization and one quantized matmul.
+        fused_qkv = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.num_heads,
+            self.num_heads,
+            bias=False,
+            quant_config=self.quant_config,
+            prefix=f"{prefix}.{_FUSED_QKV_NAME}",
+        )
+        del self.q_proj
+        del self.k_proj
+        del self.v_proj
+        self.fused_qkv = fused_qkv
+
+        self.A_log.weight_loader = partial(
+            _load_a_log,
+            num_heads=self.num_heads,
+        )
+
+        # vLLM 0.23 builds the legacy low-rank output gate unconditionally.
+        # Replace it with the checkpoint-compatible full-rank projection for K3.
+        if self.use_full_rank_gate:
+            del self.g_a_proj
+            del self.g_b_proj
+            self.g_proj = ColumnParallelLinear(
+                self.hidden_size,
+                self.head_dim * self.num_heads,
+                bias=False,
+                quant_config=self.quant_config,
+                prefix=f"{prefix}.g_proj",
+            )
+
+        # The upstream class used FusedRMSNormGated's default epsilon.  K3's
+        # checkpoint config is authoritative and uses the sigmoid gate path.
+        self.o_norm.eps = config.rms_norm_eps
+
+        # Multimodal inputs_embeds are built before the Ascend forward context,
+        # so the first decoder layer receives the full token sequence.  Every
+        # later layer receives a FlashComm token shard.  Keep this decision
+        # static so Dynamo does not need to infer the layout from tensor shapes.
+        self.is_vl_first_layer = bool(uses_kimi_k3_global_inputs_embeds(vllm_config) and parse_layer_idx(prefix) == 0)
+
+        # The checkpoint stores three fp32 convolution weights as [C, 1, W],
+        # while the AscendC kernel consumes one activation-dtype [W, 3 * C]
+        # tensor. Keep the derived kernel-format weight on q_conv1d so it uses
+        # the same parameter load/reload lifecycle as other repacked weights.
+        self.q_conv1d.register_parameter(
+            _PACKED_CONV_WEIGHT_NAME,
+            torch.nn.Parameter(
+                torch.empty(
+                    self._packed_conv_shape(),
+                    dtype=self.model_config.dtype,
+                ),
+                requires_grad=False,
+            ),
+        )
+        for conv in (self.q_conv1d, self.k_conv1d, self.v_conv1d):
+            self._wrap_conv_process_weights(conv)
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return AscendGDNAttentionBackend
+
+    def get_state_shape(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        return kimi_kda_state_shape(
+            self.tp_size,
+            self.num_heads,
+            self.head_dim,
+            self.conv_size,
+            self.num_spec,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        del positions
+        # KDA metadata and its recurrent state describe the complete sequence.
+        # KDA's gate projections do not match SequenceColumnParallelOp's prefix
+        # whitelist, so gather the token shard once before every projection.
+        # The fused module deliberately uses the ``fused_qkv`` prefix instead
+        # of ``qkv_proj`` to avoid a second automatic gather inside the linear.
+        # The multimodal first layer is already full-sized and must not gather.
+        hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+            hidden_states.contiguous(),
+            not self.is_vl_first_layer,
+        )
+        num_tokens = hidden_states.size(0)
+        qkv = self.fused_qkv(hidden_states)[0]
+        projection_size = self.local_num_heads * self.head_dim
+        q, k, v = qkv.split([projection_size] * 3, dim=-1)
+
+        beta = self.b_proj(hidden_states)[0].float().sigmoid().unsqueeze(0)
+        raw_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
+        raw_gate = rearrange(raw_gate, "n (h d) -> 1 n h d", d=self.head_dim)
+
+        if self.use_full_rank_gate:
+            output_gate = self.g_proj(hidden_states)[0]
+        else:
+            output_gate = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
+        output_gate = rearrange(output_gate, "n (h d) -> n h d", d=self.head_dim)
+
+        core_attn_out = torch.zeros(
+            (1, num_tokens, self.local_num_heads, self.head_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+        torch.ops.vllm.kda_attention(
+            q,
+            k,
+            v,
+            raw_gate,
+            beta,
+            core_attn_out,
+            self.prefix,
+        )
+        core_attn_out = self._apply_output_norm_gate(core_attn_out, output_gate)
+        core_attn_out = rearrange(core_attn_out, "1 n h d -> n (h d)")
+        output[:] = self.o_proj(core_attn_out)[0]
+
+    def _apply_output_norm_gate(
+        self,
+        core_attn_out: torch.Tensor,
+        output_gate: torch.Tensor,
+    ) -> torch.Tensor:
+        if apply_kda_rms_norm_sigmoid_gate is not None:
+            return apply_kda_rms_norm_sigmoid_gate(
+                core_attn_out,
+                output_gate,
+                self.o_norm.weight,
+                self.o_norm.eps,
+            )
+        return self.o_norm(core_attn_out, output_gate)
+
+    @staticmethod
+    def _run_causal_conv1d(
+        mixed_qkv: torch.Tensor,
+        conv_weights_t: torch.Tensor,
+        conv_state: torch.Tensor,
+        metadata,
+        *,
+        run_mode: int,
+        num_accepted_tokens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        out = torch.empty_like(mixed_qkv)
+        torch.ops._C_ascend.npu_causal_conv1d_custom(
+            out,
+            mixed_qkv,
+            conv_weights_t,
+            conv_state=conv_state,
+            bias_opt=None,
+            query_start_loc_opt=metadata.query_start_loc,
+            cache_indices_opt=metadata.cache_indices,
+            initial_state_mode_opt=getattr(metadata, "initial_state_mode", None),
+            num_accepted_tokens_opt=num_accepted_tokens,
+            activation_mode=1,
+            pad_slot_id=PAD_SLOT_ID,
+            run_mode=run_mode,
+        )
+        return out
+
+    def _packed_conv_shape(self) -> tuple[int, int]:
+        local_channels = self.local_num_heads * self.head_dim
+        return self.conv_size, 3 * local_channels
+
+    def _wrap_conv_process_weights(
+        self,
+        conv: ColumnParallelLinear,
+    ) -> None:
+        """Refresh the packed weight after a complete checkpoint load.
+
+        Kernel-format reloads address ``packed_conv_weights`` directly. They
+        must include that parameter instead of relying on these source-weight
+        post-load hooks.
+        """
+        original_process_weights = conv.quant_method.process_weights_after_loading
+
+        @wraps(original_process_weights)
+        def wrapped_process_weights(*args, **kwargs):
+            result = original_process_weights(*args, **kwargs)
+            self._pack_conv_weights()
+            return result
+
+        conv.quant_method.process_weights_after_loading = wrapped_process_weights  # type: ignore[method-assign]
+
+    @torch.no_grad()
+    def _pack_conv_weights(self) -> None:
+        source_weights = tuple(conv.weight for conv in (self.q_conv1d, self.k_conv1d, self.v_conv1d))
+        if any(weight.is_meta for weight in source_weights):
+            return
+
+        packed_param = self.q_conv1d.get_parameter(_PACKED_CONV_WEIGHT_NAME)
+        packed_weights = torch.cat(
+            [
+                weight.view(weight.size(0), weight.size(2))
+                .transpose(0, 1)
+                .to(device=packed_param.device, dtype=packed_param.dtype)
+                for weight in source_weights
+            ],
+            dim=1,
+        ).contiguous()
+        replace_parameter(
+            self.q_conv1d,
+            _PACKED_CONV_WEIGHT_NAME,
+            packed_weights,
+            prefer_copy=True,
+        )
+
+    def _conv_weights_t(self) -> torch.Tensor:
+        return self.q_conv1d.get_parameter(_PACKED_CONV_WEIGHT_NAME)
+
+    def _recurrent_gate(self, raw_gate: torch.Tensor) -> torch.Tensor:
+        flat_gate = rearrange(raw_gate, "1 n h d -> n (h d)")
+        gate = fused_kda_gate(
+            flat_gate,
+            self.A_log,
+            self.head_dim,
+            g_bias=self.dt_bias,
+            safe_gate=self.gate_lower_bound is not None,
+            lower_bound=self.gate_lower_bound if self.gate_lower_bound is not None else -5.0,
+        )
+        return gate.unsqueeze(0)
+
+    def _run_recurrent(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        raw_gate: torch.Tensor,
+        beta: torch.Tensor,
+        recurrent_state: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        state_indices: torch.Tensor,
+        *,
+        num_accepted_tokens: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        out = torch.ops._C_ascend.recurrent_kda(
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            raw_gate.contiguous(),
+            beta.contiguous(),
+            recurrent_state,
+            cu_seqlens,
+            state_indices,
+            self.A_log.reshape(-1).contiguous(),
+            self.dt_bias.contiguous(),
+            num_accepted_tokens=num_accepted_tokens,
+            scale=self.head_dim**-0.5,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            use_beta_sigmoid_in_kernel=False,
+            allow_neg_eigval=False,
+            safe_gate=self.gate_lower_bound is not None,
+            lower_bound=self.gate_lower_bound if self.gate_lower_bound is not None else -5.0,
+        )
+        return out
+
+    def _run_prefill(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        raw_gate: torch.Tensor,
+        beta: torch.Tensor,
+        recurrent_state: torch.Tensor,
+        state_indices: torch.Tensor,
+        has_initial_state: torch.Tensor,
+        prebuilt_metadata,
+    ) -> torch.Tensor:
+        if get_pcp_group().world_size > 1:
+            raise NotImplementedError("Kimi KDA prefill does not yet support PCP.")
+        _require_ascendc_prefill_ops()
+
+        cu_seqlens_kern = prebuilt_metadata.cu_seqlens_kern
+        cu_seqlens = prebuilt_metadata.cu_seqlens_host if cu_seqlens_kern is None else cu_seqlens_kern
+        keep = prebuilt_metadata.keep_meta
+        if keep is not None:
+            if keep.numel() != state_indices.shape[0] or keep.numel() != has_initial_state.numel():
+                raise ValueError(
+                    "Kimi KDA prefill metadata is inconsistent: keep_meta must have "
+                    "one entry per uncompressed sequence."
+                )
+            state_indices = state_indices[keep]
+            has_initial_state = has_initial_state[keep]
+
+        num_sequences = (cu_seqlens.numel() if isinstance(cu_seqlens, torch.Tensor) else len(cu_seqlens)) - 1
+        if state_indices.shape[0] != num_sequences or has_initial_state.numel() != num_sequences:
+            raise ValueError(
+                "Kimi KDA prefill metadata is inconsistent: compact cu_seqlens, "
+                "state_indices, and has_initial_state must describe the same number of sequences."
+            )
+
+        # The recurrent cache uses [H,V,K].  PR141's AscendC prefill operator
+        # uses [H,K,V], so transpose only at that operator boundary.
+        initial_state_vk = recurrent_state[state_indices].contiguous()
+        clear_ssm_states(initial_state_vk, has_initial_state)
+
+        initial_state_kv = initial_state_vk.transpose(-1, -2).contiguous()
+        cu_seqlens_ascendc = (
+            tuple(cu_seqlens.detach().cpu().tolist()) if isinstance(cu_seqlens, torch.Tensor) else cu_seqlens
+        )
+
+        q = l2norm_fwd(q.contiguous())
+        k = l2norm_fwd(k.contiguous())
+
+        if self.gate_lower_bound is not None:
+            gate_cumsum = torch.ops._C_ascend.kda_gate_cumsum(
+                raw_gate.contiguous(),
+                _KDA_CHUNK_SIZE,
+                A_log=self.A_log.reshape(-1).contiguous(),
+                dt_bias=self.dt_bias.contiguous(),
+                cu_seqlens=cu_seqlens_ascendc,
+                use_gate_in_kernel=True,
+                safe_gate=True,
+                lower_bound=self.gate_lower_bound,
+                layout="BSND",
+            )
+        else:
+            gate = self._recurrent_gate(raw_gate)
+            gate_cumsum = torch.ops._C_ascend.kda_gate_cumsum(
+                gate.contiguous(),
+                _KDA_CHUNK_SIZE,
+                cu_seqlens=cu_seqlens_ascendc,
+                layout="BSND",
+            )
+
+        result = torch.ops._C_ascend.chunk_kda_fwd(
+            q,
+            k,
+            v.contiguous(),
+            gate_cumsum,
+            beta.contiguous(),
+            self.head_dim**-0.5,
+            _KDA_CHUNK_SIZE,
+            layout="BSND",
+            initial_state=initial_state_kv,
+            output_final_state=True,
+            cu_seqlens=cu_seqlens_ascendc,
+            chunk_indices=prebuilt_metadata.chunk_indices_chunk64_host,
+            return_intermediate=False,
+        )
+        recurrent_state[state_indices] = result[1].transpose(-1, -2).contiguous().to(recurrent_state.dtype)
+        return result[0]
+
+    def _forward(
+        self,
+        q_proj_states: torch.Tensor,
+        k_proj_states: torch.Tensor,
+        v_proj_states: torch.Tensor,
+        g1: torch.Tensor,
+        beta: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ) -> None:
+        forward_context = get_forward_context()
+        attn_metadata_raw: AttentionMetadata | None = forward_context.attn_metadata
+        if attn_metadata_raw is None:
+            return
+
+        assert isinstance(attn_metadata_raw, dict)
+        attn_metadata = attn_metadata_raw[self.prefix]
+        assert isinstance(attn_metadata, GDNAttentionMetadata)
+
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        q_proj_states = q_proj_states[:num_actual_tokens]
+        k_proj_states = k_proj_states[:num_actual_tokens]
+        v_proj_states = v_proj_states[:num_actual_tokens]
+        g1 = g1[:, :num_actual_tokens]
+        beta = beta[:, :num_actual_tokens]
+
+        conv_state, recurrent_state = self.kv_cache
+        mixed_qkv = torch.cat((q_proj_states, k_proj_states, v_proj_states), dim=-1)
+        conv_weights_t = self._conv_weights_t()
+
+        spec_masks = attn_metadata.spec_sequence_masks
+        spec_token_indices = attn_metadata.spec_token_indx
+        non_spec_token_indices = attn_metadata.non_spec_token_indx
+
+        if spec_masks is not None:
+            if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+                mixed_spec = mixed_qkv
+                raw_gate_spec = g1
+                beta_spec = beta
+                mixed_non_spec = raw_gate_non_spec = beta_non_spec = None
+            else:
+                mixed_spec = mixed_qkv.index_select(0, spec_token_indices)
+                raw_gate_spec = g1.index_select(1, spec_token_indices)
+                beta_spec = beta.index_select(1, spec_token_indices)
+                mixed_non_spec = mixed_qkv.index_select(0, non_spec_token_indices)
+                raw_gate_non_spec = g1.index_select(1, non_spec_token_indices)
+                beta_non_spec = beta.index_select(1, non_spec_token_indices)
+        else:
+            mixed_spec = raw_gate_spec = beta_spec = None
+            mixed_non_spec = mixed_qkv
+            raw_gate_non_spec = g1
+            beta_non_spec = beta
+
+        core_spec = None
+        if mixed_spec is not None:
+            spec_meta = attn_metadata.spec_decode_metadata
+            assert spec_meta is not None
+            spec_conv_meta = spec_meta.spec_causal_conv1d
+            mixed_spec = self._run_causal_conv1d(
+                mixed_spec,
+                conv_weights_t,
+                conv_state,
+                spec_conv_meta,
+                run_mode=1,
+                num_accepted_tokens=spec_conv_meta.num_accepted_tokens,
+            )
+            q_spec, k_spec, v_spec = mixed_spec.chunk(3, dim=-1)
+            q_spec, k_spec, v_spec = (
+                rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim) for x in (q_spec, k_spec, v_spec)
+            )
+            assert raw_gate_spec is not None and beta_spec is not None
+            assert attn_metadata.spec_query_start_loc is not None
+            assert attn_metadata.spec_state_indices_tensor is not None
+            core_spec = self._run_recurrent(
+                q_spec,
+                k_spec,
+                v_spec,
+                raw_gate_spec,
+                beta_spec,
+                recurrent_state,
+                attn_metadata.spec_query_start_loc,
+                attn_metadata.spec_state_indices_tensor,
+                num_accepted_tokens=spec_conv_meta.num_accepted_tokens,
+            )
+            # Clear only static dummy rows skipped by the kernel. Real query
+            # tokens and their accepted lengths are unchanged.
+            core_spec = _zero_padded_spec_output(
+                core_spec,
+                attn_metadata.spec_query_start_loc,
+            )
+
+        core_non_spec = None
+        if mixed_non_spec is not None and mixed_non_spec.shape[0] > 0:
+            if attn_metadata.num_prefills > 0:
+                prefill_meta = attn_metadata.non_spec_prefill_metadata
+                assert prefill_meta is not None
+                mixed_non_spec = self._run_causal_conv1d(
+                    mixed_non_spec,
+                    conv_weights_t,
+                    conv_state,
+                    prefill_meta.causal_conv1d,
+                    run_mode=0,
+                )
+            elif attn_metadata.num_decodes > 0:
+                decode_meta = attn_metadata.non_spec_decode_metadata
+                assert decode_meta is not None
+                mixed_non_spec = self._run_causal_conv1d(
+                    mixed_non_spec,
+                    conv_weights_t,
+                    conv_state,
+                    decode_meta.causal_conv1d,
+                    run_mode=1,
+                )
+
+            q_non_spec, k_non_spec, v_non_spec = mixed_non_spec.chunk(3, dim=-1)
+            q_non_spec, k_non_spec, v_non_spec = (
+                rearrange(x, "n (h d) -> 1 n h d", d=self.head_dim) for x in (q_non_spec, k_non_spec, v_non_spec)
+            )
+            assert raw_gate_non_spec is not None and beta_non_spec is not None
+
+            split_non_spec = spec_masks is None and attn_metadata.num_prefills > 0 and attn_metadata.num_decodes > 0
+            num_decode_tokens = attn_metadata.num_decode_tokens
+            core_decode = None
+            if split_non_spec:
+                assert attn_metadata.non_spec_query_start_loc is not None
+                assert attn_metadata.non_spec_state_indices_tensor is not None
+                core_decode = self._run_recurrent(
+                    q_non_spec[:, :num_decode_tokens],
+                    k_non_spec[:, :num_decode_tokens],
+                    v_non_spec[:, :num_decode_tokens],
+                    raw_gate_non_spec[:, :num_decode_tokens],
+                    beta_non_spec[:, :num_decode_tokens],
+                    recurrent_state,
+                    attn_metadata.non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
+                    attn_metadata.non_spec_state_indices_tensor[: attn_metadata.num_decodes],
+                )
+
+            if attn_metadata.num_prefills > 0:
+                if split_non_spec:
+                    q_non_spec = q_non_spec[:, num_decode_tokens:]
+                    k_non_spec = k_non_spec[:, num_decode_tokens:]
+                    v_non_spec = v_non_spec[:, num_decode_tokens:]
+                    raw_gate_non_spec = raw_gate_non_spec[:, num_decode_tokens:]
+                    beta_non_spec = beta_non_spec[:, num_decode_tokens:]
+
+                assert attn_metadata.prefill_state_indices is not None
+                assert attn_metadata.prefill_has_initial_state is not None
+                prefill_meta = attn_metadata.non_spec_prefill_metadata
+                assert prefill_meta is not None
+                core_prefill = self._run_prefill(
+                    q_non_spec,
+                    k_non_spec,
+                    v_non_spec,
+                    raw_gate_non_spec,
+                    beta_non_spec,
+                    recurrent_state,
+                    attn_metadata.prefill_state_indices,
+                    attn_metadata.prefill_has_initial_state,
+                    prefill_meta.chunk,
+                )
+                core_non_spec = (
+                    torch.cat((core_decode, core_prefill), dim=1) if core_decode is not None else core_prefill
+                )
+            elif attn_metadata.num_decodes > 0:
+                assert attn_metadata.non_spec_query_start_loc is not None
+                assert attn_metadata.non_spec_state_indices_tensor is not None
+                core_non_spec = self._run_recurrent(
+                    q_non_spec,
+                    k_non_spec,
+                    v_non_spec,
+                    raw_gate_non_spec,
+                    beta_non_spec,
+                    recurrent_state,
+                    attn_metadata.non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
+                    attn_metadata.non_spec_state_indices_tensor,
+                )
+                # recurrent_kda leaves graph-padding token outputs
+                # uninitialized. Clear the uncovered non-spec decode tail
+                # before it reaches the residual and MoE layers, matching
+                # the existing spec-decode handling above.
+                core_non_spec = _zero_padded_spec_output(
+                    core_non_spec,
+                    attn_metadata.non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
+                )
+
+        if core_spec is not None and core_non_spec is not None:
+            merged = torch.empty(
+                (1, num_actual_tokens, self.local_num_heads, self.head_dim),
+                dtype=core_non_spec.dtype,
+                device=core_non_spec.device,
+            )
+            merged.index_copy_(1, spec_token_indices, core_spec)
+            merged.index_copy_(1, non_spec_token_indices, core_non_spec)
+            core_attn_out[:, :num_actual_tokens] = merged
+        elif core_spec is not None:
+            core_attn_out[:, :num_actual_tokens] = core_spec
+        elif core_non_spec is not None:
+            core_attn_out[:, :num_actual_tokens] = core_non_spec

--- a/vllm_ascend/ops/layernorm.py
+++ b/vllm_ascend/ops/layernorm.py
@@ -40,9 +40,8 @@ class AscendRMSNorm(RMSNorm):
         self.bias_loaded = False
 
         # quantization with anti_method m4 will generate none-zero norm bias
-        if vllm_config.quant_config is not None and any(
-            "norm.bias" in name for name in vllm_config.quant_config.quant_description
-        ):
+        quant_description = getattr(vllm_config.quant_config, "quant_description", None) or {}
+        if any("norm.bias" in name for name in quant_description):
             self.bias = torch.nn.Parameter(torch.zeros(hidden_size), requires_grad=False)
             self.bias.weight_loader = self._bias_weight_loader
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -3,6 +3,7 @@
 import math
 from collections import defaultdict
 
+import torch
 import vllm.v1.core.kv_cache_utils
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv, round_up
@@ -12,13 +13,27 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     UniformTypeKVCacheSpecs,
 )
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
+
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 
+_orig_get_kv_cache_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_groups
+
+_orig_get_kv_cache_config_from_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_config_from_groups
+
+_orig_pool_bytes_per_block = vllm.v1.core.kv_cache_utils._pool_bytes_per_block
+
+_orig_max_memory_usage_bytes_from_groups = vllm.v1.core.kv_cache_utils._max_memory_usage_bytes_from_groups
+
+_orig_get_max_concurrency_for_kv_cache_config = vllm.v1.core.kv_cache_utils.get_max_concurrency_for_kv_cache_config
+
+_orig_generate_scheduler_kv_cache_config = vllm.v1.core.kv_cache_utils.generate_scheduler_kv_cache_config
 
 def _ascend_resolve_kv_cache_block_sizes(
     kv_cache_config: KVCacheConfig,
@@ -54,6 +69,411 @@ def _ascend_resolve_kv_cache_block_sizes(
         return scheduler_block_size, hash_block_size
 
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+
+
+def _try_get_full_allocation_fallback_groups(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec] | None:
+    if any(isinstance(spec, HiddenStateCacheSpec) for spec in kv_cache_spec.values()):
+        return None
+    if any(isinstance(spec, SlidingWindowMLASpec) for spec in kv_cache_spec.values()):
+        return None
+
+    has_mla = any(isinstance(spec, MLAAttentionSpec) for spec in kv_cache_spec.values())
+    has_regular_swa = any(isinstance(spec, SlidingWindowSpec) for spec in kv_cache_spec.values())
+    if not (has_mla and has_regular_swa):
+        return None
+
+    full_block_sizes = {spec.block_size for spec in kv_cache_spec.values() if isinstance(spec, FullAttentionSpec)}
+    full_attention_block_size = next(iter(full_block_sizes)) if len(full_block_sizes) == 1 else None
+    promoted_specs = kv_cache_spec.copy()
+    for layer_name, spec in kv_cache_spec.items():
+        if not isinstance(spec, SlidingWindowSpec):
+            continue
+        page_size_padded = None
+        block_size = full_attention_block_size or spec.block_size
+        if spec.page_size_padded is not None:
+            unpadded_page_size = spec.unpadded_page_size_bytes * block_size // spec.block_size
+            page_size_padded = max(spec.page_size_padded, unpadded_page_size)
+        promoted_specs[layer_name] = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=spec.num_kv_heads,
+            head_size=spec.head_size,
+            head_size_v=spec.head_size_v,
+            dtype=spec.dtype,
+            kv_quant_mode=spec.kv_quant_mode,
+            page_size_padded=page_size_padded,
+            indexes_kv_by_block_stride=spec.indexes_kv_by_block_stride,
+            sliding_window=spec.sliding_window,
+        )
+
+    uniform_spec = UniformTypeKVCacheSpecs.from_specs(promoted_specs)
+    if uniform_spec is None:
+        return None
+    vllm.v1.core.kv_cache_utils.logger.warning(
+        "KV cache page sizes cannot be unified; treating sliding-window "
+        "layers as full attention for cache allocation. Sliding-window "
+        "attention compute is unchanged."
+    )
+    return vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_type(uniform_spec)
+
+
+def _is_kimi_k3_dspark_config(vllm_config: VllmConfig) -> bool:
+    """Return whether the config selects the supported K3 DSpark v1 path."""
+    if getattr(vllm_config, "use_v2_model_runner", False):
+        return False
+
+    scheduler_config = getattr(vllm_config, "scheduler_config", None)
+    if getattr(scheduler_config, "disable_hybrid_kv_cache_manager", False):
+        return False
+
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    if speculative_config is None or getattr(speculative_config, "method", None) != "dspark":
+        return False
+
+    model_config = getattr(vllm_config, "model_config", None)
+    target_text_config = getattr(model_config, "hf_text_config", None)
+    target_hf_config = getattr(model_config, "hf_config", None)
+    is_kimi_k3_target = (
+        getattr(target_text_config, "model_type", None) == "kimi_linear"
+        and getattr(target_text_config, "attn_res_block_size", None) is not None
+    ) or getattr(target_hf_config, "model_type", None) == "kimi_k3"
+    if not is_kimi_k3_target:
+        return False
+
+    draft_model_config = getattr(speculative_config, "draft_model_config", None)
+    draft_hf_config = getattr(draft_model_config, "hf_config", None)
+    return getattr(draft_hf_config, "model_type", None) == "k3_dspark"
+
+
+def _is_kimi_k3_c8_target_spec(spec: KVCacheSpec, main_page_size: int) -> bool:
+    return (
+        isinstance(spec, AscendMLAAttentionSpec)
+        and spec.dtype == torch.int8
+        and spec.compress_ratio == 1
+        and spec.model_version is None
+        and spec.sliding_window is None
+        and spec.attention_chunk_size is None
+        and not spec.indexes_kv_by_block_stride
+        and spec.page_size_bytes == main_page_size
+        and spec.page_size_padded == main_page_size
+        and spec.unpadded_page_size_bytes < main_page_size
+    )
+
+
+def _is_kimi_k3_bf16_draft_spec(spec: KVCacheSpec, main_page_size: int) -> bool:
+    return (
+        isinstance(spec, AscendMLAAttentionSpec)
+        and spec.dtype == torch.bfloat16
+        and spec.compress_ratio == 1
+        and spec.model_version is None
+        and spec.sliding_window is None
+        and spec.attention_chunk_size is None
+        and not spec.indexes_kv_by_block_stride
+        and spec.page_size_bytes > main_page_size
+        and spec.page_size_padded is None
+    )
+
+
+def _get_kimi_k3_c8_dspark_spec_partition(
+    vllm_config: VllmConfig,
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> tuple[int, dict[str, KVCacheSpec], dict[str, KVCacheSpec]] | None:
+    """Validate and partition the narrow K3 C8-target/BF16-draft layout."""
+    if not _is_kimi_k3_dspark_config(vllm_config) or not kv_cache_spec:
+        return None
+
+    if any(not isinstance(spec, (AscendMLAAttentionSpec, MambaSpec)) for spec in kv_cache_spec.values()):
+        return None
+
+    block_sizes = {spec.block_size for spec in kv_cache_spec.values()}
+    if len(block_sizes) != 1:
+        return None
+
+    mamba_specs = [spec for spec in kv_cache_spec.values() if isinstance(spec, MambaSpec)]
+    if not mamba_specs:
+        return None
+    mamba_page_sizes = {spec.page_size_bytes for spec in mamba_specs}
+    if len(mamba_page_sizes) != 1:
+        return None
+    main_page_size = next(iter(mamba_page_sizes))
+    if any(spec.page_size_padded != main_page_size or spec.mamba_cache_mode != "align" for spec in mamba_specs):
+        return None
+
+    target_specs: dict[str, KVCacheSpec] = {}
+    draft_specs: dict[str, KVCacheSpec] = {}
+    for layer_name, spec in kv_cache_spec.items():
+        if isinstance(spec, MambaSpec):
+            continue
+        if _is_kimi_k3_c8_target_spec(spec, main_page_size):
+            target_specs[layer_name] = spec
+        elif _is_kimi_k3_bf16_draft_spec(spec, main_page_size):
+            draft_specs[layer_name] = spec
+        else:
+            return None
+
+    if not target_specs or not draft_specs:
+        return None
+    return main_page_size, target_specs, draft_specs
+
+
+def _try_get_kimi_k3_c8_dspark_groups(
+    vllm_config: VllmConfig,
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec] | None:
+    partition = _get_kimi_k3_c8_dspark_spec_partition(vllm_config, kv_cache_spec)
+    if partition is None:
+        return None
+    _, target_specs, draft_specs = partition
+
+    # Keep the target/Mamba page layout intact. The draft layers share the
+    # target's logical block table, but remain distinct physical page buckets.
+    base_specs = {layer_name: spec for layer_name, spec in kv_cache_spec.items() if layer_name not in draft_specs}
+    groups = vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size(base_specs)
+    target_group_idx = next(
+        (
+            idx
+            for idx, group in enumerate(groups)
+            if isinstance(group.kv_cache_spec, AscendMLAAttentionSpec)
+            and any(layer_name in target_specs for layer_name in group.layer_names)
+        ),
+        None,
+    )
+    if target_group_idx is None:
+        return None
+
+    target_group = groups[target_group_idx]
+    logical_layer_names = [*target_group.layer_names, *draft_specs]
+    logical_specs = {layer_name: kv_cache_spec[layer_name] for layer_name in logical_layer_names}
+    uniform_spec = UniformTypeKVCacheSpecs.from_specs(logical_specs)
+    if uniform_spec is None:
+        return None
+    groups[target_group_idx] = KVCacheGroupSpec(
+        layer_names=logical_layer_names,
+        kv_cache_spec=uniform_spec,
+        is_eagle_group=True,
+    )
+    vllm.v1.core.kv_cache_utils.logger.info_once(
+        "Using the Kimi-K3 C8 target/BF16 DSpark hybrid KV cache layout: "
+        "draft layers share a target block table and use independent page buckets."
+    )
+    return groups
+
+
+def get_kv_cache_groups(vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCacheSpec]) -> list[KVCacheGroupSpec]:
+    kimi_k3_groups = _try_get_kimi_k3_c8_dspark_groups(vllm_config, kv_cache_spec)
+    if kimi_k3_groups is not None:
+        return kimi_k3_groups
+
+    try:
+        return _orig_get_kv_cache_groups(vllm_config, kv_cache_spec)
+    except NotImplementedError as exc:
+        fallback_groups = _try_get_full_allocation_fallback_groups(kv_cache_spec)
+        if fallback_groups is None:
+            spec_summary = sorted(
+                {
+                    (type(spec).__name__, spec.block_size, spec.page_size_bytes, spec.page_size_padded)
+                    for spec in kv_cache_spec.values()
+                }
+            )
+            raise NotImplementedError(
+                "KV cache page-size unification failed and the vllm-ascend "
+                "full-allocation fallback could not build a uniform KV cache "
+                "group. Detected specs are listed as "
+                "(type, block_size, page_size_bytes, page_size_padded): "
+                f"{spec_summary}."
+            ) from exc
+        return fallback_groups
+
+
+def _get_kimi_k3_c8_dspark_main_page_size(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    *,
+    allow_scheduler_layout: bool = False,
+) -> int | None:
+    """Recognize the global or PP-projected K3 hybrid group structure."""
+    if not _is_kimi_k3_dspark_config(vllm_config) or not kv_cache_groups:
+        return None
+
+    block_sizes = {group.kv_cache_spec.block_size for group in kv_cache_groups}
+    if len(block_sizes) != 1:
+        return None
+
+    mamba_specs = [group.kv_cache_spec for group in kv_cache_groups if isinstance(group.kv_cache_spec, MambaSpec)]
+    if not mamba_specs:
+        return None
+    main_page_sizes = {spec.page_size_bytes for spec in mamba_specs}
+    if len(main_page_sizes) != 1:
+        return None
+    main_page_size = next(iter(main_page_sizes))
+    if any(spec.page_size_padded != main_page_size or spec.mamba_cache_mode != "align" for spec in mamba_specs):
+        return None
+
+    has_uniform_group = False
+    has_eagle_attention_group = False
+    has_mla_spec = False
+    for group in kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, MambaSpec):
+            continue
+        if isinstance(group_spec, UniformTypeKVCacheSpecs):
+            has_uniform_group = True
+            if not set(group.layer_names).issubset(group_spec.kv_cache_specs):
+                return None
+            inner_specs = group_spec.kv_cache_specs.values()
+            for inner_spec in inner_specs:
+                if not (
+                    _is_kimi_k3_c8_target_spec(inner_spec, main_page_size)
+                    or _is_kimi_k3_bf16_draft_spec(inner_spec, main_page_size)
+                ):
+                    return None
+                has_mla_spec = True
+            continue
+        is_target_spec = _is_kimi_k3_c8_target_spec(group_spec, main_page_size)
+        is_draft_scheduler_representative = (
+            allow_scheduler_layout and group.is_eagle_group and _is_kimi_k3_bf16_draft_spec(group_spec, main_page_size)
+        )
+        if not (is_target_spec or is_draft_scheduler_representative):
+            return None
+        has_eagle_attention_group |= group.is_eagle_group
+        has_mla_spec = True
+
+    is_supported_layout = has_uniform_group or (allow_scheduler_layout and has_eagle_attention_group)
+    return main_page_size if is_supported_layout and has_mla_spec else None
+
+
+def _get_kimi_k3_c8_dspark_page_buckets(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> list[tuple[int, list[list[str]]]] | None:
+    """Return ordinary, independently allocated page buckets in layout order."""
+    main_page_size = _get_kimi_k3_c8_dspark_main_page_size(vllm_config, kv_cache_groups)
+    if main_page_size is None:
+        return None
+
+    buckets = vllm.v1.core.kv_cache_utils._bucket_layers_by_page_size(kv_cache_groups)
+    if not buckets:
+        return None
+    if any(page_size < main_page_size for page_size in buckets):
+        return None
+
+    # Keep the existing target/Mamba family first for layout compatibility,
+    # followed by larger draft buckets. These are ordinary tensors, not aliases
+    # into a packed backing.
+    ordered_page_sizes = []
+    if main_page_size in buckets:
+        ordered_page_sizes.append(main_page_size)
+    ordered_page_sizes.extend(sorted(page_size for page_size in buckets if page_size != main_page_size))
+    return [(page_size, buckets[page_size]) for page_size in ordered_page_sizes]
+
+
+def _kimi_k3_c8_dspark_pool_bytes_per_block(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int | None:
+    buckets = _get_kimi_k3_c8_dspark_page_buckets(vllm_config, kv_cache_groups)
+    if buckets is None:
+        return None
+    return sum(page_size * len(slots) for page_size, slots in buckets)
+
+
+def _pool_bytes_per_block(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    bytes_per_block = _kimi_k3_c8_dspark_pool_bytes_per_block(vllm_config, kv_cache_groups)
+    if bytes_per_block is not None:
+        return bytes_per_block
+    return _orig_pool_bytes_per_block(vllm_config, kv_cache_groups)
+
+
+def get_kv_cache_config_from_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+) -> KVCacheConfig:
+    buckets = _get_kimi_k3_c8_dspark_page_buckets(vllm_config, kv_cache_groups)
+    if buckets is None:
+        return _orig_get_kv_cache_config_from_groups(vllm_config, kv_cache_groups, available_memory)
+
+    bytes_per_block = sum(page_size * len(slots) for page_size, slots in buckets)
+    num_blocks = may_override_num_blocks(vllm_config, available_memory // bytes_per_block)
+    kv_cache_tensors = [
+        KVCacheTensor(
+            size=page_size * num_blocks,
+            shared_by=shared_by,
+        )
+        for page_size, slots in buckets
+        for shared_by in slots
+    ]
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=kv_cache_tensors,
+        kv_cache_groups=kv_cache_groups,
+    )
+
+
+def _kimi_k3_c8_dspark_blocks_per_request(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    blocks_per_request = 0
+    for group in kv_cache_groups:
+        spec = group.kv_cache_spec
+        if isinstance(spec, UniformTypeKVCacheSpecs):
+            blocks_per_request += spec.max_memory_usage_pages(vllm_config)
+        else:
+            blocks_per_request += cdiv(
+                spec.max_memory_usage_bytes(vllm_config),
+                spec.page_size_bytes,
+            )
+    return blocks_per_request
+
+
+def _max_memory_usage_bytes_from_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    bytes_per_block = _kimi_k3_c8_dspark_pool_bytes_per_block(vllm_config, kv_cache_groups)
+    if bytes_per_block is None:
+        return _orig_max_memory_usage_bytes_from_groups(vllm_config, kv_cache_groups)
+    blocks_per_request = _kimi_k3_c8_dspark_blocks_per_request(vllm_config, kv_cache_groups)
+    return bytes_per_block * blocks_per_request
+
+
+def get_max_concurrency_for_kv_cache_config(
+    vllm_config: VllmConfig,
+    kv_cache_config: KVCacheConfig,
+) -> float:
+    if (
+        _get_kimi_k3_c8_dspark_main_page_size(
+            vllm_config,
+            kv_cache_config.kv_cache_groups,
+            allow_scheduler_layout=True,
+        )
+        is None
+    ):
+        return _orig_get_max_concurrency_for_kv_cache_config(vllm_config, kv_cache_config)
+    blocks_per_request = _kimi_k3_c8_dspark_blocks_per_request(
+        vllm_config,
+        kv_cache_config.kv_cache_groups,
+    )
+    return kv_cache_config.num_blocks / blocks_per_request
+
+
+def generate_scheduler_kv_cache_config(
+    kv_cache_configs: list[KVCacheConfig],
+) -> KVCacheConfig:
+    """Preserve an EAGLE group present on any PP worker projection."""
+    scheduler_config = _orig_generate_scheduler_kv_cache_config(kv_cache_configs)
+    num_groups = len(scheduler_config.kv_cache_groups)
+    assert all(len(config.kv_cache_groups) == num_groups for config in kv_cache_configs)
+    for group_id, scheduler_group in enumerate(scheduler_config.kv_cache_groups):
+        scheduler_group.is_eagle_group = any(
+            config.kv_cache_groups[group_id].is_eagle_group for config in kv_cache_configs
+        )
+    return scheduler_config
 
 
 def group_and_unify_kv_cache_specs(
@@ -246,6 +666,12 @@ def _get_kv_cache_config_deepseek_v4(
 
 
 vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
+vllm.v1.core.kv_cache_utils.get_kv_cache_groups = get_kv_cache_groups
+vllm.v1.core.kv_cache_utils.get_kv_cache_config_from_groups = get_kv_cache_config_from_groups
+vllm.v1.core.kv_cache_utils._pool_bytes_per_block = _pool_bytes_per_block
+vllm.v1.core.kv_cache_utils._max_memory_usage_bytes_from_groups = _max_memory_usage_bytes_from_groups
+vllm.v1.core.kv_cache_utils.get_max_concurrency_for_kv_cache_config = get_max_concurrency_for_kv_cache_config
+vllm.v1.core.kv_cache_utils.generate_scheduler_kv_cache_config = generate_scheduler_kv_cache_config
 vllm.v1.core.kv_cache_utils.group_and_unify_kv_cache_specs = group_and_unify_kv_cache_specs
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_groups_uniform_groups
 # vLLM v0.24.0 renamed _get_kv_cache_config_deepseek_v4 to _get_kv_cache_config_packed and
@@ -257,3 +683,4 @@ vllm.v1.core.kv_cache_utils._get_kv_cache_config_packed = _get_kv_cache_config_d
 import vllm.v1.engine.core  # noqa: E402
 
 vllm.v1.engine.core.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
+vllm.v1.engine.core.generate_scheduler_kv_cache_config = generate_scheduler_kv_cache_config

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -9,6 +9,8 @@ from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.v1.core.kv_cache_utils import _approximate_gcd, may_override_num_blocks
 from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    HiddenStateCacheSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
@@ -16,6 +18,7 @@ from vllm.v1.kv_cache_interface import (
     MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
+    SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 
@@ -34,6 +37,7 @@ _orig_max_memory_usage_bytes_from_groups = vllm.v1.core.kv_cache_utils._max_memo
 _orig_get_max_concurrency_for_kv_cache_config = vllm.v1.core.kv_cache_utils.get_max_concurrency_for_kv_cache_config
 
 _orig_generate_scheduler_kv_cache_config = vllm.v1.core.kv_cache_utils.generate_scheduler_kv_cache_config
+
 
 def _ascend_resolve_kv_cache_block_sizes(
     kv_cache_config: KVCacheConfig,

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -8,6 +8,9 @@ from vllm.model_executor.models.config import MambaModelConfig
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE, get_dtype_size
 
+from vllm_ascend.quantization.utils import model_uses_fa_quantization
+from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD
+
 
 def _using_kv_store(vllm_config) -> bool:
     """
@@ -25,6 +28,37 @@ def _using_kv_store(vllm_config) -> bool:
         if connectors := kv_connector_extra_config.get("connectors"):
             return any(connector.get("kv_connector") == "AscendStoreConnector" for connector in connectors)
     return False
+
+
+def _uses_mla_fa_quant_cache(vllm_config) -> bool:
+    """Return whether MLA stores its latent KV cache in an 8-bit dtype.
+
+    ``verify_and_update_config`` can run before vLLM initializes
+    ``quant_config``. Prefer the initialized object when available and fall
+    back to the checkpoint's lightweight ModelSlim metadata otherwise.
+    """
+    model_config = vllm_config.model_config
+    if not model_config.use_mla:
+        return False
+
+    quant_config = getattr(vllm_config, "quant_config", None)
+    if quant_config is not None:
+        if getattr(quant_config, "enable_fa_quant", False):
+            return True
+        # A populated quantization description is authoritative. An empty
+        # ModelSlim config can still occur before maybe_update_config loads
+        # the checkpoint metadata, so only that state falls through.
+        if getattr(quant_config, "quant_description", None):
+            return False
+
+    quantization = getattr(model_config, "quantization", None)
+    if quantization not in (None, ASCEND_QUANTIZATION_METHOD):
+        return False
+
+    return model_uses_fa_quantization(
+        model_config.model,
+        revision=getattr(model_config, "revision", None),
+    )
 
 
 @classmethod
@@ -84,6 +118,24 @@ def verify_and_update_config(cls, vllm_config) -> None:
         qk_rope_head_dim = model_config.hf_text_config.qk_rope_head_dim
         attn_single_token_k_page_size = kv_lora_rank * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
         attn_rope_token_page_size = qk_rope_head_dim * attn_num_kv_heads * get_dtype_size(kv_cache_dtype)
+        if _uses_mla_fa_quant_cache(vllm_config):
+            # MLA C8 quantizes only the latent K cache; RoPE/V remains in the
+            # model dtype. Account for the actual INT8 K bytes here so the
+            # logical block grows from 384 to 768 tokens and a contiguous K
+            # block still spans one full Mamba recurrent-state slot. K and V
+            # share this doubled token capacity.
+            kv_dtype_size = get_dtype_size(kv_cache_dtype)
+            assert kv_dtype_size == 2, (
+                "Hybrid MLA C8 cache currently requires a 2-byte "
+                f"unquantized KV dtype, got {kv_cache_dtype}."
+            )
+            attn_single_token_k_page_size //= kv_dtype_size
+            logger.info(
+                "Using hybrid MLA 8-bit latent-cache double-token block layout: K=%d "
+                "B/token, V=%d B/token.",
+                attn_single_token_k_page_size,
+                attn_rope_token_page_size,
+            )
         attn_token_page_size = attn_single_token_k_page_size + attn_rope_token_page_size
     else:
         attn_num_kv_heads = model_config.get_num_kv_heads(parallel_config)

--- a/vllm_ascend/patch/platform/patch_mamba_config.py
+++ b/vllm_ascend/patch/platform/patch_mamba_config.py
@@ -126,13 +126,11 @@ def verify_and_update_config(cls, vllm_config) -> None:
             # share this doubled token capacity.
             kv_dtype_size = get_dtype_size(kv_cache_dtype)
             assert kv_dtype_size == 2, (
-                "Hybrid MLA C8 cache currently requires a 2-byte "
-                f"unquantized KV dtype, got {kv_cache_dtype}."
+                f"Hybrid MLA C8 cache currently requires a 2-byte unquantized KV dtype, got {kv_cache_dtype}."
             )
             attn_single_token_k_page_size //= kv_dtype_size
             logger.info(
-                "Using hybrid MLA 8-bit latent-cache double-token block layout: K=%d "
-                "B/token, V=%d B/token.",
+                "Using hybrid MLA 8-bit latent-cache double-token block layout: K=%d B/token, V=%d B/token.",
                 attn_single_token_k_page_size,
                 attn_rope_token_page_size,
             )

--- a/vllm_ascend/quantization/methods/kv_c8.py
+++ b/vllm_ascend/quantization/methods/kv_c8.py
@@ -31,7 +31,7 @@ def _fa_quant_weight_loader(param: torch.Tensor, loaded_weight: torch.Tensor):
 class AscendFAQuantAttentionMethod:
     def __init__(self):
         vllm_config = get_current_vllm_config()
-        config = vllm_config.model_config.hf_config
+        config = vllm_config.model_config.hf_text_config
         self.kv_lora_rank = getattr(config, "kv_lora_rank", 0)
         self.qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
 

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -19,8 +19,10 @@ from typing import Any
 
 import numpy as np
 import torch
+import torch_npu
 from vllm.config import get_current_vllm_config
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.logger import logger
 
 from vllm_ascend.ascend_config import _MEGA_MOE_SUPPORTED, get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
@@ -29,8 +31,346 @@ from vllm_ascend.ops.fused_moe.dataclass.fused_experts import build_fused_expert
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts  # noqa: F401
 from vllm_ascend.utils import ASCEND_QUANTIZATION_METHOD, COMPRESSED_TENSORS_METHOD, maybe_trans_nz
 
-from .base import AscendMoEScheme, QuantType
+from .base import AscendLinearScheme, AscendMoEScheme, QuantType
 from .registry import register_scheme
+
+
+@register_scheme("W4A8_DYNAMIC", "linear")
+class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
+    """Linear method for Ascend W4A8_DYNAMIC.
+
+    This method supports only weights quantized by msModelSlim. It supports two
+    weight layouts, distinguished by ``quant_version`` which comes from
+    ``quant_description["version"]`` in the vLLM quantization config. Version
+    ``"1.0.0"`` is the newer layout: it reduces the checkpoint weight size and
+    precomputes the ``scale_bias`` offline, reducing weight loading time.
+
+    The names below use ``linear`` as the checkpoint prefix of a linear layer,
+    ``input_size`` as the logical input dimension, ``output_size`` as the
+    logical output dimension, and ``group_size`` as the number of input
+    channels per weight quantization group. A ``group_size`` of ``0`` selects
+    per-channel weight quantization.
+
+    For ``quant_version != "1.0.0"``, the original linear weights are:
+
+    - ``linear.weight``: ``torch.int8``, ``[output_size, input_size]``.
+      Each int8 element stores one 4-bit weight value.
+    - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
+    - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
+      ``[output_size, input_size // group_size]``.
+    - For per-channel quantization, ``weight_scale`` and ``weight_offset``
+      are the only scale tensors; no second-level tensors are present.
+
+    For ``quant_version == "1.0.0"``, the original linear weights are:
+
+    - ``linear.weight``: ``torch.int8``, ``[output_size // 2, input_size]``.
+      Each int8 element stores two packed 4-bit weight values along the output
+      dimension.
+    - ``linear.weight_scale``: ``params_dtype``, ``[output_size, 1]``.
+    - ``linear.weight_offset``: ``params_dtype``, ``[output_size, 1]``.
+    - For per-group quantization, ``linear.weight_scale_second`` and
+      ``linear.weight_offset_second`` have shape
+      ``[output_size, input_size // group_size]``. Per-channel quantization
+      does not store second-level scale or offset tensors.
+    - ``linear.scale_bias``: ``torch.float32``, ``[output_size, 1]`` for
+      column-parallel linear layers and ``[output_size, 16]`` for
+      row-parallel linear layers.
+
+    In :meth:`process_weights_after_loading`, ``linear.weight`` is transposed
+    from ``[output, input]`` to the operator-oriented ``[input, output]``
+    layout. Old-version weights are converted with
+    ``torch_npu.npu_convert_weight_to_int4pack``; new-version weights are
+    already packed as int4 pairs in int8 storage and are reinterpreted as int32
+    by grouping four int8 values.
+
+    Per-group linear weights use ``torch_npu.npu_weight_quant_batchmatmul``.
+    Generic per-channel linear weights use ``torch_npu.npu_quant_matmul``.
+    Per-channel W4A8 shared experts use the grouped-matmul path: activations
+    are dynamically quantized to int8, packed int4 weights are converted to NZ,
+    and the projection is evaluated as a single expert by
+    ``torch_npu.npu_grouped_matmul``. This avoids silently degrading shared
+    experts to W4A16.
+
+    The generic linear operators consume ``weight`` as ``torch.int32`` with
+    shape ``[input_size, output_size // 8]``. The shared-expert grouped
+    operator consumes a leading singleton expert dimension, with shape
+    ``[1, input_size, output_size // 8]``.
+    """
+
+    def __init__(self):
+        logger.warning_once(
+            "W4A8_DYNAMIC linear quantization is deprecated and will be removed in the next release. "
+            "Please migrate to alternative quantization methods."
+        )
+        vllm_config = get_current_vllm_config()
+        self.group_size = vllm_config.quant_config.quant_description.get("group_size", 256)
+        self.is_per_channel_weight = self.group_size == 0
+        quant_version = vllm_config.quant_config.quant_description.get("version", "0")
+        self.new_quant_version = quant_version == "1.0.0"
+        self._use_grouped_matmul_for_shared_expert = False
+
+        self.tp_size = get_tensor_model_parallel_world_size()
+
+    def _uses_per_channel_shared_expert(self, layer: torch.nn.Module) -> bool:
+        del layer
+        return self.is_per_channel_weight and self._use_grouped_matmul_for_shared_expert
+
+    def enable_per_channel_shared_expert(self) -> None:
+        """Select the grouped-matmul path for a per-channel shared expert."""
+        self.group_size = 0
+        self.is_per_channel_weight = True
+        # This scheme instance is attached to one shared-expert projection.
+        # Retain that selection through weight loading, where layer.prefix is
+        # not a reliable discriminator for every vLLM Linear wrapper.
+        self._use_grouped_matmul_for_shared_expert = True
+
+    def _local_scale_bias(self, layer: torch.nn.Module, tp_rank: int | None = None) -> torch.Tensor:
+        """Combine the offline scale-bias shards owned by this projection."""
+        scale_bias = layer.scale_bias
+        if scale_bias.dim() != 2:
+            return scale_bias
+        if scale_bias.shape[1] == 1:
+            return scale_bias.flatten()
+
+        tp_size = getattr(layer, "tp_size", self.tp_size)
+        rank = getattr(layer, "tp_rank", tp_rank if tp_rank is not None else 0)
+        num_offline_shards = scale_bias.shape[1]
+        if tp_size <= 0 or num_offline_shards % tp_size != 0:
+            raise ValueError(
+                f"scale_bias width {num_offline_shards} must be divisible by "
+                f"the projection TP size {tp_size}"
+            )
+        if rank < 0 or rank >= tp_size:
+            raise ValueError(f"tp_rank {rank} exceeds projection TP size {tp_size}")
+
+        shards_per_rank = num_offline_shards // tp_size
+        start = rank * shards_per_rank
+        return scale_bias[:, start : start + shards_per_rank].sum(dim=1)
+
+    def get_weight(self, input_size: int, output_size: int, params_dtype: torch.dtype) -> dict[str, Any]:
+        """Create weight parameters.
+
+        For new quantization version (double int4 pack into int8), the output dimension
+        is compressed by factor 2 (e.g., [2048, 3072] -> [1024, 3072]). The returned
+        dict includes "_packed_dim" and "_packed_factor" for vLLM's weight loader.
+        """
+        params_dict = {}
+
+        if self.new_quant_version:
+            # double int4 pack into int8: output dimension is compressed
+            pack_factor = 2
+            actual_output_size = output_size // pack_factor
+            params_dict["weight"] = torch.empty(actual_output_size, input_size, dtype=torch.int8)
+            # Add packing information for vLLM's weight_loader
+            params_dict["_packed_dim"] = 0
+            params_dict["_packed_factor"] = pack_factor
+        else:
+            params_dict["weight"] = torch.empty(output_size, input_size, dtype=torch.int8)
+
+        return params_dict
+
+    def get_pergroup_param(
+        self, input_size: int, output_size: int, params_dtype: torch.dtype, layer_type: str | None = None
+    ) -> dict[str, Any]:
+        """Create per-group quantization parameters."""
+        params_dict = {}
+        params_dict["weight_scale"] = torch.empty(output_size, 1, dtype=params_dtype)
+        params_dict["weight_offset"] = torch.empty(output_size, 1, dtype=params_dtype)
+        if not self.is_per_channel_weight:
+            params_dict["weight_scale_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
+            params_dict["weight_offset_second"] = torch.empty(
+                output_size, input_size // self.group_size, dtype=params_dtype
+            )
+
+        # NOTE: In w4a8 quantization implementation,
+        #       for down_proj and o_proj(layer_type == "row") scale_bias shape is [output_size, 16],
+        #       others are [output_size, 1]
+        if self.new_quant_version:
+            scale_bias_dim = 16 if layer_type == "row" else 1
+
+            params_dict["scale_bias"] = torch.empty(output_size, scale_bias_dim, dtype=torch.float32)
+        return params_dict
+
+    @staticmethod
+    def process_scale_second(
+        weight: torch.Tensor, scale: torch.Tensor, per_group_scale: torch.Tensor, is_new_quant: bool = False
+    ):
+        """Process the scale for second-level quantization.
+
+        Args:
+            weight: weight tensor [k, n] (in new version, n is already compressed to n/2)
+            scale: first-level quantization scale [output_size]
+            per_group_scale: second-level per-group quantization scale [group_num, n_scale]
+            is_new_quant: whether it's the new quantization version (weight already compressed)
+
+        Returns:
+            (antiquant_scale, bias): dequantization scale and bias (bias=None for new version)
+        """
+        k, n = weight.shape
+        group_num, n_scale = per_group_scale.shape
+
+        if is_new_quant:
+            # Restore logical dimension for compressed weight
+            n = n * 2
+
+        bias = None
+        if not is_new_quant:
+            weight_high = weight.to(torch.float32).reshape(group_num, -1, n) * per_group_scale.reshape(group_num, 1, n)
+            weight_high = weight_high.reshape(k, n)
+            bias = 8 * (weight_high.to(torch.float32) * scale).sum(dim=0)
+        # NOTE: scale_bias is not used currently
+        #       because in msmodelslim w4a8 uses symmetric quantization
+
+        # TODO: support potential future asymmetric quantization
+        antiquant_scale = (scale * per_group_scale).reshape(group_num, n)
+        return antiquant_scale.npu(), bias
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        bias: torch.Tensor | None = None,
+        tp_rank: int | None = None,
+    ) -> torch.Tensor:
+        if self.is_per_channel_weight:
+            if self._uses_per_channel_shared_expert(layer):
+                # QuantMatmul cannot consume the A3 per-channel INT4 WeightNZ
+                # representation. Model this projection as one grouped expert
+                # instead, which keeps both the int8 activation and int4 weight.
+                if isinstance(x, tuple):
+                    quantized_x, pertoken_scale = x
+                    input_shape = quantized_x.shape
+                    output_dtype = torch.bfloat16
+                else:
+                    input_shape = x.shape
+                    x_2d = x.reshape(-1, input_shape[-1])
+                    quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x_2d)
+                    output_dtype = x.dtype
+                # Construct the single-group token count directly on the
+                # device. ``torch.tensor([count], device=x.device)`` performs
+                # a synchronous host-to-device copy, which is forbidden while
+                # ACL Graph is capturing in GLOBAL mode.
+                group_list = torch.full(
+                    (1,),
+                    quantized_x.shape[0],
+                    dtype=torch.int64,
+                    device=quantized_x.device,
+                )
+
+                scale_bias = self._local_scale_bias(layer, tp_rank)
+
+                output = torch_npu.npu_grouped_matmul(
+                    x=[quantized_x],
+                    weight=[layer.weight],
+                    scale=[layer.weight_scale.reshape(1, 1, -1)],
+                    bias=[scale_bias.reshape(1, -1)],
+                    per_token_scale=[pertoken_scale],
+                    split_item=2,
+                    group_list=group_list,
+                    group_type=0,
+                    group_list_type=1,
+                    output_dtype=output_dtype,
+                )[0]
+                if bias is not None:
+                    output = output + bias
+                return output.reshape(*input_shape[:-1], output.shape[-1])
+            quantized_x, pertoken_scale = torch_npu.npu_dynamic_quant(x)
+            need_unsqueeze = pertoken_scale.dim() == 2
+            if need_unsqueeze:
+                quantized_x = quantized_x.squeeze(dim=1)
+                pertoken_scale = pertoken_scale.squeeze(dim=1)
+
+            output = torch_npu.npu_quant_matmul(
+                quantized_x,
+                layer.weight,
+                layer.weight_scale,
+                pertoken_scale=pertoken_scale,
+                bias=bias,
+                output_dtype=x.dtype,
+            )
+            return output.unsqueeze(dim=1) if need_unsqueeze else output
+
+        # Per-group INT4 weights use the weight-only quantized operator.
+        return torch_npu.npu_weight_quant_batchmatmul(
+            x,
+            layer.weight,
+            antiquant_scale=layer.weight_scale_second.to(x.dtype),
+            antiquant_group_size=self.group_size,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module):
+        uses_per_channel_shared_expert = self._uses_per_channel_shared_expert(layer)
+        layer.weight.data = layer.weight.data.transpose(0, 1).contiguous()
+        layer.weight_scale.data = layer.weight_scale.data.flatten()
+        layer.weight_offset.data = layer.weight_offset.data.flatten()
+
+        if uses_per_channel_shared_expert:
+            if not self.new_quant_version:
+                raise ValueError(
+                    "Per-channel shared-expert W4A8 requires quantization version 1.0.0"
+                )
+
+            # Preserve the floating-point scale for the fused SiTU path, then
+            # bit-cast it to the int64 representation required by grouped
+            # matmul. Each int64 element stores one FP32 scale bit pattern.
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+            scale_np = layer.weight_scale_fp32.contiguous().cpu().numpy()
+            scale_np.dtype = np.uint32
+            layer.weight_scale.data = torch.from_numpy(scale_np.astype(np.int64)).to(layer.weight_scale.device)
+
+            if not hasattr(layer, "scale_bias"):
+                raise ValueError("Per-channel shared-expert W4A8 requires scale_bias")
+            layer.scale_bias.data = self._local_scale_bias(layer).contiguous()
+
+            # Treat the shared projection as one grouped expert. Keep packed
+            # int4 bytes while converting to NZ, then expose groups of four
+            # bytes as the int32 storage expected by the GMM interface.
+            assert layer.weight.data.shape[-1] % 4 == 0, (
+                f"the last dim of weight needs to be divided by 4 but got shape {layer.weight.data.shape}"
+            )
+            layer.weight.data = maybe_trans_nz(layer.weight.data.unsqueeze(0)).view(torch.int32).contiguous()
+            return
+
+        layer.weight.data = maybe_trans_nz(layer.weight.data)
+        if self.is_per_channel_weight:
+            # QuantMatmul consumes the checkpoint dtype, while the fused SiTU
+            # dequantization step requires an FP32 copy of the same scale.
+            layer.weight_scale_fp32 = layer.weight_scale.data.to(torch.float32)
+        scale_bias = None
+        if not self.is_per_channel_weight:
+            layer.weight_scale.data = layer.weight_scale.data.to(torch.float32)
+            layer.weight_scale_second.data, scale_bias = self.process_scale_second(
+                layer.weight.data,
+                layer.weight_scale.data,
+                layer.weight_scale_second.data.transpose(0, 1).contiguous(),
+                is_new_quant=self.new_quant_version,
+            )
+
+        if self.new_quant_version:
+            # Process the loaded data based on layer type
+            if hasattr(layer, "scale_bias"):
+                if layer.scale_bias.data.shape[1] == 1:
+                    layer.scale_bias.data = layer.scale_bias.data.flatten()
+                else:
+                    layer.scale_bias.data = layer.scale_bias.data.contiguous()
+        elif scale_bias is not None:
+            param = torch.nn.Parameter(scale_bias, requires_grad=False)
+            layer.register_parameter("weight_scale_bias", param)
+
+        # Convert to NPU-specific int4pack format.
+        if self.new_quant_version:
+            # Weights on disk are already in packed int4 format; group four
+            # int8 bytes into one int32 storage element.
+            assert layer.weight.data.shape[-1] % 4 == 0, (
+                f"the last dim of weight needs to be divided by 4 but got shape {layer.weight.data.shape}"
+            )
+            layer.weight.data = layer.weight.data.view(torch.int32).contiguous()
+        else:
+            layer.weight.data = torch_npu.npu_convert_weight_to_int4pack(layer.weight.data.to(torch.int32))
 
 
 @register_scheme("W4A8_DYNAMIC", "moe")

--- a/vllm_ascend/quantization/methods/w4a8.py
+++ b/vllm_ascend/quantization/methods/w4a8.py
@@ -139,8 +139,7 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
         num_offline_shards = scale_bias.shape[1]
         if tp_size <= 0 or num_offline_shards % tp_size != 0:
             raise ValueError(
-                f"scale_bias width {num_offline_shards} must be divisible by "
-                f"the projection TP size {tp_size}"
+                f"scale_bias width {num_offline_shards} must be divisible by the projection TP size {tp_size}"
             )
         if rank < 0 or rank >= tp_size:
             raise ValueError(f"tp_rank {rank} exceeds projection TP size {tp_size}")
@@ -310,9 +309,7 @@ class AscendW4A8DynamicLinearMethod(AscendLinearScheme):
 
         if uses_per_channel_shared_expert:
             if not self.new_quant_version:
-                raise ValueError(
-                    "Per-channel shared-expert W4A8 requires quantization version 1.0.0"
-                )
+                raise ValueError("Per-channel shared-expert W4A8 requires quantization version 1.0.0")
 
             # Preserve the floating-point scale for the fused SiTU path, then
             # bit-cast it to the int64 representation required by grouped

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -622,6 +622,7 @@ class AscendModelSlimConfig(QuantizationConfig):
     def get_cache_scale_mapper(self) -> "WeightsMapper":
         """Upstream use staticmethod, but we need to use instance attribute"""
         suffix_map = {}
+        regex_map = {}
         if self.enable_c8_quant:
             suffix_map.update(
                 {
@@ -632,26 +633,32 @@ class AscendModelSlimConfig(QuantizationConfig):
                 }
             )
         if self.enable_fa_quant:
-            suffix_map.update(
+            # Nested model wrappers can apply AutoWeightsLoader more than once.
+            # Match only the source form so a name already mapped under
+            # ``mla_attn.mla_attn`` remains unchanged.
+            regex_map.update(
                 {
-                    ".fa_q.scale": ".mla_attn.mla_attn.fa_q.scale",
-                    ".fa_k.scale": ".mla_attn.mla_attn.fa_k.scale",
-                    ".fa_v.scale": ".mla_attn.mla_attn.fa_v.scale",
-                    ".fa_q.offset": ".mla_attn.mla_attn.fa_q.offset",
-                    ".fa_k.offset": ".mla_attn.mla_attn.fa_k.offset",
-                    ".fa_v.offset": ".mla_attn.mla_attn.fa_v.offset",
+                    re.compile(
+                        r"(?<!\.mla_attn\.mla_attn)\.fa_([qkv])\.(scale|offset)$"
+                    ): r".mla_attn.mla_attn.fa_\1.\2",
                 }
             )
         if self.enable_indexer_quant:
-            suffix_map.update(
+            # Keep the same idempotency guarantee for indexer scales, which
+            # are loaded through the same nested model-loader path.
+            regex_map.update(
                 {
-                    ".indexer.q_rot": ".mla_attn.mla_attn.indexer.q_rot",
-                    ".indexer.k_rot": ".mla_attn.mla_attn.indexer.k_rot",
+                    re.compile(
+                        r"(?<!\.mla_attn\.mla_attn)\.indexer\.([qk]_rot)$"
+                    ): r".mla_attn.mla_attn.indexer.\1",
                 }
             )
-        if not suffix_map:
+        if not suffix_map and not regex_map:
             return QuantizationConfig.get_cache_scale_mapper()
-        cache_scale_mapper = WeightsMapper(orig_to_new_suffix=suffix_map)
+        cache_scale_mapper = WeightsMapper(
+            orig_to_new_regex=regex_map,
+            orig_to_new_suffix=suffix_map,
+        )
         return cache_scale_mapper | QuantizationConfig.get_cache_scale_mapper()
 
     def _has_quant_weight(self, prefix: str, packed_modules_mapping: Mapping[str, list[str]]) -> bool:
@@ -736,6 +743,14 @@ class AscendModelSlimConfig(QuantizationConfig):
                 logger.debug("Select AscendUnquantizedLinearMethod for %s (layer=%s)", prefix, "LinearBase")
                 return AscendUnquantizedLinearMethod()
             scheme = create_scheme_for_layer(self.quant_description, prefix, "linear", self.packed_modules_mapping)
+            if ".shared_experts." in prefix:
+                # Per-channel W4A8 shared-expert linears use the single-expert
+                # grouped-matmul path. Select it from quantization metadata,
+                # independent of the model architecture that owns the layer.
+                from .methods.w4a8 import AscendW4A8DynamicLinearMethod
+
+                if isinstance(scheme, AscendW4A8DynamicLinearMethod) and scheme.is_per_channel_weight:
+                    scheme.enable_per_channel_shared_expert()
             logger.debug("Select AscendLinearMethod for %s (layer=%s)", prefix, "LinearBase")
             return AscendLinearMethod(scheme)
         elif isinstance(layer, AttentionLayerBase) and (

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -648,9 +648,7 @@ class AscendModelSlimConfig(QuantizationConfig):
             # are loaded through the same nested model-loader path.
             regex_map.update(
                 {
-                    re.compile(
-                        r"(?<!\.mla_attn\.mla_attn)\.indexer\.([qk]_rot)$"
-                    ): r".mla_attn.mla_attn.indexer.\1",
+                    re.compile(r"(?<!\.mla_attn\.mla_attn)\.indexer\.([qk]_rot)$"): r".mla_attn.mla_attn.indexer.\1",
                 }
             )
         if not suffix_map and not regex_map:

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -144,9 +144,7 @@ def model_uses_fa_quantization(
             exc,
         )
         return False
-    return isinstance(quant_description, dict) and bool(
-        quant_description.get("fa_quant_type")
-    )
+    return isinstance(quant_description, dict) and bool(quant_description.get("fa_quant_type"))
 
 
 def detect_quantization_method(model: str, revision: str | None = None) -> str | None:

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -117,6 +117,38 @@ def get_model_file(
         return None
 
 
+def model_uses_fa_quantization(
+    model: str | Path,
+    revision: str | None = None,
+) -> bool:
+    """Detect fused-attention KV quantization from ModelSlim metadata.
+
+    Hybrid-cache sizing runs before vLLM has necessarily constructed the
+    quantization config. Reading the lightweight ModelSlim description here
+    keeps cache-layout decisions independent of model architecture and avoids
+    relying on a later-initialized ``quant_config`` object.
+    """
+    from vllm_ascend.quantization.modelslim_config import MODELSLIM_CONFIG_FILENAME
+
+    config_path = get_model_file(model, MODELSLIM_CONFIG_FILENAME, revision=revision)
+    if config_path is None:
+        return False
+
+    try:
+        with open(config_path) as f:
+            quant_description = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning(
+            "Could not read ModelSlim quantization metadata from %s: %s",
+            config_path,
+            exc,
+        )
+        return False
+    return isinstance(quant_description, dict) and bool(
+        quant_description.get("fa_quant_type")
+    )
+
+
 def detect_quantization_method(model: str, revision: str | None = None) -> str | None:
     """Auto-detect the quantization method from model files.
 

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3877,6 +3877,106 @@ class NPUModelRunner(GPUModelRunner):
 
         return dsa_k_tensor, dsa_k_scale_tensor
 
+    def _get_hybrid_attn_mamba_layout_layers(
+        self,
+        kv_cache_config: KVCacheConfig,
+        layer_kv_cache_spec: dict[str, KVCacheSpec],
+    ) -> set[str]:
+        """Return layers that use Ascend's shared attention-Mamba layout.
+
+        A tensor directly shared by attention and Mamba identifies a hybrid
+        physical page size. Other tensors with the same page size must use the
+        same planar raw layout as well (for example, an unpaired target/MTP
+        attention layer). Tensors with another page size, such as a standalone
+        BF16 draft cache, keep the normal contiguous K/V layout.
+
+        Classifying all tensors before allocation makes the result independent
+        of ``kv_cache_config.kv_cache_tensors`` iteration order.
+        """
+
+        def is_layout_attention_spec(spec: KVCacheSpec) -> bool:
+            return (
+                isinstance(spec, AttentionSpec)
+                and not isinstance(spec, AscendSFAIndexerCacheSpec)
+                and not is_hidden_state_cache_spec(spec)
+            )
+
+        hybrid_page_sizes: set[int] = set()
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            tensor_specs = [
+                layer_kv_cache_spec[layer_name]
+                for layer_name in kv_cache_tensor.shared_by
+            ]
+            has_mamba = any(isinstance(spec, MambaSpec) for spec in tensor_specs)
+            has_attention = any(
+                is_layout_attention_spec(spec) for spec in tensor_specs
+            )
+            if not (has_mamba and has_attention):
+                continue
+
+            page_sizes = {
+                spec.page_size_bytes
+                for spec in tensor_specs
+                if isinstance(spec, MambaSpec) or is_layout_attention_spec(spec)
+            }
+            if len(page_sizes) != 1:
+                raise ValueError(
+                    "Attention and Mamba layers sharing a KV cache tensor must "
+                    f"have one physical page size, got {sorted(page_sizes)} for "
+                    f"layers {kv_cache_tensor.shared_by}."
+                )
+            hybrid_page_sizes.update(page_sizes)
+
+        # Pipeline-parallel projection keeps empty KV groups in the worker
+        # config. A stage can therefore own only a padded target-attention
+        # tensor while the corresponding Mamba group has no local layer and no
+        # directly shared descriptor. The retained group spec still identifies
+        # the physical page family that must use the hybrid planar layout.
+        mamba_group_page_sizes = {
+            group.kv_cache_spec.page_size_bytes
+            for group in kv_cache_config.kv_cache_groups
+            if isinstance(group.kv_cache_spec, MambaSpec)
+        }
+        padded_mla_page_sizes = {
+            spec.page_size_bytes
+            for spec in layer_kv_cache_spec.values()
+            if isinstance(spec, AscendMLAAttentionSpec)
+            and spec.page_size_padded is not None
+            and spec.page_size_padded > spec.unpadded_page_size_bytes
+        }
+        hybrid_page_sizes.update(
+            mamba_group_page_sizes.intersection(padded_mla_page_sizes)
+        )
+
+        if not hybrid_page_sizes:
+            return set()
+
+        hybrid_layout_layers: set[str] = set()
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            layout_layers = []
+            other_layout_layers = []
+            for layer_name in kv_cache_tensor.shared_by:
+                spec = layer_kv_cache_spec[layer_name]
+                if not (
+                    isinstance(spec, MambaSpec)
+                    or is_layout_attention_spec(spec)
+                ):
+                    continue
+                if spec.page_size_bytes in hybrid_page_sizes:
+                    layout_layers.append(layer_name)
+                else:
+                    other_layout_layers.append(layer_name)
+
+            if layout_layers and other_layout_layers:
+                raise ValueError(
+                    "A KV cache tensor cannot mix Ascend hybrid-planar and "
+                    "standard contiguous layouts. Hybrid layers: "
+                    f"{layout_layers}; standard layers: {other_layout_layers}."
+                )
+            hybrid_layout_layers.update(layout_layers)
+
+        return hybrid_layout_layers
+
     def _allocate_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """
         Initializes the KV cache buffer with the correct size. The buffer needs
@@ -3898,24 +3998,30 @@ class NPUModelRunner(GPUModelRunner):
         # prefill disaggregation need the addr of cache tensor be aligned with 2M
         alignment = 2 * 1024 * 1024
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
-        # If some tensors are shared by linear layers and attention layers,
-        # the same tensor format must be maintained even if some layers
-        # have only linear or attention layers, for example, the mtp layer.
-        self.hybrid_with_attn_and_mamba = False
+        hybrid_layout_layers = self._get_hybrid_attn_mamba_layout_layers(
+            kv_cache_config,
+            layer_kv_cache_spec,
+        )
+        # Keep this model-level flag for callers that only need to know whether
+        # a hybrid layout exists. Allocation and reshape must use the per-layer
+        # classification above, never this sticky/global value.
+        self.hybrid_with_attn_and_mamba = bool(hybrid_layout_layers)
+        self._hybrid_attn_mamba_layout_layers = hybrid_layout_layers
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-            use_mamba, use_attn = False, False
+            use_mamba = False
             for layer_name in kv_cache_tensor.shared_by:
                 if isinstance(layer_kv_cache_spec[layer_name], MambaSpec):
                     use_mamba = True
-                if isinstance(layer_kv_cache_spec[layer_name], AttentionSpec):
-                    use_attn = True
-            self.hybrid_with_attn_and_mamba = self.hybrid_with_attn_and_mamba or (use_mamba and use_attn)
+            use_hybrid_layout = any(
+                layer_name in hybrid_layout_layers
+                for layer_name in kv_cache_tensor.shared_by
+            )
             for idx in range(len(kv_cache_tensor.shared_by)):
                 layer_name = kv_cache_tensor.shared_by[idx]
                 # Single tensor path for: mamba, hybrid attn-mamba, or cache_only_layers
                 if (
                     "linear_attn" in layer_name
-                    or self.hybrid_with_attn_and_mamba
+                    or use_hybrid_layout
                     or "cache_only_layers" in layer_name
                     or is_hidden_state_cache_spec(layer_kv_cache_spec.get(layer_name))
                 ) and layer_name not in kv_cache_raw_tensors:
@@ -4030,6 +4136,9 @@ class NPUModelRunner(GPUModelRunner):
                             layer_name,
                             current_kv_cache_spec,
                         )
+                        # Ascend MLA FA quantization is a per-layer property.
+                        # A standalone BF16 draft must not inherit the target
+                        # model's globally enabled KV quantization config.
                         if mla_fa_quant_dtypes is not None:
                             k_cache_dtype, v_cache_dtype = mla_fa_quant_dtypes
                             kv_head_dim_list = [
@@ -4037,7 +4146,14 @@ class NPUModelRunner(GPUModelRunner):
                                 v_dim * get_dtype_size(v_cache_dtype),
                             ]
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
-                        elif not self.use_sparse and enable_fa_quant(self.vllm_config):
+                        elif (
+                            not isinstance(
+                                current_kv_cache_spec,
+                                AscendMLAAttentionSpec,
+                            )
+                            and not self.use_sparse
+                            and enable_fa_quant(self.vllm_config)
+                        ):
                             kv_head_dim_list = [k_dim, v_dim]
                             k_tensor_split_factor, v_tensor_split_factor = (
                                 self.vllm_config.quant_config.get_kv_quant_split_factor(layer_name, kv_head_dim_list)
@@ -4145,6 +4261,12 @@ class NPUModelRunner(GPUModelRunner):
         """
         kv_caches: dict[str, torch.Tensor] = {}
         layer_kv_cache_spec = self._get_layer_kv_cache_specs(kv_cache_config)
+        hybrid_layout_layers = self._get_hybrid_attn_mamba_layout_layers(
+            kv_cache_config,
+            layer_kv_cache_spec,
+        )
+        self.hybrid_with_attn_and_mamba = bool(hybrid_layout_layers)
+        self._hybrid_attn_mamba_layout_layers = hybrid_layout_layers
         for group in self._kv_cache_spec_attn_group_iterator():
             attn_backend = group.backend
             current_kv_cache_spec = group.kv_cache_spec
@@ -4281,7 +4403,7 @@ class NPUModelRunner(GPUModelRunner):
                             sum_page_size_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
                     elif (
                         self.use_hybrid_blocks
-                        and self.hybrid_with_attn_and_mamba
+                        and layer_name in hybrid_layout_layers
                         and "cache_only_layers" not in layer_name
                         and not is_hidden_state_cache_spec(current_kv_cache_spec)
                     ):
@@ -4355,7 +4477,7 @@ class NPUModelRunner(GPUModelRunner):
                             current_kv_cache_spec.num_kv_heads,
                             current_kv_cache_spec.head_size,
                         )
-                        if self.hybrid_with_attn_and_mamba:
+                        if layer_name in hybrid_layout_layers:
                             if not isinstance(current_kv_cache_spec, AscendMLAAttentionSpec):
                                 attn_tensor_page_size = int(np.prod(kv_cache_shape[1:])) * get_dtype_size(
                                     current_kv_cache_spec.dtype
@@ -4426,9 +4548,17 @@ class NPUModelRunner(GPUModelRunner):
                         layer_name,
                         current_kv_cache_spec,
                     )
+                    # Keep this consistent with allocation: helper=None means
+                    # an Ascend MLA layer uses its own cache dtype.
                     if mla_fa_quant_dtypes is not None:
                         k_cache_dtype, v_cache_dtype = mla_fa_quant_dtypes
-                    elif enable_fa_quant(self.vllm_config):
+                    elif (
+                        not isinstance(
+                            current_kv_cache_spec,
+                            AscendMLAAttentionSpec,
+                        )
+                        and enable_fa_quant(self.vllm_config)
+                    ):
                         k_cache_dtype, v_cache_dtype = self.vllm_config.quant_config.get_kv_quant_dtype(
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3778,6 +3778,23 @@ class NPUModelRunner(GPUModelRunner):
         head_size_v = kv_cache_spec.head_size_v if hasattr(kv_cache_spec, "head_size_v") else kv_cache_spec.head_size
         return kv_cache_spec.head_size, head_size_v
 
+    def _get_mla_fa_quant_cache_dtypes(
+        self,
+        layer_name: str,
+        kv_cache_spec: AttentionSpec,
+    ) -> tuple[torch.dtype, torch.dtype] | None:
+        if not isinstance(kv_cache_spec, AscendMLAAttentionSpec):
+            return None
+        attn_layers = get_layers_from_vllm_config(
+            self.vllm_config,
+            AttentionLayerBase,
+            [layer_name],
+        )
+        attn_layer = attn_layers[layer_name]
+        if isinstance(attn_layer, MLAAttention) and getattr(attn_layer.impl, "fa_quant_layer", False):
+            return attn_layer.impl.dtype, self.model_config.dtype
+        return None
+
     @staticmethod
     def _align_up(value: int, alignment: int) -> int:
         return (value + alignment - 1) // alignment * alignment
@@ -4009,15 +4026,24 @@ class NPUModelRunner(GPUModelRunner):
                     else:
                         k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
                         assert k_dim > 0 and v_dim > 0
-                        kv_head_dim_list = [
-                            k_dim,
-                            v_dim,
-                        ]
-                        if not self.use_sparse and enable_fa_quant(self.vllm_config):
+                        mla_fa_quant_dtypes = self._get_mla_fa_quant_cache_dtypes(
+                            layer_name,
+                            current_kv_cache_spec,
+                        )
+                        if mla_fa_quant_dtypes is not None:
+                            k_cache_dtype, v_cache_dtype = mla_fa_quant_dtypes
+                            kv_head_dim_list = [
+                                k_dim * get_dtype_size(k_cache_dtype),
+                                v_dim * get_dtype_size(v_cache_dtype),
+                            ]
+                            k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
+                        elif not self.use_sparse and enable_fa_quant(self.vllm_config):
+                            kv_head_dim_list = [k_dim, v_dim]
                             k_tensor_split_factor, v_tensor_split_factor = (
                                 self.vllm_config.quant_config.get_kv_quant_split_factor(layer_name, kv_head_dim_list)
                             )
                         else:
+                            kv_head_dim_list = [k_dim, v_dim]
                             k_tensor_split_factor, v_tensor_split_factor = calc_split_factor(kv_head_dim_list)
                         k_tensor_size = int(kv_cache_tensor.size // k_tensor_split_factor)
                         v_tensor_size = int(kv_cache_tensor.size // v_tensor_split_factor)
@@ -4340,11 +4366,19 @@ class NPUModelRunner(GPUModelRunner):
                                 raw_v_tensor = raw_kv_tensor[attn_tensor_page_size:]
                             else:
                                 k_dim, v_dim = self._get_attention_kv_cache_dims(layer_name, current_kv_cache_spec)
-                                nope_page_size = int(np.prod(kv_cache_shape[:-1])) * k_dim * get_dtype_size(
-                                    current_kv_cache_spec.dtype
+                                mla_fa_quant_dtypes = self._get_mla_fa_quant_cache_dtypes(
+                                    layer_name,
+                                    current_kv_cache_spec,
                                 )
-                                rope_page_size = int(np.prod(kv_cache_shape[:-1])) * v_dim * get_dtype_size(
-                                    current_kv_cache_spec.dtype
+                                if mla_fa_quant_dtypes is None:
+                                    k_cache_dtype = v_cache_dtype = current_kv_cache_spec.dtype
+                                else:
+                                    k_cache_dtype, v_cache_dtype = mla_fa_quant_dtypes
+                                nope_page_size = (
+                                    int(np.prod(kv_cache_shape[:-1])) * k_dim * get_dtype_size(k_cache_dtype)
+                                )
+                                rope_page_size = (
+                                    int(np.prod(kv_cache_shape[:-1])) * v_dim * get_dtype_size(v_cache_dtype)
                                 )
                                 conv_block_padding_size = raw_k_tensor.numel() - nope_page_size - rope_page_size
                                 raw_kv_tensor = raw_k_tensor[conv_block_padding_size:]
@@ -4388,7 +4422,13 @@ class NPUModelRunner(GPUModelRunner):
                             v_dim,
                         )
                     k_cache_dtype = v_cache_dtype = current_kv_cache_spec.dtype
-                    if enable_fa_quant(self.vllm_config):
+                    mla_fa_quant_dtypes = self._get_mla_fa_quant_cache_dtypes(
+                        layer_name,
+                        current_kv_cache_spec,
+                    )
+                    if mla_fa_quant_dtypes is not None:
+                        k_cache_dtype, v_cache_dtype = mla_fa_quant_dtypes
+                    elif enable_fa_quant(self.vllm_config):
                         k_cache_dtype, v_cache_dtype = self.vllm_config.quant_config.get_kv_quant_dtype(
                             layer_name, current_kv_cache_spec.dtype, self.model_config
                         )
@@ -4714,8 +4754,15 @@ class NPUModelRunner(GPUModelRunner):
                     )
                 elif spec := attn_module.get_kv_cache_spec(self.vllm_config):
                     if getattr(attn_module.impl, "fa_quant_layer", False):
-                        head_size = attn_module.head_size + attn_module.qk_rope_head_dim
                         dtype, cache_dtype_str = attn_module.impl.dtype, None
+                        dtype_size = get_dtype_size(dtype)
+                        # Latent KV is C8, while the positional cache remains in model dtype.
+                        head_size_bytes = (
+                            attn_module.kv_lora_rank * dtype_size
+                            + attn_module.qk_rope_head_dim * get_dtype_size(self.model_config.dtype)
+                        )
+                        assert head_size_bytes % dtype_size == 0
+                        head_size = head_size_bytes // dtype_size
                     else:
                         head_size, dtype, cache_dtype_str = spec.head_size, spec.dtype, spec.cache_dtype_str
                     kv_cache_spec[layer_name] = AscendMLAAttentionSpec(


### PR DESCRIPTION
### What this PR does / why we need it?

This PR rebases and combines the applicable changes from #14612 and #14704 onto the latest `vllm-ascend` main.

For Kimi K3, it:

- includes the K3 A3 MLA C8 prerequisite from #13225;
- fixes KV-cache initialization when A3 MLA C8, hybrid MLA + Mamba cache, and K3 DSpark speculative decoding with a BF16 draft cache are used together;
- keeps target and draft layers in one logical KV-cache group while allocating heterogeneous physical cache tensors safely;
- accounts for heterogeneous page sizes in cache capacity and memory calculations;
- preserves EAGLE metadata and per-layer cache layout selection;
- restores the Kimi K3 SiTU activation path.

For MiniMax M3 and shared experts, it:

- tolerates quantization configs without `quant_description` in RMSNorm;
- clamps the zero-prefix sparse-attention score range to prevent negative block access;
- uses the Triton sparse decode implementation on A5;
- defers shared-expert quantization imports to avoid loading unavailable optional implementations.

The old #14704 changes for `SequenceRowParallelOp` and `matmul_and_reduce*` are intentionally omitted. FlashComm v1 and those custom-op paths were removed from main by #13946. The upstream SP path passes pre-quantized MXFP8 tuples into the quantization method and performs communication on the resulting tensor, so the FlashComm-specific tuple reduction fix is no longer required.

This PR is intended to supersede #14612 and #14704.

### Does this PR introduce _any_ user-facing change?

Yes.

- Kimi K3 deployments using A3 MLA C8 with K3 DSpark can initialize and use heterogeneous target/draft KV-cache layouts.
- MiniMax M3 MXFP8 and sparse attention avoid the covered configuration and index-bound failures.
- There are no new public CLI or configuration-format changes.

### How was this patch tested?

Validated in the current workspace with:

```bash
python3 -m compileall -q <all changed Python files>
git diff --check upstream/main...HEAD
```

Both checks passed.

Ruff, pytest, and NPU end-to-end tests were not run in this workspace because the corresponding Python packages and NPU runtime are unavailable. CI should run the repository checks; before merge, an A3 Kimi K3 W4A8C8 + DSpark smoke test and a MiniMax M3 MXFP8 test with upstream SP (`DP > 1`, `TP > 1`, EP, and `allgather_reducescatter`) are recommended.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
