### PR TITLE
[BugFix][Quantization] Avoid target C8 metadata inheritance for Qwen3.5 MTP

### DIFF
--- a/tests/ut/quantization/configs/test_modelslim_config.py
+++ b/tests/ut/quantization/configs/test_modelslim_config.py
@@ -248,6 +248,42 @@ class TestAscendModelSlimConfig(TestBase):
 
             self.assertIsInstance(args[0], AscendC8KVCacheAttentionMethod)
 
+    def test_mtp_does_not_inherit_target_c8_layer_by_index(self):
+        config = AscendModelSlimConfig(
+            {
+                "kv_cache_type": "C8",
+                "model.layers.0.self_attn.k_proj.kv_cache_scale": "C8",
+            }
+        )
+
+        self.assertTrue(config.is_c8_quant_layer("model.layers.0.self_attn.attn"))
+        self.assertFalse(config.is_c8_quant_layer("mtp.layers.0.self_attn.attn"))
+
+    def test_mtp_c8_requires_its_own_kv_scale_metadata(self):
+        config = AscendModelSlimConfig(
+            {
+                "kv_cache_type": "C8",
+                "model.layers.0.self_attn.k_proj.kv_cache_scale": "C8",
+                "mtp.layers.0.self_attn.k_proj.kv_cache_scale": "C8",
+            }
+        )
+
+        self.assertTrue(config.is_c8_quant_layer("mtp.layers.0.self_attn.attn"))
+
+    def test_qwen3_5_mtp_float_packed_layers_are_unquantized(self):
+        from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
+
+        mapping = Qwen3_5MTP.packed_modules_mapping
+        quant_description = {
+            "mtp.layers.0.self_attn.q_proj.weight": "FLOAT",
+            "mtp.layers.0.self_attn.k_proj.weight": "FLOAT",
+            "mtp.layers.0.self_attn.v_proj.weight": "FLOAT",
+            "mtp.layers.0.mlp.gate_proj.weight": "FLOAT",
+            "mtp.layers.0.mlp.up_proj.weight": "FLOAT",
+        }
+        self.assertIsNone(get_quant_type_for_layer(quant_description, "mtp.layers.0.self_attn.qkv_proj", mapping))
+        self.assertIsNone(get_quant_type_for_layer(quant_description, "mtp.layers.0.mlp.gate_up_proj", mapping))
+
     def test_missing_k_eq_v_v_proj_shard_uses_present_shards(self):
         prefix = "model.layers.5.self_attn.qkv_proj"
         fused_mapping = {"qkv_proj": ["q_proj", "k_proj", "v_proj"]}

--- a/tests/ut/quantization/configs/test_modelslim_config.py
+++ b/tests/ut/quantization/configs/test_modelslim_config.py
@@ -274,6 +274,24 @@ class TestAscendModelSlimConfig(TestBase):
         self.assertTrue(config.is_c8_quant_layer("mtp.layers.0.self_attn.attn"))
         self.assertTrue(config.is_c8_quant_layer("language_model.mtp.layers.1.self_attn.attn"))
 
+    def test_mtp_layer_id_ignores_nested_numeric_segments(self):
+        layer_zero_config = AscendModelSlimConfig(
+            {
+                "kv_cache_type": "C8",
+                "language_model.mtp.layers.0.self_attn.k_proj.kv_cache_scale": "C8",
+            }
+        )
+        layer_three_config = AscendModelSlimConfig(
+            {
+                "kv_cache_type": "C8",
+                "language_model.mtp.layers.3.self_attn.k_proj.kv_cache_scale": "C8",
+            }
+        )
+        nested_prefix = "language_model.mtp.layers.0.blocks.3.self_attn.attn"
+
+        self.assertTrue(layer_zero_config.is_c8_quant_layer(nested_prefix))
+        self.assertFalse(layer_three_config.is_c8_quant_layer(nested_prefix))
+
     def test_qwen3_5_mtp_float_packed_layers_are_unquantized(self):
         from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP
 

