### PR TITLE
[Test][Model] Add Kimi K3 A3 nightly coverage

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -91,6 +91,9 @@ a2:
 a3:
   multi_node:
     test_config:
+      - name: kimi-k3-w4a8-a3
+        config_file_path: Kimi-K3-W4A8-A3.yaml
+        size: 4
       - name: multi-node-deepseek-v3.2-W8A8-EP
         config_file_path: DeepSeek-V3_2-W8A8-EP.yaml
         config_base_path: tests/e2e/nightly/multi_node/internal_dp/config

--- a/.github/workflows/misc/model_dataset_list.json
+++ b/.github/workflows/misc/model_dataset_list.json
@@ -19,6 +19,7 @@
       "Eco-Tech/DeepSeek-V3.1-w8a8-mtp-QuaRot",
       "Eco-Tech/Qwen3-30B-A3B-w8a8",
       "Eco-Tech/Kimi-K2.5-W4A8",
+      "Eco-Tech/Kimi-K3-w4a8",
       "Eco-Tech/Qwen3-VL-235B-A22B-Instruct-w8a8-QuaRot",
       "Eco-Tech/Qwen3-VL-32B-Instruct-w8a8-QuaRot",
       "Howeee/Qwen2.5-1.5B-apeach",

--- a/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/Kimi-K3-W4A8-A3.yaml
@@ -1,0 +1,166 @@
+test_name: "test Kimi-K3-W4A8 A3 four-node mixed deployment"
+model: "Eco-Tech/Kimi-K3-w4a8"
+num_nodes: 4
+npu_per_node: 16
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: true
+  HCCL_BUFFSIZE: 800
+  PYTORCH_NPU_ALLOC_CONF: expandable_segments:True
+  OMP_PROC_BIND: false
+  OMP_NUM_THREADS: 1
+  TASK_QUEUE_ENABLE: 1
+  VLLM_ENGINE_READY_TIMEOUT_S: 7200
+  SERVER_PORT: 8080
+
+deployment:
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 0
+        --data-parallel-address $LOCAL_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --headless
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 1
+        --data-parallel-address $MASTER_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --headless
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 2
+        --data-parallel-address $MASTER_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+  - envs:
+      <<: *env_common
+    server_cmd: >
+      env -u HCCL_OP_EXPANSION_MODE vllm serve Eco-Tech/Kimi-K3-w4a8
+        --host 0.0.0.0
+        --headless
+        --port $SERVER_PORT
+        --quantization ascend
+        --allowed-local-media-path /
+        --trust-remote-code
+        --tokenizer-mode kimi_k3
+        --tensor-parallel-size 16
+        --data-parallel-size 4
+        --data-parallel-size-local 1
+        --data-parallel-start-rank 3
+        --data-parallel-address $MASTER_IP
+        --data-parallel-rpc-port 13389
+        --enable-expert-parallel
+        --enable-prefix-caching
+        --max-num-seqs 16
+        --max-model-len 131027
+        --max-num-batched-tokens 8192
+        --gpu-memory-utilization 0.9
+        --compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
+        --additional-config '{"enable_cpu_binding":true,"enable_flashcomm1":true}'
+        --mm-processor-cache-gb 0
+        --mm-encoder-tp-mode data
+        --limit-mm-per-prompt '{"vision_chunk":2}'
+        --enable-auto-tool-choice
+        --reasoning-parser kimi_k3
+        --tool-call-parser kimi_k3
+
+benchmarks:
+  acc_gsm8k:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gsm8k-lite
+    request_conf: vllm_api_general_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+    max_out_len: 4096
+    batch_size: 32
+    baseline: 95
+    threshold: 10
+
+  perf_16k_prefix0:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K_prefix0_in16384_bs200_kimi
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 16
+    max_out_len: 1024
+    batch_size: 4
+    request_rate: 0
+    # Calibrate this value from repeated A3 CI runs before enabling a regression gate.
+    baseline: 1
+    threshold: 0


### PR DESCRIPTION
### What this PR does / why we need it?

Adds a four-node A3 mixed-deployment nightly configuration for Eco-Tech/Kimi-K3-w4a8 (DP4/TP16 with expert parallelism). The test registers the model in the nightly matrix and ModelScope pre-download list, runs a GSM8K accuracy check, and collects 16K no-prefix-cache performance metrics for later baseline calibration.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- Parsed the new YAML and nightly matrix; validated the four-node topology, rank assignments, ports, and required startup options.
- Validated the model and datasets are present in the ModelScope cache list.
- NPU runtime verification and performance-baseline calibration are pending a targeted /nightly kimi-k3-w4a8-a3 run on the A3 CI cluster.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
