### PR TITLE
[Test] Add DeepSeek V4 DSpark PD nightly

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -171,6 +171,10 @@ a3:
         config_file_path: DeepSeek-V4-flash-w8a8-PD-prefix.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config
         size: 2
+      - name: DeepSeek-V4-Flash-w4a8-DSpark-PD
+        config_file_path: DeepSeek-V4-Flash-w4a8-DSpark-PD.yaml
+        config_base_path: tests/e2e/nightly/multi_node/external_dp/config
+        size: 2
       - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
         config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
         config_base_path: tests/e2e/nightly/multi_node/external_dp/config

--- a/tests/e2e/nightly/multi_node/external_dp/config/DeepSeek-V4-Flash-w4a8-DSpark-PD.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/DeepSeek-V4-Flash-w4a8-DSpark-PD.yaml
@@ -168,12 +168,13 @@ templates:
       - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"enable_dsa_cp":false,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
 
 benchmarks:
-  acc_gsm8k_lite:
+  acc-gpqa:
     case_type: accuracy
-    dataset_path: vllm-ascend/gsm8k-lite
+    dataset_path: vllm-ascend/gpqa
     request_conf: vllm_api_general_chat
-    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
-    max_out_len: 1024
-    batch_size: 16
-    baseline: 80
-    threshold: 20
+    dataset_conf: gpqa/gpqa_gen_0_shot_cot_chat_prompt
+    max_out_len: 65536
+    batch_size: 32
+    baseline: 86.36
+    threshold: 5
+    thinking: true

--- a/tests/e2e/nightly/multi_node/external_dp/config/DeepSeek-V4-Flash-w4a8-DSpark-PD.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/DeepSeek-V4-Flash-w4a8-DSpark-PD.yaml
@@ -1,0 +1,179 @@
+test_name: "DeepSeek-V4-Flash-w4a8-DSpark-PD"
+model: "UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test"
+num_nodes: 2
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0 ]
+    decoder: [ 1 ]
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 4
+    dp_size_local: 4
+    dp_rank_start: 0
+    tp_size: 4
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 12321
+    dp_size: 16
+    dp_size_local: 16
+    dp_rank_start: 0
+    tp_size: 1
+    dp_address: "${NODE_1_IP}"
+
+env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  VLLM_RPC_TIMEOUT: "3600"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+  HCCL_EXEC_TIMEOUT: "204"
+  HCCL_CONNECT_TIMEOUT: "120"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "10"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+
+env_prefill: &env_prefill
+  <<: *env_common
+  HCCL_BUFFSIZE: "1024"
+  TASK_QUEUE_ENABLE: "1"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+  VLLM_PREFIX_CACHE_RETENTION_INTERVAL: "4096"
+
+env_decode: &env_decode
+  <<: *env_common
+  HCCL_BUFFSIZE: "1800"
+  VLLM_ASCEND_APPLY_DSV4_PATCH: "1"
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_prefill
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --served-model-name
+      - "dsv4"
+      - --max-model-len
+      - "1048576"
+      - --max-num-batched-tokens
+      - "8192"
+      - --max-num-seqs
+      - "16"
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --speculative-config
+      - '{"num_speculative_tokens": 5, "method": "dspark"}'
+      - --trust-remote-code
+      - --block-size
+      - "32"
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --gpu-memory-utilization
+      - "0.9"
+      - --quantization
+      - "ascend"
+      - --enforce-eager
+      - --enable-prefix-caching
+      - --additional-config
+      - '{"enable_cpu_binding": true, "enable_dsa_cp": true, "enable_flashcomm1": true}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_producer", "kv_port": "30000", "engine_id": "0", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 4}, "decode": {"dp_size": 16, "tp_size": 1}}}'
+
+  - node_index: 1
+    envs:
+      <<: *env_decode
+    server_cmd_template:
+      - --host
+      - "0.0.0.0"
+      - --port
+      - $SERVER_PORT
+      - --data-parallel-size
+      - ${DP_SIZE}
+      - --data-parallel-rank
+      - ${DP_RANK}
+      - --data-parallel-address
+      - ${DP_ADDRESS}
+      - --data-parallel-rpc-port
+      - ${DP_RPC_PORT}
+      - --tensor-parallel-size
+      - ${TP_SIZE}
+      - --enable-expert-parallel
+      - --seed
+      - "1024"
+      - --served-model-name
+      - "dsv4"
+      - --max-model-len
+      - "1048576"
+      - --max-num-batched-tokens
+      - "400"
+      - --max-num-seqs
+      - "32"
+      - --async-scheduling
+      - --block-size
+      - "32"
+      - --no-enable-prefix-caching
+      - --no-disable-hybrid-kv-cache-manager
+      - --model-loader-extra-config
+      - '{"enable_multithread_load": true, "num_threads": 128}'
+      - --trust-remote-code
+      - --tokenizer-mode
+      - "deepseek_v4"
+      - --tool-call-parser
+      - "deepseek_v4"
+      - --enable-auto-tool-choice
+      - --reasoning-parser
+      - "deepseek_v4"
+      - --gpu-memory-utilization
+      - "0.95"
+      - --quantization
+      - "ascend"
+      - --speculative-config
+      - '{"num_speculative_tokens": 5, "method": "dspark", "enforce_eager": true}'
+      - --compilation-config
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+      - --kv-transfer-config
+      - '{"kv_connector": "MooncakeHybridConnector", "kv_role": "kv_consumer", "kv_port": "30100", "engine_id": "1", "kv_connector_extra_config": {"prefill": {"dp_size": 4, "tp_size": 4}, "decode": {"dp_size": 16, "tp_size": 1}}}'
+      - --additional-config
+      - '{"ascend_compilation_config":{"enable_npugraph_ex":true,"enable_static_kernel":false},"enable_cpu_binding":true,"enable_dsa_cp":false,"multistream_overlap_shared_expert":true,"recompute_scheduler_enable":true}'
+
+benchmarks:
+  acc_gsm8k_lite:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gsm8k-lite
+    request_conf: vllm_api_general_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+    max_out_len: 1024
+    batch_size: 16
+    baseline: 80
+    threshold: 20


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a new A3 two-node external-DP nightly case for DeepSeek V4 Flash W4A8 DSpark PD disaggregation:

- config: `tests/e2e/nightly/multi_node/external_dp/config/DeepSeek-V4-Flash-w4a8-DSpark-PD.yaml`
- model: `UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test`
- nightly entry: `DeepSeek-V4-Flash-w4a8-DSpark-PD` under `a3.double_node`
- accuracy benchmark: `acc-gpqa`, aligned with the existing DeepSeek V4 Flash accuracy coverage (`baseline: 86.36`, `threshold: 5`, `thinking: true`)

The case is intended to cover the DSpark model path, which is becoming a key DeepSeek V4 scenario, while also validating asymmetric PD behavior:

- Prefill node: DP4/TP4, `enable_dsa_cp=true`, prefix cache enabled, DSpark enabled, eager mode. This protects the DSA CP prefill path and KV producer path.
- Decode node: DP16/TP1, `enable_dsa_cp=false`, DSpark enabled, `FULL_DECODE_ONLY` graph mode, async scheduling, recompute scheduler, and multistream overlap. This protects the normal decode path after consuming KV from the CP-enabled prefiller.
- KV transfer uses `MooncakeHybridConnector` with `prefill: {dp_size: 4, tp_size: 4}` and `decode: {dp_size: 16, tp_size: 1}`.

This fills a coverage gap between the existing DeepSeek V4 nightly cases and the existing DSpark PR tests:

- Existing nightly covers DeepSeek V4 Flash W8A8 PD and Pro W4A8 PD paths.
- Existing PR tests cover DSpark acceptance on four cards.
- This new nightly adds DSpark + PD disaggregation + P-side DSA CP / D-side normal decode coverage.

### Does this PR introduce _any_ user-facing change?

No. This only adds a nightly E2E test configuration and registers it in the nightly matrix.

### How was this patch tested?

- Parsed `.github/workflows/configs/nightly_config.yaml` with PyYAML.
- Parsed `DeepSeek-V4-Flash-w4a8-DSpark-PD.yaml` with PyYAML.
- Loaded the new external-DP config through `ExternalDPConfigLoader` using dummy cluster IPs.
- Verified `RankResolver` expands the topology to 20 ranks:
  - prefiller: 4 ranks, TP4, 16 NPUs on node 0
  - decoder: 16 ranks, TP1, 16 NPUs on node 1
- Verified the accuracy benchmark is loaded as `acc-gpqa` with GPQA CoT chat config, `baseline: 86.36`, `threshold: 5`, and `thinking: true`.

The NPU nightly workload itself was not run locally.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
