### PR TITLE
[BugFix][Attention] Use physical block size for C8 NZ cache writes

### DIFF
--- a/tests/ut/attention/test_attention_v1.py
+++ b/tests/ut/attention/test_attention_v1.py
@@ -588,6 +588,29 @@ class TestAscendAttentionBackendImpl(TestBase):
         self.assertIs(returned[2], value)
         self.assertIs(returned[3], output)
 
+    @patch("vllm_ascend.attention.attention_v1.notify_kv_cache_written")
+    @patch("torch_npu.npu_scatter_pa_kv_cache", create=True)
+    def test_c8_nz_cache_write_uses_physical_block_size(self, mock_scatter_pa_kv_cache, _mock_notify):
+        query = torch.randn(2, 8, 64)
+        key = torch.randn(2, 8, 64)
+        value = torch.randn(2, 8, 64)
+        kv_cache = (
+            torch.empty(24, 128, 8, 64, dtype=torch.int8),
+            torch.empty(24, 128, 8, 64, dtype=torch.int8),
+        )
+        output = torch.empty_like(query)
+        metadata = MagicMock()
+        metadata.slot_mapping = torch.arange(2)
+        metadata.num_actual_tokens = 2
+        self.mock_vllm_config.cache_config.block_size = 1536
+        self.impl_c8_kv_share.kv_sharing_target_layer_name = None
+
+        self.impl_c8_kv_share._reshape_and_cache(query, key, value, kv_cache, metadata, output)
+
+        cache_args = mock_scatter_pa_kv_cache.call_args.kwargs
+        self.assertEqual(cache_args["key_cache"].shape, (24, 8, 2, 128, 32))
+        self.assertEqual(cache_args["value_cache"].shape, (24, 8, 2, 128, 32))
+
     def test_forward_no_attn_metadata(self):
         """Test forward pass when attn_metadata is None"""
         query = torch.randn(10, 8 * 64)

--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -2207,7 +2207,10 @@ class AscendC8AttentionBackendImpl(AscendAttentionBackendImpl):
             encoder_decoder = self.attn_type == AttentionType.ENCODER_DECODER
 
             # NZ write path: 5D view + npu_scatter_pa_kv_cache
-            block_size = self.vllm_config.cache_config.block_size
+            # Hybrid models can use a scheduler block size that differs from
+            # the physical attention cache block size. PA_NZ packing must use
+            # the physical cache dimension so the write layout matches FIA.
+            block_size = self.key_cache.shape[1]
             k_cache_layer = self._nz_5d_view(self.key_cache, block_size)
             v_cache_layer = self._nz_5d_view(self.value_cache, block_size)
 


### PR DESCRIPTION
### What this PR does / why we need it?

Hybrid models may use a scheduler block size that differs from the physical attention KV cache block size. For example, the scheduler/Mamba-aligned block size can be 1536 while the C8 attention cache tensor uses 128.

The C8 PA_NZ write path previously reshaped the cache with `cache_config.block_size`, while FIA read paths derive the block size from the cache tensor. This makes writes and reads use different layouts and corrupts C8 KV cache contents.

This PR derives the PA_NZ write block size from `self.key_cache.shape[1]` and adds a regression test covering scheduler block size 1536 with physical cache block size 128.

### Does this PR introduce _any_ user-facing change?

Yes. C8 KV cache inference remains correct when a hybrid model uses different logical scheduler and physical attention cache block sizes. No API changes are introduced.

### How was this patch tested?

- Added `test_c8_nz_cache_write_uses_physical_block_size`, which verifies the 5D PA_NZ cache view uses physical block size 128 even when the scheduler block size is 1536.
- `uvx ruff format --check vllm_ascend/attention/attention_v1.py tests/ut/attention/a2/test_attention_v1.py`
- `uvx ruff check vllm_ascend/attention/attention_v1.py tests/ut/attention/a2/test_attention_v1.py`
- `git diff --check`
- Manually verified on Ascend 910B3 with Qwen3.8-27B W8A8C8: TP1 and TP2 inference passed 1K/8K/32K/64K/128K prompt cases with 512/1024 generated tokens; TP1 also passed 32K/128K/256K marker retrieval and multimodal correctness checks.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