--- a/tests/ut/quantization/configs/test_modelslim_config.py
+++ b/tests/ut/quantization/configs/test_modelslim_config.py
@@ -258,6 +258,8 @@ class TestAscendModelSlimConfig(TestBase):
 
         self.assertTrue(config.is_c8_quant_layer("model.layers.0.self_attn.attn"))
         self.assertFalse(config.is_c8_quant_layer("mtp.layers.0.self_attn.attn"))
+        self.assertFalse(config.is_c8_quant_layer("model.mtp.layers.0.self_attn.attn"))
+        self.assertFalse(config.is_c8_quant_layer("language_model.mtp.layers.0.self_attn.attn"))
 
     def test_mtp_c8_requires_its_own_kv_scale_metadata(self):
         config = AscendModelSlimConfig(
@@ -265,10 +267,12 @@ class TestAscendModelSlimConfig(TestBase):
                 "kv_cache_type": "C8",
                 "model.layers.0.self_attn.k_proj.kv_cache_scale": "C8",
                 "mtp.layers.0.self_attn.k_proj.kv_cache_scale": "C8",
+                "language_model.mtp.layers.1.self_attn.k_proj.kv_cache_scale": "C8",
             }
         )
 
         self.assertTrue(config.is_c8_quant_layer("mtp.layers.0.self_attn.attn"))
+        self.assertTrue(config.is_c8_quant_layer("language_model.mtp.layers.1.self_attn.attn"))
 
     def test_qwen3_5_mtp_float_packed_layers_are_unquantized(self):
         from vllm.model_executor.models.qwen3_5_mtp import Qwen3_5MTP

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -635,20 +635,20 @@ class AscendModelSlimConfig(QuantizationConfig):
 
     def is_c8_quant_layer(self, prefix):
         if self.enable_c8_quant:
-            layer_id_str = "".join(re.findall(r"\.(\d+)\.", prefix))
-            if not layer_id_str.isdigit():
-                return False
-
             # MTP layer indices restart at zero and overlap the target model's
             # decoder indices. Looking only at ``layers.<n>`` therefore marks
             # an MTP attention layer as C8 whenever target layer ``n`` has C8
             # metadata, even when the checkpoint contains no MTP KV scales.
             # Require namespace-local metadata for MTP, while retaining the
             # legacy index fallback for target model layers.
-            if "mtp.layers." in prefix:
-                layer_sub = f"mtp.layers.{int(layer_id_str)}."
+            mtp_layer_match = re.search(r"(?:^|\.)mtp\.layers\.(\d+)(?:\.|$)", prefix)
+            if mtp_layer_match:
+                layer_sub = f"mtp.layers.{mtp_layer_match.group(1)}."
                 return any(layer_sub in key and key.endswith("k_proj.kv_cache_scale") for key in self.quant_description)
 
+            layer_id_str = "".join(re.findall(r"\.(\d+)\.", prefix))
+            if not layer_id_str.isdigit():
+                return False
             if int(layer_id_str) in self.c8_quant_layers:
                 return True
         return False

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -645,12 +645,9 @@ class AscendModelSlimConfig(QuantizationConfig):
             # metadata, even when the checkpoint contains no MTP KV scales.
             # Require namespace-local metadata for MTP, while retaining the
             # legacy index fallback for target model layers.
-            if prefix.startswith("mtp."):
-                layer_prefix = f"mtp.layers.{int(layer_id_str)}."
-                return any(
-                    key.startswith(layer_prefix) and key.endswith("k_proj.kv_cache_scale")
-                    for key in self.quant_description
-                )
+            if "mtp.layers." in prefix:
+                layer_sub = f"mtp.layers.{int(layer_id_str)}."
+                return any(layer_sub in key and key.endswith("k_proj.kv_cache_scale") for key in self.quant_description)
 
             if int(layer_id_str) in self.c8_quant_layers:
                 return True

--- a/vllm_ascend/quantization/configs/modelslim_config.py
+++ b/vllm_ascend/quantization/configs/modelslim_config.py
@@ -636,7 +636,23 @@ class AscendModelSlimConfig(QuantizationConfig):
     def is_c8_quant_layer(self, prefix):
         if self.enable_c8_quant:
             layer_id_str = "".join(re.findall(r"\.(\d+)\.", prefix))
