### PR TITLE
[Feature][KV Pool] Add Mooncake tenant ID support

### DIFF
--- a/docs/source/user_guide/feature_guide/kv_pool.md
+++ b/docs/source/user_guide/feature_guide/kv_pool.md
@@ -75,12 +75,15 @@ export PYTHONHASHSEED=0
         python3 -m pip install mooncake-transfer-engine-npu==0.3.11.post1 --extra-index-url https://mirrors.aliyun.com/pypi/web/simple
         ```
 
+        Mooncake `0.3.11.post1` remains supported when `tenant_id` is omitted or resolves to `default`. A non-default tenant requires a Mooncake version whose `MooncakeDistributedStore.setup()` accepts `tenant_id`; use Mooncake `0.3.12` or later for multi-tenant deployments.
+
 ### Step 2.2: Run Mooncake Master
 
 **Note:** Before proceeding, review the following Mooncake guides:
 
 * [Mooncake Store Deployment Guide](https://github.com/kvcache-ai/Mooncake/blob/main/docs/source/deployment/mooncake-store-deployment-guide.md)
 * [SSD Offload](https://github.com/kvcache-ai/Mooncake/blob/main/docs/source/deployment/ssd/ssd-offload.md)
+* [Tenant Quota Management](https://github.com/kvcache-ai/Mooncake/blob/main/docs/source/deployment/mooncake-store-deployment-guide.md#tenant-quota-management)
 
 #### Step 2.2.1: Configure mooncake.json
 
@@ -96,7 +99,8 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
     "preferred_segment": false,
     "prefer_alloc_in_same_node": true,
     "enable_ssd_offload": false, # only required when the SSD offload feature is enabled
-    "ssd_offload_path": "/nvme/mooncake_offload" # only required when the SSD offload feature is enabled)
+    "ssd_offload_path": "/nvme/mooncake_offload", # only required when the SSD offload feature is enabled)
+    "tenant_id": "default"
 }
 ```
 
@@ -111,6 +115,7 @@ The environment variable **MOONCAKE_CONFIG_PATH** is configured to the full path
 | `prefer_alloc_in_same_node` | Whether to prefer allocating KV on the same node. Defaults to **true**. |
 | `enable_ssd_offload` | Set to `true` to enable SSD offload. Environment variables are not supported. |
 | `ssd_offload_path` | **Required when `enable_ssd_offload` is `true`.** Absolute path to a local directory where Mooncake stores offloaded KV data (for example, `/nvme/mooncake_offload`). The directory must exist and be writable by the vLLM process; create it before startup (`mkdir -p <path>`). Relative paths, symbolic links, and paths containing `..` are rejected by Mooncake. |
+| `tenant_id` | Optional Mooncake tenant namespace. Missing, `null`, empty, or whitespace-only values use `default`; surrounding whitespace is removed. All Prefill, Decode, scheduler, and replica instances that share KV entries must use the same tenant ID. Non-default tenants require Mooncake `0.3.12` or later. |
 
 #### Step 2.2.2: Start mooncake_master
 
