### PR TITLE
[Feature][MRV2]sparse mla offload modelrunnerV2

### DIFF
--- a/tests/ut/attention/test_indexer.py
+++ b/tests/ut/attention/test_indexer.py
@@ -17,7 +17,13 @@ def test_sfa_indexer_backend_contract():
     assert AscendSFAIndexerBackend.accept_output_buffer
     assert AscendSFAIndexerBackend.get_name() == "ASCEND_SFA_INDEXER"
     assert AscendSFAIndexerBackend.get_builder_cls() is AscendSFAIndexerMetadataBuilder
-    assert AscendSFAIndexerBackend.get_kv_cache_shape(8, 128, 1, 160) == (
+    assert AscendSFAIndexerBackend.get_kv_cache_shape(
+        8,
+        128,
+        1,
+        160,
+        cache_dtype_str="auto",
+    ) == (
         8,
         128,
         1,

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -8,8 +8,6 @@ import pytest
 torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
-from vllm.config.compilation import CUDAGraphMode  # noqa: E402
-
 from vllm_ascend.attention.attention_v1 import AscendAttentionState  # noqa: E402
 from vllm_ascend.attention.sfa_kv_offload import (  # noqa: E402
     AscendSFAKVOffloadImpl,
@@ -106,45 +104,32 @@ def test_pd_decode_consumer_still_rejects_long_prefill_classification():
 
 
 @pytest.mark.parametrize(
-    ("runtime_mode", "expected"),
+    ("capturing", "expected"),
     [
-        (CUDAGraphMode.NONE, False),
-        (CUDAGraphMode.PIECEWISE, True),
+        (None, False),
+        (False, False),
+        (True, True),
     ],
 )
-def test_graph_runtime_supports_forward_context_without_capturing(runtime_mode, expected):
-    forward_context = SimpleNamespace(cudagraph_runtime_mode=runtime_mode)
+def test_graph_capture_uses_extra_forward_context(capturing, expected):
     with (
         patch(
-            "vllm_ascend.attention.sfa_kv_offload.torch.npu.is_current_stream_capturing",
+            "vllm_ascend.attention.sfa_kv_offload._EXTRA_CTX",
+            SimpleNamespace(capturing=capturing),
+        ),
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
+            return_value=True,
+        ),
+    ):
+        assert AscendSFAKVOffloadImpl._is_graph_capturing() is expected
+
+
+def test_graph_capture_is_false_without_forward_context():
+    with (
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
             return_value=False,
         ),
-        patch(
-            "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
-            return_value=True,
-        ),
-        patch(
-            "vllm_ascend.attention.sfa_kv_offload.get_forward_context",
-            return_value=forward_context,
-        ),
     ):
-        assert AscendSFAKVOffloadImpl._in_graph_runtime() is expected
-
-
-def test_graph_runtime_prefers_actual_stream_capture():
-    forward_context = SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE)
-    with (
-        patch(
-            "vllm_ascend.attention.sfa_kv_offload.torch.npu.is_current_stream_capturing",
-            return_value=True,
-        ),
-        patch(
-            "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
-            return_value=True,
-        ),
-        patch(
-            "vllm_ascend.attention.sfa_kv_offload.get_forward_context",
-            return_value=forward_context,
-        ),
-    ):
-        assert AscendSFAKVOffloadImpl._in_graph_runtime() is True
+        assert AscendSFAKVOffloadImpl._is_graph_capturing() is False

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -8,6 +8,7 @@ import pytest
 torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
+from torch import nn  # noqa: E402
 from vllm.config.compilation import CUDAGraphMode  # noqa: E402
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState  # noqa: E402
@@ -28,7 +29,6 @@ def _make_boundary_decode_metadata():
         query_start_loc_cpu=torch.tensor([0, 1]),
         is_prefilling=torch.tensor([True]),
         req_ids_tensor=torch.tensor([7]),
-        token_to_req=torch.tensor([0]),
     )
 
 
@@ -42,7 +42,10 @@ def _make_boundary_decode_metadata():
     ],
 )
 def test_pd_decode_consumer_is_derived_from_kv_role(kv_transfer_config, expected):
-    vllm_config = SimpleNamespace(kv_transfer_config=kv_transfer_config)
+    vllm_config = SimpleNamespace(
+        kv_transfer_config=kv_transfer_config,
+        scheduler_config=SimpleNamespace(max_num_batched_tokens=8),
+    )
     with patch.object(AscendSFAMetadataBuilder, "__init__", return_value=None):
         builder = AscendSFAKVOffloadMetadataBuilder(
             kv_cache_spec=None,
@@ -69,6 +72,7 @@ def test_boundary_token_classification_depends_on_pd_decode_role(
     builder = AscendSFAKVOffloadMetadataBuilder.__new__(AscendSFAKVOffloadMetadataBuilder)
     builder.decode_threshold = 1
     builder.is_pd_decode_consumer = is_pd_decode_consumer
+    builder.token_to_req_buffer = torch.empty(4, dtype=torch.int32)
     metadata = SimpleNamespace(attn_state=AscendAttentionState.DecodeOnly)
 
     with patch(
@@ -89,6 +93,7 @@ def test_pd_decode_consumer_still_rejects_long_prefill_classification():
     builder = AscendSFAKVOffloadMetadataBuilder.__new__(AscendSFAKVOffloadMetadataBuilder)
     builder.decode_threshold = 1
     builder.is_pd_decode_consumer = True
+    builder.token_to_req_buffer = torch.empty(4, dtype=torch.int32)
     metadata = SimpleNamespace()
     common_metadata = _make_boundary_decode_metadata()
     common_metadata.max_query_len = 2
@@ -104,6 +109,32 @@ def test_pd_decode_consumer_still_rejects_long_prefill_classification():
     assert metadata.num_decodes == 0
     assert metadata.num_prefills == 1
     assert metadata.num_decode_tokens == 0
+
+
+def test_builder_owns_graph_stable_token_to_req_buffer():
+    builder = AscendSFAKVOffloadMetadataBuilder.__new__(AscendSFAKVOffloadMetadataBuilder)
+    builder.token_to_req_buffer = torch.empty(6, dtype=torch.int32)
+    buffer_ptr = builder.token_to_req_buffer.data_ptr()
+
+    token_to_req = builder._build_token_to_req(
+        SimpleNamespace(
+            num_actual_tokens=6,
+            query_start_loc_cpu=torch.tensor([0, 2, 5]),
+        )
+    )
+
+    assert token_to_req.tolist() == [0, 0, 1, 1, 1, 0]
+    assert token_to_req.data_ptr() == buffer_ptr
+
+    token_to_req = builder._build_token_to_req(
+        SimpleNamespace(
+            num_actual_tokens=4,
+            query_start_loc_cpu=torch.tensor([0, 1, 3]),
+        )
+    )
+
+    assert token_to_req.tolist() == [0, 1, 1, 0]
+    assert token_to_req.data_ptr() == buffer_ptr
 
 
 @pytest.mark.parametrize(
@@ -149,7 +180,7 @@ def test_graph_capture_signal_matches_model_runner_v2_wrapper(runtime_mode, expe
     extra_context = SimpleNamespace(capturing=False)
     forward_context = SimpleNamespace(cudagraph_runtime_mode=runtime_mode)
 
-    class CaptureProbe(torch.nn.Module):
+    class CaptureProbe(nn.Module):
         def forward(self):
             return AscendSFAKVOffloadImpl._is_graph_capturing()
 

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -8,6 +8,8 @@ import pytest
 torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
+from vllm.config.compilation import CUDAGraphMode  # noqa: E402
+
 from vllm_ascend.attention.attention_v1 import AscendAttentionState  # noqa: E402
 from vllm_ascend.attention.sfa_kv_offload import (  # noqa: E402
     AscendSFAKVOffloadImpl,
@@ -101,3 +103,25 @@ def test_pd_decode_consumer_still_rejects_long_prefill_classification():
     assert metadata.num_decodes == 0
     assert metadata.num_prefills == 1
     assert metadata.num_decode_tokens == 0
+
+
+@pytest.mark.parametrize(
+    ("runtime_mode", "expected"),
+    [
+        (CUDAGraphMode.NONE, False),
+        (CUDAGraphMode.PIECEWISE, True),
+    ],
+)
+def test_graph_runtime_supports_forward_context_without_capturing(runtime_mode, expected):
+    forward_context = SimpleNamespace(cudagraph_runtime_mode=runtime_mode)
+    with (
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
+            return_value=True,
+        ),
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.get_forward_context",
+            return_value=forward_context,
+        ),
+    ):
+        assert AscendSFAKVOffloadImpl._in_graph_runtime() is expected

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -8,12 +8,15 @@ import pytest
 torch = pytest.importorskip("torch")
 pytest.importorskip("vllm")
 
+from vllm.config.compilation import CUDAGraphMode  # noqa: E402
+
 from vllm_ascend.attention.attention_v1 import AscendAttentionState  # noqa: E402
 from vllm_ascend.attention.sfa_kv_offload import (  # noqa: E402
     AscendSFAKVOffloadImpl,
     AscendSFAKVOffloadMetadataBuilder,
 )
 from vllm_ascend.attention.sfa_v1 import AscendSFAMetadataBuilder  # noqa: E402
+from vllm_ascend.worker.v2.aclgraph_utils import ModelWithContext  # noqa: E402
 
 
 def _make_boundary_decode_metadata():
@@ -133,3 +136,44 @@ def test_graph_capture_is_false_without_forward_context():
         ),
     ):
         assert AscendSFAKVOffloadImpl._is_graph_capturing() is False
+
+
+@pytest.mark.parametrize(
+    ("runtime_mode", "expected"),
+    [
+        (CUDAGraphMode.NONE, True),
+        (CUDAGraphMode.PIECEWISE, False),
+    ],
+)
+def test_graph_capture_signal_matches_model_runner_v2_wrapper(runtime_mode, expected):
+    extra_context = SimpleNamespace(capturing=False)
+    forward_context = SimpleNamespace(cudagraph_runtime_mode=runtime_mode)
+
+    class CaptureProbe(torch.nn.Module):
+        def forward(self):
+            return AscendSFAKVOffloadImpl._is_graph_capturing()
+
+    model = ModelWithContext(CaptureProbe())
+    with (
+        patch(
+            "vllm_ascend.worker.v2.aclgraph_utils.torch.npu.is_current_stream_capturing",
+            return_value=True,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.aclgraph_utils.get_forward_context",
+            return_value=forward_context,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.aclgraph_utils._EXTRA_CTX",
+            extra_context,
+        ),
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload._EXTRA_CTX",
+            extra_context,
+        ),
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
+            return_value=True,
+        ),
+    ):
+        assert model() is expected

