### PR TITLE
[Performance] Parallelize AscendStore KV load receivers

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -42,6 +42,19 @@ To guarantee uniform hash generation, it is required to synchronize the PYTHONHA
 export PYTHONHASHSEED=0
 ```
 
+For non-layerwise `AscendStoreConnector` deployments using the Mooncake
+backend, `VLLM_MOONCAKE_LOAD_RECV_THREADS` controls the number of KV-load
+receiver threads (default: `1`):
+
+```bash
+export VLLM_MOONCAKE_LOAD_RECV_THREADS=4
+```
+
+Values greater than `1` enable request-level parallel loading for both
+`load_async: true` and synchronous loading. Each request is handled by one
+receiver thread, so a single request is not split across the pool. The setting
+is ignored by layerwise transfer and non-Mooncake AscendStore backends.
+
 ## 2. Example of using Mooncake as a KV Pool backend
 
 ### Step 2.1: Software Installation

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -703,7 +703,7 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
 
     def test_synchronous_request_propagates_error_without_killing_worker(self):
         store = FakeStore()
-        store.get = MagicMock(side_effect=RuntimeError("get failed"))
+        store.get = MagicMock(side_effect=RuntimeError("get failed"))  # type: ignore[method-assign]
         thread = KVCacheStoreRecvingThread(
             m_store=store,
             token_database=FakeTokenDatabase(),

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -15,8 +15,10 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import queue
 import threading
 import unittest
+from concurrent.futures import Future
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -44,6 +46,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import
     KVCacheStoreSendingThread,
     KVTransferThread,
     LayerBatchBuilder,
+    SynchronousLoadRequest,
 )
 
 
@@ -607,6 +610,19 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
 
 class TestKVCacheStoreRecvingThread(unittest.TestCase):
+    def test_uses_shared_request_queue(self):
+        shared_queue: queue.Queue = queue.Queue()
+
+        thread = KVCacheStoreRecvingThread(
+            m_store=FakeStore(),
+            token_database=FakeTokenDatabase(),
+            block_size=16,
+            tp_rank=0,
+            request_queue=shared_queue,
+        )
+
+        self.assertIs(thread.request_queue, shared_queue)
+
     def test_handle_request(self):
         store = FakeStore()
         db = FakeTokenDatabase()
@@ -659,6 +675,58 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         t._handle_request(req)
         keys, _, _ = store.get_calls[0]
         self.assertEqual(len(keys), 1)
+
+    def test_synchronous_request_completes_without_async_notification(self):
+        store = FakeStore()
+        thread = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=FakeTokenDatabase(),
+            block_size=16,
+            tp_rank=0,
+        )
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+            load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
+        )
+        completion: Future[None] = Future()
+        load_request = SynchronousLoadRequest(request, completion)
+        thread.request_queue.put(load_request)
+
+        thread._handle_request(load_request)
+
+        self.assertIsNone(completion.result())
+        self.assertEqual(thread.get_and_clear_finished_requests(), set())
+        self.assertEqual(thread.request_queue.unfinished_tasks, 0)
+
+    def test_synchronous_request_propagates_error_without_killing_worker(self):
+        store = FakeStore()
+        store.get = MagicMock(side_effect=RuntimeError("get failed"))
+        thread = KVCacheStoreRecvingThread(
+            m_store=store,
+            token_database=FakeTokenDatabase(),
+            block_size=16,
+            tp_rank=0,
+        )
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=16,
+            block_ids=[0],
+            block_hashes=[b"h0"],  # type: ignore[arg-type]
+            load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
+        )
+        completion: Future[None] = Future()
+        load_request = SynchronousLoadRequest(request, completion)
+        thread.request_queue.put(load_request)
+
+        thread._handle_request(load_request)
+
+        with self.assertRaisesRegex(RuntimeError, "get failed"):
+            completion.result()
+        self.assertIsNone(thread._fatal_error)
+        self.assertEqual(thread.request_queue.unfinished_tasks, 0)
 
 
 class TestLayerBatchBuilder(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -15,10 +15,8 @@
 # This file is a part of the vllm-ascend project.
 #
 
-import queue
 import threading
 import unittest
-from concurrent.futures import Future
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -46,7 +44,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import
     KVCacheStoreSendingThread,
     KVTransferThread,
     LayerBatchBuilder,
-    SynchronousLoadRequest,
 )
 
 
@@ -610,19 +607,6 @@ class TestKVCacheStoreSendingThread(unittest.TestCase):
 
 
 class TestKVCacheStoreRecvingThread(unittest.TestCase):
-    def test_uses_shared_request_queue(self):
-        shared_queue: queue.Queue = queue.Queue()
-
-        thread = KVCacheStoreRecvingThread(
-            m_store=FakeStore(),
-            token_database=FakeTokenDatabase(),
-            block_size=16,
-            tp_rank=0,
-            request_queue=shared_queue,
-        )
-
-        self.assertIs(thread.request_queue, shared_queue)
-
     def test_handle_request(self):
         store = FakeStore()
         db = FakeTokenDatabase()
@@ -675,58 +659,6 @@ class TestKVCacheStoreRecvingThread(unittest.TestCase):
         t._handle_request(req)
         keys, _, _ = store.get_calls[0]
         self.assertEqual(len(keys), 1)
-
-    def test_synchronous_request_completes_without_async_notification(self):
-        store = FakeStore()
-        thread = KVCacheStoreRecvingThread(
-            m_store=store,
-            token_database=FakeTokenDatabase(),
-            block_size=16,
-            tp_rank=0,
-        )
-        request = ReqMeta(
-            req_id="r1",
-            token_len_chunk=16,
-            block_ids=[0],
-            block_hashes=[b"h0"],  # type: ignore[arg-type]
-            load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
-        )
-        completion: Future[None] = Future()
-        load_request = SynchronousLoadRequest(request, completion)
-        thread.request_queue.put(load_request)
-
-        thread._handle_request(load_request)
-
-        self.assertIsNone(completion.result())
-        self.assertEqual(thread.get_and_clear_finished_requests(), set())
-        self.assertEqual(thread.request_queue.unfinished_tasks, 0)
-
-    def test_synchronous_request_propagates_error_without_killing_worker(self):
-        store = FakeStore()
-        store.get = MagicMock(side_effect=RuntimeError("get failed"))  # type: ignore[method-assign]
-        thread = KVCacheStoreRecvingThread(
-            m_store=store,
-            token_database=FakeTokenDatabase(),
-            block_size=16,
-            tp_rank=0,
-        )
-        request = ReqMeta(
-            req_id="r1",
-            token_len_chunk=16,
-            block_ids=[0],
-            block_hashes=[b"h0"],  # type: ignore[arg-type]
-            load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
-        )
-        completion: Future[None] = Future()
-        load_request = SynchronousLoadRequest(request, completion)
-        thread.request_queue.put(load_request)
-
-        thread._handle_request(load_request)
-
-        with self.assertRaisesRegex(RuntimeError, "get failed"):
-            completion.result()
-        self.assertIsNone(thread._fatal_error)
-        self.assertEqual(thread.request_queue.unfinished_tasks, 0)
 
 
 class TestLayerBatchBuilder(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -15,6 +15,7 @@
 # This file is a part of the vllm-ascend project.
 #
 
+import queue
 import threading
 import unittest
 from types import SimpleNamespace
@@ -606,6 +607,107 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
         self.assertEqual(recv_thread.call_args.args[2], worker.grouped_block_size)
         event.return_value.wait.assert_called()
 
+    @patch(
+        "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.KVCacheStoreRecvingThread.start",
+        autospec=True,
+    )
+    def test_starts_configured_receiver_pool_with_shared_queue(self, start_thread):
+        start_thread.side_effect = lambda thread: thread.ready_event.set()
+        env_path = (
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.envs.VLLM_MOONCAKE_LOAD_RECV_THREADS"
+        )
+        with patch(env_path, 3):
+            worker = self._make_worker(kv_role="kv_consumer")
+        worker.token_database.set_group_buffers({0: [1000]}, {0: [160]})
+
+        worker._start_kv_transfer_threads()
+
+        self.assertEqual(len(worker.kv_recv_threads), 3)
+        self.assertIs(worker.kv_recv_thread, worker.kv_recv_threads[0])
+        self.assertTrue(all(thread.request_queue is worker.recv_request_queue for thread in worker.kv_recv_threads))
+        self.assertEqual(start_thread.call_count, 3)
+
+    def test_receiver_pool_parallelizes_synchronous_request_batch(self):
+        env_path = (
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.envs.VLLM_MOONCAKE_LOAD_RECV_THREADS"
+        )
+        with patch(env_path, 2):
+            worker = self._make_worker(kv_role="kv_consumer")
+        worker.token_database.set_group_buffers({0: [1000]}, {0: [160]})
+        rendezvous = threading.Barrier(2)
+        receiver_names = []
+
+        def concurrent_get(keys, _addrs, _sizes):
+            receiver_names.append(threading.current_thread().name)
+            rendezvous.wait(timeout=5)
+            return [0] * len(keys)
+
+        worker.m_store.get.side_effect = concurrent_get
+        worker._start_kv_transfer_threads()
+        metadata = AscendConnectorMetadata(set())
+        for index in range(2):
+            metadata.add_request(
+                ReqMeta(
+                    req_id=f"r{index}",
+                    token_len_chunk=16,
+                    block_ids=[index],
+                    block_hashes=[f"h{index}"],
+                    load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
+                )
+            )
+
+        worker.start_load_kv(metadata)
+
+        self.assertEqual(len(set(receiver_names)), 2)
+        self.assertEqual(worker.m_store.set_device.call_count, 2)
+        self.assertTrue(all(thread.is_alive() for thread in worker.kv_recv_threads))
+
+    def test_synchronous_receiver_pool_propagates_load_exception(self):
+        env_path = (
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.envs.VLLM_MOONCAKE_LOAD_RECV_THREADS"
+        )
+        with patch(env_path, 2):
+            worker = self._make_worker(kv_role="kv_consumer")
+        worker.token_database.set_group_buffers({0: [1000]}, {0: [160]})
+        worker.m_store.get.side_effect = RuntimeError("get failed")
+        worker._start_kv_transfer_threads()
+        metadata = AscendConnectorMetadata(set())
+        metadata.add_request(
+            ReqMeta(
+                req_id="r1",
+                token_len_chunk=16,
+                block_ids=[0],
+                block_hashes=["h0"],
+                load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
+            )
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "get failed"):
+            worker.start_load_kv(metadata)
+
+        self.assertTrue(all(thread.is_alive() for thread in worker.kv_recv_threads))
+
+    def test_layerwise_ignores_receiver_pool_setting(self):
+        env_path = (
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.envs.VLLM_MOONCAKE_LOAD_RECV_THREADS"
+        )
+        with patch(env_path, 4):
+            worker = self._make_worker(kv_role="kv_consumer", use_layerwise=True)
+
+        self.assertEqual(worker.num_load_recv_threads, 1)
+
+    def test_non_mooncake_backend_ignores_receiver_pool_setting(self):
+        env_path = (
+            "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker.envs.VLLM_MOONCAKE_LOAD_RECV_THREADS"
+        )
+        with patch(env_path, 4):
+            worker = self._make_worker(
+                kv_role="kv_consumer",
+                extra_config={"backend": "memcache"},
+            )
+
+        self.assertEqual(worker.num_load_recv_threads, 1)
+
     def test_register_kv_caches_initializes_layerwise_memcache(self):
         worker = self._make_worker(extra_config={"backend": "memcache"}, use_layerwise=True)
         fake_cache = MagicMock()
@@ -907,6 +1009,26 @@ class TestKVPoolWorkerGetFinishedAsync(unittest.TestCase):
         worker.get_finished(set(), meta)
         recv_thread.discard_finished_requests.assert_called_once_with({"r_preempted"})
 
+    def test_get_finished_merges_receiver_pool_results(self):
+        worker = self._make_worker(kv_role="kv_consumer")
+        first = MagicMock()
+        second = MagicMock()
+        first.get_and_clear_finished_requests.return_value = {"r1"}
+        second.get_and_clear_finished_requests.return_value = {"r2"}
+        worker.kv_recv_threads = [first, second]
+        worker.kv_recv_thread = first
+        loading_req_ids = {"r1", "r2"}
+        meta = AscendConnectorMetadata({"preempted"}, loading_req_ids=loading_req_ids)
+
+        done_sending, done_recving = worker.get_finished(set(), meta)
+
+        self.assertEqual(done_sending, set())
+        self.assertEqual(done_recving, loading_req_ids)
+        for recv_thread in (first, second):
+            recv_thread.raise_if_failed.assert_called_once()
+            recv_thread.discard_finished_requests.assert_called_once_with({"preempted"})
+            recv_thread.get_and_clear_finished_requests.assert_called_once_with(loading_req_ids)
+
     def test_get_finished_layerwise_send_thread(self):
         worker = self._make_worker(kv_role="kv_producer")
         worker.use_layerwise = True
@@ -954,6 +1076,27 @@ class TestKVPoolWorkerStartLoadKVAsync(unittest.TestCase):
         worker.kv_recv_thread = recv_thread
         worker.start_load_kv(AscendConnectorMetadata(set()))
         recv_thread.add_request.assert_not_called()
+
+    def test_async_receiver_pool_uses_shared_queue(self):
+        worker = self._make_worker()
+        worker.recv_request_queue = queue.Queue()
+        worker.kv_recv_threads = [MagicMock(), MagicMock()]
+        worker.kv_recv_thread = worker.kv_recv_threads[0]
+        meta = AscendConnectorMetadata(set())
+        for index in range(2):
+            meta.add_request(
+                ReqMeta(
+                    req_id=f"r{index}",
+                    token_len_chunk=16,
+                    block_ids=[index],
+                    block_hashes=[f"h{index}"],
+                    load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
+                )
+            )
+
+        worker.start_load_kv(meta)
+
+        self.assertEqual(worker.recv_request_queue.qsize(), 2)
 
 
 class TestKVPoolWorkerProcessLayerData(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -15,7 +15,6 @@
 # This file is a part of the vllm-ascend project.
 #
 
-import queue
 import threading
 import unittest
 from types import SimpleNamespace
@@ -624,7 +623,8 @@ class TestKVPoolWorkerRegisterAndTransfer(unittest.TestCase):
 
         self.assertEqual(len(worker.kv_recv_threads), 3)
         self.assertIs(worker.kv_recv_thread, worker.kv_recv_threads[0])
-        self.assertTrue(all(thread.request_queue is worker.recv_request_queue for thread in worker.kv_recv_threads))
+        shared_queue = worker.kv_recv_threads[0].request_queue
+        self.assertTrue(all(thread.request_queue is shared_queue for thread in worker.kv_recv_threads))
         self.assertEqual(start_thread.call_count, 3)
 
     def test_receiver_pool_parallelizes_synchronous_request_batch(self):
@@ -1056,6 +1056,7 @@ class TestKVPoolWorkerStartLoadKVAsync(unittest.TestCase):
     def test_start_load_kv_async(self):
         worker = self._make_worker()
         recv_thread = MagicMock()
+        worker.kv_recv_threads = [recv_thread]
         worker.kv_recv_thread = recv_thread
 
         load_spec = LoadSpec(vllm_cached_tokens=0, kvpool_cached_tokens=16, can_load=True, token_len=16)
@@ -1073,30 +1074,10 @@ class TestKVPoolWorkerStartLoadKVAsync(unittest.TestCase):
 
         recv_thread.reset_mock()
         worker = self._make_worker()
+        worker.kv_recv_threads = [recv_thread]
         worker.kv_recv_thread = recv_thread
         worker.start_load_kv(AscendConnectorMetadata(set()))
         recv_thread.add_request.assert_not_called()
-
-    def test_async_receiver_pool_uses_shared_queue(self):
-        worker = self._make_worker()
-        worker.recv_request_queue = queue.Queue()
-        worker.kv_recv_threads = [MagicMock(), MagicMock()]
-        worker.kv_recv_thread = worker.kv_recv_threads[0]
-        meta = AscendConnectorMetadata(set())
-        for index in range(2):
-            meta.add_request(
-                ReqMeta(
-                    req_id=f"r{index}",
-                    token_len_chunk=16,
-                    block_ids=[index],
-                    block_hashes=[f"h{index}"],
-                    load_spec=LoadSpec(0, 16, can_load=True, token_len=16),
-                )
-            )
-
-        worker.start_load_kv(meta)
-
-        self.assertEqual(worker.recv_request_queue.qsize(), 2)
 
 
 class TestKVPoolWorkerProcessLayerData(unittest.TestCase):

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -6,6 +6,8 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from concurrent.futures import Future
+from dataclasses import dataclass
 from typing import Any
 
 import numpy as np
@@ -34,6 +36,14 @@ def _circular_shift(lst: list, offset: int) -> list:
     if not lst or offset == 0:
         return lst
     return lst[offset:] + lst[:offset]
+
+
+@dataclass(frozen=True)
+class SynchronousLoadRequest:
+    """A receiver-pool request whose completion is awaited by the caller."""
+
+    request: ReqMeta
+    completion: Future[None]
 
 
 class LayerBatchBuilder:
@@ -313,6 +323,7 @@ class KVTransferThread(threading.Thread):
         dcp_size: int = 1,
         ready_event: threading.Event | None = None,
         name: str = "KVTransferThread",
+        request_queue: queue.Queue[Any] | None = None,
     ):
         super().__init__(daemon=True, name=name)
         self.m_store = m_store
@@ -324,7 +335,7 @@ class KVTransferThread(threading.Thread):
         self.token_database = token_database
         self.num_addrs_per_block = len(token_database.group_block_len[0])
         self.done_task_lock = threading.Lock()
-        self.request_queue: queue.Queue[Any] = queue.Queue()
+        self.request_queue: queue.Queue[Any] = request_queue if request_queue is not None else queue.Queue()
         self.stored_requests: defaultdict[str, int] = defaultdict(int)
         self.finished_requests: set[str] = set()
         self.kv_event_lock = threading.Lock()
@@ -878,6 +889,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         invalid_block_ids: set[int] | None = None,
         invalid_block_ids_lock: threading.Lock | None = None,
         worker: Any = None,
+        request_queue: queue.Queue[Any] | None = None,
     ):
         super().__init__(
             m_store,
@@ -888,17 +900,25 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             dcp_size,
             ready_event,
             name="KVCacheStoreRecvingThread",
+            request_queue=request_queue,
         )
         self._invalid_block_ids = invalid_block_ids if invalid_block_ids is not None else set()
         self._invalid_block_ids_lock = invalid_block_ids_lock or threading.Lock()
         self.worker = worker
 
-    def _handle_request(self, req_meta: ReqMeta):
+    def _handle_request(self, request_data: ReqMeta | SynchronousLoadRequest):
+        sync_completion: Future[None] | None = None
+        if isinstance(request_data, SynchronousLoadRequest):
+            req_meta = request_data.request
+            sync_completion = request_data.completion
+        else:
+            req_meta = request_data
+        load_error: BaseException | None = None
         try:
             load_spec = req_meta.load_spec
             req_id = req_meta.req_id
             if load_spec is None:
-                logger.error("KV pool async recv request %s has no load spec; skip load.", req_id)
+                logger.error("KV pool recv request %s has no load spec; skip load.", req_id)
                 self.set_finished_request(req_id)
                 return
 
@@ -960,7 +980,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 block_id_list[self.tp_rank % len(block_id_list) :] + block_id_list[: self.tp_rank % len(block_id_list)]
             )
             logger.debug(
-                "KV pool async recv calls backend get request=%s token_len=%d groups=%s keys=%d sample_keys=%s",
+                "KV pool recv calls backend get request=%s token_len=%d groups=%s keys=%d sample_keys=%s",
                 req_id,
                 token_len,
                 req_meta.kv_cache_group_ids or [0],
@@ -1001,14 +1021,25 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                         missing_block_ids,
                     )
             logger.debug(
-                "KV pool async recv backend get returned request=%s token_len=%d groups=%s keys=%d",
+                "KV pool recv backend get returned request=%s token_len=%d groups=%s keys=%d",
                 req_id,
                 token_len,
                 req_meta.kv_cache_group_ids or [0],
                 len(key_list_c),
             )
             self.set_finished_request(req_id)
+        except BaseException as error:
+            load_error = error
+            if sync_completion is None:
+                raise
         finally:
+            if sync_completion is not None:
+                self.discard_finished_requests({req_meta.req_id})
+                if not sync_completion.done():
+                    if load_error is None:
+                        sync_completion.set_result(None)
+                    else:
+                        sync_completion.set_exception(load_error)
             self.request_queue.task_done()
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -913,7 +913,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             sync_completion = request_data.completion
         else:
             req_meta = request_data
-        load_error: BaseException | None = None
+        load_error: Exception | None = None
         try:
             load_spec = req_meta.load_spec
             req_id = req_meta.req_id
@@ -1028,7 +1028,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 len(key_list_c),
             )
             self.set_finished_request(req_id)
-        except BaseException as error:
+        except Exception as error:
             load_error = error
             if sync_completion is None:
                 raise

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -346,7 +346,6 @@ class KVPoolWorker:
         self.kv_send_thread: KVTransferThread | None = None
         self.kv_recv_thread: KVTransferThread | None = None
         self.kv_recv_threads: list[KVCacheStoreRecvingThread] = []
-        self.recv_request_queue: queue.Queue[Any] | None = None
         self._transfer_threads_started = False
         self.external_slot_release_waiter: Callable[[int], None] | None = None
         # Per-rank GVA cache: maps per-rank store key to its allocated GVA.
@@ -578,7 +577,7 @@ class KVPoolWorker:
                 self.kv_send_thread.start()
                 ready_event_sending.wait()
             if self.load_async or self.num_load_recv_threads > 1:
-                self.recv_request_queue = queue.Queue()
+                recv_request_queue: queue.Queue[Any] = queue.Queue()
                 ready_events = []
                 for index in range(self.num_load_recv_threads):
                     ready_event = threading.Event()
@@ -593,7 +592,7 @@ class KVPoolWorker:
                         invalid_block_ids=self._invalid_block_ids,
                         invalid_block_ids_lock=self._invalid_block_ids_lock,
                         worker=self,
-                        request_queue=self.recv_request_queue,
+                        request_queue=recv_request_queue,
                     )
                     recv_thread.name = f"AscendStoreRecv-{index}"
                     recv_thread.start()
@@ -892,12 +891,11 @@ class KVPoolWorker:
                 self.load_async,
             )
             if self.kv_recv_threads:
-                assert self.recv_request_queue is not None
                 if self.load_async:
-                    self.recv_request_queue.put(request)
+                    self.kv_recv_threads[0].add_request(request)
                 else:
                     completion: Future[None] = Future()
-                    self.recv_request_queue.put(SynchronousLoadRequest(request, completion))
+                    self.kv_recv_threads[0].add_request(SynchronousLoadRequest(request, completion))
                     sync_load_completions.append(completion)
                 continue
             if self.load_async:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import importlib
 import math
+import queue
 import threading
 import time
 from collections.abc import Callable, Generator
+from concurrent.futures import Future
 from typing import Any
 
 import numpy as np
@@ -45,6 +47,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.kv_transfer import
     KVCacheStoreSendingThread,
     KVTransferThread,
     LayerBatchBuilder,
+    SynchronousLoadRequest,
     _circular_shift,
     record_failed_blocks,
 )
@@ -154,6 +157,12 @@ class KVPoolWorker:
         self.consumer_is_to_put = extra_config.get("consumer_is_to_put", False)
         self.backend = extra_config.get("backend", "mooncake")
         self.backend_name = self.backend.lower()
+        configured_recv_threads = max(1, envs.VLLM_MOONCAKE_LOAD_RECV_THREADS)
+        self.num_load_recv_threads = (
+            configured_recv_threads if self.backend_name == "mooncake" and not self.use_layerwise else 1
+        )
+        if self.backend_name == "mooncake" and self.use_layerwise and configured_recv_threads > 1:
+            logger.warning("VLLM_MOONCAKE_LOAD_RECV_THREADS is ignored by AscendStore layerwise transfer")
         self.use_gva_layerwise = self.use_layerwise and self.backend_name == "memcache"
         kv_cache_groups = kv_cache_config.kv_cache_groups if kv_cache_config is not None else None
         self.use_hybrid = uses_hybrid_kv_cache(vllm_config.scheduler_config, kv_cache_groups)
@@ -336,6 +345,8 @@ class KVPoolWorker:
     def _init_state_vars(self) -> None:
         self.kv_send_thread: KVTransferThread | None = None
         self.kv_recv_thread: KVTransferThread | None = None
+        self.kv_recv_threads: list[KVCacheStoreRecvingThread] = []
+        self.recv_request_queue: queue.Queue[Any] | None = None
         self._transfer_threads_started = False
         self.external_slot_release_waiter: Callable[[int], None] | None = None
         # Per-rank GVA cache: maps per-rank store key to its allocated GVA.
@@ -566,21 +577,35 @@ class KVPoolWorker:
                 )
                 self.kv_send_thread.start()
                 ready_event_sending.wait()
-            if self.load_async:
-                ready_event = threading.Event()
-                self.kv_recv_thread = KVCacheStoreRecvingThread(
-                    self.m_store,
-                    self.token_database,
-                    self.grouped_block_size,
-                    self.tp_rank,
-                    self.tp_size,
-                    self.dcp_size,
-                    ready_event,
-                    invalid_block_ids=self._invalid_block_ids,
-                    invalid_block_ids_lock=self._invalid_block_ids_lock,
+            if self.load_async or self.num_load_recv_threads > 1:
+                self.recv_request_queue = queue.Queue()
+                ready_events = []
+                for index in range(self.num_load_recv_threads):
+                    ready_event = threading.Event()
+                    recv_thread = KVCacheStoreRecvingThread(
+                        self.m_store,
+                        self.token_database,
+                        self.grouped_block_size,
+                        self.tp_rank,
+                        self.tp_size,
+                        self.dcp_size,
+                        ready_event,
+                        invalid_block_ids=self._invalid_block_ids,
+                        invalid_block_ids_lock=self._invalid_block_ids_lock,
+                        worker=self,
+                        request_queue=self.recv_request_queue,
+                    )
+                    recv_thread.name = f"AscendStoreRecv-{index}"
+                    recv_thread.start()
+                    self.kv_recv_threads.append(recv_thread)
+                    ready_events.append(ready_event)
+                for ready_event in ready_events:
+                    ready_event.wait()
+                self.kv_recv_thread = self.kv_recv_threads[0]
+                logger.info(
+                    "Started %d AscendStore KV-load receive thread(s)",
+                    self.num_load_recv_threads,
                 )
-                self.kv_recv_thread.start()
-                ready_event.wait()
         self._transfer_threads_started = True
 
     def _build_cache_coordinator(self, vllm_config: VllmConfig) -> AscendStoreCoordinator | None:
@@ -835,6 +860,7 @@ class KVPoolWorker:
         if self.use_layerwise:
             self.process_layer_data(metadata.requests)
             return
+        sync_load_completions: list[Future[None]] = []
         for request in metadata.requests:
             load_spec = request.load_spec
             if load_spec is None or not load_spec.can_load:  # load =0
@@ -865,6 +891,15 @@ class KVPoolWorker:
                 load_group_ids,
                 self.load_async,
             )
+            if self.kv_recv_threads:
+                assert self.recv_request_queue is not None
+                if self.load_async:
+                    self.recv_request_queue.put(request)
+                else:
+                    completion: Future[None] = Future()
+                    self.recv_request_queue.put(SynchronousLoadRequest(request, completion))
+                    sync_load_completions.append(completion)
+                continue
             if self.load_async:
                 self.kv_recv_thread.add_request(  # type: ignore[union-attr]
                     request,
@@ -965,6 +1000,8 @@ class KVPoolWorker:
                 load_group_ids,
                 len(key_list_c),
             )
+        for completion in sync_load_completions:
+            completion.result()
 
     def _process_save_for_layer_batch(
         self,
@@ -2041,7 +2078,14 @@ class KVPoolWorker:
             done_sending = set()
 
         done_recving = set()
-        if self.kv_recv_thread is not None:
+        if self.kv_recv_threads:
+            for recv_thread in self.kv_recv_threads:
+                recv_thread.raise_if_failed()
+                recv_thread.discard_finished_requests(meta.preempted_req_ids)
+                if self.load_async:
+                    done_recving |= recv_thread.get_and_clear_finished_requests(meta.loading_req_ids)
+        elif self.kv_recv_thread is not None:
+            self.kv_recv_thread.raise_if_failed()
             self.kv_recv_thread.discard_finished_requests(meta.preempted_req_ids)
             if self.load_async:
                 done_recving = self.kv_recv_thread.get_and_clear_finished_requests(meta.loading_req_ids)


### PR DESCRIPTION
### What this PR does / why we need it?

Add a request-level receive-thread pool to the non-layerwise Mooncake backend of `AscendStoreConnector`, reusing vLLM's `VLLM_MOONCAKE_LOAD_RECV_THREADS` setting.

- all receiver workers share one request queue and bind the backend device in each worker thread
- `load_async: true` dispatches requests to the pool and merges completion/error state from every worker
- synchronous loading dispatches the whole metadata batch to the same pool, waits on per-request futures, and returns only after every load completes
- synchronous exceptions are propagated to the caller without terminating the receiver worker
- the default remains one receiver; non-Mooncake backends and layerwise transfer keep their existing single-thread behavior

The pool parallelizes independent requests. It intentionally does not split one request across multiple workers.

### Does this PR introduce _any_ user-facing change?

Yes. Non-layerwise `AscendStoreConnector` deployments with the Mooncake backend can set:

```bash
export VLLM_MOONCAKE_LOAD_RECV_THREADS=4
```

Values greater than `1` enable request-level parallel loads for both asynchronous and synchronous loading. The default is `1`.

### How was this patch tested?

- all pre-commit hooks passed
- targeted mypy passed for the changed production and test modules
- `tests/ut/distributed/ascend_store`: 296 passed
- added tests for shared-queue construction, per-thread device setup, real synchronous two-request concurrency, synchronous completion/error propagation, asynchronous dispatch, completion fan-in, and layerwise/non-Mooncake gating

NPU end-to-end throughput and latency validation is still required.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