@@ -129,6 +134,43 @@ mooncake_master --port 50088 --eviction_high_watermark_ratio 0.9 --eviction_rati
 | `default_kv_lease_ttl` | Controls the default lease TTL for KV objects (milliseconds). Keep it larger than `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`. |
 | `enable_offload` | Set to `true` to enable SSD offload in Mooncake master. Keep the master port aligned with `master_server_address` in `mooncake.json`. Only required when SSD offload is enabled. |
 | `client_ttl` | Seconds a client stays alive after the last Ping. CLI default is `10`; see [SEGMENT_NOT_FOUND with SSD offload](#5321-segment_not_found-with-ssd-offload). Only required when SSD offload is enabled. |
+
+#### Step 2.2.3: Enable Strict Multi-Tenant Mode
+
+Tenant IDs are ignored for object placement while strict multi-tenant mode is disabled, and objects remain in the `default` namespace. To enable isolated namespaces and per-tenant memory quota admission, start Mooncake master with strict multi-tenant mode and a policy connector:
+
+```shell
+mooncake_master \
+    --port 50088 \
+    --enable_multi_tenants=true \
+    --tenant_quota_connector_type=file \
+    --tenant_quota_connector_uri=/etc/mooncake/tenant_quotas.yaml
+```
+
+For example, `/etc/mooncake/tenant_quotas.yaml` can contain:
+
+```yaml
+version: 1
+
+tenants:
+  - name: tenant-a
+    quota: 200GB
+  - name: tenant-b
+    quota: 200GB
+  - name: default
+    quota: 100GB
+```
+
+The file connector can be replaced with `etcd` when Mooncake is built with `STORE_USE_ETCD=ON`; in that case, set `tenant_quota_connector_uri` to the etcd endpoints. Strict mode rejects writes for unregistered tenants, including `default`, so every tenant used by vLLM-Ascend must appear in the policy.
+
+Mooncake exposes tenant quota snapshots through the master metrics HTTP port (default `9003`):
+
+```shell
+curl -s http://<master_host>:9003/api/v1/tenant_quotas
+curl -s "http://<master_host>:9003/api/v1/tenant_quotas?tenant_id=tenant-a"
+```
+
+`tenant_id` is an instance-level namespace and quota identity, not an authentication mechanism. A client that can access Mooncake can still declare a tenant ID. Keep incompatible models, model versions, quantization formats, and KV layouts in separate model or release namespaces even when tenant isolation is enabled.
 
 ### Step 2.3: PD Disaggregation Scenario
 

--- a/tests/ut/distributed/ascend_store/test_backend.py
+++ b/tests/ut/distributed/ascend_store/test_backend.py
@@ -17,6 +17,7 @@
 
 import json
 import os
+import sys
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
@@ -24,6 +25,8 @@ from unittest.mock import MagicMock, patch
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.base import Backend
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import (
+    DEFAULT_TENANT_ID,
+    MooncakeBackend,
     MooncakeStoreConfig,
     _convert_to_bytes,
     _parse_global_segment_size,
@@ -82,11 +85,28 @@ class TestMooncakeStoreConfig(unittest.TestCase):
         self.assertEqual(defaults.protocol, "ascend")
         self.assertEqual(defaults.device_name, "")
         self.assertFalse(defaults.enable_ssd_offload)
+        self.assertEqual(defaults.tenant_id, DEFAULT_TENANT_ID)
 
         ssd_path = TestMooncakeStoreConfig._writable_ssd_path()
         self.addCleanup(lambda: os.rmdir(ssd_path))
         ssd = _make_mooncake_store_config(enable_ssd_offload=True, ssd_offload_path=ssd_path)
         self.assertEqual(ssd.ssd_offload_path, ssd_path)
+
+    def test_from_file_normalizes_tenant_id(self):
+        for value, expected in (
+            (None, DEFAULT_TENANT_ID),
+            ("", DEFAULT_TENANT_ID),
+            ("   ", DEFAULT_TENANT_ID),
+            ("tenant-a", "tenant-a"),
+            ("  tenant-a  ", "tenant-a"),
+        ):
+            with self.subTest(value=value):
+                cfg = _make_mooncake_store_config(tenant_id=value)
+                self.assertEqual(cfg.tenant_id, expected)
+
+    def test_from_file_rejects_non_string_tenant_id(self):
+        with self.assertRaisesRegex(TypeError, "tenant_id must be a string or null"):
+            _make_mooncake_store_config(tenant_id=False)
 
     def test_ssd_offload_validation(self):
         for path in ("relative/path", None):
@@ -221,10 +241,134 @@ class TestYuanrongConfig(unittest.TestCase):
 # =========================================================================
 # MooncakeBackend (mocked store)
 # =========================================================================
+class TestMooncakeBackendSetup(unittest.TestCase):
+    _MODULE_PATH = "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend"
+
+    def _make_backend(
+        self,
+        *,
+        config: MooncakeStoreConfig,
+        use_fabric_mem: bool,
+        contribute_memory: bool = True,
+    ) -> MooncakeBackend:
+        backend = MooncakeBackend.__new__(MooncakeBackend)
+        backend.parallel_config = MagicMock()
+        backend.config = config
+        backend.local_seg = None
+        backend._use_fabric_mem = use_fabric_mem
+        backend._contribute_memory = contribute_memory
+        return backend
+
+    def _setup_store(self, backend: MooncakeBackend, store: MagicMock):
+        transfer_engine = MagicMock()
+        transfer_engine.get_rpc_port.return_value = 50052
+        fake_store_module = sys.modules["mooncake.store"]
+        with (
+            patch.object(
+                fake_store_module,
+                "MooncakeDistributedStore",
+                return_value=store,
+                create=True,
+            ),
+            patch(f"{self._MODULE_PATH}.get_ip", return_value="10.0.0.7"),
+            patch(f"{self._MODULE_PATH}.global_te") as mock_global_te,
+            patch(f"{self._MODULE_PATH}.get_global_rank", return_value=3),
+            patch(
+                f"{self._MODULE_PATH}._mooncake_setup_supports_ssd_offload",
+                return_value=True,
+            ),
+        ):
+            mock_global_te.get_transfer_engine.return_value = transfer_engine
+            return backend._setup_store()
+
+    def test_setup_omits_default_tenant_for_all_memory_paths(self):
+        for use_fabric_mem in (False, True):
+            with self.subTest(use_fabric_mem=use_fabric_mem):
+                backend = self._make_backend(
+                    config=_make_mooncake_store_config(),
+                    use_fabric_mem=use_fabric_mem,
+                )
+                store = MagicMock()
+                store.setup.return_value = 0
+
+                result = self._setup_store(backend, store)
+
+                self.assertIs(result, store)
+                self.assertNotIn("tenant_id", store.setup.call_args.kwargs)
+
+    def test_setup_forwards_tenant_for_all_memory_paths(self):
+        for use_fabric_mem in (False, True):
+            with self.subTest(use_fabric_mem=use_fabric_mem):
+                backend = self._make_backend(
+                    config=_make_mooncake_store_config(tenant_id="  tenant-a  "),
+                    use_fabric_mem=use_fabric_mem,
+                )
+                store = MagicMock()
+                store.setup.return_value = 0
+
+                self._setup_store(backend, store)
+
+                self.assertEqual(store.setup.call_args.kwargs["tenant_id"], "tenant-a")
+
+    def test_setup_preserves_ssd_kwargs_with_tenant(self):
+        with tempfile.TemporaryDirectory(prefix="mooncake_ssd_ut_") as ssd_path:
+            config = _make_mooncake_store_config(
+                tenant_id="tenant-a",
+                enable_ssd_offload=True,
+                ssd_offload_path=ssd_path,
+            )
+            for use_fabric_mem in (False, True):
+                with self.subTest(use_fabric_mem=use_fabric_mem):
+                    backend = self._make_backend(
+                        config=config,
+                        use_fabric_mem=use_fabric_mem,
+                    )
+                    store = MagicMock()
+                    store.setup.return_value = 0
+
+                    self._setup_store(backend, store)
+
+                    setup_kwargs = store.setup.call_args.kwargs
+                    self.assertEqual(setup_kwargs["tenant_id"], "tenant-a")
+                    self.assertIs(setup_kwargs["enable_ssd_offload"], True)
+                    self.assertEqual(setup_kwargs["ssd_offload_path"], os.path.join(ssd_path, "rank_3"))
+
+    def test_scheduler_client_forwards_tenant(self):
+        config = _make_mooncake_store_config(tenant_id="tenant-a")
+        for use_fabric_mem in (False, True):
+            with self.subTest(use_fabric_mem=use_fabric_mem):
+                backend = self._make_backend(
+                    config=config,
+                    use_fabric_mem=use_fabric_mem,
+                    contribute_memory=False,
+                )
+                store = MagicMock()
+                store.setup.return_value = 0
+
+                self._setup_store(backend, store)
+
+                setup_kwargs = store.setup.call_args.kwargs
+                self.assertEqual(setup_kwargs["tenant_id"], "tenant-a")
+                self.assertEqual(setup_kwargs["global_segment_size"], 0)
+                self.assertEqual(setup_kwargs["local_buffer_size"], 0)
+
+    def test_non_default_tenant_preserves_setup_type_error(self):
+        setup_error = TypeError("setup(): incompatible function arguments")
+        backend = self._make_backend(
+            config=_make_mooncake_store_config(tenant_id="tenant-a"),
+            use_fabric_mem=False,
+        )
+        store = MagicMock()
+        store.setup.side_effect = setup_error
+
+        with self.assertRaises(TypeError) as context:
+            self._setup_store(backend, store)
+
+        self.assertIs(context.exception, setup_error)
+
+
 class TestMooncakeBackendMethods(unittest.TestCase):
     def _make_backend(self):
-        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.backend.mooncake_backend import MooncakeBackend
-
         with (
             patch.dict(os.environ, {"MOONCAKE_CONFIG_PATH": "/dev/null"}),
             patch.object(MooncakeBackend, "__init__", lambda self, pc: None),

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py
@@ -22,6 +22,7 @@ from vllm_ascend.distributed.parallel_state import get_global_rank
 
 DEFAULT_GLOBAL_SEGMENT_SIZE = 1073741824  # 1.0 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
+DEFAULT_TENANT_ID = "default"
 
 
 @functools.lru_cache(maxsize=1)
@@ -115,6 +116,9 @@ class MooncakeBackend(Backend):
             except OSError as e:
                 raise RuntimeError(f"Failed to create per-rank SSD offload directory: {rank_path!r} ({e})")
             ssd_kwargs["ssd_offload_path"] = rank_path
+        setup_kwargs = dict(ssd_kwargs)
+        if self.config.tenant_id != DEFAULT_TENANT_ID:
+            setup_kwargs["tenant_id"] = self.config.tenant_id
         # ASCEND_ENABLE_USE_FABRIC_MEM: Enable unified memory address direct transmission scheme
         # and only can be used for 800 I/T A3 series.
         # Required supporting hardware versions are as follows:
@@ -130,7 +134,7 @@ class MooncakeBackend(Backend):
                 rdma_devices=self.config.device_name,
                 master_server_addr=self.config.master_server_address,
                 engine=transfer_engine.get_engine(),
-                **ssd_kwargs,
+                **setup_kwargs,
             )
         else:
             self.local_seg = local_hostname
@@ -142,7 +146,7 @@ class MooncakeBackend(Backend):
                 protocol=self.config.protocol,
                 rdma_devices=self.config.device_name,
                 master_server_addr=self.config.master_server_address,
-                **ssd_kwargs,
+                **setup_kwargs,
             )
 
         if ret != 0:
@@ -158,6 +162,7 @@ class MooncakeBackend(Backend):
                 "Mooncake SSD offload enabled (Mode A): path=%s",
                 self.config.ssd_offload_path,
             )
