### PR TITLE
[Refactor][Config] Remove weight NZ environment variable

### DIFF
--- a/docs/source/tutorials/models/DeepSeekOCR2.md
+++ b/docs/source/tutorials/models/DeepSeekOCR2.md
@@ -124,7 +124,6 @@ Run the following script to execute online inference.
 #!/bin/sh
 
 export VLLM_USE_V1=1
-export VLLM_ASCEND_ENABLE_NZ=0
 export TOKENIZERS_PARALLELISM=false
 export PYTORCH_NPU_ALLOC_CONF="expandable_segments:True"
 export TASK_QUEUE_ENABLE=1
@@ -140,6 +139,7 @@ vllm serve /root/.cache/DeepSeek-OCR-2 \
     --gpu-memory-utilization 0.8 \
     --allowed-local-media-path / \
     --additional-config '{
+      "weight_nz_mode": 0,
       "enable_cpu_binding": true,
       "multistream_overlap_shared_expert": true,
       "ascend_compilation_config": {"fuse_qknorm_rope": false}

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -1279,7 +1279,6 @@ The 1M context scenarios are validated on Atlas 800 A3 only; the A2 series is no
 Recommended command:
 
 ```shell
-export VLLM_ASCEND_ENABLE_NZ=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
@@ -1308,7 +1307,7 @@ vllm serve <MODEL_PATH> \
   --decode-context-parallel-size 16 \
   --cp-kv-cache-interleave-size 128 \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [4, 16, 128]}' \
-  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true}' \
+  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true,"weight_nz_mode":1}' \
   --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
   --enable-expert-parallel \
@@ -1319,7 +1318,7 @@ Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single
 
 **1M-specific environment variables:**
 
-- `VLLM_ASCEND_ENABLE_NZ=1`: Enables NZ format memory layout for the C8 quantized tensors, required for the 1M context deployment.
+- `additional_config.weight_nz_mode=1`: Enables NZ format memory layout for the C8 quantized tensors, required for the 1M context deployment.
 - `VLLM_WORKER_MULTIPROC_METHOD=spawn`: Uses the spawn start method for multi-process workers (required in this scenario).
 
 **1M-specific vllm serve parameters:**
@@ -1345,7 +1344,6 @@ export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
 export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_ASCEND_ENABLE_NZ=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
@@ -1378,7 +1376,7 @@ vllm serve <MODEL_PATH> \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true}' \
+  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true,"weight_nz_mode":1}' \
   --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
   --enable-expert-parallel \
@@ -1411,7 +1409,6 @@ export GLOO_SOCKET_IFNAME=$nic_name
 export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
 
-export VLLM_ASCEND_ENABLE_NZ=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
@@ -1445,7 +1442,7 @@ vllm serve <MODEL_PATH> \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
   --enforce-eager \
-  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
+  --additional-config '{"enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true,"weight_nz_mode":1}' \
   --speculative-config '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
   --enable-expert-parallel \
@@ -1484,7 +1481,6 @@ export HCCL_IF_IP=$local_ip
 export GLOO_SOCKET_IFNAME=$nic_name
 export TP_SOCKET_IFNAME=$nic_name
 export HCCL_SOCKET_IFNAME=$nic_name
-export VLLM_ASCEND_ENABLE_NZ=1
 export HCCL_OP_EXPANSION_MODE="AIV"
 export OMP_PROC_BIND=false
 export OMP_NUM_THREADS=20
@@ -1518,7 +1514,7 @@ vllm serve <MODEL_PATH> \
   --decode-context-parallel-size 8 \
   --cp-kv-cache-interleave-size 128 \
   --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
-  --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true},"multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}' \
+  --additional-config '{"ascend_compilation_config": {"enable_npugraph_ex": true},"multistream_overlap_shared_expert": true,"enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true,"weight_nz_mode":1}' \
   --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp", "enforce_eager": true}' \
   --quantization ascend \
   --enable-expert-parallel \

--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -70,7 +70,7 @@ The following table lists additional configuration options available in vLLM Asc
 | `msmonitor_use_daemon`              | bool | `False` | Whether to use daemon mode for msmonitor. The legacy `MSMONITOR_USE_DAEMON` environment variable is no longer supported. |
 | `enable_mlapo`                      | bool | `True`  | Whether to enable MLAPO (Model Layer-wise Adaptive Parallel Optimization). Can also be configured via the `VLLM_ASCEND_ENABLE_MLAPO` environment variable during the migration period. |
 | `mlapo_keep_prefill_weights`        | bool | `False` | When True, keep MLAPO prefill weights on NPU instead of freeing them on kv_consumer (decode-only D) nodes. D nodes have normal local-prefill paths (recompute / fallback / preempt) that crash when the weights are freed (issue #11882). Enable this to trade NPU memory for stability. |
-| `weight_nz_mode`                    | int  | `1`     | Weight NZ mode. Can also be configured via the `VLLM_ASCEND_ENABLE_NZ` environment variable during the migration period. |
+| `weight_nz_mode`                    | int  | `1`     | Weight NZ mode. `0` disables NZ, `1` enables NZ only for quantized weights, and `2` also enables NZ for BF16/FP16 weights when supported. The legacy `VLLM_ASCEND_ENABLE_NZ` environment variable is no longer supported. |
 | `enable_fused_mc2`                  | int  | `0`     | Fused MC2 configuration. `0` disables the fused path and `1` enables it when the model and parallel configuration support it. The legacy `VLLM_ASCEND_ENABLE_FUSED_MC2` environment variable is no longer supported. |
 | `enable_transpose_kv_cache_by_block`| bool | `True`  | Whether to enable transpose KV cache by block. The legacy `VLLM_ASCEND_FUSION_OP_TRANSPOSE_KV_CACHE_BY_BLOCK` environment variable is no longer supported. |
 | `enable_dsa_cp`                     | bool | `False` | Whether to enable dsa_cp for DeepSeek V3.2, DeepSeek V4, and other models with the same architecture. This feature requires sequence parallelism to be enabled.|
@@ -229,9 +229,9 @@ ShortRequestFirst is a waiting-queue policy for FCFS synchronous or asynchronous
 
 <span id="rl_config"></span>**rl_config**
 
-`rl_config` is a one-click RL mode switch. When `enabled` is `true`, it refreshes the global Ascend configuration on every initialization, forces `AscendConfig.weight_nz_mode=0`, synchronizes `VLLM_ASCEND_ENABLE_NZ=0`, sets `VLLM_SERVER_DEV_MODE=1`, and removes the `expandable_segments` entry from `PYTORCH_NPU_ALLOC_CONF` with an informational log. These fixed RL behaviors are not configurable as `rl_config` sub-fields. When `enabled` is `false`, all other sub-fields are ignored.
+`rl_config` is a one-click RL mode switch. When `enabled` is `true`, it refreshes the global Ascend configuration on every initialization, forces `AscendConfig.weight_nz_mode=0`, sets `VLLM_SERVER_DEV_MODE=1`, and removes the `expandable_segments` entry from `PYTORCH_NPU_ALLOC_CONF` with an informational log. These fixed RL behaviors are not configurable as `rl_config` sub-fields. When `enabled` is `false`, all other sub-fields are ignored.
 
-When RL mode is enabled, its fixed NZ and developer-endpoint settings take precedence over top-level configuration and environment variables. `VLLM_BATCH_INVARIANT=1` remains enabled when `rl_config.enable_batch_invariant` is false.
+When RL mode is enabled, its fixed NZ setting takes precedence over the top-level `weight_nz_mode` configuration. `VLLM_BATCH_INVARIANT=1` remains enabled when `rl_config.enable_batch_invariant` is false.
 
 | Name | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |

--- a/docs/source/user_guide/feature_guide/rl.md
+++ b/docs/source/user_guide/feature_guide/rl.md
@@ -161,8 +161,8 @@ The repository contains runnable examples for both backends:
 - [`rlhf_async_new_apis.py`](https://github.com/vllm-project/vllm-ascend/blob/main/examples/rl/rlhf_async_new_apis.py)
 
 FRACTAL_NZ must be disabled for weight updates. RL mode forces
-`weight_nz_mode=0` and synchronizes `VLLM_ASCEND_ENABLE_NZ=0`; the
-weight-transfer start path validates the effective Ascend configuration.
+`weight_nz_mode=0`; the weight-transfer start path validates the effective
+Ascend configuration.
 
 ### Pause and resume generation
 

--- a/docs/source/user_guide/feature_guide/sleep_mode.md
+++ b/docs/source/user_guide/feature_guide/sleep_mode.md
@@ -100,7 +100,6 @@ The following is a simple example of how to use sleep mode.
 
     os.environ["VLLM_USE_MODELSCOPE"] = "True"
     os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
-    os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
 
     if __name__ == "__main__":
         prompt = "How are you?"
@@ -109,7 +108,11 @@ The following is a simple example of how to use sleep mode.
         print(f"Free memory before sleep: {free / 1024 ** 3:.2f} GiB")
         # record npu memory use baseline in case other process is running
         used_bytes_baseline = total - free
-        llm = LLM("Qwen/Qwen2.5-0.5B-Instruct", enable_sleep_mode=True)
+        llm = LLM(
+            "Qwen/Qwen2.5-0.5B-Instruct",
+            enable_sleep_mode=True,
+            additional_config={"weight_nz_mode": 0},
+        )
         sampling_params = SamplingParams(temperature=0, max_tokens=10)
         output = llm.generate(prompt, sampling_params)
 
@@ -137,9 +140,10 @@ The following is a simple example of how to use sleep mode.
     export VLLM_SERVER_DEV_MODE="1"
     export VLLM_WORKER_MULTIPROC_METHOD="spawn"
     export VLLM_USE_MODELSCOPE="True"
-    export VLLM_ASCEND_ENABLE_NZ="0"
 
-    vllm serve Qwen/Qwen2.5-0.5B-Instruct --enable-sleep-mode
+    vllm serve Qwen/Qwen2.5-0.5B-Instruct \
+        --enable-sleep-mode \
+        --additional-config='{"weight_nz_mode": 0}'
 
     # after serving is up, post to these endpoints.
     # /sleep reads level from the query string (JSON body is ignored).

--- a/examples/rl/rlhf_async_new_apis.py
+++ b/examples/rl/rlhf_async_new_apis.py
@@ -200,9 +200,6 @@ ray_env_vars = {
     "VLLM_BATCH_INVARIANT": "1",
     "HCCL_DETERMINISTIC": "strict",
     "LCCL_DETERMINISTIC": "1",
-    # Disable FRACTAL_NZ mode (also handled by batch invariance override_envs)
-    "VLLM_ASCEND_ENABLE_NZ": "0",
-    "VLLM_ASCEND_ENABLE_MATMUL_ALLREDUCE": "0",
     # Enable expandable segments for PyTorch NPU allocator
     "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
 }
@@ -220,6 +217,7 @@ llm_kwargs = dict(
     max_model_len=8192,
     distributed_executor_backend="ray",
     gpu_memory_utilization=0.75,
+    additional_config={"weight_nz_mode": 0},
     weight_transfer_config=WeightTransferConfig(backend="hccl"),
 )
 

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8-DCP.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8-DCP.yaml
@@ -6,7 +6,6 @@ test_cases:
   - name: "DeepSeek-V3.2-W8A8-DCP-replicated-indexer"
     model: "vllm-ascend/DeepSeek-V3.2-W8A8"
     envs:
-      VLLM_ASCEND_ENABLE_NZ: "1"
       HCCL_OP_EXPANSION_MODE: "AIV"
       OMP_PROC_BIND: "false"
       OMP_NUM_THREADS: "20"
@@ -61,7 +60,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes":[4, 16, 64, 128]}'
       - "--additional-config"
-      - '{"enable_dsa_cp": true, "ascend_compilation_config":{"enable_npugraph_ex": true, "enable_static_kernel": false}, "multistream_overlap_shared_expert": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false,"enable_fused_mc2":0}'
+      - '{"enable_dsa_cp": true, "ascend_compilation_config":{"enable_npugraph_ex": true, "enable_static_kernel": false}, "multistream_overlap_shared_expert": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": false,"enable_fused_mc2":0,"weight_nz_mode":1}'
       - "--speculative-config"
       - '{"num_speculative_tokens": 3, "method": "deepseek_mtp"}'
     test_content: []

--- a/tests/e2e/nightly/single_node/models/configs/Kimi-K2.5.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Kimi-K2.5.yaml
@@ -11,7 +11,6 @@ _envs: &envs
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
   TASK_QUEUE_ENABLE: "1"
   VLLM_ASCEND_ENABLE_MLAPO: "1"
-  VLLM_ASCEND_ENABLE_NZ: "1"
 
 _server_cmd: &server_cmd
   - "--enable-expert-parallel"
@@ -43,7 +42,7 @@ _server_cmd: &server_cmd
   - "--speculative-config"
   - '{"method":"eagle3", "model":"lightseekorg/kimi-k2.5-eagle3", "num_speculative_tokens":3}'
   - "--additional-config"
-  - '{"enable_shared_expert_dp":true}'
+  - '{"enable_shared_expert_dp":true,"weight_nz_mode":1}'
   - "--mm-processor-cache-gb"
   - "0"
   - "--mm-encoder-tp-mode"

--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A2.yaml
@@ -11,7 +11,6 @@ test_cases:
       PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       VLLM_TORCH_PROFILER_WITH_STACK: "0"
       VLLM_TORCH_PROFILER_DIR: "./profile"
       VLLM_USE_MODELSCOPE: "true"
@@ -50,7 +49,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false},"enable_fused_mc2":1}'
+      - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false},"enable_fused_mc2":1,"weight_nz_mode":1}'
     benchmarks:
       acc:
         case_type: accuracy

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3-VL-235B-A22B-Instruct-W8A8.yaml
@@ -9,7 +9,6 @@ _envs: &envs
   HCCL_OP_EXPANSION_MODE: "AIV"
   HCCL_BUFFSIZE: "1536"
   PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
-  VLLM_ASCEND_ENABLE_NZ: "2"
   SERVER_PORT: "DEFAULT_PORT"
 
 _server_cmd: &server_cmd
@@ -64,6 +63,6 @@ test_cases:
       - "--compilation_config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY", "cudagraph_capture_sizes": [1,2,4,8,16,24,32]}'
       - --additional-config
-      - '{"enable_fused_mc2":1,"scheduler_config":{"enable_balance_scheduling":true}}'
+      - '{"enable_fused_mc2":1,"weight_nz_mode":2,"scheduler_config":{"enable_balance_scheduling":true}}'
     benchmarks:
       <<: *benchmarks

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
@@ -13,7 +13,6 @@ test_cases:
       OMP_NUM_THREADS: "1"
       TASK_QUEUE_ENABLE: "1"
       VLLM_ASCEND_ENABLE_DENSE_OPTIMIZE: "1"
-      VLLM_ASCEND_ENABLE_NZ: "1"
       SERVER_PORT: "DEFAULT_PORT"
     server_cmd:
       - "--tensor-parallel-size"

--- a/tests/e2e/pull_request/one_card/rlhf/conftest.py
+++ b/tests/e2e/pull_request/one_card/rlhf/conftest.py
@@ -93,7 +93,6 @@ def server(
     env = {
         **os.environ,
         "VLLM_SERVER_DEV_MODE": "1",
-        "VLLM_ASCEND_ENABLE_NZ": "0",
         "HF_HUB_OFFLINE": "1",
     }
     base = _DUMMY_ARGS if dummy_weights else _BASE_ARGS
@@ -107,6 +106,8 @@ def server(
         str(port),
         "--served-model-name",
         "m",
+        "--additional-config",
+        '{"weight_nz_mode": 0}',
         *(base + (extra_args or [])),
     ]
     # Establish the test process's NPU device context while the card is still

--- a/tests/e2e/pull_request/one_card/rlhf/state_transitions/test_sleep_wake.py
+++ b/tests/e2e/pull_request/one_card/rlhf/state_transitions/test_sleep_wake.py
@@ -28,7 +28,7 @@ All tests require:
   --enable-sleep-mode   KV cache allocated via CuMemAllocator; without this
                         flag sleep/wake are no-ops and the bug cannot trigger.
   VLLM_SERVER_DEV_MODE=1
-  VLLM_ASCEND_ENABLE_NZ=0
+  --additional-config '{"weight_nz_mode": 0}'
 """
 
 import requests

--- a/tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py
+++ b/tests/e2e/pull_request/one_card/test_npu_ipc_weight_transfer.py
@@ -97,6 +97,8 @@ def test_npu_ipc_weight_transfer_updates_server_weights():
         "--port",
         str(port),
         "--trust-remote-code",
+        "--additional-config",
+        '{"weight_nz_mode": 0}',
     ]
     # VLLM_SERVER_DEV_MODE registers the dev endpoints; insecure serialization
     # lets the server unpickle the IPC handles sent over HTTP. Pin the server to
@@ -105,7 +107,6 @@ def test_npu_ipc_weight_transfer_updates_server_weights():
         "VLLM_SERVER_DEV_MODE": "1",
         "VLLM_ALLOW_INSECURE_SERIALIZATION": "1",
         "ASCEND_RT_VISIBLE_DEVICES": str(INFERENCE_DEVICE_INDEX),
-        "VLLM_ASCEND_ENABLE_NZ": "0",
     }
 
     with RemoteOpenAIServer(

--- a/tests/e2e/pull_request/one_card/test_xlite.py
+++ b/tests/e2e/pull_request/one_card/test_xlite.py
@@ -23,14 +23,10 @@ Run `pytest tests/e2e/pull_request/one_card/test_xlite.py`.
 
 # ruff: noqa: E501
 
-import os
-
 import pytest
 
 from tests.e2e.conftest import wait_until_npu_memory_free
 from tests.e2e.pull_request.utils import PROMPTS_SHORT, compare_logprobs
-
-os.environ["VLLM_ASCEND_ENABLE_NZ"] = "2"
 
 MODELS: list[str] = ["Qwen/Qwen3-0.6B"]
 
@@ -52,7 +48,10 @@ def test_models_with_xlite_decode_only(model: str):
         "model_name": model,
         "max_model_len": 1024,
         "block_size": 128,
-        "additional_config": {"xlite_graph_config": {"enabled": True, "full_mode": False}},
+        "additional_config": {
+            "weight_nz_mode": 2,
+            "xlite_graph_config": {"enabled": True, "full_mode": False},
+        },
     }
     compare_logprobs(runner_kwargs=runner_kwargs, prompts=PROMPTS_SHORT)
 
@@ -74,6 +73,9 @@ def test_models_with_xlite_full_mode(model: str):
         "model_name": model,
         "max_model_len": 1024,
         "block_size": 128,
-        "additional_config": {"xlite_graph_config": {"enabled": True, "full_mode": True}},
+        "additional_config": {
+            "weight_nz_mode": 2,
+            "xlite_graph_config": {"enabled": True, "full_mode": True},
+        },
     }
     compare_logprobs(runner_kwargs=runner_kwargs, prompts=PROMPTS_SHORT)

--- a/tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py
+++ b/tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py
@@ -188,6 +188,8 @@ def test_hccl_weight_transfer_updates_server_weights():
         "--port",
         str(port),
         "--trust-remote-code",
+        "--additional-config",
+        '{"weight_nz_mode": 0}',
     ]
     # The dev-mode endpoints (/init_weight_transfer_engine, /update_weights,
     # /pause, /resume, ...) are only registered when VLLM_SERVER_DEV_MODE=1.
@@ -195,7 +197,6 @@ def test_hccl_weight_transfer_updates_server_weights():
     env_dict = {
         "VLLM_SERVER_DEV_MODE": "1",
         "ASCEND_RT_VISIBLE_DEVICES": "0",
-        "VLLM_ASCEND_ENABLE_NZ": "0",
     }
 
     _log(f"starting server on port {port} (device 0, dummy weights) ...")

--- a/tests/e2e/pull_request/two_card/test_xlite.py
+++ b/tests/e2e/pull_request/two_card/test_xlite.py
@@ -28,8 +28,6 @@ import pytest
 from tests.e2e.conftest import DPVllmRunner, VllmRunner, wait_until_npu_memory_free
 from tests.e2e.pull_request.utils import PROMPTS_SHORT
 
-os.environ["VLLM_ASCEND_ENABLE_NZ"] = "2"
-
 MODELS: list[str] = ["Qwen/Qwen3-30B-A3B"]
 TPDP_SIZES: list[tuple[int, int]] = [(2, 1), (1, 2)]
 
@@ -58,7 +56,10 @@ def test_models_with_xlite_decode_only(model: str, tpdp: tuple[int, int]):
         enable_expert_parallel=True,
         block_size=128,
         max_model_len=2048,
-        additional_config={"xlite_graph_config": {"enabled": True, "full_mode": False}},
+        additional_config={
+            "weight_nz_mode": 2,
+            "xlite_graph_config": {"enabled": True, "full_mode": False},
+        },
     ) as vllm_model:
         outputs = vllm_model.generate_greedy(PROMPTS_SHORT, 3)
 
@@ -89,7 +90,10 @@ def test_models_with_xlite_full_mode(model: str, tpdp: tuple[int, int]):
         enable_expert_parallel=True,
         block_size=128,
         max_model_len=2048,
-        additional_config={"xlite_graph_config": {"enabled": True, "full_mode": True}},
+        additional_config={
+            "weight_nz_mode": 2,
+            "xlite_graph_config": {"enabled": True, "full_mode": True},
+        },
     ) as vllm_model:
         outputs = vllm_model.generate_greedy(PROMPTS_SHORT, 3)
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W4A8C8-1M-PD-DCP.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W4A8C8-1M-PD-DCP.yaml
@@ -50,7 +50,6 @@ env_common: &env_common
   VLLM_USE_MODELSCOPE: "true"
   SERVER_PORT: "${PORT}"
   ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
-  VLLM_ASCEND_ENABLE_NZ: "1"
   HCCL_OP_EXPANSION_MODE: "AIV"
   OMP_PROC_BIND: "false"
   OMP_NUM_THREADS: "20"
@@ -109,7 +108,7 @@ templates:
       - "128"
       - --enforce-eager
       - --additional-config
-      - '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}'
+      - '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true, "weight_nz_mode": 1}'
       - --speculative-config
       - '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}'
       - --quantization
@@ -165,7 +164,7 @@ templates:
       - "128"
       - --enforce-eager
       - --additional-config
-      - '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true}'
+      - '{"enable_flashcomm1": true, "enable_dsa_cp": true, "ascend_compilation_config": {"enable_npugraph_ex": true}, "multistream_overlap_shared_expert": true, "enable_sparse_li_c8": true, "enable_cpu_binding": true, "recompute_scheduler_enable": true, "weight_nz_mode": 1}'
       - --speculative-config
       - '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}'
       - --quantization

--- a/tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
+++ b/tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
@@ -85,7 +85,6 @@ async def test_models(model: str, tp_size: int) -> None:
         "HCCL_BUFFSIZE": "1024",
         "OMP_NUM_THREADS": "1",
         "PYTORCH_NPU_ALLOC_CONF": "expandable_segments:True",
-        "VLLM_ASCEND_ENABLE_NZ": "2",
         "MOONCAKE_CONFIG_PATH": "mooncake.json",
     }
     kv_transfer_config = {

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -505,11 +505,10 @@ class TestAscendConfig(TestBase):
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
     def test_weight_nz_mode_ignores_removed_env(self, mock_fix_incompatible_config):
         test_vllm_config = VllmConfig()
-        test_vllm_config.additional_config = {"weight_nz_mode": 2}
         with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"}):
             ascend_config = init_ascend_config(test_vllm_config)
 
-        self.assertEqual(ascend_config.weight_nz_mode, 2)
+        self.assertEqual(ascend_config.weight_nz_mode, 1)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.ascend_config.logger.warning")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -489,7 +489,6 @@ class TestAscendConfig(TestBase):
         self.assertTrue(ascend_config.enable_transpose_kv_cache_by_block)
         self.assertEqual(ascend_config.weight_nz_mode, 1)
         mock_info_once.assert_any_call("AscendConfig.enable_mlapo is set from additional_config with value True.")
-        mock_info_once.assert_any_call("AscendConfig.weight_nz_mode is set from additional_config with value 1.")
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -186,6 +186,7 @@ class TestAscendConfig(TestBase):
         ascend_config = init_ascend_config(test_vllm_config)
         self.assertFalse(ascend_config.multistream_overlap_shared_expert)
         self.assertFalse(ascend_config.enable_kv_nz)
+        self.assertEqual(ascend_config.weight_nz_mode, 1)
 
         ascend_compilation_config = ascend_config.ascend_compilation_config
         self.assertTrue(ascend_compilation_config.fuse_norm_quant)
@@ -204,7 +205,7 @@ class TestAscendConfig(TestBase):
 
             self.assertTrue(ascend_config.rl_config.enabled)
             self.assertEqual(ascend_config.weight_nz_mode, 0)
-            self.assertEqual(os.environ["VLLM_ASCEND_ENABLE_NZ"], "0")
+            self.assertNotIn("VLLM_ASCEND_ENABLE_NZ", os.environ)
             self.assertEqual(os.environ["VLLM_SERVER_DEV_MODE"], "1")
 
     @_clean_up_ascend_config
@@ -433,7 +434,6 @@ class TestAscendConfig(TestBase):
             os.environ,
             {
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",
-                "VLLM_ASCEND_ENABLE_NZ": "2",
             },
         ):
             ascend_config = init_ascend_config(test_vllm_config)
@@ -441,16 +441,11 @@ class TestAscendConfig(TestBase):
         self.assertEqual(ascend_config.enable_fused_mc2, 0)
         self.assertFalse(ascend_config.enable_mlapo)
         self.assertTrue(ascend_config.enable_transpose_kv_cache_by_block)
-        self.assertEqual(ascend_config.weight_nz_mode, 2)
+        self.assertEqual(ascend_config.weight_nz_mode, 1)
         mock_info_once.assert_any_call(
             "AscendConfig.enable_mlapo falls back to environment variable VLLM_ASCEND_ENABLE_MLAPO with value False. "
             "Please use additional_config.enable_mlapo instead, because VLLM_ASCEND_ENABLE_MLAPO will be "
             "removed in the next release."
-        )
-        mock_info_once.assert_any_call(
-            "AscendConfig.weight_nz_mode falls back to environment variable VLLM_ASCEND_ENABLE_NZ with value 2. "
-            "Please use additional_config.weight_nz_mode instead, because VLLM_ASCEND_ENABLE_NZ will be removed "
-            "in the next release."
         )
 
     @_clean_up_ascend_config
@@ -484,7 +479,6 @@ class TestAscendConfig(TestBase):
             os.environ,
             {
                 "VLLM_ASCEND_ENABLE_MLAPO": "0",
-                "VLLM_ASCEND_ENABLE_NZ": "2",
             },
         ):
             ascend_config = init_ascend_config(test_vllm_config)
@@ -506,6 +500,16 @@ class TestAscendConfig(TestBase):
         ascend_config = init_ascend_config(test_vllm_config)
 
         self.assertTrue(ascend_config.msmonitor_use_daemon)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_weight_nz_mode_ignores_removed_env(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {"weight_nz_mode": 2}
+        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"}):
+            ascend_config = init_ascend_config(test_vllm_config)
+
+        self.assertEqual(ascend_config.weight_nz_mode, 2)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.ascend_config.logger.warning")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -502,15 +502,6 @@ class TestAscendConfig(TestBase):
         self.assertTrue(ascend_config.msmonitor_use_daemon)
 
     @_clean_up_ascend_config
-    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
-    def test_weight_nz_mode_ignores_removed_env(self, mock_fix_incompatible_config):
-        test_vllm_config = VllmConfig()
-        with patch.dict(os.environ, {"VLLM_ASCEND_ENABLE_NZ": "0"}):
-            ascend_config = init_ascend_config(test_vllm_config)
-
-        self.assertEqual(ascend_config.weight_nz_mode, 1)
-
-    @_clean_up_ascend_config
     @patch("vllm_ascend.ascend_config.logger.warning")
     def test_flashcomm_config_warns(self, mock_warning):
         test_vllm_config = VllmConfig()

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -1786,10 +1786,7 @@ class TestNPUWorkerWeightUpdate(TestBase):
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
 
-        # The runtime AscendConfig is authoritative even when the deprecated
-        # environment variable still carries a stale import-time value.
-        with patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "1"}):
-            worker.start_weight_update()
+        worker.start_weight_update()
 
         engine.start_weight_update.assert_called_once_with()
         self.assertTrue(worker._weight_update_active)
@@ -1810,10 +1807,7 @@ class TestNPUWorkerWeightUpdate(TestBase):
         engine = MagicMock()
         worker = self._make_worker(engine=engine)
 
-        with (
-            patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"}),
-            self.assertRaises(ValueError),
-        ):
+        with self.assertRaises(ValueError):
             worker.start_weight_update()
 
     def test_update_weights_requires_start(self):
@@ -1822,7 +1816,6 @@ class TestNPUWorkerWeightUpdate(TestBase):
         with self.assertRaises(RuntimeError):
             worker.update_weights({"names": [], "dtype_names": [], "shapes": []})
 
-    @patch.dict("os.environ", {"VLLM_ASCEND_ENABLE_NZ": "0"})
     def test_update_weights_dispatches_to_engine(self):
         engine = MagicMock()
         worker = self._make_worker(engine=engine)

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -196,7 +196,6 @@ class RlConfig:
                 ascend_config.weight_nz_mode,
             )
         ascend_config.weight_nz_mode = 0
-        os.environ["VLLM_ASCEND_ENABLE_NZ"] = "0"
 
         from vllm_ascend.platform import _disable_expandable_segments
 
@@ -307,7 +306,6 @@ class AscendConfig:
 
         _A_FAMILY = {
             "enable_mlapo": "VLLM_ASCEND_ENABLE_MLAPO",
-            "weight_nz_mode": "VLLM_ASCEND_ENABLE_NZ",
         }
         for key, env_name in _A_FAMILY.items():
             if key in kw:

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -72,12 +72,6 @@ env_variables: dict[str, Callable[[], Any]] = {
     # for your DeepSeek W8A8 scene, then disable it.
     # DEPRECATED: use additional_config.enable_mlapo instead.
     "VLLM_ASCEND_ENABLE_MLAPO": lambda: bool(int(os.getenv("VLLM_ASCEND_ENABLE_MLAPO", "1"))),
-    # Whether to enable weight cast format to FRACTAL_NZ.
-    # 0: close nz;
-    # 1: only quant case enable nz;
-    # 2: enable nz as long as possible.
-    # DEPRECATED: use additional_config.weight_nz_mode instead.
-    "VLLM_ASCEND_ENABLE_NZ": lambda: int(os.getenv("VLLM_ASCEND_ENABLE_NZ", 1)),
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.

--- a/vllm_ascend/utils.py
+++ b/vllm_ascend/utils.py
@@ -277,7 +277,7 @@ def _should_trans_nz(weight: torch.Tensor) -> bool:
 
 # NZ conversion policy:
 # - 310P: always convert supported weights to FRACTAL_NZ
-# - non-310P: follow VLLM_ASCEND_ENABLE_NZ
+# - non-310P: follow additional_config.weight_nz_mode
 # - FP32: never convert
 # - meta tensor: never convert
 def maybe_trans_nz(weight: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
### What this PR does / why we need it?

Removes the legacy `VLLM_ASCEND_ENABLE_NZ` environment variable after its behavior was migrated to `additional_config.weight_nz_mode`. Runtime code, deployment examples, test configurations, and documentation are migrated to the config field where applicable.

This is one independently reviewable part of the seven-variable split of #14637.

### Does this PR introduce _any_ user-facing change?

Yes. `VLLM_ASCEND_ENABLE_NZ` is no longer read. Users must configure the behavior with `--additional-config '{"weight_nz_mode":1}'`.

### How was this patch tested?

- `ruff check` and `ruff format --check` on changed Python files
- Python byte-compilation of changed Python files
- YAML parsing of changed YAML files
- JSON parsing of concrete `additional-config` payloads
- Scan confirming no active references to `VLLM_ASCEND_ENABLE_NZ` remain outside migration documentation
- NPU end-to-end tests were not run in this Windows environment

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
