### PR TITLE
[Performance][KV Cache] Group Kimi K3 DSpark caches

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -38,6 +38,7 @@ from vllm_ascend.patch.platform.patch_kv_cache_utils import (
     group_and_unify_kv_cache_specs,
 )
 from vllm_ascend.patch.platform.patch_mamba_manager import AscendMambaManager
+from vllm_ascend.utils import vllm_version_is
 
 
 def _make_hybrid_kv_cache_config(
@@ -353,6 +354,8 @@ def test_kimi_k3_mla_dspark_uses_four_groups_and_five_builders() -> None:
 def test_kimi_k3_gqa_mixed_groups_preserve_scheduler_and_mamba_contracts() -> None:
     groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(_make_kimi_k3_dspark_kv_cache_specs())
     assert groups is not None
+    max_model_len = 133120
+    vllm_config = _make_vllm_config(enable_prefix_caching=True, dcp=1, block_size=384)
     worker_config = KVCacheConfig(
         num_blocks=100,
         kv_cache_tensors=[],
@@ -361,17 +364,19 @@ def test_kimi_k3_gqa_mixed_groups_preserve_scheduler_and_mamba_contracts() -> No
 
     assert worker_config.has_mamba_layers
     assert worker_config.needs_kv_cache_zeroing
-    assert (
-        groups[1].kv_cache_spec.max_num_blocks_per_req(
-            _make_vllm_config(enable_prefix_caching=True, dcp=1, block_size=384),
-            3840,
-        )
-        == 17
-    )
+    worker_mamba_widths = {
+        group.kv_cache_spec.max_num_blocks_per_req(vllm_config, max_model_len) for group in groups[1:]
+    }
+    assert worker_mamba_widths == {354}
 
     scheduler_config = generate_scheduler_kv_cache_config([worker_config])
     assert isinstance(scheduler_config.kv_cache_groups[0].kv_cache_spec, MLAAttentionSpec)
     assert all(isinstance(group.kv_cache_spec, MambaSpec) for group in scheduler_config.kv_cache_groups[1:])
+    scheduler_mamba_widths = {
+        group.kv_cache_spec.max_num_blocks_per_req(vllm_config, max_model_len)
+        for group in scheduler_config.kv_cache_groups[1:]
+    }
+    assert scheduler_mamba_widths == worker_mamba_widths
     assert scheduler_config.needs_kv_cache_zeroing
 
 
@@ -399,10 +404,9 @@ def test_kimi_k3_gqa_mixed_groups_use_expected_physical_layout(monkeypatch) -> N
     assert sum(tensor.size for tensor in tensors) == available_memory
 
 
-def test_kimi_k3_gqa_mixed_grouping_falls_back_on_partial_signature() -> None:
+def test_kimi_k3_gqa_mixed_grouping_falls_back_on_unrecognized_layer() -> None:
     specs = _make_kimi_k3_dspark_kv_cache_specs()
-    draft_layer = "model.layers.93.self_attn.attn"
-    specs.pop(draft_layer)
+    specs["unrecognized.layer"] = next(iter(specs.values()))
 
     assert _get_kimi_k3_dspark_mixed_kv_cache_groups(specs) is None
 
@@ -560,6 +564,10 @@ def test_get_kv_cache_coordinator_delegates_hybrid_without_caching(monkeypatch) 
 
 
 @pytest.mark.parametrize("num_prefill_lookahead", [0, 8])
+@pytest.mark.skipif(
+    vllm_version_is("0.27.1"),
+    reason="num_prefill_lookahead was added to the coordinator after v0.27.1",
+)
 def test_get_kv_cache_coordinator_forwards_prefill_lookahead(
     monkeypatch,
     num_prefill_lookahead: int,

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import generate_scheduler_kv_cache_config
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
     SlidingWindowManager,
@@ -30,6 +32,8 @@ from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
 )
 from vllm_ascend.patch.platform.patch_kv_cache_utils import (
     _ascend_resolve_kv_cache_block_sizes,
+    _get_kimi_k3_dspark_mixed_kv_cache_groups,
+    _get_kv_cache_config_deepseek_v4,
     group_and_unify_kv_cache_specs,
 )
 from vllm_ascend.patch.platform.patch_mamba_manager import AscendMambaManager
@@ -62,6 +66,65 @@ def _make_hybrid_kv_cache_config(
             KVCacheGroupSpec(layer_names=["mamba"], kv_cache_spec=mamba_spec),
         ],
     )
+
+
+def _make_kimi_k3_dspark_kv_cache_specs(
+    *,
+    block_size: int = 384,
+    page_size: int = 488448,
+    target_layer_count: int = 24,
+    draft_layer_count: int = 5,
+    mamba_layer_count: int = 69,
+    draft_uses_mla: bool = False,
+) -> dict:
+    target_mla_spec = MLAAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+        page_size_padded=page_size,
+        cache_dtype_str="auto",
+    )
+    if draft_uses_mla:
+        draft_attention_spec = MLAAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+            page_size_padded=page_size,
+            cache_dtype_str="auto",
+            non_causal_multi_token_decode=True,
+        )
+    else:
+        draft_attention_spec = FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=64,
+            dtype=torch.bfloat16,
+            page_size_padded=page_size,
+        )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((10, 2304), (6, 128, 128)),
+        dtypes=(torch.bfloat16, torch.float32),
+        page_size_padded=page_size,
+        mamba_cache_mode="align",
+        num_speculative_blocks=7,
+    )
+    specs = {
+        f"language_model.model.layers.{layer_idx}.self_attn.attn": target_mla_spec
+        for layer_idx in range(target_layer_count)
+    }
+    specs.update(
+        {
+            f"model.layers.{layer_idx}.self_attn.attn": draft_attention_spec
+            for layer_idx in range(93, 93 + draft_layer_count)
+        }
+    )
+    specs.update(
+        {f"language_model.model.layers.{layer_idx}.self_attn": mamba_spec for layer_idx in range(mamba_layer_count)}
+    )
+    return specs
 
 
 def _make_deepseek_v4_kv_cache_config() -> KVCacheConfig:
@@ -108,6 +171,7 @@ def _make_vllm_config(
         cache_config=SimpleNamespace(
             block_size=block_size,
             enable_prefix_caching=enable_prefix_caching,
+            mamba_cache_mode="align",
             prefix_match_unit=None,
         ),
         parallel_config=SimpleNamespace(
@@ -193,6 +257,134 @@ def test_deepseek_v4_groups_use_logical_sizes_and_full_attention_manager() -> No
     for group in grouped_specs[:2]:
         spec = next(iter(group.kv_cache_specs.values()))
         assert KVCacheSpecRegistry.get_manager_class(spec) is FullAttentionManager
+
+
+@pytest.mark.parametrize(
+    ("block_size", "page_size"),
+    [
+        pytest.param(384, 488448, id="tp16"),
+        pytest.param(768, 976896, id="tp8"),
+    ],
+)
+def test_kimi_k3_gqa_uses_four_mixed_kv_groups_and_five_builders(
+    block_size: int,
+    page_size: int,
+) -> None:
+    groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(
+        _make_kimi_k3_dspark_kv_cache_specs(
+            block_size=block_size,
+            page_size=page_size,
+        )
+    )
+
+    assert groups is not None
+    assert [len(group.layer_names) for group in groups] == [29, 23, 23, 23]
+    assert all(isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs) for group in groups)
+
+    mixed_specs = groups[0].kv_cache_spec.kv_cache_specs
+    assert sum(isinstance(spec, MLAAttentionSpec) for spec in mixed_specs.values()) == 24
+    assert (
+        sum(
+            isinstance(spec, FullAttentionSpec) and not isinstance(spec, MLAAttentionSpec)
+            for spec in mixed_specs.values()
+        )
+        == 5
+    )
+
+    # The model runner keys builders by backend and exact inner spec. The
+    # mixed attention group contributes MLA + GQA, and each Mamba group one.
+    metadata_builder_count = sum(len(set(group.kv_cache_spec.kv_cache_specs.values())) for group in groups)
+    assert metadata_builder_count == 5
+
+
+def test_kimi_k3_mla_dspark_uses_four_groups_and_five_builders() -> None:
+    groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(_make_kimi_k3_dspark_kv_cache_specs(draft_uses_mla=True))
+
+    assert groups is not None
+    assert [len(group.layer_names) for group in groups] == [29, 23, 23, 23]
+    # Target MLA is causal while draft MLA enables non-causal multi-token
+    # decode, so the mixed group needs two exact-spec builders. The three
+    # recurrent groups each contribute one more builder.
+    metadata_builder_count = sum(len(set(group.kv_cache_spec.kv_cache_specs.values())) for group in groups)
+    assert metadata_builder_count == 5
+
+
+def test_kimi_k3_gqa_mixed_groups_preserve_scheduler_and_mamba_contracts() -> None:
+    groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(_make_kimi_k3_dspark_kv_cache_specs())
+    assert groups is not None
+    worker_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+    assert worker_config.has_mamba_layers
+    assert worker_config.needs_kv_cache_zeroing
+    assert (
+        groups[1].kv_cache_spec.max_num_blocks_per_req(
+            _make_vllm_config(enable_prefix_caching=True, dcp=1, block_size=384),
+            3840,
+        )
+        == 17
+    )
+
+    scheduler_config = generate_scheduler_kv_cache_config([worker_config])
+    assert isinstance(scheduler_config.kv_cache_groups[0].kv_cache_spec, MLAAttentionSpec)
+    assert all(isinstance(group.kv_cache_spec, MambaSpec) for group in scheduler_config.kv_cache_groups[1:])
+    assert scheduler_config.needs_kv_cache_zeroing
+
+
+def test_kimi_k3_gqa_mixed_groups_use_expected_physical_layout(monkeypatch) -> None:
+    groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(_make_kimi_k3_dspark_kv_cache_specs())
+    assert groups is not None
+    page_size = 488448
+    expected_num_blocks = 100
+    available_memory = page_size * 29 * expected_num_blocks
+    monkeypatch.setattr(
+        "vllm_ascend.patch.platform.patch_kv_cache_utils.may_override_num_blocks",
+        lambda _config, num_blocks: num_blocks,
+    )
+
+    num_blocks, tensors = _get_kv_cache_config_deepseek_v4(
+        SimpleNamespace(),
+        groups,
+        available_memory,
+    )
+
+    assert num_blocks == expected_num_blocks
+    assert len(tensors) == 29
+    assert [len(tensor.shared_by) for tensor in tensors] == [4] * 23 + [1] * 6
+    assert all(tensor.size == page_size * expected_num_blocks for tensor in tensors)
+    assert sum(tensor.size for tensor in tensors) == available_memory
+
+
+def test_kimi_k3_gqa_mixed_grouping_falls_back_on_partial_signature() -> None:
+    specs = _make_kimi_k3_dspark_kv_cache_specs()
+    draft_layer = "model.layers.93.self_attn.attn"
+    specs[draft_layer] = replace(specs[draft_layer], non_causal=True)
+
+    assert _get_kimi_k3_dspark_mixed_kv_cache_groups(specs) is None
+
+
+def test_kimi_k3_dspark_group_count_is_derived_from_layer_ratio() -> None:
+    groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(
+        _make_kimi_k3_dspark_kv_cache_specs(
+            target_layer_count=20,
+            draft_layer_count=4,
+            mamba_layer_count=70,
+        )
+    )
+
+    assert groups is not None
+    assert [len(group.layer_names) for group in groups] == [24, 24, 23, 23]
+
+
+def test_kimi_k3_dspark_mixed_grouping_falls_back_on_unaligned_pages() -> None:
+    specs = _make_kimi_k3_dspark_kv_cache_specs()
+    draft_layer = "model.layers.93.self_attn.attn"
+    specs[draft_layer] = replace(specs[draft_layer], page_size_padded=976896)
+
+    assert _get_kimi_k3_dspark_mixed_kv_cache_groups(specs) is None
 
 
 def test_deepseek_v4_scheduler_lcm_uses_logical_group_sizes() -> None:
@@ -324,6 +516,46 @@ def test_get_kv_cache_coordinator_delegates_hybrid_without_caching(monkeypatch) 
     )
 
     assert coordinator is sentinel
+
+
+@pytest.mark.parametrize(
+    ("num_prefill_lookahead", "expected"),
+    [(None, 0), (8, 8)],
+)
+def test_get_kv_cache_coordinator_normalizes_prefill_lookahead(
+    monkeypatch,
+    num_prefill_lookahead: int | None,
+    expected: int,
+) -> None:
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        full_block_size=16,
+        mamba_block_size=16,
+    )
+    captured_kwargs = {}
+
+    def _fake_ascend_coordinator(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        "vllm_ascend.patch.platform.patch_kv_cache_coordinator.AscendHybridKVCacheCoordinator",
+        _fake_ascend_coordinator,
+    )
+
+    get_kv_cache_coordinator(
+        kv_cache_config,
+        max_model_len=1024,
+        max_num_batched_tokens=1024,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=16,
+        num_prefill_lookahead=num_prefill_lookahead,
+    )
+
+    assert captured_kwargs["num_prefill_lookahead"] == expected
 
 
 def test_get_kv_cache_coordinator_uses_ascend_for_deepseek_v4(monkeypatch) -> None:

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -25,6 +25,7 @@ from vllm.v1.kv_cache_interface import (
 )
 from vllm.v1.kv_cache_spec_registry import KVCacheSpecRegistry
 
+from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec
 from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
     AscendHybridKVCacheCoordinator,
     _is_deepseek_v4_kv_cache_spec,
@@ -77,7 +78,7 @@ def _make_kimi_k3_dspark_kv_cache_specs(
     mamba_layer_count: int = 69,
     draft_uses_mla: bool = False,
 ) -> dict:
-    target_mla_spec = MLAAttentionSpec(
+    target_mla_spec = AscendMLAAttentionSpec(
         block_size=block_size,
         num_kv_heads=1,
         head_size=576,
@@ -86,7 +87,7 @@ def _make_kimi_k3_dspark_kv_cache_specs(
         cache_dtype_str="auto",
     )
     if draft_uses_mla:
-        draft_attention_spec = MLAAttentionSpec(
+        draft_attention_spec = AscendMLAAttentionSpec(
             block_size=block_size,
             num_kv_heads=1,
             head_size=576,
@@ -190,6 +191,46 @@ def _make_coordinator_for_effective_block_size(
     coordinator.dcp_world_size = dcp_world_size
     coordinator.enable_caching = enable_caching
     return coordinator
+
+
+def test_ascend_mla_page_size_includes_scale_storage() -> None:
+    spec = AscendMLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+        scale_dim=1,
+        scale_dtype=torch.float16,
+    )
+
+    expected_page_size = 16 * (128 * 2 + 2)
+    assert spec.unpadded_page_size_bytes == expected_page_size
+    assert spec.real_page_size_bytes == expected_page_size
+    assert spec.page_size_bytes == expected_page_size
+
+
+def test_ascend_mla_merge_preserves_upstream_layout_fields() -> None:
+    spec = AscendMLAAttentionSpec(
+        block_size=512,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.bfloat16,
+        cache_dtype_str="fp8_ds_mla",
+        compress_ratio=4,
+        model_version="deepseek_v4",
+        indexes_kv_by_block_stride=True,
+        scale_dim=1,
+        scale_dtype=torch.float16,
+    )
+
+    merged = AscendMLAAttentionSpec.merge([spec, replace(spec)])
+
+    assert merged.block_size == spec.block_size
+    assert merged.compress_ratio == spec.compress_ratio
+    assert merged.model_version == spec.model_version
+    assert merged.indexes_kv_by_block_stride == spec.indexes_kv_by_block_stride
+    assert merged.scale_dim == spec.scale_dim
+    assert merged.scale_dtype == spec.scale_dtype
 
 
 @pytest.mark.parametrize(
@@ -361,7 +402,7 @@ def test_kimi_k3_gqa_mixed_groups_use_expected_physical_layout(monkeypatch) -> N
 def test_kimi_k3_gqa_mixed_grouping_falls_back_on_partial_signature() -> None:
     specs = _make_kimi_k3_dspark_kv_cache_specs()
     draft_layer = "model.layers.93.self_attn.attn"
-    specs[draft_layer] = replace(specs[draft_layer], non_causal=True)
+    specs.pop(draft_layer)
 
     assert _get_kimi_k3_dspark_mixed_kv_cache_groups(specs) is None
 
@@ -518,14 +559,10 @@ def test_get_kv_cache_coordinator_delegates_hybrid_without_caching(monkeypatch) 
     assert coordinator is sentinel
 
 
-@pytest.mark.parametrize(
-    ("num_prefill_lookahead", "expected"),
-    [(None, 0), (8, 8)],
-)
-def test_get_kv_cache_coordinator_normalizes_prefill_lookahead(
+@pytest.mark.parametrize("num_prefill_lookahead", [0, 8])
+def test_get_kv_cache_coordinator_forwards_prefill_lookahead(
     monkeypatch,
-    num_prefill_lookahead: int | None,
-    expected: int,
+    num_prefill_lookahead: int,
 ) -> None:
     kv_cache_config = _make_hybrid_kv_cache_config(
         full_block_size=16,
@@ -555,7 +592,7 @@ def test_get_kv_cache_coordinator_normalizes_prefill_lookahead(
         num_prefill_lookahead=num_prefill_lookahead,
     )
 
-    assert captured_kwargs["num_prefill_lookahead"] == expected
+    assert captured_kwargs["num_prefill_lookahead"] == num_prefill_lookahead
 
 
 def test_get_kv_cache_coordinator_uses_ascend_for_deepseek_v4(monkeypatch) -> None:

--- a/tests/ut/patch/worker/test_patch_mamba_utils_uniform_groups.py
+++ b/tests/ut/patch/worker/test_patch_mamba_utils_uniform_groups.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.worker.mamba_utils import MambaCopyBuffers
+
+from vllm_ascend.patch.worker.patch_mamba_utils import _get_mamba_groups
+
+
+def test_uniform_mamba_groups_are_visible_to_all_mamba_buffers() -> None:
+    mamba_spec = MambaSpec(
+        block_size=384,
+        shapes=((10, 2304), (6, 128, 128)),
+        dtypes=(torch.bfloat16, torch.float32),
+        page_size_padded=488448,
+        mamba_cache_mode="align",
+        num_speculative_blocks=7,
+    )
+    groups = []
+    for group_id in range(3):
+        layer_specs = {f"mamba.{group_id}.{layer_id}": mamba_spec for layer_id in range(23)}
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+        assert uniform_spec is not None
+        groups.append(
+            KVCacheGroupSpec(
+                layer_names=list(layer_specs),
+                kv_cache_spec=uniform_spec,
+            )
+        )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+    group_ids, resolved_spec = _get_mamba_groups(kv_cache_config)
+    assert group_ids == [0, 1, 2]
+    assert resolved_spec == mamba_spec
+
+    def make_buffer(n: int, dtype: torch.dtype) -> SimpleNamespace:
+        return SimpleNamespace(n=n, dtype=dtype)
+
+    copy_bufs = MambaCopyBuffers.create(
+        max_num_reqs=2,
+        kv_cache_config=kv_cache_config,
+        copy_funcs=(object(), object()),
+        make_buffer=make_buffer,
+    )
+    assert copy_bufs.mamba_group_ids == [0, 1, 2]
+    assert copy_bufs.mamba_spec == mamba_spec
+    assert copy_bufs.src_ptrs.n == 2 * 69 * 2
+    assert copy_bufs.src_ptrs.dtype == torch.int64
+    assert copy_bufs.dst_ptrs.dtype == torch.int64
+    assert copy_bufs.sizes.dtype == torch.int32

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -26,6 +26,12 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    MLAAttentionSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
@@ -723,4 +729,83 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
         kv_cache_config = SimpleNamespace(kv_cache_groups=[non_overlapping_group])
         with pytest.raises(RuntimeError, match="registered draft attention groups"):
             proposer.initialize_attn_backend(kv_cache_config)
+    @pytest.mark.parametrize("draft_uses_mla", [False, True], ids=["gqa", "mla"])
+    def test_mixed_target_and_dspark_group_creates_one_draft_attention_group(
+        self, monkeypatch, draft_uses_mla: bool
+    ):
+        page_size = 488448
+        target_layer = "language_model.model.layers.3.self_attn.attn"
+        draft_layers = [
+            f"model.layers.{layer_idx}.self_attn.attn"
+            for layer_idx in range(93, 98)
+        ]
+        target_spec = MLAAttentionSpec(
+            block_size=384,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+            page_size_padded=page_size,
+        )
+        if draft_uses_mla:
+            draft_spec = MLAAttentionSpec(
+                block_size=384,
+                num_kv_heads=1,
+                head_size=576,
+                dtype=torch.bfloat16,
+                page_size_padded=page_size,
+                non_causal_multi_token_decode=True,
+            )
+        else:
+            draft_spec = FullAttentionSpec(
+                block_size=384,
+                num_kv_heads=1,
+                head_size=64,
+                dtype=torch.bfloat16,
+                page_size_padded=page_size,
+            )
+        mixed_spec = UniformTypeKVCacheSpecs.from_specs(
+            {
+                target_layer: target_spec,
+                **{layer_name: draft_spec for layer_name in draft_layers},
+            }
+        )
+        assert mixed_spec is not None
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.gqa.backend"
+        layers = {}
+        for layer_name in draft_layers:
+            layer = MagicMock()
+            layer.get_attn_backend.return_value = backend
+            layers[layer_name] = layer
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *args, **kwargs: layers,
+        )
+
+        proposer = self._make_proposer_for_init()
+        proposer.model = SimpleNamespace(
+            get_draft_kv_cache_layer_names=lambda: set(draft_layers)
+        )
+        proposer.max_query_tokens = 16
+        proposer.max_num_tokens = 32
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=[target_layer, *draft_layers],
+                    kv_cache_spec=mixed_spec,
+                )
+            ]
+        )
+
+        with patch.object(AttentionGroup, "create_metadata_builders"):
+            proposer.initialize_attn_backend(
+                kv_cache_config,
+                kernel_block_sizes=[128],
+            )
+
+        assert len(proposer.draft_attn_groups) == 1
+        assert set(proposer.draft_attn_groups[0].layer_names) == set(draft_layers)
+        assert proposer.draft_attn_groups[0].kv_cache_group_id == 0
+        assert proposer._layer_group_idx == [0] * 5
 # fmt: on

--- a/tests/ut/test_compressed_prefix_cache.py
+++ b/tests/ut/test_compressed_prefix_cache.py
@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
     get_block_hash,
     get_request_block_hasher,
     init_none_hash,
+    is_kv_cache_spec_uniform,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     FullAttentionManager,
@@ -22,6 +23,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    MambaSpec,
     MLAAttentionSpec,
 )
 from vllm.v1.request import Request
@@ -78,6 +80,22 @@ def _make_full_manager(
         scheduler_block_size=logical_block_size,
     )
     return spec, block_pool, manager
+
+
+def test_ascend_mla_spec_is_not_uniform_with_mamba() -> None:
+    mla_spec, _, _ = _make_full_manager()
+    mamba_spec = MambaSpec(
+        block_size=1,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+    )
+
+    assert not is_kv_cache_spec_uniform(
+        {
+            "mla": mla_spec,
+            "mamba": mamba_spec,
+        }
+    )
 
 
 @pytest.mark.parametrize("physical_block_size", [32, 64, 128])
@@ -273,3 +291,87 @@ def test_hybrid_coordinator_rejects_partial_compressed_prefix_hit() -> None:
 
     assert hit_length == 0
     assert hit_blocks == ([], [])
+
+
+def test_hybrid_coordinator_truncates_every_full_attention_group() -> None:
+    hash_block_size = 2
+    block_size = 2 * hash_block_size
+    coordinator = AscendHybridKVCacheCoordinator(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=32,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full_a"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["full_b"],
+                    FullAttentionSpec(
+                        block_size=2 * block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["mamba"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=((1,),),
+                        dtypes=(torch.float32,),
+                        mamba_cache_mode="align",
+                    ),
+                ),
+            ],
+        ),
+        max_model_len=8192,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        hash_block_size=hash_block_size,
+        scheduler_block_size=block_size,
+        max_num_batched_tokens=8192,
+    )
+    request = _make_request(
+        "a",
+        [index // hash_block_size for index in range(24)],
+        hash_block_size,
+    )
+
+    for group_id in (0, 1):
+        group_block_size = block_size * (1 + group_id)
+        num_full_blocks = len(request.prompt_token_ids) // group_block_size
+        blocks = coordinator.block_pool.get_new_blocks(num_full_blocks)
+        coordinator.block_pool.cache_full_blocks(
+            request=request,
+            blocks=blocks,
+            num_cached_blocks=0,
+            num_full_blocks=num_full_blocks,
+            block_size=group_block_size,
+            kv_cache_group_id=group_id,
+        )
+
+    mamba_block = coordinator.block_pool.get_new_blocks(1)[0]
+    coordinator.block_pool.cache_partial_block(
+        request=request,
+        block=mamba_block,
+        num_tokens=6,
+        kv_cache_group_id=2,
+        block_size=block_size,
+    )
+
+    hit_blocks, hit_length, _ = coordinator.find_longest_cache_hit(
+        request.block_hashes,
+        max_cache_hit_length=len(request.prompt_token_ids),
+    )
+
+    assert hit_length == 6
+    assert [len(blocks) for blocks in hit_blocks] == [2, 1, 2]

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -14,6 +14,7 @@
 #
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -21,6 +22,11 @@ import torch
 
 # import vllm.utils.cpu_triton_utils as cpu_tl
 from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.v1.kv_cache_interface import (
+    KVCacheGroupSpec,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 
 from tests.ut.base import TestBase
 
@@ -97,6 +103,43 @@ class TestBlockTableComputeSlotMapping(TestBase):
 
         self.assertEqual(block_table.slot_mapping.cpu.numel(), 128)
         self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
+
+    def test_uniform_mamba_group_disables_slot_mapping(self):
+        mamba_spec = MambaSpec(
+            block_size=self.block_size,
+            shapes=((4, 8),),
+            dtypes=(torch.float32,),
+            page_size_padded=128,
+            mamba_cache_mode="align",
+            num_speculative_blocks=7,
+        )
+        layer_specs = {f"mamba.{i}": mamba_spec for i in range(3)}
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+        self.assertIsNotNone(uniform_spec)
+        kv_cache_group = KVCacheGroupSpec(
+            layer_names=list(layer_specs),
+            kv_cache_spec=uniform_spec,
+        )
+
+        with patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group:
+            mock_get_dcp_group.return_value = SimpleNamespace(
+                world_size=1,
+                rank_in_group=0,
+            )
+            from vllm_ascend.worker.block_table import BlockTable
+
+            block_table = BlockTable(
+                block_size=self.block_size,
+                max_num_reqs=self.max_num_reqs,
+                max_num_blocks_per_req=self.max_num_blocks_per_req,
+                max_num_batched_tokens=self.max_num_batched_tokens,
+                pin_memory=self.pin_memory,
+                device=self.device,
+                kernel_sizes=[0],
+                kv_cache_group=kv_cache_group,
+            )
+
+        self.assertTrue(block_table.is_mamba_group)
 
     def setup_block_table_data(self, block_table, num_reqs=2):
         """Helper method to populate block table with test data"""

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -104,7 +104,7 @@ class TestBlockTableComputeSlotMapping(TestBase):
         self.assertEqual(block_table.slot_mapping.cpu.numel(), 128)
         self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
 
-    def test_uniform_mamba_group_disables_slot_mapping(self):
+    def test_uniform_mamba_group_is_recognized_as_mamba(self):
         mamba_spec = MambaSpec(
             block_size=self.block_size,
             shapes=((4, 8),),

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -104,9 +104,11 @@ class TestBlockTableComputeSlotMapping(TestBase):
         self.assertEqual(block_table.slot_mapping.cpu.numel(), 128)
         self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
 
-    def test_uniform_mamba_group_is_recognized_as_mamba(self):
+    def test_mamba_table_preserves_speculative_capacity_with_dcp(self):
+        from vllm_ascend.worker.block_table import BlockTable
+
         mamba_spec = MambaSpec(
-            block_size=self.block_size,
+            block_size=384,
             shapes=((4, 8),),
             dtypes=(torch.float32,),
             page_size_padded=128,
@@ -116,30 +118,42 @@ class TestBlockTableComputeSlotMapping(TestBase):
         layer_specs = {f"mamba.{i}": mamba_spec for i in range(3)}
         uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
         self.assertIsNotNone(uniform_spec)
-        kv_cache_group = KVCacheGroupSpec(
-            layer_names=list(layer_specs),
-            kv_cache_spec=uniform_spec,
-        )
+        # ceil(133120 / 384) + 7 speculative state slots, on every DCP rank.
+        expected_width = 354
+        for spec in (mamba_spec, uniform_spec):
+            for dcp_size in (1, 4):
+                with self.subTest(spec=type(spec).__name__, dcp_size=dcp_size):
+                    config = SimpleNamespace(
+                        cache_config=SimpleNamespace(mamba_cache_mode="align"),
+                        parallel_config=SimpleNamespace(decode_context_parallel_size=dcp_size),
+                    )
+                    width = spec.max_num_blocks_per_req(config, 133120)
+                    self.assertEqual(width, expected_width)
+                    group = KVCacheGroupSpec(layer_names=list(layer_specs), kv_cache_spec=spec)
+                    with patch(
+                        "vllm_ascend.worker.block_table.get_dcp_group",
+                        return_value=SimpleNamespace(world_size=dcp_size, rank_in_group=0),
+                    ):
+                        table = BlockTable(
+                            block_size=spec.block_size,
+                            max_num_reqs=self.max_num_reqs,
+                            max_num_blocks_per_req=width,
+                            max_num_batched_tokens=self.max_num_batched_tokens,
+                            pin_memory=self.pin_memory,
+                            device=self.device,
+                            kernel_sizes=[0],
+                            num_speculative_tokens=7,
+                            kv_cache_group=group,
+                        )
 
-        with patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group:
-            mock_get_dcp_group.return_value = SimpleNamespace(
-                world_size=1,
-                rank_in_group=0,
-            )
-            from vllm_ascend.worker.block_table import BlockTable
-
-            block_table = BlockTable(
-                block_size=self.block_size,
-                max_num_reqs=self.max_num_reqs,
-                max_num_blocks_per_req=self.max_num_blocks_per_req,
-                max_num_batched_tokens=self.max_num_batched_tokens,
-                pin_memory=self.pin_memory,
-                device=self.device,
-                kernel_sizes=[0],
-                kv_cache_group=kv_cache_group,
-            )
-
-        self.assertTrue(block_table.is_mamba_group)
+                    self.assertTrue(table.is_mamba_group)
+                    self.assertEqual(table.block_table.cpu.shape[1], expected_width)
+                    self.assertEqual(table.max_num_blocks_per_req, expected_width)
+                    # Exercise the last speculative slot, not just the formula.
+                    block_ids = list(range(expected_width))
+                    table.add_row(block_ids[:-2], 0)
+                    table.append_row(block_ids[-2:], 0)
+                    np.testing.assert_array_equal(table.block_table.np[0], block_ids)
 
     def setup_block_table_data(self, block_table, num_reqs=2):
         """Helper method to populate block table with test data"""

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -11,11 +11,13 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MLAAttentionSpec,
     UniformTypeKVCacheSpecs,
 )
 
 from vllm_ascend.attention.utils import get_sfa_qsfa_packed_head_dim
 from vllm_ascend.core.kv_cache_interface import AscendMLAAttentionSpec, AscendSFAIndexerCacheSpec
+from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
 from vllm_ascend.utils import AscendDeviceType
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
@@ -51,6 +53,49 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         runner.attn_backend = backend
         return runner
 
+    @patch("vllm_ascend.worker.model_runner_v1.has_kv_transfer_group", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.apply_layerwise_kv_cache_plan")
+    def test_drafter_receives_logical_block_size_for_every_cache_group(
+        self,
+        _mock_apply_layerwise_plan,
+        _mock_has_kv_transfer_group,
+    ):
+        runner = self._build_runner()
+        runner.attn_groups = []
+        runner.model_config.enable_return_routed_experts = False
+        runner.speculative_config = SimpleNamespace(
+            use_eagle=lambda: False,
+            uses_draft_model=lambda: True,
+            uses_extract_hidden_states=lambda: False,
+        )
+        drafter = AscendDSparkProposer.__new__(AscendDSparkProposer)
+        drafter.initialize_attn_backend = MagicMock()
+        runner.drafter = drafter
+        runner.may_add_encoder_only_layers_to_kv_cache_config = MagicMock()
+        runner.maybe_add_kv_sharing_layers_to_kv_cache_groups = MagicMock()
+
+        def initialize_attn_backend(_kv_cache_config):
+            runner.attn_groups = [
+                [SimpleNamespace(kv_cache_spec=object())],
+                [SimpleNamespace(kv_cache_spec=object())],
+            ]
+
+        runner.initialize_attn_backend = MagicMock(side_effect=initialize_attn_backend)
+
+        def reinitialize_input_batch(_kv_cache_config):
+            runner.kernel_block_sizes = [[0], [128]]
+
+        runner.may_reinitialize_input_batch = MagicMock(side_effect=reinitialize_input_batch)
+        runner.initialize_kv_cache_tensors = MagicMock(return_value={})
+
+        runner.initialize_kv_cache(SimpleNamespace(kv_cache_groups=[]))
+
+        drafter.initialize_attn_backend.assert_called_once()
+        self.assertEqual(
+            drafter.initialize_attn_backend.call_args.args[1],
+            [0, 128],
+        )
+
     def test_allocate_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()
         runner.sparse_kv_offload_enabled = False
@@ -72,6 +117,53 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(k_cache_raw.numel(), kv_cache_spec.page_size_bytes)
         self.assertEqual(v_cache_raw.numel(), kv_cache_spec.page_size_bytes)
+
+    @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_draft_mla_uses_separate_target_kv_cache_group(
+        self,
+        mock_get_layers,
+        _mock_has_ec_transfer,
+    ):
+        runner = self._build_runner()
+        runner.block_size = 16
+        runner.shared_kv_cache_layers = {}
+
+        draft_attn = MLAAttention.__new__(MLAAttention)
+        torch.nn.Module.__init__(draft_attn)
+        draft_attn.impl = SimpleNamespace(fa_quant_layer=False)
+        draft_attn.get_kv_cache_spec = MagicMock(
+            return_value=MLAAttentionSpec(
+                block_size=16,
+                num_kv_heads=1,
+                head_size=576,
+                dtype=torch.bfloat16,
+                non_causal_multi_token_decode=True,
+            )
+        )
+        mock_get_layers.return_value = {"draft.self_attn": draft_attn}
+
+        draft_spec = runner.get_kv_cache_spec()["draft.self_attn"]
+        target_spec = AscendMLAAttentionSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+        )
+
+        self.assertTrue(draft_spec.non_causal_multi_token_decode)
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(
+            {
+                "target.self_attn": target_spec,
+                "draft.self_attn": draft_spec,
+            }
+        )
+        self.assertIsNone(uniform_spec)
+        with self.assertRaisesRegex(
+            AssertionError,
+            "Causal target layers and non-causal multi-token draft layers",
+        ):
+            AscendMLAAttentionSpec.merge([target_spec, draft_spec])
 
     def test_sparse_c8_indexer_reuses_raw_cache_from_shared_descriptor(self):
         runner = self._build_runner()
@@ -138,6 +230,91 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
 
         self.assertEqual(k_cache.shape, (2, 16, 8, 64))
         self.assertEqual(v_cache.shape, (2, 16, 8, 64))
+
+    @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")
+    def test_hybrid_mla_cache_uses_logical_kernel_block_shape(
+        self,
+        mock_get_layers,
+    ):
+        """A 384-token scheduler page is exposed as three 128-token blocks."""
+        runner = self._build_runner()
+        runner.use_hybrid_blocks = True
+        runner.hybrid_with_attn_and_mamba = False
+        runner.model_config.hf_text_config = SimpleNamespace(
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+        )
+
+        layer_name = "draft_attn"
+        attn_module = MLAAttention.__new__(MLAAttention)
+        torch.nn.Module.__init__(attn_module)
+        attn_module.kv_lora_rank = 512
+        attn_module.qk_rope_head_dim = 64
+        mock_get_layers.return_value = {layer_name: attn_module}
+
+        physical_block_size = 384
+        kernel_block_size = 128
+        num_physical_blocks = 2
+        kv_cache_spec = AscendMLAAttentionSpec(
+            block_size=physical_block_size,
+            num_kv_heads=1,
+            head_size=512 + 64,
+            dtype=torch.bfloat16,
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_physical_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=kv_cache_spec.page_size_bytes * num_physical_blocks,
+                    shared_by=[layer_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[layer_name],
+                    kv_cache_spec=kv_cache_spec,
+                )
+            ],
+        )
+
+        # Raw cache tensors are byte buffers. Together they contain two
+        # physical pages: 512 latent dimensions plus 64 RoPE dimensions.
+        raw_k_cache = torch.empty(
+            num_physical_blocks * physical_block_size * 512 * 2,
+            dtype=torch.uint8,
+        )
+        raw_v_cache = torch.empty(
+            num_physical_blocks * physical_block_size * 64 * 2,
+            dtype=torch.uint8,
+        )
+        backend = MagicMock()
+        backend.get_supported_kernel_block_sizes.return_value = [kernel_block_size]
+        backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
+        )
+        runner._kv_cache_spec_attn_group_iterator = lambda: [
+            SimpleNamespace(
+                kv_cache_spec=kv_cache_spec,
+                backend=backend,
+                layer_names=[layer_name],
+            )
+        ]
+
+        k_cache, v_cache = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            {layer_name: (raw_k_cache, raw_v_cache)},
+        )[layer_name]
+
+        num_kernel_blocks = num_physical_blocks * physical_block_size // kernel_block_size
+        self.assertEqual(k_cache.shape, (num_kernel_blocks, 128, 1, 512))
+        self.assertEqual(v_cache.shape, (num_kernel_blocks, 128, 1, 64))
+        self.assertEqual(
+            backend.get_kv_cache_shape.call_args.args[:2],
+            (num_kernel_blocks, kernel_block_size),
+        )
 
     @patch("vllm_ascend.worker.model_runner_v1.has_ec_transfer", return_value=False)
     @patch("vllm_ascend.worker.model_runner_v1.get_layers_from_vllm_config")

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -93,14 +93,6 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
             store_on_host=first_spec.store_on_host,
         )
 
