### PR TITLE
[Feature][MLA] Support Kimi K3 attention

### DIFF
--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -2194,6 +2194,49 @@ class TestAscendMLAImpl(TestBase):
         self.assertIsNotNone(decode_res)
         self.assertIsNotNone(prefill_res)
 
+    @patch("vllm_ascend.attention.mla_v1.DeviceOperator.reshape_and_cache")
+    @patch("torch_npu.npu_interleave_rope")
+    @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
+    def test_mla_preprocess_prefill_without_rope(self, mock_rope_cache, mock_rope, mock_cache):
+        self.impl.use_mla_rope = False
+        self.impl.num_heads = self.impl.num_kv_heads = 1
+        self.impl.qk_nope_head_dim = self.impl.qk_rope_head_dim = 2
+        self.impl.qk_head_dim = 4
+        self.impl.kv_lora_rank = self.impl.v_head_dim = 2
+        self.impl.q_proj.side_effect = lambda x: (x,)
+        self.impl.kv_a_layernorm = torch.nn.Identity()
+        self.impl.kv_b_proj.side_effect = lambda x: (torch.cat((x, x), dim=-1),)
+
+        q_c = torch.arange(16, dtype=torch.float32).view(4, 4)
+        kv_no_split = q_c + 100
+        kv_cache = (torch.empty(4, 1, 2), torch.empty(4, 1, 2))
+        for num_decode_tokens in (0, 1):
+            with self.subTest(num_decode_tokens=num_decode_tokens):
+                num_actual_tokens = num_decode_tokens + 2
+                metadata = SimpleNamespace(
+                    num_decode_tokens=num_decode_tokens,
+                    num_actual_tokens=num_actual_tokens,
+                    slot_mapping=torch.arange(4),
+                    prefill=SimpleNamespace(cos=None, sin=None),
+                )
+                result = self.impl.mla_preprocess_prefill(q_c, kv_no_split, kv_cache, metadata)
+
+                q = q_c[num_decode_tokens:num_actual_tokens].unsqueeze(1)
+                kv = kv_no_split[num_decode_tokens:num_actual_tokens].unsqueeze(1)
+                torch.testing.assert_close(result.q_nope, q[..., :2])
+                torch.testing.assert_close(result.q_pe, q[..., 2:])
+                torch.testing.assert_close(result.k_nope, kv[..., :2])
+                torch.testing.assert_close(result.k_pe, kv[..., 2:])
+                torch.testing.assert_close(result.value, kv[..., :2])
+                torch.testing.assert_close(mock_cache.call_args.kwargs["key"], kv[..., :2])
+                torch.testing.assert_close(mock_cache.call_args.kwargs["value"], kv[..., 2:])
+                torch.testing.assert_close(
+                    mock_cache.call_args.kwargs["slot_mapping"],
+                    metadata.slot_mapping[num_decode_tokens:num_actual_tokens],
+                )
+        mock_rope.assert_not_called()
+        mock_rope_cache.assert_not_called()
+
     @patch("torch_npu.npu_kv_rmsnorm_rope_cache")
     def test_exec_kv_prefill(self, mock_kv_rmsnorm_rope_cache):
         B = 2

--- a/tests/ut/attention/a2/test_mla_v1.py
+++ b/tests/ut/attention/a2/test_mla_v1.py
@@ -426,6 +426,7 @@ class TestAscendMLAMetadata(TestBase):
         self.assertEqual(metadata.head_dim, head_dim)
         self.assertEqual(metadata.attn_mask, attn_mask)
         self.assertEqual(metadata.attn_state, attn_state)
+        self.assertTrue(metadata.causal)
         self.assertEqual(metadata.decode, decode)
         self.assertEqual(metadata.prefill, prefill)
 
@@ -463,6 +464,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
+        mock_vllm_config.model_config.hf_text_config.mla_use_nope = False
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.enable_chunked_prefill = False
@@ -472,10 +474,74 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
         ascend_config = MagicMock()
         with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+            builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
 
             self.assertEqual(builder.block_size, mock_vllm_config.cache_config.block_size)
             self.assertEqual(builder.chunked_prefill_enabled, mock_vllm_config.scheduler_config.enable_chunked_prefill)
