### PR TITLE
[v0.26.0rc][BugFix][DCP] Adapt K3 DSpark and P/D topology

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -319,7 +319,7 @@ class AscendAttentionMetadataBuilder(AttentionMetadataBuilder[AscendMetadata]):
             seq_lens = common_attn_metadata.seq_lens
             slot_mapping = common_attn_metadata.slot_mapping.to(torch.int32)
         elif self.speculative_config and self.speculative_config.parallel_drafting:
-            seq_lens = common_attn_metadata.seq_lens
+            seq_lens = common_attn_metadata.seq_lens.to("cpu")
 
         attn_state = common_attn_metadata.attn_state
 

--- a/vllm_ascend/attention/context_parallel/attention_cp.py
+++ b/vllm_ascend/attention/context_parallel/attention_cp.py
@@ -76,6 +76,7 @@ class AscendMetadataForDecode:
     num_computed_tokens_of_dcp: list[list[int]] | None = None
     block_tables: torch.Tensor = None
     dcp_mtp_attn_mask: torch.Tensor = None
+    query_lens: list[int] | None = None
 
 
 @dataclass
@@ -121,6 +122,12 @@ class AscendAttentionDCPMetadataBuilder(
         num_prefills: int,
     ) -> dict[str, object]:
         dcp_metadata = self._require_dcp_metadata(common_attn_metadata)
+        dcp_query_lens = dcp_metadata.query_lens_cpu
+        if dcp_query_lens is not None:
+            query_lens = dcp_query_lens[: num_decodes + num_prefills].to(
+                device=query_lens.device,
+                dtype=query_lens.dtype
+            )
         prefill_metadata = None
         if num_prefills > 0:
             prefill_query_lens = query_lens[num_decodes:]
@@ -162,6 +169,7 @@ class AscendAttentionDCPMetadataBuilder(
                 num_computed_tokens_of_dcp=np.asarray(dcp_metadata.num_computed_tokens_of_dcp)[:num_decodes],
                 block_tables=block_table[:num_decodes],
                 dcp_mtp_attn_mask=dcp_metadata.dcp_mtp_attn_mask,
+                query_lens=query_lens[:num_decodes].tolist(),
             )
 
         return {
@@ -169,6 +177,35 @@ class AscendAttentionDCPMetadataBuilder(
             "decode_meta": decode_metadata,
         }
 
+def pad_decode_query_to_bsnd(
+        query: torch.Tensor,
+        query_lens: list[int],
+        max_q: int,
+) -> torch.Tensor:
+    num_decodes = len(query_lens)
+    num_heads, head_size = query.shape[1], query.shape[-1]
+    out = query.new_zeros((num_decodes, max_q, num_heads, head_size))
+    offset = 0
+    for i, qlen in enumerate(query_lens):
+        if qlen > 0:
+            out[i, :qlen] = query[offset : offset + qlen]
+            offset += qlen
+    return out
+
+def _compact_bsnd_out(
+    attn_out: torch.Tensor,
+    attn_lse: torch.Tensor,
+    decode_q_lens: list[int],
+    max_q: int,
+):
+    num_decodes = len(decode_q_lens)
+    out_q = attn_out.view(num_decodes, max_q, *attn_out.shape[1:])
+    out_l = attn_lse.view(num_decodes, max_q, *attn_lse.shape[1:])
+    pieces_o, pieces_l = [], []
+    for i, qlen in enumerate(decode_q_lens):
+        pieces_o.append(out_q[i, :qlen])
+        pieces_l.append(out_l[i, :qlen])
+    return torch.cat(pieces_o, dim=0), torch.cat(pieces_l, dim=0)
 
 class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
     @staticmethod
@@ -221,17 +258,20 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
                     attn_mask,
                 ) = param
 
+                actual_seq_lengths_q_is_cumulative = False
                 if _EXTRA_CTX.is_draft_model:
                     draft_step = attn_count // num_layers
-                    actual_seq_lengths_kv = attn_metadata[draft_step][key].decode_meta.num_computed_tokens_of_dcp[
-                        :, dcp_rank
-                    ]
+                    draft_attn_metadata = attn_metadata[draft_step][key]
+                    actual_seq_lengths_kv = draft_attn_metadata.decode_meta.num_computed_tokens_of_dcp[:, dcp_rank]
                     pad_length = num_tokens - len(actual_seq_lengths_kv)
                     if pad_length > 0:
                         pad_tensor = np.zeros(pad_length, dtype=actual_seq_lengths_kv.dtype)
                         actual_seq_lengths_kv = np.concatenate([actual_seq_lengths_kv, pad_tensor])
 