-    def is_uniform_with_collection(self, kv_cache_specs: dict[str, KVCacheSpec]) -> bool:
-        if any(
-            getattr(spec, "non_causal_multi_token_decode", False) != self.non_causal_multi_token_decode
-            for spec in kv_cache_specs.values()
-        ):
-            return False
-        return super().is_uniform_with_collection(kv_cache_specs)
-
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size

--- a/vllm_ascend/core/kv_cache_interface.py
+++ b/vllm_ascend/core/kv_cache_interface.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import torch
 from typing_extensions import Self
@@ -53,7 +53,7 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         return self.block_size // self.compress_ratio
 
     @property
-    def page_size_bytes(self) -> int:
+    def real_page_size_bytes(self) -> int:
         return (
             self.storage_block_size
             * self.num_kv_heads
@@ -65,45 +65,41 @@ class AscendMLAAttentionSpec(MLAAttentionSpec):
         assert all(isinstance(spec, MLAAttentionSpec) for spec in specs), (
             "All attention layers in the same KV cache group must be MLAAttentionSpec."
         )
-        layout_set = {
+        ascend_layouts = {
             (
-                spec.block_size,
-                spec.num_kv_heads,
-                spec.head_size,
                 spec.scale_dim,
                 spec.scale_dtype,
-                spec.dtype,
-                spec.compress_ratio,
+                spec.cache_sparse_sfa_c8,
+                spec.store_on_host,
+                spec.alignment,
             )
             for spec in specs
         }
-        assert len(layout_set) == 1, (
-            "All attention layers in the same KV cache group must use the same KV cache layout."
+        assert len(ascend_layouts) == 1, (
+            "All attention layers in the same KV cache group must use the same Ascend KV cache layout."
         )
-        cache_dtype_str_set = set(spec.cache_dtype_str for spec in specs)
-        assert len(cache_dtype_str_set) == 1, (
-            "All attention layers in the same KV cache group must use the same quantization method."
+        non_causal_multi_token_decode_set = set(spec.non_causal_multi_token_decode for spec in specs)
+        assert len(non_causal_multi_token_decode_set) == 1, (
+            "Causal target layers and non-causal multi-token draft layers must use separate KV cache groups."
         )
-        cache_sparse_sfa_c8_set = set(spec.cache_sparse_sfa_c8 for spec in specs)
-        assert len(cache_sparse_sfa_c8_set) == 1, (
-            "All attention layers in the same KV cache group must use the same sparse SFA C8 setting."
+        first_spec = specs[0]
+        merged = super().merge(specs)
+        return replace(
+            merged,
+            scale_dim=first_spec.scale_dim,
+            scale_dtype=first_spec.scale_dtype,
+            alignment=first_spec.alignment,
+            cache_sparse_sfa_c8=first_spec.cache_sparse_sfa_c8,
+            store_on_host=first_spec.store_on_host,
         )
-        store_on_host_set = set(spec.store_on_host for spec in specs)
-        assert len(store_on_host_set) == 1, (
-            "All attention layers in the same KV cache group must use the same host storage setting."
-        )
-        return cls(
-            block_size=specs[0].block_size,
-            num_kv_heads=specs[0].num_kv_heads,
-            head_size=specs[0].head_size,
-            scale_dim=specs[0].scale_dim,
-            scale_dtype=specs[0].scale_dtype,
-            dtype=specs[0].dtype,
-            cache_dtype_str=cache_dtype_str_set.pop(),
-            compress_ratio=specs[0].compress_ratio,
-            cache_sparse_sfa_c8=specs[0].cache_sparse_sfa_c8,
-            store_on_host=store_on_host_set.pop(),
-        )
+
+    def is_uniform_with_collection(self, kv_cache_specs: dict[str, KVCacheSpec]) -> bool:
+        if any(
+            getattr(spec, "non_causal_multi_token_decode", False) != self.non_causal_multi_token_decode
+            for spec in kv_cache_specs.values()
+        ):
+            return False
+        return super().is_uniform_with_collection(kv_cache_specs)
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -584,13 +584,12 @@ else:
         eagle_attn_layer_names: list[str] | None = None,
         metrics_collector: KVCacheMetricsCollector | None = None,
         max_num_batched_tokens: int | None = None,
-        num_prefill_lookahead: int | None = None,
+        num_prefill_lookahead: int = 0,
     ) -> KVCacheCoordinator:
         # Keep pcp_world_size in this patched function for upstream call
         # compatibility; platform validation guarantees that it is one.
         del pcp_world_size
         token_budget = _select_kv_token_budget(max_model_len, max_in_flight_tokens, max_num_batched_tokens)
-        prefill_lookahead = 0 if num_prefill_lookahead is None else num_prefill_lookahead
         if _is_deepseek_v4_kv_cache_config(kv_cache_config):
             return AscendHybridKVCacheCoordinator(  # type: ignore[call-arg]
                 kv_cache_config,
@@ -606,7 +605,7 @@ else:
                 max_in_flight_tokens=token_budget,
                 max_num_batched_tokens=token_budget,
                 scheduler_block_size=scheduler_block_size,
-                num_prefill_lookahead=prefill_lookahead,
+                num_prefill_lookahead=num_prefill_lookahead,
             )
 
         if len(kv_cache_config.kv_cache_groups) == 1 or not enable_caching:
@@ -623,8 +622,7 @@ else:
             )
             orig_kwargs["max_in_flight_tokens"] = token_budget
             orig_kwargs["scheduler_block_size"] = scheduler_block_size
-            if num_prefill_lookahead is not None:
-                orig_kwargs["num_prefill_lookahead"] = num_prefill_lookahead
+            orig_kwargs["num_prefill_lookahead"] = num_prefill_lookahead
             return _orig_get_kv_cache_coordinator(**orig_kwargs)
 
         return AscendHybridKVCacheCoordinator(  # type: ignore[call-arg]
@@ -641,7 +639,7 @@ else:
             max_in_flight_tokens=token_budget,
             max_num_batched_tokens=token_budget,
             scheduler_block_size=scheduler_block_size,
-            num_prefill_lookahead=prefill_lookahead,
+            num_prefill_lookahead=num_prefill_lookahead,
         )
 
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -590,6 +590,7 @@ else:
         # compatibility; platform validation guarantees that it is one.
         del pcp_world_size
         token_budget = _select_kv_token_budget(max_model_len, max_in_flight_tokens, max_num_batched_tokens)
+        prefill_lookahead = 0 if num_prefill_lookahead is None else num_prefill_lookahead
         if _is_deepseek_v4_kv_cache_config(kv_cache_config):
             return AscendHybridKVCacheCoordinator(  # type: ignore[call-arg]
                 kv_cache_config,
@@ -605,7 +606,7 @@ else:
                 max_in_flight_tokens=token_budget,
                 max_num_batched_tokens=token_budget,
                 scheduler_block_size=scheduler_block_size,
-                num_prefill_lookahead=num_prefill_lookahead,
+                num_prefill_lookahead=prefill_lookahead,
             )
 
         if len(kv_cache_config.kv_cache_groups) == 1 or not enable_caching:
@@ -640,7 +641,7 @@ else:
             max_in_flight_tokens=token_budget,
             max_num_batched_tokens=token_budget,
             scheduler_block_size=scheduler_block_size,
-            num_prefill_lookahead=num_prefill_lookahead,
+            num_prefill_lookahead=prefill_lookahead,
         )
 
 

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -28,6 +28,26 @@ _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cach
 _orig_get_kv_cache_groups_uniform_page_size = vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size
 
 
+if UniformTypeKVCacheSpecs.max_num_blocks_per_req is KVCacheSpec.max_num_blocks_per_req:
+
+    def _uniform_type_max_num_blocks_per_req(
+        self: UniformTypeKVCacheSpecs,
+        vllm_config: VllmConfig,
+        max_len: int,
+    ) -> int:
+        """Preserve the inner spec's block-table width."""
+        widths = {spec.max_num_blocks_per_req(vllm_config, max_len) for spec in self.kv_cache_specs.values()}
+        assert len(widths) == 1, (
+            "All layers in the same KV cache group must need the same number "
+            f"of block table entries, got {sorted(widths)}."
+        )
+        return next(iter(widths))
+
+    UniformTypeKVCacheSpecs.max_num_blocks_per_req = (  # type: ignore[method-assign]
+        _uniform_type_max_num_blocks_per_req
+    )
+
+
 def _ascend_resolve_kv_cache_block_sizes(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -24,18 +24,8 @@ from vllm.v1.kv_cache_interface import (
 
 _KIMI_K3_TARGET_LAYER_PREFIX = "language_model.model.layers."
 _KIMI_K3_DRAFT_LAYER_PREFIX = "model.layers."
-_ATTENTION_LAYER_SUFFIX = ".self_attn.attn"
-_MAMBA_LAYER_SUFFIX = ".self_attn"
-
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 _orig_get_kv_cache_groups_uniform_page_size = vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size
-
-
-class _MambaUniformKVCacheSpecs(UniformTypeKVCacheSpecs):
-    """Preserve Mamba-specific worker block-table capacity after grouping."""
-
-    def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
-        return max(spec.max_num_blocks_per_req(vllm_config, max_len) for spec in self.kv_cache_specs.values())
 
 
 def _ascend_resolve_kv_cache_block_sizes(
@@ -74,40 +64,6 @@ def _ascend_resolve_kv_cache_block_sizes(
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
 
 
-def _is_kimi_k3_target_attention_layer(layer_name: str, spec: KVCacheSpec) -> bool:
-    return (
-        layer_name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX)
-        and layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
-        and isinstance(spec, FullAttentionSpec)
-        and not spec.non_causal
-        and spec.sliding_window is None
-        and spec.attention_chunk_size is None
-        and not getattr(spec, "non_causal_multi_token_decode", False)
-    )
-
-
-def _is_kimi_k3_dspark_attention_layer(layer_name: str, spec: KVCacheSpec) -> bool:
-    return (
-        layer_name.startswith(_KIMI_K3_DRAFT_LAYER_PREFIX)
-        and layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
-        and isinstance(spec, FullAttentionSpec)
-        and not spec.non_causal
-        and spec.sliding_window is None
-        and spec.attention_chunk_size is None
-    )
-
-
-def _is_kimi_k3_mamba_layer(layer_name: str, spec: KVCacheSpec) -> bool:
-    return (
-        layer_name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX)
-        and layer_name.endswith(_MAMBA_LAYER_SUFFIX)
-        and not layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
-        and isinstance(spec, MambaSpec)
-        and spec.mamba_cache_mode == "align"
-        and spec.num_speculative_blocks > 0
-    )
-
-
 def _get_kimi_k3_dspark_mixed_kv_cache_groups(
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> list[KVCacheGroupSpec] | None:
@@ -126,12 +82,20 @@ def _get_kimi_k3_dspark_mixed_kv_cache_groups(
     hybrid grouping.
     """
     target_attention_specs = {
-        name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_target_attention_layer(name, spec)
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX) and isinstance(spec, FullAttentionSpec)
     }
     draft_attention_specs = {
-        name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_dspark_attention_layer(name, spec)
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if name.startswith(_KIMI_K3_DRAFT_LAYER_PREFIX) and isinstance(spec, FullAttentionSpec)
     }
-    mamba_specs = {name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_mamba_layer(name, spec)}
+    mamba_specs = {
+        name: spec
+        for name, spec in kv_cache_spec.items()
+        if name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX) and isinstance(spec, MambaSpec)
+    }
 
     matched_layer_count = len(target_attention_specs) + len(draft_attention_specs) + len(mamba_specs)
     if (
@@ -169,7 +133,7 @@ def _get_kimi_k3_dspark_mixed_kv_cache_groups(
     for group_idx in range(mamba_group_count):
         layer_names = mamba_layer_names[group_idx::mamba_group_count]
         group_specs = {name: mamba_specs[name] for name in layer_names}
-        uniform_mamba_spec = _MambaUniformKVCacheSpecs.from_specs(group_specs)
+        uniform_mamba_spec = UniformTypeKVCacheSpecs.from_specs(group_specs)
         assert uniform_mamba_spec is not None
         groups.append(
             KVCacheGroupSpec(

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -5,19 +5,37 @@ from collections import defaultdict
 
 import vllm.v1.core.kv_cache_utils
 from vllm.config import VllmConfig
+from vllm.logger import logger
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.v1.core.kv_cache_utils import _approximate_gcd, may_override_num_blocks
 from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVCacheSpecKind,
     KVCacheTensor,
+    MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     UniformTypeKVCacheSpecs,
+    get_kv_cache_spec_kind,
 )
 
+_KIMI_K3_TARGET_LAYER_PREFIX = "language_model.model.layers."
+_KIMI_K3_DRAFT_LAYER_PREFIX = "model.layers."
+_ATTENTION_LAYER_SUFFIX = ".self_attn.attn"
+_MAMBA_LAYER_SUFFIX = ".self_attn"
+
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
+_orig_get_kv_cache_groups_uniform_page_size = vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size
+
+
+class _MambaUniformKVCacheSpecs(UniformTypeKVCacheSpecs):
+    """Preserve Mamba-specific worker block-table capacity after grouping."""
+
+    def max_num_blocks_per_req(self, vllm_config: VllmConfig, max_len: int) -> int:
+        return max(spec.max_num_blocks_per_req(vllm_config, max_len) for spec in self.kv_cache_specs.values())
 
 
 def _ascend_resolve_kv_cache_block_sizes(
@@ -54,6 +72,133 @@ def _ascend_resolve_kv_cache_block_sizes(
         return scheduler_block_size, hash_block_size
 
     return _orig_resolve_kv_cache_block_sizes(kv_cache_config, vllm_config)
+
+
+def _is_kimi_k3_target_attention_layer(layer_name: str, spec: KVCacheSpec) -> bool:
+    return (
+        layer_name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX)
+        and layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
+        and isinstance(spec, FullAttentionSpec)
+        and not spec.non_causal
+        and spec.sliding_window is None
+        and spec.attention_chunk_size is None
+        and not getattr(spec, "non_causal_multi_token_decode", False)
+    )
+
+
+def _is_kimi_k3_dspark_attention_layer(layer_name: str, spec: KVCacheSpec) -> bool:
+    return (
+        layer_name.startswith(_KIMI_K3_DRAFT_LAYER_PREFIX)
+        and layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
+        and isinstance(spec, FullAttentionSpec)
+        and not spec.non_causal
+        and spec.sliding_window is None
+        and spec.attention_chunk_size is None
+    )
+
+
+def _is_kimi_k3_mamba_layer(layer_name: str, spec: KVCacheSpec) -> bool:
+    return (
+        layer_name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX)
+        and layer_name.endswith(_MAMBA_LAYER_SUFFIX)
+        and not layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
+        and isinstance(spec, MambaSpec)
+        and spec.mamba_cache_mode == "align"
+        and spec.num_speculative_blocks > 0
+    )
+
+
+def _get_kimi_k3_dspark_mixed_kv_cache_groups(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec] | None:
+    """Build topology-independent Kimi K3 DSpark scheduler groups.
+
+    Target and causal draft attention layers require the same full-sequence
+    block ownership. Putting them in one UniformType group lets them share one
+    scheduler block table while preserving a separate physical page per layer.
+    Recurrent layers are split into the fewest balanced groups whose size does
+    not exceed the attention group. This minimizes scheduler groups while
+    keeping the recurrent groups balanced.
+
+    Block and page sizes are resolved by the runtime and intentionally not
+    fixed here: TP8 and TP16 produce different sizes but the same ownership
+    relation. A partial or incompatible signature falls back to vLLM's generic
+    hybrid grouping.
+    """
+    target_attention_specs = {
+        name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_target_attention_layer(name, spec)
+    }
+    draft_attention_specs = {
+        name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_dspark_attention_layer(name, spec)
+    }
+    mamba_specs = {name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_mamba_layer(name, spec)}
+
+    matched_layer_count = len(target_attention_specs) + len(draft_attention_specs) + len(mamba_specs)
+    if (
+        not target_attention_specs
+        or not draft_attention_specs
+        or not mamba_specs
+        or matched_layer_count != len(kv_cache_spec)
+    ):
+        return None
+
+    all_specs = [*target_attention_specs.values(), *draft_attention_specs.values(), *mamba_specs.values()]
+    if len({spec.block_size for spec in all_specs}) != 1 or len({spec.page_size_bytes for spec in all_specs}) != 1:
+        return None
+
+    first_mamba_spec = next(iter(mamba_specs.values()))
+    if any(spec != first_mamba_spec for spec in mamba_specs.values()):
+        return None
+
+    # Insert target attention first. generate_scheduler_kv_cache_config unwraps a
+    # UniformType group to its first spec, and this representative is registered
+    # with the FullAttentionManager needed by both target and draft attention.
+    mixed_attention_specs = {**target_attention_specs, **draft_attention_specs}
+    mixed_attention_spec = UniformTypeKVCacheSpecs.from_specs(mixed_attention_specs)
+    if mixed_attention_spec is None:
+        return None
+
+    groups = [
+        KVCacheGroupSpec(
+            layer_names=list(mixed_attention_specs),
+            kv_cache_spec=mixed_attention_spec,
+        )
+    ]
+    mamba_layer_names = list(mamba_specs)
+    mamba_group_count = cdiv(len(mamba_layer_names), len(mixed_attention_specs))
+    for group_idx in range(mamba_group_count):
+        layer_names = mamba_layer_names[group_idx::mamba_group_count]
+        group_specs = {name: mamba_specs[name] for name in layer_names}
+        uniform_mamba_spec = _MambaUniformKVCacheSpecs.from_specs(group_specs)
+        assert uniform_mamba_spec is not None
+        groups.append(
+            KVCacheGroupSpec(
+                layer_names=layer_names,
+                kv_cache_spec=uniform_mamba_spec,
+            )
+        )
+
+    logger.info(
+        "Using Kimi K3 DSpark mixed KV grouping: %d target + %d draft attention layers, followed by Mamba groups %s",
+        len(target_attention_specs),
+        len(draft_attention_specs),
+        [len(group.layer_names) for group in groups[1:]],
+    )
+    return groups
+
+
+def _get_kv_cache_groups_uniform_page_size(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    kimi_k3_groups = _get_kimi_k3_dspark_mixed_kv_cache_groups(kv_cache_spec)
+    if kimi_k3_groups is not None:
+        return kimi_k3_groups
+    return _orig_get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+
+
+def _kv_cache_config_has_mamba_layers(self: KVCacheConfig) -> bool:
+    """Recognize Mamba layers nested in UniformType cache groups."""
+    return any(get_kv_cache_spec_kind(group.kv_cache_spec) == KVCacheSpecKind.MAMBA for group in self.kv_cache_groups)
 
 
 def group_and_unify_kv_cache_specs(
@@ -248,10 +393,14 @@ def _get_kv_cache_config_deepseek_v4(
 vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_cache_block_sizes
 vllm.v1.core.kv_cache_utils.group_and_unify_kv_cache_specs = group_and_unify_kv_cache_specs
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_groups_uniform_groups
+vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size = _get_kv_cache_groups_uniform_page_size
 # vLLM v0.24.0 renamed _get_kv_cache_config_deepseek_v4 to _get_kv_cache_config_packed and
 # get_kv_cache_config_from_groups now calls _get_kv_cache_config_packed directly, bypassing
 # the alias patch above. Patch the canonical name so Ascend's non-packed layout is used.
 vllm.v1.core.kv_cache_utils._get_kv_cache_config_packed = _get_kv_cache_config_deepseek_v4
+KVCacheConfig.has_mamba_layers = property(  # type: ignore[assignment]
+    _kv_cache_config_has_mamba_layers
+)
 
 # Also patch the reference used by engine/core.py which imports the function directly.
 import vllm.v1.engine.core  # noqa: E402

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -8,7 +8,11 @@ from vllm.config import CacheConfig
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
@@ -21,6 +25,31 @@ from vllm_ascend.utils import is_310p
 
 def _can_launch_triton_batch_memcpy() -> bool:
     return not is_310p()
+
+
+def _get_mamba_groups(
+    kv_cache_config: KVCacheConfig,
+) -> tuple[list[int], MambaSpec]:
+    """Find Mamba groups, including uniform worker-side group wrappers."""
+    mamba_group_ids: list[int] = []
+    mamba_specs: list[MambaSpec] = []
+    for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, MambaSpec):
+            mamba_group_ids.append(group_id)
+            mamba_specs.append(group_spec)
+            continue
+        if not isinstance(group_spec, UniformTypeKVCacheSpecs):
+            continue
+
+        inner_specs = list(group_spec.kv_cache_specs.values())
+        if inner_specs and all(isinstance(spec, MambaSpec) for spec in inner_specs):
+            mamba_group_ids.append(group_id)
+            mamba_specs.append(inner_specs[0])
+
+    assert mamba_group_ids, "no mamba layers in the model"
+    assert all(mamba_specs[0] == spec for spec in mamba_specs)
+    return mamba_group_ids, mamba_specs[0]
 
 
 def _batch_memcpy_triton(src_ptrs, dst_ptrs, sizes):
@@ -203,6 +232,11 @@ else:
     mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch
     mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_torch
     mamba_utils.postprocess_mamba_align_gpu = _postprocess_mamba_align_gpu_cpu_fallback
+
+# Worker KV configs retain UniformTypeKVCacheSpecs so per-layer physical page
+# layouts are available while the scheduler receives unwrapped representative
+# specs. Teach all upstream Mamba buffer/context helpers to see those groups.
+mamba_utils.get_mamba_groups = _get_mamba_groups
 
 # Ascend NPU does not support DT_UINT64 in aclnnInplaceZero.
 # MambaCopyBuffers.create() uses torch.uint64 for src_ptrs/dst_ptrs,

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -3,7 +3,11 @@ import torch
 from vllm.distributed import get_dcp_group
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
-from vllm.v1.kv_cache_interface import KVCacheGroupSpec, MambaSpec
+from vllm.v1.kv_cache_interface import (
+    KVCacheGroupSpec,
+    KVCacheSpecKind,
+    get_kv_cache_spec_kind,
+)
 from vllm.v1.utils import CpuGpuBuffer
 
 from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
@@ -30,23 +34,19 @@ class BlockTable:
         self.max_num_reqs = max_num_reqs
         self.dcp_world_size = get_dcp_group().world_size
         self.dcp_rank = get_dcp_group().rank_in_group
-        if (
+        is_mamba_group = (
             kv_cache_group is not None
             and hasattr(kv_cache_group, "kv_cache_spec")
-            and self.dcp_world_size > 1
-            and isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
-        ):
+            and get_kv_cache_spec_kind(kv_cache_group.kv_cache_spec) == KVCacheSpecKind.MAMBA
+        )
+        if self.dcp_world_size > 1 and is_mamba_group:
             max_num_blocks_per_req = max_num_blocks_per_req * self.dcp_world_size
         self.max_num_blocks_per_req = max_num_blocks_per_req
         self.max_num_batched_tokens = max_num_batched_tokens
         self.pin_memory = pin_memory
         self.device = device
         self.physical_block_size = block_size
-        self.is_mamba_group = (
-            kv_cache_group is not None
-            and hasattr(kv_cache_group, "kv_cache_spec")
-            and isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
-        )
+        self.is_mamba_group = is_mamba_group
 
         # If kernel_sizes is None or [0], use physical block size (no splitting)
         if kernel_sizes is None or kernel_sizes == [0]:

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -39,8 +39,8 @@ class BlockTable:
             and hasattr(kv_cache_group, "kv_cache_spec")
             and get_kv_cache_spec_kind(kv_cache_group.kv_cache_spec) == KVCacheSpecKind.MAMBA
         )
-        if self.dcp_world_size > 1 and is_mamba_group:
-            max_num_blocks_per_req = max_num_blocks_per_req * self.dcp_world_size
+        # The KV cache spec already provides the per-rank table capacity.
+        # Mamba state is replicated across DCP ranks, not sharded then expanded.
         self.max_num_blocks_per_req = max_num_blocks_per_req
         self.max_num_batched_tokens = max_num_batched_tokens
         self.pin_memory = pin_memory

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3666,6 +3666,8 @@ class NPUModelRunner(GPUModelRunner):
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
         self.use_hybrid_blocks = len(self.attn_groups) > 1
+        # K3's packed layout keeps Mamba specs inside UniformType groups, so the
+        # old first-spec scan over attn_groups cannot recognize them.
         self.need_accepted_tokens = kv_cache_config.has_mamba_layers
 
         self.may_reinitialize_input_batch(kv_cache_config)
@@ -3689,25 +3691,17 @@ class NPUModelRunner(GPUModelRunner):
                 self.drafter,
                 AscendEagleProposer | AscendDflashProposer | AscendDSparkProposer | AscendDraftModelProposer,
             )
+            kernel_block_sizes = self.kernel_block_sizes
             if isinstance(self.drafter, AscendDSparkProposer):
-                if isinstance(self.kernel_block_sizes, list):
-                    draft_kernel_block_sizes = [
-                        int(sizes[0] if isinstance(sizes, (list, tuple)) else sizes)
-                        for sizes in self.kernel_block_sizes
-                    ]
-                else:
-                    draft_kernel_block_sizes = [int(self.kernel_block_sizes)]
-                self.drafter.initialize_attn_backend(
-                    kv_cache_config,
-                    draft_kernel_block_sizes,
-                )
+                sizes = kernel_block_sizes if isinstance(kernel_block_sizes, list) else [kernel_block_sizes]
+                draft_kernel_block_sizes = [
+                    int(size[0] if isinstance(size, (list, tuple)) else size) for size in sizes
+                ]
             else:
-                block_size = (
-                    self.kernel_block_sizes[0]
-                    if isinstance(self.kernel_block_sizes, list)
-                    else self.kernel_block_sizes
+                draft_kernel_block_sizes = (
+                    kernel_block_sizes[0] if isinstance(kernel_block_sizes, list) else kernel_block_sizes
                 )
-                self.drafter.initialize_attn_backend(kv_cache_config, block_size)
+            self.drafter.initialize_attn_backend(kv_cache_config, draft_kernel_block_sizes)
 
         if (
             self.speculative_config

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -143,7 +143,6 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
     reshape_kv_cache_tensors_for_sparse_kv_offload,
     update_sparse_kv_offload_metadata,
 )
-from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
@@ -3667,10 +3666,7 @@ class NPUModelRunner(GPUModelRunner):
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
         self.use_hybrid_blocks = len(self.attn_groups) > 1
-        # NOTE: Currently, we determine whether we need `num_accepted_tokens` through `MambaSpec`.
-        self.need_accepted_tokens = any(
-            [isinstance(attn_group[0].kv_cache_spec, MambaSpec) for attn_group in self.attn_groups]
-        )
+        self.need_accepted_tokens = kv_cache_config.has_mamba_layers
 
         self.may_reinitialize_input_batch(kv_cache_config)
         if self.sparse_kv_offload_enabled:
@@ -3693,10 +3689,26 @@ class NPUModelRunner(GPUModelRunner):
                 self.drafter,
                 AscendEagleProposer | AscendDflashProposer | AscendDSparkProposer | AscendDraftModelProposer,
             )
-            block_size = (self.kernel_block_sizes[0] if isinstance(
-                self.kernel_block_sizes, list) else self.kernel_block_sizes)
-            self.drafter.initialize_attn_backend(kv_cache_config, block_size)
-        
+            if isinstance(self.drafter, AscendDSparkProposer):
+                if isinstance(self.kernel_block_sizes, list):
+                    draft_kernel_block_sizes = [
+                        int(sizes[0] if isinstance(sizes, (list, tuple)) else sizes)
+                        for sizes in self.kernel_block_sizes
+                    ]
+                else:
+                    draft_kernel_block_sizes = [int(self.kernel_block_sizes)]
+                self.drafter.initialize_attn_backend(
+                    kv_cache_config,
+                    draft_kernel_block_sizes,
+                )
+            else:
+                block_size = (
+                    self.kernel_block_sizes[0]
+                    if isinstance(self.kernel_block_sizes, list)
+                    else self.kernel_block_sizes
+                )
+                self.drafter.initialize_attn_backend(kv_cache_config, block_size)
+
         if (
             self.speculative_config
             and self.speculative_config.uses_extract_hidden_states()
@@ -4528,18 +4540,10 @@ class NPUModelRunner(GPUModelRunner):
         max_num_blocks = []
         max_model_len = max(self.max_model_len, self.max_encoder_len)
         for kv_cache_group in non_encoder_groups:
-            max_num_blocks_per_req = cdiv(
+            max_num_blocks_per_req = kv_cache_group.kv_cache_spec.max_num_blocks_per_req(
+                self.vllm_config,
                 max_model_len,
-                kv_cache_group.kv_cache_spec.block_size
-                * get_decode_context_model_parallel_world_size(),
             )
-            if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
-                mamba_blocks_per_req = (
-                    max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1
-                ) 
-
-                max_num_blocks_per_req = max(max_num_blocks_per_req, mamba_blocks_per_req)
-                max_num_blocks_per_req += kv_cache_group.kv_cache_spec.num_speculative_blocks
             max_num_blocks.append(max_num_blocks_per_req)
 
         if (block_sizes != [self.cache_config.block_size]
@@ -4754,6 +4758,7 @@ class NPUModelRunner(GPUModelRunner):
                         head_size=head_size,
                         dtype=dtype,
                         cache_dtype_str=cache_dtype_str,
+                        non_causal_multi_token_decode=spec.non_causal_multi_token_decode,
                     )
                     attn_layer_names.add(layer_name)
 


### PR DESCRIPTION
### What this PR does / why we need it?

- Groups Kimi K3 target attention and DSpark draft attention by shared scheduler block ownership while retaining each layer's exact physical cache spec.
- Splits recurrent layers into the minimum balanced group count derived from the runtime layer layout.
- Supports TP8 and TP16, plus both GQA and MLA DSpark drafts, without hard-coding block or page sizes.
- Carries logical and physical block sizes through scheduler, block-table, model-runner, Mamba, and DSpark metadata paths.
- Preserves upstream MLA compression fields and separates causal target MLA from non-causal multi-token draft MLA.
- Preserves Mamba request capacity for Prefix Cache and speculative blocks by forwarding UniformTypeKVCacheSpecs capacity calculation to its inner specs when upstream still inherits the generic formula.
- Allocates block tables from the resolved per-rank capacity without multiplying replicated Mamba tables by DCP again. For a 133120-token limit, 384-token blocks and seven speculative slots, scheduler and worker both retain 354 columns at DCP1 and DCP4.

For the Kimi K3 layout, 24 target attention layers plus five draft layers form one group and 69 recurrent layers form three balanced groups: **29/23/23/23**. Both GQA and MLA DSpark create **five exact-spec metadata builders**: two attention builders plus three recurrent builders.

### Dependencies

Merge after #14597 and #14601.

### How was this patch tested?

- 31 targeted CPU block-table and Prefix Cache tests pass on vLLM 0.27.1; two coordinator-API cases introduced after v0.27.1 are skipped. Tests check raw/wrapped Mamba specs, DCP1/DCP4, scheduler/worker agreement, and writes to the last speculative slots. `bash format.sh ci` passes. Full-model NPU serving was not rerun for these capacity changes.

- `git diff --check`
- Python bytecode compilation for all changed implementation and test files
- Focused TP8/TP16, GQA/MLA, scheduler, Mamba-wrapper, block-table, compressed-cache, capacity, fallback, and proposer tests
- Integrated four-node DSpark coverage for known accuracy, Prefix Cache, long-context, concurrency, and hang-trigger cases

### Does this PR introduce any user-facing change?

Yes. Compatible Kimi K3 DSpark deployments use four topology-derived KV groups for TP8 and TP16.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