--- a/tests/ut/attention/test_sfa_kv_offload.py
+++ b/tests/ut/attention/test_sfa_kv_offload.py
@@ -116,6 +116,10 @@ def test_graph_runtime_supports_forward_context_without_capturing(runtime_mode, 
     forward_context = SimpleNamespace(cudagraph_runtime_mode=runtime_mode)
     with (
         patch(
+            "vllm_ascend.attention.sfa_kv_offload.torch.npu.is_current_stream_capturing",
+            return_value=False,
+        ),
+        patch(
             "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
             return_value=True,
         ),
@@ -125,3 +129,22 @@ def test_graph_runtime_supports_forward_context_without_capturing(runtime_mode, 
         ),
     ):
         assert AscendSFAKVOffloadImpl._in_graph_runtime() is expected
+
+
+def test_graph_runtime_prefers_actual_stream_capture():
+    forward_context = SimpleNamespace(cudagraph_runtime_mode=CUDAGraphMode.NONE)
+    with (
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.torch.npu.is_current_stream_capturing",
+            return_value=True,
+        ),
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.is_forward_context_available",
+            return_value=True,
+        ),
+        patch(
+            "vllm_ascend.attention.sfa_kv_offload.get_forward_context",
+            return_value=forward_context,
+        ),
+    ):
+        assert AscendSFAKVOffloadImpl._in_graph_runtime() is True

--- a/tests/ut/attention/test_sfa_v1.py
+++ b/tests/ut/attention/test_sfa_v1.py
@@ -72,7 +72,13 @@ class TestAscendSFABackend(TestBase):
         self.assertEqual(AscendSFABackend.get_builder_cls(), AscendSFAMetadataBuilder)
 
     def test_get_kv_cache_shape(self):
-        result = AscendSFABackend.get_kv_cache_shape(2, 4, 8, 128)
+        result = AscendSFABackend.get_kv_cache_shape(
+            2,
+            4,
+            8,
+            128,
+            cache_dtype_str="auto",
+        )
         self.assertEqual(result, (2, 4, 8, 128))
 
     @patch("vllm_ascend.attention.sfa_v1.get_ascend_config")

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -224,6 +224,29 @@ class TestAscendStoreConnector(unittest.TestCase):
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
+    def test_external_slot_release_waiter_uses_worker_capability(self, mock_worker_cls, mock_lookup_cls):
+        config = self._make_vllm_config(extra_config={"use_layerwise": True, "backend": "memcache"})
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+        connector = AscendStoreConnector(
+            vllm_config=config,
+            role=KVConnectorRole.WORKER,
+            kv_cache_config=None,
+        )
+        worker = mock_worker_cls.return_value
+        waiter = MagicMock()
+
+        worker.use_gva_layerwise = True
+        self.assertTrue(connector.set_external_slot_release_waiter(waiter))
+        worker.set_external_slot_release_waiter.assert_called_once_with(waiter)
+
+        worker.reset_mock()
+        worker.use_gva_layerwise = False
+        self.assertFalse(connector.set_external_slot_release_waiter(waiter))
+        worker.set_external_slot_release_waiter.assert_not_called()
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
     def test_layerwise_methods_return_early(self, mock_worker_cls, mock_lookup_cls):
         from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -686,6 +686,53 @@ class TestSparseKVOffloadConfig(TestBase):
         self.assertEqual(config.dram_size_per_dp_GB, 64)
         self.assertFalse(config.keep_device_kv_cache)
 
+    def test_model_runner_v2_allows_graph_mode_and_mtp(self):
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(index_topk=128),
+                enforce_eager=False,
+            ),
+            parallel_config=SimpleNamespace(
+                prefill_context_parallel_size=1,
+                decode_context_parallel_size=1,
+                pipeline_parallel_size=1,
+            ),
+            kv_transfer_config=SimpleNamespace(is_kv_consumer=True),
+            use_v2_model_runner=True,
+            speculative_config=None,
+        )
+
+        config = SparseKVOffloadConfig.from_additional_config(
+            vllm_config,
+            {
+                "enabled": True,
+                "topk_buffer_size": 256,
+            },
+        )
+
+        self.assertTrue(config.enabled)
+        self.assertEqual(config.topk, 128)
+
+        vllm_config.speculative_config = SimpleNamespace(method="deepseek_mtp")
+        config = SparseKVOffloadConfig.from_additional_config(
+            vllm_config,
+            {
+                "enabled": True,
+                "topk_buffer_size": 256,
+            },
+        )
+        self.assertTrue(config.enabled)
+
+        vllm_config.speculative_config = SimpleNamespace(method="ngram")
+        with self.assertRaisesRegex(ValueError, "only supports MTP speculative decoding"):
+            SparseKVOffloadConfig.from_additional_config(
+                vllm_config,
+                {
+                    "enabled": True,
+                    "topk_buffer_size": 256,
+                },
+            )
+
     def test_unknown_key_is_rejected_even_when_disabled(self):
         with self.assertRaises(ValueError):
             SparseKVOffloadConfig.from_additional_config(SimpleNamespace(), {"unknown_option": False})

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -506,7 +506,6 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
             positions=torch.arange(8, dtype=torch.int32),
             attn_state=None,
             offload_req_ids=None,
