### PR TITLE
[CI] Limit image build concurrency

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -11,6 +11,9 @@
 #   - is for final release image
 #   - Publish when tag with v* (pep440 version)  ===>  vllm-ascend:v1.2.3 / vllm-ascend:v1.2.3rc1
 name: Image Build and Push
+concurrency:
+  group: image-build-${{ github.ref }}
+  cancel-in-progress: false
 on:
   push:
     tags:
@@ -106,6 +109,7 @@ jobs:
         && !(github.event_name == 'workflow_dispatch' && inputs.vllm_commit != '' && inputs.vllm_ascend_commit != '') }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         build_meta:
           - name: A2 Ubuntu
@@ -180,6 +184,7 @@ jobs:
         && inputs.branch == 'none' }}
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         build_meta:
           - name: A2 Ubuntu


### PR DESCRIPTION
## What this PR does / why we need it?

Image build concurrency is too high, causing buildkitd overload errors (EOF, DeadlineExceeded, timeout). A single trigger launches 8 configs × 2 architectures = 16 parallel builds. Multiple triggers (push tag + PR + workflow_dispatch) amplify the problem.

Changes:
1. Add `concurrency` group at workflow level (keyed by `github.ref`, `cancel-in-progress: false`) — serializes multiple runs for the same ref
2. Add `max-parallel: 3` to both `image_build` and `image_build_by_commit` matrices — limits concurrent builds within a single run

## Does this PR introduce any user-facing change?

No

## How was this patch tested?

- YAML syntax validated
- No CI behavior changes, only concurrency limits