+        logger.info("Mooncake tenant_id=%s", self.config.tenant_id)
         return store
 
     @classmethod
@@ -278,6 +283,7 @@ class MooncakeStoreConfig:
     prefer_alloc_in_same_node: bool
     enable_ssd_offload: bool = False
     ssd_offload_path: str = ""
+    tenant_id: str = DEFAULT_TENANT_ID
 
     def __post_init__(self) -> None:
         if not self.enable_ssd_offload:
@@ -312,6 +318,7 @@ class MooncakeStoreConfig:
             prefer_alloc_in_same_node=config.get("prefer_alloc_in_same_node", True),
             enable_ssd_offload=bool(config.get("enable_ssd_offload", False)),
             ssd_offload_path=config.get("ssd_offload_path", ""),
+            tenant_id=_normalize_tenant_id(config.get("tenant_id", DEFAULT_TENANT_ID)),
         )
 
     @staticmethod
@@ -320,6 +327,15 @@ class MooncakeStoreConfig:
         if not config_path:
             raise ValueError("The environment variable 'MOONCAKE_CONFIG_PATH' is not set.")
         return MooncakeStoreConfig.from_file(config_path)
+
+
+def _normalize_tenant_id(value: Any) -> str:
+    if value is None:
+        return DEFAULT_TENANT_ID
+    if not isinstance(value, str):
+        raise TypeError(f"tenant_id must be a string or null, got {type(value).__name__}: {value!r}")
+    tenant_id = value.strip()
+    return tenant_id if tenant_id else DEFAULT_TENANT_ID
 
 
 def _parse_global_segment_size(value) -> int:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds Mooncake tenant ID support to the vLLM-Ascend AscendStore backend, following the tenant propagation behavior introduced by [vLLM PR #48069](https://github.com/vllm-project/vllm/pull/48069).

- Read an optional `tenant_id` from `mooncake.json`.
- Normalize a missing, `null`, empty, or whitespace-only value to `default`, and trim surrounding whitespace from non-empty strings.
- Reject non-string, non-null tenant values.
- Preserve backward compatibility by omitting the `tenant_id` keyword when the normalized value is `default`.
- Forward a non-default tenant to `MooncakeDistributedStore.setup()` in both FabricMem and non-FabricMem paths without silently falling back to `default`.
- Preserve the existing SSD offload setup arguments while adding the tenant argument.
- Document strict Mooncake multi-tenant mode, tenant quota configuration, and deployment constraints.

The tenant ID is an instance-level namespace and quota identity. It is not an authentication mechanism or a request-level tenant selector. Prefill, Decode, scheduler, and replica instances that share KV entries must use the same tenant ID.

### Does this PR introduce _any_ user-facing change?

Yes. `mooncake.json` accepts a new optional `tenant_id` field.

The default behavior is unchanged when the field is omitted or resolves to `default`. A non-default tenant requires a Mooncake binding that supports `MooncakeDistributedStore.setup(..., tenant_id=...)`. Strict namespace isolation and quota admission also require Mooncake Master multi-tenant mode and a registered tenant quota policy.

### How was this patch tested?

Static and mocked unit checks on the rebased head:

```bash
python -m py_compile \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py \
  tests/ut/distributed/ascend_store/test_backend.py

pre-commit run ruff-check --files \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py \
  tests/ut/distributed/ascend_store/test_backend.py

pre-commit run ruff-format --files \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py \
  tests/ut/distributed/ascend_store/test_backend.py

pre-commit run codespell --files \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py \
  tests/ut/distributed/ascend_store/test_backend.py \
  docs/source/user_guide/feature_guide/kv_pool.md

pre-commit run typos --files \
  vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/backend/mooncake_backend.py \
  tests/ut/distributed/ascend_store/test_backend.py \
  docs/source/user_guide/feature_guide/kv_pool.md

git diff --check upstream/main...HEAD
```

Results:

- Python compilation, Ruff check, Ruff format check, codespell, typos, and diff check passed.
- The Mooncake backend mock test classes passed: 14 tests covering tenant normalization and validation, default omission, non-default forwarding in FabricMem and non-FabricMem paths, scheduler-only setup, SSD kwargs preservation, and original `TypeError` propagation.
- AscendStore unit tests were also validated in a Linux environment on vLLM-Ascend `508e5a8ce3cc8bbf2684bb6c7c47186fd61a8532` with vLLM `58d3918e3ea0a544ffedadad2ba84559e9c51d8f`.

A3 end-to-end validation used:

- vLLM-Ascend: `508e5a8ce3cc8bbf2684bb6c7c47186fd61a8532`
- vLLM: `58d3918e3ea0a544ffedadad2ba84559e9c51d8f`

Validated scenarios:

- A new `tenant-a` Prefill/Decode deployment missed and stored KV in Mooncake.
- A fresh `tenant-a` deployment externally hit the stored KV.
- A fresh `tenant-b` deployment did not read `tenant-a` KV for the same token IDs.
- A small-quota tenant write was rejected by Mooncake Master and attributed to the correct tenant.
- Omitting `tenant_id` completed a compatible default-tenant startup and request.
- FabricMem, SSD offload, and a non-default tenant were enabled together; Store PUT/GET succeeded and SSD setup parameters were preserved.

The SSD validation confirms successful Store PUT/GET with the combined FabricMem, SSD, and tenant configuration. It does not distinguish whether the observed GET was served from FabricMem or the SSD tier.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/cdc4824a21eaa986d4d1fee90a7e6465c9f706e6
