### PR TITLE
[Feature][Model] Support MiniMax M3 with CANN MegaMoE

### DIFF
--- a/tests/ut/ops/test_cann_mega_moe.py
+++ b/tests/ut/ops/test_cann_mega_moe.py
@@ -1,0 +1,102 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from vllm_ascend.ascend_config import AscendConfig
+from vllm_ascend.ops.fused_moe.moe_comm_method import (
+    _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL,
+    FusedMC2CommImpl,
+)
+from vllm_ascend.ops.fused_moe.token_dispatcher import TokenDispatcherWithMC2
+from vllm_ascend.quantization.methods.base import QuantType
+
+
+def _make_comm_impl():
+    comm_impl = object.__new__(FusedMC2CommImpl)
+    comm_impl.token_dispatcher = object.__new__(TokenDispatcherWithMC2)
+    comm_impl.token_dispatcher.global_bs = 1
+    comm_impl.mega_moe_symm_buffer = SimpleNamespace(
+        dispatch_quant_mode=None,
+        dispatch_quant_out_dtype=None,
+    )
+    comm_impl.mega_moe = MagicMock()
+    comm_impl.swiglu_limit = 7.0
+    comm_impl.swiglu_alpha = 1.5
+    comm_impl.swiglu_beta = 0.25
+    return comm_impl
+
+
+def _make_fused_experts_input(num_tokens, mc2_mask=None):
+    return SimpleNamespace(
+        hidden_states=torch.empty(num_tokens, 4),
+        topk_ids=torch.zeros(num_tokens, 1, dtype=torch.int64),
+        topk_weights=torch.ones(num_tokens, 1),
+        activation="swigluoai_uninterleave",
+        weights=SimpleNamespace(
+            w1=[torch.empty(4, 8, dtype=torch.int8)],
+            w2=[torch.empty(4, 4, dtype=torch.int8)],
+            w1_scale=[torch.empty(8, dtype=torch.int64)],
+            w2_scale=[torch.empty(4, dtype=torch.int64)],
+            w1_scale_bias=None,
+            w2_scale_bias=None,
+        ),
+        routing=SimpleNamespace(mc2_mask=mc2_mask),
+        quant=SimpleNamespace(quant_type=QuantType.W8A8),
+    )
+
+
+def test_cann_mega_moe_receives_swigluoai_parameters():
+    comm_impl = _make_comm_impl()
+    comm_impl.mega_moe.return_value = (torch.empty(1, 4), torch.empty(2, dtype=torch.int32))
+
+    comm_impl._apply_cann_mega_moe(_make_fused_experts_input(1))
+
+    call_kwargs = comm_impl.mega_moe.call_args.kwargs
+    assert call_kwargs["activation"] == "swigluoai"
+    assert call_kwargs["activation_clamp"] == 7.0
+    assert call_kwargs["activation_params"] == {"alpha": 1.5, "beta": 0.25}
+
+
+def test_cann_mega_moe_splits_batches_above_operator_limit():
+    comm_impl = _make_comm_impl()
+    comm_impl.token_dispatcher.global_bs = 0
+    first_out = torch.ones(_CANN_MEGA_MOE_MAX_TOKENS_PER_CALL, 4)
+    second_out = torch.full((1, 4), 2.0)
+    comm_impl.mega_moe.side_effect = [
+        (first_out, torch.tensor([1, 2], dtype=torch.int32)),
+        (second_out, torch.tensor([3, 4], dtype=torch.int32)),
+    ]
+    num_tokens = _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL + 1
+
+    with patch("vllm_ascend.ops.fused_moe.moe_comm_method.torch.cat") as mock_cat:
+        out, expert_tokens = comm_impl._apply_cann_mega_moe(
+            _make_fused_experts_input(num_tokens, mc2_mask=torch.ones(num_tokens, dtype=torch.bool))
+        )
+
+    mock_cat.assert_not_called()
+    assert [call.args[0].shape[0] for call in comm_impl.mega_moe.call_args_list] == [
+        _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL,
+        1,
+    ]
+    assert [call.kwargs["x_active_mask"].shape[0] for call in comm_impl.mega_moe.call_args_list] == [
+        _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL,
+        1,
+    ]
+    torch.testing.assert_close(out, torch.cat([first_out, second_out], dim=0))
+    torch.testing.assert_close(expert_tokens, torch.tensor([4, 6], dtype=torch.int32))
+
+
+def test_minimax_m3_uses_intermediate_size_for_megamoe_support():
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            architectures=["MiniMaxM3ForCausalLM"],
+            hf_text_config=SimpleNamespace(
+                hidden_size=4096,
+                intermediate_size=1536,
+                moe_quantize="w8a8",
+            ),
+        )
+    )
+
+    assert AscendConfig._is_megamoe_supported_by_config(vllm_config)