-                    actual_seq_lengths_q = attn_metadata[draft_step][key].actual_seq_lengths_q
+                    actual_seq_lengths_q = draft_attn_metadata.decode_meta.query_lens
+                    if actual_seq_lengths_q is None:
+                        actual_seq_lengths_q = draft_attn_metadata.actual_seq_lengths_q
+                        actual_seq_lengths_q_is_cumulative = True
                     attn_count = attn_count + 1
                 else:
                     actual_seq_lengths_kv = attn_metadata[key].decode_meta.num_computed_tokens_of_dcp[:, dcp_rank]
@@ -248,9 +288,13 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
                 torch.npu.graph_task_update_begin(update_stream, handle)
 
                 input_layout = "TND"
-                if speculative_config is not None:
+                if _EXTRA_CTX.is_draft_model and speculative_config is not None:
                     input_layout = "BSND"
-                    actual_seq_lengths_q = [actual_seq_lengths_q[0] for _ in range(len(actual_seq_lengths_q))]
+                    if actual_seq_lengths_q_is_cumulative and isinstance(actual_seq_lengths_q, list) and actual_seq_lengths_q:
+                        actual_seq_lengths_q = [actual_seq_lengths_q[0]]+ [
+                            actual_seq_lengths_q[i] - actual_seq_lengths_q[i-1]
+                            for i in range(1, len(actual_seq_lengths_q))
+                        ]
 
                 torch_npu.npu_fused_infer_attention_score.out(
                     q_nope,
@@ -295,15 +339,25 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
         attn_mask = None
         input_layerout = "TND"
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q[: attn_metadata.num_decodes]
-        if self.vllm_config.speculative_config is not None:
+        is_uniform = True
+        decode_q_lens: list[int] | None = None
+        max_q = 0
+        if _EXTRA_CTX.is_draft_model and self.vllm_config.speculative_config is not None:
             input_layerout = "BSND"
             num_decodes = attn_metadata.num_decodes
             if attn_metadata.decode_meta.dcp_mtp_attn_mask is not None:
                 attn_mask = attn_metadata.decode_meta.dcp_mtp_attn_mask
             else:
                 attn_mask = None
-            query = query.view(num_decodes, -1, query.shape[1], query.shape[-1])
-            actual_seq_lengths_q = [actual_seq_lengths_q[0] for _ in range(len(actual_seq_lengths_q))]
+            decode_q_lens = attn_metadata.decode_meta.query_lens
+            spec = self.vllm_config.speculative_config
+            max_q = 1 + (spec.num_speculative_tokens if spec is not None else 0)
+            is_uniform = attn_metadata.num_decode_tokens == num_decodes * max_q
+            if is_uniform:
+                query = query.view(num_decodes, max_q, query.shape[1], query.shape[-1])
+            else:
+                query = pad_decode_query_to_bsnd(query, decode_q_lens, max_q)
+            actual_seq_lengths_q = decode_q_lens
 
         common_kwargs = {
             "num_heads": num_heads,
@@ -386,6 +440,13 @@ class AscendAttentionDCPImpl(DCPImplMixin, AscendAttentionBackendImpl):
         if input_layerout == "BSND":
             attn_out = attn_out.view(-1, attn_out.shape[2], attn_out.shape[3])
             attn_lse = attn_lse.transpose(1, 2).reshape(-1, attn_lse.shape[1], 1)
+            if not is_uniform:
+                attn_out, attn_lse = _compact_bsnd_out(
+                    attn_out,
+                    attn_lse,
+                    decode_q_lens,
+                    max_q
+                )
         return self._merge_dcp_attention_output(
             attn_out,
             attn_lse,

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -1912,6 +1912,10 @@ class MooncakeConnectorScheduler:
             logger.info("Delaying free of %d blocks for request %s", sum(computed_block_lens), request.request_id)
             self._reqs_need_send[request.request_id] = time.time()
 
+        connector_extra = self.vllm_config.kv_transfer_config.kv_connector_extra_config or {}
+        decode_topology = connector_extra.get("decode", {})
+        advertised_remote_dcp_size = int(decode_topology.get("dcp_size", self.dcp_size))
+
         return delay_free_blocks, dict(
             do_remote_prefill=True,
             do_remote_decode=False,
@@ -1921,7 +1925,7 @@ class MooncakeConnectorScheduler:
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             remote_pcp_size=self.pcp_size,
-            remote_dcp_size=self.dcp_size,
+            remote_dcp_size=advertised_remote_dcp_size,
             remote_ptp_size=self.tp_size,
             last_token_id=request.output_token_ids[-1],
             remote_multi_nodes_meta_mapping=self.multi_nodes_meta_mapping,

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -94,7 +94,12 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
     batch_size,  # tl.int32
     HAS_NUM_REJECTED: tl.constexpr = False,
     SAMPLE_FROM_ANCHOR: tl.constexpr = False,
+    total_cp_world_size: tl.constexpr = 1,
+    current_cp_rank: tl.constexpr = 0,
+    cp_kv_cache_interleave_size: tl.constexpr = 1,
+    PAD_ID: tl.constexpr = -1,
 ):
+    virtual_block = block_size * total_cp_world_size
     for req_idx in range(0, batch_size):
         ctx_start = tl.load(query_start_loc_ptr + req_idx)
         ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
@@ -126,9 +131,22 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid(
             tl.store(out_query_positions_ptr + query_out_idx, query_pos)
 
             query_cache_pos = effective_seq_len + q_idx
-            block_num_q = query_cache_pos // block_size
-            block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
-            slot_q = block_id_q * block_size + (query_cache_pos % block_size)
+            if total_cp_world_size > 1:
+                voff = query_cache_pos % virtual_block
+                owner = (voff // cp_kv_cache_interleave_size) % total_cp_world_size
+                local_off = (voff // (total_cp_world_size * cp_kv_cache_interleave_size)
+                             ) * cp_kv_cache_interleave_size + (voff % cp_kv_cache_interleave_size)
+                block_num_q = (query_cache_pos // virtual_block) + (local_off // block_size)
+                block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
+                slot_q = tl.where(
+                    owner == current_cp_rank,
+                    block_id_q * block_size + (local_off % block_size),
+                    PAD_ID
+                )
+            else:
+                block_num_q = query_cache_pos // block_size
+                block_id_q = tl.load(block_table_ptr + req_idx * block_table_stride + block_num_q).to(tl.int64)
+                slot_q = block_id_q * block_size + (query_cache_pos % block_size)
             tl.store(out_query_slot_mapping_ptr + query_out_idx, slot_q)
 
             if q_idx == 0:

--- a/vllm_ascend/spec_decode/dflash_proposer.py
+++ b/vllm_ascend/spec_decode/dflash_proposer.py
@@ -4,10 +4,12 @@ import torch
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.forward_context import get_forward_context
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
 
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.attention.context_parallel.common_cp import get_dcp_local_seq_lens
+from vllm_ascend.attention.utils import AscendCommonAttentionMetadata, AscendDCPMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.eagle_proposer import AscendEagleProposer
 
@@ -91,6 +93,9 @@ class AscendDflashProposer(AscendEagleProposer):
         )
 
         has_num_rejected = num_rejected_tokens_gpu is not None
+        total_cp_world_size = self.dcp_size
+        current_cp_rank = self.dcp_rank
+        cp_kv_cache_interleave_size = self.vllm_config.parallel_config.cp_kv_cache_interleave_size
 
         copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid[1,](
             # Inputs
@@ -119,6 +124,10 @@ class AscendDflashProposer(AscendEagleProposer):
             total_input_tokens=num_context,
             batch_size=batch_size,
             HAS_NUM_REJECTED=has_num_rejected,
+            total_cp_world_size=total_cp_world_size,
+            current_cp_rank=current_cp_rank,
+            cp_kv_cache_interleave_size=cp_kv_cache_interleave_size,
+            PAD_ID=PADDING_SLOT_ID,
         )
 
         query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
@@ -147,7 +156,29 @@ class AscendDflashProposer(AscendEagleProposer):
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 
-        return num_query_total, token_indices_to_sample, cad, None
+        if cad.is_prefilling is not None:
+            cad.is_prefilling = torch.zeros_like(cad.is_prefilling)
+        long_seq_args = None
+        if self.dcp_size > 1:
+            seq_lens_cpu = cad.seq_lens.cpu()
+            cad.seq_lens_cpu = seq_lens_cpu
+            if cad._seq_lens_cpu is not None:
+                cad._seq_lens_cpu = seq_lens_cpu
+            cad.max_seq_len = int(seq_lens_cpu.max().item())
+            local_seq_lens = get_dcp_local_seq_lens(
+                seq_lens_cpu,
+                self.dcp_size,
+                self.vllm_config.parallel_config.cp_kv_cache_interleave_size,
+            )
+            cad.context_parallel_metadata = AscendDCPMetadata(
+                num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+                query_lens_cpu=None,
+                max_query_len=0,
+                dcp_mtp_attn_mask=None,
+            )
+            long_seq_args = (None, None)
+
+        return num_query_total, token_indices_to_sample, cad, long_seq_args
 
     @torch.inference_mode()
     def dummy_run(
@@ -161,7 +192,9 @@ class AscendDflashProposer(AscendEagleProposer):
         is_profile=False,
         **kwargs,
     ) -> None:
-        num_query_tokens = min(num_tokens, self.max_query_tokens)
+        num_query_per_req = 1 + self.num_speculative_tokens
+        num_query_total = num_reqs * num_query_per_req if num_reqs > 0 else num_tokens
+        num_query_tokens = num_query_total
 
         (
             num_input_tokens,
@@ -171,8 +204,21 @@ class AscendDflashProposer(AscendEagleProposer):
 
         if not self.use_cuda_graph:
             aclgraph_runtime_mode = CUDAGraphMode.NONE
-        num_query_per_req = 1 + self.num_speculative_tokens
-        num_query_total = num_reqs * num_query_per_req
+        if (
+            self.dcp_size > 1
+            and self.use_cuda_graph
+            and not is_profile
+            and self.block_table_tensor_clone is None
+        ):
+            self.block_table_tensor_clone = torch.zeros(
+                (
+                    self.runner.max_num_tokens + 2 * self.runner.max_num_reqs,
+                    self.runner.input_batch.block_table[0].get_device_tensor().shape[1],
+                ),
+                dtype=torch.int32,
+                device=self.device,
+                pin_memory=self.runner.pin_memory,
+            )
 
         context_positions = self._context_positions_buffer[:num_input_tokens]
         context_states = self.hidden_states[:num_input_tokens]
@@ -180,6 +226,22 @@ class AscendDflashProposer(AscendEagleProposer):
         multi_steps_attn_metadata = []
         if aclgraph_runtime_mode == CUDAGraphMode.FULL and len(self.runner.attn_groups) > 0:
             builder = self.draft_attn_groups[0].get_metadata_builder()
+            if self.dcp_size > 1:
+                query_lens_cpu = torch.full(
+                    (num_reqs,),
+                    num_query_per_req,
+                    dtype=torch.int32,
+                )
+                local_seq_lens = get_dcp_local_seq_lens(
+                    self.runner.optimistic_seq_lens[:num_reqs],
+                    self.dcp_size,
+                    self.vllm_config.parallel_config.cp_kv_cache_interleave_size,
+                )
+                cp_metadata = AscendDCPMetadata(
+                    num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+                    query_lens_cpu=query_lens_cpu,
+                    max_query_len=num_query_per_req
+                )
             common_attn_metadata = AscendCommonAttentionMetadata(
                 query_start_loc=self.arange_dflash[: num_reqs + 1] * num_query_per_req,
                 query_start_loc_cpu=torch.from_numpy(self.token_arange_np[: num_reqs + 1]).clone() * num_query_per_req,
@@ -197,6 +259,7 @@ class AscendDflashProposer(AscendEagleProposer):
                 block_table_tensor=self.runner.input_batch.block_table[self.kv_cache_gid].get_device_tensor()[
                     :num_reqs
                 ],
+                context_parallel_metadata=cp_metadata,
             )
 
             attn_metadata_dflash = builder.build_for_graph_capture(
@@ -248,7 +311,7 @@ class AscendDflashProposer(AscendEagleProposer):
 
             forward_context = get_forward_context()
             if forward_context.cudagraph_runtime_mode == CUDAGraphMode.FULL and not _EXTRA_CTX.capturing:
-                self._update_full_graph_params(forward_context, num_tokens, multi_steps_attn_metadata)
+                self._update_full_graph_params(forward_context, num_input_tokens, multi_steps_attn_metadata)
 
     def build_model_inputs_first_pass(
         self,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -8,11 +8,14 @@ from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
+from vllm.v1.spec_decode.utils import PADDING_SLOT_ID
 from vllm.v1.worker.utils import AttentionGroup
 
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.attention.context_parallel.common_cp import get_dcp_local_seq_lens
 from vllm_ascend.attention.mla_v1 import AscendMLAMetadataBuilder
+from vllm_ascend.attention.utils import AscendDCPMetadata
 from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel_single_grid
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.transformers_utils.configs.kimi_k3 import (
@@ -332,6 +335,12 @@ class AscendDSparkProposer(AscendDflashProposer):
                 batch_size=batch_size,
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
+                total_cp_world_size=self.dcp_size,
+                current_cp_rank=self.dcp_rank,
+                cp_kv_cache_interleave_size=(
+                    self.vllm_config.parallel_config.cp_kv_cache_interleave_size
+                ),
+                PAD_ID=PADDING_SLOT_ID,
             )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
@@ -367,7 +376,29 @@ class AscendDSparkProposer(AscendDflashProposer):
         cad.attn_mask = None
         cad.attn_state = AscendAttentionState.ChunkedPrefill
 
-        return num_query_total, token_indices_to_sample, cad, None
+        long_seq_args = None
+        if self.dcp_size > 1:
+            seq_lens_cpu = cad.seq_lens.cpu()
+            cad.seq_lens_cpu = seq_lens_cpu
+            if cad._seq_lens_cpu is not None:
+                cad._seq_lens_cpu = seq_lens_cpu
+            cad.max_seq_len = int(seq_lens_cpu.max().item())
+            local_seq_lens = get_dcp_local_seq_lens(
+                seq_lens_cpu,
+                self.dcp_size,
+                self.vllm_config.parallel_config.cp_kv_cache_interleave_size,
+            )
+            cad.context_parallel_metadata = AscendDCPMetadata(
+                num_computed_tokens_of_dcp=local_seq_lens.numpy(),
+                query_lens_cpu=torch.full(
+                    (batch_size,), self.num_query_per_req, dtype=torch.int32
+                ),
+                max_query_len=self.num_query_per_req,
+                dcp_mtp_attn_mask=None,
+            )
+            long_seq_args = (None, None)
+
+        return num_query_total, token_indices_to_sample, cad, long_seq_args
 
     @torch.inference_mode()
     def dummy_run(

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1056,7 +1056,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         )
         assert self.runner is not None
         dcp_manager = getattr(self.runner, "dcp_manager", None)
-        if dcp_manager is not None:
+        if dcp_manager is not None and not self.parallel_drafting:
             assert long_seq_args is not None
             _, ori_token_indices_to_sample = long_seq_args
 

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -150,6 +150,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.attn_mask_builder = AttentionMaskBuilder(self.device)
 
         self.dcp_size = self.runner.dcp_size
+        self.dcp_rank = self.runner.dcp_rank
 
         self.use_sparse = hasattr(vllm_config.model_config.hf_text_config, "index_topk")
 
@@ -1210,7 +1211,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             "slot_indices": None,
             "mtp_slot_mapping": None,
         }
-        if dcp_manager is not None:
+        if dcp_manager is not None and not self.parallel_drafting:
             dcp_mtp_inputs = dcp_manager.prepare_spec_decode_mtp_drafting_inputs(
                 common_attn_metadata=common_attn_metadata,
                 attn_metadata=attn_metadata_i,


### PR DESCRIPTION
## What this PR does

This draft organizes the DCP adaptations identified while bringing up Kimi K3 with DSpark and P/D disaggregation on `releases/v0.26.0rc`.

- carries the production-only DCP parallel-drafting changes from #14744 as a prerequisite commit (its UT change is intentionally excluded)
- advertises the decode-side DCP topology from the Mooncake producer so P DCP1 can transfer to D DCP8
- skips long-sequence DCP-manager inputs for parallel drafting
- populates DCP-aware slot mapping and attention metadata in the K3 DSpark override

Each adaptation is isolated in its own commit.

## Dependencies and runtime configuration

- Depends on #14744; the first commit is the production-only prerequisite so this draft remains reviewable before #14744 lands.
- The matching vLLM core change that registers `k3_dspark` as MLA belongs to the vLLM repository and is not included here.
- The validated deployment shape uses P TP8/DCP1 and D TP8/DCP8, with `decode.dcp_size=8` in both Mooncake topology descriptions and `--cp-kv-cache-interleave-size` equal to the KV block size (768 in the K3 setup).

## Validation

- `python -m py_compile` on all 7 changed Python files
- `git diff --check releases/v0.26.0rc..HEAD`
- no UT files added or modified, per request

The local patches were applied across the eight-node environment and passed syntax checks. The final combined metadata patch was not followed by a completed end-to-end request rerun before the source task was interrupted, so this PR remains draft.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
