### PR TITLE
[Attention][BugFix] Temporarily strip prefill and decode sub-configs during draft config reconstruction

### DIFF
--- a/tests/ut/kv_offload/test_mooncake_connector.py
+++ b/tests/ut/kv_offload/test_mooncake_connector.py
@@ -1204,6 +1204,7 @@ class MockVllmConfig:
         self.model_config.get_num_layers = MagicMock(return_value=32)
         self.parallel_config.tensor_parallel_size = 2
         self.parallel_config.data_parallel_rank = 0
+        self.parallel_config.data_parallel_index = 0
         self.parallel_config.data_parallel_size = 1
         self.parallel_config.data_parallel_size_local = 1
         self.parallel_config.pipeline_parallel_size = 1
@@ -1575,6 +1576,42 @@ class TestMooncakeConnector(unittest.TestCase):
         request = MockRequest("req1")
         connector.request_finished(request, [1, 2, 3])
         mock_method.assert_called_once_with(request, ([1, 2, 3],))
+
+
+class TestMooncakeConnectorHandshakePortUniquePerDPRank(unittest.TestCase):
+    """Regression: handshake base port must stay unique per DP rank even when
+    ``data_parallel_rank`` is reset to 0 (non-MoE internal DP, where
+    vllm/v1/engine/core.py treats each rank like DP=1). The port formula uses
+    ``data_parallel_index`` (preserved per DP rank) instead of
+    ``data_parallel_rank`` (reset to 0); otherwise DP ranks collide on the same
+    ZMQ port (``Address already in use``)."""
+
+    @staticmethod
+    def _make_scheduler(data_parallel_index: int, data_parallel_rank: int = 0):
+        cfg = MockVllmConfig()
+        cfg.parallel_config.data_parallel_index = data_parallel_index
+        cfg.parallel_config.data_parallel_rank = data_parallel_rank
+        with (
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p."
+                "mooncake_connector.init_ascend_config"
+            ),
+            patch(
+                "vllm_ascend.distributed.kv_transfer.kv_p2p."
+                "mooncake_connector.get_ascend_config",
+                return_value=MagicMock(),
+            ),
+        ):
+            return MooncakeConnectorScheduler(cfg, "test_engine", MockKVCacheConfig())
+
+    def test_port_differs_across_dp_ranks_with_reset_data_parallel_rank(self):
+        # MockVllmConfig defaults: kv_port=5000, tp=2, pp=1, pcp=1.
+        # side_channel_port = 5000 + data_parallel_index * 2 * 1 * 1
+        s0 = self._make_scheduler(data_parallel_index=0, data_parallel_rank=0)
+        s1 = self._make_scheduler(data_parallel_index=1, data_parallel_rank=0)
+        self.assertEqual(s0.side_channel_port, 5000)
+        self.assertEqual(s1.side_channel_port, 5002)
+        self.assertNotEqual(s0.side_channel_port, s1.side_channel_port)
 
 
 class TestMooncakeConnectorScheduler(unittest.TestCase):

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -19,11 +19,13 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
-from vllm.config import CUDAGraphMode
+from vllm.config import CUDAGraphMode, KVTransferConfig, VllmConfig
 
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
+from vllm_ascend.utils import check_kv_extra_config
 
 # CUDAGraphMode values whose ``has_full_cudagraphs()`` is True: FULL plus the
 # two composite modes that mix FULL with NONE / PIECEWISE.
@@ -110,3 +112,80 @@ class TestDisablePaddedDrafterBatchWithFullGraph:
         )
 
         proposer._raise_if_padded_drafter_batch_disabled_and_full_graph_enabled()
