### PR TITLE
perf: fuse DCP index remap and stable compaction

### DIFF
--- a/csrc/kernels/dcp_remap_compact.cpp
+++ b/csrc/kernels/dcp_remap_compact.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "kernel_operator.h"
+
+class DcpRemapCompactKernel {
+public:
+    __aicore__ inline DcpRemapCompactKernel() {}
+
+    __aicore__ inline void Init(GM_ADDR input, GM_ADDR output, int64_t rows,
+                                int64_t width, int64_t alignedWidth,
+                                int64_t dcpRank, int64_t dcpSize,
+                                int64_t interleaveSize)
+    {
+        inputGm.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(input), rows * width);
+        outputGm.SetGlobalBuffer(reinterpret_cast<__gm__ int32_t *>(output), rows * width);
+        rows_ = rows;
+        width_ = width;
+        alignedWidth_ = alignedWidth;
+        dcpRank_ = static_cast<int32_t>(dcpRank);
+        dcpSize_ = static_cast<int32_t>(dcpSize);
+        interleaveSize_ = static_cast<int32_t>(interleaveSize);
+        maskBytes_ = ((alignedWidth_ + 255) / 256) * 32;
+        pipe.InitBuffer(inputBuf, alignedWidth_ * sizeof(int32_t));
+        pipe.InitBuffer(outputBuf, alignedWidth_ * sizeof(int32_t));
+        pipe.InitBuffer(inputFloatBuf, alignedWidth_ * sizeof(float));
+        pipe.InitBuffer(blockFloatBuf, alignedWidth_ * sizeof(float));
+        pipe.InitBuffer(groupFloatBuf, alignedWidth_ * sizeof(float));
+        pipe.InitBuffer(tempFloatBuf, alignedWidth_ * sizeof(float));
+        pipe.InitBuffer(gatheredFloatBuf, alignedWidth_ * sizeof(float));
+        pipe.InitBuffer(ownerMaskBuf, maskBytes_);
+        pipe.InitBuffer(validMaskBuf, maskBytes_);
+        pipe.InitBuffer(combinedMaskBuf, maskBytes_);
+    }
+
+    __aicore__ inline void Process()
+    {
+        const int64_t block = AscendC::GetBlockIdx();
+        const int64_t blocks = AscendC::GetBlockNum();
+        for (int64_t row = block; row < rows_; row += blocks) {
+            ProcessRow(row);
+        }
+    }
+
+private:
+    __aicore__ inline void ProcessRow(int64_t row)
+    {
+        AscendC::LocalTensor<int32_t> inputLocal = inputBuf.Get<int32_t>();
+        AscendC::LocalTensor<int32_t> outputLocal = outputBuf.Get<int32_t>();
+        AscendC::LocalTensor<float> inputFloat = inputFloatBuf.Get<float>();
+        AscendC::LocalTensor<float> blockFloat = blockFloatBuf.Get<float>();
+        AscendC::LocalTensor<float> groupFloat = groupFloatBuf.Get<float>();
+        AscendC::LocalTensor<float> tempFloat = tempFloatBuf.Get<float>();
+        AscendC::LocalTensor<float> gatheredFloat = gatheredFloatBuf.Get<float>();
+        AscendC::LocalTensor<uint8_t> ownerMask = ownerMaskBuf.Get<uint8_t>();
+        AscendC::LocalTensor<uint8_t> validMask = validMaskBuf.Get<uint8_t>();
+        AscendC::LocalTensor<uint8_t> combinedMask = combinedMaskBuf.Get<uint8_t>();
+
+        AscendC::DataCopyExtParams copyIn;
+        copyIn.blockCount = 1;
+        copyIn.blockLen = static_cast<uint32_t>(width_ * sizeof(int32_t));
+        copyIn.srcStride = 0;
+        copyIn.dstStride = 0;
+        AscendC::DataCopyPadExtParams<int32_t> pad;
+        pad.isPad = false;
+        pad.leftPadding = 0;
+        pad.rightPadding = 0;
+        pad.paddingValue = -1;
+        AscendC::Duplicate(inputLocal, static_cast<int32_t>(-1), alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::DataCopyPad(inputLocal, inputGm[row * width_], copyIn, pad);
+
+        AscendC::Duplicate(outputLocal, static_cast<int32_t>(-1), alignedWidth_);
+        AscendC::PipeBarrier<PIPE_ALL>();
+
+        AscendC::Cast(inputFloat, inputLocal, AscendC::RoundMode::CAST_ROUND,
+                      alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(blockFloat, inputFloat,
+                      1.0f / static_cast<float>(interleaveSize_), alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Floor(blockFloat, blockFloat, alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(groupFloat, blockFloat,
+                      1.0f / static_cast<float>(dcpSize_), alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Floor(groupFloat, groupFloat, alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // owner = block - floor(block / dcp_size) * dcp_size
+        AscendC::Muls(tempFloat, groupFloat, static_cast<float>(dcpSize_),
+                      alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Sub(tempFloat, blockFloat, tempFloat, alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::CompareScalar(ownerMask, tempFloat,
+                               static_cast<float>(dcpRank_),
+                               AscendC::CMPMODE::EQ, alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::CompareScalar(validMask, inputFloat, 0.0f,
+                               AscendC::CMPMODE::GE, alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::And(combinedMask.ReinterpretCast<uint16_t>(),
+                     ownerMask.ReinterpretCast<uint16_t>(),
+                     validMask.ReinterpretCast<uint16_t>(),
+                     static_cast<int32_t>(alignedWidth_ / 16));
+        AscendC::PipeBarrier<PIPE_V>();
+
+        // local = group * interleave + (index - block * interleave)
+        AscendC::Muls(tempFloat, blockFloat,
+                      static_cast<float>(interleaveSize_), alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Sub(tempFloat, inputFloat, tempFloat, alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Muls(groupFloat, groupFloat,
+                      static_cast<float>(interleaveSize_), alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Add(tempFloat, groupFloat, tempFloat, alignedWidth_);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::GatherMaskParams gatherParams;
+        gatherParams.repeatTimes = 1;
+        gatherParams.src0BlockStride = 1;
+        gatherParams.src0RepeatStride = 8;
+        gatherParams.src1RepeatStride = 8;
+        uint64_t validCount = 0;
+        AscendC::GatherMask(gatheredFloat, tempFloat,
+                            combinedMask.ReinterpretCast<uint32_t>(), true,
+                            static_cast<uint32_t>(width_), gatherParams,
+                            validCount);
+        AscendC::PipeBarrier<PIPE_V>();
+        if (validCount > 0) {
+            AscendC::Cast(outputLocal, gatheredFloat,
+                          AscendC::RoundMode::CAST_ROUND, validCount);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+
+        AscendC::DataCopyExtParams copyOut;
+        copyOut.blockCount = 1;
+        copyOut.blockLen = static_cast<uint32_t>(width_ * sizeof(int32_t));
+        copyOut.srcStride = 0;
+        copyOut.dstStride = 0;
+        AscendC::DataCopyPad(outputGm[row * width_], outputLocal, copyOut);
+        AscendC::PipeBarrier<PIPE_ALL>();
+    }
+
+private:
+    AscendC::TPipe pipe;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> inputBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> outputBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> inputFloatBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> blockFloatBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> groupFloatBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> tempFloatBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> gatheredFloatBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> ownerMaskBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> validMaskBuf;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> combinedMaskBuf;
+    AscendC::GlobalTensor<int32_t> inputGm;
+    AscendC::GlobalTensor<int32_t> outputGm;
+    int64_t rows_ = 0;
+    int64_t width_ = 0;
+    int64_t alignedWidth_ = 0;
+    int32_t dcpRank_ = 0;
+    int32_t dcpSize_ = 1;
+    int32_t interleaveSize_ = 1;
+    int64_t maskBytes_ = 0;
+};
+
+extern "C" __global__ __aicore__ void dcp_remap_compact_kernel(
+    GM_ADDR input, GM_ADDR output, int64_t rows, int64_t width,
+    int64_t alignedWidth, int64_t dcpRank, int64_t dcpSize,
+    int64_t interleaveSize)
+{
+    DcpRemapCompactKernel op;
+    op.Init(input, output, rows, width, alignedWidth, dcpRank, dcpSize,
+            interleaveSize);
+    op.Process();
+}
+
+namespace vllm_ascend {
+extern void dcp_remap_compact_impl(void *stream, void *input, void *output,
+                                   int64_t rows, int64_t width,
+                                   int64_t alignedWidth, int64_t dcpRank,
+                                   int64_t dcpSize, int64_t interleaveSize,
+                                   uint32_t blockDim)
+{
+    dcp_remap_compact_kernel<<<blockDim, nullptr, stream>>>(
+        input, output, rows, width, alignedWidth, dcpRank, dcpSize,
+        interleaveSize);
+}
+} // namespace vllm_ascend

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -24,6 +24,18 @@
 #include "torch_npu/csrc/aten/common/from_blob.h"
 
 namespace vllm_ascend {
+    extern void dcp_remap_compact_impl(
+        void *stream,
+        void *input,
+        void *output,
+        int64_t rows,
+        int64_t width,
+        int64_t aligned_width,
+        int64_t dcp_rank,
+        int64_t dcp_size,
+        int64_t interleave_size,
+        uint32_t block_dim);
+
   extern void bgmv_shrink_impl(
         AscendType type,
         void *stream,

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -21,6 +21,7 @@
 #include <ATen/core/Formatting.h>
 #include "acl/acl.h"
 #include "acl/acl_rt.h"
+#include "tiling/platform/platform_ascendc.h"
 #include <torch_npu/csrc/core/npu/NPUStream.h>
 #include <torch_npu/csrc/framework/OpCommand.h>
 #include <torch_npu/csrc/framework/utils/OpPreparation.h>
@@ -318,6 +319,66 @@ AscendType get_dtype_from_torch(at::ScalarType scalarType)
         return AscendType::FP16;
     }
 }
+
+#ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
+at::Tensor dcp_remap_compact(const at::Tensor &topk_indices,
+                             int64_t dcp_rank, int64_t dcp_size,
+                             int64_t interleave_size)
+{
+    TORCH_CHECK(topk_indices.is_privateuseone(),
+                "dcp_remap_compact: topk_indices must be on an NPU");
+    TORCH_CHECK(topk_indices.scalar_type() == at::kInt,
+                "dcp_remap_compact: topk_indices must have dtype int32");
+    TORCH_CHECK(topk_indices.dim() >= 1,
+                "dcp_remap_compact: topk_indices must have at least one dimension");
+    TORCH_CHECK(dcp_size > 0, "dcp_remap_compact: dcp_size must be positive");
+    TORCH_CHECK(dcp_rank >= 0 && dcp_rank < dcp_size,
+                "dcp_remap_compact: dcp_rank must be in [0, dcp_size)");
+    TORCH_CHECK(interleave_size > 0,
+                "dcp_remap_compact: interleave_size must be positive");
+
+    at::Tensor input = topk_indices.contiguous();
+    at::Tensor output = at::empty_like(input);
+    if (input.numel() == 0) {
+        return output;
+    }
+
+    int64_t width = input.size(-1);
+    TORCH_CHECK(width > 0,
+                "dcp_remap_compact: the last dimension must be positive");
+    int64_t rows = input.numel() / width;
+    int64_t aligned_width = (width + 63) / 64 * 64;
+
+    auto platform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    int64_t core_num = static_cast<int64_t>(platform->GetCoreNumAiv());
+    uint64_t ub_size = 0;
+    platform->GetCoreMemSize(platform_ascendc::CoreMemType::UB, ub_size);
+    int64_t mask_bytes = ((aligned_width + 255) / 256) * 32;
+    uint64_t required_ub = static_cast<uint64_t>(
+        aligned_width * sizeof(int32_t) * 7 + mask_bytes * 3);
+    TORCH_CHECK(required_ub <= ub_size,
+                "dcp_remap_compact: row scratch does not fit in UB; width=",
+                width, ", required bytes=", required_ub,
+                ", UB bytes=", ub_size);
+
+    uint32_t block_dim = static_cast<uint32_t>(rows < core_num ? rows : core_num);
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    void *input_ptr = input.data_ptr();
+    void *output_ptr = output.data_ptr();
+    at_npu::native::OpCommand cmd;
+    cmd.Name("dcp_remap_compact");
+    cmd.SetCustomHandler([stream, input_ptr, output_ptr, rows, width,
+                          aligned_width, dcp_rank, dcp_size, interleave_size,
+                          block_dim]() -> int {
+        dcp_remap_compact_impl(stream, input_ptr, output_ptr, rows, width,
+                               aligned_width, dcp_rank, dcp_size,
+                               interleave_size, block_dim);
+        return 0;
+    });
+    cmd.Run();
+    return output;
+}
+#endif
 
 void bgmv_shrink(at::Tensor &x, at::Tensor &weight, at::Tensor &indices, at::Tensor &y, double scale)
 {
@@ -1967,6 +2028,12 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
 
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
     // Direct kernel custom ops
+    ops.def(
+        "dcp_remap_compact(Tensor topk_indices, int dcp_rank, "
+        "                  int dcp_size, int interleave_size) -> Tensor");
+    ops.impl("dcp_remap_compact", torch::kPrivateUse1,
+             &vllm_ascend::dcp_remap_compact);
+
     ops.def("bgmv_shrink(Tensor! x, Tensor! weight, Tensor! indices, Tensor! y, float scale) -> ()");
     ops.impl("bgmv_shrink", torch::kPrivateUse1, &vllm_ascend::bgmv_shrink);
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dcp_remap_compact.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dcp_remap_compact.py
@@ -1,0 +1,67 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(torch.ops._C_ascend, "dcp_remap_compact"),
+    reason="dcp_remap_compact direct kernel is unavailable on this platform",
+)
+
+
+def reference(indices: torch.Tensor, rank: int, size: int, interleave: int) -> torch.Tensor:
+    rows = indices.reshape(-1, indices.shape[-1])
+    output = torch.full_like(rows, -1)
+    for row_id, row in enumerate(rows):
+        valid = []
+        for value in row.tolist():
+            if value < 0:
+                continue
+            block = value // interleave
+            if block % size == rank:
+                valid.append((block // size) * interleave + value % interleave)
+        if valid:
+            output[row_id, : len(valid)] = torch.tensor(valid, dtype=indices.dtype)
+    return output.reshape_as(indices)
+
+
+def make_case(rows: int, width: int, seed: int) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    values = torch.randint(0, 1024 * 1024, (rows, 1, width), generator=generator, dtype=torch.int32)
+    holes = torch.rand((rows, 1, width), generator=generator) < 0.08
+    return torch.where(holes, torch.full_like(values, -1), values)
+
+
+@pytest.mark.parametrize("rows,width", [(1, 1), (3, 17), (32, 2048), (512, 2048)])
+@pytest.mark.parametrize("size,interleave", [(1, 1), (2, 128), (16, 128)])
+def test_random(rows: int, width: int, size: int, interleave: int) -> None:
+    cpu = make_case(rows, width, rows * 10000 + width + size)
+    npu = cpu.npu()
+    for rank in sorted({0, size - 1}):
+        actual = torch.ops._C_ascend.dcp_remap_compact(npu, rank, size, interleave).cpu()
+        expected = reference(cpu, rank, size, interleave)
+        torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("mask", itertools.product([False, True], repeat=6))
+def test_all_small_masks(mask: tuple[bool, ...]) -> None:
+    values = torch.tensor([0, 128, 256, 384, 512, 640], dtype=torch.int32)
+    cpu = torch.where(torch.tensor(mask), values, torch.full_like(values, -1)).reshape(1, 1, -1)
+    actual = torch.ops._C_ascend.dcp_remap_compact(cpu.npu(), 1, 2, 128).cpu()
+    expected = reference(cpu, 1, 2, 128)
+    torch.testing.assert_close(actual, expected, rtol=0, atol=0)

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -936,6 +936,16 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
                 f"topk_indices last dimension ({topk_count}) exceeds configured index_topk ({self._dcp_index_topk})."
             )
 
+        if hasattr(torch.ops._C_ascend, "dcp_remap_compact"):
+            original_dtype = topk_indices.dtype
+            remapped_indices = torch.ops._C_ascend.dcp_remap_compact(
+                topk_indices.to(torch.int32),
+                self.dcp_rank,
+                self.dcp_size,
+                self._dcp_interleave_size,
+            )
+            return remapped_indices.to(original_dtype)
+
         # Remap the topk indices from the replicated view to the DCP-local KV cache view.
         # We use float32 for better performance on Ascend.
         topk_indices_fp32 = topk_indices.to(torch.float32)


### PR DESCRIPTION
### What this PR does / why we need it?

The DCP sparse-attention path currently remaps and stably compacts every
TopK index row with a 25-kernel PyTorch `sort + gather` chain. This occurs once
per attention layer and adds about 12 ms to every GLM-5.2 decode iteration at
TP16/DCP16/MTP3.

This PR:

- adds the native `torch.ops._C_ascend.dcp_remap_compact` AscendC AIV kernel;
- fuses owner filtering, DCP-local index remapping, and stable compaction with
  `GatherMask`;
- preserves TopK order, dtype, fixed-width output shape, and trailing `-1`
  padding;
- retains the original PyTorch path when direct kernels are unavailable, so
  A5 and 310P behavior is unchanged.

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance optimization with unchanged output
semantics and no new configuration or environment variable.

### How was this patch tested?

- Built the complete upstream tree into an AArch64 wheel with Python 3.11,
  PyTorch/torch-npu 2.10, CANN 9.1, and Ascend A3.
- Ran the added native NPU test: `76 passed in 2.35s`. The suite covers
  multiple shapes, DCP sizes/ranks, interleave sizes, and every 6-bit owner
  mask.
- Verified the production `[16, 1, 2048]` ABI element-for-element on every
  DCP rank for 8K, 16K, 32K, 64K, 128K, 512K, and 1M contexts.
- Measured operator P50 speedups of 5.71x to 6.49x across that context sweep.
- In a 1M MindStudio A/B capture, replaced a median 148.75 us 25-kernel chain
  with a median 5.37 us kernel across 16 ranks (27.70x), reducing steady decode
  layer span from about 98.0 ms to 86.5 ms.
- Ran full public benchmark splits with identical service/evaluator settings:
  GSM8K test 68.54% -> 69.22%, C-Eval validation 83.21% -> 83.58%, and the
  complete LongBench-v2 Long In-context Learning domain 54.32% -> 53.09%.
  Paired confidence intervals and McNemar tests found no significant accuracy
  regression.

```bash
pip install -v .
pytest -q \
  tests/e2e/nightly/single_node/ops/singlecard_ops/test_dcp_remap_compact.py
bash format.sh ci
```

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
