### PR TITLE
[v0.26.0rc][Feature][SpecDecode] Support Kimi K3 GQA and MLA DSpark

### DIFF
--- a/tests/ut/models/test_kimi_k3_dspark.py
+++ b/tests/ut/models/test_kimi_k3_dspark.py
@@ -4,9 +4,21 @@ from vllm_ascend.models.kimi_k3_dspark import K3DSparkForCausalLM, K3DSparkModel
 
 
 def test_k3_mla_draft_reports_non_causal_attention_per_layer():
-    draft_model = SimpleNamespace(layers=[object(), object(), object()])
+    draft_model = SimpleNamespace(config=SimpleNamespace(), layers=[object(), object(), object()])
 
     assert K3DSparkModel.get_draft_attn_causal(draft_model) == [False, False, False]
+
+
+def test_k3_mla_draft_uses_checkpoint_attention_causality():
+    draft_model = SimpleNamespace(
+        config=SimpleNamespace(
+            full_attention_causal=True,
+            dflash_config={"causal": True},
+        ),
+        layers=[object(), object(), object()],
+    )
+
+    assert K3DSparkModel.get_draft_attn_causal(draft_model) == [True, True, True]
 
 
 def test_k3_mla_causal_lm_forwards_attention_causality():

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -1,12 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 import torch
 from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import generate_scheduler_kv_cache_config
 from vllm.v1.core.single_type_kv_cache_manager import (
     SlidingWindowManager,
 )
@@ -28,6 +30,8 @@ from vllm_ascend.patch.platform.patch_kv_cache_coordinator import (
 )
 from vllm_ascend.patch.platform.patch_kv_cache_utils import (
     _ascend_resolve_kv_cache_block_sizes,
+    _get_kimi_k3_gqa_mixed_kv_cache_groups,
+    _get_kv_cache_config_deepseek_v4,
 )
 from vllm_ascend.patch.platform.patch_mamba_manager import AscendMambaManager
 
@@ -100,16 +104,47 @@ def _make_vllm_config(
     enable_prefix_caching: bool,
     dcp: int,
     block_size: int = 16,
+    mamba_cache_mode: str = "none",
 ) -> SimpleNamespace:
     return SimpleNamespace(
         cache_config=SimpleNamespace(
             block_size=block_size,
             enable_prefix_caching=enable_prefix_caching,
+            mamba_cache_mode=mamba_cache_mode,
         ),
         parallel_config=SimpleNamespace(
             decode_context_parallel_size=dcp,
         ),
     )
+
+
+def _make_kimi_k3_gqa_kv_cache_specs(page_size: int = 488448) -> dict:
+    target_mla_spec = MLAAttentionSpec(
+        block_size=384,
+        num_kv_heads=1,
+        head_size=576,
+        dtype=torch.bfloat16,
+        page_size_padded=page_size,
+    )
+    draft_gqa_spec = FullAttentionSpec(
+        block_size=384,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.bfloat16,
+        page_size_padded=page_size,
+    )
+    mamba_spec = MambaSpec(
+        block_size=384,
+        shapes=((10, 2304), (6, 128, 128)),
+        dtypes=(torch.bfloat16, torch.float32),
+        page_size_padded=page_size,
+        mamba_cache_mode="align",
+        num_speculative_blocks=7,
+    )
+    specs = {f"language_model.model.layers.{layer_idx}.self_attn.attn": target_mla_spec for layer_idx in range(24)}
+    specs.update({f"model.layers.{layer_idx}.self_attn.attn": draft_gqa_spec for layer_idx in range(93, 98)})
+    specs.update({f"language_model.model.layers.{layer_idx}.self_attn": mamba_spec for layer_idx in range(69)})
+    return specs
 
 
 def _make_coordinator_for_effective_block_size(
@@ -459,3 +494,104 @@ def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:
         f"expected {expected} cached blocks ({4}/{128} per segment), got {true_blocks}/{total_blocks}"
     )
     assert true_blocks > 0 and true_blocks < total_blocks, f"mask should be sparse, got {true_blocks}/{total_blocks}"
