### PR TITLE
[CI] Fix run-selected-tests-a5 skipped under ready-all label

### DIFF
--- a/.github/workflows/pr_test.yaml
+++ b/.github/workflows/pr_test.yaml
@@ -571,7 +571,16 @@ jobs:
 
   run-selected-tests-a5:
     needs: [pre-commit, select-tests]
-    if: ${{ needs.select-tests.outputs.has_tests_a5 == 'true' && contains(github.event.pull_request.labels.*.name, 'ready-a5') }}
+    # !cancelled() overrides transitive skip-propagation from recommend-tests-from-coverage
+    # (skipped under ready-all) through select-tests, without running after workflow cancel.
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.pre-commit.result == 'success' &&
+        needs.select-tests.result == 'success' &&
+        needs.select-tests.outputs.has_tests_a5 == 'true' &&
+        contains(github.event.pull_request.labels.*.name, 'ready-a5')
+      }}
     strategy:
       matrix:
         vllm_version:


### PR DESCRIPTION

### What this PR does / why we need it?

Add !cancelled() to run-selected-tests-a5 if condition to match run-selected-tests, preventing transitive skip-propagation when recommend-tests-from-coverage is skipped under ready-all label.

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