+
+
+class TestCreateDraftVllmConfigPD:
+    """Regression for the false "conflicting data parallel size" raised while
+    reconstructing the drafter's draft config in a PD-disaggregated, internal-DP
+    setup.
+
+    For non-MoE internal DP, ``vllm/v1/engine/core.py`` sets
+    ``data_parallel_size=1`` on each EngineCore's config, while the
+    user-declared ``kv_transfer_config`` still carries ``prefill``/``decode``
+    ``dp_size`` > 1. The drafter's ``replace()``-based draft config
+    reconstruction re-runs ``check_kv_extra_config``, which compared those two
+    and raised. The drafter never owns a KV connector (it is built from the
+    main worker's ``vllm_config``), so
+    ``AscendSpecDecodeBaseProposer._create_draft_vllm_config`` strips the
+    ``prefill``/``decode`` sub-configs from the worker config around the
+    ``super()`` call and restores it afterwards.
+    """
+
+    @staticmethod
+    def _make_proposer(vllm_config, speculative_config) -> AscendSpecDecodeBaseProposer:
+        proposer = AscendSpecDecodeBaseProposer.__new__(AscendSpecDecodeBaseProposer)
+        proposer.vllm_config = vllm_config
+        proposer.speculative_config = speculative_config
+        return proposer
+
+    @staticmethod
+    def _platform_check_only_kv(*args):
+        # Reduce NPUPlatform.check_and_update_config to the subset this
+        # regression is about: run check_kv_extra_config only, and only when a
+        # kv_transfer_config is present (mirroring platform.py:483). Robust to
+        # the (cfg) / (cls, cfg) calling convention of the patched classmethod.
+        for cfg in args:
+            if hasattr(cfg, "kv_transfer_config"):
+                if cfg.kv_transfer_config is not None:
+                    check_kv_extra_config(cfg)
+                return
+
+    def test_strips_prefill_decode_and_restores_worker_config(self):
+        with patch(
+            "vllm_ascend.platform.NPUPlatform.check_and_update_config",
+            side_effect=self._platform_check_only_kv,
+        ):
+            cfg = VllmConfig()
+            cfg.kv_transfer_config = KVTransferConfig(
+                kv_connector="MooncakeConnectorV1",
+                kv_role="kv_producer",
+                kv_connector_extra_config={
+                    "prefill": {"dp_size": 2, "tp_size": 1},
+                    "decode": {"dp_size": 2, "tp_size": 1},
+                    "keep_me": 1,
+                },
+            )
+            # Non-MoE per-rank EngineCore view (vllm/v1/engine/core.py sets
+            # data_parallel_size=1). tp=1 keeps world_size=1 so the
+            # reconstruction does not trip device-count selection.
+            cfg.parallel_config.data_parallel_size = 1
+            cfg.parallel_config.tensor_parallel_size = 1
+
+            proposer = self._make_proposer(
+                cfg,
+                SimpleNamespace(moe_backend=None, attention_backend=None),
+            )
+            draft = proposer._create_draft_vllm_config()
+
+        # The draft config no longer carries the PD sub-configs that triggered
+        # the false positive; unrelated extra_config is preserved.
+        extra = draft.kv_transfer_config.kv_connector_extra_config
+        assert "prefill" not in extra
+        assert "decode" not in extra
+        assert extra.get("keep_me") == 1
+
+        # The worker config is restored, so the main engine's connector config
+        # is untouched.
+        worker_extra = proposer.vllm_config.kv_transfer_config.kv_connector_extra_config
+        assert "prefill" in worker_extra
+        assert "decode" in worker_extra

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -189,3 +189,33 @@ class TestCreateDraftVllmConfigPD:
         worker_extra = proposer.vllm_config.kv_transfer_config.kv_connector_extra_config
         assert "prefill" in worker_extra
         assert "decode" in worker_extra
+
+    def test_handles_none_kv_connector_extra_config(self):
+        """Defensive: ``kv_connector_extra_config`` defaults to ``{}`` but an
+        override may leave it ``None``. The strip must not raise
+        ``AttributeError`` on ``.items()`` in that case."""
+        with patch(
+            "vllm_ascend.platform.NPUPlatform.check_and_update_config",
+            side_effect=self._platform_check_only_kv,
+        ):
+            cfg = VllmConfig()
+            cfg.kv_transfer_config = KVTransferConfig(
+                kv_connector="MooncakeConnectorV1",
+                kv_role="kv_producer",
+            )
+            cfg.kv_transfer_config.kv_connector_extra_config = None
+            cfg.parallel_config.data_parallel_size = 1
+            cfg.parallel_config.tensor_parallel_size = 1
+
+            proposer = self._make_proposer(
+                cfg,
+                SimpleNamespace(moe_backend=None, attention_backend=None),
+            )
+            draft = proposer._create_draft_vllm_config()
+
+        # No prefill/decode in the (empty) result; worker config restored.
+        assert draft.kv_transfer_config.kv_connector_extra_config == {}
+        assert (
+            proposer.vllm_config.kv_transfer_config.kv_connector_extra_config
+            is None
+        )

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -165,6 +165,11 @@ class TestCreateDraftVllmConfigPD:
                     "keep_me": 1,
                 },
             )