+
+
+def test_kimi_k3_gqa_uses_four_mixed_kv_groups_and_five_builders() -> None:
+    groups = _get_kimi_k3_gqa_mixed_kv_cache_groups(_make_kimi_k3_gqa_kv_cache_specs())
+
+    assert groups is not None
+    assert [len(group.layer_names) for group in groups] == [29, 23, 23, 23]
+    assert all(isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs) for group in groups)
+
+    mixed_specs = groups[0].kv_cache_spec.kv_cache_specs
+    assert sum(isinstance(spec, MLAAttentionSpec) for spec in mixed_specs.values()) == 24
+    assert (
+        sum(
+            isinstance(spec, FullAttentionSpec) and not isinstance(spec, MLAAttentionSpec)
+            for spec in mixed_specs.values()
+        )
+        == 5
+    )
+
+    # The model runner keys builders by backend and exact inner spec. The
+    # mixed attention group contributes MLA + GQA, and each Mamba group one.
+    metadata_builder_count = sum(
+        len({type(spec) for spec in group.kv_cache_spec.kv_cache_specs.values()}) for group in groups
+    )
+    assert metadata_builder_count == 5
+
+
+def test_kimi_k3_gqa_mixed_groups_preserve_scheduler_and_mamba_contracts() -> None:
+    groups = _get_kimi_k3_gqa_mixed_kv_cache_groups(_make_kimi_k3_gqa_kv_cache_specs())
+    assert groups is not None
+    worker_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+    assert worker_config.has_mamba_layers
+    assert worker_config.needs_kv_cache_zeroing
+    assert (
+        groups[1].kv_cache_spec.max_num_blocks_per_req(
+            _make_vllm_config(
+                enable_prefix_caching=True,
+                dcp=1,
+                block_size=384,
+                mamba_cache_mode="align",
+            ),
+            3840,
+        )
+        == 17
+    )
+
+    scheduler_config = generate_scheduler_kv_cache_config([worker_config])
+    assert isinstance(scheduler_config.kv_cache_groups[0].kv_cache_spec, MLAAttentionSpec)
+    assert all(isinstance(group.kv_cache_spec, MambaSpec) for group in scheduler_config.kv_cache_groups[1:])
+    assert scheduler_config.needs_kv_cache_zeroing
+
+
+def test_kimi_k3_gqa_mixed_groups_use_expected_physical_layout(monkeypatch) -> None:
+    groups = _get_kimi_k3_gqa_mixed_kv_cache_groups(_make_kimi_k3_gqa_kv_cache_specs())
+    assert groups is not None
+    page_size = 488448
+    expected_num_blocks = 100
+    available_memory = page_size * 29 * expected_num_blocks
+    monkeypatch.setattr(
+        "vllm_ascend.patch.platform.patch_kv_cache_utils.may_override_num_blocks",
+        lambda _config, num_blocks: num_blocks,
+    )
+
+    num_blocks, tensors = _get_kv_cache_config_deepseek_v4(
+        SimpleNamespace(),
+        groups,
+        available_memory,
+    )
+
+    assert num_blocks == expected_num_blocks
+    assert len(tensors) == 29
+    assert [len(tensor.shared_by) for tensor in tensors] == [4] * 23 + [1] * 6
+    assert all(tensor.size == page_size * expected_num_blocks for tensor in tensors)
+    assert sum(tensor.size for tensor in tensors) == available_memory
+
+
+def test_kimi_k3_gqa_mixed_grouping_falls_back_on_partial_signature() -> None:
+    specs = _make_kimi_k3_gqa_kv_cache_specs()
+    draft_layer = "model.layers.93.self_attn.attn"
+    specs[draft_layer] = replace(specs[draft_layer], non_causal=True)
+
+    assert _get_kimi_k3_gqa_mixed_kv_cache_groups(specs) is None
+
+
+def test_kimi_k3_gqa_mixed_grouping_accepts_derived_page_size() -> None:
+    groups = _get_kimi_k3_gqa_mixed_kv_cache_groups(_make_kimi_k3_gqa_kv_cache_specs(page_size=976896))
+    assert groups is not None
+    assert all(spec.page_size_bytes == 976896 for spec in groups[0].kv_cache_spec.kv_cache_specs.values())
+
+
+def test_kimi_k3_gqa_mixed_grouping_falls_back_on_unaligned_pages() -> None:
+    specs = _make_kimi_k3_gqa_kv_cache_specs()
+    draft_layer = "model.layers.93.self_attn.attn"
+    specs[draft_layer] = replace(specs[draft_layer], page_size_padded=98304)
+
+    assert _get_kimi_k3_gqa_mixed_kv_cache_groups(specs) is None

--- a/tests/ut/patch/worker/test_patch_mamba_utils_uniform_groups.py
+++ b/tests/ut/patch/worker/test_patch_mamba_utils_uniform_groups.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    MambaSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.worker.mamba_utils import MambaCopyBuffers
+
+from vllm_ascend.patch.worker.patch_mamba_utils import _get_mamba_groups
+
+
+def test_uniform_mamba_groups_are_visible_to_all_mamba_buffers() -> None:
+    mamba_spec = MambaSpec(
+        block_size=384,
+        shapes=((10, 2304), (6, 128, 128)),
+        dtypes=(torch.bfloat16, torch.float32),
+        page_size_padded=488448,
+        mamba_cache_mode="align",
+        num_speculative_blocks=7,
+    )
+    groups = []
+    for group_id in range(3):
+        layer_specs = {f"mamba.{group_id}.{layer_id}": mamba_spec for layer_id in range(23)}
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+        assert uniform_spec is not None
+        groups.append(
+            KVCacheGroupSpec(
+                layer_names=list(layer_specs),
+                kv_cache_spec=uniform_spec,
+            )
+        )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=100,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+
+    group_ids, resolved_spec = _get_mamba_groups(kv_cache_config)
+    assert group_ids == [0, 1, 2]
+    assert resolved_spec == mamba_spec
+
+    def make_buffer(n: int, dtype: torch.dtype) -> SimpleNamespace:
+        return SimpleNamespace(n=n, dtype=dtype)
+
+    copy_bufs = MambaCopyBuffers.create(
+        max_num_reqs=2,
+        kv_cache_config=kv_cache_config,
+        copy_funcs=(object(), object()),
+        make_buffer=make_buffer,
+    )
+    assert copy_bufs.mamba_group_ids == [0, 1, 2]
+    assert copy_bufs.mamba_spec == mamba_spec
+    assert copy_bufs.src_ptrs.n == 2 * 69 * 2
+    assert copy_bufs.src_ptrs.dtype == torch.int64
+    assert copy_bufs.dst_ptrs.dtype == torch.int64
+    assert copy_bufs.sizes.dtype == torch.int32

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -26,6 +26,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 import torch
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec, UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
 
 import vllm_ascend.spec_decode.dspark_proposer as dspark_proposer_module
