### PR TITLE
[BugFix][Worker] Remove temporary pass_config.enable_sp override

### DIFF
--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4807,19 +4807,18 @@ class NPUModelRunner(GPUModelRunner):
                     min_cg_support = cg_support
                     min_cg_attn_backend = attn_backend.__name__
 
-        with update_pass_config(self):
-            cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
-                min_cg_support=min_cg_support,
-                min_cg_attn_backend=min_cg_attn_backend,
-                uniform_decode_query_len=self.uniform_decode_query_len,
-                use_v2_model_runner=False,
-                tensor_parallel_size=self.parallel_config.tensor_parallel_size,
-                kv_cache_config=self.kv_cache_config,
-                max_num_reqs=self.max_num_reqs,
-            )
-            self.cudagraph_dispatcher.initialize_cudagraph_keys(
-                cudagraph_mode, self.uniform_decode_query_len
-            )
+        cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
+            min_cg_support=min_cg_support,
+            min_cg_attn_backend=min_cg_attn_backend,
+            uniform_decode_query_len=self.uniform_decode_query_len,
+            use_v2_model_runner=False,
+            tensor_parallel_size=self.parallel_config.tensor_parallel_size,
+            kv_cache_config=self.kv_cache_config,
+            max_num_reqs=self.max_num_reqs,
+        )
+        self.cudagraph_dispatcher.initialize_cudagraph_keys(
+            cudagraph_mode, self.uniform_decode_query_len
+        )
 
         if (
             self.speculative_config
@@ -4994,13 +4993,3 @@ def _replace_gpu_model_runner_function_wrapper(target_module_name):
         _vllm_encoder_cudagraph.EncoderCudaGraphManager = _encoder_mgr_orig
         if target_module is not None:
             setattr(target_module, "graph_capture", graph_capture)  # noqa: B010
-
-
-@contextmanager
-def update_pass_config(model_runner):
-    try:
-        original_pass_config_sp = model_runner.compilation_config.pass_config.enable_sp
-        model_runner.compilation_config.pass_config.enable_sp = enable_sp(model_runner.vllm_config)
-        yield
-    finally:
-        model_runner.compilation_config.pass_config.enable_sp = original_pass_config_sp


### PR DESCRIPTION
### What this PR does / why we need it?
Since flashcomm and sp pass has been deleted, update pass config is no longer supported.
- Remove the temporary `pass_config.enable_sp` override and restore logic.
- Remove the obsolete `update_pass_config()` context manager.
- Resolve CUDAGraph mode directly from the existing compilation configuration.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
- `ruff check vllm_ascend/worker/model_runner_v1.py`
- `ruff format --check vllm_ascend/worker/model_runner_v1.py`
- `git diff --check`
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