-            offload_token_to_req=None,
         )
         metadata = model_state.prepare_attn(
             input_batch=input_batch,

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -1,7 +1,6 @@
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
-from zlib import adler32
 
 import numpy as np
 import pytest
@@ -61,6 +60,7 @@ def test_mrv2_sparse_mla_spec_is_host_resident(monkeypatch):
     vllm_config = SimpleNamespace(
         cache_config=SimpleNamespace(cache_dtype="auto"),
         model_config=SimpleNamespace(dtype=torch.bfloat16),
+        parallel_config=SimpleNamespace(decode_context_parallel_size=1),
     )
     monkeypatch.setattr(attn_utils, "MLAAttention", FakeMLAAttention)
     monkeypatch.setattr(
@@ -75,36 +75,6 @@ def test_mrv2_sparse_mla_spec_is_host_resident(monkeypatch):
     spec = specs["model.layers.0.self_attn.attn"]
     assert isinstance(spec, AscendMLAAttentionSpec)
     assert spec.store_on_host is True
-
-
-def test_mrv2_sparse_metadata_maps_requests_and_tokens():
-    model_state = AscendModelState.__new__(AscendModelState)
-    model_state.sparse_kv_offload_enabled = True
-    model_state._offload_req_ids_cpu = torch.zeros(4, dtype=torch.int64)
-    model_state._offload_token_to_req_cpu = torch.zeros(8, dtype=torch.int32)
-    model_state._offload_req_ids_tensor = torch.zeros(4, dtype=torch.int64)
-    model_state._offload_token_to_req = torch.zeros(8, dtype=torch.int32)
-    input_batch = SimpleNamespace(
-        req_ids=["request-a", "request-b"],
-        num_reqs=2,
-        num_tokens=3,
-        query_start_loc_np=np.array([0, 2, 3], dtype=np.int32),
-    )
-
-    req_ids, token_to_req = model_state._prepare_sparse_kv_offload_metadata(
-        input_batch,
-        num_reqs=4,
-        num_tokens=5,
-    )
-
-    assert req_ids is not None
-    assert token_to_req is not None
-    assert req_ids[:2].tolist() == [
-        adler32(b"request-a"),
-        adler32(b"request-b"),
-    ]
-    assert req_ids[2:].tolist() == [0, 0]
-    assert token_to_req.tolist() == [0, 0, 1, 0, 0]
 
 
 @pytest.mark.parametrize(
@@ -225,6 +195,14 @@ def test_mrv2_initializes_dsv4_cache_only_layer(
         attn_utils,
         "get_current_vllm_config",
         lambda: vllm_config,
+    )
+    monkeypatch.setattr(
+        attn_utils,
+        "get_ascend_config",
+        lambda: SimpleNamespace(
+            sparse_kv_offload_config=SimpleNamespace(enabled=False),
+            is_sparse_li_c8_layer=lambda _layer_name: False,
+        ),
     )
     monkeypatch.setattr(
         upstream_attn_utils,
@@ -527,6 +505,8 @@ def test_mrv2_builds_shared_dsa_metadata_for_each_execution_mode(
             dcp_local_seq_lens=dcp_local_seq_lens,
             positions=torch.arange(8, dtype=torch.int32),
             attn_state=None,
+            offload_req_ids=None,
+            offload_token_to_req=None,
         )
         metadata = model_state.prepare_attn(
             input_batch=input_batch,

--- a/tests/ut/worker/test_attn_utils_v2.py
+++ b/tests/ut/worker/test_attn_utils_v2.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
+from zlib import adler32
 
 import numpy as np
 import pytest
@@ -11,6 +12,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MLAAttentionSpec,
 )
 from vllm.v1.worker.gpu import attn_utils as upstream_attn_utils
 from vllm.v1.worker.utils import AttentionGroup
@@ -35,6 +37,74 @@ from vllm_ascend.models.deepseek_v4 import indexer as deepseek_v4_indexer
 from vllm_ascend.models.deepseek_v4 import model as deepseek_v4_model
 from vllm_ascend.worker.v2 import attn_utils
 from vllm_ascend.worker.v2.model_states.default import AscendModelState
+
+
+def test_mrv2_sparse_mla_spec_is_host_resident(monkeypatch):
+    class FakeMLAAttention:
+        kv_sharing_target_layer_name = None
+        impl = SimpleNamespace(
+            fa_quant_layer=False,
+            enable_sparse_sfa_c8=False,
+        )
+
+        def get_kv_cache_spec(self, _vllm_config):
+            return MLAAttentionSpec(
+                block_size=128,
+                num_kv_heads=1,
+                head_size=576,
+                dtype=torch.bfloat16,
+            )
+
+    fake_ascend_config = SimpleNamespace(
+        sparse_kv_offload_config=SimpleNamespace(enabled=True),
+    )
+    vllm_config = SimpleNamespace(
+        cache_config=SimpleNamespace(cache_dtype="auto"),
+        model_config=SimpleNamespace(dtype=torch.bfloat16),
+    )
+    monkeypatch.setattr(attn_utils, "MLAAttention", FakeMLAAttention)
+    monkeypatch.setattr(
+        attn_utils,
+        "get_layers_from_vllm_config",
+        lambda *_args, **_kwargs: {"model.layers.0.self_attn.attn": FakeMLAAttention()},
+    )
+    monkeypatch.setattr(attn_utils, "get_ascend_config", lambda: fake_ascend_config)
+
+    specs = attn_utils.get_kv_cache_spec(vllm_config)
+
+    spec = specs["model.layers.0.self_attn.attn"]
+    assert isinstance(spec, AscendMLAAttentionSpec)
+    assert spec.store_on_host is True
+
+
+def test_mrv2_sparse_metadata_maps_requests_and_tokens():
+    model_state = AscendModelState.__new__(AscendModelState)
+    model_state.sparse_kv_offload_enabled = True
+    model_state._offload_req_ids_cpu = torch.zeros(4, dtype=torch.int64)
+    model_state._offload_token_to_req_cpu = torch.zeros(8, dtype=torch.int32)
+    model_state._offload_req_ids_tensor = torch.zeros(4, dtype=torch.int64)
+    model_state._offload_token_to_req = torch.zeros(8, dtype=torch.int32)
+    input_batch = SimpleNamespace(
+        req_ids=["request-a", "request-b"],
+        num_reqs=2,
+        num_tokens=3,
+        query_start_loc_np=np.array([0, 2, 3], dtype=np.int32),
+    )
+
+    req_ids, token_to_req = model_state._prepare_sparse_kv_offload_metadata(
+        input_batch,
+        num_reqs=4,
+        num_tokens=5,
+    )
+
+    assert req_ids is not None
+    assert token_to_req is not None
+    assert req_ids[:2].tolist() == [
+        adler32(b"request-a"),
+        adler32(b"request-b"),
+    ]
+    assert req_ids[2:].tolist() == [0, 0]
+    assert token_to_req.tolist() == [0, 0, 1, 0, 0]
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/worker/test_model_runner_v2_mamba.py
+++ b/tests/ut/worker/test_model_runner_v2_mamba.py
@@ -302,6 +302,89 @@ def test_attention_cache_reshape_uses_virtual_kernel_block_count(
     assert backend.get_kv_cache_shape.call_args.args[0] == num_kernel_blocks
 
 
+@patch("vllm_ascend.worker.v2.attn_utils.get_tensor_model_parallel_rank", return_value=0)
+@patch("vllm_ascend.worker.v2.attn_utils._get_attention_kv_cache_dims", return_value=(4, 2))
+@patch("vllm_ascend.worker.v2.attn_utils.allocate_kv_cache_tensors_for_sparse_kv_offload")
+@patch("vllm_ascend.worker.v2.attn_utils.get_current_vllm_config")
+@patch("vllm_ascend.worker.v2.attn_utils.get_ascend_config")
+def test_mrv2_sparse_mla_allocation_and_reshape_contract(
+    mock_get_ascend_config,
+    mock_get_current_config,
+    mock_allocate_sparse,
+    _mock_cache_dims,
+    _mock_tp_rank,
+):
+    sparse_config = SimpleNamespace(enabled=True, keep_device_kv_cache=False)
+    mock_get_ascend_config.return_value = SimpleNamespace(
+        sparse_kv_offload_config=sparse_config,
+    )
+    mock_get_current_config.return_value = SimpleNamespace(
+        kv_transfer_config=SimpleNamespace(),
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(model_type="glm4_moe")),
+    )
+    raw_sparse_cache = (None, None, "cpu-k", "cpu-v", 96)
+    mock_allocate_sparse.return_value = raw_sparse_cache
+    spec = AscendMLAAttentionSpec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=6,
+        dtype=torch.bfloat16,
+        store_on_host=True,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[KVCacheTensor(size=96, shared_by=["mla_attn"])],
+        kv_cache_groups=[
+            KVCacheGroupSpec(layer_names=["mla_attn"], kv_cache_spec=spec),
+        ],
+    )
+
+    raw_caches = _allocate_kv_cache(
+        kv_cache_config,
+        shared_layers={},
+        device=torch.device("cpu"),
+    )
+    assert raw_caches["mla_attn"] is raw_sparse_cache
+    assert mock_allocate_sparse.call_args.args[:5] == (
+        64,
+        32,
+        2 * 1024 * 1024,
+        0,
+        False,
+    )
+
+    reshaped_sparse_cache = (None, None, "cpu-k", "cpu-v", "topk-k", "topk-v")
+    group = SimpleNamespace(
+        kv_cache_group_id=0,
+        kv_cache_spec=spec,
+        layer_names=["mla_attn"],
+        backend=MagicMock(),
+    )
+    manager = MagicMock()
+    with (
+        patch(
+            "vllm_ascend.worker.v2.attn_utils.reshape_kv_cache_tensors_for_sparse_kv_offload",
+            return_value=reshaped_sparse_cache,
+        ) as mock_reshape,
+        patch(
+            "vllm_ascend.worker.v2.attn_utils.get_sparse_kv_offload_manager",
+            return_value=manager,
+        ),
+    ):
+        caches = _reshape_kv_cache_v2(
+            attn_groups=[group],
+            kv_cache_raw_tensors=raw_caches,
+            cache_dtype="auto",
+            kernel_block_sizes=[spec.block_size],
+            shared_kv_cache_layers={},
+            kv_cache_config=kv_cache_config,
+        )
+
+    assert caches["mla_attn"] is reshaped_sparse_cache
+    assert mock_reshape.call_args.args[0] is raw_sparse_cache
+    manager.register_kv_caches.assert_called_once_with(caches)
+
+
 @patch("vllm_ascend.worker.v2.attn_utils.get_layers_from_vllm_config")
 def test_get_kv_cache_spec_keeps_mamba_layers(mock_get_layers):
     spec = _mamba_spec()

--- a/tests/ut/worker/test_model_runner_v2_sparse_offload.py
+++ b/tests/ut/worker/test_model_runner_v2_sparse_offload.py
@@ -15,7 +15,6 @@ def _make_speculator():
         target_input_buffers=SimpleNamespace(
             offload_req_ids=torch.tensor([11, 22, 0, 0], dtype=torch.int64),
         ),
-        _offload_draft_metadata_logged=False,
     )
 
 

--- a/tests/ut/worker/test_model_runner_v2_sparse_offload.py
+++ b/tests/ut/worker/test_model_runner_v2_sparse_offload.py
@@ -1,8 +1,11 @@
 from types import SimpleNamespace
+from zlib import adler32
 
+import numpy as np
 import pytest
 import torch
 
+from vllm_ascend.worker.v2.input_batch import prepare_sparse_kv_offload_metadata
 from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import (
     AscendAutoRegressiveSpeculator,
 )
@@ -10,12 +13,50 @@ from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import (
 
 def _make_speculator():
     return SimpleNamespace(
-        model_state=SimpleNamespace(
-            _offload_req_ids_tensor=torch.tensor([11, 22, 0, 0], dtype=torch.int64),
+        target_input_buffers=SimpleNamespace(
+            offload_req_ids=torch.tensor([11, 22, 0, 0], dtype=torch.int64),
         ),
         _offload_draft_token_to_req=torch.arange(8, dtype=torch.int32),
         _offload_draft_metadata_logged=False,
     )
+
+
+def test_stages_sparse_kv_offload_metadata_in_input_buffers(monkeypatch):
+    def copy_to_cpu(value, out=None, device=None):
+        value = torch.from_numpy(value) if isinstance(value, np.ndarray) else value
+        if out is None:
+            return value.to(device=device)
+        return out.copy_(value)
+
+    monkeypatch.setattr(
+        "vllm_ascend.worker.v2.input_batch.async_copy_to_gpu",
+        copy_to_cpu,
+    )
+    input_buffers = SimpleNamespace(
+        offload_req_ids=torch.zeros(4, dtype=torch.int64),
+        offload_token_to_req=torch.zeros(8, dtype=torch.int32),
+    )
+    input_batch = SimpleNamespace(
+        req_ids=["request-a", "request-b"],
+        num_reqs=2,
+        num_reqs_after_padding=4,
+        num_tokens=3,
+        num_tokens_after_padding=5,
+        query_start_loc_np=np.array([0, 2, 3], dtype=np.int32),
+        offload_req_ids=None,
+        offload_token_to_req=None,
+    )
+
+    result = prepare_sparse_kv_offload_metadata(input_batch, input_buffers)
+
+    assert result is input_batch
+    assert result.offload_req_ids.tolist() == [
+        adler32(b"request-a"),
+        adler32(b"request-b"),
+        0,
+        0,
+    ]
+    assert result.offload_token_to_req.tolist() == [0, 0, 1, 0, 0]
 
 
 def test_populates_sparse_kv_offload_mtp_draft_metadata():

--- a/tests/ut/worker/test_model_runner_v2_sparse_offload.py
+++ b/tests/ut/worker/test_model_runner_v2_sparse_offload.py
@@ -4,7 +4,9 @@ from zlib import adler32
 import numpy as np
 import torch
 
-from vllm_ascend.worker.v2.input_batch import prepare_sparse_kv_offload_metadata
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    prepare_sparse_kv_offload_metadata,
+)
 from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import (
     AscendAutoRegressiveSpeculator,
 )
@@ -26,7 +28,7 @@ def test_stages_sparse_kv_offload_request_metadata_in_input_buffers(monkeypatch)
         return out.copy_(value)
 
     monkeypatch.setattr(
-        "vllm_ascend.worker.v2.input_batch.async_copy_to_gpu",
+        "vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager.async_copy_to_gpu",
         copy_to_cpu,
     )
     input_buffers = SimpleNamespace(

--- a/tests/ut/worker/test_model_runner_v2_sparse_offload.py
+++ b/tests/ut/worker/test_model_runner_v2_sparse_offload.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 from zlib import adler32
 
 import numpy as np
-import pytest
 import torch
 
 from vllm_ascend.worker.v2.input_batch import prepare_sparse_kv_offload_metadata
@@ -16,12 +15,11 @@ def _make_speculator():
         target_input_buffers=SimpleNamespace(
             offload_req_ids=torch.tensor([11, 22, 0, 0], dtype=torch.int64),
         ),
-        _offload_draft_token_to_req=torch.arange(8, dtype=torch.int32),
         _offload_draft_metadata_logged=False,
     )
 
 
-def test_stages_sparse_kv_offload_metadata_in_input_buffers(monkeypatch):
+def test_stages_sparse_kv_offload_request_metadata_in_input_buffers(monkeypatch):
     def copy_to_cpu(value, out=None, device=None):
         value = torch.from_numpy(value) if isinstance(value, np.ndarray) else value
         if out is None:
@@ -34,17 +32,12 @@ def test_stages_sparse_kv_offload_metadata_in_input_buffers(monkeypatch):
     )
     input_buffers = SimpleNamespace(
         offload_req_ids=torch.zeros(4, dtype=torch.int64),
-        offload_token_to_req=torch.zeros(8, dtype=torch.int32),
     )
     input_batch = SimpleNamespace(
         req_ids=["request-a", "request-b"],
         num_reqs=2,
         num_reqs_after_padding=4,
-        num_tokens=3,
-        num_tokens_after_padding=5,
-        query_start_loc_np=np.array([0, 2, 3], dtype=np.int32),
         offload_req_ids=None,
-        offload_token_to_req=None,
     )
 
     result = prepare_sparse_kv_offload_metadata(input_batch, input_buffers)
@@ -56,33 +49,18 @@ def test_stages_sparse_kv_offload_metadata_in_input_buffers(monkeypatch):
         0,
         0,
     ]
-    assert result.offload_token_to_req.tolist() == [0, 0, 1, 0, 0]
 
 
-def test_populates_sparse_kv_offload_mtp_draft_metadata():
+def test_populates_only_sparse_kv_offload_mtp_draft_request_metadata():
     speculator = _make_speculator()
-    metadata = SimpleNamespace(req_ids_tensor=None, token_to_req=None)
+    token_to_req = torch.tensor([0, 1], dtype=torch.int32)
+    metadata = SimpleNamespace(req_ids_tensor=None, token_to_req=token_to_req)
 
     AscendAutoRegressiveSpeculator._populate_sparse_kv_offload_draft_metadata(
         speculator,
         {"layer": metadata},
         num_reqs_padded=2,
-        num_tokens_padded=2,
-        num_query_per_req=1,
     )
 
     assert metadata.req_ids_tensor.tolist() == [11, 22]
-    assert metadata.token_to_req.tolist() == [0, 1]
-
-
-def test_rejects_non_unit_sparse_kv_offload_mtp_draft_width():
-    speculator = _make_speculator()
-
-    with pytest.raises(RuntimeError, match="requires one token per request"):
-        AscendAutoRegressiveSpeculator._populate_sparse_kv_offload_draft_metadata(
-            speculator,
-            {"layer": SimpleNamespace()},
-            num_reqs_padded=2,
-            num_tokens_padded=4,
-            num_query_per_req=2,
-        )
+    assert metadata.token_to_req is token_to_req

--- a/tests/ut/worker/test_model_runner_v2_sparse_offload.py
+++ b/tests/ut/worker/test_model_runner_v2_sparse_offload.py
@@ -1,0 +1,47 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm_ascend.worker.v2.spec_decode.autoregressive.speculator import (
+    AscendAutoRegressiveSpeculator,
+)
+
+
+def _make_speculator():
+    return SimpleNamespace(
+        model_state=SimpleNamespace(
+            _offload_req_ids_tensor=torch.tensor([11, 22, 0, 0], dtype=torch.int64),
+        ),
+        _offload_draft_token_to_req=torch.arange(8, dtype=torch.int32),
+        _offload_draft_metadata_logged=False,
+    )
+
+
+def test_populates_sparse_kv_offload_mtp_draft_metadata():
+    speculator = _make_speculator()
+    metadata = SimpleNamespace(req_ids_tensor=None, token_to_req=None)
+
+    AscendAutoRegressiveSpeculator._populate_sparse_kv_offload_draft_metadata(
+        speculator,
+        {"layer": metadata},
+        num_reqs_padded=2,
+        num_tokens_padded=2,
+        num_query_per_req=1,
+    )
+
+    assert metadata.req_ids_tensor.tolist() == [11, 22]
+    assert metadata.token_to_req.tolist() == [0, 1]
+
+
+def test_rejects_non_unit_sparse_kv_offload_mtp_draft_width():
+    speculator = _make_speculator()
+
+    with pytest.raises(RuntimeError, match="requires one token per request"):
+        AscendAutoRegressiveSpeculator._populate_sparse_kv_offload_draft_metadata(
+            speculator,
+            {"layer": SimpleNamespace()},
+            num_reqs_padded=2,
+            num_tokens_padded=4,
+            num_query_per_req=2,
+        )

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1312,10 +1312,13 @@ class SparseKVOffloadConfig:
                     "you can enable keep_device_kv_cache."
                 )
         if vllm_config.use_v2_model_runner:
-            if not vllm_config.model_config.enforce_eager:
-                raise ValueError("Sparse KV offload with model_runner_v2 currently requires enforce_eager=True.")
             if vllm_config.speculative_config is not None:
-                raise ValueError("Sparse KV offload with model_runner_v2 does not support speculative decoding yet.")
+                method = getattr(vllm_config.speculative_config, "method", None)
+                if method not in ("mtp", "deepseek_mtp"):
+                    raise ValueError(
+                        "Sparse KV offload with model_runner_v2 only supports "
+                        "MTP speculative decoding."
+                    )
 
         self.topk = vllm_config.model_config.hf_text_config.index_topk
         if self.topk_buffer_size < self.topk:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1315,10 +1315,7 @@ class SparseKVOffloadConfig:
             if vllm_config.speculative_config is not None:
                 method = getattr(vllm_config.speculative_config, "method", None)
                 if method not in ("mtp", "deepseek_mtp"):
-                    raise ValueError(
-                        "Sparse KV offload with model_runner_v2 only supports "
-                        "MTP speculative decoding."
-                    )
+                    raise ValueError("Sparse KV offload with model_runner_v2 only supports MTP speculative decoding.")
 
         self.topk = vllm_config.model_config.hf_text_config.index_topk
         if self.topk_buffer_size < self.topk:

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -1312,7 +1312,10 @@ class SparseKVOffloadConfig:
                     "you can enable keep_device_kv_cache."
                 )
         if vllm_config.use_v2_model_runner:
-            raise ValueError("Sparse KV offload doesn't support model_runner_v2 now.")
+            if not vllm_config.model_config.enforce_eager:
+                raise ValueError("Sparse KV offload with model_runner_v2 currently requires enforce_eager=True.")
+            if vllm_config.speculative_config is not None:
+                raise ValueError("Sparse KV offload with model_runner_v2 does not support speculative decoding yet.")
 
         self.topk = vllm_config.model_config.hf_text_config.index_topk
         if self.topk_buffer_size < self.topk:

--- a/vllm_ascend/attention/indexer.py
+++ b/vllm_ascend/attention/indexer.py
@@ -53,8 +53,9 @@ class AscendSFAIndexerBackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
+        del cache_dtype_str
         return (num_blocks, block_size, num_kv_heads, head_size)
 
     @staticmethod

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -249,7 +249,11 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
             "cudagraph_runtime_mode",
             CUDAGraphMode.NONE,
         )