@@ -839,6 +840,75 @@ class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):
             call.kwargs["kernel_block_size"]
             for call in create_builders.call_args_list
         ] == [128, 64]
+
+    def test_mixed_target_and_gqa_group_creates_one_draft_attention_group(
+        self, monkeypatch
+    ):
+        page_size = 488448
+        target_layer = "language_model.model.layers.3.self_attn.attn"
+        draft_layers = [
+            f"model.layers.{layer_idx}.self_attn.attn"
+            for layer_idx in range(93, 98)
+        ]
+        target_spec = MLAAttentionSpec(
+            block_size=384,
+            num_kv_heads=1,
+            head_size=576,
+            dtype=torch.bfloat16,
+            page_size_padded=page_size,
+        )
+        draft_spec = FullAttentionSpec(
+            block_size=384,
+            num_kv_heads=1,
+            head_size=64,
+            dtype=torch.bfloat16,
+            page_size_padded=page_size,
+        )
+        mixed_spec = UniformTypeKVCacheSpecs.from_specs(
+            {
+                target_layer: target_spec,
+                **{layer_name: draft_spec for layer_name in draft_layers},
+            }
+        )
+        assert mixed_spec is not None
+
+        backend = MagicMock()
+        backend.full_cls_name.return_value = "fake.gqa.backend"
+        layers = {}
+        for layer_name in draft_layers:
+            layer = MagicMock()
+            layer.get_attn_backend.return_value = backend
+            layers[layer_name] = layer
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.dspark_proposer.get_layers_from_vllm_config",
+            lambda *args, **kwargs: layers,
+        )
+
+        proposer = self._make_proposer_for_init()
+        proposer.model = SimpleNamespace(
+            get_draft_kv_cache_layer_names=lambda: set(draft_layers)
+        )
+        proposer.max_query_tokens = 16
+        proposer.max_num_tokens = 32
+        kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=[target_layer, *draft_layers],
+                    kv_cache_spec=mixed_spec,
+                )
+            ]
+        )
+
+        with patch.object(AttentionGroup, "create_metadata_builders"):
+            proposer.initialize_attn_backend(
+                kv_cache_config,
+                kernel_block_sizes=[128],
+            )
+
+        assert len(proposer.draft_attn_groups) == 1
+        assert set(proposer.draft_attn_groups[0].layer_names) == set(draft_layers)
+        assert proposer.draft_attn_groups[0].kv_cache_group_id == 0
+        assert proposer._layer_group_idx == [0] * 5
 
     def test_k3_initialization_enables_rope_on_mla_builders(self, monkeypatch):
         class FakeK3Config:

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -198,6 +198,30 @@ class TestQuaRotDraftBoundaries:
         torch.testing.assert_close(context_proj.weight, expected)
         torch.testing.assert_close(proposer._quarot_rotation, rotation)
 
+    def test_qwen3_dspark_keeps_fc_and_still_loads_rotation(self, monkeypatch):
+        proposer = self._make_proposer()
+        rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]], dtype=torch.float32)
+        fc = nn.Linear(10, 2, bias=False)
+        initial_weight = torch.arange(1.0, 21.0).reshape(2, 10)
+        fc.weight.data.copy_(initial_weight)
+
+        class FakeQwen3DSpark:
+            pass
+
+        fake_model = FakeQwen3DSpark()
+        fake_model.model = SimpleNamespace(fc=fc)
+        proposer.model = fake_model
+        monkeypatch.setattr(proposer, "_load_quarot_rotation", lambda _: rotation)
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.llm_base_proposer.Qwen3DSparkForCausalLM",
+            FakeQwen3DSpark,
+        )
+
+        proposer._maybe_anti_rotate_fc()
+
+        torch.testing.assert_close(fc.weight, initial_weight)
+        torch.testing.assert_close(proposer._quarot_rotation, rotation)
+
     def test_copies_unrotated_shared_weight_without_mutating_target(self):
         proposer = self._make_proposer()
         proposer._quarot_rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])

--- a/tests/ut/worker/a2/test_block_table.py
+++ b/tests/ut/worker/a2/test_block_table.py
@@ -14,6 +14,7 @@
 #
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -21,6 +22,7 @@ import torch
 
 # import vllm.utils.cpu_triton_utils as cpu_tl
 from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.v1.kv_cache_interface import KVCacheGroupSpec, MambaSpec, UniformTypeKVCacheSpecs
 
 from tests.ut.base import TestBase
 
@@ -97,6 +99,43 @@ class TestBlockTableComputeSlotMapping(TestBase):
 
         self.assertEqual(block_table.slot_mapping.cpu.numel(), 128)
         self.assertEqual(block_table.slot_mapping.cpu[: req_indices.size].numel(), 110)