+
+    def test_metadata_builder_uses_draft_layer_rope_mode(self):
+        mock_vllm_config = MagicMock()
+        mock_vllm_config.model_config.max_model_len = 1024
+        mock_vllm_config.model_config.get_head_size.return_value = 64
+        mock_vllm_config.model_config.dtype = torch.float16
+        mock_vllm_config.model_config.hf_text_config = SimpleNamespace(
+            qk_rope_head_dim=64,
+            mla_use_nope=True,
+        )
+        mock_vllm_config.cache_config.block_size = 16
+        mock_vllm_config.scheduler_config.max_num_seqs = 4
+        mock_vllm_config.scheduler_config.enable_chunked_prefill = False
+        mock_vllm_config.speculative_config = None
+        mock_vllm_config.compilation_config.static_forward_context = {
+            "draft.self_attn": SimpleNamespace(
+                impl=SimpleNamespace(use_mla_rope=True),
+            ),
+        }
+
+        with patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_config",
+            return_value=MagicMock(),
+        ):
+            builder = AscendMLAMetadataBuilder(
+                None,
+                ["draft.self_attn"],
+                mock_vllm_config,
+                "cpu",
+            )
+
+        self.assertTrue(builder.use_mla_rope)
+
+    def test_metadata_builder_uses_target_layer_nope_mode(self):
+        mock_vllm_config = MagicMock()
+        mock_vllm_config.model_config.max_model_len = 1024
+        mock_vllm_config.model_config.get_head_size.return_value = 64
+        mock_vllm_config.model_config.dtype = torch.float16
+        mock_vllm_config.model_config.hf_text_config = SimpleNamespace(
+            qk_rope_head_dim=64,
+            mla_use_nope=False,
+        )
+        mock_vllm_config.cache_config.block_size = 16
+        mock_vllm_config.scheduler_config.max_num_seqs = 4
+        mock_vllm_config.scheduler_config.enable_chunked_prefill = False
+        mock_vllm_config.speculative_config = None
+        mock_vllm_config.compilation_config.static_forward_context = {
+            "target.self_attn": SimpleNamespace(
+                impl=SimpleNamespace(use_mla_rope=False),
+            ),
+        }
+
+        with patch(
+            "vllm_ascend.attention.mla_v1.get_ascend_config",
+            return_value=MagicMock(),
+        ):
+            builder = AscendMLAMetadataBuilder(
+                None,
+                ["target.self_attn"],
+                mock_vllm_config,
+                "cpu",
+            )
+
+        self.assertFalse(builder.use_mla_rope)
 
     def test_ascend_mla_metadata_builder_spec_decode(self):
         mock_vllm_config = MagicMock()
@@ -494,7 +560,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
         ascend_config = MagicMock()
         with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+            builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
 
             self.assertEqual(builder.block_size, mock_vllm_config.cache_config.block_size)
             self.assertEqual(builder.chunked_prefill_enabled, mock_vllm_config.scheduler_config.enable_chunked_prefill)
@@ -506,6 +572,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.model_config.get_head_size.return_value = 64
         mock_vllm_config.model_config.dtype = torch.float16
         mock_vllm_config.model_config.hf_text_config.qk_rope_head_dim = 64
+        mock_vllm_config.model_config.hf_text_config.mla_use_nope = False
         mock_vllm_config.cache_config.block_size = 16
         mock_vllm_config.scheduler_config.max_num_seqs = 4
         mock_vllm_config.scheduler_config.chunked_prefill_enabled = False
@@ -520,7 +587,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_spec_config.disable_padded_drafter_batch = True
         mock_vllm_config.speculative_config = mock_spec_config
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
         common_metadata = MagicMock()
         common_metadata.graph_pad_size = 8
         common_metadata.num_reqs = 4
@@ -531,10 +598,12 @@ class TestAscendMLAMetadataBuilder(TestBase):
         common_metadata.query_start_loc = torch.Tensor([0, 1, 2, 4, 5]).int()
         common_metadata.query_start_loc_cpu = torch.Tensor([0, 1, 2, 4, 5]).int()
         common_metadata.positions = torch.Tensor([1, 2, 3, 4, 5, 6]).int()
+        common_metadata.causal = False
         block_table = torch.Tensor([[1, 0], [2, 0], [3, 0], [4, 0]]).int()
         common_metadata.block_table_tensor = block_table
         mock_get_cos_and_sin_mla.return_value = (torch.tensor([6, 6]), torch.Tensor([6, 6]))
         metadata = builder.build(0, common_metadata)
+        self.assertFalse(metadata.causal)
 
         self.assertEqual(metadata.decode.actual_seq_lengths_q, [1, 2, 4, 5, 6, 6, 7, 8])
         self.assertEqual(metadata.decode.block_table.shape[0], 8)
@@ -555,7 +624,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_vllm_config.speculative_config = None
 
         with patch("vllm_ascend.attention.mla_v1.get_ascend_config", return_value=ascend_config):
-            builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+            builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
             builder.decode_threshold = 1
 
         input_batch = MagicMock()
@@ -606,7 +675,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
 
         mock_vllm_config.speculative_config = None
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
         common_attn_metadata = MagicMock()
         common_attn_metadata.num_actual_tokens = 100
 
@@ -626,7 +695,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         mock_device = "cpu"
         mock_vllm_config.speculative_config = None
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
         input_seq_lens = [1, 2, 4, 5]
         expect_output = [1, 2, 4, 5, 6, 6, 7, 8]
         num_reqs = 4
@@ -650,7 +719,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         common_metadata = MagicMock()
         common_metadata.actual_seq_lengths_q = [2, 4, 6, 8]
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
         input_seq_lens = [2, 4, 6]
         expect_output = [2, 4, 6, 8]
         num_reqs = 3
@@ -676,7 +745,7 @@ class TestAscendMLAMetadataBuilder(TestBase):
         common_metadata = MagicMock()
         common_metadata.actual_seq_lengths_q = [2, 4, 6, 100]
 
-        builder = AscendMLAMetadataBuilder(None, None, mock_vllm_config, mock_device)
+        builder = AscendMLAMetadataBuilder(None, [], mock_vllm_config, mock_device)
         input_seq_lens = [2, 4, 6]
         num_reqs = 3
         num_reqs_pad_size = 1
