### PR TITLE
fix(quantization): cache dynamic MX scale algorithm

### DIFF
--- a/tests/ut/quantization/test_utils.py
+++ b/tests/ut/quantization/test_utils.py
@@ -42,12 +42,12 @@ class TestDynamicMxQuantScaleAlg(TestBase):
         self.assertEqual(get_dynamic_mx_quant_scale_alg(minimax_config), 0)
 
     @patch("vllm_ascend.quantization.utils.get_ascend_device_type", return_value=AscendDeviceType.A5)
-    @patch("vllm.config.get_current_vllm_config")
-    def test_uses_current_vllm_config_when_config_is_omitted(self, mock_current_config, _mock_device_type):
-        minimax_config = self._config(None, model_type="minimax_m3")
-        mock_current_config.return_value = minimax_config
+    @patch("vllm_ascend.ascend_config.get_ascend_config")
+    def test_uses_cached_scale_alg_when_config_is_omitted(self, mock_ascend_config, _mock_device_type):
+        mock_ascend_config.return_value = SimpleNamespace(dynamic_mx_quant_scale_alg=1)
 
         self.assertEqual(get_dynamic_mx_quant_scale_alg(), 1)
+        mock_ascend_config.assert_called_once_with()
 
 
 class TestDetectQuantizationMethod(TestBase):

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -283,6 +283,7 @@ class AscendConfig:
     pd_tp_ratio: int = 1
     pd_head_ratio: int = 1
     num_head_replica: int = 1
+    dynamic_mx_quant_scale_alg: int = dataclasses.field(default=0, init=False)
 
     # ---- private derived state (init=False) ----
     _sparse_li_c8_layer_ids: set[int] = dataclasses.field(default_factory=set, init=False, repr=False)
@@ -331,6 +332,10 @@ class AscendConfig:
     # the max_num_batched_tokens that sequence-parallel writeback corrected).
     def derive_and_validate(self, vllm_config: VllmConfig) -> AscendConfig:
         vc = vllm_config
+        from vllm_ascend.quantization.utils import get_dynamic_mx_quant_scale_alg
+
+        self.dynamic_mx_quant_scale_alg = get_dynamic_mx_quant_scale_alg(vc)
+
         self._check_mooncake_c8_kv_cache_quant(vc)
 
         # profiling_chunk vs min_chunk clamp

--- a/vllm_ascend/quantization/utils.py
+++ b/vllm_ascend/quantization/utils.py
@@ -49,9 +49,9 @@ def get_dynamic_mx_quant_scale_alg(vllm_config=None) -> int:
         return 0
 
     if vllm_config is None:
-        from vllm.config import get_current_vllm_config
+        from vllm_ascend.ascend_config import get_ascend_config
 
-        vllm_config = get_current_vllm_config()
+        return get_ascend_config().dynamic_mx_quant_scale_alg
 
     model_config = vllm_config.model_config
     architectures = getattr(model_config, "architectures", None) or ()


### PR DESCRIPTION
## Summary

- cache `dynamic_mx_quant_scale_alg` in `AscendConfig` during configuration derivation
- use the cached value when quantization helpers are called without an explicit `VllmConfig`
- avoid calling `get_current_vllm_config()` from model forward/AOT trace paths
- update regression coverage for the cached configuration behavior

## Testing

```text
python -m pytest -q tests/ut/quantization/test_utils.py tests/ut/test_ascend_config.py
108 passed, 1 skipped, 14 warnings in 8.48s
```

`git diff --check upstream/main..HEAD` also passes.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
