### PR TITLE
[Feature][MLA] Support Kimi-K3 DCP decode on main

### DIFF
--- a/tests/ut/attention/a2/test_common_cp.py
+++ b/tests/ut/attention/a2/test_common_cp.py
@@ -6,6 +6,7 @@ import torch
 from vllm_ascend.attention.context_parallel.common_cp import (
     DCPImplMixin,
     DCPMetadataBuilderMixin,
+    _mask_empty_kv_shards,
     _npu_attention_update,
     _npu_attn_out_lse_update,
     _update_out_and_lse,
@@ -177,6 +178,45 @@ class TestCommonCP(unittest.TestCase):
         self.assertEqual(lse_final.shape, (2, 4, 1))
         self.assertIsInstance(out_final, torch.Tensor)
         self.assertIsInstance(lse_final, torch.Tensor)
+
+    def test_empty_kv_shard_is_online_softmax_identity(self):
+        attn_output = torch.tensor([[[[7.0, 9.0]]], [[[2.0, 3.0]]]])
+        softmax_lse = torch.tensor([[[[5.0]]], [[[4.0]]]])
+
+        output, lse = _mask_empty_kv_shards(
+            attn_output,
+            softmax_lse,
+            torch.tensor([0, 8]),
+        )
+
+        torch.testing.assert_close(output[0], torch.zeros_like(output[0]))
+        self.assertTrue(torch.isneginf(lse[0]).all())
+        torch.testing.assert_close(output[1], attn_output[1])
+        torch.testing.assert_close(lse[1], softmax_lse[1])
+
+    def test_empty_kv_shard_mask_graph_replay_is_dynamic(self):
+        compiled = torch.compile(_mask_empty_kv_shards, backend="eager", fullgraph=True)
+        attn_output = torch.tensor([[[[7.0, 9.0]]], [[[2.0, 3.0]]]])
+        softmax_lse = torch.tensor([[[[5.0]]], [[[4.0]]]])
+
+        first_output, first_lse = compiled(attn_output, softmax_lse, torch.tensor([0, 8]))
+        second_output, second_lse = compiled(attn_output, softmax_lse, torch.tensor([8, 0]))
+
+        torch.testing.assert_close(first_output[0], torch.zeros_like(first_output[0]))
+        torch.testing.assert_close(first_output[1], attn_output[1])
+        self.assertTrue(torch.isneginf(first_lse[0]).all())
+        torch.testing.assert_close(second_output[0], attn_output[0])
+        torch.testing.assert_close(second_output[1], torch.zeros_like(second_output[1]))
+        self.assertTrue(torch.isneginf(second_lse[1]).all())
+
+    def test_all_empty_lse_combine_returns_finite_zero_output(self):
+        outputs = torch.randn(2, 1, 1, 2)
+        lses = torch.full((2, 1, 1, 1), float("-inf"))
+
+        output, lse = _update_out_and_lse(outputs, lses)
+
+        torch.testing.assert_close(output, torch.zeros_like(output))
+        self.assertTrue(torch.isneginf(lse).all())
 
     @patch("vllm_ascend.attention.context_parallel.common_cp.get_decode_context_model_parallel_world_size")
     @patch("torch_npu.npu_attention_update")

--- a/tests/ut/attention/a2/test_mla_cp.py
+++ b/tests/ut/attention/a2/test_mla_cp.py
@@ -7,6 +7,10 @@ from unittest.mock import patch
 import torch
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.context_parallel.fia_mla_heads import (
+    pad_fia_mla_query_heads,
+    trim_fia_mla_query_heads,
+)
 from vllm_ascend.attention.context_parallel.mla_cp import (
     AscendMLADCPDecodeMetadata,
     AscendMlaDCPImpl,
@@ -31,8 +35,56 @@ def test_mla_dcp_extends_v1_backend() -> None:
     assert AscendMlaDCPMetadataBuilder.decode_metadata_cls is (AscendMLADCPDecodeMetadata)
     base_fields = {field.name for field in fields(AscendMLADecodeMetadata)}
     dcp_fields = {field.name for field in fields(AscendMLADCPDecodeMetadata)}
-    assert {"cp_seq_len", "dcp_mtp_attn_mask"}.isdisjoint(base_fields)
-    assert {"cp_seq_len", "dcp_mtp_attn_mask"} <= dcp_fields
+    assert {"cp_seq_len", "cp_seq_len_tensor", "dcp_mtp_attn_mask"}.isdisjoint(base_fields)
+    assert {"cp_seq_len", "cp_seq_len_tensor", "dcp_mtp_attn_mask"} <= dcp_fields
+
+
+def test_kimi_k3_fia_query_heads_pad_and_trim() -> None:
+    q_nope = torch.arange(2 * 12 * 512, dtype=torch.float32).view(2, 12, 1, 512)
+    q_pe = torch.arange(2 * 12 * 64, dtype=torch.float32).view(2, 12, 1, 64)
+
+    padded_nope, padded_pe, padded_heads = pad_fia_mla_query_heads(q_nope, q_pe, "BNSD", 12)
+    output, lse = trim_fia_mla_query_heads(
+        padded_nope,
+        torch.arange(2 * 16, dtype=torch.float32).view(2, 16, 1, 1),
+        "BNSD",
+        12,
+    )
+
+    assert padded_heads == 16
+    torch.testing.assert_close(output, q_nope)
+    torch.testing.assert_close(lse, torch.arange(2 * 16, dtype=torch.float32).view(2, 16, 1, 1)[:, :12])
+    torch.testing.assert_close(padded_nope[:, 12:], torch.zeros_like(padded_nope[:, 12:]))
+    torch.testing.assert_close(padded_pe[:, 12:], torch.zeros_like(padded_pe[:, 12:]))
+
+
+def test_kimi_k3_fia_query_heads_pad_and_trim_bsnd() -> None:
+    q_nope = torch.randn(2, 1, 12, 512)
+    q_pe = torch.randn(2, 1, 12, 64)
+
+    padded_nope, padded_pe, padded_heads = pad_fia_mla_query_heads(q_nope, q_pe, "BSND", 12)
+    lse = torch.randn(2, 16, 1, 1)
+    output, trimmed_lse = trim_fia_mla_query_heads(padded_nope, lse, "BSND", 12)
+
+    assert padded_heads == 16
+    torch.testing.assert_close(output, q_nope)
+    torch.testing.assert_close(trimmed_lse, lse[:, :12])
+    torch.testing.assert_close(padded_pe[:, :, 12:], torch.zeros_like(padded_pe[:, :, 12:]))
+
+
+def test_kimi_k3_fia_query_head_padding_graph_replay() -> None:
+    compiled = torch.compile(pad_fia_mla_query_heads, backend="eager", fullgraph=True)
+    first = torch.ones(1, 12, 1, 512)
+    second = torch.full((1, 12, 1, 512), 2.0)
+    rope = torch.ones(1, 12, 1, 64)
+
+    first_padded, _, first_heads = compiled(first, rope, "BNSD", 12)
+    second_padded, _, second_heads = compiled(second, rope, "BNSD", 12)
+
+    assert first_heads == second_heads == 16
+    torch.testing.assert_close(first_padded[:, :12], first)
+    torch.testing.assert_close(second_padded[:, :12], second)
+    torch.testing.assert_close(second_padded[:, 12:], torch.zeros_like(second_padded[:, 12:]))
 
 
 def test_mla_dcp_reorg_decode_query_gathers_fused_query() -> None:
@@ -96,6 +148,30 @@ def test_mla_dcp_uses_padded_local_chunk_lengths() -> None:
     torch.testing.assert_close(impl.get_context_seq_len_npu(1, metadata), padded_lengths[1])
 
 
+def test_mla_dcp_decode_metadata_keeps_graph_stable_local_lengths() -> None:
+    builder = AscendMlaDCPMetadataBuilder.__new__(AscendMlaDCPMetadataBuilder)
+    builder.num_decodes = 2
+    builder.graph_pad_size = 4
+    builder.cp_seq_len_tensor = torch.empty(8, dtype=torch.int32)
+    builder._require_dcp_metadata = lambda _metadata: SimpleNamespace(
+        draft_cp_seq_len=torch.tensor([8, 0], dtype=torch.int32),
+        dcp_mtp_attn_mask=None,
+    )
+    decode = AscendMLADCPDecodeMetadata(
+        input_positions=torch.arange(2),
+        block_table=torch.ones((2, 2), dtype=torch.int32),
+        seq_lens=torch.tensor([8, 0]),
+        max_seq_lens=8,
+        seq_lens_list=[8, 0],
+    )
+
+    with patch.object(AscendMLAMetadataBuilder, "build_decode_metadata", return_value=decode):
+        result = AscendMlaDCPMetadataBuilder.build_decode_metadata(builder, 0, SimpleNamespace())
+
+    assert result.cp_seq_len_tensor.data_ptr() == builder.cp_seq_len_tensor.data_ptr()
+    torch.testing.assert_close(result.cp_seq_len_tensor, torch.tensor([8, 0, 0, 0], dtype=torch.int32))
+
+
 @patch(
     "vllm_ascend.attention.context_parallel.mla_cp._EXTRA_CTX",
     SimpleNamespace(is_draft_model=False, capturing=False),
@@ -120,6 +196,7 @@ def test_mla_dcp_mixed_cache_hit_batch_uses_decode_bsnd_metadata(mock_fia) -> No
         max_seq_lens=20,
         seq_lens_list=[20],
         cp_seq_len=torch.tensor([10], dtype=torch.int32),
+        cp_seq_len_tensor=torch.tensor([10], dtype=torch.int32),
         dcp_mtp_attn_mask=torch.zeros((1, 1, 4, 4)),
     )
     metadata = AscendMLAMetadata(
@@ -155,3 +232,72 @@ def test_mla_dcp_mixed_cache_hit_batch_uses_decode_bsnd_metadata(mock_fia) -> No
     assert call_kwargs["actual_seq_lengths"] == [4]
     assert call_kwargs["block_table"].shape[0] == 1
     assert call_kwargs["actual_seq_lengths_kv"].tolist() == [10]
+
+
+@patch(
+    "vllm_ascend.attention.context_parallel.mla_cp._EXTRA_CTX",
+    SimpleNamespace(is_draft_model=False, capturing=False),
+)
+@patch("vllm_ascend.attention.context_parallel.mla_cp.torch_npu.npu_fused_infer_attention_score")
+def test_kimi_k3_dcp_decode_handles_graph_padded_local_lengths(mock_fia) -> None:
+    impl = AscendMlaDCPImpl.__new__(AscendMlaDCPImpl)
+    impl.dcp_size = 1
+    impl.num_heads = 12
+    impl.num_kv_heads = 1
+    impl.kv_lora_rank = 3
+    impl.qk_rope_head_dim = 2
+    impl.scale = 1.0
+    impl.speculative_config = None
+    merged = {}
+
+    def merge(output, lse, _head_size):
+        merged["output"] = output
+        merged["lse"] = lse
+        return output
+
+    impl._merge_dcp_attention_output = merge
+    impl._v_up_proj_batch_major = lambda output: output
+    metadata = AscendMLAMetadata(
+        num_actual_tokens=2,
+        slot_mapping=torch.arange(2),
+        query_start_loc=torch.tensor([0, 1, 2]),
+        seq_lens=torch.tensor([0, 8]),
+        seq_lens_cpu=torch.tensor([0, 8]),
+        block_tables=torch.ones((2, 2), dtype=torch.int32),
+        num_decodes=2,
+        num_decode_tokens=2,
+        num_prefills=0,
+        query_lens=[1, 1],
+        attn_state=AscendAttentionState.DecodeOnly,
+        decode=AscendMLADCPDecodeMetadata(
+            input_positions=torch.arange(2),
+            block_table=torch.ones((2, 2), dtype=torch.int32),
+            seq_lens=torch.tensor([0, 8]),
+            max_seq_lens=8,
+            seq_lens_list=[0, 8],
+            cp_seq_len=[0, 8],
+            cp_seq_len_tensor=torch.tensor([0, 8, 0, 0], dtype=torch.int32),
+        ),
+    )
+    mock_fia.return_value = (
+        torch.ones(2, 16, 1, 3),
+        torch.full((2, 16, 1, 1), 4.0),
+    )
+
+    impl._forward_decode(
+        torch.randn(2, 12, 3),
+        torch.randn(2, 12, 2),
+        torch.randn(2, 1, 2, 3),
+        torch.randn(2, 1, 2, 2),
+        2,
+        metadata,
+    )
+
+    query = mock_fia.call_args.args[0]
+    assert query.shape == (2, 16, 1, 3)
+    assert mock_fia.call_args.kwargs["num_heads"] == 16
+    torch.testing.assert_close(query[:, 12:], torch.zeros_like(query[:, 12:]))
+    assert merged["output"].shape == (2, 12, 3)
+    torch.testing.assert_close(merged["output"][0], torch.zeros_like(merged["output"][0]))
+    assert torch.isneginf(merged["lse"][0]).all()
+    torch.testing.assert_close(merged["output"][1], torch.ones_like(merged["output"][1]))

--- a/vllm_ascend/attention/context_parallel/common_cp.py
+++ b/vllm_ascend/attention/context_parallel/common_cp.py
@@ -136,6 +136,25 @@ class DCPImplMixin:
         )
 
 
+def _mask_empty_kv_shards(
+    attn_output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    local_kv_seq_lens: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Turn empty local KV shards into the online-softmax identity."""
+    local_kv_seq_lens = local_kv_seq_lens[: attn_output.shape[0]]
+    if local_kv_seq_lens.numel() != attn_output.shape[0]:
+        raise ValueError(
+            "local KV sequence lengths must match attention rows: "
+            f"{local_kv_seq_lens.numel()} != {attn_output.shape[0]}"
+        )
+    valid = local_kv_seq_lens.reshape((-1,) + (1,) * (attn_output.ndim - 1)) > 0
+    return (
+        torch.where(valid, attn_output, torch.zeros_like(attn_output)),
+        torch.where(valid, softmax_lse, torch.full_like(softmax_lse, float("-inf"))),
+    )
+
+
 def _process_attn_out_lse(
     attn_output: torch.Tensor,
     softmax_lse: torch.Tensor,
@@ -229,5 +248,9 @@ def _update_out_and_lse(out_list: torch.Tensor, lse_list: torch.Tensor) -> torch
         lse_final: shape = [batch_size, num_heads, 1]
     """
     lse_final = torch.logsumexp(lse_list, dim=0, keepdim=False)
-    out_final = torch.sum(torch.exp(lse_list - lse_final) * out_list, dim=0)
+    all_empty = torch.isneginf(lse_final)
+    safe_lse_final = torch.where(all_empty, torch.zeros_like(lse_final), lse_final)
+    weights = torch.exp(lse_list - safe_lse_final)
+    weights = torch.where(all_empty, torch.zeros_like(weights), weights)
+    out_final = torch.sum(weights * out_list, dim=0)
     return out_final, lse_final

--- a/vllm_ascend/attention/context_parallel/fia_mla_heads.py
+++ b/vllm_ascend/attention/context_parallel/fia_mla_heads.py
@@ -1,0 +1,43 @@
+import torch
+
+_SUPPORTED_NUM_HEADS = (1, 2, 4, 8, 16, 32, 64, 128)
+
+
+def pad_fia_mla_query_heads(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    input_layout: str,
+    num_heads: int,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Pad MLA query heads to a shape accepted by FIA with D=512 and RoPE."""
+    if num_heads in _SUPPORTED_NUM_HEADS:
+        return q_nope, q_pe, num_heads
+
+    head_axis = {"BNSD": 1, "BSND": 2}.get(input_layout)
+    if head_axis is None:
+        raise ValueError(f"Cannot pad FIA MLA query heads for input layout {input_layout}")
+    padded_num_heads = next((value for value in _SUPPORTED_NUM_HEADS if value > num_heads), None)
+    if padded_num_heads is None:
+        raise ValueError(f"FIA MLA query head count {num_heads} exceeds the supported range")
+
+    pad_shape = list(q_nope.shape)
+    pad_shape[head_axis] = padded_num_heads - num_heads
+    q_nope = torch.cat((q_nope, q_nope.new_zeros(pad_shape)), dim=head_axis)
+    pad_shape[-1] = q_pe.shape[-1]
+    q_pe = torch.cat((q_pe, q_pe.new_zeros(pad_shape)), dim=head_axis)
+    return q_nope, q_pe, padded_num_heads
+
+
+def trim_fia_mla_query_heads(
+    attn_output: torch.Tensor,
+    softmax_lse: torch.Tensor,
+    input_layout: str,
+    num_heads: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    output_head_axis = {"BNSD": 1, "BSND": 2}.get(input_layout)
+    if output_head_axis is None:
+        raise ValueError(f"Cannot trim FIA MLA query heads for input layout {input_layout}")
+    return (
+        attn_output.narrow(output_head_axis, 0, num_heads),
+        softmax_lse.narrow(1, 0, num_heads),
+    )

--- a/vllm_ascend/attention/context_parallel/mla_cp.py
+++ b/vllm_ascend/attention/context_parallel/mla_cp.py
@@ -23,6 +23,11 @@ from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.context_parallel.common_cp import (
     DCPImplMixin,
     DCPMetadataBuilderMixin,
+    _mask_empty_kv_shards,
+)
+from vllm_ascend.attention.context_parallel.fia_mla_heads import (
+    pad_fia_mla_query_heads,
+    trim_fia_mla_query_heads,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
 from vllm_ascend.compilation.acl_graph import (
@@ -51,6 +56,7 @@ class AscendMLADCPDecodeMetadata(AscendMLADecodeMetadata):
     """MLA decode metadata fields used only by DCP."""
 
     cp_seq_len: torch.Tensor = None
+    cp_seq_len_tensor: torch.Tensor = None
     dcp_mtp_attn_mask: torch.Tensor = None
 
 
@@ -77,6 +83,11 @@ class AscendMlaDCPMetadataBuilder(
         self.block_size = (self.block_size * self.cp_virtual_block_size) // np.gcd(
             self.block_size,
             self.cp_virtual_block_size,
+        )
+        self.cp_seq_len_tensor = torch.zeros(
+            vllm_config.scheduler_config.max_num_seqs,
+            dtype=torch.int32,
+            device=device,
         )
 
     def build_chunked_metadata(
@@ -148,12 +159,19 @@ class AscendMlaDCPMetadataBuilder(
         assert isinstance(decode_metadata, AscendMLADCPDecodeMetadata)
         dcp_metadata = self._require_dcp_metadata(common_attn_metadata)
         if dcp_metadata.draft_cp_seq_len is not None:
-            decode_metadata.cp_seq_len = dcp_metadata.draft_cp_seq_len[: self.num_decodes]
+            cp_seq_len = dcp_metadata.draft_cp_seq_len[: self.num_decodes]
+            decode_metadata.cp_seq_len = cp_seq_len
         else:
-            decode_metadata.cp_seq_len = self._get_dcp_rank_context_lens(
+            cp_seq_len = self._get_dcp_rank_context_lens(
                 common_attn_metadata,
                 end=self.num_decodes,
-            ).tolist()
+            )
+            decode_metadata.cp_seq_len = cp_seq_len.tolist()
+        mask_num_rows = max(self.num_decodes, self.graph_pad_size)
+        cp_seq_len_tensor = self.cp_seq_len_tensor[:mask_num_rows]
+        cp_seq_len_tensor.zero_()
+        cp_seq_len_tensor[: self.num_decodes].copy_(cp_seq_len, non_blocking=True)
+        decode_metadata.cp_seq_len_tensor = cp_seq_len_tensor
         decode_metadata.actual_seq_lengths_q = torch.arange(self.num_decodes) + 1
         decode_metadata.dcp_mtp_attn_mask = dcp_metadata.dcp_mtp_attn_mask
         return decode_metadata
@@ -339,6 +357,9 @@ class AscendMlaDCPImpl(DCPImplMixin, AscendMLAImpl):
             sparse_mode = 0
             spec_attn_mask = None
 
+        original_num_heads = num_heads
+        q_nope, q_pe, num_heads = pad_fia_mla_query_heads(q_nope, q_pe, input_layout, num_heads)
+
         common_kwargs = {
             "query_rope": q_pe,
             "key_rope": k_pe,
@@ -422,6 +443,18 @@ class AscendMlaDCPImpl(DCPImplMixin, AscendMLAImpl):
                 k_nope,
                 k_nope,
                 **common_kwargs,
+            )
+        attn_output, softmax_lse = _mask_empty_kv_shards(
+            attn_output,
+            softmax_lse,
+            decode_meta.cp_seq_len_tensor,
+        )
+        if num_heads != original_num_heads:
+            attn_output, softmax_lse = trim_fia_mla_query_heads(
+                attn_output,
+                softmax_lse,
+                input_layout,
+                original_num_heads,
             )
         if input_layout == "BSND":
             attn_output = attn_output.view(-1, attn_output.shape[2], attn_output.shape[3])


### PR DESCRIPTION
# [Feature][MLA] Support Kimi-K3 DCP decode on main

### What this PR does / why we need it?

This is the current-main port of vLLM Ascend PR [#14126](https://github.com/vllm-project/vllm-ascend/pull/14126), which targeted `releases/v0.23.0` and validated the Kimi-K3 DCP path on Ascend A3.

Kimi-K3 exposes 12 local MLA query heads under its TP/DCP layout, while Ascend FIA accepts power-of-two head counts for the D=512 plus RoPE path. This patch pads the query to 16 heads for FIA and trims the output and LSE back to 12 heads.

DCP ranks can also receive an empty local KV shard. The patch keeps DCP-local sequence lengths in a graph-stable device buffer and maps empty FIA results to the online-softmax identity (`O=0`, `LSE=-inf`) before the cross-rank merge. Fully empty padding rows produce finite zero output.

When graph padding reserves more sequence-length rows than eager FIA returns, masking consumes only the actual output-row prefix while retaining the validation for genuinely short metadata.

Current main already provides the generic DCP query gather, chunked-prefill KV reassembly, metadata split, and output merge. This patch does not include Query/Output VMM or later O/LSE optimization experiments.

Port provenance:

- Previous PR: `vllm-project/vllm-ascend#14126`
- Previous PR branch/base: `codex/kimi-k3-dcp2-upstream` → `releases/v0.23.0`
- Previous PR feature commit: `23802e71bc20e205f9a67892314c7f6a47b8dd59`
- Additional focused-test source: `2dd93760744896be25b2758b200b99af826662bc`
- Source base: `releases/v0.23.0` at `19695928d47c222e44f35320da7dd84b7b18a422`
- Target base: `main` at `1a086ce8ab27a01d2b2fdef32797b6d989f4727f`
- Port commit: `53a0da8fc4cb29c68e6dbfa1e38ac6c5c7adcd29`

### Does this PR introduce _any_ user-facing change?

Yes. Kimi-K3 MLA decode can use DCP when the local query-head count is unsupported by FIA and when individual DCP KV shards are empty.

### How was this patch tested?

#### Current-main port tests

The directory segment `tests/ut/attention/a2/` is the existing repository test-suite path; it does **not** mean the tests ran on A2 hardware.

The focused tests also run CPU-only locally with device-backend autoload disabled:

```bash
TORCH_DEVICE_BACKEND_AUTOLOAD=0 \
python -m pytest -q \
  tests/ut/attention/a2/test_common_cp.py \
  tests/ut/attention/a2/test_mla_cp.py \
  tests/ut/attention/a2/test_mla_cp_precision.py \
  tests/ut/attention/a2/test_attention_cp_precision.py \
  -k "not test_npu_attention_update and not test_npu_attn_out_lse_update"
```

Result: `22 passed, 2 deselected`. The two deselected pre-existing tests require `torch_npu.npu_attention_update`, which is unavailable when backend autoload is disabled in this CPU-only environment. Live NPU validation of the current-main port remains a separate follow-up.

#### Prior A3 runtime evidence

PR #14126 validated the v0.23 implementation on two ARM Ascend A3 nodes with DP2/TP16/EP32, including DCP2, DCP8, DCP16, graph capture, long-context requests, and post-run 32/32 chip health. That evidence establishes the source feature's A3 behavior, but it has not yet been rerun against this current-main port and is not presented as fresh runtime validation here.

Static validation:

```text
ruff check: passed
ruff format --check: passed
git diff --check: passed
```

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