--- a/tests/ut/ops/test_cann_mega_moe.py
+++ b/tests/ut/ops/test_cann_mega_moe.py
@@ -4,10 +4,8 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from vllm_ascend.ascend_config import AscendConfig
-from vllm_ascend.ops.fused_moe.moe_comm_method import (
-    _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL,
-    FusedMC2CommImpl,
-)
+from vllm_ascend.ascend_forward_context import _MEGA_MOE_TOKENS_PER_RANK_LIMIT
+from vllm_ascend.ops.fused_moe.moe_comm_method import FusedMC2CommImpl
 from vllm_ascend.ops.fused_moe.token_dispatcher import TokenDispatcherWithMC2
 from vllm_ascend.quantization.methods.base import QuantType
 
@@ -58,16 +56,37 @@ def test_cann_mega_moe_receives_swigluoai_parameters():
     assert call_kwargs["activation_params"] == {"alpha": 1.5, "beta": 0.25}
 
 
+def test_cann_mega_moe_symm_buffer_uses_chunk_capacity():
+    comm_impl = _make_comm_impl()
+    comm_impl.token_dispatcher.ep_world_size = 2
+    comm_impl.token_dispatcher.ep_rank_id = 0
+    comm_impl.token_dispatcher.max_num_tokens_per_rank = 40
+    comm_impl.moe_config = SimpleNamespace(
+        experts_per_token=2,
+        num_experts=8,
+        hidden_dim=4096,
+        intermediate_size_per_partition=1536,
+    )
+    comm_impl.get_symm_buffer_for_mega_moe = MagicMock()
+    mc2_group = SimpleNamespace(device_group=object())
+
+    with patch("vllm_ascend.ops.fused_moe.moe_comm_method.get_mc2_group", return_value=mc2_group):
+        comm_impl._init_mega_moe_symm_buffer()
+
+    call = comm_impl.get_symm_buffer_for_mega_moe.call_args
+    assert call.args[2] == _MEGA_MOE_TOKENS_PER_RANK_LIMIT
+
+
 def test_cann_mega_moe_splits_batches_above_operator_limit():
     comm_impl = _make_comm_impl()
     comm_impl.token_dispatcher.global_bs = 0
-    first_out = torch.ones(_CANN_MEGA_MOE_MAX_TOKENS_PER_CALL, 4)
+    first_out = torch.ones(_MEGA_MOE_TOKENS_PER_RANK_LIMIT, 4)
     second_out = torch.full((1, 4), 2.0)
     comm_impl.mega_moe.side_effect = [
         (first_out, torch.tensor([1, 2], dtype=torch.int32)),
         (second_out, torch.tensor([3, 4], dtype=torch.int32)),
     ]
-    num_tokens = _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL + 1
+    num_tokens = _MEGA_MOE_TOKENS_PER_RANK_LIMIT + 1
 
     with patch("vllm_ascend.ops.fused_moe.moe_comm_method.torch.cat") as mock_cat:
         out, expert_tokens = comm_impl._apply_cann_mega_moe(
@@ -76,11 +95,11 @@ def test_cann_mega_moe_splits_batches_above_operator_limit():
 
     mock_cat.assert_not_called()
     assert [call.args[0].shape[0] for call in comm_impl.mega_moe.call_args_list] == [
-        _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL,
+        _MEGA_MOE_TOKENS_PER_RANK_LIMIT,
         1,
     ]
     assert [call.kwargs["x_active_mask"].shape[0] for call in comm_impl.mega_moe.call_args_list] == [
-        _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL,
+        _MEGA_MOE_TOKENS_PER_RANK_LIMIT,
         1,
     ]
     torch.testing.assert_close(out, torch.cat([first_out, second_out], dim=0))

--- a/tests/ut/ops/test_cann_mega_moe.py
+++ b/tests/ut/ops/test_cann_mega_moe.py
@@ -1,12 +1,16 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 
 from vllm_ascend.ascend_config import AscendConfig
 from vllm_ascend.ascend_forward_context import _MEGA_MOE_TOKENS_PER_RANK_LIMIT
 from vllm_ascend.ops.fused_moe.moe_comm_method import FusedMC2CommImpl
-from vllm_ascend.ops.fused_moe.token_dispatcher import TokenDispatcherWithMC2
+from vllm_ascend.ops.fused_moe.token_dispatcher import (
+    TokenDispatcherWithMC2,
+    _get_mega_moe_max_num_tokens_per_rank,
+)
 from vllm_ascend.quantization.methods.base import QuantType
 
 
@@ -17,6 +21,7 @@ def _make_comm_impl():
     comm_impl.mega_moe_symm_buffer = SimpleNamespace(
         dispatch_quant_mode=None,
         dispatch_quant_out_dtype=None,
+        num_max_tokens_per_rank=_MEGA_MOE_TOKENS_PER_RANK_LIMIT,
     )
     comm_impl.mega_moe = MagicMock()
     comm_impl.swiglu_limit = 7.0
@@ -44,6 +49,23 @@ def _make_fused_experts_input(num_tokens, mc2_mask=None):
     )
 
 