+            # Simulate the non-field marker that platform init injects at
+            # startup (platform.py sets _engine_id_patched=True). The drafter
+            # sees this on the worker's kv_transfer_config; rebuilding it must
+            # not choke on the injected attr.
+            cfg.kv_transfer_config._engine_id_patched = True
             # Non-MoE per-rank EngineCore view (vllm/v1/engine/core.py sets
             # data_parallel_size=1). tp=1 keeps world_size=1 so the
             # reconstruction does not trip device-count selection.
@@ -204,6 +209,7 @@ class TestCreateDraftVllmConfigPD:
                 kv_role="kv_producer",
             )
             cfg.kv_transfer_config.kv_connector_extra_config = None
+            cfg.kv_transfer_config._engine_id_patched = True
             cfg.parallel_config.data_parallel_size = 1
             cfg.parallel_config.tensor_parallel_size = 1
 

--- a/tests/ut/test_check_kv_extra_config.py
+++ b/tests/ut/test_check_kv_extra_config.py
@@ -1,0 +1,107 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm_ascend.utils import check_kv_extra_config
+
+
+def _make_vllm_config(
+    *,
+    kv_role: str,
+    prefill: dict | None = None,
+    decode: dict | None = None,
+    dp_size: int = 1,
+    tp_size: int = 1,
+):
+    """Minimal stand-in for VllmConfig that ``check_kv_extra_config`` reads.
+
+    ``check_kv_extra_config`` only touches ``parallel_config`` (dp/tp size) and
+    ``kv_transfer_config`` (``is_kv_producer``/``is_kv_consumer`` and
+    ``get_from_extra_config``), so a mock is sufficient and NPU-free.
+    """
+    kvtc = MagicMock()
+    kvtc.is_kv_producer = kv_role in ("kv_producer", "kv_both")
+    kvtc.is_kv_consumer = kv_role in ("kv_consumer", "kv_both")
+
+    extra: dict = {}
+    if prefill is not None:
+        extra["prefill"] = prefill
+    if decode is not None:
+        extra["decode"] = decode
+    kvtc.get_from_extra_config.side_effect = lambda key, default: extra.get(key, default)
+
+    vllm_config = MagicMock()
+    vllm_config.parallel_config = SimpleNamespace(
+        data_parallel_size=dp_size, tensor_parallel_size=tp_size
+    )
+    vllm_config.kv_transfer_config = kvtc
+    return vllm_config
+
+
+class TestCheckKVExtraConfig:
+    def test_producer_prefill_dp_mismatch_raises(self):
+        """Producer with prefill.dp_size != launch dp must be caught."""
+        cfg = _make_vllm_config(
+            kv_role="kv_producer",
+            prefill={"dp_size": 2, "tp_size": 2},
+            dp_size=1,
+        )
+        with pytest.raises(ValueError, match="prefill.*conflicting data parallel size"):
+            check_kv_extra_config(cfg)
+
+    def test_producer_prefill_dp_match_passes(self):
+        cfg = _make_vllm_config(
+            kv_role="kv_producer",
+            prefill={"dp_size": 2, "tp_size": 2},
+            dp_size=2,
+        )
+        check_kv_extra_config(cfg)  # must not raise
+
+    def test_producer_prefill_tp_mismatch_raises(self):
+        cfg = _make_vllm_config(
+            kv_role="kv_producer",
+            prefill={"dp_size": 1, "tp_size": 2},
+            dp_size=1,
+            tp_size=1,
+        )
+        with pytest.raises(ValueError, match="conflicting tensor parallel size"):
+            check_kv_extra_config(cfg)
+
+    def test_consumer_decode_dp_mismatch_raises(self):
+        """Consumer with decode.dp_size != launch dp must be caught."""
+        cfg = _make_vllm_config(
+            kv_role="kv_consumer",
+            decode={"dp_size": 2, "tp_size": 2},
+            dp_size=1,
+        )
+        with pytest.raises(ValueError, match="decode.*conflicting data parallel size"):
+            check_kv_extra_config(cfg)
+
+    def test_skips_when_prefill_decode_absent(self):
+        """When the prefill/decode sub-configs are absent (e.g. stripped from
+        the drafter's draft config), the check must skip. This is the contract
+        the drafter fix in AscendSpecDecodeBaseProposer relies on: a dp_size
+        that would otherwise mismatch is no longer compared."""
+        cfg = _make_vllm_config(
+            kv_role="kv_producer",
+            prefill=None,
+            decode=None,
+            dp_size=1,  # would mismatch if a prefill dp_size were present
+        )
+        check_kv_extra_config(cfg)  # must not raise

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1647,10 +1647,14 @@ class MooncakeConnectorScheduler:
             * vllm_config.parallel_config.pipeline_parallel_size
         )
 