+
+    def test_uniform_mamba_group_disables_slot_mapping(self):
+        mamba_spec = MambaSpec(
+            block_size=self.block_size,
+            shapes=((4, 8),),
+            dtypes=(torch.float32,),
+            page_size_padded=128,
+            mamba_cache_mode="align",
+            num_speculative_blocks=7,
+        )
+        layer_specs = {f"mamba.{i}": mamba_spec for i in range(3)}
+        uniform_spec = UniformTypeKVCacheSpecs.from_specs(layer_specs)
+        self.assertIsNotNone(uniform_spec)
+        kv_cache_group = KVCacheGroupSpec(
+            layer_names=list(layer_specs),
+            kv_cache_spec=uniform_spec,
+        )
+
+        with patch("vllm_ascend.worker.block_table.get_dcp_group") as mock_get_dcp_group:
+            mock_get_dcp_group.return_value = SimpleNamespace(
+                world_size=1,
+                rank_in_group=0,
+            )
+            from vllm_ascend.worker.block_table import BlockTable
+
+            block_table = BlockTable(
+                block_size=self.block_size,
+                max_num_reqs=self.max_num_reqs,
+                max_num_blocks_per_req=self.max_num_blocks_per_req,
+                max_num_batched_tokens=self.max_num_batched_tokens,
+                pin_memory=self.pin_memory,
+                device=self.device,
+                kernel_sizes=[0],
+                kv_cache_group=kv_cache_group,
+            )
+
+        self.assertTrue(block_table.is_mamba_group)
 
     def setup_block_table_data(self, block_table, num_reqs=2):
         """Helper method to populate block table with test data"""

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 
 import numpy as np
 import torch
+from vllm.config import CUDAGraphMode
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.models.deepseek_v2 import DeepseekV32IndexerCache
@@ -97,6 +98,33 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         )
         runner.attn_backend = backend
         return runner
+
+    def test_explicit_capture_sizes_must_align_spec_decode_and_sp(self):
+        for capture_sizes, expected_tp_size in (([48, 96], 1), ([16, 32], 16)):
+            with self.subTest(capture_sizes=capture_sizes):
+                runner = self._build_runner()
+                compilation_config = SimpleNamespace(
+                    pass_config=SimpleNamespace(enable_sp=True),
+                    cudagraph_capture_sizes=capture_sizes,
+                    resolve_cudagraph_mode_and_sizes=MagicMock(return_value=CUDAGraphMode.FULL_DECODE_ONLY),
+                )
+                runner.compilation_config = compilation_config
+                runner.vllm_config.compilation_config = compilation_config
+                runner.parallel_config = SimpleNamespace(tensor_parallel_size=16)
+                runner.uniform_decode_query_len = 6
+                runner.kv_cache_config = SimpleNamespace()
+                runner.max_num_reqs = 16
+                runner.cudagraph_dispatcher = MagicMock()
+                runner.cudagraph_dispatcher.get_capture_descs.return_value = []
+                runner.speculative_config = None
+                runner.drafter = None
+                runner.use_aclgraph = False
+
+                with patch("vllm_ascend.worker.model_runner_v1.enable_sp", return_value=True):
+                    runner._check_and_update_cudagraph_mode([], [])
+
+                call_kwargs = compilation_config.resolve_cudagraph_mode_and_sizes.call_args.kwargs
+                self.assertEqual(call_kwargs["tensor_parallel_size"], expected_tp_size)
 
     def test_allocate_kv_cache_uses_layer_spec_for_draft_gqa(self):
         runner = self._build_runner()

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -456,9 +456,12 @@ class K3DSparkModel(nn.Module):
         return [layer.self_attn.attn.layer_name for layer in self.layers]
 
     def get_draft_attn_causal(self) -> list[bool]:
-        # K3 MLA drafts verify the speculative block bidirectionally. Keep the
-        # per-layer contract aligned with get_draft_kv_cache_layer_names().
-        return [False] * len(self.layers)
+        # Older checkpoints omit the flag and use bidirectional attention.
+        causal = getattr(self.config, "full_attention_causal", False)
+        dflash_config = getattr(self.config, "dflash_config", None)
+        if dflash_config is not None:
+            causal = dflash_config.get("causal", causal)
+        return [bool(causal)] * len(self.layers)
 
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_head.embed(token_ids)

--- a/vllm_ascend/patch/platform/patch_kv_cache_utils.py
+++ b/vllm_ascend/patch/platform/patch_kv_cache_utils.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 import vllm.v1.core.kv_cache_utils
 from vllm.config import VllmConfig