+@pytest.mark.parametrize(
+    ("kv_transfer_config", "expected_capacity"),
+    [
+        (None, _MEGA_MOE_TOKENS_PER_RANK_LIMIT),
+        (SimpleNamespace(is_kv_consumer=True, is_kv_producer=False), 40),
+        (
+            SimpleNamespace(is_kv_consumer=True, is_kv_producer=True),
+            _MEGA_MOE_TOKENS_PER_RANK_LIMIT,
+        ),
+    ],
+)
+def test_mega_moe_capacity_accounts_for_pd_role(kv_transfer_config, expected_capacity):
+    vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
+
+    assert _get_mega_moe_max_num_tokens_per_rank(vllm_config, 40) == expected_capacity
+
+
 def test_cann_mega_moe_receives_swigluoai_parameters():
     comm_impl = _make_comm_impl()
     comm_impl.mega_moe.return_value = (torch.empty(1, 4), torch.empty(2, dtype=torch.int32))
@@ -56,11 +78,18 @@ def test_cann_mega_moe_receives_swigluoai_parameters():
     assert call_kwargs["activation_params"] == {"alpha": 1.5, "beta": 0.25}
 
 
-def test_cann_mega_moe_symm_buffer_uses_chunk_capacity():
+@pytest.mark.parametrize(
+    ("is_pd_decode_consumer", "expected_capacity"),
+    [(False, _MEGA_MOE_TOKENS_PER_RANK_LIMIT), (True, 40)],
+)
+def test_cann_mega_moe_symm_buffer_uses_instance_capacity(is_pd_decode_consumer, expected_capacity):
     comm_impl = _make_comm_impl()
     comm_impl.token_dispatcher.ep_world_size = 2
     comm_impl.token_dispatcher.ep_rank_id = 0
     comm_impl.token_dispatcher.max_num_tokens_per_rank = 40
+    comm_impl.token_dispatcher.mega_moe_max_num_tokens_per_rank = (
+        40 if is_pd_decode_consumer else _MEGA_MOE_TOKENS_PER_RANK_LIMIT
+    )
     comm_impl.moe_config = SimpleNamespace(
         experts_per_token=2,
         num_experts=8,
@@ -74,7 +103,8 @@ def test_cann_mega_moe_symm_buffer_uses_chunk_capacity():
         comm_impl._init_mega_moe_symm_buffer()
 
     call = comm_impl.get_symm_buffer_for_mega_moe.call_args
-    assert call.args[2] == _MEGA_MOE_TOKENS_PER_RANK_LIMIT
+    assert call.args[2] == expected_capacity
+    assert call.kwargs["max_recv_token_num"] == expected_capacity * 4
 
 
 def test_cann_mega_moe_splits_batches_above_operator_limit():
@@ -102,6 +132,26 @@ def test_cann_mega_moe_splits_batches_above_operator_limit():
         _MEGA_MOE_TOKENS_PER_RANK_LIMIT,
         1,
     ]