-        return forward_context.capturing or runtime_mode not in (
+        # ``ForwardContext.capturing`` was removed in vLLM 0.27.1. The
+        # runtime mode remains the authoritative signal for graph replay on
+        # current vLLM, while older versions may still expose ``capturing``
+        # during graph capture.
+        return getattr(forward_context, "capturing", False) or runtime_mode not in (
             None,
             CUDAGraphMode.NONE,
         )

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -241,6 +241,8 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
 
     @staticmethod
     def _in_graph_runtime() -> bool:
+        if torch.npu.is_current_stream_capturing():
+            return True
         if not is_forward_context_available():
             return False
         forward_context = get_forward_context()

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -20,14 +20,12 @@ from typing import Any, TypeVar
 
 import torch
 import torch_npu
-from vllm.config import CUDAGraphMode, VllmConfig
-from vllm.forward_context import (
-    get_forward_context,
-    is_forward_context_available,
-)
+from vllm.config import VllmConfig
+from vllm.forward_context import is_forward_context_available
 from vllm.logger import logger
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.sfa_v1 import (
     AscendSFAImpl,
@@ -240,25 +238,10 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
         return padded
 
     @staticmethod
-    def _in_graph_runtime() -> bool:
-        if torch.npu.is_current_stream_capturing():
-            return True
+    def _is_graph_capturing() -> bool:
         if not is_forward_context_available():
             return False
-        forward_context = get_forward_context()
-        runtime_mode = getattr(
-            forward_context,
-            "cudagraph_runtime_mode",
-            CUDAGraphMode.NONE,
-        )
-        # ``ForwardContext.capturing`` was removed in vLLM 0.27.1. The
-        # runtime mode remains the authoritative signal for graph replay on
-        # current vLLM, while older versions may still expose ``capturing``
-        # during graph capture.
-        return getattr(forward_context, "capturing", False) or runtime_mode not in (
-            None,
-            CUDAGraphMode.NONE,
-        )
+        return bool(_EXTRA_CTX.capturing)
 
     def forward(
         self,
@@ -323,7 +306,7 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
                 k=k_nope,
                 v=k_pe,
                 has_prefill=False,
-                capturing=self._in_graph_runtime(),
+                capturing=self._is_graph_capturing(),
             )
             return k_pe, k_nope
 
@@ -344,7 +327,7 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
             k=None,
             v=None,
             has_prefill=True,
-            capturing=self._in_graph_runtime(),
+            capturing=self._is_graph_capturing(),
         )
         return result
 
@@ -438,7 +421,7 @@ class AscendSFAKVOffloadImpl(AscendSFAImpl):
             decode_req_ids,
             decode_stable_prefix_lens,
             token_to_req,
-            capturing=self._in_graph_runtime(),
+            capturing=self._is_graph_capturing(),
             skip_topk=self.skip_topk,
         )
         decode_attn_output = DeviceOperator.execute_sparse_flash_attention_process(

--- a/vllm_ascend/attention/sfa_kv_offload.py
+++ b/vllm_ascend/attention/sfa_kv_offload.py
@@ -18,11 +18,13 @@ Data plane (see zsc-sfa-kv-offload-merge-plan.md):
 
 from typing import Any, TypeVar
 
+import numpy as np
 import torch
 import torch_npu
 from vllm.config import VllmConfig
 from vllm.forward_context import is_forward_context_available
 from vllm.logger import logger
+from vllm.utils.torch_utils import np_to_pinned_tensor
 
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
@@ -59,7 +61,7 @@ def _check_device_kv_cache_exist() -> None:
 
 
 class AscendSFAKVOffloadMetadataBuilder(AscendSFAMetadataBuilder):
-    """Fills the offload-specific SFA metadata (decode split + request ids)."""
+    """Fills offload-specific SFA metadata."""
 
     def __init__(
         self,
@@ -78,12 +80,44 @@ class AscendSFAKVOffloadMetadataBuilder(AscendSFAMetadataBuilder):
             metadata_cls,
             supports_dcp_with_varlen,
         )
+        self.token_to_req_buffer = torch.empty(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            dtype=torch.int32,
+            device=device,
+        )
         kv_transfer_config = vllm_config.kv_transfer_config
         self.is_pd_decode_consumer = (
             kv_transfer_config is not None
             and kv_transfer_config.is_kv_consumer
             and not kv_transfer_config.is_kv_producer
         )
+
+    def _build_token_to_req(
+        self,
+        common_attn_metadata: AscendCommonAttentionMetadata,
+    ) -> torch.Tensor:
+        num_tokens = common_attn_metadata.num_actual_tokens
+        starts = np.asarray(
+            common_attn_metadata.query_start_loc_cpu,
+            dtype=np.int32,
+        )
+        query_lens = np.diff(starts)
+        token_to_req = np.repeat(
+            np.arange(query_lens.shape[0], dtype=np.int32),
+            query_lens,
+        )
+        num_mapped_tokens = token_to_req.shape[0]
+        assert self.token_to_req_buffer.shape[0] >= max(
+            num_mapped_tokens,
+            num_tokens,
+        )
+        self.token_to_req_buffer[:num_mapped_tokens].copy_(
+            np_to_pinned_tensor(token_to_req),
+            non_blocking=True,
+        )
+        if num_mapped_tokens < num_tokens:
+            self.token_to_req_buffer[num_mapped_tokens:num_tokens].zero_()
+        return self.token_to_req_buffer[:num_tokens]
 
     def _populate_offload_metadata(
         self,
@@ -104,7 +138,7 @@ class AscendSFAKVOffloadMetadataBuilder(AscendSFAMetadataBuilder):
         metadata.num_prefills = num_prefills
         metadata.num_decode_tokens = num_decode_tokens
         metadata.req_ids_tensor = common_attn_metadata.req_ids_tensor
-        metadata.token_to_req = common_attn_metadata.token_to_req
+        metadata.token_to_req = self._build_token_to_req(common_attn_metadata)
         return metadata
 
     def build(

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -121,8 +121,9 @@ class AscendSFABackend(AttentionBackend):
         block_size: int,
         num_kv_heads: int,
         head_size: int,
-        cache_type: str = "",
+        cache_dtype_str: str = "auto",
     ) -> tuple[int, ...]:
+        del cache_dtype_str
         return (num_blocks, block_size, num_kv_heads, head_size)
 
     @staticmethod

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -30,8 +30,12 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.utils import CpuGpuBuffer
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 
 from vllm_ascend.ascend_config import SparseKVOffloadConfig, get_ascend_config
+
+if typing.TYPE_CHECKING:
+    from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 
 # Main BF16 cache:
 # [k_cache, v_cache, k_cache_cpu, v_cache_cpu, topk_buffer_k, topk_buffer_v].
@@ -382,6 +386,36 @@ def update_sparse_kv_offload_metadata(
     if num_tokens_padded > num_tokens:
         offload_token_to_req.np[num_tokens:num_tokens_padded].fill(0)
     offload_token_to_req.copy_to_gpu(num_tokens_padded)
+
+
+def prepare_sparse_kv_offload_metadata(
+    input_batch: "AscendInputBatch",
+    input_buffers: "AscendInputBuffers",
+) -> "AscendInputBatch":
+    """Stage sparse-offload request metadata into MRV2 input buffers."""
+    req_ids_buffer = input_buffers.offload_req_ids
+    if req_ids_buffer is None:
+        input_batch.offload_req_ids = None
+        return input_batch
+
+    num_reqs = input_batch.num_reqs
+    num_reqs_padded = input_batch.num_reqs_after_padding
+    if len(input_batch.req_ids) < num_reqs:
+        raise RuntimeError(
+            "KV offload request metadata is shorter than the scheduled batch: "
+            f"metadata={len(input_batch.req_ids)}, requests={num_reqs}"
+        )
+
+    req_ids_np = np.zeros(num_reqs_padded, dtype=np.int64)
+    req_ids_np[:num_reqs] = np.fromiter(
+        (adler32(req_id.encode("utf-8")) for req_id in input_batch.req_ids[:num_reqs]),
+        dtype=np.int64,
+        count=num_reqs,
+    )
+
+    async_copy_to_gpu(req_ids_np, out=req_ids_buffer[:num_reqs_padded])
+    input_batch.offload_req_ids = req_ids_buffer[:num_reqs_padded]
+    return input_batch
 
 
 def prepare_sparse_kv_offload_mtp_dummy_metadata(

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -216,7 +216,6 @@ def build_attn_metadata(
     for_cudagraph_capture: bool = False,
     causal: bool | Mapping[int, bool] = True,
     req_ids_tensor: torch.Tensor | None = None,
-    token_to_req: torch.Tensor | None = None,
 ) -> dict[str, Any]:
     """Build attention metadata for Ascend NPUs."""
     # TODO(Ronald1995): optimize AscendCommonAttentionMetadata.
@@ -279,7 +278,6 @@ def build_attn_metadata(
             causal=group_causal,
             dcp_local_seq_lens=dcp_local_seq_lens,
             req_ids_tensor=req_ids_tensor,
-            token_to_req=token_to_req,
             **common_attn_metadata_extra_kwargs,
         )
 
@@ -669,7 +667,7 @@ def _allocate_kv_cache(
             continue
 
         if isinstance(example_spec, AscendSFAIndexerCacheSpec):
-            raw_cache: tuple[torch.Tensor, ...]
+            indexer_raw_cache: tuple[torch.Tensor, ...]
             num_blocks = kv_cache_tensor.size // example_spec.page_size_bytes
 
             k_tensor_size = (
@@ -696,17 +694,17 @@ def _allocate_kv_cache(
                     scale_dtype=example_spec.scale_dtype,
                     device=device,
                 )
-                raw_cache = (k_tensor, scale_tensor)
+                indexer_raw_cache = (k_tensor, scale_tensor)
             else:
                 k_tensor = _allocate_int8_cache_tensor(
                     k_tensor_size,
                     alignment,
                     device,
                 )
-                raw_cache = (k_tensor,)
+                indexer_raw_cache = (k_tensor,)
 
             for layer_name_inner in kv_cache_tensor.shared_by:
-                kv_cache_raw_tensors[layer_name_inner] = raw_cache
+                kv_cache_raw_tensors[layer_name_inner] = indexer_raw_cache
 
             continue
 

--- a/vllm_ascend/worker/v2/attn_utils.py
+++ b/vllm_ascend/worker/v2/attn_utils.py
@@ -26,6 +26,7 @@ import numpy as np
 import torch
 import vllm
 from vllm.config import VllmConfig, get_current_vllm_config, get_layers_from_vllm_config
+from vllm.distributed import get_tensor_model_parallel_rank
 from vllm.model_executor.layers.attention.mla_attention import MLAAttention
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.utils.torch_utils import get_dtype_size, get_kv_cache_torch_dtype
@@ -56,6 +57,11 @@ from vllm_ascend.core.kv_cache_interface import (
     AscendSlidingWindowMLASpec,
 )
 from vllm_ascend.device.hardware_profile import HardwareCapability, get_current_hardware_profile
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    allocate_kv_cache_tensors_for_sparse_kv_offload,
+    get_sparse_kv_offload_manager,
+    reshape_kv_cache_tensors_for_sparse_kv_offload,
+)
 from vllm_ascend.quantization.utils import enable_fa_quant
 from vllm_ascend.utils import (
     calc_split_factor,
@@ -127,6 +133,7 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
                 dtype=dtype,
                 cache_dtype_str=cache_dtype_str,
                 cache_sparse_sfa_c8=cache_sparse_sfa_c8,
+                store_on_host=get_ascend_config().sparse_kv_offload_config.enabled,
             )
         if isinstance(attn_module, DeepseekV32IndexerCache):
             # GLM-5.3-Flash kpool indexer/tail caches keep their own spec.
@@ -208,6 +215,8 @@ def build_attn_metadata(
     model_specific_attn_metadata: ModelSpecificAttnMetadata | None = None,
     for_cudagraph_capture: bool = False,
     causal: bool | Mapping[int, bool] = True,
+    req_ids_tensor: torch.Tensor | None = None,
+    token_to_req: torch.Tensor | None = None,
 ) -> dict[str, Any]:
     """Build attention metadata for Ascend NPUs."""
     # TODO(Ronald1995): optimize AscendCommonAttentionMetadata.
@@ -269,6 +278,8 @@ def build_attn_metadata(
             max_seq_len=max_seq_len,
             causal=group_causal,
             dcp_local_seq_lens=dcp_local_seq_lens,
+            req_ids_tensor=req_ids_tensor,
+            token_to_req=token_to_req,
             **common_attn_metadata_extra_kwargs,
         )
 
@@ -564,7 +575,7 @@ def _allocate_kv_cache(
     kv_cache_config: KVCacheConfig,
     shared_layers: dict[str, str],
     device: torch.device,
-) -> dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]]:
+) -> dict[str, Any]:
     """
     Initialize the KV cache buffer with the correct size. The buffer needs to be
     reshaped to the desired shape before being used by the models.
@@ -582,7 +593,7 @@ def _allocate_kv_cache(
     vllm_config = get_current_vllm_config()
     is_dsv4_model = _is_dsv4_model(vllm_config)
     # init kv cache tensors
-    kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]] = {}
+    kv_cache_raw_tensors: dict[str, Any] = {}
     # prefill disaggregation need the addr of cache tensor be aligned with 2M
     alignment = 2 * 1024 * 1024
     layer_kv_cache_spec = _get_layer_kv_cache_specs(kv_cache_config)
@@ -633,6 +644,29 @@ def _allocate_kv_cache(
                 kv_cache_raw_tensors[layer_name] = tensor
             continue
         assert isinstance(example_spec, AttentionSpec)
+
+        if bool(getattr(example_spec, "store_on_host", False)):
+            if len(kv_cache_tensor.shared_by) != 1:
+                raise ValueError("Sparse KV offload does not support shared main-cache allocations.")
+            k_dim, v_dim = _get_attention_kv_cache_dims(example_layer_name, example_spec)
+            k_factor, v_factor = calc_split_factor([k_dim, v_dim])
+            k_size = int(kv_cache_tensor.size // k_factor)
+            v_size = int(kv_cache_tensor.size // v_factor)
+            sparse_config = get_ascend_config().sparse_kv_offload_config
+            raw_cache = allocate_kv_cache_tensors_for_sparse_kv_offload(
+                k_size,
+                v_size,
+                alignment,
+                get_tensor_model_parallel_rank(),
+                sparse_config.keep_device_kv_cache,
+                lambda size, cache_alignment: _allocate_int8_cache_tensor(
+                    size,
+                    cache_alignment,
+                    device,
+                ),
+            )
+            kv_cache_raw_tensors[example_layer_name] = raw_cache
+            continue
 
         if isinstance(example_spec, AscendSFAIndexerCacheSpec):
             raw_cache: tuple[torch.Tensor, ...]
@@ -736,7 +770,7 @@ def _reshape_mamba_kv_cache(
 
 def _reshape_kv_cache_v2(
     attn_groups: Sequence[AttentionGroup],
-    kv_cache_raw_tensors: dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]],
+    kv_cache_raw_tensors: dict[str, Any],
     cache_dtype: str,
     kernel_block_sizes: list[int],
     shared_kv_cache_layers: dict[str, str],
@@ -833,6 +867,17 @@ def _reshape_kv_cache_v2(
             if not isinstance(kv_cache_spec, AttentionSpec):
                 raise TypeError(f"Unsupported KV cache spec: {type(kv_cache_spec).__name__}.")
 
+            if bool(getattr(kv_cache_spec, "store_on_host", False)):
+                kv_caches[layer_name] = reshape_kv_cache_tensors_for_sparse_kv_offload(
+                    kv_cache_raw_tensors[layer_name],
+                    kv_cache_spec,
+                    group.backend,
+                    get_tensor_model_parallel_rank(),
+                    vllm_config,
+                    get_ascend_config().sparse_kv_offload_config,
+                )
+                continue
+
             if isinstance(raw_cache, tuple):
                 raw_k_tensor, raw_v_tensor = raw_cache
                 total_bytes = raw_k_tensor.numel() + raw_v_tensor.numel()
@@ -904,6 +949,11 @@ def _reshape_kv_cache_v2(
 
     for layer_name, target_layer_name in shared_kv_cache_layers.items():
         kv_caches[layer_name] = kv_caches[target_layer_name]
+    if get_ascend_config().sparse_kv_offload_config.enabled:
+        manager = get_sparse_kv_offload_manager()
+        if manager is None:
+            raise RuntimeError("Sparse KV offload manager must be initialized before KV-cache reshape.")
+        manager.register_kv_caches(kv_caches)
     return kv_caches
 
 

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -66,16 +66,10 @@ class AscendInputBuffers(InputBuffers):
         self.seq_lens_np: np.ndarray = self.seq_lens_cpu.numpy()
 
         self.offload_req_ids: torch.Tensor | None = None
-        self.offload_token_to_req: torch.Tensor | None = None
         if enable_sparse_kv_offload:
             self.offload_req_ids = torch.zeros(
                 max_num_reqs,
                 dtype=torch.int64,
-                device=device,
-            )
-            self.offload_token_to_req = torch.zeros(
-                max_num_tokens,
-                dtype=torch.int32,
                 device=device,
             )
 
@@ -96,7 +90,6 @@ class AscendInputBatch(InputBatch):
     attn_state: AscendAttentionState | None = None
     is_dummy: bool = False
     offload_req_ids: torch.Tensor | None = None
-    offload_token_to_req: torch.Tensor | None = None
 
     if vllm_version_is("0.27.1"):
 
@@ -169,16 +162,12 @@ def prepare_sparse_kv_offload_metadata(
 ) -> AscendInputBatch:
     """Stage sparse-offload request metadata into MRV2 input buffers."""
     req_ids_buffer = input_buffers.offload_req_ids
-    token_to_req_buffer = input_buffers.offload_token_to_req
-    if req_ids_buffer is None or token_to_req_buffer is None:
+    if req_ids_buffer is None:
         input_batch.offload_req_ids = None
-        input_batch.offload_token_to_req = None
         return input_batch
 
     num_reqs = input_batch.num_reqs
     num_reqs_padded = input_batch.num_reqs_after_padding
-    num_tokens = input_batch.num_tokens
-    num_tokens_padded = input_batch.num_tokens_after_padding
     if len(input_batch.req_ids) < num_reqs:
         raise RuntimeError(
             "KV offload request metadata is shorter than the scheduled batch: "
@@ -187,28 +176,11 @@ def prepare_sparse_kv_offload_metadata(
 
     req_ids_np = np.zeros(num_reqs_padded, dtype=np.int64)
     req_ids_np[:num_reqs] = np.fromiter(
-        (
-            adler32(req_id.encode("utf-8"))
-            for req_id in input_batch.req_ids[:num_reqs]
-        ),
+        (adler32(req_id.encode("utf-8")) for req_id in input_batch.req_ids[:num_reqs]),
         dtype=np.int64,
         count=num_reqs,
     )
 
-    query_lens = np.diff(
-        input_batch.query_start_loc_np[: num_reqs + 1]
-    ).astype(np.int32, copy=False)
-    token_to_req = np.repeat(np.arange(num_reqs, dtype=np.int32), query_lens)
-    if token_to_req.shape[0] < num_tokens:
-        raise RuntimeError(
-            "KV offload token_to_req metadata is shorter than the scheduled "
-            f"token batch: metadata={token_to_req.shape[0]}, tokens={num_tokens}"
-        )
-    token_to_req_np = np.zeros(num_tokens_padded, dtype=np.int32)
-    token_to_req_np[:num_tokens] = token_to_req[:num_tokens]
-
     async_copy_to_gpu(req_ids_np, out=req_ids_buffer[:num_reqs_padded])
-    async_copy_to_gpu(token_to_req_np, out=token_to_req_buffer[:num_tokens_padded])
     input_batch.offload_req_ids = req_ids_buffer[:num_reqs_padded]
-    input_batch.offload_token_to_req = token_to_req_buffer[:num_tokens_padded]
     return input_batch

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -17,11 +17,9 @@
 # This file is a part of the vllm-ascend project.
 #
 from dataclasses import dataclass, fields
-from zlib import adler32
 
 import numpy as np
 import torch
-from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -120,7 +118,13 @@ class AscendInputBatch(InputBatch):
                 attn_state=AscendAttentionState.DecodeOnly,
                 is_dummy=True,
             )
-            return prepare_sparse_kv_offload_metadata(batch, input_buffers)
+            if input_buffers.offload_req_ids is not None:
+                from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+                    prepare_sparse_kv_offload_metadata,
+                )
+
+                batch = prepare_sparse_kv_offload_metadata(batch, input_buffers)
+            return batch
 
     else:
 
@@ -153,34 +157,10 @@ class AscendInputBatch(InputBatch):
                 attn_state=AscendAttentionState.DecodeOnly,
                 is_dummy=True,
             )
-            return prepare_sparse_kv_offload_metadata(batch, input_buffers)
+            if input_buffers.offload_req_ids is not None:
+                from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+                    prepare_sparse_kv_offload_metadata,
+                )
 
-
-def prepare_sparse_kv_offload_metadata(
-    input_batch: AscendInputBatch,
-    input_buffers: AscendInputBuffers,
-) -> AscendInputBatch:
-    """Stage sparse-offload request metadata into MRV2 input buffers."""
-    req_ids_buffer = input_buffers.offload_req_ids
-    if req_ids_buffer is None:
-        input_batch.offload_req_ids = None
-        return input_batch
-
-    num_reqs = input_batch.num_reqs
-    num_reqs_padded = input_batch.num_reqs_after_padding
-    if len(input_batch.req_ids) < num_reqs:
-        raise RuntimeError(
-            "KV offload request metadata is shorter than the scheduled batch: "
-            f"metadata={len(input_batch.req_ids)}, requests={num_reqs}"
-        )
-
-    req_ids_np = np.zeros(num_reqs_padded, dtype=np.int64)
-    req_ids_np[:num_reqs] = np.fromiter(
-        (adler32(req_id.encode("utf-8")) for req_id in input_batch.req_ids[:num_reqs]),
-        dtype=np.int64,
-        count=num_reqs,
-    )
-
-    async_copy_to_gpu(req_ids_np, out=req_ids_buffer[:num_reqs_padded])
-    input_batch.offload_req_ids = req_ids_buffer[:num_reqs_padded]
-    return input_batch
+                batch = prepare_sparse_kv_offload_metadata(batch, input_buffers)
+            return batch

--- a/vllm_ascend/worker/v2/input_batch.py
+++ b/vllm_ascend/worker/v2/input_batch.py
@@ -17,9 +17,11 @@
 # This file is a part of the vllm-ascend project.
 #
 from dataclasses import dataclass, fields
+from zlib import adler32
 
 import numpy as np
 import torch
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
@@ -35,6 +37,7 @@ class AscendInputBuffers(InputBuffers):
         max_num_reqs: int,
         max_num_tokens: int,
         device: torch.device,
+        enable_sparse_kv_offload: bool = False,
     ):
         super().__init__(
             max_num_reqs,
@@ -62,6 +65,20 @@ class AscendInputBuffers(InputBuffers):
         # define seq_lens_np for easier calculation with numpy.
         self.seq_lens_np: np.ndarray = self.seq_lens_cpu.numpy()
 
+        self.offload_req_ids: torch.Tensor | None = None
+        self.offload_token_to_req: torch.Tensor | None = None
+        if enable_sparse_kv_offload:
+            self.offload_req_ids = torch.zeros(
+                max_num_reqs,
+                dtype=torch.int64,
+                device=device,
+            )
+            self.offload_token_to_req = torch.zeros(
+                max_num_tokens,
+                dtype=torch.int32,
+                device=device,
+            )
+
 
 @dataclass
 class AscendInputBatch(InputBatch):
@@ -78,6 +95,8 @@ class AscendInputBatch(InputBatch):
     # attn_state is used to build attention metadata.
     attn_state: AscendAttentionState | None = None
     is_dummy: bool = False
+    offload_req_ids: torch.Tensor | None = None
+    offload_token_to_req: torch.Tensor | None = None
 
     if vllm_version_is("0.27.1"):
 
@@ -102,12 +121,13 @@ class AscendInputBatch(InputBatch):
             seq_lens_np = input_buffers.seq_lens_np[:num_reqs]
             update_cos_sin(input_batch.positions)
             base_fields = {field.name: getattr(input_batch, field.name) for field in fields(InputBatch)}
-            return cls(
+            batch = cls(
                 **base_fields,
                 seq_lens_np=seq_lens_np,
                 attn_state=AscendAttentionState.DecodeOnly,
                 is_dummy=True,
             )
+            return prepare_sparse_kv_offload_metadata(batch, input_buffers)
 
     else:
 
@@ -134,9 +154,61 @@ class AscendInputBatch(InputBatch):
             seq_lens_np = input_buffers.seq_lens_np[:num_reqs]
             update_cos_sin(input_batch.positions)
             base_fields = {field.name: getattr(input_batch, field.name) for field in fields(InputBatch)}
-            return cls(
+            batch = cls(
                 **base_fields,
                 seq_lens_np=seq_lens_np,
                 attn_state=AscendAttentionState.DecodeOnly,
                 is_dummy=True,
             )
+            return prepare_sparse_kv_offload_metadata(batch, input_buffers)
+
+
+def prepare_sparse_kv_offload_metadata(
+    input_batch: AscendInputBatch,
+    input_buffers: AscendInputBuffers,
+) -> AscendInputBatch:
+    """Stage sparse-offload request metadata into MRV2 input buffers."""
+    req_ids_buffer = input_buffers.offload_req_ids
+    token_to_req_buffer = input_buffers.offload_token_to_req
+    if req_ids_buffer is None or token_to_req_buffer is None:
+        input_batch.offload_req_ids = None
+        input_batch.offload_token_to_req = None
+        return input_batch
+
+    num_reqs = input_batch.num_reqs
+    num_reqs_padded = input_batch.num_reqs_after_padding
+    num_tokens = input_batch.num_tokens
+    num_tokens_padded = input_batch.num_tokens_after_padding
+    if len(input_batch.req_ids) < num_reqs:
+        raise RuntimeError(
+            "KV offload request metadata is shorter than the scheduled batch: "
+            f"metadata={len(input_batch.req_ids)}, requests={num_reqs}"
+        )
+
+    req_ids_np = np.zeros(num_reqs_padded, dtype=np.int64)
+    req_ids_np[:num_reqs] = np.fromiter(
+        (
+            adler32(req_id.encode("utf-8"))
+            for req_id in input_batch.req_ids[:num_reqs]
+        ),
+        dtype=np.int64,
+        count=num_reqs,
+    )
+
+    query_lens = np.diff(
+        input_batch.query_start_loc_np[: num_reqs + 1]
+    ).astype(np.int32, copy=False)
+    token_to_req = np.repeat(np.arange(num_reqs, dtype=np.int32), query_lens)
+    if token_to_req.shape[0] < num_tokens:
+        raise RuntimeError(
+            "KV offload token_to_req metadata is shorter than the scheduled "
+            f"token batch: metadata={token_to_req.shape[0]}, tokens={num_tokens}"
+        )
+    token_to_req_np = np.zeros(num_tokens_padded, dtype=np.int32)
+    token_to_req_np[:num_tokens] = token_to_req[:num_tokens]
+
+    async_copy_to_gpu(req_ids_np, out=req_ids_buffer[:num_reqs_padded])
+    async_copy_to_gpu(token_to_req_np, out=token_to_req_buffer[:num_tokens_padded])
+    input_batch.offload_req_ids = req_ids_buffer[:num_reqs_padded]
+    input_batch.offload_token_to_req = token_to_req_buffer[:num_tokens_padded]
+    return input_batch

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -73,7 +73,11 @@ if not vllm_version_is("0.27.1"):
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
-from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
+from vllm_ascend.worker.v2.input_batch import (
+    AscendInputBatch,
+    AscendInputBuffers,
+    prepare_sparse_kv_offload_metadata,
+)
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 from vllm_ascend.worker.v2.pp_utils import (
     bypass_upstream_spec_pp_guard,
@@ -197,6 +201,7 @@ class NPUModelRunner(GPUModelRunner):
             max_num_reqs=self.max_num_reqs,
             max_num_tokens=self.max_num_tokens,
             device=self.device,
+            enable_sparse_kv_offload=self.sparse_kv_offload_enabled,
         )
 
         # we need to copy num_computed_tokens back to cpu to help
@@ -547,6 +552,7 @@ class NPUModelRunner(GPUModelRunner):
             )
 
             input_batch = vllm_model_runner.pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
+            input_batch = prepare_sparse_kv_offload_metadata(input_batch, self.input_buffers)
 
             # For mla/sfa, update cos/sin. Here is for execute_model.
             update_cos_sin(input_batch.positions)
@@ -768,6 +774,7 @@ class NPUModelRunner(GPUModelRunner):
             )
 
             input_batch = vllm_model_runner.pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
+            input_batch = prepare_sparse_kv_offload_metadata(input_batch, self.input_buffers)
 
             # For mla/sfa, update cos/sin. Here is for execute_model.
             update_cos_sin(input_batch.positions)

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -18,6 +18,7 @@
 #
 
 from contextlib import contextmanager
+from copy import deepcopy
 
 import numpy as np
 import torch
@@ -55,6 +56,13 @@ from vllm_ascend.ascend_forward_context import (
 from vllm_ascend.core.profiling_chunk_predictor import (
     _finish_profiling_chunk_timing,
     _start_profiling_chunk_timing,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
+    apply_layerwise_kv_cache_plan,
+)
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    allocate_kv_offload_topk_profile_buffers,
+    init_sparse_kv_offload_manager,
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import lmhead_tp_enable, set_potential_max_tokens, vllm_version_is
@@ -110,6 +118,9 @@ class NPUModelRunner(GPUModelRunner):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         # Ascend-specific configurations
         self.ascend_config = get_ascend_config()
+        self.sparse_kv_offload_config = self.ascend_config.sparse_kv_offload_config
+        self.sparse_kv_offload_enabled = self.sparse_kv_offload_config.enabled
+        self.sparse_kv_offload_manager = None
         # FusedMoE can be constructed by the parent initializer and reads this
         # capacity while setting up MC2 communication.
         set_potential_max_tokens(vllm_config)
@@ -235,6 +246,14 @@ class NPUModelRunner(GPUModelRunner):
         return output
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        kv_cache_config = deepcopy(kv_cache_config)
+        apply_layerwise_kv_cache_plan(kv_cache_config, self.vllm_config)
+        if self.sparse_kv_offload_enabled:
+            self.sparse_kv_offload_manager = init_sparse_kv_offload_manager(
+                self.vllm_config,
+                kv_cache_config,
+                self.sparse_kv_offload_config,
+            )
         with graph_manager_wrapper(self), _use_ascend_pcp_manager_for_vllm_0271():
             super().initialize_kv_cache(kv_cache_config)
             if self.pcp_manager is not None:
@@ -292,6 +311,13 @@ class NPUModelRunner(GPUModelRunner):
         necessary HCCL buffer for the MC2 operator before standard `profile_run`. Additionally, we set
         override_mrv2_in_profile_run to True to force moe load to be balanced when executing `profile_run`
         """
+        if self.sparse_kv_offload_enabled:
+            allocate_kv_offload_topk_profile_buffers(
+                self.get_kv_cache_spec(),
+                self.vllm_config,
+                self.sparse_kv_offload_config,
+            )
+
         mc2_tokens_capacity = get_mc2_tokens_capacity()
         with override_mrv2_in_profile_run(True):
             if (

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -63,6 +63,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     allocate_kv_offload_topk_profile_buffers,
     init_sparse_kv_offload_manager,
+    prepare_sparse_kv_offload_metadata,
 )
 from vllm_ascend.ops.rotary_embedding import set_cos_and_sin, update_cos_sin
 from vllm_ascend.utils import lmhead_tp_enable, set_potential_max_tokens, vllm_version_is
@@ -73,11 +74,7 @@ if not vllm_version_is("0.27.1"):
 from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
-from vllm_ascend.worker.v2.input_batch import (
-    AscendInputBatch,
-    AscendInputBuffers,
-    prepare_sparse_kv_offload_metadata,
-)
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 from vllm_ascend.worker.v2.pp_utils import (
     bypass_upstream_spec_pp_guard,
@@ -552,7 +549,8 @@ class NPUModelRunner(GPUModelRunner):
             )
 
             input_batch = vllm_model_runner.pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
-            input_batch = prepare_sparse_kv_offload_metadata(input_batch, self.input_buffers)
+            if self.input_buffers.offload_req_ids is not None:
+                input_batch = prepare_sparse_kv_offload_metadata(input_batch, self.input_buffers)
 
             # For mla/sfa, update cos/sin. Here is for execute_model.
             update_cos_sin(input_batch.positions)
@@ -774,7 +772,8 @@ class NPUModelRunner(GPUModelRunner):
             )
 
             input_batch = vllm_model_runner.pcp.maybe_partition_pcp_batch(self.pcp_manager, input_batch)
-            input_batch = prepare_sparse_kv_offload_metadata(input_batch, self.input_buffers)
+            if self.input_buffers.offload_req_ids is not None:
+                input_batch = prepare_sparse_kv_offload_metadata(input_batch, self.input_buffers)
 
             # For mla/sfa, update cos/sin. Here is for execute_model.
             update_cos_sin(input_batch.positions)

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -18,13 +18,16 @@
 #
 
 from typing import TYPE_CHECKING, Any
+from zlib import adler32
 
+import numpy as np
 import torch
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.utils import AttentionGroup
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 
@@ -36,6 +39,80 @@ class AscendModelState(DefaultModelState):
     """Model state for Ascend NPUs."""
 
     pcp_manager: "AscendPCPManager | None" = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.sparse_kv_offload_enabled = get_ascend_config().sparse_kv_offload_config.enabled
+        if self.sparse_kv_offload_enabled:
+            self._offload_req_ids_cpu = torch.zeros(
+                self.max_num_reqs,
+                dtype=torch.int64,
+                device="cpu",
+                pin_memory=True,
+            )
+            self._offload_token_to_req_cpu = torch.zeros(
+                self.max_num_tokens,
+                dtype=torch.int32,
+                device="cpu",
+                pin_memory=True,
+            )
+            self._offload_req_ids_tensor = torch.zeros(
+                self.max_num_reqs,
+                dtype=torch.int64,
+                device=self.device,
+            )
+            self._offload_token_to_req = torch.zeros(
+                self.max_num_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
+
+    def _prepare_sparse_kv_offload_metadata(
+        self,
+        input_batch: AscendInputBatch,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        if not getattr(self, "sparse_kv_offload_enabled", False):
+            return None, None
+
+        actual_num_reqs = input_batch.num_reqs
+        actual_num_tokens = input_batch.num_tokens
+        req_ids_np = self._offload_req_ids_cpu.numpy()
+        req_ids_np[:num_reqs].fill(0)
+        req_ids_np[:actual_num_reqs] = np.asarray(
+            [adler32(req_id.encode("utf-8")) for req_id in input_batch.req_ids],
+            dtype=np.int64,
+        )
+
+        query_lens = np.diff(input_batch.query_start_loc_np[: actual_num_reqs + 1]).astype(np.int32, copy=False)
+        token_to_req = np.repeat(
+            np.arange(actual_num_reqs, dtype=np.int32),
+            query_lens,
+        )
+        if token_to_req.shape[0] < actual_num_tokens:
+            raise RuntimeError(
+                "KV offload token_to_req metadata is shorter than the scheduled "
+                f"token batch: metadata={token_to_req.shape[0]}, "
+                f"tokens={actual_num_tokens}"
+            )
+        token_to_req_np = self._offload_token_to_req_cpu.numpy()
+        token_to_req_np[:actual_num_tokens] = token_to_req[:actual_num_tokens]
+        if num_tokens > actual_num_tokens:
+            token_to_req_np[actual_num_tokens:num_tokens].fill(0)
+
+        self._offload_req_ids_tensor[:num_reqs].copy_(
+            self._offload_req_ids_cpu[:num_reqs],
+            non_blocking=True,
+        )
+        self._offload_token_to_req[:num_tokens].copy_(
+            self._offload_token_to_req_cpu[:num_tokens],
+            non_blocking=True,
+        )
+        return (
+            self._offload_req_ids_tensor[:num_reqs],
+            self._offload_token_to_req[:num_tokens],
+        )
 
     def prepare_attn(
         self,
@@ -69,6 +146,11 @@ class AscendModelState(DefaultModelState):
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)
         max_query_len = input_batch.num_scheduled_tokens.max().item()
         pcp_context = self.pcp_manager.build_attention_context() if self.pcp_manager is not None else None
+        req_ids_tensor, token_to_req = self._prepare_sparse_kv_offload_metadata(
+            input_batch,
+            num_reqs,
+            num_input_tokens,
+        )
         # attn_metadata is needed when update_full_graph_params, but no way can get it now.
         # Temporarily store it in model_state.
         self.attn_metadata = build_attn_metadata(
@@ -94,5 +176,7 @@ class AscendModelState(DefaultModelState):
             attn_state=input_batch.attn_state,
             pcp_context=pcp_context,
             for_cudagraph_capture=for_capture,
+            req_ids_tensor=req_ids_tensor,
+            token_to_req=token_to_req,
         )
         return self.attn_metadata

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -95,14 +95,7 @@ class AscendModelState(DefaultModelState):
             pcp_context=pcp_context,
             for_cudagraph_capture=for_capture,
             req_ids_tensor=(
-                input_batch.offload_req_ids[:num_reqs]
-                if input_batch.offload_req_ids is not None
-                else None
-            ),
-            token_to_req=(
-                input_batch.offload_token_to_req[:num_input_tokens]
-                if input_batch.offload_token_to_req is not None
-                else None
+                input_batch.offload_req_ids[:num_reqs] if input_batch.offload_req_ids is not None else None
             ),
         )
         return self.attn_metadata

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -18,16 +18,13 @@
 #
 
 from typing import TYPE_CHECKING, Any
-from zlib import adler32
 
-import numpy as np
 import torch
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.model_states.default import DefaultModelState
 from vllm.v1.worker.utils import AttentionGroup
 
-from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 
@@ -39,80 +36,6 @@ class AscendModelState(DefaultModelState):
     """Model state for Ascend NPUs."""
 
     pcp_manager: "AscendPCPManager | None" = None
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.sparse_kv_offload_enabled = get_ascend_config().sparse_kv_offload_config.enabled
-        if self.sparse_kv_offload_enabled:
-            self._offload_req_ids_cpu = torch.zeros(
-                self.max_num_reqs,
-                dtype=torch.int64,
-                device="cpu",
-                pin_memory=True,
-            )
-            self._offload_token_to_req_cpu = torch.zeros(
-                self.max_num_tokens,
-                dtype=torch.int32,
-                device="cpu",
-                pin_memory=True,
-            )
-            self._offload_req_ids_tensor = torch.zeros(
-                self.max_num_reqs,
-                dtype=torch.int64,
-                device=self.device,
-            )
-            self._offload_token_to_req = torch.zeros(
-                self.max_num_tokens,
-                dtype=torch.int32,
-                device=self.device,
-            )
-
-    def _prepare_sparse_kv_offload_metadata(
-        self,
-        input_batch: AscendInputBatch,
-        num_reqs: int,
-        num_tokens: int,
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-        if not getattr(self, "sparse_kv_offload_enabled", False):
-            return None, None
-
-        actual_num_reqs = input_batch.num_reqs
-        actual_num_tokens = input_batch.num_tokens
-        req_ids_np = self._offload_req_ids_cpu.numpy()
-        req_ids_np[:num_reqs].fill(0)
-        req_ids_np[:actual_num_reqs] = np.asarray(
-            [adler32(req_id.encode("utf-8")) for req_id in input_batch.req_ids],
-            dtype=np.int64,
-        )
-
-        query_lens = np.diff(input_batch.query_start_loc_np[: actual_num_reqs + 1]).astype(np.int32, copy=False)
-        token_to_req = np.repeat(
-            np.arange(actual_num_reqs, dtype=np.int32),
-            query_lens,
-        )
-        if token_to_req.shape[0] < actual_num_tokens:
-            raise RuntimeError(
-                "KV offload token_to_req metadata is shorter than the scheduled "
-                f"token batch: metadata={token_to_req.shape[0]}, "
-                f"tokens={actual_num_tokens}"
-            )
-        token_to_req_np = self._offload_token_to_req_cpu.numpy()
-        token_to_req_np[:actual_num_tokens] = token_to_req[:actual_num_tokens]
-        if num_tokens > actual_num_tokens:
-            token_to_req_np[actual_num_tokens:num_tokens].fill(0)
-
-        self._offload_req_ids_tensor[:num_reqs].copy_(
-            self._offload_req_ids_cpu[:num_reqs],
-            non_blocking=True,
-        )
-        self._offload_token_to_req[:num_tokens].copy_(
-            self._offload_token_to_req_cpu[:num_tokens],
-            non_blocking=True,
-        )
-        return (
-            self._offload_req_ids_tensor[:num_reqs],
-            self._offload_token_to_req[:num_tokens],
-        )
 
     def prepare_attn(
         self,
@@ -146,11 +69,6 @@ class AscendModelState(DefaultModelState):
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)
         max_query_len = input_batch.num_scheduled_tokens.max().item()
         pcp_context = self.pcp_manager.build_attention_context() if self.pcp_manager is not None else None
-        req_ids_tensor, token_to_req = self._prepare_sparse_kv_offload_metadata(
-            input_batch,
-            num_reqs,
-            num_input_tokens,
-        )
         # attn_metadata is needed when update_full_graph_params, but no way can get it now.
         # Temporarily store it in model_state.
         self.attn_metadata = build_attn_metadata(
@@ -176,7 +94,15 @@ class AscendModelState(DefaultModelState):
             attn_state=input_batch.attn_state,
             pcp_context=pcp_context,
             for_cudagraph_capture=for_capture,
-            req_ids_tensor=req_ids_tensor,
-            token_to_req=token_to_req,
+            req_ids_tensor=(
+                input_batch.offload_req_ids[:num_reqs]
+                if input_batch.offload_req_ids is not None
+                else None
+            ),
+            token_to_req=(
+                input_batch.offload_token_to_req[:num_input_tokens]
+                if input_batch.offload_token_to_req is not None
+                else None
+            ),
         )
         return self.attn_metadata

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -94,7 +94,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
-        self._offload_draft_metadata_logged = False
 
     def _create_draft_vllm_config(self) -> VllmConfig:
         """Build the runtime config used while executing the draft model."""
@@ -192,8 +191,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # Use the first executable draft attention layer as the architecture
         # discriminator and cache it for ACL graph parameter updates.
         self.attn_backend = _get_graph_update_backend(self.attn_groups)
-        if self.attn_backend is None:
-            raise ValueError("Draft model does not have an executable attention backend")
         if issubclass(self.attn_backend, AscendDSABackend):
             self.attn_architecture = "DSA"
         elif issubclass(self.attn_backend, AscendMLABackend):
@@ -389,10 +386,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             if metadata is None:
                 continue
             metadata.req_ids_tensor = req_ids_tensor
-
-        if not self._offload_draft_metadata_logged:
-            logger.info("Sparse KV offload MTP draft request metadata uses ModelRunner V2 input buffers.")
-            self._offload_draft_metadata_logged = True
 
     def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
         """Build draft_attn_metadatas for partial-merged draft graph."""

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -94,7 +94,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
-        self._offload_draft_token_to_req: torch.Tensor | None = None
         self._offload_draft_metadata_logged = False
 
     def _create_draft_vllm_config(self) -> VllmConfig:
@@ -190,18 +189,11 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             target_attn_groups,
         )
 
-        if getattr(target_input_buffers, "offload_req_ids", None) is not None:
-            # Draft decode always has one token per request. Keep the mapping
-            # at a stable address so captured graphs can reuse it at replay.
-            self._offload_draft_token_to_req = torch.arange(
-                self.max_num_tokens,
-                dtype=torch.int32,
-                device=self.device,
-            )
-
         # Use the first executable draft attention layer as the architecture
         # discriminator and cache it for ACL graph parameter updates.
         self.attn_backend = _get_graph_update_backend(self.attn_groups)
+        if self.attn_backend is None:
+            raise ValueError("Draft model does not have an executable attention backend")
         if issubclass(self.attn_backend, AscendDSABackend):
             self.attn_architecture = "DSA"
         elif issubclass(self.attn_backend, AscendMLABackend):
@@ -380,8 +372,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             self._populate_sparse_kv_offload_draft_metadata(
                 attn_metadata,
                 num_reqs_padded,
-                num_tokens_padded,
-                num_query_per_req,
             )
         return attn_metadata
 
@@ -389,32 +379,19 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         self,
         attn_metadata: dict[str, Any],
         num_reqs_padded: int,
-        num_tokens_padded: int,
-        num_query_per_req: int,
     ) -> None:
         req_ids_tensor = getattr(self.target_input_buffers, "offload_req_ids", None)
         if req_ids_tensor is None:
             return
-        if num_query_per_req != 1 or num_tokens_padded > num_reqs_padded:
-            raise RuntimeError(
-                "Sparse KV offload MTP draft decode requires one token per request: "
-                f"num_query_per_req={num_query_per_req}, "
-                f"num_tokens_padded={num_tokens_padded}, "
-                f"num_reqs_padded={num_reqs_padded}"
-            )
-        if self._offload_draft_token_to_req is None:
-            raise RuntimeError("Sparse KV offload MTP draft metadata buffer is not initialized")
 
         req_ids_tensor = req_ids_tensor[:num_reqs_padded]
-        token_to_req = self._offload_draft_token_to_req[:num_tokens_padded]
         for metadata in attn_metadata.values():
             if metadata is None:
                 continue
             metadata.req_ids_tensor = req_ids_tensor
-            metadata.token_to_req = token_to_req
 
         if not self._offload_draft_metadata_logged:
-            logger.info("Sparse KV offload MTP draft metadata uses ModelRunner V2 input buffers.")
+            logger.info("Sparse KV offload MTP draft request metadata uses ModelRunner V2 input buffers.")
             self._offload_draft_metadata_logged = True
 
     def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -190,7 +190,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             target_attn_groups,
         )
 