@@ -1122,6 +1191,8 @@ class TestAscendMLAImpl(TestBase):
             "fused_qkv_a_proj": MagicMock(),
             "kv_a_layernorm": kv_a_layernorm,
             "rotary_emb": MagicMock(),
+            "g_proj": None,
+            "use_mla_rope": True,
         }
 
         self.impl = AscendMLAImpl(
@@ -1180,6 +1251,8 @@ class TestAscendMLAImpl(TestBase):
             "fused_qkv_a_proj": MagicMock(),
             "kv_a_layernorm": MagicMock(),
             "rotary_emb": MagicMock(),
+            "g_proj": None,
+            "use_mla_rope": True,
         }
         impl = AscendMLAImpl(
             num_heads=20,
@@ -1296,7 +1369,6 @@ class TestAscendMLAImpl(TestBase):
         mock_attn_metadata.decode.seq_lens_list = [10, 20, 30]
         mock_attn_metadata.decode.actual_seq_lengths_q = [10, 20, 30]
         mock_attn_metadata.decode.block_table = torch.randint(0, 100, (3, 4))
-
         mock_graph_params = MagicMock()
 
         mock_graph_params.attn_params = {
@@ -1338,13 +1410,14 @@ class TestAscendMLAImpl(TestBase):
         mock_speculative_config = MagicMock()
         mock_speculative_config.disable_padded_drafter_batch = False
 
-        # Test non-draft model
-        mock_ctx.is_draft_model = False
+        mock_ctx.is_draft_model = True
+        mock_ctx.is_draft_model_prefill = False
         AscendMLAImpl.update_graph_params(
             mock_update_stream,
             mock_forward_context,
             100,
             speculative_config=mock_speculative_config,
+            draft_attn_metadatas=[{"layer_0": mock_attn_metadata}],
         )
 
     @patch("vllm_ascend.ascend_forward_context.get_forward_context")
@@ -1541,6 +1614,8 @@ class TestAscendMLAImpl(TestBase):
         self.impl.q_proj.weight.data = torch.randn(128, 128)
         self.impl.q_proj.weight_scale.data = torch.randn(128, 128, 128)
         self.impl.q_lora_rank = 32
+        self.impl._mlapo_quant_type = object
+        self.impl._mlapo_uses_native_weights = False
 
         from vllm_ascend.attention.mla_v1 import AscendDeviceType
 
@@ -1626,6 +1701,8 @@ class TestAscendMLAImpl(TestBase):
             "fused_qkv_a_proj": MagicMock(),
             "kv_a_layernorm": MagicMock(),
             "rotary_emb": MagicMock(),
+            "g_proj": None,
+            "use_mla_rope": True,
         }
         impl = AscendMLAImpl(
             num_heads=num_heads,
@@ -1972,6 +2049,8 @@ class TestAscendMLAImpl(TestBase):
             "fused_qkv_a_proj": MagicMock(),
             "kv_a_layernorm": MagicMock(),
             "rotary_emb": MagicMock(),
+            "g_proj": None,
+            "use_mla_rope": True,
         }
         impl = AscendMLAImpl(
             num_heads=num_heads,
@@ -2251,6 +2330,8 @@ class TestAscendMLAImpl(TestBase):
             "fused_qkv_a_proj": MagicMock(),
             "kv_a_layernorm": MagicMock(),
             "rotary_emb": MagicMock(),
+            "g_proj": None,
+            "use_mla_rope": True,
         }
         impl = AscendMLAImpl(
             num_heads=num_heads,
@@ -2325,6 +2406,8 @@ class TestAscendMLAImpl(TestBase):
             "fused_qkv_a_proj": MagicMock(),
             "kv_a_layernorm": MagicMock(),
             "rotary_emb": MagicMock(),
+            "g_proj": None,
+            "use_mla_rope": True,
         }
         impl = AscendMLAImpl(
             num_heads=num_heads,

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -76,6 +76,13 @@ BUILD_METADATA_STEP_DECODE = 1
 MLAPO_MAX_SUPPORTED_TOKENS = 1024
 
 
+def _npu_mla_prolog_v3_no_rope(**kwargs):
+    """Call the AscendC MLA prolog with optional RoPE inputs omitted."""
+    import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401, PLC0415
+
+    return torch.ops._C_ascend.npu_mla_prolog_v3(**kwargs)
+
+
 class AscendMLABackend(AttentionBackend):
     accept_output_buffer: bool = True
 
@@ -217,6 +224,7 @@ class AscendMLAMetadata:
     attn_mask: torch.Tensor = None
     # chunked prefill by default if no attn_states passed
     attn_state: AscendAttentionState = AscendAttentionState.ChunkedPrefill
+    causal: bool = True
 
     decode: AscendMLADecodeMetadata | None = None
     prefill: AscendMLAPrefillMetadata | None = None
@@ -289,6 +297,9 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
 
         self.reorder_batch_threshold = self.decode_threshold
         self.rope_dim = self.model_config.hf_text_config.qk_rope_head_dim
+        static_forward_context = vllm_config.compilation_config.static_forward_context
+        # MLA layers are grouped by RoPE mode before metadata builders are created.
+        self.use_mla_rope = static_forward_context[layer_names[0]].impl.use_mla_rope if layer_names else True
         self.cos_cache = None
         self.sin_cache = None
 
@@ -473,8 +484,8 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
 
         query_seq_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         self.query_lens = query_seq_lens_cpu[:num_reqs]
-        # Prefer _seq_lens_cpu (always available, updated during draft
-        # iterations) over seq_lens_cpu (None in async spec decode mode).
+        # Prefer _seq_lens_cpu, which remains populated in async speculative
+        # decode, over seq_lens_cpu, which is intentionally None in that mode.
         if common_attn_metadata._seq_lens_cpu is not None:
             self.seq_lens = common_attn_metadata._seq_lens_cpu[:num_reqs]
         elif common_attn_metadata.seq_lens_cpu is not None:
@@ -504,6 +515,7 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             num_prefills=self.num_prefills,
             attn_mask=self.attn_mask_builder.get_splitfuse_attn_mask(),
             attn_state=common_attn_metadata.attn_state,
+            causal=common_attn_metadata.causal,
             prefill=prefill_metadata,
             decode=decode_metadata,
             query_start_loc=query_start_loc,
@@ -588,7 +600,10 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
         prefill_query_start_loc = query_start_loc[reqs_start:] - query_start_loc[reqs_start]
 
         prefill_input_positions = input_positions[tokens_start:]
-        cos, sin = get_cos_and_sin_mla(prefill_input_positions)
+        if self.use_mla_rope:
+            cos, sin = get_cos_and_sin_mla(prefill_input_positions)
+        else:
+            cos = sin = None
         prefill_query_lens = self.query_lens[reqs_start:].to(torch.int32)
         actual_seq_lengths_q = torch.cumsum(prefill_query_lens, dim=0).tolist()
         return AscendMLAPrefillMetadata(
@@ -672,7 +687,12 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
                     num_reqs_pad_size, num_reqs, actual_seq_lengths_q, common_attn_metadata
                 )
 
-        cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
+        if self.use_mla_rope:
+            cos, sin = get_cos_and_sin_mla(input_positions, use_cache=True)
+            cos = cos[: self.num_decode_tokens, ...]
+            sin = sin[: self.num_decode_tokens, ...]
+        else:
+            cos = sin = None
         decode_metadata = self.decode_metadata_cls(
             input_positions=input_positions,
             block_table=self.block_table,
@@ -681,8 +701,8 @@ class AscendMLAMetadataBuilder(MLACommonMetadataBuilder[AscendMLAMetadata]):
             max_seq_lens=max_seq_lens,
             attn_mask=self.attn_mask_builder.get_splitfuse_attn_mask(),
             actual_seq_lengths_q=actual_seq_lengths_q,
-            sin=sin[: self.num_decode_tokens, ...],
-            cos=cos[: self.num_decode_tokens, ...],
+            sin=sin,
+            cos=cos,
         )
         return decode_metadata
 
@@ -826,6 +846,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         self.q_proj = kwargs["q_proj"] if self.q_lora_rank is None else kwargs["q_b_proj"]
         self.kv_b_proj = kwargs["kv_b_proj"]
         self.o_proj = kwargs["o_proj"]
+        self.g_proj = kwargs.get("g_proj")
+        self.use_output_gate = self.g_proj is not None
+        self.use_mla_rope = kwargs.get("use_mla_rope", True)
         self.vllm_config = get_current_vllm_config()
         self.kv_a_proj_with_mqa = kwargs.get("kv_a_proj_with_mqa")
         self.kv_a_layernorm = kwargs.get("kv_a_layernorm")
@@ -851,6 +874,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         # next power of 2.
         self.num_heads_padded = 1 << (self.num_heads - 1).bit_length()
         self.head_padding = self.num_heads_padded - self.num_heads
+        self.mlapo_num_heads = self.num_heads
+        self.mlapo_weight_quant_mode = 3
+        self._mlapo_uses_native_weights = False
 
     @staticmethod
     def update_graph_params(
@@ -914,15 +940,16 @@ class AscendMLAImpl(MLAAttentionImpl):
                 else:
                     attn_metadata_current = attn_metadata
 
-                seq_lens_list = attn_metadata_current[key].decode.seq_lens_list
+                layer_metadata = attn_metadata_current[key]
+                seq_lens_list = layer_metadata.decode.seq_lens_list
                 if speculative_config and speculative_config.use_eagle() and not _EXTRA_CTX.is_draft_model:
-                    actual_seq_lengths = attn_metadata_current[key].decode.actual_seq_lengths_q
+                    actual_seq_lengths = layer_metadata.decode.actual_seq_lengths_q
                     spec_multiple = speculative_config.num_speculative_tokens + 1
                     seq_lens_list = seq_lens_list + [0] * (num_tokens // spec_multiple - len(seq_lens_list))
                     actual_seq_lengths = [spec_multiple * (i + 1) for i in range(num_tokens // spec_multiple)]
                 elif _EXTRA_CTX.is_draft_model:
-                    actual_seq_lengths = attn_metadata_current[key].decode.actual_seq_lengths_q
-                    block_table = attn_metadata_current[key].decode.block_table
+                    actual_seq_lengths = layer_metadata.decode.actual_seq_lengths_q
+                    block_table = layer_metadata.decode.block_table
                     # TODO: This is a hack and should be fixed in the future.
                     if speculative_config.disable_padded_drafter_batch:
                         block_table = block_table[: len(actual_seq_lengths)]
@@ -1038,26 +1065,36 @@ class AscendMLAImpl(MLAAttentionImpl):
         else:
             self.W_UV.copy_(W_UV.transpose(0, 1).contiguous())
             self.W_UK_T.copy_(W_UK.permute(1, 2, 0).contiguous())
+        self.mlapo_W_UK_T = self.W_UK_T
 
         # TODO(zzzzwwjj): Currently, torch.ops._C_ascend.batch_matmul_transpose cannot support weight nz
         # self.W_UV = maybe_trans_nz(self.W_UV)
 
         if self.enable_mlapo:
-            # Currently mlapo only supports W8A8 and W8A8MXFP8 quantization in MLA scenario
-            # TODO(whx): modify this limitation when mlapo supports floating point
-            if self.fused_qkv_a_proj is None or (
-                not isinstance(
-                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None), AscendW8A8LinearMethod
-                )
-                and not isinstance(
-                    getattr(self.fused_qkv_a_proj.quant_method, "quant_method", None),
-                    AscendW8A8MXFP8DynamicLinearMethod,
-                )
-            ):
+            device_type = get_ascend_device_type()
+            layer_quant_method = None if self.fused_qkv_a_proj is None else self.fused_qkv_a_proj.quant_method
+            if layer_quant_method is None or isinstance(layer_quant_method, UnquantizedLinearMethod):
+                quant_method = None
+            else:
+                # Quantized Ascend linears always expose their concrete scheme
+                # through AscendLinearMethod.quant_method. Let an unsupported
+                # wrapper fail here instead of silently disabling MLAPO.
+                quant_method = layer_quant_method.quant_method
+            self._mlapo_uses_native_weights = quant_method is None
+            supports_quantized_weights = isinstance(
+                quant_method,
+                (AscendW8A8LinearMethod, AscendW8A8MXFP8DynamicLinearMethod),
+            )
+            supports_native_weights = device_type == AscendDeviceType.A5 and isinstance(
+                layer_quant_method,
+                UnquantizedLinearMethod,
+            )
+            if self.fused_qkv_a_proj is None or not (supports_quantized_weights or supports_native_weights):
                 self.enable_mlapo = False
                 logger.warning_once(
-                    "mlapo only supports W8A8 quantization in MLA. "
-                    "Some layers not W8A8 quantized, mlapo disabled for these layers."
+                    "MLAPO supports W8A8/W8A8-MXFP8 weights, plus native "
+                    "floating-point weights on A5. Some layers use an "
+                    "unsupported weight type, so MLAPO is disabled for these layers."
                 )
         if self.enable_mlapo or self.fa_quant_layer:
             self._process_weights_for_fused(act_dtype)
@@ -1076,18 +1113,41 @@ class AscendMLAImpl(MLAAttentionImpl):
             self._load_fa_quant_scales()
 
         assert self.q_proj is not None
-        assert hasattr(self.q_proj, "weight_scale")
-        assert hasattr(self.fused_qkv_a_proj, "weight_scale")
         assert self.fused_qkv_a_proj is not None
 
-        self.weight_dq = self.fused_qkv_a_proj.weight.data[..., : self.q_lora_rank].contiguous()  # type: ignore[union-attr]
-        self.weight_dkv_kr = self.fused_qkv_a_proj.weight.data[..., self.q_lora_rank :].contiguous()  # type: ignore[union-attr]
-        self.weight_uq_qr = self.q_proj.weight.data
+        is_native = self._mlapo_uses_native_weights
+        fused_weight = self.fused_qkv_a_proj.weight.data
+        weight_uq_qr = self.q_proj.weight.data
+        if is_native:
+            # Native Linear stores [out_features, in_features], while the
+            # prolog consumes [in_features, out_features].
+            fused_weight = fused_weight.T
+            weight_uq_qr = weight_uq_qr.T.contiguous()
+            if self.head_padding > 0:
+                weight_uq_qr = weight_uq_qr.view(
+                    self.q_lora_rank,
+                    self.num_heads,
+                    self.qk_head_dim,
+                )
+                weight_uq_qr = F.pad(weight_uq_qr, (0, 0, 0, self.head_padding))
+                weight_uq_qr = weight_uq_qr.view(
+                    self.q_lora_rank,
+                    self.num_heads_padded * self.qk_head_dim,
+                )
+
+        self.weight_dq = fused_weight[..., : self.q_lora_rank].contiguous()
+        self.weight_dkv_kr = fused_weight[..., self.q_lora_rank :].contiguous()
+        self.weight_uq_qr = weight_uq_qr.contiguous()
         self.weight_dq = torch_npu.npu_format_cast(self.weight_dq, ACL_FORMAT_FRACTAL_NZ)
-        self.weight_uq_qr = torch_npu.npu_format_cast(self.weight_uq_qr.contiguous(), ACL_FORMAT_FRACTAL_NZ)
+        self.weight_uq_qr = torch_npu.npu_format_cast(self.weight_uq_qr, ACL_FORMAT_FRACTAL_NZ)
         self.weight_dkv_kr = torch_npu.npu_format_cast(self.weight_dkv_kr, ACL_FORMAT_FRACTAL_NZ)
 
-        if get_ascend_device_type() == AscendDeviceType.A5:
+        self.mlapo_weight_quant_mode = 0 if is_native else 3
+        if is_native:
+            self.mlapo_num_heads = self.num_heads_padded
+            if self.head_padding > 0:
+                self.mlapo_W_UK_T = F.pad(self.W_UK_T, (0, 0, 0, 0, 0, self.head_padding))
+        elif get_ascend_device_type() == AscendDeviceType.A5:
             self.dequant_scale_w_uq_qr = self.q_proj.weight_scale.data.transpose(0, 1).flatten(1)
             weight_scale = self.fused_qkv_a_proj.weight_scale.transpose(0, 1).flatten(1)
             self.dequant_scale_w_dq = weight_scale[: self.q_lora_rank, ...]
@@ -1323,6 +1383,37 @@ class AscendMLAImpl(MLAAttentionImpl):
 
         return attn_output
 
+    def _exec_kv_no_rope(
+        self,
+        kv_no_split: torch.Tensor,
+        kv_cache: tuple,
+        slots: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Normalize and cache K3 MLA KV without rotating its raw slice."""
+        assert self.kv_a_layernorm is not None
+        assert len(kv_cache) > 1
+        num_tokens = kv_no_split.shape[0]
+        kv_no_split = kv_no_split.view(
+            num_tokens,
+            self.num_kv_heads,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+        )
+        kv_c, k_pe = kv_no_split.split(
+            [self.kv_lora_rank, self.qk_rope_head_dim],
+            dim=-1,
+        )
+        kv_c_normed = self.kv_a_layernorm(kv_c.contiguous())
+        kv_c_normed = kv_c_normed.view(num_tokens, self.num_kv_heads, self.kv_lora_rank)
+        k_pe = k_pe.view(num_tokens, self.num_kv_heads, self.qk_rope_head_dim)
+        DeviceOperator.reshape_and_cache(
+            key=kv_c_normed,
+            value=k_pe,
+            key_cache=kv_cache[0],
+            value_cache=kv_cache[1],
+            slot_mapping=slots,
+        )
+        return k_pe, kv_c_normed
+
     def exec_kv_decode(
         self,
         kv_no_split: torch.Tensor,
@@ -1331,6 +1422,10 @@ class AscendMLAImpl(MLAAttentionImpl):
         kv_cache: tuple,
         slots: torch.Tensor,
     ):
+        if not self.use_mla_rope:
+            self._exec_kv_no_rope(kv_no_split, kv_cache, slots)
+            return kv_cache[1], kv_cache[0]
+
         assert self.kv_a_layernorm is not None
         B = kv_no_split.shape[0]
         N = self.num_kv_heads
@@ -1365,6 +1460,9 @@ class AscendMLAImpl(MLAAttentionImpl):
         *,
         attn_metadata: AscendMLAMetadata | None = None,
     ):
+        if not self.use_mla_rope:
+            return self._exec_kv_no_rope(kv_no_split, kv_cache, slots)
+
         assert self.kv_a_layernorm is not None
         B = kv_no_split.shape[0]
         N = self.num_kv_heads
@@ -1396,6 +1494,8 @@ class AscendMLAImpl(MLAAttentionImpl):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
+        if not self.use_mla_rope:
+            return x
         B, N, D = x.shape
         S = 1
         x = x.view(B, N, S, D)
@@ -1465,8 +1565,15 @@ class AscendMLAImpl(MLAAttentionImpl):
                 q_nope = F.pad(q_nope, (0, 0, 0, self.head_padding), "constant", 0)
             # Output shape: [num_heads, num_tokens, dim]
             attn_output_shape = (self.num_heads_padded, num_tokens, self.kv_lora_rank)
-            sparse_mode = 3
-            attn_mask = attn_metadata.decode.attn_mask  # type:ignore
+            if not attn_metadata.causal:
+                # K3's DSpark draft block is bidirectional. With FIA this is
+                # sparse_mode=0 and no mask; a default mask here would hide the
+                # upper triangle and silently make the draft causal.
+                sparse_mode = 0
+                attn_mask = None
+            else:
+                sparse_mode = 3
+                attn_mask = decode_meta.attn_mask
             actual_seq_lengths = decode_meta.actual_seq_lengths_q
             if self.fa_quant_layer:
                 dequant_scale_q_nope = dequant_scale_q_nope.view(num_tokens, self.num_heads)
@@ -1609,31 +1716,51 @@ class AscendMLAImpl(MLAAttentionImpl):
         return self._v_up_proj(attn_output)
 
     def reorg_decode_q(self, decode_q_nope, decode_q_pe):
+        if self.mlapo_num_heads > self.num_heads:
+            decode_q_nope = decode_q_nope[:, : self.num_heads]
+            decode_q_pe = decode_q_pe[:, : self.num_heads]
         return decode_q_nope, decode_q_pe
 
     def mla_preprocess_only_decode(self, hidden_states, kv_cache, attn_metadata):
         bsz = attn_metadata.num_decode_tokens
-        cos_shape = attn_metadata.decode.cos.shape
         cache_index = attn_metadata.slot_mapping[:bsz].to(torch.int64)
         decode_k_nope, decode_k_pe = kv_cache[0], kv_cache[1]
         hidden_states = hidden_states[:bsz]
 
         if get_ascend_device_type() == AscendDeviceType.A5:
-            hidden_states = hidden_states.unsqueeze(1)
-            quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
-            dequant_scale_x = dynamic_scale.reshape(quantized_x.shape[0] * quantized_x.shape[1], -1).view(
-                torch.float8_e8m0fnu
-            )
-            dequant_scale_w_dq = self.dequant_scale_w_dq.view(torch.float8_e8m0fnu)
-            dequant_scale_w_uq_qr = self.dequant_scale_w_uq_qr.view(torch.float8_e8m0fnu)
-            dequant_scale_w_dkv_kr = self.dequant_scale_w_dkv_kr.view(torch.float8_e8m0fnu)
-            cos = attn_metadata.decode.cos.view(cos_shape[0], 1, cos_shape[-1])
-            sin = attn_metadata.decode.sin.view(cos_shape[0], 1, cos_shape[-1])
-            cache_index = cache_index.view(bsz, -1)
+            if self.mlapo_weight_quant_mode == 0:
+                quantized_x = hidden_states
+                dequant_scale_x = None
+                dequant_scale_w_dq = None
+                dequant_scale_w_uq_qr = None
+                dequant_scale_w_dkv_kr = None
+            else:
+                hidden_states = hidden_states.unsqueeze(1)
+                quantized_x, dynamic_scale = torch_npu.npu_dynamic_mx_quant(hidden_states, dst_type=torch.float8_e4m3fn)
+                dequant_scale_x = dynamic_scale.reshape(quantized_x.shape[0] * quantized_x.shape[1], -1).view(
+                    torch.float8_e8m0fnu
+                )
+                dequant_scale_w_dq = self.dequant_scale_w_dq.view(torch.float8_e8m0fnu)
+                dequant_scale_w_uq_qr = self.dequant_scale_w_uq_qr.view(torch.float8_e8m0fnu)
+                dequant_scale_w_dkv_kr = self.dequant_scale_w_dkv_kr.view(torch.float8_e8m0fnu)
+            if self.use_mla_rope:
+                cos_shape = attn_metadata.decode.cos.shape
+                rope_shape = (
+                    (cos_shape[0], 1, cos_shape[-1]) if quantized_x.dim() == 3 else (cos_shape[0], cos_shape[-1])
+                )
+                cos = attn_metadata.decode.cos.view(rope_shape)
+                sin = attn_metadata.decode.sin.view(rope_shape)
+                prolog_op = torch_npu.npu_mla_prolog_v3
+            else:
+                cos = None
+                sin = None
+                prolog_op = _npu_mla_prolog_v3_no_rope
+            cache_index = cache_index.view(bsz, -1) if quantized_x.dim() == 3 else cache_index.view(-1)
             cache_mode = "PA_BSND"
-            weight_quant_mode = 3
+            weight_quant_mode = self.mlapo_weight_quant_mode
             quant_scale_ckv = self.fak_descale_reciprocal if self.fa_quant_layer else None
         else:
+            cos_shape = attn_metadata.decode.cos.shape
             quantized_x, dynamic_scale = torch_npu.npu_dynamic_quant(hidden_states)
             dequant_scale_x = dynamic_scale.view(-1, 1)
             dequant_scale_w_dq = self.dequant_scale_w_dq
@@ -1641,19 +1768,20 @@ class AscendMLAImpl(MLAAttentionImpl):
             dequant_scale_w_dkv_kr = self.dequant_scale_w_dkv_kr
             cos = attn_metadata.decode.cos.view(cos_shape[0], cos_shape[-1])
             sin = attn_metadata.decode.sin.view(cos_shape[0], cos_shape[-1])
+            prolog_op = torch_npu.npu_mla_prolog_v3
             cache_mode = "PA_NZ" if (self.fa_quant_layer or self.enable_kv_nz) else "PA_BSND"
             weight_quant_mode = 2
             # v3 full-quant uses a per-tensor kv scale; quant_kscale is one scalar
             # broadcast to (1, Hckv), so slice out the single per-tensor value.
             quant_scale_ckv = self.quant_kscale[:, :1] if self.fa_quant_layer else None
 
-        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = torch_npu.npu_mla_prolog_v3(
+        decode_q_nope, decode_q_pe, dequant_scale_q_nope, _, _ = prolog_op(
             kv_cache=decode_k_nope,
             kr_cache=decode_k_pe,
             token_x=quantized_x,
             weight_dq=self.weight_dq,
             weight_uq_qr=self.weight_uq_qr,
-            weight_uk=self.W_UK_T,
+            weight_uk=self.mlapo_W_UK_T,
             weight_dkv_kr=self.weight_dkv_kr,
             rmsnorm_gamma_cq=self.q_a_layernorm.weight.data,  # type: ignore[union-attr]
             rmsnorm_gamma_ckv=self.kv_a_layernorm.weight.data,  # type: ignore[union-attr]
@@ -1671,8 +1799,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             quant_scale_ckv=quant_scale_ckv,
         )
 
-        decode_q_nope = decode_q_nope.view(bsz, self.num_heads, self.kv_lora_rank)
-        decode_q_pe = decode_q_pe.view(bsz, self.num_heads, -1)
+        decode_q_nope = decode_q_nope.view(bsz, self.mlapo_num_heads, self.kv_lora_rank)
+        decode_q_pe = decode_q_pe.view(bsz, self.mlapo_num_heads, -1)
 
         decode_q_nope, decode_q_pe = self.reorg_decode_q(decode_q_nope, decode_q_pe)
         decode_preprocess_res = DecodeMLAPreprocessResult(
@@ -1834,9 +1962,18 @@ class AscendMLAImpl(MLAAttentionImpl):
         o_proj_input_shape = (_EXTRA_CTX.num_tokens, self.num_heads * self.v_head_dim)
         o_proj_input = torch.zeros(o_proj_input_shape, dtype=hidden_states.dtype, device=hidden_states.device)
 
+        gate = None
+        if self.use_output_gate:
+            assert self.g_proj is not None
+            gate = self.g_proj(hidden_states.contiguous())[0]
+
         # MLA Preprocess
-        if (self.fa_quant_layer or self.enable_mlapo) and (
-            attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS and attn_metadata.num_prefills == 0
+        can_use_decode_prolog = self.use_mla_rope or get_ascend_device_type() == AscendDeviceType.A5
+        if (
+            (self.fa_quant_layer or self.enable_mlapo)
+            and can_use_decode_prolog
+            and attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
+            and attn_metadata.num_prefills == 0
         ):
             decode_preprocess_res, prefill_preprocess_res = self.mla_preprocess_only_decode(
                 hidden_states, kv_cache, attn_metadata
@@ -1874,6 +2011,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             )
 
             o_proj_input[num_decode_tokens:num_actual_tokens] = output_prefill
+        if gate is not None:
+            o_proj_input.mul_(torch.sigmoid(gate))
         # O proj
         output[...] = self.o_proj(o_proj_input, is_prefill=prefill_preprocess_res is not None)[0]
 

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1829,13 +1829,13 @@ class AscendMLAImpl(MLAAttentionImpl):
         prefill_slots = attn_metadata.slot_mapping[num_decode_tokens:num_actual_tokens]
         prefill_q_pe = self.rope_single(
             prefill_q_pe,
-            cos[:num_actual_prefill_tokens],
-            sin[:num_actual_prefill_tokens],
+            cos[:num_actual_prefill_tokens] if cos is not None else None,
+            sin[:num_actual_prefill_tokens] if sin is not None else None,
         )
         prefill_k_pe, prefill_k_c_normed = self.exec_kv_prefill(
             prefill_kv_no_split,
-            cos[:num_prefill_kv_tokens],
-            sin[:num_prefill_kv_tokens],
+            cos[:num_prefill_kv_tokens] if cos is not None else None,
+            sin[:num_prefill_kv_tokens] if sin is not None else None,
             kv_cache,
             prefill_slots,
             attn_metadata=attn_metadata,

--- a/vllm_ascend/ops/mla.py
+++ b/vllm_ascend/ops/mla.py
@@ -77,6 +77,8 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         skip_topk: bool = False,
+        non_causal_multi_token_decode: bool = False,
+        allow_short_prefill_indexer_scoring_skip: bool = False,
     ) -> None:
         nn.Module.__init__(self)
         self.hidden_size = hidden_size
@@ -88,6 +90,9 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
         self.v_head_dim = v_head_dim
         self.prefix = prefix
         self.skip_topk = skip_topk
+        # This is an upstream CUDA indexer hint. Ascend accepts it to preserve
+        # constructor compatibility, but its indexer does not consume it.
+        del allow_short_prefill_indexer_scoring_skip
         hf_config = get_current_vllm_config().model_config.hf_text_config
         self.tp_size = get_tensor_model_parallel_world_size()
         self.layers = hf_config.num_hidden_layers
@@ -111,6 +116,7 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             indexer=ascend_indexer,
             skip_topk=skip_topk,
             topk_indices_buffer=getattr(mla_modules, "topk_indices_buffer", None),
+            non_causal_multi_token_decode=non_causal_multi_token_decode,
             # extra args
             rotary_emb=mla_modules.rotary_emb,
             fused_qkv_a_proj=mla_modules.fused_qkv_a_proj,
@@ -120,6 +126,8 @@ class AscendMultiHeadLatentAttention(MultiHeadLatentAttentionWrapper):
             kv_a_proj_with_mqa=mla_modules.kv_a_proj_with_mqa,
             kv_a_layernorm=mla_modules.kv_a_layernorm,
             o_proj=mla_modules.o_proj,
+            g_proj=mla_modules.g_proj,
+            use_mla_rope=mla_modules.rotary_emb is not None,
             layer_name=f"{prefix}.attn",
         )
 


### PR DESCRIPTION
### What this PR does / why we need it?

- Adds Kimi K3 target and DSpark MLA execution on Ascend.
- Preserves per-group RoPE/no-RoPE semantics and causal/non-causal draft metadata through the MLA backend.
- Adds Kimi K3 rotary inputs and MLA weight post-processing, including native floating-point MLAPO handling on A5.
- Covers MLA metadata, mixed rotary modes, graph updates, and rotary behavior with focused unit tests.

### Dependencies

- #14426 provides the required AscendC operator bindings.
- The Kimi K3 model adapter PR consumes this attention implementation.

### How was this patch tested?

- Python bytecode compilation for all changed Python files.
- Ruff 0.14.0 format and lint checks for all changed Python files.
- Focused coverage in `tests/ut/attention/a2/test_mla_v1.py` and `tests/ut/ops/test_rotary_embedding.py`.

### Does this PR introduce any user-facing change?

Yes. It enables Kimi K3 MLA execution on Ascend.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