+    torch.testing.assert_close(out, torch.cat([first_out, second_out], dim=0))
+    torch.testing.assert_close(expert_tokens, torch.tensor([4, 6], dtype=torch.int32))
+
+
+def test_cann_mega_moe_chunks_at_symm_buffer_capacity():
+    comm_impl = _make_comm_impl()
+    comm_impl.token_dispatcher.global_bs = 0
+    comm_impl.mega_moe_symm_buffer.num_max_tokens_per_rank = 40
+    first_out = torch.ones(40, 4)
+    second_out = torch.full((1, 4), 2.0)
+    comm_impl.mega_moe.side_effect = [
+        (first_out, torch.tensor([1, 2], dtype=torch.int32)),
+        (second_out, torch.tensor([3, 4], dtype=torch.int32)),
+    ]
+
+    out, expert_tokens = comm_impl._apply_cann_mega_moe(
+        _make_fused_experts_input(41, mc2_mask=torch.ones(41, dtype=torch.bool))
+    )
+
+    assert [call.args[0].shape[0] for call in comm_impl.mega_moe.call_args_list] == [40, 1]
     torch.testing.assert_close(out, torch.cat([first_out, second_out], dim=0))
     torch.testing.assert_close(expert_tokens, torch.tensor([4, 6], dtype=torch.int32))
 

--- a/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
+++ b/tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
@@ -241,6 +241,46 @@ class TestAscendW8A8FusedMoEMethod(TestBase):
         self.assertIs(fused_experts_input.topk_ids, topk_ids)
         self.assertIs(fused_experts_input.lora_context, lora_context)
 
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic._MEGA_MOE_SUPPORTED", True)
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
+    @patch("vllm_ascend.quantization.methods.w8a8_dynamic._EXTRA_CTX")
+    def test_apply_swigluoai_uses_cann_mega_moe_weights(self, mock_extra_ctx, mock_get_config):
+        mock_get_config.return_value.enable_fused_mc2 = 1
+        mock_extra_ctx.moe_comm_type = MoECommType.FUSED_MC2
+        mock_extra_ctx.moe_comm_method.fused_experts.return_value = torch.empty(1, self.hidden_size)
+        self.quant_method.in_dtype = torch.float32
+        self.quant_method.use_expert_weight_list = False
+
+        layer = SimpleNamespace(
+            activation="swigluoai_uninterleave",
+            cann_mega_moe_w13_weight_list=[torch.empty(self.hidden_size, 2 * self.intermediate_size)],
+            cann_mega_moe_w2_weight_list=[torch.empty(self.intermediate_size, self.hidden_size)],
+            cann_mega_moe_fused_w1_scale_list=[torch.empty(2 * self.intermediate_size)],
+            cann_mega_moe_fused_w2_scale_list=[torch.empty(self.hidden_size)],
+            ascend_expert_map=None,
+            global_redundant_expert_num=0,
+            ascend_mc2_mask=None,
+            apply_router_weight_on_input=False,
+            ascend_pertoken_scale=None,
+        )
+
+        self.quant_method.apply(
+            layer=layer,
+            x=torch.empty(1, self.hidden_size),
+            topk_weights=torch.ones(1, 1),
+            topk_ids=torch.zeros(1, 1, dtype=torch.int64),
+            shared_experts=None,
+            shared_experts_input=None,
+        )
+
+        fused_experts_input = mock_extra_ctx.moe_comm_method.fused_experts.call_args.kwargs["fused_experts_input"]
+        self.assertIs(fused_experts_input.weights.w1, layer.cann_mega_moe_w13_weight_list)
+        self.assertIs(fused_experts_input.weights.w2, layer.cann_mega_moe_w2_weight_list)
+        self.assertIs(fused_experts_input.weights.w1_scale, layer.cann_mega_moe_fused_w1_scale_list)
+        self.assertIs(fused_experts_input.weights.w2_scale, layer.cann_mega_moe_fused_w2_scale_list)
+        self.assertIsNone(fused_experts_input.weights.w1_scale_bias)
+        self.assertIsNone(fused_experts_input.weights.w2_scale_bias)
+
     @patch("torch_npu.npu_format_cast")
     @patch("vllm_ascend.quantization.methods.w8a8_dynamic.get_ascend_config")
     def test_process_weights_after_loading(self, mock_get_config, mock_format_cast):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -404,16 +404,8 @@ class AscendConfig:
                 "only guaranteed when the recompute scheduler is enabled."
             )
 
-        # enable_fused_mc2 enum + MiniMax mutex + multistream auto-disable
+        # enable_fused_mc2 enum + multistream auto-disable
         assert self.enable_fused_mc2 in (0, 1), f"enable_fused_mc2 must be 0 or 1, got {self.enable_fused_mc2}"