-        if getattr(model_state, "_offload_req_ids_tensor", None) is not None:
+        if getattr(target_input_buffers, "offload_req_ids", None) is not None:
             # Draft decode always has one token per request. Keep the mapping
             # at a stable address so captured graphs can reuse it at replay.
             self._offload_draft_token_to_req = torch.arange(
@@ -392,7 +392,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         num_tokens_padded: int,
         num_query_per_req: int,
     ) -> None:
-        req_ids_tensor = getattr(self.model_state, "_offload_req_ids_tensor", None)
+        req_ids_tensor = getattr(self.target_input_buffers, "offload_req_ids", None)
         if req_ids_tensor is None:
             return
         if num_query_per_req != 1 or num_tokens_padded > num_reqs_padded:
@@ -414,7 +414,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             metadata.token_to_req = token_to_req
 
         if not self._offload_draft_metadata_logged:
-            logger.info("Sparse KV offload MTP draft metadata uses ModelRunner V2 model state.")
+            logger.info("Sparse KV offload MTP draft metadata uses ModelRunner V2 input buffers.")
             self._offload_draft_metadata_logged = True
 
     def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -94,6 +94,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
+        self._offload_draft_token_to_req: torch.Tensor | None = None
+        self._offload_draft_metadata_logged = False
 
     def _create_draft_vllm_config(self) -> VllmConfig:
         """Build the runtime config used while executing the draft model."""
