### PR TITLE
[Feature][model_runner_v2] Support vllm feature mask_reply on Ascend

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_pack_sampling_mask.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_pack_sampling_mask.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Precision test for the sampling-mask packing kernel (mask_reply).
+
+Validates ``_pack_sampling_mask_kernel`` from
+``vllm_ascend.ops.triton.v2.sample.pack_sampling_mask`` against a pure NumPy
+reference. This is the NPU replacement for the upstream kernel replaced by
+``patch/worker/patch_v2/patch_triton.py``; the one-line fix (cast ``keep`` to
+int32 before the ``tl.sum`` reduction) is exercised by the ``counts``
+comparison, which fails on the upstream form when any request keeps more than
+one token.
+"""
+
+import numpy as np
+import pytest
+import torch
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON
+
+from vllm_ascend.ops.triton.v2.sample.pack_sampling_mask import (
+    SAMPLING_MASK_BLOCK_SIZE,
+    _pack_sampling_mask_kernel,
+)
+
+DEVICE_TYPE = current_platform.device_type
+
+
+def _launch(logits: torch.Tensor, num_sampled_tokens: torch.Tensor):
+    """Launch the kernel, mirroring ``SamplingMaskTensors.from_logits``."""
+    num_reqs, vocab_size = logits.shape
+    packed_width = (vocab_size + 7) // 8
+    packed_mask = torch.empty((num_reqs, packed_width), dtype=torch.uint8, device=logits.device)
+    counts = torch.empty(num_reqs, dtype=torch.int32, device=logits.device)
+    _pack_sampling_mask_kernel[(num_reqs,)](
+        logits,
+        logits.stride(0),
+        logits.stride(1),
+        num_sampled_tokens,
+        packed_mask,
+        packed_mask.stride(0),
+        counts,
+        vocab_size,
+        BLOCK_SIZE=SAMPLING_MASK_BLOCK_SIZE,
+    )
+    return packed_mask, counts
+
+
+def _reference(logits: torch.Tensor, num_sampled_tokens: torch.Tensor):
+    """Pure NumPy reference for ``packed_mask``/``counts`` (little-endian)."""
+    num_reqs, vocab_size = logits.shape
+    packed_width = (vocab_size + 7) // 8
+    logits_np = logits.detach().float().cpu().numpy()
+    num_sampled_np = num_sampled_tokens.detach().cpu().numpy()
+
+    keep = np.isfinite(logits_np) & (num_sampled_np[:, None] > 0)
+    counts = keep.sum(axis=1).astype(np.int32)
+
+    padded = np.zeros((num_reqs, packed_width * 8), dtype=np.uint8)
+    padded[:, :vocab_size] = keep.astype(np.uint8)
+    packed = (padded.reshape(num_reqs, packed_width, 8) * (1 << np.arange(8))).sum(axis=2).astype(np.uint8)
+    return packed, counts
+
+
+@pytest.mark.skipif(not HAS_TRITON, reason="Triton not available on this platform")
+class TestPackSamplingMask:
+    @pytest.mark.parametrize(
+        "num_reqs,vocab_size",
+        [
+            (2, 8),  # exact multiple of 8, smallest useful case
+            (4, 100),  # non-multiple of 8, tail byte high bits are zero
+            (2, 8193),  # just above 2*BLOCK_SIZE, exercises the multi-block tail
+            (3, 32000),  # realistic vocab, multiple blocks
+        ],
+    )
+    def test_matches_reference(self, num_reqs, vocab_size):
+        torch.manual_seed(0)
+        logits = torch.randn(num_reqs, vocab_size, dtype=torch.float32, device=DEVICE_TYPE)
+        num_sampled_tokens = torch.randint(0, 4, (num_reqs,), dtype=torch.int32, device=DEVICE_TYPE)
+        # Always include at least one inactive request (num_sampled == 0).
+        num_sampled_tokens[0] = 0
+
+        packed, counts = _launch(logits, num_sampled_tokens)
+        torch.npu.synchronize()
+
+        ref_packed, ref_counts = _reference(logits, num_sampled_tokens)
+        assert torch.equal(packed.cpu(), torch.from_numpy(ref_packed))
+        assert torch.equal(counts.cpu(), torch.from_numpy(ref_counts))
+
+    def test_non_finite_logits_filtered(self):
+        vocab_size = 16
+        logits = torch.full((1, vocab_size), -float("inf"), dtype=torch.float32, device=DEVICE_TYPE)
+        logits[0, 2] = 1.0
+        logits[0, 5] = float("inf")
+        logits[0, 7] = float("nan")
+        num_sampled_tokens = torch.tensor([1], dtype=torch.int32, device=DEVICE_TYPE)
+
+        packed, counts = _launch(logits, num_sampled_tokens)
+        torch.npu.synchronize()
+
+        # Only token 2 is finite (excludes -inf, +inf and NaN) and active.
+        assert counts.cpu().item() == 1
+        assert packed.cpu()[0, 0].item() == (1 << 2)
+
+    def test_num_sampled_zero_clears_row(self):
+        vocab_size = 32
+        logits = torch.randn(2, vocab_size, dtype=torch.float32, device=DEVICE_TYPE)
+        num_sampled_tokens = torch.tensor([0, 1], dtype=torch.int32, device=DEVICE_TYPE)
+
+        packed, counts = _launch(logits, num_sampled_tokens)
+        torch.npu.synchronize()
+
+        # Inactive request: count 0 and fully-zero mask.
+        assert counts.cpu()[0].item() == 0
+        assert packed.cpu()[0].eq(0).all().item()
+        # Active request with all-finite logits: every token is in the support.
+        assert counts.cpu()[1].item() == vocab_size
+        assert packed.cpu()[1].eq(0xFF).all().item()
+
+    def test_non_contiguous_logits(self):
+        vocab_size = 32
+        base = torch.randn(1, vocab_size * 2, dtype=torch.float32, device=DEVICE_TYPE)
+        logits = base[:, ::2]  # stride-2 view exercises logits_col_stride
+        num_sampled_tokens = torch.tensor([1], dtype=torch.int32, device=DEVICE_TYPE)
+
+        packed, counts = _launch(logits, num_sampled_tokens)
+        torch.npu.synchronize()
+
+        ref_packed, ref_counts = _reference(logits, num_sampled_tokens)
+        assert torch.equal(packed.cpu(), torch.from_numpy(ref_packed))
+        assert torch.equal(counts.cpu(), torch.from_numpy(ref_counts))

--- a/vllm_ascend/ops/triton/v2/sample/pack_sampling_mask.py
+++ b/vllm_ascend/ops/triton/v2/sample/pack_sampling_mask.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Ascend replacement for the sampling-mask packing kernel.
+
+This is the NPU-ported ``_pack_sampling_mask_kernel`` from
+``vllm.v1.worker.gpu.sample.output``. It packs the finite-logit support of
+each request (the set of token ids whose logits are not ``±inf``/``NaN``) into
+a bit-packed ``uint8`` buffer plus a per-request ``counts`` tensor.
+
+The only difference from the upstream kernel is a single line: triton-ascend
+does not upcast the result of ``tl.sum`` on an ``int1`` tensor to ``int32``
+(unlike native CUDA Triton), which truncates ``counts`` to 0/1. We therefore
+cast ``keep`` to ``int32`` *before* the reduction.
+"""
+
+import torch
+from vllm.triton_utils import tl, triton
+
+# NPU backend cannot launch the kernel with the upstream BLOCK_SIZE=8192.
+# The tightest constraint is the strided-load path: when logits is
+# non-contiguous (logits_col_stride != 1) the masked ``tl.load`` lowers to a
+# gather, whose max block on Ascend is far smaller than a contiguous load's.
+# 2048/4096 fail on that case even though contiguous inputs work; 1024 keeps
+# both contiguous and strided cases under the limit. Temporary reduction
+# pending an NPU-side fix.
+SAMPLING_MASK_BLOCK_SIZE = 1024
+
+
+@triton.jit
+def _pack_sampling_mask_kernel(
+    logits_ptr,
+    logits_row_stride,
+    logits_col_stride,
+    num_sampled_tokens_ptr,
+    packed_mask_ptr,
+    packed_mask_row_stride,
+    counts_ptr,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    is_active = tl.load(num_sampled_tokens_ptr + req_idx) > 0
+    count = tl.zeros((), dtype=tl.int32)
+
+    for start_idx in range(0, vocab_size, BLOCK_SIZE):
+        offsets = start_idx + tl.arange(0, BLOCK_SIZE)
+        valid = offsets < vocab_size
+        logits = tl.load(
+            logits_ptr + req_idx * logits_row_stride + offsets * logits_col_stride,
+            mask=valid,
+            other=-float("inf"),
+        )
+        keep = (logits > -float("inf")) & (logits < float("inf")) & is_active
+        # triton-ascend keeps the int1 sum in int1, truncating large counts;
+        # cast to int32 first so the reduction accumulates the full count.
+        count += tl.sum(keep.to(tl.int32))
+        keep = tl.reshape(keep.to(tl.int32), (BLOCK_SIZE // 8, 8))
+        bit_shifts = tl.arange(0, 8)[None, :]
+        packed = tl.sum(keep << bit_shifts, axis=1).to(tl.uint8)
+        byte_offsets = start_idx // 8 + tl.arange(0, BLOCK_SIZE // 8)
+        tl.store(
+            packed_mask_ptr + req_idx * packed_mask_row_stride + byte_offsets,
+            packed,
+            mask=byte_offsets < tl.cdiv(vocab_size, 8),
+        )
+
+    tl.store(counts_ptr + req_idx, count)
+
+
+def sampling_mask_from_logits(cls, logits, num_sampled_tokens):
+    """NPU replacement for ``SamplingMaskTensors.from_logits``.
+
+    Identical to the upstream classmethod except it launches with the reduced
+    ``SAMPLING_MASK_BLOCK_SIZE`` instead of the upstream hard-coded 8192, which
+    the Ascend backend cannot launch. Wired in via
+    ``patch/worker/patch_v2/patch_triton.py``.
+    """
+    num_reqs, vocab_size = logits.shape
+    packed_width = (vocab_size + 7) // 8
+
+    packed_mask = torch.empty(
+        (num_reqs, packed_width), dtype=torch.uint8, device=logits.device
+    )
+    counts = torch.empty(num_reqs, dtype=torch.int32, device=logits.device)
+    _pack_sampling_mask_kernel[(num_reqs,)](
+        logits,
+        logits.stride(0),
+        logits.stride(1),
+        num_sampled_tokens,
+        packed_mask,
+        packed_mask.stride(0),
+        counts,
+        vocab_size,
+        BLOCK_SIZE=SAMPLING_MASK_BLOCK_SIZE,
+    )
+
+    return cls(packed_mask, counts, vocab_size)

--- a/vllm_ascend/ops/triton/v2/sample/pack_sampling_mask.py
+++ b/vllm_ascend/ops/triton/v2/sample/pack_sampling_mask.py
@@ -78,9 +78,7 @@ def sampling_mask_from_logits(cls, logits, num_sampled_tokens):
     num_reqs, vocab_size = logits.shape
     packed_width = (vocab_size + 7) // 8
 
-    packed_mask = torch.empty(
-        (num_reqs, packed_width), dtype=torch.uint8, device=logits.device
-    )
+    packed_mask = torch.empty((num_reqs, packed_width), dtype=torch.uint8, device=logits.device)
     counts = torch.empty(num_reqs, dtype=torch.int32, device=logits.device)
     _pack_sampling_mask_kernel[(num_reqs,)](
         logits,

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -1100,6 +1100,34 @@
 #       Remove this patch once vLLM selects the Triton libdevice through a
 #       backend-dispatch mechanism.
 #
+#   3. `vllm.v1.worker.gpu.sample.output._pack_sampling_mask_kernel` and
+#      `SamplingMaskTensors.from_logits`
+#    Why:
+#       (1) The upstream kernel sums an int1 tensor (`tl.sum(keep)`) before
+#       casting to int32, which native CUDA Triton upcasts automatically.
+#       triton-ascend does not upcast, so `counts` is truncated to 0/1 and the
+#       sampling-mask replay (mask_reply) returns wrong candidate sets on NPU.
+#       (2) The upstream `from_logits` launcher hard-codes `BLOCK_SIZE=8192`,
+#       which the Ascend backend cannot launch. The tightest constraint is the
+#       non-contiguous (strided/gather) load path, whose max block is far
+#       smaller than a contiguous load's, so the block must be reduced to 1024.
+#    How:
+#       Rebind `output._pack_sampling_mask_kernel` to the Ascend copy in
+#       `vllm_ascend/ops/triton/v2/sample/pack_sampling_mask.py`, which casts
+#       `keep` to int32 before the reduction (`tl.sum(keep.to(tl.int32))`).
+#       Also rebind `output.SamplingMaskTensors.from_logits` to the module's
+#       `sampling_mask_from_logits`, which launches with the reduced
+#       `SAMPLING_MASK_BLOCK_SIZE` (1024) instead of 8192.
+#    Test:
+#       Precision test added at
+#       tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_pack_sampling_mask.py
+#    Related PR (if no, explain why):
+#       No. This is a Triton-Ascend backend compatibility patch.
+#    Future Plan:
+#       Remove once triton-ascend upcasts int1 reductions and supports the
+#       upstream BLOCK_SIZE, or vLLM adds a backend-dispatch mechanism for
+#       this kernel.
+#
 # ** 29. File: worker/patch_v2/patch_use_v2_model_runner.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.vllm.VllmConfig.use_v2_model_runner`

--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -1,7 +1,7 @@
 import vllm.v1.worker.gpu.spec_decode.speculator as base_speculator
 from vllm.v1.sample.ops import topk_topp_sampler
 from vllm.v1.worker.gpu import structured_outputs
-from vllm.v1.worker.gpu.sample import bad_words, gumbel, logprob, penalties, prompt_logprob, sampler, states
+from vllm.v1.worker.gpu.sample import bad_words, gumbel, logprob, output, penalties, prompt_logprob, sampler, states
 from vllm.v1.worker.gpu.spec_decode import rejection_sampler, rejection_sampler_utils
 from vllm.v1.worker.gpu.spec_decode.dflash import speculator as dflash_speculator
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator
@@ -9,6 +9,10 @@ from vllm.v1.worker.gpu.spec_decode.eagle import speculator
 from vllm_ascend.ops.triton.v2.metrics.num_nans import get_num_nans
 from vllm_ascend.ops.triton.v2.sample.apply_top_k_top_p_triton import apply_top_k_top_p_triton
 from vllm_ascend.ops.triton.v2.sample.fill_logprob_token_idx import _fill_logprob_token_ids_kernel
+from vllm_ascend.ops.triton.v2.sample.pack_sampling_mask import (
+    _pack_sampling_mask_kernel,
+    sampling_mask_from_logits,
+)
 from vllm_ascend.worker.v2.sample.bad_words import apply_bad_words
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
 from vllm_ascend.worker.v2.sample.logprob import compute_token_logprobs, compute_topk_logprobs
@@ -42,6 +46,8 @@ rejection_sampler.rejection_sample = npu_rejection_sample
 dflash_speculator._prepare_dflash_inputs_kernel = _prepare_dflash_inputs_kernel_ascend
 # triton ops that filed in ops/triton
 topk_topp_sampler.apply_top_k_top_p_triton = apply_top_k_top_p_triton
+output._pack_sampling_mask_kernel = _pack_sampling_mask_kernel
+output.SamplingMaskTensors.from_logits = classmethod(sampling_mask_from_logits)
 # This patch may be revisited or reverted once the compiler and Triton Ascend toolkit
 # support the upstream implementation of fill_logprob_token_ids_kernel.
 # For now, use the Ascend-specific implementation.


### PR DESCRIPTION
  ### What this PR does / why we need it?

  Migrate vLLM's sampling-distribution-replay feature (`mask_reply`) to Ascend.  `mask_reply` packs each request's finite-logit support (token ids whose logits are not `±inf`/`NaN`) into a bit-packed mask so the client can replay the exact sampling distribution. Two Ascend-specific changes are needed on top of the upstream Triton kernel and its launcher:
1. **Port `_pack_sampling_mask_kernel`** — upstream computes the per-request count with `tl.sum(keep)` where `keep` is an `int1` tensor. Native CUDA Triton upcasts the result to `int32` automatically, but triton-ascend does not, so `counts` is truncated to `0/1` and the replay returns wrong candidate sets. The ported kernel casts `keep` to `int32` before the reduction (`tl.sum(keep.to(tl.int32))`).

2. **Override `SamplingMaskTensors.from_logits`** — the upstream launcher hard-codes `BLOCK_SIZE=8192`, which Ascend cannot launch. The tightest constraint is the non-contiguous (strided/gather) load path, whose max block is far smaller than a contiguous load's. The replacement launcher uses `SAMPLING_MASK_BLOCK_SIZE = 1024`, keeping both contiguous and strided inputs under the limit.

3. **Wire the patch** — rebind `output._pack_sampling_mask_kernel` and `output.SamplingMaskTensors.from_logits` in `patch/worker/patch_v2/patch_triton.py`, documented in `patch/__init__.py`.

### Does this PR introduce _any_ user-facing change?

No. This is an Ascend-backend compatibility patch that makes the existing `mask_reply` feature work on NPU; no API, interface, or behavior change for end users.

### How was this patch tested?

- Added precision test
    `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_pack_sampling_mask.py` comparing `packed_mask`/`counts` against a pure NumPy reference across vocab sizes (8 / 100 / 8193 / 32000), filtering non-finite logits, clearing inactive rows, and exercising non-contiguous (stride-2) logits.
- Verified the end-to-end path
    `tests/entrypoints/scale_out/token_in_token_out/test_serving_tokens.py`
 (`test_generate_sampling_mask`) on an Ascend device with `VLLM_USE_V2_MODEL_RUNNER=1`.

---

vllm commit: `cdc4824a21eaa986d4d1fee90a7e6465c9f706e6`
vllm-ascend commit: `c6f4afbd6341851dac05719cc018ae919292bcde`

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