-            if layer_id_str.isdigit() and int(layer_id_str) in self.c8_quant_layers:
+            if not layer_id_str.isdigit():
+                return False
+
+            # MTP layer indices restart at zero and overlap the target model's
+            # decoder indices. Looking only at ``layers.<n>`` therefore marks
+            # an MTP attention layer as C8 whenever target layer ``n`` has C8
+            # metadata, even when the checkpoint contains no MTP KV scales.
+            # Require namespace-local metadata for MTP, while retaining the
+            # legacy index fallback for target model layers.
+            if prefix.startswith("mtp."):
+                layer_prefix = f"mtp.layers.{int(layer_id_str)}."
+                return any(
+                    key.startswith(layer_prefix) and key.endswith("k_proj.kv_cache_scale")
+                    for key in self.quant_description
+                )
+
+            if int(layer_id_str) in self.c8_quant_layers:
                 return True
         return False
 


### PR DESCRIPTION
### What this PR does / why we need it?

Qwen3.5 MTP layer indices restart at zero and overlap the target decoder indices. Selecting C8 by the numeric layer index alone classifies unscaled BF16 MTP attention as C8 whenever the target layer has C8 metadata. That can write incorrectly scaled draft KV contents.

This patch requires MTP-local `k_proj.kv_cache_scale` metadata before selecting C8, including nested `model.mtp` and `language_model.mtp` prefixes. It extracts the MTP layer index from its namespace, so unrelated numeric path segments do not affect selection. Target layers retain the existing index fallback. The FLOAT QKV and gate/up regression now uses the upstream Qwen3_5MTP packed mapping and `get_quant_type_for_layer`. No duplicate model mapping is added.

The patch is rebased onto `5e062cbc85c3c9a1dc6297eb31c4884e9a660e1b`. It follows the upstream `quantization/configs/` migration and the new packed-mapping/quant-type refactor (#16051). Changes are limited to MTP C8 selection and regression tests. The previous CI checkout/rebase failure against that refactor is resolved.

### Does this PR introduce _any_ user-facing change?

Yes. A checkpoint can use C8 KV cache for the target model while keeping MTP layers in BF16 unless the MTP namespace explicitly supplies C8 KV scales. No API or configuration defaults change.

### How was this patch tested?

Current validation (2026-09-10), patch commit `f8c50d30da2966144f70590332706e505f2f97ac`:

- Ascend base: `5e062cbc85c3c9a1dc6297eb31c4884e9a660e1b`.
- vLLM: the base's verified main commit `b2f685834a6458197e7033966fdef52a23f1abcd`.
- Isolated CPU-only container on an Ascend 910B3 host (no NPU devices, `TORCH_DEVICE_BACKEND_AUTOLOAD=0`), CANN 9.1.0, PyTorch 2.10.0+cpu, torch-npu 2.10.0.post4, transformers 5.14.1.
- `python3 -m pytest -q tests/ut/quantization/configs/test_modelslim_config.py`: **58 passed**, no failures or skips. This is the complete module count, including four MTP regression tests, not 58 new tests.
- The regressions cover target/MTP index overlap, nested prefixes, explicitly scaled MTP, unrelated numeric segments, and FLOAT packed projections.
- Complete manual pre-commit suite (`format.sh ci` hooks, including ShellCheck with the script's options): passed. `git diff --check` and a secret scan of all three PR commits passed.
- Installed source paths and hashes were verified. vLLM used its empty-device source build and Ascend used `COMPILE_CUSTOM_KERNELS=0`; this module tests quantization configuration and does not validate custom kernels or end-to-end generation. No model checkpoint or runtime source overlay was used. Existing service containers were not restarted or modified.

Historical integration validation before this rebase used vLLM `ba07e4a48fc951300d97eb506217dd530583dea3`, Ascend 910B3, a Qwen3.8-27B W8A8 target with C8 target KV and BF16 MTP3. Math, common-knowledge, strict JSON, multimodal, and 32K/128K/258K marker checks passed, with 1K–128K generation under TP1 and TP2. Those model runs were not repeated for this rebase and are not included in the current 58-test result.

Upstream hardware CI still requires a maintainer's `ready-precise` or `ready-all` label; local validation does not replace that gate.

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