+from vllm.logger import logger
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.v1.core.kv_cache_utils import _approximate_gcd, may_override_num_blocks
 from vllm.v1.kv_cache_interface import (
@@ -14,15 +15,27 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    MambaSpec,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
 
+_KIMI_K3_TARGET_MLA_LAYER_COUNT = 24
+_KIMI_K3_DSPARK_GQA_LAYER_COUNT = 5
+_KIMI_K3_MAMBA_LAYER_COUNT = 69
+_KIMI_K3_MAMBA_GROUP_COUNT = 3
+_KIMI_K3_DSPARK_SPECULATIVE_BLOCKS = 7
+_KIMI_K3_TARGET_LAYER_PREFIX = "language_model.model.layers."
+_KIMI_K3_DRAFT_LAYER_PREFIX = "model.layers."
+_ATTENTION_LAYER_SUFFIX = ".self_attn.attn"
+_MAMBA_LAYER_SUFFIX = ".self_attn"
+
 _orig_resolve_kv_cache_block_sizes = vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes
 
 _orig_get_kv_cache_groups = vllm.v1.core.kv_cache_utils.get_kv_cache_groups
+_orig_get_kv_cache_groups_uniform_page_size = vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size
 
 
 def _ascend_resolve_kv_cache_block_sizes(
@@ -108,7 +121,171 @@ def _try_get_full_allocation_fallback_groups(
     return vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_type(uniform_spec)
 
 
+def _is_kimi_k3_target_mla_layer(layer_name: str, spec: KVCacheSpec) -> bool:
+    return (
+        layer_name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX)
+        and layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
+        and isinstance(spec, MLAAttentionSpec)
+        and not isinstance(spec, SlidingWindowMLASpec)
+        and not getattr(spec, "non_causal", False)
+        and not getattr(spec, "non_causal_multi_token_decode", False)
+    )
+
+
+def _is_kimi_k3_dspark_gqa_layer(layer_name: str, spec: KVCacheSpec) -> bool:
+    return (
+        layer_name.startswith(_KIMI_K3_DRAFT_LAYER_PREFIX)
+        and layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
+        and isinstance(spec, FullAttentionSpec)
+        and not isinstance(spec, MLAAttentionSpec)
+        and not spec.non_causal
+        and spec.sliding_window is None
+        and spec.attention_chunk_size is None
+    )
+
+
+def _is_kimi_k3_mamba_layer(layer_name: str, spec: KVCacheSpec) -> bool:
+    return (
+        layer_name.startswith(_KIMI_K3_TARGET_LAYER_PREFIX)
+        and layer_name.endswith(_MAMBA_LAYER_SUFFIX)
+        and not layer_name.endswith(_ATTENTION_LAYER_SUFFIX)
+        and isinstance(spec, MambaSpec)
+        and spec.mamba_cache_mode == "align"
+        and spec.num_speculative_blocks == _KIMI_K3_DSPARK_SPECULATIVE_BLOCKS
+    )
+
+
+def _get_kimi_k3_gqa_mixed_kv_cache_groups(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec] | None:
+    """Build the Kimi K3 GQA DSpark mixed scheduler groups.
+
+    Target MLA and causal draft GQA layers require the same full-sequence
+    block ownership. Putting them in one UniformType group lets them share one
+    scheduler block table while preserving a separate physical page per layer.
+    The 69 recurrent layers are split into three equal groups, matching the
+    29-layer attention group closely enough to avoid layer padding.
+
+    Keep the signature deliberately strict. A partial match falls back to
+    vLLM's generic hybrid grouping instead of changing another model's cache
+    ownership semantics. Block and page sizes are taken from the matched specs
+    rather than hardcoded TP16/C16 constants.
+    """
+    target_mla_specs = {name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_target_mla_layer(name, spec)}
+    draft_gqa_specs = {name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_dspark_gqa_layer(name, spec)}
+    mamba_specs = {name: spec for name, spec in kv_cache_spec.items() if _is_kimi_k3_mamba_layer(name, spec)}
+
+    matched_layer_count = len(target_mla_specs) + len(draft_gqa_specs) + len(mamba_specs)
+    signature_matched = (
+        len(target_mla_specs) == _KIMI_K3_TARGET_MLA_LAYER_COUNT
+        and len(draft_gqa_specs) == _KIMI_K3_DSPARK_GQA_LAYER_COUNT
+        and len(mamba_specs) == _KIMI_K3_MAMBA_LAYER_COUNT
+        and matched_layer_count == len(kv_cache_spec)
+    )
+    if not signature_matched:
+        return None
+
+    all_specs = [*target_mla_specs.values(), *draft_gqa_specs.values(), *mamba_specs.values()]
+    block_sizes = {spec.block_size for spec in all_specs}
+    page_sizes = {spec.page_size_bytes for spec in all_specs}
+    if len(block_sizes) != 1 or len(page_sizes) != 1:
+        logger.warning(
+            "Kimi K3 GQA DSpark layer signature matched (%d MLA + %d GQA + %d "
+            "Mamba) but block/page sizes are not unified (block_sizes=%s, "
+            "page_sizes=%s). Falling back to generic hybrid grouping.",
+            len(target_mla_specs),
+            len(draft_gqa_specs),
+            len(mamba_specs),
+            sorted(block_sizes),
+            sorted(page_sizes),
+        )
+        return None
+
+    first_mamba_spec = next(iter(mamba_specs.values()))
+    if any(spec != first_mamba_spec for spec in mamba_specs.values()):
+        logger.warning("Kimi K3 GQA DSpark Mamba specs are not identical; falling back to generic hybrid grouping.")
+        return None
+
+    # Insert target MLA first. generate_scheduler_kv_cache_config unwraps a
+    # UniformType group to its first spec, and this representative is registered
+    # with the same full-attention manager needed by both target MLA and draft GQA.
+    mixed_attention_specs = {**target_mla_specs, **draft_gqa_specs}
+    mixed_attention_spec = UniformTypeKVCacheSpecs.from_specs(mixed_attention_specs)
+    if mixed_attention_spec is None:
+        logger.warning(
+            "Kimi K3 GQA DSpark mixed MLA/GQA specs cannot form a UniformType group; "
+            "falling back to generic hybrid grouping."
+        )
+        return None
+
+    groups = [
+        KVCacheGroupSpec(
+            layer_names=list(mixed_attention_specs),
+            kv_cache_spec=mixed_attention_spec,
+        )
+    ]
+    mamba_layer_names = list(mamba_specs)
+    for group_idx in range(_KIMI_K3_MAMBA_GROUP_COUNT):
+        layer_names = mamba_layer_names[group_idx::_KIMI_K3_MAMBA_GROUP_COUNT]
+        group_specs = {name: mamba_specs[name] for name in layer_names}
+        uniform_mamba_spec = UniformTypeKVCacheSpecs.from_specs(group_specs)
+        assert uniform_mamba_spec is not None
+        groups.append(
+            KVCacheGroupSpec(
+                layer_names=layer_names,
+                kv_cache_spec=uniform_mamba_spec,
+            )
+        )
+
+    logger.info(
+        "Using Kimi K3 GQA DSpark mixed KV grouping: %d target MLA + %d "
+        "draft GQA layers (block_size=%d, page_size=%d), followed by %d "
+        "groups of %d Mamba layers",
+        len(target_mla_specs),
+        len(draft_gqa_specs),
+        next(iter(block_sizes)),
+        next(iter(page_sizes)),
+        _KIMI_K3_MAMBA_GROUP_COUNT,
+        len(groups[1].layer_names),
+    )
+    return groups
+
+
+def _get_kv_cache_groups_uniform_page_size(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    kimi_k3_groups = _get_kimi_k3_gqa_mixed_kv_cache_groups(kv_cache_spec)
+    if kimi_k3_groups is not None:
+        return kimi_k3_groups
+    return _orig_get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+
+
+def _uniform_kv_cache_specs_max_num_blocks_per_req(
+    self: UniformTypeKVCacheSpecs,
+    vllm_config: VllmConfig,
+    max_len: int,
+) -> int:
+    """Preserve the largest worker block-table requirement of inner specs."""
+    return max(spec.max_num_blocks_per_req(vllm_config, max_len) for spec in self.kv_cache_specs.values())
+
+
+def _kv_cache_config_has_mamba_layers(self: KVCacheConfig) -> bool:
+    """Recognize Mamba layers nested in UniformType cache groups."""
+    for group in self.kv_cache_groups:
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, MambaSpec):
+            return True
+        if isinstance(group_spec, UniformTypeKVCacheSpecs) and any(
+            isinstance(spec, MambaSpec) for spec in group_spec.kv_cache_specs.values()
+        ):
+            return True
+    return False
+
+
 def get_kv_cache_groups(vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCacheSpec]) -> list[KVCacheGroupSpec]:
+    kimi_k3_groups = _get_kimi_k3_gqa_mixed_kv_cache_groups(kv_cache_spec)
+    if kimi_k3_groups is not None:
+        return kimi_k3_groups
     try:
         return _orig_get_kv_cache_groups(vllm_config, kv_cache_spec)
     except NotImplementedError as exc:
@@ -323,10 +500,17 @@ vllm.v1.core.kv_cache_utils.resolve_kv_cache_block_sizes = _ascend_resolve_kv_ca
 vllm.v1.core.kv_cache_utils.get_kv_cache_groups = get_kv_cache_groups
 vllm.v1.core.kv_cache_utils.group_and_unify_kv_cache_specs = group_and_unify_kv_cache_specs
 vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_groups = _get_kv_cache_groups_uniform_groups
+vllm.v1.core.kv_cache_utils._get_kv_cache_groups_uniform_page_size = _get_kv_cache_groups_uniform_page_size
 # vLLM v0.24.0 renamed _get_kv_cache_config_deepseek_v4 to _get_kv_cache_config_packed and
 # get_kv_cache_config_from_groups now calls _get_kv_cache_config_packed directly, bypassing
 # the alias patch above. Patch the canonical name so Ascend's non-packed layout is used.
 vllm.v1.core.kv_cache_utils._get_kv_cache_config_packed = _get_kv_cache_config_deepseek_v4
+UniformTypeKVCacheSpecs.max_num_blocks_per_req = (  # type: ignore[method-assign]
+    _uniform_kv_cache_specs_max_num_blocks_per_req
+)
+KVCacheConfig.has_mamba_layers = property(  # type: ignore[assignment]
+    _kv_cache_config_has_mamba_layers
+)
 
 # Also patch the reference used by engine/core.py which imports the function directly.
 import vllm.v1.engine.core  # noqa: E402

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -8,7 +8,7 @@ from vllm.config import CacheConfig
 from vllm.model_executor.layers.mamba.mamba_utils import MambaStateCopyFunc
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.sched.output import SchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec, UniformTypeKVCacheSpecs
 from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.gpu_input_batch import CachedRequestState
 from vllm.v1.worker.lora_model_runner_mixin import GPUInputBatch
@@ -21,6 +21,31 @@ from vllm_ascend.utils import is_310p
 
 def _can_launch_triton_batch_memcpy() -> bool:
     return not is_310p()
+
+
+def _get_mamba_groups(
+    kv_cache_config: KVCacheConfig,
+) -> tuple[list[int], MambaSpec]:
+    """Find Mamba groups, including uniform worker-side group wrappers."""
+    mamba_group_ids: list[int] = []
+    mamba_specs: list[MambaSpec] = []
+    for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+        group_spec = group.kv_cache_spec
+        if isinstance(group_spec, MambaSpec):
+            mamba_group_ids.append(group_id)
+            mamba_specs.append(group_spec)
+            continue
+        if not isinstance(group_spec, UniformTypeKVCacheSpecs):
+            continue
+
+        inner_specs = list(group_spec.kv_cache_specs.values())
+        if inner_specs and all(isinstance(spec, MambaSpec) for spec in inner_specs):
+            mamba_group_ids.append(group_id)
+            mamba_specs.append(inner_specs[0])
+
+    assert mamba_group_ids, "no mamba layers in the model"
+    assert all(mamba_specs[0] == spec for spec in mamba_specs)
+    return mamba_group_ids, mamba_specs[0]
 
 
 def _batch_memcpy_triton(src_ptrs, dst_ptrs, sizes):
@@ -191,6 +216,11 @@ else:
     mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch
     mamba_utils.do_mamba_copy_block = _do_mamba_copy_block_torch
     mamba_utils.postprocess_mamba_align_gpu = _postprocess_mamba_align_gpu_cpu_fallback
+
+# Worker KV configs retain UniformTypeKVCacheSpecs so per-layer physical page
+# layouts are available while the scheduler receives unwrapped representative
+# specs. Teach all upstream Mamba buffer/context helpers to see those groups.
+mamba_utils.get_mamba_groups = _get_mamba_groups
 
 # Ascend NPU does not support DT_UINT64 in aclnnInplaceZero.
 # MambaCopyBuffers.create() uses torch.uint64 for src_ptrs/dst_ptrs,

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -267,10 +267,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         """Align the draft hidden-state projection with a QuaRot target."""
         if self.method not in ("dflash", "dspark"):
             return
-        # Qwen3 DSpark aligns fc.* in its model-specific weight loader and owns
-        # separate embedding/lm_head weights, so no generic alignment is needed.
-        if isinstance(self.model, Qwen3DSparkForCausalLM):
-            return
         target_model_path = self.vllm_config.model_config.model
         rotation = self._load_quarot_rotation(target_model_path)
         if rotation is None:
@@ -281,6 +277,11 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # modules must not directly consume rotated target tensors.
         rotation = rotation.to(self.device, dtype=torch.float32)
         self._quarot_rotation = rotation
+        # Qwen3 / GQA DSpark already anti-rotates fc.* in its weight loader.
+        # Still keep the rotation so shared embed/lm_head can be unrotated,
+        # matching the 0.27 `_maybe_load_quarot_rotation` path.
+        if isinstance(self.model, Qwen3DSparkForCausalLM):
+            return
         draft_model = getattr(self.model, "model", None)
         projection_name = "fc"
         projection = getattr(draft_model, projection_name, None) if draft_model is not None else None

--- a/vllm_ascend/worker/block_table.py
+++ b/vllm_ascend/worker/block_table.py
@@ -13,6 +13,18 @@ from vllm_ascend.ops.triton.compute_slot_mapping import (
 )
 
 
+def _is_mamba_kv_cache_group(kv_cache_group: KVCacheGroupSpec | None) -> bool:
+    if kv_cache_group is None or not hasattr(kv_cache_group, "kv_cache_spec"):
+        return False
+    spec = kv_cache_group.kv_cache_spec
+    if isinstance(spec, MambaSpec):
+        return True
+    if isinstance(spec, UniformTypeKVCacheSpecs):
+        inner_specs = list(spec.kv_cache_specs.values())
+        return bool(inner_specs) and all(isinstance(inner, MambaSpec) for inner in inner_specs)
+    return False
+
+
 class BlockTable:
     def __init__(
         self,
@@ -39,12 +51,8 @@ class BlockTable:
             kv_cache_spec = next(iter(kv_cache_group.kv_cache_spec.kv_cache_specs.values()), None)
             if kv_cache_spec is not None and hasattr(kv_cache_spec, "compress_ratio"):
                 compress_ratio = kv_cache_spec.compress_ratio
-        if (
-            kv_cache_group is not None
-            and hasattr(kv_cache_group, "kv_cache_spec")
-            and self.dcp_world_size > 1
-            and isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
-        ):
+        is_mamba_group = _is_mamba_kv_cache_group(kv_cache_group)
+        if self.dcp_world_size > 1 and is_mamba_group:
             max_num_blocks_per_req = max_num_blocks_per_req * self.dcp_world_size
         max_num_blocks_per_req = max(cdiv(max_num_blocks_per_req, compress_ratio), 1)
         self.max_num_blocks_per_req = max_num_blocks_per_req
@@ -52,11 +60,7 @@ class BlockTable:
         self.pin_memory = pin_memory
         self.device = device
         self.physical_block_size = block_size
-        self.is_mamba_group = (
-            kv_cache_group is not None
-            and hasattr(kv_cache_group, "kv_cache_spec")
-            and isinstance(kv_cache_group.kv_cache_spec, MambaSpec)
-        )
+        self.is_mamba_group = is_mamba_group
 
         # If kernel_sizes is None or [0], use physical block size (no splitting)
         if kernel_sizes is None or kernel_sizes == [0]:

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -141,7 +141,6 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
     reshape_kv_cache_tensors_for_sparse_kv_offload,
     update_sparse_kv_offload_metadata,
 )
-from vllm_ascend.distributed.utils import get_decode_context_model_parallel_world_size
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
 from vllm_ascend.eplb.core.eplb_device_transfer_loader import D2DExpertWeightLoader
 from vllm_ascend.eplb.core.eplb_worker import EplbProcess
@@ -3752,10 +3751,7 @@ class NPUModelRunner(GPUModelRunner):
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
         self.use_hybrid_blocks = len(self.attn_groups) > 1
-        # NOTE: Currently, we determine whether we need `num_accepted_tokens` through `MambaSpec`.
-        self.need_accepted_tokens = any(
-            [isinstance(attn_group[0].kv_cache_spec, MambaSpec) for attn_group in self.attn_groups]
-        )
+        self.need_accepted_tokens = kv_cache_config.has_mamba_layers
 
         self.may_reinitialize_input_batch(kv_cache_config)
         if self.sparse_kv_offload_enabled:
@@ -4628,21 +4624,15 @@ class NPUModelRunner(GPUModelRunner):
 
         max_num_blocks = []
         max_model_len = max(self.max_model_len, self.max_encoder_len)
-        for i, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
             if isinstance(kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec):
                 continue
-            max_num_blocks_per_req = cdiv(
-                max_model_len,
-                block_sizes[i] * get_decode_context_model_parallel_world_size(),
+            max_num_blocks.append(
+                kv_cache_group.kv_cache_spec.max_num_blocks_per_req(
+                    self.vllm_config,
+                    max_model_len,
+                )
             )
-            if isinstance(kv_cache_group.kv_cache_spec, MambaSpec):
-                mamba_blocks_per_req = (
-                    max_num_blocks_per_req if self.cache_config.enable_prefix_caching else 1
-                ) 
-
-                max_num_blocks_per_req = max(max_num_blocks_per_req, mamba_blocks_per_req)
-                max_num_blocks_per_req += kv_cache_group.kv_cache_spec.num_speculative_blocks
-            max_num_blocks.append(max_num_blocks_per_req)
 
         if (block_sizes != [self.cache_config.block_size]
                 or self.kernel_block_sizes != [[self.cache_config.block_size]]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4929,12 +4929,33 @@ class NPUModelRunner(GPUModelRunner):
                     min_cg_attn_backend = attn_backend.__name__
 
         with update_pass_config(self):
+            tensor_parallel_size = self.parallel_config.tensor_parallel_size
+            resolver_tensor_parallel_size = tensor_parallel_size
+            if (
+                self.compilation_config.pass_config.enable_sp
+                and self.uniform_decode_query_len > 1
+                and tensor_parallel_size > 1
+            ):
+                graph_alignment = math.lcm(
+                    self.uniform_decode_query_len,
+                    tensor_parallel_size,
+                )
+                capture_sizes = self.compilation_config.cudagraph_capture_sizes
+                # Explicit sizes aligned to both speculative steps and SP do
+                # not need the resolver's second TP adjustment.
+                if (
+                    graph_alignment
+                    > max(self.uniform_decode_query_len, tensor_parallel_size)
+                    and capture_sizes
+                    and all(size % graph_alignment == 0 for size in capture_sizes)
+                ):
+                    resolver_tensor_parallel_size = 1
             cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
                 min_cg_support=min_cg_support,
                 min_cg_attn_backend=min_cg_attn_backend,
                 uniform_decode_query_len=self.uniform_decode_query_len,
                 use_v2_model_runner=False,
-                tensor_parallel_size=self.parallel_config.tensor_parallel_size,
+                tensor_parallel_size=resolver_tensor_parallel_size,
                 kv_cache_config=self.kv_cache_config,
                 max_num_reqs=self.max_num_reqs,
             )


### PR DESCRIPTION
### What this PR does / why we need it?

This PR supports Kimi K3 GQA DSpark and the newer causal MLA Block5 DSpark checkpoint on `releases/v0.26.0rc`.

KV-cache grouping for GQA DSpark:

- Group the 24 target MLA layers and 5 draft GQA layers into one `UniformType` scheduler group because they share full-sequence block ownership.
- Split the 69 align-mode Mamba layers into three groups of 23.
- The resulting scheduler layout is `[29, 23, 23, 23]`; model-runner metadata is built for MLA, GQA, and the three Mamba groups instead of the generic approximately 20-group layout.
- Derive block and page sizes from the matched cache specs, so the implementation is not limited to TP16 or a hard-coded page size.

QuaRot support for GQA DSpark:

- Load the descriptor-selected global rotation before the Qwen3 DSpark early return.
- Keep the existing Qwen3 loader responsible for FC anti-rotation.
- Give the draft unrotated embedding and LM-head copies instead of aliasing the rotated target tensors.

New MLA Block5 checkpoint support:

- Read draft-attention causality from the checkpoint's `dflash_config.causal`, falling back to `full_attention_causal`; legacy checkpoints that omit both fields remain bidirectional.
- Preserve explicit speculative-decoding graph sizes when every size is already aligned to both the speculative query length and TP size. This allows the intended `[48, 96]` sizes for Block5 + TP16 without changing vLLM's generic graph-size resolver.

This PR does not add a runtime restriction between checkpoint `block_size` and `num_speculative_tokens`, and it does not bring back the four-plane physical KV layout.

### Does this PR introduce _any_ user-facing change?

No API change. Matching Kimi K3 GQA DSpark deployments use the mixed scheduler groups, QuaRot GQA drafts use correctly aligned shared boundaries, and causal MLA DSpark checkpoints use their serialized attention mode. Other model signatures continue through the existing generic paths.

### How was this patch tested?

- 107 focused unit tests passed on the v0.26 environment, covering KV grouping, Mamba grouping, block-table updates, DSpark proposer behavior, QuaRot sharing, explicit graph alignment, and MLA causality.
- `pre-commit` passed for all changed files.
- Four-node full-expert GQA and MLA Block5 validation is in progress. Single-node 16-expert runs are startup/function smoke only and are not used as accuracy evidence.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