-        model_architectures = getattr(vc.model_config, "architectures", None) or []
-        assert not (
-            self.enable_fused_mc2 == 1
-            and any(architecture.startswith("MiniMaxM3") for architecture in model_architectures)
-        ), (
-            "MiniMax M3 does not support enable_fused_mc2=1. Please set "
-            "additional_config.enable_fused_mc2 to 0 or unset VLLM_ASCEND_ENABLE_FUSED_MC2."
-        )
         if self.enable_fused_mc2 == 1 and self.multistream_overlap_shared_expert:
             self.multistream_overlap_shared_expert = False
             logger.warning_once(
@@ -587,6 +579,11 @@ class AscendConfig:
             return False
 
         moe_intermediate_size = getattr(hf_text_config, "moe_intermediate_size", None)
+        model_architectures = getattr(vllm_config.model_config, "architectures", None) or []
+        if moe_intermediate_size is None and any(
+            architecture.startswith("MiniMaxM3") for architecture in model_architectures
+        ):
+            moe_intermediate_size = getattr(hf_text_config, "intermediate_size", None)
         if moe_intermediate_size is None:
             return False
         if moe_intermediate_size < 1024 or moe_intermediate_size > 3072 or moe_intermediate_size % 512 != 0:

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -23,7 +23,7 @@ from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_config import _MEGA_MOE_SUPPORTED, get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_TOKENS_PER_RANK_LIMIT, MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe import moe_utils
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEFusedExpertsInput
@@ -290,10 +290,7 @@ class FusedMC2CommImpl(MoECommMethod):
         # Assert it so mypy resolves those attributes off the base dispatcher.
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
         group = get_mc2_group().device_group
-        # The symmetric CCL buffer must be large enough for every MegaMoe call.
-        # Use the same rank-invariant capacity that bounds the chunks below so
-        # prefill does not reuse a buffer sized only for the decode capacity.
-        num_max_tokens_per_rank = _MEGA_MOE_TOKENS_PER_RANK_LIMIT
+        num_max_tokens_per_rank = self.token_dispatcher.mega_moe_max_num_tokens_per_rank
         num_topk = self.moe_config.experts_per_token
         num_experts = self.moe_config.num_experts
         expert_per_rank = max(1, num_experts // int(self.token_dispatcher.ep_world_size))
@@ -388,11 +385,12 @@ class FusedMC2CommImpl(MoECommMethod):
         topk_ids = fused_experts_input.topk_ids.to(torch.int32)
         topk_weights = fused_experts_input.topk_weights.to(torch.float32)
         num_tokens = hidden_states.shape[0]
+        max_tokens_per_call = int(self.mega_moe_symm_buffer.num_max_tokens_per_rank)
 
-        out = torch.empty_like(hidden_states) if num_tokens > _MEGA_MOE_TOKENS_PER_RANK_LIMIT else None
+        out = torch.empty_like(hidden_states) if num_tokens > max_tokens_per_call else None
         expert_tokens = None
-        for start in range(0, num_tokens, _MEGA_MOE_TOKENS_PER_RANK_LIMIT):
-            end = min(start + _MEGA_MOE_TOKENS_PER_RANK_LIMIT, num_tokens)
+        for start in range(0, num_tokens, max_tokens_per_call):
+            end = min(start + max_tokens_per_call, num_tokens)
             chunk_mask = None if x_active_mask is None else x_active_mask[start:end]
             chunk_out, chunk_expert_tokens = self.mega_moe(
                 hidden_states[start:end],

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -23,7 +23,7 @@ from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
 from vllm_ascend.ascend_config import _MEGA_MOE_SUPPORTED, get_ascend_config
-from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX, _MEGA_MOE_TOKENS_PER_RANK_LIMIT, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe import moe_utils
 from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEFusedExpertsInput
@@ -46,7 +46,6 @@ from vllm_ascend.ops.fused_moe.token_dispatcher import (
 from vllm_ascend.quantization.quant_type import QuantType
 
 _MoECommMethods: dict[MoECommType | None, MoECommMethod] = {}
-_CANN_MEGA_MOE_MAX_TOKENS_PER_CALL = 4096
 
 
 def get_moe_comm_method(moe_comm_type: MoECommType | None) -> MoECommMethod | None:
@@ -291,24 +290,10 @@ class FusedMC2CommImpl(MoECommMethod):
         # Assert it so mypy resolves those attributes off the base dispatcher.
         assert isinstance(self.token_dispatcher, TokenDispatcherWithMC2)
         group = get_mc2_group().device_group
-        # The sym buffer is allocated by get_symm_buffer_for_mega_moe, a
-        # collective handshake over the EP (mc2) group. Its shape params —
-        # especially num_max_tokens_per_rank — MUST be identical on every EP
-        # rank, otherwise ranks allocate mismatched buffers / at different
-        # times and HCCL aborts (SUSPECT REMOTE ERROR 507057). So this value
-        # must be derived ONLY from rank-invariant, compile-time config,
-        # NEVER from the current forward's per-rank token count.
-        if self.token_dispatcher.global_bs > 0:
-            # global_bs = num_tokens_per_tp_rank * ep_world_size (compile-time).
-            num_max_tokens_per_rank = max(
-                1,
-                int(self.token_dispatcher.global_bs // self.token_dispatcher.ep_world_size),
-            )
-        else:
-            # num_tokens_per_tp_rank, set once in TokenDispatcherWithMC2.__init__
-            # from scheduler/graph config — rank-invariant.
-            rank_invariant_cap = getattr(self.token_dispatcher, "max_num_tokens_per_rank", 0)
-            num_max_tokens_per_rank = max(1, int(rank_invariant_cap))
+        # The symmetric CCL buffer must be large enough for every MegaMoe call.
+        # Use the same rank-invariant capacity that bounds the chunks below so
+        # prefill does not reuse a buffer sized only for the decode capacity.
+        num_max_tokens_per_rank = _MEGA_MOE_TOKENS_PER_RANK_LIMIT
         num_topk = self.moe_config.experts_per_token
         num_experts = self.moe_config.num_experts
         expert_per_rank = max(1, num_experts // int(self.token_dispatcher.ep_world_size))
@@ -318,10 +303,12 @@ class FusedMC2CommImpl(MoECommMethod):
         )
 
         logger.info(
-            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): ep_rank=%s ep_world=%s global_bs=%s",
+            "CANN MegaMoe sym-buffer alloc (must match across all EP ranks): "
+            "ep_rank=%s ep_world=%s global_bs=%s num_max_tokens_per_rank=%s",
             getattr(self.token_dispatcher, "ep_rank_id", "?"),
             getattr(self.token_dispatcher, "ep_world_size", "?"),
             self.token_dispatcher.global_bs,
+            num_max_tokens_per_rank,
         )
 
         return self.get_symm_buffer_for_mega_moe(
@@ -402,10 +389,10 @@ class FusedMC2CommImpl(MoECommMethod):
         topk_weights = fused_experts_input.topk_weights.to(torch.float32)
         num_tokens = hidden_states.shape[0]
 
-        out = torch.empty_like(hidden_states) if num_tokens > _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL else None
+        out = torch.empty_like(hidden_states) if num_tokens > _MEGA_MOE_TOKENS_PER_RANK_LIMIT else None
         expert_tokens = None
-        for start in range(0, num_tokens, _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL):
-            end = min(start + _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL, num_tokens)
+        for start in range(0, num_tokens, _MEGA_MOE_TOKENS_PER_RANK_LIMIT):
+            end = min(start + _MEGA_MOE_TOKENS_PER_RANK_LIMIT, num_tokens)
             chunk_mask = None if x_active_mask is None else x_active_mask[start:end]
             chunk_out, chunk_expert_tokens = self.mega_moe(
                 hidden_states[start:end],

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -46,6 +46,7 @@ from vllm_ascend.ops.fused_moe.token_dispatcher import (
 from vllm_ascend.quantization.quant_type import QuantType
 
 _MoECommMethods: dict[MoECommType | None, MoECommMethod] = {}
+_CANN_MEGA_MOE_MAX_TOKENS_PER_CALL = 4096
 
 
 def get_moe_comm_method(moe_comm_type: MoECommType | None) -> MoECommMethod | None:
@@ -386,22 +387,51 @@ class FusedMC2CommImpl(MoECommMethod):
         l1_bias = fused_experts_input.weights.w1_scale_bias
         l2_bias = fused_experts_input.weights.w2_scale_bias
 
-        out, expert_tokens = self.mega_moe(
-            fused_experts_input.hidden_states,
-            fused_experts_input.topk_ids.to(torch.int32),
-            fused_experts_input.topk_weights.to(torch.float32),
-            weight1,
-            weight2,
-            self.mega_moe_symm_buffer,
-            l1_weights_sf=weight_scales1,
-            l2_weights_sf=weight_scales2,
-            l1_bias=l1_bias,
-            l2_bias=l2_bias,
-            x_active_mask=x_active_mask,
-            activation_clamp=activation_clamp,
-            weight1_type=weight_type,
-            weight2_type=weight_type,
-        )
+        activation_kwargs = {}
+        if getattr(fused_experts_input.activation, "value", fused_experts_input.activation) == "swigluoai_uninterleave":
+            activation_kwargs = {
+                "activation": "swigluoai",
+                "activation_params": {
+                    "alpha": self.swiglu_alpha,
+                    "beta": self.swiglu_beta,
+                },
+            }
+
+        hidden_states = fused_experts_input.hidden_states
+        topk_ids = fused_experts_input.topk_ids.to(torch.int32)
+        topk_weights = fused_experts_input.topk_weights.to(torch.float32)
+        num_tokens = hidden_states.shape[0]
+
+        out = torch.empty_like(hidden_states) if num_tokens > _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL else None
+        expert_tokens = None
+        for start in range(0, num_tokens, _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL):
+            end = min(start + _CANN_MEGA_MOE_MAX_TOKENS_PER_CALL, num_tokens)
+            chunk_mask = None if x_active_mask is None else x_active_mask[start:end]
+            chunk_out, chunk_expert_tokens = self.mega_moe(
+                hidden_states[start:end],
+                topk_ids[start:end],
+                topk_weights[start:end],
+                weight1,
+                weight2,
+                self.mega_moe_symm_buffer,
+                l1_weights_sf=weight_scales1,
+                l2_weights_sf=weight_scales2,
+                l1_bias=l1_bias,
+                l2_bias=l2_bias,
+                x_active_mask=chunk_mask,
+                activation_clamp=activation_clamp,
+                **activation_kwargs,
+                weight1_type=weight_type,
+                weight2_type=weight_type,
+            )
+            if out is None:
+                out = chunk_out
+            else:
+                out[start:end].copy_(chunk_out)
+            expert_tokens = chunk_expert_tokens if expert_tokens is None else expert_tokens + chunk_expert_tokens
+
+        assert out is not None, "MegaMoe requires at least one input token."
+        assert expert_tokens is not None, "MegaMoe requires at least one input token."
         # NOTE: self.expert_token_nums is only used by the
         # mega_moe path (enable_fused_mc2 == 1) as a
         # pre-allocated in/out buffer. The MegaMoe op returns a fresh

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -25,11 +25,11 @@ from typing import Generic
 
 import torch
 import torch_npu
-from vllm.config import get_current_vllm_config
+from vllm.config import VllmConfig, get_current_vllm_config
 from vllm.distributed.parallel_state import get_ep_group
 
 from vllm_ascend.ascend_config import get_ascend_config
-from vllm_ascend.ascend_forward_context import get_mc2_tokens_capacity
+from vllm_ascend.ascend_forward_context import _MEGA_MOE_TOKENS_PER_RANK_LIMIT, get_mc2_tokens_capacity
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.lora.fused_moe import (
@@ -58,6 +58,14 @@ from vllm_ascend.utils import (
 
 EXPERT_TOKEN_NUMS_TYPE_CUMSUM = 0
 EXPERT_TOKEN_NUMS_TYPE_COUNT = 1
+
+
+def _get_mega_moe_max_num_tokens_per_rank(vllm_config: VllmConfig, decode_capacity_per_rank: int) -> int:
+    kv_transfer_config = vllm_config.kv_transfer_config
+    is_pd_decode_consumer = (
+        kv_transfer_config is not None and kv_transfer_config.is_kv_consumer and not kv_transfer_config.is_kv_producer
+    )
+    return decode_capacity_per_rank if is_pd_decode_consumer else _MEGA_MOE_TOKENS_PER_RANK_LIMIT
 
 
 def _get_expert_token_nums_type(token_dispatch_input: MoETokenDispatchInput) -> int:
@@ -140,6 +148,12 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         # this, MegaMoe falls back to hidden_states.shape[0] which jitters
         # under eager mode and forces sym-buffer rebuilds every step.
         self.max_num_tokens_per_rank = num_tokens_per_tp_rank
+        # A disaggregated decode instance never receives prefill batches, so
+        # size its CANN MegaMoe buffer for the rank-invariant decode capacity.
+        # Other instances must retain the operator limit for prefill chunks.
+        self.mega_moe_max_num_tokens_per_rank = _get_mega_moe_max_num_tokens_per_rank(
+            vllm_config, num_tokens_per_tp_rank
+        )
         _max_global_bs = num_tokens_per_tp_rank * self.ep_world_size
 
         # When allreduce across DP is not skipped, tokens are uniform across ranks:

--- a/vllm_ascend/quantization/methods/w8a8_dynamic.py
+++ b/vllm_ascend/quantization/methods/w8a8_dynamic.py
@@ -236,12 +236,9 @@ class AscendW8A8DynamicFusedMoEMethod(AscendMoEScheme):
         topk_weights = topk_weights.to(self.in_dtype)
 
         activation = getattr(layer, "activation", "silu")
-        act_name = getattr(activation, "value", activation)
         moe_comm_method = _EXTRA_CTX.moe_comm_method
         fused_scale_flag = (
-            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2
-            and get_ascend_config().enable_fused_mc2 == 1
-            and act_name != "swigluoai_uninterleave"
+            _EXTRA_CTX.moe_comm_type == MoECommType.FUSED_MC2 and get_ascend_config().enable_fused_mc2 == 1
         )
         use_mega_moe = fused_scale_flag and _MEGA_MOE_SUPPORTED
         if self.use_expert_weight_list:


### PR DESCRIPTION
### What this PR does / why we need it?

MiniMax M3 uses the `swigluoai_uninterleave` activation, so its MegaMoE path must forward the activation name together with the clamp, alpha, and beta parameters.

Assuming the latest `cann_ops_transformer` package provides `swigluoai` support, this PR keeps MiniMax M3 on the existing shared CANN MegaMoE implementation instead of introducing a local `_C_ascend.mega_moe` operator:

- removes the startup guard that rejected `enable_fused_mc2=1` for MiniMax M3;
- recognizes MiniMax M3 as MegaMoE-compatible by using its `intermediate_size` when `moe_intermediate_size` is absent;
- uses `enable_fused_mc2` as the single gate for fused-scale preparation, independent of activation type;
- retains the existing `_MEGA_MOE_SUPPORTED` check for selecting the CANN MegaMoE weight path;
- maps the internal activation name to `swigluoai` and passes `alpha`/`beta` through `activation_params`;
- splits inputs above the CANN MegaMoE BS limit of 4096 and writes chunk results into a preallocated output tensor to avoid `torch.cat` peak memory;
- adds regression coverage for config detection, weight selection, activation forwarding, chunking, output placement, masks, and expert-count accumulation.

This is a minimal alternative to #14096 and does not vendor the MegaMoE operator implementation.

### Does this PR introduce _any_ user-facing change?

Yes. MiniMax M3 can enable fused MC2 and use the shared CANN MegaMoE path when a `cann_ops_transformer` version with `swigluoai` support is installed. Token batches larger than 4096 are handled in chunks.

### How was this patch tested?

Added unit tests:

- `tests/ut/ops/test_cann_mega_moe.py`
- `tests/ut/quantization/methods/a2/test_w8a8_dynamic.py::TestAscendW8A8FusedMoEMethod::test_apply_swigluoai_uses_cann_mega_moe_weights`

Local checks completed:

```bash
python -m ruff format --check vllm_ascend/ascend_config.py vllm_ascend/ops/fused_moe/moe_comm_method.py vllm_ascend/quantization/methods/w8a8_dynamic.py tests/ut/ops/test_cann_mega_moe.py tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
python -m ruff check vllm_ascend/ascend_config.py vllm_ascend/ops/fused_moe/moe_comm_method.py vllm_ascend/quantization/methods/w8a8_dynamic.py tests/ut/ops/test_cann_mega_moe.py tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
python -m py_compile vllm_ascend/ascend_config.py vllm_ascend/ops/fused_moe/moe_comm_method.py vllm_ascend/quantization/methods/w8a8_dynamic.py tests/ut/ops/test_cann_mega_moe.py tests/ut/quantization/methods/a2/test_w8a8_dynamic.py
git diff --check
```

The unit tests could not be executed in the current Windows workspace because its Python environment does not contain `torch` or `pytest`, and no Ascend NPU/operator runtime is available. Per the requested scope, no service startup or NPU inference validation was performed.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