-        # Handshake base port
+        # Handshake base port. Use data_parallel_index (not data_parallel_rank):
+        # for non-MoE internal DP, vllm/v1/engine/core.py resets data_parallel_rank
+        # to 0 on each EngineCore ("treat like DP=1"), so data_parallel_rank would
+        # collide handshake ports across DP ranks. data_parallel_index preserves the
+        # original DP rank for all modes (dense/MoE internal, external) -> unique ports.
         self.side_channel_port = (
             vllm_config.kv_transfer_config.kv_port
-            + vllm_config.parallel_config.data_parallel_rank
+            + vllm_config.parallel_config.data_parallel_index
             * vllm_config.parallel_config.tensor_parallel_size
             * vllm_config.parallel_config.pipeline_parallel_size
             * self.pcp_size
@@ -2026,10 +2030,14 @@ class MooncakeConnectorWorker:
             layer: group.kv_cache_spec for group in kv_cache_config.kv_cache_groups for layer in group.layer_names
         }
 
-        # Handshake base port
+        # Handshake base port. Use data_parallel_index (not data_parallel_rank):
+        # for non-MoE internal DP, vllm/v1/engine/core.py resets data_parallel_rank
+        # to 0 on each EngineCore ("treat like DP=1"), so data_parallel_rank would
+        # collide handshake ports across DP ranks. data_parallel_index preserves the
+        # original DP rank for all modes (dense/MoE internal, external) -> unique ports.
         self.side_channel_port = (
             vllm_config.kv_transfer_config.kv_port
-            + vllm_config.parallel_config.data_parallel_rank
+            + vllm_config.parallel_config.data_parallel_index
             * vllm_config.parallel_config.tensor_parallel_size
             * vllm_config.parallel_config.pipeline_parallel_size
             * self.pcp_size

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -1197,10 +1197,14 @@ class MooncakeConnectorScheduler:
             * vllm_config.parallel_config.pipeline_parallel_size
         )
 
-        # Handshake base port
+        # Handshake base port. Use data_parallel_index (not data_parallel_rank):
+        # for non-MoE internal DP, vllm/v1/engine/core.py resets data_parallel_rank
+        # to 0 on each EngineCore ("treat like DP=1"), so data_parallel_rank would
+        # collide handshake ports across DP ranks. data_parallel_index preserves the
+        # original DP rank for all modes (dense/MoE internal, external) -> unique ports.
         self.side_channel_port = (
             vllm_config.kv_transfer_config.kv_port
-            + vllm_config.parallel_config.data_parallel_rank
+            + vllm_config.parallel_config.data_parallel_index
             * vllm_config.parallel_config.tensor_parallel_size
             * vllm_config.parallel_config.pipeline_parallel_size
         )
@@ -1547,10 +1551,14 @@ class MooncakeConnectorWorker:
         self._mamba_ssm_size = mamba_ssm_size
         self.use_compress = hasattr(self.vllm_config.model_config.hf_config, "compress_ratios")
 
-        # Handshake base port
+        # Handshake base port. Use data_parallel_index (not data_parallel_rank):
+        # for non-MoE internal DP, vllm/v1/engine/core.py resets data_parallel_rank
+        # to 0 on each EngineCore ("treat like DP=1"), so data_parallel_rank would
+        # collide handshake ports across DP ranks. data_parallel_index preserves the
+        # original DP rank for all modes (dense/MoE internal, external) -> unique ports.
         self.side_channel_port = (
             vllm_config.kv_transfer_config.kv_port
-            + vllm_config.parallel_config.data_parallel_rank
+            + vllm_config.parallel_config.data_parallel_index
             * vllm_config.parallel_config.tensor_parallel_size
             * vllm_config.parallel_config.pipeline_parallel_size
         )

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -310,9 +310,12 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         orig_vllm_config = self.vllm_config
         kvtc = orig_vllm_config.kv_transfer_config
         if kvtc is not None:
+            # kv_connector_extra_config defaults to {} (default_factory), but
+            # guard against None in case a caller/override leaves it unset.
+            extra_src = kvtc.kv_connector_extra_config or {}
             extra = {
                 k: v
-                for k, v in kvtc.kv_connector_extra_config.items()
+                for k, v in extra_src.items()
                 if k not in ("prefill", "decode")
             }
             self.vllm_config = vllm_replace(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -294,6 +294,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             )
 
     def _create_draft_vllm_config(self) -> VllmConfig:
+        from dataclasses import fields as dc_fields
         from vllm.config.utils import replace as vllm_replace
 
         # The drafter inherits the main engine's kv_transfer_config, including
@@ -310,19 +311,27 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         orig_vllm_config = self.vllm_config
         kvtc = orig_vllm_config.kv_transfer_config
         if kvtc is not None:
+            # Build a separate KVTransferConfig with prefill/decode stripped.
+            # vllm_replace(kvtc, ...) cannot be used here: platform init injects
+            # a non-field marker (_engine_id_patched) onto the instance, and
+            # vllm_replace iterates __dict__ requiring every key to be a declared
+            # field. Reconstruct from declared fields only so injected attrs are
+            # filtered out.
+            declared = {f.name for f in dc_fields(type(kvtc))}
+            stripped_values = {
+                k: v for k, v in kvtc.__dict__.items() if k in declared
+            }
             # kv_connector_extra_config defaults to {} (default_factory), but
             # guard against None in case a caller/override leaves it unset.
-            extra_src = kvtc.kv_connector_extra_config or {}
-            extra = {
+            extra_src = stripped_values.get("kv_connector_extra_config") or {}
+            stripped_values["kv_connector_extra_config"] = {
                 k: v
                 for k, v in extra_src.items()
                 if k not in ("prefill", "decode")
             }
             self.vllm_config = vllm_replace(
                 orig_vllm_config,
-                kv_transfer_config=vllm_replace(
-                    kvtc, kv_connector_extra_config=extra
-                ),
+                kv_transfer_config=type(kvtc)(**stripped_values),
             )
         try:
             return super()._create_draft_vllm_config()

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -293,6 +293,39 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
                 "disable_padded_drafter_batch in the speculative_config."
             )
 
+    def _create_draft_vllm_config(self) -> VllmConfig:
+        from vllm.config.utils import replace as vllm_replace
+
+        # The drafter inherits the main engine's kv_transfer_config, including
+        # the "prefill"/"decode" sub-configs that declare PD parallelism
+        # (dp_size/tp_size). Reconstructing the draft config via replace()
+        # re-runs check_kv_extra_config, which compares those declared dp_size
+        # values against the drafter's own (per-rank) data_parallel_size and
+        # raises a false "conflicting data parallel size" error. The drafter
+        # never owns a KV connector (it is built from the main worker's
+        # vllm_config, not the draft config), so temporarily strip these
+        # sub-configs from the worker config around the super() call. This
+        # defers the kernel/attention overrides to the base implementation and
+        # stays compatible with proposer subclasses that wrap super() themselves.
+        orig_vllm_config = self.vllm_config
+        kvtc = orig_vllm_config.kv_transfer_config
+        if kvtc is not None:
+            extra = {
+                k: v
+                for k, v in kvtc.kv_connector_extra_config.items()
+                if k not in ("prefill", "decode")
+            }
+            self.vllm_config = vllm_replace(
+                orig_vllm_config,
+                kv_transfer_config=vllm_replace(
+                    kvtc, kv_connector_extra_config=extra
+                ),
+            )
+        try:
+            return super()._create_draft_vllm_config()
+        finally:
+            self.vllm_config = orig_vllm_config
+
     def _get_model(self) -> nn.Module:
         """
         Default method to call get_model(). Can be overridden by subclasses which


### PR DESCRIPTION
### What this PR does / why we need it?
This PR resolves a false "conflicting data parallel size" error during the reconstruction of the drafter's draft config in a PD-disaggregated, internal-DP setup. It temporarily strips the `prefill` and `decode` sub-configs from the worker's `kv_transfer_config` during `_create_draft_vllm_config` and restores them afterward.

Feedback: A potential `AttributeError` was identified in `llm_base_proposer.py` if `kv_connector_extra_config` is `None` when calling `.items()`. A check should be added to prevent this.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added unit tests in `tests/ut/spec_decode/test_llm_base_proposer.py` and `tests/ut/test_check_kv_extra_config.py`.


- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
