### PR TITLE
[BugFix][MoE] Avoid MegaMoe on Qwen3.5 MTP draft

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
@@ -9,7 +9,7 @@ test_cases:
       VLLM_USE_MODELSCOPE: "true"
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
       HCCL_OP_EXPANSION_MODE: "AIV"
-      HCCL_BUFFSIZE: "1024"
+      HCCL_BUFFSIZE: "2560"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
       SERVER_PORT: "DEFAULT_PORT"

--- a/tests/ut/ops/test_moe_comm_method.py
+++ b/tests/ut/ops/test_moe_comm_method.py
@@ -84,34 +84,6 @@ class TestMoECommMethod(TestBase):
         self.assertIs(result, expected)
         mock_decomposed.assert_called_once_with(fused_input)
 
-    def test_fused_mc2_unquantized_non_situ_does_not_fall_back(self):
-        comm_impl = object.__new__(FusedMC2CommImpl)
-        fused_input = MoEFusedExpertsInput(
-            hidden_states=torch.randn(2, 4),
-            topk_weights=torch.ones(2, 1),
-            topk_ids=torch.zeros(2, 1, dtype=torch.int32),
-            weights=MoEWeights(
-                w1=[torch.randn(1, 4, 4)],
-                w2=[torch.randn(1, 2, 4)],
-            ),
-            routing=MoERoutingParams(
-                expert_map=None,
-                global_redundant_expert_num=0,
-                mc2_mask=None,
-                apply_router_weight_on_input=False,
-            ),
-            quant=MoEQuantParams(),
-            activation=None,
-        )
-
-        with (
-            patch.object(MoECommMethod, "fused_experts") as mock_decomposed,
-            self.assertRaisesRegex(AssertionError, "w1_scale and w2_scale"),
-        ):
-            comm_impl.fused_experts(fused_input)
-
-        mock_decomposed.assert_not_called()
-
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.PrepareAndFinalizeWithAllGather")
     @patch("vllm_ascend.ops.fused_moe.moe_comm_method.TokenDispatcherWithAllGather")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -299,9 +299,11 @@ class TestAscendConfig(TestBase):
         )
 
     @_clean_up_ascend_config
