### PR TITLE
[Doc][Misc] Sync v0.23.0 release notes and documentation versions

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -29,6 +29,7 @@ on:
         type: choice
         options:
           - main
+          - v0.23.0
           - v0.23.0rc1
           - v0.22.1rc1
           - v0.21.0rc1

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -230,5 +230,3 @@ jobs:
 
     secrets:
       quay_temp_password: ${{ inputs.build_type == 'daily' && secrets.QUAY_DAILY_TEMP_PASSWORD || secrets.QUAY_TEMP_PASSWORD }}
-      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
-      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -230,3 +230,5 @@ jobs:
 
     secrets:
       quay_temp_password: ${{ inputs.build_type == 'daily' && secrets.QUAY_DAILY_TEMP_PASSWORD || secrets.QUAY_TEMP_PASSWORD }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -33,6 +33,7 @@ on:
         type: choice
         options:
           - main
+          - v0.23.0
           - v0.23.0rc1
           - v0.22.1rc1
           - v0.21.0rc1

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ vLLM Ascend Plugin
 ---
 *Latest News* 🔥
 
-- [2026/07] We released the first release candidate [v0.23.0rc1](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0rc1)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/) to start using vLLM Ascend Plugin on Ascend.
+- [2026/08] We released the new official version [v0.23.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.23.0/) to start using vLLM Ascend Plugin on Ascend.
 - [2026/05] We released the new official version [v0.18.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.18.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.18.0/) to start using vLLM Ascend Plugin on Ascend.
 - [2026/02] We released the new official version [v0.13.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.13.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.13.0/) to start using vLLM Ascend Plugin on Ascend.
 
@@ -77,8 +77,7 @@ Please use the following recommended versions to get started quickly:
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-| v0.23.0rc1 | Latest release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/installation.html) for more details |
-| v0.18.0 | Latest stable version | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.18.0/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html) for more details |
+| v0.23.0 | Latest stable version | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.23.0/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.23.0/installation.html) for more details |
 
 ## Branch
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,7 @@ vLLM Ascend Plugin
 ---
 *最新消息* 🔥
 
+- [2026/08] 我们发布了新的正式版本 [v0.23.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0/)开始在 Ascend 上部署 vLLM Ascend Plugin。
 - [2026/05] 我们发布了新的正式版本 [v0.18.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.18.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.18.0/)开始在Ascend上部署vLLM Ascend Plugin。
 - [2026/02] 我们发布了新的正式版本 [v0.13.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.13.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.13.0/)开始在Ascend上部署vLLM Ascend Plugin。
 
@@ -70,8 +71,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
-| v0.23.0rc1 | 最新RC版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0rc1/installation.html)了解更多 |
-| v0.18.0 | 最新正式/稳定版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.18.0/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.18.0/installation.html)了解更多 |
+| v0.23.0    | 最新正式/稳定版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.23.0/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0/installation.html)了解更多 |
 
 ## 分支策略
 

--- a/docs/source/community/contributors.md
+++ b/docs/source/community/contributors.md
@@ -25,10 +25,28 @@
 
 Every release of vLLM Ascend would not have been possible without the following contributors:
 
-Updated on 2026-07-17:
+Updated on 2026-08-16:
 
 | Number | Contributor | Date | Commit ID |
 |:------:|:-----------:|:-----:|:---------:|
