### PR TITLE
[Test][Misc] Fix typos in DeepSeek V4 Flash A5 test case names

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek_V4_Flash_A5.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek_V4_Flash_A5.yaml
@@ -66,7 +66,7 @@ _benchmarks_per2: &benchmarks_per
 # ACTUAL TEST CASES
 # ==========================================
 test_cases:
-  - name: "DeepSeekV4_Flash_A5_Signle_GPQA_Accurancy_Test_01"
+  - name: "DeepSeekV4_Flash_A5_Single_GPQA_Accuracy_Test_01"
     model: "/root/.cache/modelscope/hub/models/models--deepseek-ai--DeepSeek-V4-Flash"
     envs:
       <<: *envs

--- a/tests/e2e/weekly/single_node/configs/DeepSeek_V4_Flash_A5.yaml
+++ b/tests/e2e/weekly/single_node/configs/DeepSeek_V4_Flash_A5.yaml
@@ -66,7 +66,7 @@ _benchmarks_per2: &benchmarks_per
 # ACTUAL TEST CASES
 # ==========================================
 test_cases:
-  - name: "DeepSeekV4_Flash_A5_Signle_GPQA_Accurancy_Test_01"
+  - name: "DeepSeekV4_Flash_A5_Single_GPQA_Accuracy_Test_01"
     model: "/root/.cache/modelscope/hub/models/models--deepseek-ai--DeepSeek-V4-Flash"
     envs:
       <<: *envs


### PR DESCRIPTION
### What this PR does / why we need it?
This PR fixes spelling errors in the test case names for the DeepSeek V4 Flash A5 configuration files. Specifically, "Signle" is corrected to "Single" and "Accurancy" is corrected to "Accuracy" in both the nightly and weekly e2e test configurations.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
No functional changes were made; only test case names were corrected.