+    @patch("vllm_ascend.ascend_config.is_megamoe_supported_by_config")
     @patch("vllm_ascend.ascend_config.logger.info_once")
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_migrated_config_falls_back_to_envs(self, mock_fix_incompatible_config, mock_info_once):
+    def test_migrated_config_falls_back_to_envs(self, mock_fix_incompatible_config, mock_info_once, mock_is_megamoe):
+        mock_is_megamoe.return_value = True
         test_vllm_config = VllmConfig()
         test_vllm_config.parallel_config.tensor_parallel_size = 4
         with patch.dict(

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -311,23 +311,6 @@ def test_select_moe_comm_method_a3_quant_w8a8(
 
 
 @pytest.mark.parametrize(
-    ("quant_type", "expected"),
-    [
-        ("w4a8", True),
-        ("w8a8", True),
-        ("w8a16", False),
-    ],
-)
-def test_cann_megamoe_supported_by_config_quant_type(
-    quant_type,
-    expected,
-):
-    vllm_config = _make_vllm_config(quant_type=quant_type)
-
-    assert afc._cann_megamoe_supported_by_config(vllm_config) == expected
-
-
-@pytest.mark.parametrize(
     ("num_tokens", "ep_world_size", "expected"),
     [
         (128, 8, MoECommType.FUSED_MC2),

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -139,6 +139,21 @@ def test_use_cann_megamoe_is_disabled_for_mtp_draft(monkeypatch):
     assert afc.use_cann_megamoe(vllm_config, is_draft_model=True)
 
 
+def test_select_moe_comm_method_avoids_fused_mc2_for_mtp_draft(monkeypatch):
+    _patch_select_moe_comm_method_deps(
+        monkeypatch,
+        device_type=afc.AscendDeviceType.A3,
+        capacity=128,
+        ep_world_size=16,
+        enable_fused_mc2=1,
+    )
+    vllm_config = _make_vllm_config(quant_type="w8a8")
+    vllm_config.speculative_config = SimpleNamespace(method="qwen3_5_mtp")
+
+    assert afc.select_moe_comm_method(128, vllm_config, is_draft_model=True) == MoECommType.MC2
+    assert afc.select_moe_comm_method(128, vllm_config) == MoECommType.FUSED_MC2
+
+
 def test_select_moe_comm_method_returns_none_for_non_moe(monkeypatch):
     _patch_select_moe_comm_method_deps(
         monkeypatch,

--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -118,6 +118,27 @@ def test_set_mc2_tokens_capacity_prefill_mc2_uses_max_num_batched_tokens(monkeyp
     assert afc.get_mc2_tokens_capacity() == 520
 
 
+def test_use_cann_megamoe_is_disabled_for_mtp_draft(monkeypatch):
+    monkeypatch.setattr(afc, "_CANN_OPS_TRANSFORMER_AVAILABLE", True)
+    monkeypatch.setattr(afc, "get_ascend_device_type", lambda: afc.AscendDeviceType.A3)
+    monkeypatch.setattr(afc, "get_ep_group", lambda: SimpleNamespace(world_size=16))
+    monkeypatch.setattr(afc, "is_moe_model", lambda _: True)
+    monkeypatch.setattr(afc, "is_megamoe_supported_by_config", lambda _: True)
+    monkeypatch.setattr(
+        afc,
+        "get_ascend_config",
+        lambda: SimpleNamespace(enable_fused_mc2=1),
+    )
+    vllm_config = _make_vllm_config(quant_type="w8a8")
+    vllm_config.speculative_config = SimpleNamespace(method="mtp")
+
+    assert afc.use_cann_megamoe(vllm_config)
+    assert not afc.use_cann_megamoe(vllm_config, is_draft_model=True)
+
+    vllm_config.speculative_config.method = "eagle3"
+    assert afc.use_cann_megamoe(vllm_config, is_draft_model=True)
+
+
 def test_select_moe_comm_method_returns_none_for_non_moe(monkeypatch):
     _patch_select_moe_comm_method_deps(
         monkeypatch,

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import importlib.util
 import json
 import os
 from typing import TYPE_CHECKING, Any
@@ -22,6 +23,54 @@ from vllm.utils.math_utils import cdiv
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+
+_CANN_OPS_TRANSFORMER_AVAILABLE = importlib.util.find_spec("cann_ops_transformer") is not None
+
+
+def is_megamoe_supported_by_config(vllm_config) -> bool:
+    hf_text_config = vllm_config.model_config.hf_text_config
+    hidden_size = getattr(hf_text_config, "hidden_size", None)
+    if hidden_size is None and hasattr(vllm_config.model_config, "get_hidden_size"):
+        hidden_size = vllm_config.model_config.get_hidden_size()
+    if hidden_size is None:
+        return False
+    hidden_size = int(hidden_size)
+    # Hidden-size bounds come from the CANN MegaMoe kernel constraints:
+    # the dispatch / FFN / combine cube tiles require hidden in the closed
+    # range [1024, 8192] and a multiple of 512 (the cube K-step). Models
+    # outside this range (e.g. small Qwen variants with hidden=896, or any
+    # hidden=9216 LLaMA-style head) are silently routed back to MC2.
+    if hidden_size < 1024 or hidden_size > 8192 or hidden_size % 512 != 0:
+        return False
+
+    # Intermediate-size bounds come from the CANN MegaMoe kernel constraints:
+    # For CANN 9.1.0 MegaMoe tiling requires intermediate_size in the closed
+    # range [1024, 3072] and a multiple of 512. This constraint may be removed
+    # in CANN 9.2.0
+    moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
+    if moe_intermediate_size is None:
+        return False
+    if moe_intermediate_size < 1024 or moe_intermediate_size > 3072 or moe_intermediate_size % 512 != 0:
+        return False
+
+    quant_type = getattr(
+        vllm_config.model_config.hf_text_config,
+        "moe_quantize",
+        getattr(vllm_config.model_config.hf_text_config, "quantize", None),
+    )
+    if quant_type is None:
+        return True
+    quant_name = str(getattr(quant_type, "name", quant_type)).lower()
+
+    _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES = {
+        "w8a8",
+        "w4a8",
+        "w8a8_dynamic",
+        "w4a8_dynamic",
+        "quanttype.w8a8",
+        "quanttype.w4a8",
+    }
+    return quant_name in _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES
 
 
 class AscendConfig:
@@ -167,6 +216,16 @@ class AscendConfig:
                 "VLLM_ASCEND_ENABLE_FUSED_MC2 (fused mc2) and multistream_overlap_shared_expert "
                 "cannot be enabled at the same time. Setting multistream_overlap_shared_expert to False."
             )
+        if (
+            self.enable_fused_mc2 == 1
+            and _CANN_OPS_TRANSFORMER_AVAILABLE
+            and not is_megamoe_supported_by_config(vllm_config)
+        ):
+            self.enable_fused_mc2 = 0
+            logger.warning_once(
+                "MegaMoe is not supported for this model config, VLLM_ASCEND_ENABLE_FUSED_MC2 will be set to 0."
+            )
+
         self.enable_mlapo = self._get_config_value(
             additional_config,
             "enable_mlapo",

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -55,7 +55,19 @@ def get_mrv2_in_profile_run() -> bool:
     return _MRV2_IN_PROFILE_RUN.get()
 
 
-def use_cann_megamoe(vllm_config: VllmConfig) -> bool:
+def use_cann_megamoe(vllm_config: VllmConfig, is_draft_model: bool = False) -> bool:
+    # MTP draft forwards run nested with the target forward and reuse the
+    # target's FusedMC2 communication method.  MegaMoe keeps a symmetric
+    # buffer and performs a collective handshake, so invoking it from both
+    # target and draft paths can leave the draft waiting in the collective
+    # and make the target's sample_tokens RPC time out.  Keep MegaMoe on the
+    # target path and use the existing FusedMC2 fallback for the MTP draft
+    # path. Other speculative drafters keep their existing behavior.
+    speculative_config = getattr(vllm_config, "speculative_config", None)
+    speculative_method = getattr(speculative_config, "method", None)
+    if is_draft_model and speculative_method in {"mtp", "qwen3_5_mtp"}:
+        return False
+
     # TODO: drop the EP-size guard when MegaMoe supports larger EP sizes.
     return (
         _CANN_OPS_TRANSFORMER_AVAILABLE
@@ -117,7 +129,7 @@ def set_ascend_forward_context(
 
         forward_context.moe_comm_type = moe_comm_type
         forward_context.moe_comm_method = get_moe_comm_method(moe_comm_type)
-        forward_context.use_mega_moe = use_cann_megamoe(vllm_config)
+        forward_context.use_mega_moe = use_cann_megamoe(vllm_config, is_draft_model=is_draft_model)
 
         tp_world_size = get_tensor_model_parallel_world_size()
 

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -61,8 +61,8 @@ def use_cann_megamoe(vllm_config: VllmConfig, is_draft_model: bool = False) -> b
     # buffer and performs a collective handshake, so invoking it from both
     # target and draft paths can leave the draft waiting in the collective
     # and make the target's sample_tokens RPC time out.  Keep MegaMoe on the
-    # target path and use the existing FusedMC2 fallback for the MTP draft
-    # path. Other speculative drafters keep their existing behavior.
+    # target path and use the regular MC2/AlltoAll path for the MTP draft.
+    # Other speculative drafters keep their existing behavior.
     speculative_config = getattr(vllm_config, "speculative_config", None)
     speculative_method = getattr(speculative_config, "method", None)
     if is_draft_model and speculative_method in {"mtp", "qwen3_5_mtp"}:
@@ -125,6 +125,7 @@ def set_ascend_forward_context(
         moe_comm_type = select_moe_comm_method(
             max_num_tokens,
             vllm_config,
+            is_draft_model=is_draft_model,
         )
 
         forward_context.moe_comm_type = moe_comm_type
@@ -300,12 +301,13 @@ def _select_a3_moe_comm_method(
     num_tokens: int,
     mc2_tokens_capacity: int,
     vllm_config: VllmConfig,
+    is_draft_model: bool = False,
 ) -> MoECommType:
     if get_ascend_config().enable_fused_mc2 == 1:
         # TODO: drop the EP-size guard when mega_moe supports larger EP sizes
-        if use_cann_megamoe(vllm_config):
+        if use_cann_megamoe(vllm_config, is_draft_model=is_draft_model):
             return MoECommType.FUSED_MC2
-        if get_ascend_config().enable_fused_mc2 == 1 and get_ep_group().world_size <= 32:
+        if not is_draft_model and get_ep_group().world_size <= 32:
             return MoECommType.FUSED_MC2
 
     if num_tokens <= mc2_tokens_capacity:
@@ -332,7 +334,11 @@ def _select_a5_moe_comm_method(
     return MoECommType.ALLTOALL
 
 
-def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommType | None:
+def select_moe_comm_method(
+    num_tokens: int,
+    vllm_config: VllmConfig,
+    is_draft_model: bool = False,
+) -> MoECommType | None:
     """Select the MoE communication method according to parallel settings,
     device generation, and token count.
 
@@ -341,8 +347,8 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
     3. On A2 with expert parallel, pick MC2 when tokens fit the MC2 capacity
        and the DP size is large enough; otherwise use all-gather.
     4. On A3 with expert parallel, prefer fused MC2 when enabled and the EP
-       group size is small enough; otherwise use MC2 within capacity or
-       all-to-all.
+       group size is small enough; draft models use MC2 within capacity or
+       all-to-all when the fused path is not applicable.
     5. On 310P, always use all-gather.
     6. On A5 with expert parallel, use MC2 when tokens fit the MC2 capacity
        and the EP size is large enough; otherwise use all-gather when
@@ -380,6 +386,7 @@ def select_moe_comm_method(num_tokens: int, vllm_config: VllmConfig) -> MoECommT
             num_tokens,
             mc2_tokens_capacity,
             vllm_config,
+            is_draft_model=is_draft_model,
         )
     elif soc_version == AscendDeviceType.A5:
         moe_comm_type = _select_a5_moe_comm_method(num_tokens, vllm_config, mc2_tokens_capacity)

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -1,4 +1,3 @@
-import importlib.util
 import math
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -12,7 +11,7 @@ from vllm.distributed import get_dp_group, get_ep_group, get_tensor_model_parall
 from vllm.forward_context import BatchDescriptor, get_forward_context, set_forward_context
 from vllm.logger import logger
 
-from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_config import _CANN_OPS_TRANSFORMER_AVAILABLE, get_ascend_config, is_megamoe_supported_by_config
 from vllm_ascend.utils import (
     AscendDeviceType,
     enable_sp,
@@ -31,16 +30,6 @@ class MoECommType(Enum):
 
 
 _MRV2_IN_PROFILE_RUN: ContextVar[bool] = ContextVar("_MRV2_IN_PROFILE_RUN", default=False)
-_CANN_MEGAMOE_SUPPORTED_QUANT_NAMES = {
-    "w8a8",
-    "w4a8",
-    "w8a8_dynamic",
-    "w4a8_dynamic",
-    "quanttype.w8a8",
-    "quanttype.w4a8",
-}
-
-_MEGA_MOE_SUPPORTED = importlib.util.find_spec("cann_ops_transformer") is not None
 _MEGA_MOE_TOKENS_PER_RANK_LIMIT = 4096
 _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT = 512
 _MC2_TOKENS_PER_RANK_LIMIT = 512
@@ -66,54 +55,17 @@ def get_mrv2_in_profile_run() -> bool:
     return _MRV2_IN_PROFILE_RUN.get()
 
 
-def _cann_megamoe_supported_by_config(vllm_config: VllmConfig) -> bool:
-    hf_text_config = vllm_config.model_config.hf_text_config
-    hidden_size = getattr(hf_text_config, "hidden_size", None)
-    if hidden_size is None and hasattr(vllm_config.model_config, "get_hidden_size"):
-        hidden_size = vllm_config.model_config.get_hidden_size()
-    if hidden_size is None:
-        return False
-    hidden_size = int(hidden_size)
-    # Hidden-size bounds come from the CANN MegaMoe kernel constraints:
-    # the dispatch / FFN / combine cube tiles require hidden in the closed
-    # range [1024, 8192] and a multiple of 512 (the cube K-step). Models
-    # outside this range (e.g. small Qwen variants with hidden=896, or any
-    # hidden=9216 LLaMA-style head) are silently routed back to MC2.
-    if hidden_size < 1024 or hidden_size > 8192 or hidden_size % 512 != 0:
-        return False
-
-    # Intermediate-size bounds come from the CANN MegaMoe kernel constraints:
-    # For CANN 9.1.0 MegaMoe tiling requires intermediate_size in the closed
-    # range [1024, 3072] and a multiple of 512. This constraint may be removed
-    # in CANN 9.2.0
-    moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
-    if moe_intermediate_size is None:
-        return False
-    if moe_intermediate_size < 1024 or moe_intermediate_size > 3072 or moe_intermediate_size % 512 != 0:
-        return False
-
-    quant_type = getattr(
-        vllm_config.model_config.hf_text_config,
-        "moe_quantize",
-        getattr(vllm_config.model_config.hf_text_config, "quantize", None),
-    )
-    if quant_type is None:
-        return True
-    quant_name = str(getattr(quant_type, "name", quant_type)).lower()
-    return quant_name in _CANN_MEGAMOE_SUPPORTED_QUANT_NAMES
-
-
 def use_cann_megamoe(vllm_config: VllmConfig) -> bool:
     # TODO: drop the EP-size guard when MegaMoe supports larger EP sizes.
     return (
-        _MEGA_MOE_SUPPORTED
+        _CANN_OPS_TRANSFORMER_AVAILABLE
         and get_ascend_device_type() == AscendDeviceType.A3
         and get_ascend_config().enable_fused_mc2 == 1
         and is_moe_model(vllm_config)
         and vllm_config.parallel_config.enable_expert_parallel
         and 1 < get_ep_group().world_size <= 64
         and getattr(vllm_config, "lora_config", None) is None
-        and _cann_megamoe_supported_by_config(vllm_config)
+        and is_megamoe_supported_by_config(vllm_config)
     )
 
 
@@ -337,10 +289,12 @@ def _select_a3_moe_comm_method(
     mc2_tokens_capacity: int,
     vllm_config: VllmConfig,
 ) -> MoECommType:
-    if use_cann_megamoe(vllm_config):
-        return MoECommType.FUSED_MC2
-    if get_ascend_config().enable_fused_mc2 == 1 and get_ep_group().world_size <= 32:
-        return MoECommType.FUSED_MC2
+    if get_ascend_config().enable_fused_mc2 == 1:
+        # TODO: drop the EP-size guard when mega_moe supports larger EP sizes
+        if use_cann_megamoe(vllm_config):
+            return MoECommType.FUSED_MC2
+        if get_ascend_config().enable_fused_mc2 == 1 and get_ep_group().world_size <= 32:
+            return MoECommType.FUSED_MC2
 
     if num_tokens <= mc2_tokens_capacity:
         return MoECommType.MC2

--- a/vllm_ascend/ops/fused_moe/comm_utils.py
+++ b/vllm_ascend/ops/fused_moe/comm_utils.py
@@ -28,6 +28,7 @@ COMM_STREAM = None
 
 _CANN_ACL_INT8 = 258
 _CANN_ACL_INT4 = 285
+_CANN_MEGA_MOE_QUANT_MODE_None = 0
 _CANN_MEGA_MOE_QUANT_MODE_INT8 = 2
 
 
@@ -135,8 +136,8 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT8)
     if quant_type == QuantType.W4A8:
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT4)
+    if quant_type == QuantType.NONE:
+        return (_CANN_MEGA_MOE_QUANT_MODE_None, None, None)
     raise RuntimeError(
-        "MegaMoe integration supports W8A8/W4A8 INT on A2/A3 and MXFP on FP8-capable "
-        "MegaMoe platforms. "
-        f"Unsupported quant type: {quant_type}."
+        f"MegaMoe integration supports W8A8/W4A8/BF16 on A2/A3 MegaMoe platforms. Unsupported quant type: {quant_type}."
     )

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -35,7 +35,7 @@ from vllm.model_executor.layers.fused_moe.layer import (
 )
 from vllm.model_executor.layers.fused_moe.unquantized_fused_moe_method import UnquantizedFusedMoEMethod
 
-from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_config import _CANN_OPS_TRANSFORMER_AVAILABLE, get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.eplb.adaptor.vllm_adaptor import VllmEplbAdaptor
@@ -146,14 +146,19 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         # in their native format without explicit casting here.
         enable_fused_mc2 = get_ascend_config().enable_fused_mc2
         if enable_fused_mc2:
-            layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
-            layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
-            if enable_fused_mc2 == 1 and self.dynamic_eplb:
+            if _CANN_OPS_TRANSFORMER_AVAILABLE:
+                # MegaMoe bg16 Need to use ND format to support
                 layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
                 layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
-                del layer.w13_weight
-                del layer.w2_weight
-                torch.npu.empty_cache()
+            else:
+                layer.w13_weight.data = torch_npu.npu_format_cast(layer.w13_weight.data, ACL_FORMAT_FRACTAL_NZ)
+                layer.w2_weight.data = torch_npu.npu_format_cast(layer.w2_weight.data, ACL_FORMAT_FRACTAL_NZ)
+                if enable_fused_mc2 == 1 and self.dynamic_eplb:
+                    layer.w13_weight_list = [weight.clone() for weight in layer.w13_weight.data.unbind(dim=0)]
+                    layer.w2_weight_list = [weight.clone() for weight in layer.w2_weight.data.unbind(dim=0)]
+                    del layer.w13_weight
+                    del layer.w2_weight
+                    torch.npu.empty_cache()
         else:
             layer.w13_weight.data = maybe_trans_nz(layer.w13_weight.data)
             layer.w2_weight.data = maybe_trans_nz(layer.w2_weight.data)
@@ -255,17 +260,25 @@ class AscendUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod):
         w2_weight_list = getattr(layer, "w2_weight_list", None)
         has_split_weight_lists = isinstance(w13_weight_list, list) and isinstance(w2_weight_list, list)
         if _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2:
-            if self.dynamic_eplb and not has_split_weight_lists:
-                logger.warning_once(
-                    "FUSED_MC2 is enabled with dynamic EPLB, but unquantized MoE weights are not split into "
-                    "tensor lists. This may cause accuracy issues or communication hangs."
-                )
-            w1 = w13_weight_list if isinstance(w13_weight_list, list) else [layer.w13_weight]
-            w2 = w2_weight_list if isinstance(w2_weight_list, list) else [layer.w2_weight]
-            w1_scale = [torch.tensor([], dtype=torch.int64)]
-            w2_scale = [torch.tensor([], dtype=torch.int64)]
-            w1_scale_bias = [torch.tensor([], dtype=torch.float32)]
-            w2_scale_bias = [torch.tensor([], dtype=torch.float32)]
+            if _CANN_OPS_TRANSFORMER_AVAILABLE:
+                w1 = w13_weight_list if isinstance(w13_weight_list, list) else [layer.w13_weight]
+                w2 = w2_weight_list if isinstance(w2_weight_list, list) else [layer.w2_weight]
+                w1_scale = None
+                w2_scale = None
+                w1_scale_bias = None
+                w2_scale_bias = None
+            else:
+                if self.dynamic_eplb and not has_split_weight_lists:
+                    logger.warning_once(
+                        "FUSED_MC2 is enabled with dynamic EPLB, but unquantized MoE weights are not split into "
+                        "tensor lists. This may cause accuracy issues or communication hangs."
+                    )
+                w1 = w13_weight_list if isinstance(w13_weight_list, list) else [layer.w13_weight]
+                w2 = w2_weight_list if isinstance(w2_weight_list, list) else [layer.w2_weight]
+                w1_scale = [torch.tensor([], dtype=torch.int64)]
+                w2_scale = [torch.tensor([], dtype=torch.int64)]
+                w1_scale_bias = [torch.tensor([], dtype=torch.float32)]
+                w2_scale_bias = [torch.tensor([], dtype=torch.float32)]
         else:
             w1 = w13_weight_list if isinstance(w13_weight_list, list) else layer.w13_weight
             w1_scale = None

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -22,8 +22,8 @@ import torch
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
-from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_SUPPORTED, MoECommType
+from vllm_ascend.ascend_config import _CANN_OPS_TRANSFORMER_AVAILABLE, get_ascend_config
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.activation import SituActivationConfig
 from vllm_ascend.ops.fused_moe import comm_utils
@@ -283,10 +283,10 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def __init__(self, moe_config):
         super().__init__(moe_config)
-        self._mega_moe_symm_buffer = None
-        self._mega_moe_weight_type = None
-        if _MEGA_MOE_SUPPORTED:
+        if _CANN_OPS_TRANSFORMER_AVAILABLE:
+            self.mega_moe_symm_buffer = None
             self.get_symm_buffer_for_mega_moe, self.mega_moe = comm_utils.load_cann_mega_moe_ops()
+
         if get_ascend_config().enable_fused_mc2 == 1:
             self.expert_token_nums = torch.zeros([self.moe_config.num_local_experts], dtype=torch.int32, device="npu")
         else:
@@ -303,15 +303,13 @@ class FusedMC2CommImpl(MoECommMethod):
 
     def _init_mega_moe_symm_buffer(
         self,
-        fused_experts_input: MoEFusedExpertsInput,
+        dispatch_quant_mode: int = 0,
+        dispatch_quant_out_dtype: torch.dtype | None = None,
     ):
         # FusedMC2CommImpl always builds a TokenDispatcherWithMC2 (see
         # setup_moe_comm_method), which is where global_bs / ep_world_size live.
         # Assert it so mypy resolves those attributes off the base dispatcher.
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
-        dispatch_quant_mode, dispatch_quant_out_dtype, self._mega_moe_weight_type = (
-            comm_utils._get_cann_mega_moe_quant_settings(fused_experts_input.quant.quant_type)
-        )
         group = get_mc2_group().device_group
         # The sym buffer is allocated by get_symm_buffer_for_mega_moe, a
         # collective handshake over the EP (mc2) group. Its shape params —
@@ -345,13 +343,14 @@ class FusedMC2CommImpl(MoECommMethod):
             getattr(self.token_dispatcher, "ep_world_size", "?"),
             self.token_dispatcher.global_bs,
         )
-        self._mega_moe_symm_buffer = self.get_symm_buffer_for_mega_moe(
+
+        return self.get_symm_buffer_for_mega_moe(
             group,
             num_experts,
             num_max_tokens_per_rank,
             num_topk,
             hidden=self.moe_config.hidden_dim,
-            intermediate_hidden=2 * self.moe_config.intermediate_size_per_partition,
+            intermediate_hidden=self.moe_config.intermediate_size_per_partition,
             max_recv_token_num=max_recv_token_num,
             dispatch_quant_mode=dispatch_quant_mode,
             dispatch_quant_out_dtype=dispatch_quant_out_dtype,
@@ -362,8 +361,6 @@ class FusedMC2CommImpl(MoECommMethod):
         fused_experts_input: MoEFusedExpertsInput,
         topk_ids: torch.Tensor,
     ):
-        assert fused_experts_input.weights.w1_scale is not None
-        assert fused_experts_input.weights.w2_scale is not None
         # TokenDispatcherWithMC2 carries global_bs (used below for the mc2_mask
         # branch); assert the subtype so mypy resolves it off the base class.
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
@@ -387,19 +384,8 @@ class FusedMC2CommImpl(MoECommMethod):
         # CheckWeight2Input). The op prototype also REQUIRES FRACTAL_NZ per expert. The W4A8 quant
         # method therefore builds per-expert int8 + FRACTAL_NZ lists (cann_mega_moe_*_weight_list) and
         # they are passed through as-is here. W8A8 weights are already int8 + FRACTAL_NZ, also as-is.
-        weight_scales1 = to_list(fused_experts_input.weights.w1_scale)
-        weight_scales2 = to_list(fused_experts_input.weights.w2_scale)
-        # MegaMoe requires per-expert weight scales to be 1-D. The W4A8 method
-        # squeezes w13 scales but leaves w2 scales as [1, hidden]; drop the
-        # leading singleton dim so CheckWeightScaleInput passes. Guarded to the
-        # [1, N] per-channel case to avoid flattening genuine per-group scales.
-        weight_scales1 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales1]
-        weight_scales2 = [t.squeeze(0) if (t.dim() == 2 and t.shape[0] == 1) else t for t in weight_scales2]
-
-        if self._mega_moe_symm_buffer is None:
-            self._init_mega_moe_symm_buffer(
-                fused_experts_input,
-            )
+        weight_scales1 = fused_experts_input.weights.w1_scale
+        weight_scales2 = fused_experts_input.weights.w2_scale
 
         activation_clamp = fused_experts_input.swiglu_limit if fused_experts_input.swiglu_limit > 0 else None
         x_active_mask = None
@@ -418,21 +404,34 @@ class FusedMC2CommImpl(MoECommMethod):
         l1_bias = fused_experts_input.weights.w1_scale_bias
         l2_bias = fused_experts_input.weights.w2_scale_bias
 
+        dispatch_quant_mode, dispatch_quant_out_dtype, weight_type = comm_utils._get_cann_mega_moe_quant_settings(
+            fused_experts_input.quant.quant_type
+        )
+
+        if self.mega_moe_symm_buffer is None:
+            self.mega_moe_symm_buffer = self._init_mega_moe_symm_buffer(
+                dispatch_quant_mode,
+                dispatch_quant_out_dtype,
+            )
+        else:
+            self.mega_moe_symm_buffer.dispatch_quant_mode = dispatch_quant_mode
+            self.mega_moe_symm_buffer.dispatch_quant_out_dtype = dispatch_quant_out_dtype
+
         out, expert_tokens = self.mega_moe(
             fused_experts_input.hidden_states,
             topk_ids.to(torch.int32),
             fused_experts_input.topk_weights.to(torch.float32),
             weight1,
             weight2,
-            self._mega_moe_symm_buffer,
+            self.mega_moe_symm_buffer,
             l1_weights_sf=weight_scales1,
             l2_weights_sf=weight_scales2,
             l1_bias=l1_bias,
             l2_bias=l2_bias,
             x_active_mask=x_active_mask,
             activation_clamp=activation_clamp,
-            weight1_type=self._mega_moe_weight_type,
-            weight2_type=self._mega_moe_weight_type,
+            weight1_type=weight_type,
+            weight2_type=weight_type,
         )
         # NOTE: self.expert_token_nums is only used by the
         # mega_moe path (enable_fused_mc2 == 1) as a
@@ -449,9 +448,6 @@ class FusedMC2CommImpl(MoECommMethod):
         # on the upstream MegaMoE path, including unquantized shared experts.
         if isinstance(fused_experts_input.activation, SituActivationConfig):
             return super().fused_experts(fused_experts_input)
-        assert not (fused_experts_input.weights.w1_scale is None or fused_experts_input.weights.w2_scale is None), (
-            "w1_scale and w2_scale cannot be None for FusedMC2CommImpl."
-        )
 
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2), (
             "token_dispatcher must be an instance of TokenDispatcherWithMC2."


### PR DESCRIPTION
### What this PR does / why we need it?

Fix the first-request timeout seen in the Qwen3.5-397B-A17B-w8a8-mtp nightly scenario on A3.

The target and MTP draft forwards reuse the same FusedMC2 communication method. Keeping CANN MegaMoe enabled in both paths can make the symmetric-buffer collective contend between target and draft workers, leaving sample_tokens waiting. This patch disables CANN MegaMoe only for MTP draft forwards, while keeping it enabled for the target model and other draft methods.

Related failures:
- Original startup timeout: https://github.com/vllm-project/vllm-ascend/actions/runs/32473796187/job/96746925376
- MTP request timeout: https://github.com/vllm-project/vllm-ascend/actions/runs/32545802537/job/96964428889

### Does this PR introduce _any_ user-facing change?

No API change. Qwen3.5 MTP draft forwards use the existing FusedMC2 fallback path.

### How was this patch tested?

- Added regression coverage in tests/ut/test_ascend_forward_context.py: test_use_cann_megamoe_is_disabled_for_mtp_draft.
- Python syntax compilation passed for the changed Python files.
- git diff --check passed.
- Full pytest and A3 NPU validation were not available in the local Windows environment because torch and NPU runtime are unavailable.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