+| 518 | [@DavidJiang9](https://github.com/DavidJiang9) | 2026/08/13 | [c10e1c0](https://github.com/vllm-project/vllm-ascend/commit/c10e1c01d51c533021ae4bc5eeebf784ae36dafc) |
+| 517 | [@hw-zhoutianyang](https://github.com/hw-zhoutianyang) | 2026/08/12 | [6c47fb9](https://github.com/vllm-project/vllm-ascend/commit/6c47fb9e3ac8af04c873fce79318bc2afabf9188) |
+| 516 | [@lrf-vm](https://github.com/lrf-vm) | 2026/08/08 | [462154e](https://github.com/vllm-project/vllm-ascend/commit/462154e6cd99084d81b94fcfdf26b4aed2cac914) |
+| 515 | [@voidvelocity](https://github.com/voidvelocity) | 2026/08/07 | [60eacbe](https://github.com/vllm-project/vllm-ascend/commit/60eacbe8bd20ad9dcd7615896184110e556c0584) |
+| 514 | [@xqchen7](https://github.com/xqchen7) | 2026/08/07 | [7c0f6e6](https://github.com/vllm-project/vllm-ascend/commit/7c0f6e6d8cc3134019ea6ebd71a3dad6733492e5) |
+| 513 | [@Karryking3](https://github.com/Karryking3) | 2026/08/06 | [bb630a6](https://github.com/vllm-project/vllm-ascend/commit/bb630a62a210059ba04041bdb952e3fca22f94df) |
+| 512 | [@ella1107](https://github.com/ella1107) | 2026/07/30 | [71d136c](https://github.com/vllm-project/vllm-ascend/commit/71d136ca26c4692db6b1e5bd07f507b73f09887b) |
+| 511 | [@axx-ty911](https://github.com/axx-ty911) | 2026/07/30 | [7890de8](https://github.com/vllm-project/vllm-ascend/commit/7890de8eb72ff669c4962ff379090a14dc19b21a) |
+| 510 | [@ffggs](https://github.com/ffggs) | 2026/07/29 | [5cf0420](https://github.com/vllm-project/vllm-ascend/commit/5cf0420ab3a4ca5f8ba2a707e4e5c31eef1cc968) |
+| 509 | [@jiaqi-lee](https://github.com/jiaqi-lee) | 2026/07/25 | [5225ae2](https://github.com/vllm-project/vllm-ascend/commit/5225ae20fb09aa41cc3278b294aad23c9dc33f22) |
+| 508 | [@Oranbean258](https://github.com/Oranbean258) | 2026/07/23 | [e6f3f49](https://github.com/vllm-project/vllm-ascend/commit/e6f3f4954602a3d2fc41857e0c61806b9c8840ff) |
+| 507 | [@lyur01](https://github.com/lyur01) | 2026/07/23 | [f9602a1](https://github.com/vllm-project/vllm-ascend/commit/f9602a13c52359fe1b56dc8318436d31f03012ba) |
+| 506 | [@zhangjiale-zjl](https://github.com/zhangjiale-zjl) | 2026/07/23 | [9d03a3a](https://github.com/vllm-project/vllm-ascend/commit/9d03a3a682d196cb534885a7cbdf86ef0b0694aa) |
+| 505 | [@aisong1988](https://github.com/aisong1988) | 2026/07/22 | [c926c21](https://github.com/vllm-project/vllm-ascend/commit/c926c213cbf2ca0c1d13d4bdaea97d39a5748b15) |
+| 504 | [@q664171689](https://github.com/q664171689) | 2026/07/18 | [ebad45e](https://github.com/vllm-project/vllm-ascend/commit/ebad45e3666f8453e045ade27d02b47a7fe1669c) |
+| 503 | [@qijiajin](https://github.com/qijiajin) | 2026/07/18 | [d42948a](https://github.com/vllm-project/vllm-ascend/commit/d42948ac2c1cba80fe30acd0bd61e4991beb58d2) |
+| 502 | [@Wyz-134](https://github.com/Wyz-134) | 2026/07/17 | [9b8423e](https://github.com/vllm-project/vllm-ascend/commit/9b8423e15a836f1b011b61aece5305459f939c32) |
+| 501 | [@zh98530](https://github.com/zh98530) | 2026/07/17 | [a272c88](https://github.com/vllm-project/vllm-ascend/commit/a272c88a5c6560c2ef655b05970a05b895d342e4) |
 | 500 | [@singzhou](https://github.com/singzhou) | 2026/07/15 | [f924703](https://github.com/vllm-project/vllm-ascend/commit/f924703d7d97a90c5d72d58bf32865501b7f87c0) |
 | 499 | [@ZhangwenTaoHW](https://github.com/ZhangwenTaoHW) | 2026/07/13 | [b89a491](https://github.com/vllm-project/vllm-ascend/commit/b89a491644cd02a16a5b17c1a124cec254866559) |
 | 498 | [@zhaochuang001](https://github.com/zhaochuang001) | 2026/07/11 | [7be596c](https://github.com/vllm-project/vllm-ascend/commit/7be596cd3fa93c45a4ef4ff5384d0c852659d83c) |

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -23,6 +23,7 @@ The table below is the release compatibility matrix for vLLM Ascend release.
 
 | vLLM Ascend | vLLM              | Python          | Stable CANN |        PyTorch/torch_npu        |   Triton Ascend   |    Mooncake  |
 |-------------|-------------------|-----------------|-------------|---------------------------------|-------------------|--------------|
+| v0.23.0     | v0.23.0           | >= 3.10, < 3.13 | 9.1.0       | 2.10.0 / 2.10.0.post4           | 3.2.2             | v0.3.11.post1 |
 | v0.23.0rc1  | v0.23.0           | >= 3.10, < 3.13 | 9.0.1       | 2.10.0 / 2.10.0.post2           | 3.2.1             | v0.3.11.post1 |
 | v0.22.1rc1  | v0.22.1           | >= 3.10, < 3.13 | 9.0.0       | 2.10.0 / 2.10.0                 | 3.2.1             | v0.3.9       |
 | v0.21.0rc1  | v0.21.0           | >= 3.10, < 3.13 | 9.0.0       | 2.10.0 / 2.10.0                 | 3.2.1             | v0.3.9       |
@@ -87,6 +88,7 @@ Using `--no-build-isolation` can bypass build-environment resolution, so run
 
 | Date       | Event                                     |
 |------------|-------------------------------------------|
+| 2026.08.16 | v0.23.0 Final release, v0.23.0            |
 | 2026.07.20 | Release candidates, v0.23.0rc1            |
 | 2026.06.30 | Release candidates, v0.22.1rc1            |
 | 2026.06.16 | Release candidates, v0.21.0rc1            |

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -2,6 +2,7 @@
 
 ## Version Specific FAQs
 
+- [[v0.23.0] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/12916)
 - [[v0.23.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/12238)
 - [[v0.22.1rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/10593)
 - [[v0.21.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/9970)

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -1,5 +1,158 @@
 # Release Notes
 
+## v0.23.0 - 2026.08.16
+
+We're excited to announce the official vLLM Ascend v0.23.0 release, aligned with upstream vLLM v0.23.0. This note summarizes the cumulative user-facing changes since the previous official release, v0.18.0, including the v0.19.1rc1, v0.20.2rc1, v0.21.0rc1, v0.22.1rc1, and v0.23.0rc1 development cycles. Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/v0.23.0/) to get started.
+
+PR references marked with **†** were merged into the v0.23.0 release branch after v0.23.0rc1.
+
+### Highlights
+
+- **Ascend 950 and DeepSeek V4**: Added end-to-end DeepSeek V4 support on Ascend 950, including DSA attention, MTP, piecewise graph execution, distributed inference, sparse attention, CPU binding, and MXFP quantization and communication paths. [#9757](https://github.com/vllm-project/vllm-ascend/pull/9757) [#9935](https://github.com/vllm-project/vllm-ascend/pull/9935) [#10236](https://github.com/vllm-project/vllm-ascend/pull/10236) [#11014](https://github.com/vllm-project/vllm-ascend/pull/11014)
+- **Model and hardware coverage**: Expanded support and deployment guidance for GLM-5.2, GLM-4.7-Flash, Qwen3.5/Qwen3.6, Qwen3-ASR, Qwen3-Omni, Bailing MoE, Gemma4, Step3, and MiniMax 2.x models across A2, A3, Ascend 950, and Atlas 300I DUO. GLM-5.2 supports long-sequence inference up to 1M tokens on Atlas 800 A3. [#8657](https://github.com/vllm-project/vllm-ascend/pull/8657) [#9560](https://github.com/vllm-project/vllm-ascend/pull/9560) [#10441](https://github.com/vllm-project/vllm-ascend/pull/10441) [#10697](https://github.com/vllm-project/vllm-ascend/pull/10697) [#11091](https://github.com/vllm-project/vllm-ascend/pull/11091) [#11264](https://github.com/vllm-project/vllm-ascend/pull/11264) [#12115](https://github.com/vllm-project/vllm-ascend/pull/12115)
+- **Context parallelism and sparse attention**: Added SFA DCP with a replicated indexer, compact KV gather, C8 support, and device-side metadata paths for long-context and P/D-disaggregated deployments. [#9638](https://github.com/vllm-project/vllm-ascend/pull/9638) [#9809](https://github.com/vllm-project/vllm-ascend/pull/9809) [#11819](https://github.com/vllm-project/vllm-ascend/pull/11819) [#11871](https://github.com/vllm-project/vllm-ascend/pull/11871) [#11981](https://github.com/vllm-project/vllm-ascend/pull/11981)
+- **KV-cache lifecycle and offload**: Added hybrid/Mamba attention prefix caching; CPU and SSD offload in AscendStore that covers all backends. [#8743](https://github.com/vllm-project/vllm-ascend/pull/8743) [#9533](https://github.com/vllm-project/vllm-ascend/pull/9533) [#9731](https://github.com/vllm-project/vllm-ascend/pull/9731) [#10393](https://github.com/vllm-project/vllm-ascend/pull/10393)
+- **Graph and speculative execution**: Added `FULL_AND_PIECEWISE` graph mode, which is enabled by default and requires no manual configuration; DFlash `FULL_DECODE_ONLY`; zero-bubble async scheduling; P-Eagle and PARD; and expanded MTP/Eagle3 support. [#7640](https://github.com/vllm-project/vllm-ascend/pull/7640) [#8118](https://github.com/vllm-project/vllm-ascend/pull/8118) [#9572](https://github.com/vllm-project/vllm-ascend/pull/9572) [#10042](https://github.com/vllm-project/vllm-ascend/pull/10042) [#10566](https://github.com/vllm-project/vllm-ascend/pull/10566)
+
+### Features
+
+- Added multimodal DFlash, FlashComm support for Qwen VL/MoE models, and PCP-aware multimodal reasoning. [#7486](https://github.com/vllm-project/vllm-ascend/pull/7486) [#7897](https://github.com/vllm-project/vllm-ascend/pull/7897) [#8038](https://github.com/vllm-project/vllm-ascend/pull/8038) [#9340](https://github.com/vllm-project/vllm-ascend/pull/9340)
+- Added HCCL weight transfer for reinforcement-learning workloads and D2D NetLoader support for speculative draft models. [#9152](https://github.com/vllm-project/vllm-ascend/pull/9152) [#9893](https://github.com/vllm-project/vllm-ascend/pull/9893)
+- Expanded Model Runner V2 with initial MoE and Eagle support. [#7885](https://github.com/vllm-project/vllm-ascend/pull/7885) [#7922](https://github.com/vllm-project/vllm-ascend/pull/7922)
+- Expanded EPLB with additional observability and dynamic load-balancer examples. [#9536](https://github.com/vllm-project/vllm-ascend/pull/9536) [#10627](https://github.com/vllm-project/vllm-ascend/pull/10627)
+- Extended C8 INT8 KV cache to sparse-attention paths with packed layouts and a DCP replicated indexer, and added W8A8FP8 and W4A16 MXFP quantization paths for Ascend 950. [#10236](https://github.com/vllm-project/vllm-ascend/pull/10236) [#11014](https://github.com/vllm-project/vllm-ascend/pull/11014) [#11846](https://github.com/vllm-project/vllm-ascend/pull/11846) [#11871](https://github.com/vllm-project/vllm-ascend/pull/11871)
+
+### Hardware and Operator Support
+
+- Added and optimized recurrent GDN, causal Conv1D, sparse-attention, LightningIndexer, compressor, and fused quantization operators. [#7798](https://github.com/vllm-project/vllm-ascend/pull/7798) [#7926](https://github.com/vllm-project/vllm-ascend/pull/7926) [#9382](https://github.com/vllm-project/vllm-ascend/pull/9382) [#9491](https://github.com/vllm-project/vllm-ascend/pull/9491) [#9825](https://github.com/vllm-project/vllm-ascend/pull/9825) [#10730](https://github.com/vllm-project/vllm-ascend/pull/10730)
+- Expanded Atlas 300I DUO support for Qwen3.5, Qwen3.6, Qwen3-ASR, Qwen3-VL, quantized MoE paths, MTP, and graph execution. [#7674](https://github.com/vllm-project/vllm-ascend/pull/7674) [#7725](https://github.com/vllm-project/vllm-ascend/pull/7725) [#10309](https://github.com/vllm-project/vllm-ascend/pull/10309) [#12115](https://github.com/vllm-project/vllm-ascend/pull/12115) [#13262](https://github.com/vllm-project/vllm-ascend/pull/13262)†
+- Added Python 3.12 support and moved release images to Python 3.12. [#9558](https://github.com/vllm-project/vllm-ascend/pull/9558)
+
+### Performance
+
+Unless stated otherwise, these optimizations are selected automatically for the targeted path and need no additional configuration.
+
+- Replaced `npu_fusion_attention` with `_npu_flash_attention_unpad` for supported A2/A3 attention workloads. It is selected automatically; no manual setting is needed. [#8671](https://github.com/vllm-project/vllm-ascend/pull/8671)
+- Avoided projecting unused tail KV tokens during MLA prefill with PCP. Enable PCP with `--prefill-context-parallel-size`; the optimization then applies automatically. [#8787](https://github.com/vllm-project/vllm-ascend/pull/8787)
+- Reduced scheduler issuance bubbles for workloads using asynchronous scheduling. Enable it with `--async-scheduling`. [#8766](https://github.com/vllm-project/vllm-ascend/pull/8766)
+- Added zero-bubble scheduling for asynchronous speculative decoding. Enable it with `--async-scheduling` together with a speculative decoding configuration. [#7640](https://github.com/vllm-project/vllm-ascend/pull/7640)
+- Batched KV-cache offload copies with `aclrtMemcpyBatchAsync` for CPU-offload workloads. Configure KV cache CPU offload as documented; batching is automatic within that path. [#7819](https://github.com/vllm-project/vllm-ascend/pull/7819)
+- Reduced PCP/DCP KV-cache all-gather traffic by selecting the required blocks before communication. Enable PCP or DCP with `--prefill-context-parallel-size` or `--decode-context-parallel-size`; no separate optimization switch is needed. [#8050](https://github.com/vllm-project/vllm-ascend/pull/8050)
+- Optimized `split_qkv_tp_rmsnorm_rope` kernels for supported quantized model paths. Kernel selection is automatic; no manual setting is needed. [#8059](https://github.com/vllm-project/vllm-ascend/pull/8059) [#9830](https://github.com/vllm-project/vllm-ascend/pull/9830)
+- Removed prefill host-device synchronization in Qwen3-Next and Qwen3.5 paths. It applies automatically to those models. [#7967](https://github.com/vllm-project/vllm-ascend/pull/7967)
+- Reduced SFA prefill KV all-gather communication for PCP/DCP. Enable the corresponding context-parallel mode; the optimized communication path is automatic. [#8043](https://github.com/vllm-project/vllm-ascend/pull/8043)
+- Added a Triton penalty kernel for requests using repetition, frequency, or presence penalties. It is selected automatically when penalties are requested. [#7569](https://github.com/vllm-project/vllm-ascend/pull/7569)
+- Optimized Model Runner V2 temperature and top-k log-softmax kernels. They are selected automatically for sampling workloads on Model Runner V2. [#8083](https://github.com/vllm-project/vllm-ascend/pull/8083)
+- Optimized the Model Runner V2 min-p kernel. It applies automatically when min-p sampling is requested. [#8243](https://github.com/vllm-project/vllm-ascend/pull/8243) [#7767](https://github.com/vllm-project/vllm-ascend/pull/7767)
+- Added a Model Runner V2 Triton kernel for bad-word filtering. It applies automatically when `bad_words` is supplied. [#8030](https://github.com/vllm-project/vllm-ascend/pull/8030)
+- Optimized the Model Runner V2 bincount kernel. It is selected automatically for sampling paths that require token counts. [#7757](https://github.com/vllm-project/vllm-ascend/pull/7757)
+- Optimized the Model Runner V2 ranks kernel. It is selected automatically for the corresponding sampling path. [#7767](https://github.com/vllm-project/vllm-ascend/pull/7767)
+- Reduced avoidable Triton recompilation caused by runtime function parameters. The cache-friendly path is automatic; no manual setting is needed. [#7481](https://github.com/vllm-project/vllm-ascend/pull/7481) [#7483](https://github.com/vllm-project/vllm-ascend/pull/7483)
+- Reused equivalent HCCL process groups to reduce distributed initialization overhead. Reuse is automatic for matching groups. [#7654](https://github.com/vllm-project/vllm-ascend/pull/7654)
+- Deferred CPU binding until worker warmup completes to avoid interfering with initialization. CPU binding is enabled by default on supported ARM servers; no manual setting is needed unless it was explicitly disabled. [#7829](https://github.com/vllm-project/vllm-ascend/pull/7829)
+- Converted eligible Conv3D operations to linear operations when kernel size equals stride. Conversion is automatic for matching models. [#8318](https://github.com/vllm-project/vllm-ascend/pull/8318)
+- Optimized MoE routing on Ascend 310P. It applies automatically to supported 310P MoE workloads. [#9105](https://github.com/vllm-project/vllm-ascend/pull/9105)
+- Added NZ-format W4A8 MoE compressed tensors for supported quantized models. Load a compatible W4A8 checkpoint with Ascend quantization; format selection is automatic. [#9625](https://github.com/vllm-project/vllm-ascend/pull/9625)
+- Optimized irregular-mask construction for PCP/DCP with speculative decoding. Enable context parallelism and speculative decoding; no separate optimization switch is needed. [#9678](https://github.com/vllm-project/vllm-ascend/pull/9678)
+- Reworked reduce sampling for DFlash and MTP. This remains experimental and disabled by default; enable it with `additional_config.enable_reduce_sample=true` for distributed greedy, top-k/top-p, or rejection sampling. [#8308](https://github.com/vllm-project/vllm-ascend/pull/8308) [#9735](https://github.com/vllm-project/vllm-ascend/pull/9735)
+- Added multistream compute-communication overlap for DeepSeek V4 DSA compressor, indexer-select, CV-parallel, and pure-prefill paths. Enable FlashComm1 and the applicable DSA-CP/overlap configuration; the optimized subpaths are then selected automatically. [#9433](https://github.com/vllm-project/vllm-ascend/pull/9433) [#9441](https://github.com/vllm-project/vllm-ascend/pull/9441) [#9450](https://github.com/vllm-project/vllm-ascend/pull/9450) [#9504](https://github.com/vllm-project/vllm-ascend/pull/9504) [#9530](https://github.com/vllm-project/vllm-ascend/pull/9530) [#10518](https://github.com/vllm-project/vllm-ascend/pull/10518)
+- Reused DeepSeek V4 DSA `topk_indices` across decode steps through IndexCache. It applies automatically to eligible DSA decode workloads. [#9390](https://github.com/vllm-project/vllm-ascend/pull/9390)
+- Removed a host-device synchronization point from PIECEWISE graph execution. `FULL_AND_PIECEWISE` is the default graph mode, so no manual configuration is needed. [#9025](https://github.com/vllm-project/vllm-ascend/pull/9025)
+- Optimized shared-expert overlap timing in FusedMoE. Enable the supported shared-expert overlap configuration; timing optimization is automatic within that path. [#9413](https://github.com/vllm-project/vllm-ascend/pull/9413)
+- Skipped unnecessary slot-mapping computation for Mamba groups in hybrid-cache models. It applies automatically when the model uses a Mamba cache group. [#10492](https://github.com/vllm-project/vllm-ascend/pull/10492)
+- Built single-rank DSA compressor metadata on device to remove CPU construction and synchronization. It applies automatically to eligible non-CP DSA compressed-KV paths. [#10741](https://github.com/vllm-project/vllm-ascend/pull/10741)
+- Vectorized SFA local-sequence-length computation to remove per-request NPU-to-CPU synchronization. It applies automatically to SFA workloads. [#11816](https://github.com/vllm-project/vllm-ascend/pull/11816)
+- Replaced the SFA DSA-CP output merge's full all-gather with token-sharded all-to-all to reduce communication and peak receive-buffer use. Enable FlashComm1 and `additional_config.enable_dsa_cp=true`; no separate optimization switch is needed. [#12137](https://github.com/vllm-project/vllm-ascend/pull/12137)
+- Reduced restore and output-merge overhead in the PCP FlashAttention path. Enable PCP with `--prefill-context-parallel-size`; the optimized restore path is automatic. [#11842](https://github.com/vllm-project/vllm-ascend/pull/11842)
+- Avoided host-to-device synchronization while building context-parallel speculative-proposer metadata. Enable context parallelism and speculative decoding; the optimized metadata path is automatic. [#11862](https://github.com/vllm-project/vllm-ascend/pull/11862)
+- Snapshotted query start locations before asynchronous host-to-device copies to preserve non-blocking metadata transfers. It applies automatically to asynchronous copy paths. [#12071](https://github.com/vllm-project/vllm-ascend/pull/12071)
+- Added fused W4A8 MoE dispatch, FFN, and combine to overlap communication with computation. Load a supported W4A8 MoE checkpoint with Ascend quantization; fused-kernel selection is automatic. [#7779](https://github.com/vllm-project/vllm-ascend/pull/7779)
+- Added asynchronous all-gather for DSA-CP output-projection TP weights. Enable FlashComm1 and `additional_config.enable_dsa_cp=true`; the asynchronous path is automatic. [#10694](https://github.com/vllm-project/vllm-ascend/pull/10694)
+- Improved DeepSeek V4 prefix-cache hit rates when MTP is enabled. Prefix caching is enabled by default in vLLM V1; no flag is needed unless it was previously disabled. [#11107](https://github.com/vllm-project/vllm-ascend/pull/11107)
+- Reused prebuilt chunk host metadata to reduce synchronization overhead for Qwen3.5 and MiniMax-M2.5 workloads. It applies automatically to the affected model paths. [#9310](https://github.com/vllm-project/vllm-ascend/pull/9310)
+- Parallelized Mooncake KV receive handling for P/D-disaggregated deployments. Configure the Mooncake KV-transfer connector; receive parallelism is automatic. [#10548](https://github.com/vllm-project/vllm-ascend/pull/10548)
+- Optimized AscendStore key construction and KV Pool miss handling to reduce host overhead. Configure `AscendStoreConnector`; the optimized paths are selected automatically. [#12783](https://github.com/vllm-project/vllm-ascend/pull/12783)†
+- Reused grouped block hashes across AscendStore query, save, and load operations to reduce repeated host-side hashing. Configure `AscendStoreConnector`; reuse is automatic. [#13169](https://github.com/vllm-project/vllm-ascend/pull/13169)†
+
+### Stability and Bug Fixes
+
+- Fixed GDN state and graph-dispatch accuracy regressions across P/D, PCP, MTP, and DCP, including one-token stateful prefill handling. [#11195](https://github.com/vllm-project/vllm-ascend/pull/11195) [#11893](https://github.com/vllm-project/vllm-ascend/pull/11893) [#12027](https://github.com/vllm-project/vllm-ascend/pull/12027) [#12255](https://github.com/vllm-project/vllm-ascend/pull/12255)†
+- Fixed Qwen3.5/Qwen3.6 speculative-decoding accuracy, Mamba prefix-cache corruption, block-table overflow, and Atlas 300I DUO graph failures. [#11337](https://github.com/vllm-project/vllm-ascend/pull/11337) [#11408](https://github.com/vllm-project/vllm-ascend/pull/11408) [#11353](https://github.com/vllm-project/vllm-ascend/pull/11353) [#11659](https://github.com/vllm-project/vllm-ascend/pull/11659) [#11920](https://github.com/vllm-project/vllm-ascend/pull/11920) [#12038](https://github.com/vllm-project/vllm-ascend/pull/12038)
+- Fixed GLM-5.1 IndexCache weight loading and a GLM-4.7-Flash first-request `IndexError` with MTP and layerwise Memcache. [#11363](https://github.com/vllm-project/vllm-ascend/pull/11363) [#11829](https://github.com/vllm-project/vllm-ascend/pull/11829)
+- Fixed Qwen MoE routing overflow and shared-expert gate failures, Qwen3-Omni ModelSlim W8A8 checkpoint loading, and Qwen3-VL rotary-embedding copy races on Atlas 300I DUO. [#11391](https://github.com/vllm-project/vllm-ascend/pull/11391) [#11730](https://github.com/vllm-project/vllm-ascend/pull/11730) [#12321](https://github.com/vllm-project/vllm-ascend/pull/12321) [#11679](https://github.com/vllm-project/vllm-ascend/pull/11679) [#12132](https://github.com/vllm-project/vllm-ascend/pull/12132)
+- Fixed the DeepSeek-R1-0528 W8A8 shared-expert no-clamp accuracy path and malformed streamed tool calls or TP8+EP startup for MiniMax-M2/M2.5. [#11775](https://github.com/vllm-project/vllm-ascend/pull/11775) [#11505](https://github.com/vllm-project/vllm-ascend/pull/11505)
+- Fixed DeepSeek V4 MXFP routing precision, W4A16MXFP communication accuracy, and eager draft compilation configuration isolation. [#11663](https://github.com/vllm-project/vllm-ascend/pull/11663) [#11718](https://github.com/vllm-project/vllm-ascend/pull/11718) [#12587](https://github.com/vllm-project/vllm-ascend/pull/12587)† [#12722](https://github.com/vllm-project/vllm-ascend/pull/12722)†
+- Fixed KV-transfer ordering and TP-shard consistency, Mooncake grouping, AscendStore hash/lease/lookup handling, and layerwise KV Pool failures. [#11887](https://github.com/vllm-project/vllm-ascend/pull/11887) [#12252](https://github.com/vllm-project/vllm-ascend/pull/12252) [#12371](https://github.com/vllm-project/vllm-ascend/pull/12371)† [#12797](https://github.com/vllm-project/vllm-ascend/pull/12797)† [#12819](https://github.com/vllm-project/vllm-ascend/pull/12819)†
+- Fixed DCP/DP service hangs, limited the recompute scheduler to decode nodes, and delayed AscendStore initialization until the first real decode request. [#12034](https://github.com/vllm-project/vllm-ascend/pull/12034) [#11490](https://github.com/vllm-project/vllm-ascend/pull/11490) [#11673](https://github.com/vllm-project/vllm-ascend/pull/11673)
+- Disabled unsupported shared-expert multistream overlap with fused MC2 and fixed low MTP acceptance for SFA with DSA-CP and multiple speculative tokens. [#12245](https://github.com/vllm-project/vllm-ascend/pull/12245) [#10878](https://github.com/vllm-project/vllm-ascend/pull/10878)
+- Fixed AscendStore compatibility with pipeline parallelism and surfaced backend failures. [#12762](https://github.com/vllm-project/vllm-ascend/pull/12762)†
+- Fixed invalid-GVA handling for layerwise KV Pool transfers. [#12643](https://github.com/vllm-project/vllm-ascend/pull/12643)†
+- Fixed A5 BF16 `mm_reduce_scatter` communication-mode selection and restricted FP8 quantization detection to A5 devices. [#12826](https://github.com/vllm-project/vllm-ascend/pull/12826)† [#12895](https://github.com/vllm-project/vllm-ascend/pull/12895)†
+- Packed SFA DSA-CP KV tensors into one all-gather to correct and streamline the communication path. [#12867](https://github.com/vllm-project/vllm-ascend/pull/12867)†
+- Disabled unsupported `npugraph_ex` compilation automatically on Atlas 300I DUO and fixed low-level rotary and sparse-attention tiling/metadata issues. [#12366](https://github.com/vllm-project/vllm-ascend/pull/12366)† [#12446](https://github.com/vllm-project/vllm-ascend/pull/12446)† [#12841](https://github.com/vllm-project/vllm-ascend/pull/12841)†
+- Fixed `npu_dequant_swiglu_quant` precision for small token shapes and propagated `return_lse` to QuantSFA operators. [#12913](https://github.com/vllm-project/vllm-ascend/pull/12913)† [#13197](https://github.com/vllm-project/vllm-ascend/pull/13197)†
+- Removed unnecessary Memcache lazy initialization and hardened AscendStore transfers by restoring synchronous saves, reporting asynchronous load failures to the scheduler, and using grouped block sizes in transfer threads. [#13028](https://github.com/vllm-project/vllm-ascend/pull/13028)† [#13024](https://github.com/vllm-project/vllm-ascend/pull/13024)† [#13099](https://github.com/vllm-project/vllm-ascend/pull/13099)† [#13110](https://github.com/vllm-project/vllm-ascend/pull/13110)†
+- Removed `-Werror` from custom-operator CMake builds so compiler warnings do not fail release builds. [#13095](https://github.com/vllm-project/vllm-ascend/pull/13095)†
+
+### Dependencies
+
+- **Upstream vLLM**: v0.23.0.
+- **Python**: >= 3.10, < 3.13.
+- **CANN**: 9.1.0 for A2, A3, and Ascend 950; refer to the Atlas 300I DUO installation guide for its platform-specific CANN package. [#13421](https://github.com/vllm-project/vllm-ascend/pull/13421)†
+- **PyTorch / torch_npu**: 2.10.0 / 2.10.0.post4.
+- **Triton Ascend**: 3.2.2 for A2, A3, and Ascend 950; Triton Ascend is not supported on Atlas 300I DUO.
+- **Mooncake**: 0.3.11.post1 in the release images.
+
+### Deprecation and Configuration Changes
+
+- The former `enable_sparse_c8` option was split into `enable_sparse_sfa_c8` and `enable_sparse_li_c8`; update `--additional-config` according to the sparse-attention components in use. [#12351](https://github.com/vllm-project/vllm-ascend/pull/12351)
+- Migrate FlashComm1 deployments from `VLLM_ASCEND_ENABLE_FLASHCOMM1` to `additional_config.enable_flashcomm1`. [#9064](https://github.com/vllm-project/vllm-ascend/pull/9064)
+- `VLLM_ASCEND_ENABLE_CONTEXT_PARALLEL` was removed during the `AscendConfig` migration. DSA-CP is now controlled by `additional_config.enable_dsa_cp`; deployments that previously relied on FlashComm1 implicitly enabling DSA-CP must explicitly enable both options. [#9668](https://github.com/vllm-project/vllm-ascend/pull/9668) [#9697](https://github.com/vllm-project/vllm-ascend/pull/9697) [#9910](https://github.com/vllm-project/vllm-ascend/pull/9910)
+- Sequence Parallelism is marked unavailable for all current model categories in the v0.23.0 support matrix; deployments that used it in v0.18.0 should move to FlashComm1 where applicable. [#12860](https://github.com/vllm-project/vllm-ascend/pull/12860)†
+- `ASCEND_BUFFER_POOL` was removed. Use `ASCEND_ENABLE_USE_FABRIC_MEM=1` or `HCCL_INTRA_ROCE_ENABLE=1` according to the hardware and deployment path. [#13834](https://github.com/vllm-project/vllm-ascend/pull/13834)†
+
+### Ready to Deprecate
+
+The following features and optimizations are planned for deprecation in a future release:
+
+- Layer sharding.
+- FlashComm2.
+- The FlashComm3 multistream-overlap gate.
+- Hamming sparse.
+- Asynchronous exponential overlap.
+- Matmul all-reduce and matmul all-reduce RMSNorm fusions.
+- Weight prefetch.
+- Dynamic-batch SLO.
+- KV offload in KV Pool.
+- Fused MC2 mode 2 (`enable_fused_mc2=2`).
+- Paged attention and `pa_shape_list`.
+
+### Documentation
+
+- Refreshed Ascend 950 DeepSeek-V3.1/V3.2 and GLM-5.2 deployment guidance. [#12937](https://github.com/vllm-project/vllm-ascend/pull/12937)† [#13043](https://github.com/vllm-project/vllm-ascend/pull/13043)†
+
+### Known Issues
+
+- Pipeline parallelism (PP) combined with prefill context parallelism (PCP) is not supported in v0.23.0.
+- Reduce sampling (`additional_config.enable_reduce_sample=true`) is experimental. It is incompatible with P/D-disaggregated serving and lmhead tensor parallelism, where it is automatically disabled. Do not enable it when sampling logprobs are requested because the logprob values and top-k rankings would be computed over partitioned logits and can be incorrect. [#13469](https://github.com/vllm-project/vllm-ascend/pull/13469)† [#13632](https://github.com/vllm-project/vllm-ascend/pull/13632)†
+- GLM-5.2 1M-context deployments were validated only on Atlas 800 A3; the A2 series was not validated for 1M context.
+- For P/D-disaggregated serving of models using Sparse Flash Attention (SFA), including DeepSeek-V3.2, GLM-5.1, and GLM-5.2, DCP must be enabled on both prefiller and decoder nodes or disabled on both. Asymmetric DCP configuration can cause accuracy issues. [#14322](https://github.com/vllm-project/vllm-ascend/pull/14322)†
+- On Ascend 950, context parallelism is not supported with SFA; context-parallel MLA and GQA paths are experimental. [#13303](https://github.com/vllm-project/vllm-ascend/pull/13303)†
+- In v0.23.0, combining GLM-5.2 DCP with Sparse Flash Attention C8 (`enable_sparse_sfa_c8`) has known issues, including performance degradation, and is not recommended. [#14011](https://github.com/vllm-project/vllm-ascend/pull/14011)†
+- On Atlas 300I DUO or Atlas 200I Pro (310P), Qwen3.5-2B-W8A8 GSM8K accuracy can fluctuate by more than 1% compared with the floating-point model. [#14335](https://github.com/vllm-project/vllm-ascend/issues/14335)
+- DeepSeek V4 on A2 or A3 can experience 1-2 second TPOT spikes under high concurrency when varying input shapes trigger Triton kernel recompilation. [#14324](https://github.com/vllm-project/vllm-ascend/issues/14324)
+- DeepSeek V4 Flash and GLM-5.1 SWE benchmark results can vary because of intermittent evaluation failures, including container crashes, timeouts, dependency-download failures, and agent nondeterminism. [#14326](https://github.com/vllm-project/vllm-ascend/issues/14326)
+- DeepSeek-V3.1 large-EP deployments have a reported 3%-5% performance gap from the target performance. [#14327](https://github.com/vllm-project/vllm-ascend/issues/14327)
+- GLM-5.1 on an Ascend 950 single-node mixed P/D deployment can incur excessive P/D transfer overhead for a 64K-input/1K-output workload without a prefix-cache hit. [#14328](https://github.com/vllm-project/vllm-ascend/issues/14328)
+- GLM-5.1 P/D-disaggregated serving with both `sfa_c8` and `li_c8` enabled has a reported performance regression for 64K-input/1K-output workloads. [#14329](https://github.com/vllm-project/vllm-ascend/issues/14329)
+- In graph mode, `torch.ops._C_ascend.mla_preprocess` and `torch.ops._C_ascend.batch_matmul_transpose` can emit an `rtMemcpy` 107030 error in plog; the reported error does not affect inference. [#14347](https://github.com/vllm-project/vllm-ascend/issues/14347)
+- GLM-5.2-W4A8C8 P/D-disaggregated serving with `enable_sparse_sfa_c8` can show GPQA accuracy fluctuations of approximately 2-3 percentage points across repeated runs. [#14378](https://github.com/vllm-project/vllm-ascend/issues/14378)
+- DeepSeek-V3.1 2P1D throughput has a reported regression of about 15% compared with v0.18.0 in high-throughput deployments. [#12349](https://github.com/vllm-project/vllm-ascend/issues/12349)
+- DeepSeek V4 Pro has an open long-running stability report involving increasing memory use. [#12345](https://github.com/vllm-project/vllm-ascend/issues/12345)
+- Qwen3-30B-A3B floating-point serving has a reported single-batch performance regression. [#12337](https://github.com/vllm-project/vllm-ascend/issues/12337)
+- AscendStore KV Pool has backend-specific constraints for layerwise Memcache, SSD offload, hybrid-attention load failures, and graph fallback behavior. [#12390](https://github.com/vllm-project/vllm-ascend/issues/12390)
+- Ascend 950 graph capture is temporarily limited to a reduced set of stages because of HDK incompatibility, which avoids crashes but can reduce performance. [#12998](https://github.com/vllm-project/vllm-ascend/issues/12998)
+
 ## v0.23.0rc1 - 2026.07.20
 
 We're excited to announce v0.23.0rc1, the first release candidate for the vLLM Ascend v0.23.0 release line. This release aligns the plugin with upstream vLLM v0.23.0 and expands model, context-parallel, KV-cache offload, and Ascend 950 support. Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/v0.23.0/) to get started.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,10 +157,10 @@ extra:
   rtd_version: !ENV [READTHEDOCS_VERSION, latest]
   docs_lang: !ENV [DOCS_LANG, en]
   # Version substitutions used by macros plugin
-  vllm_version: v0.22.1
-  vllm_ascend_version: v0.22.1rc1
-  pip_vllm_ascend_version: 0.22.1rc1
-  pip_vllm_version: 0.22.1
+  vllm_version: v0.23.0
+  vllm_ascend_version: v0.23.0
+  pip_vllm_ascend_version: v0.23.0
+  pip_vllm_version: v0.23.0
   cann_image_tag: 9.1.0-910b-ubuntu22.04-py3.12
   main_python_version: ">= 3.10, < 3.13"
   main_cann_version: "9.1.0"


### PR DESCRIPTION
### What this PR does / why we need it?

This PR updates the documentation, release notes, and version configurations to reflect the official `v0.23.0` release of the vLLM Ascend Plugin. Specifically, it:
- Updates the latest stable version to `v0.23.0` in `README.md` and `README.zh.md`.
- Adds the `v0.23.0` release notes detailing highlights, features, performance optimizations, stability fixes, and dependencies.
- Updates the version compatibility matrix and release history in `versioning_policy.md`.
- Updates version macro substitutions in `mkdocs.yml` to `v0.23.0`.
- Adds the `v0.23.0` FAQ link in `faqs.md`.
- Updates the contributors list in `contributors.md`.

### Does this PR introduce _any_ user-facing change?

Yes, this is a documentation-only update that updates the user-facing installation guides, release notes, and FAQs to reference the new stable `v0.23.0` release.

### How was this patch tested?

This is a documentation-only change. Verified that the Markdown files and `mkdocs.yml` configuration are correctly formatted.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