@@ -187,6 +189,15 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             target_input_buffers,
             target_attn_groups,
         )
+
+        if getattr(model_state, "_offload_req_ids_tensor", None) is not None:
+            # Draft decode always has one token per request. Keep the mapping
+            # at a stable address so captured graphs can reuse it at replay.
+            self._offload_draft_token_to_req = torch.arange(
+                self.max_num_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
 
         # Use the first executable draft attention layer as the architecture
         # discriminator and cache it for ACL graph parameter updates.
@@ -366,7 +377,45 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 if metadata is None:
                     continue
                 metadata.attn_state = AscendAttentionState.DecodeOnly
+            self._populate_sparse_kv_offload_draft_metadata(
+                attn_metadata,
+                num_reqs_padded,
+                num_tokens_padded,
+                num_query_per_req,
+            )
         return attn_metadata
+
+    def _populate_sparse_kv_offload_draft_metadata(
+        self,
+        attn_metadata: dict[str, Any],
+        num_reqs_padded: int,
+        num_tokens_padded: int,
+        num_query_per_req: int,
+    ) -> None:
+        req_ids_tensor = getattr(self.model_state, "_offload_req_ids_tensor", None)
+        if req_ids_tensor is None:
+            return
+        if num_query_per_req != 1 or num_tokens_padded > num_reqs_padded:
+            raise RuntimeError(
+                "Sparse KV offload MTP draft decode requires one token per request: "
+                f"num_query_per_req={num_query_per_req}, "
+                f"num_tokens_padded={num_tokens_padded}, "
+                f"num_reqs_padded={num_reqs_padded}"
+            )
+        if self._offload_draft_token_to_req is None:
+            raise RuntimeError("Sparse KV offload MTP draft metadata buffer is not initialized")
+
+        req_ids_tensor = req_ids_tensor[:num_reqs_padded]
+        token_to_req = self._offload_draft_token_to_req[:num_tokens_padded]
+        for metadata in attn_metadata.values():
+            if metadata is None:
+                continue
+            metadata.req_ids_tensor = req_ids_tensor
+            metadata.token_to_req = token_to_req
+
+        if not self._offload_draft_metadata_logged:
+            logger.info("Sparse KV offload MTP draft metadata uses ModelRunner V2 model state.")
+            self._offload_draft_metadata_logged = True
 
     def build_draft_attn_metadatas(self, num_reqs_padded, is_draft_model_prefill):
         """Build draft_attn_metadatas for partial-merged draft graph."""


### PR DESCRIPTION
### What this PR does / why we need it?

This PR migrates layerwise sparse mla offload for GLM5.x to MRV2. We did not change the original logic of it. The changes are mainly 2 folds:

1. add `apply_layerwise_kv_cache_plan` for layerwise reuse.
2. add decode sparse mla offload metadata preparation, host kv allocation.

### Does this PR introduce _any_ user-facing change?

Yes, now layerwise sparse mla offload can be enabled both with MRV2.

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
