### PR TITLE
[MRV2][BugFix] fix rejection sampler on mrv2 with upstream commits

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -443,3 +443,46 @@ def test_chunked_requests_match_full_batch(has_draft_logits: bool):
 
     gc.collect()
     torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize("temperature", [0.0, 1.0])
+@torch.inference_mode()
+def test_all_nan_target_logits_in_range(temperature: float):
+    """Regression test for NaN breaking tl.argmax index bounds.
+
+    An all-NaN target logits row makes every per-block local max NaN.
+    tl.argmax over such a block returns an index into the padded region
+    (>= num_blocks), causing an OOB read of the local-argmax tensors in
+    _compute_global_target_argmax (greedy) and _insert_resampled_kernel
+    (stochastic). The vocab size below gives a non-power-of-2 block count
+    (3 blocks of 8192, padded to 4) so the padded region exists. Post-fix,
+    NaN is mapped to -inf, so the kernels must complete without error and
+    emit in-range token ids.
+    """
+    torch.manual_seed(0)
+    device = "npu"
+    num_trials = 4
+    K = 1
+    vocab_size = 20000  # 3 vocab blocks of 8192, padded to 4
+
+    target_logits_1d = torch.full((vocab_size,), float("nan"), device=device, dtype=torch.float32)
+    draft_logits_1d = torch.randn(vocab_size, device=device, dtype=torch.float32)
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        K,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=K)
+
+    assert ((num_sampled >= 1) & (num_sampled <= K + 1)).all()
+    steps = torch.arange(K + 1, device=device).unsqueeze(0)
+    valid = steps < num_sampled.unsqueeze(1)
+    assert (sampled[valid] >= 0).all()
+    assert (sampled[valid] < vocab_size).all()
+
+    gc.collect()
+    torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -1,0 +1,445 @@
+# Adapt from https://github.com/vllm-project/vllm/blob/main/tests/v1/spec_decode/test_rejection_sampler_utils.py
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import gc
+import math
+
+import pytest
+import torch
+from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
+
+from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import rejection_sample
+
+VOCAB_SIZE = 4096
+
+pytest.importorskip("triton")
+if not (hasattr(torch, "npu") and torch.npu.is_available()):
+    pytest.skip("NPU required for MRV2 rejection sampler tests", allow_module_level=True)
+
+
+def _build_rejection_sample_inputs(
+    target_logits_1d: torch.Tensor,
+    draft_logits_1d: torch.Tensor,
+    num_speculative_steps: int,
+    temperature: float,
+    num_trials: int,
+) -> dict:
+    """Build rejection_sample kwargs from a fixed target and draft distribution.
+
+    target_logits_1d must already have temperature applied (the sampler applies
+    sampling params before verification), whereas draft_logits_1d must not:
+    rejection_sample divides the draft logits by the temperature on load.
+    """
+    device = target_logits_1d.device
+    vocab_size = target_logits_1d.shape[0]
+    K = num_speculative_steps
+    num_logits = num_trials * (K + 1)
+
+    target_logits = target_logits_1d.unsqueeze(0).expand(num_logits, -1).contiguous()
+    draft_logits = draft_logits_1d.view(1, 1, vocab_size).expand(num_trials, K, -1).contiguous()
+
+    scaled_draft_logits_1d = draft_logits_1d.float()
+    if temperature > 0:
+        scaled_draft_logits_1d = scaled_draft_logits_1d / temperature
+    draft_probs = torch.softmax(scaled_draft_logits_1d, dim=0)
+    # Sample on CPU: torch.multinomial is not reliably available on NPU.
+    draft_tokens = torch.multinomial(draft_probs.cpu().expand(num_trials, -1), K, replacement=True).to(device)
+    draft_sampled_2d = torch.zeros(num_trials, K + 1, dtype=torch.int64, device=device)
+    draft_sampled_2d[:, 1:] = draft_tokens
+    draft_sampled = draft_sampled_2d.reshape(-1)
+
+    cu_num_logits = torch.arange(num_trials + 1, dtype=torch.int32, device=device) * (K + 1)
+    pos = torch.arange(num_logits, dtype=torch.int32, device=device)
+    idx_mapping = torch.arange(num_trials, dtype=torch.int32, device=device)
+    expanded_idx_mapping = torch.arange(num_trials, dtype=torch.int32, device=device).repeat_interleave(K + 1)
+    expanded_local_pos = torch.arange(K + 1, dtype=torch.int32, device=device).repeat(num_trials)
+    temp_tensor = torch.full((num_trials,), temperature, dtype=torch.float32, device=device)
+    seed = torch.arange(num_trials, dtype=torch.int64, device=device)
+
+    return dict(
+        target_logits=target_logits,
+        draft_logits=draft_logits,
+        draft_sampled=draft_sampled,
+        cu_num_logits=cu_num_logits,
+        pos=pos,
+        idx_mapping=idx_mapping,
+        expanded_idx_mapping=expanded_idx_mapping,
+        expanded_local_pos=expanded_local_pos,
+        temperature=temp_tensor,
+        seed=seed,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_speculative_steps,temperature,unconditional_rates",
+    [
+        (3, 1.0, [0.9, 0.5, 0.2]),
+        (3, 0.0, [0.9, 0.5, 0.2]),
+        (3, 1.0, [1.0, 1.0, 1.0]),
+        (3, 0.0, [1.0, 1.0, 1.0]),
+        (3, 1.0, [0.0, 0.0, 0.0]),
+        (3, 0.0, [0.0, 0.0, 0.0]),
+        (1, 1.0, [0.7]),
+        (1, 0.0, [0.7]),
+    ],
+)
+@torch.inference_mode()
+def test_synthetic_rejection_sample(
+    num_speculative_steps: int,
+    temperature: float,
+    unconditional_rates: list[float],
+):
+    """
+    Verify that synthetic rejection sampling produces the expected
+    per-position acceptance rates. The unconditional rate at position i
+    is P(all draft steps 0..i accepted) = product(conditional_rates[0:i+1]).
+    This is approximately mean(num accepted >= i + 1) over many trials.
+    """
+    torch.manual_seed(42)
+    device = "npu"
+    num_trials = 10 * VOCAB_SIZE
+    deviation_tol = 1e-2
+
+    target_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+    draft_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+
+    if temperature > 0:
+        target_logits_1d /= temperature
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+
+    conditional_rates = unconditional_to_conditional_rates(unconditional_rates)
+    synthetic_conditional_rates = torch.tensor(conditional_rates, dtype=torch.float32, device=device)
+
+    _, num_sampled = rejection_sample(
+        **inputs,
+        num_speculative_steps=num_speculative_steps,
+        synthetic_conditional_rates=synthetic_conditional_rates,
+    )
+
+    # num_sampled includes the resampled/bonus token.
+    num_accepted = num_sampled - 1
+    for i, expected_rate in enumerate(unconditional_rates):
+        observed_rate = (num_accepted >= i + 1).float().mean().item()
+        assert abs(observed_rate - expected_rate) < deviation_tol, (
+            f"Step {i}: observed rate {observed_rate:.4f} deviates from "
+            f"expected rate {expected_rate:.4f} by more than {deviation_tol}."
+        )
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+def _assert_distribution_match(
+    sampled_tokens: torch.Tensor,
+    target_probs: torch.Tensor,
+    device: str,
+    label: str = "",
+    min_expected: float = 5.0,
+):
+    """
+    Assert sampled tokens match the target distribution via a
+    chi-squared goodness-of-fit test. This is done by computing
+    observed vs expected token counts (target_probs * num_samples),
+    then checking that the chi-squared statistic is below a conservative
+    threshold. The threshold is set at df + 10*sqrt(2*df), which
+    corresponds to ~10 sigma under the chi-squared distribution's
+    normal approximation, effectively disallowing false positives.
+
+    NOTE: Tokens with expected count < min_expected are merged into
+    a single "other" bin to minimize chi-squared noise.
+    """
+    num_samples = sampled_tokens.shape[0]
+    vocab_size = target_probs.shape[0]
+
+    observed = torch.zeros(vocab_size, device=device, dtype=torch.float32)
+    observed.scatter_add_(0, sampled_tokens, torch.ones(num_samples, device=device))
+    expected = target_probs * num_samples
+
+    sufficient = expected >= min_expected
+    obs_main = observed[sufficient]
+    exp_main = expected[sufficient]
+
+    obs_other = observed[~sufficient].sum().unsqueeze(0)
+    exp_other = expected[~sufficient].sum().unsqueeze(0)
+
+    if exp_other.item() >= min_expected:
+        obs_all = torch.cat([obs_main, obs_other])
+        exp_all = torch.cat([exp_main, exp_other])
+    else:
+        obs_all = obs_main
+        exp_all = exp_main
+
+    chi2 = ((obs_all - exp_all) ** 2 / exp_all).sum().item()
+    df = obs_all.shape[0] - 1
+    if df < 1:
+        # All samples were merged into < 2 bins, which is too
+        # few to evaluate.
+        return
+
+    threshold = df + 10 * math.sqrt(2 * df)
+    prefix = f"[{label}] " if label else ""
+    assert chi2 < threshold, (
+        f"{prefix}Chi-squared test failed: chi2={chi2:.1f}, "
+        f"df={df}, threshold={threshold:.1f}. "
+        f"Output distribution does not match target distribution."
+    )
+
+
+@pytest.mark.parametrize("use_block_verification", [False, True])
+@torch.inference_mode()
+def test_placeholder_blocks_later_draft_tokens(use_block_verification: bool):
+    """A placeholder is not necessarily the final draft. Nothing at or after
+    one may be accepted, even when a valid draft follows it.
+    """
+    torch.manual_seed(0)
+    device = "npu"
+    num_trials = 4 * VOCAB_SIZE
+    K = 3
+    temperature = 1.0
+
+    # An identical draft is accepted with probability ~1, so any token after
+    # the placeholder would be accepted unless it is explicitly blocked. The
+    # draft logits are stored pre-temperature, so pass the unscaled base.
+    draft_logits_1d = torch.randn(VOCAB_SIZE, device=device)
+    target_logits_1d = draft_logits_1d / temperature
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        K,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+    inputs["draft_sampled"].view(num_trials, K + 1)[:, 2] = -1
+
+    _, num_sampled = rejection_sample(
+        **inputs,
+        num_speculative_steps=K,
+        use_block_verification=use_block_verification,
+    )
+
+    # Only the first draft is verifiable, plus one resampled token.
+    assert (num_sampled <= 2).all(), "Accepted a draft token past a placeholder."
+    assert (num_sampled == 2).float().mean().item() > 0.9, (
+        "The first draft was rarely accepted; the test is not exercising acceptance past the placeholder."
+    )
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize("has_draft_logits", [True, False])
+@pytest.mark.parametrize("num_placeholders", [1, 2])
+@torch.inference_mode()
+def test_block_verification_placeholder_truncates_block(has_draft_logits: bool, num_placeholders: int):
+    """Trailing placeholder (-1) draft ids end the block early. The last real
+    draft token must then be verified against the closed-form threshold rather
+    than a residual mass derived from the placeholder position, whose logits
+    describe a token that was never drafted.
+    """
+    torch.manual_seed(42)
+    device = "npu"
+    num_trials = 20 * VOCAB_SIZE
+    K = 3
+    temperature = 1.0
+
+    target_logits_1d = torch.randn(VOCAB_SIZE, device=device) / temperature
+    draft_logits_1d = torch.randn(VOCAB_SIZE, device=device)
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        K,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+    if not has_draft_logits:
+        inputs["draft_logits"] = None
+    inputs["draft_sampled"].view(num_trials, K + 1)[:, K + 1 - num_placeholders :] = -1
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=K, use_block_verification=True)
+
+    num_real = K - num_placeholders
+    assert (num_sampled <= num_real + 1).all(), "Accepted a draft token at or after a placeholder."
+    target_probs = torch.softmax(target_logits_1d, dim=0)
+    for pos in range(num_real + 1):
+        accepted_mask = num_sampled >= pos + 1
+        _assert_distribution_match(sampled[accepted_mask, pos], target_probs, device, label=f"position {pos}")
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize(
+    "num_speculative_steps,temperature",
+    [
+        (1, 0.6),
+        (3, 0.6),
+        (1, 1.0),
+        (3, 1.0),
+        (5, 1.0),
+    ],
+)
+@pytest.mark.parametrize("has_draft_logits", [True, False])
+@torch.inference_mode()
+def test_block_verification_rejection_sample(num_speculative_steps: int, temperature: float, has_draft_logits: bool):
+    """
+    Verify that block verification (Sun et al.) preserves the target
+    distribution at every accepted position, for both the full draft-logits
+    case and the one-hot (no draft logits) case. Block verification changes
+    *which* prefix is accepted, but the marginal of every output position must
+    still match the target distribution p(x).
+    """
+
+    torch.manual_seed(42)
+    device = "npu"
+    num_trials = 10 * VOCAB_SIZE
+
+    target_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+    draft_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+
+    if temperature > 0:
+        target_logits_1d /= temperature
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+    if not has_draft_logits:
+        inputs["draft_logits"] = None
+
+    sampled, num_sampled = rejection_sample(
+        **inputs,
+        num_speculative_steps=num_speculative_steps,
+        use_block_verification=True,
+    )
+
+    target_probs = torch.softmax(target_logits_1d, dim=0)
+    for pos in range(num_speculative_steps + 1):
+        accepted_mask = num_sampled >= pos + 1
+        _assert_distribution_match(sampled[accepted_mask, pos], target_probs, device, label=f"position {pos}")
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize("num_speculative_steps", [3, 5])
+@torch.inference_mode()
+def test_block_verification_accepts_at_least_as_many(num_speculative_steps: int):
+    """
+    Block verification is designed to accept at least as long a prefix as
+    token verification in expectation. Verify the mean accepted length is no
+    worse than the standard method on the same inputs.
+    """
+
+    torch.manual_seed(0)
+    device = "npu"
+    num_trials = 20 * VOCAB_SIZE
+    temperature = 1.0
+
+    target_logits_1d = torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+    # A draft close to the target gives block verification room to recover
+    # prefixes that token verification would have truncated.
+    draft_logits_1d = target_logits_1d + 0.5 * torch.randn(VOCAB_SIZE, device=device, dtype=torch.float32)
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=temperature,
+        num_trials=num_trials,
+    )
+
+    _, num_sampled_standard = rejection_sample(**inputs, num_speculative_steps=num_speculative_steps)
+    _, num_sampled_block = rejection_sample(
+        **inputs,
+        num_speculative_steps=num_speculative_steps,
+        use_block_verification=True,
+    )
+
+    mean_standard = (num_sampled_standard - 1).float().mean().item()
+    mean_block = (num_sampled_block - 1).float().mean().item()
+    # Allow a small slack for sampling noise.
+    assert mean_block >= mean_standard - 1e-2, (
+        f"Block verification mean accepted length {mean_block:.4f} is worse than standard {mean_standard:.4f}."
+    )
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+@pytest.mark.parametrize("has_draft_logits", [True, False])
+@torch.inference_mode()
+def test_chunked_requests_match_full_batch(has_draft_logits: bool):
+    """Verify that verifying requests in chunks (as done by the rejection
+    sampler to avoid OOM) matches the full-batch result, including when the
+    target logits are a non-contiguous view (padded vocab).
+    """
+    torch.manual_seed(7)
+    device = "npu"
+    num_reqs = 5
+    num_speculative_steps = 3
+    vocab_size = 257
+
+    target_logits = torch.randn(vocab_size, device=device)
+    draft_logits = torch.randn(vocab_size, device=device)
+    inputs = _build_rejection_sample_inputs(
+        target_logits,
+        draft_logits,
+        num_speculative_steps,
+        temperature=0.6,
+        num_trials=num_reqs,
+    )
+    # Build a padded, non-contiguous target logits view whose last dim
+    # stays unit-stride, as required by the rejection kernels.
+    padded_target_logits = torch.empty(inputs["target_logits"].shape[0], vocab_size + 3, device=device)
+    padded_target_logits[:, :vocab_size].copy_(inputs["target_logits"])
+    inputs["target_logits"] = padded_target_logits[:, :vocab_size]
+    assert inputs["target_logits"].stride(-1) == 1
+    assert not inputs["target_logits"].is_contiguous()
+    if not has_draft_logits:
+        inputs["draft_logits"] = None
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=num_speculative_steps)
+
+    sampled_chunks = []
+    num_sampled_chunks = []
+    for start, end in ((0, 2), (2, 5)):
+        lo = start * (num_speculative_steps + 1)
+        hi = end * (num_speculative_steps + 1)
+        chunk_inputs = dict(inputs)
+        for name in (
+            "target_logits",
+            "draft_sampled",
+            "pos",
+            "expanded_idx_mapping",
+            "expanded_local_pos",
+        ):
+            chunk_inputs[name] = inputs[name][lo:hi]
+        chunk_inputs["cu_num_logits"] = inputs["cu_num_logits"][start : end + 1] - lo
+        chunk_inputs["idx_mapping"] = inputs["idx_mapping"][start:end]
+
+        chunk_sampled, chunk_num_sampled = rejection_sample(**chunk_inputs, num_speculative_steps=num_speculative_steps)
+        sampled_chunks.append(chunk_sampled)
+        num_sampled_chunks.append(chunk_num_sampled)
+
+    chunked_sampled = torch.cat(sampled_chunks)
+    chunked_num_sampled = torch.cat(num_sampled_chunks)
+    assert torch.equal(chunked_num_sampled, num_sampled)
+    steps = torch.arange(num_speculative_steps + 1, device=device)
+    valid = steps.unsqueeze(0) < num_sampled.unsqueeze(1)
+    assert torch.equal(chunked_sampled[valid], sampled[valid])
+
+    gc.collect()
+    torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from vllm.v1.spec_decode.utils import unconditional_to_conditional_rates
 
+from vllm_ascend.worker.v2.sample.gumbel import gumbel_sample
 from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import rejection_sample
 
 VOCAB_SIZE = 4096
@@ -521,6 +522,97 @@ def test_greedy_placeholder_emits_target_argmax():
     steps = torch.arange(K + 1, device=device).unsqueeze(0)
     emitted = sampled[steps < num_sampled.unsqueeze(1)]
     assert (emitted == target_argmax).all(), "Greedy sampling emitted a token that is not the target argmax"
+
+    gc.collect()
+    torch.npu.empty_cache()
+
+
+# The wide-vocab stochastic tests above spread their samples too thin to
+# resolve a small distributional bias, so this test runs narrow: 16 bins over
+# 200K trials is ~12K per bin, which resolves a few percent.
+NARROW_VOCAB_SIZE = 16
+NARROW_NUM_TRIALS = 200_000
+
+
+def _gumbel_drafted_tokens(
+    inputs: dict,
+    draft_logits_1d: torch.Tensor,
+    num_trials: int,
+    num_speculative_steps: int,
+) -> torch.Tensor:
+    """Proposals drawn with gumbel_sample, shaped like inputs["draft_sampled"].
+
+    _build_rejection_sample_inputs draws them with torch.multinomial, which is
+    independent of the resample noise by construction. Production drafts come
+    from gumbel_sample keyed by pos[t * (K + 1) + i] for step i of trial t --
+    the same entry _rejection_kernel and _resample_kernel read for that token --
+    so the draft and the residual compete for one noise stream.
+
+    NPU: pos is int32 (triton-ascend philox), matching the pos tensor built by
+    _build_rejection_sample_inputs.
+    """
+    k = num_speculative_steps
+    vocab_size = draft_logits_1d.shape[0]
+    device = draft_logits_1d.device
+    draft_tokens = gumbel_sample(
+        draft_logits_1d.unsqueeze(0).expand(num_trials * k, vocab_size).float(),
+        inputs["expanded_idx_mapping"].view(num_trials, k + 1)[:, :k].reshape(-1).contiguous(),
+        inputs["temperature"],
+        inputs["seed"],
+        inputs["pos"].view(num_trials, k + 1)[:, :k].reshape(-1).contiguous(),
+        apply_temperature=True,
+        is_drafting=True,
+    )
+    draft_sampled = torch.zeros(num_trials * (k + 1), dtype=torch.int64, device=device)
+    draft_sampled.view(num_trials, k + 1)[:, 1:] = draft_tokens.view(num_trials, k)
+    return draft_sampled
+
+
+@pytest.mark.parametrize("num_speculative_steps", [1, 3])
+@torch.inference_mode()
+def test_gumbel_drafted_rejection_sample_is_unbiased(num_speculative_steps: int):
+    """The proposal and the residual resample must not share a noise vector.
+
+    Draws proposals on the same (seed, pos) stream the sampler verifies and
+    resamples with, then checks the output still follows the target. Conditioned
+    on a proposal winning the argmax, every other token's Gumbel is truncated
+    below that max -- most tightly for the tokens the draft ranked highest -- so
+    a shared stream makes the residual under-weight exactly those tokens.
+
+    Runs narrow because the wide-vocab test above cannot resolve this: dropping
+    `is_drafting=True` in _gumbel_drafted_tokens takes position 0 from chi2 ~12
+    to ~1500 against a threshold of ~70 here, while leaving that test passing.
+    """
+    torch.manual_seed(42)
+    device = "npu"
+
+    # A draft that ranks tokens in exactly the opposite order rejects ~73% of
+    # proposals, so most trials reach the residual resample where the bias
+    # lives. The disagreement has to be constructed rather than sampled: two
+    # independent randn draws land close together often enough that the signal
+    # swings between chi2 ~14 and ~1900 depending on the seed. At temperature
+    # 1.0 the target needs no scaling before being passed in.
+    target_logits_1d = torch.randn(NARROW_VOCAB_SIZE, device=device, dtype=torch.float32)
+    draft_logits_1d = -target_logits_1d
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        num_speculative_steps,
+        temperature=1.0,
+        num_trials=NARROW_NUM_TRIALS,
+    )
+    inputs["draft_sampled"] = _gumbel_drafted_tokens(inputs, draft_logits_1d, NARROW_NUM_TRIALS, num_speculative_steps)
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=num_speculative_steps)
+
+    # Position 0 carries the power: every trial reaches it, while later
+    # positions are only reached on acceptance, which is rare by construction.
+    assert (num_sampled >= 1).all()
+    target_probs = torch.softmax(target_logits_1d, dim=0)
+    for pos in range(num_speculative_steps + 1):
+        accepted_mask = num_sampled >= pos + 1
+        _assert_distribution_match(sampled[accepted_mask, pos], target_probs, device, label=f"position {pos}")
 
     gc.collect()
     torch.npu.empty_cache()

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample_v2.py
@@ -486,3 +486,41 @@ def test_all_nan_target_logits_in_range(temperature: float):
 
     gc.collect()
     torch.npu.empty_cache()
+
+
+@torch.inference_mode()
+def test_greedy_placeholder_emits_target_argmax():
+    """Greedy sampling skips resampling and relies on the rejection kernel
+    storing the target argmax at the rejected position. A placeholder must not
+    bypass that store, or the output slot is returned uninitialized.
+    """
+    torch.manual_seed(0)
+    device = "npu"
+    num_trials = 512
+    K = 3
+
+    target_logits_1d = torch.randn(VOCAB_SIZE, device=device)
+    draft_logits_1d = torch.randn(VOCAB_SIZE, device=device)
+
+    inputs = _build_rejection_sample_inputs(
+        target_logits_1d,
+        draft_logits_1d,
+        K,
+        temperature=0.0,
+        num_trials=num_trials,
+    )
+    target_argmax = int(target_logits_1d.argmax())
+    draft_sampled = inputs["draft_sampled"].view(num_trials, K + 1)
+    # Accept the first draft so that the rejection lands on the placeholder.
+    draft_sampled[:, 1] = target_argmax
+    draft_sampled[:, 2:] = -1
+
+    sampled, num_sampled = rejection_sample(**inputs, num_speculative_steps=K)
+
+    assert torch.equal(num_sampled, torch.full_like(num_sampled, 2))
+    steps = torch.arange(K + 1, device=device).unsqueeze(0)
+    emitted = sampled[steps < num_sampled.unsqueeze(1)]
+    assert (emitted == target_argmax).all(), "Greedy sampling emitted a token that is not the target argmax"
+
+    gc.collect()
+    torch.npu.empty_cache()

--- a/tests/ut/sample/a2/test_gumbel_sampling.py
+++ b/tests/ut/sample/a2/test_gumbel_sampling.py
@@ -313,7 +313,9 @@ class TestGumbelSampling:
 
     def test_gumbel_sample_apply_temperature_true_nonzero(self):
         """apply_temperature=True with temp>0 must divide logits by temperature
-        before adding Gumbel noise. Verify via processed_logits output."""
+        before adding Gumbel noise. The logits cache stores the input logits
+        *before* temperature; consumers (the rejection sampler) divide by the
+        same temperature on load."""
         torch.manual_seed(77)
         num_tokens, num_reqs, vocab_size = 4, 4, 32000
         logits = torch.randn(num_tokens, vocab_size, dtype=torch.float32, device=DEVICE)
@@ -322,7 +324,6 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        # Use processed_logits to verify temperature was applied
         out_logits = torch.zeros(num_reqs, vocab_size, dtype=torch.float32, device=DEVICE)
         gumbel_sample(
             logits,
@@ -331,21 +332,21 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             assert torch.allclose(out_logits[req].float(), expected, atol=1e-4, rtol=1e-4), (
-                f"processed_logits mismatch at token {tok} (req {req}, temp={temp:.3f}): "
+                f"logits_cache mismatch at token {tok} (req {req}): "
                 f"max_diff={(out_logits[req].float() - expected).abs().max().item():.6f}"
             )
 
     def test_gumbel_sample_apply_temperature_false_nonzero(self):
-        """apply_temperature=False with temp>0: processed_logits must contain
+        """apply_temperature=False with temp>0: the logits cache must contain
         raw logits (no temperature division), but Gumbel noise is still added
         to sampling."""
         torch.manual_seed(78)
@@ -364,7 +365,7 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=False,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
@@ -373,12 +374,12 @@ class TestGumbelSampling:
             # Without temperature application, stored logits should match raw logits
             expected = logits[tok].float()
             assert torch.allclose(out_logits[req].float(), expected, atol=1e-4, rtol=1e-4), (
-                f"processed_logits should be raw logits when apply_temperature=False: "
+                f"logits_cache should be raw logits when apply_temperature=False: "
                 f"max_diff={(out_logits[req].float() - expected).abs().max().item():.6f}"
             )
 
-    def test_gumbel_sample_processed_logits_req_state_idx(self):
-        """Processed logits must be stored at req_state_idx position, not token_idx.
+    def test_gumbel_sample_logits_cache_req_state_idx(self):
+        """Cached logits must be stored at req_state_idx position, not token_idx.
 
         This tests the EAGLE speculative decoding scenario where the idx_mapping
         is non-contiguous (e.g., active requests [2,5,7,0] out of 8 slots).
@@ -405,17 +406,17 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             actual = out_logits[req]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
-                f"Req {req} (tok={tok}, temp={temp:.3f}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
+                f"Req {req} (tok={tok}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
             )
 
         # Also verify that unused request slots remain zero
@@ -424,8 +425,8 @@ class TestGumbelSampling:
             if req not in used_reqs:
                 assert (out_logits[req] == 0).all(), f"Unused request slot {req} should be all zeros"
 
-    def test_gumbel_sample_processed_logits_col(self):
-        """output_processed_logits_col selects which column (draft step) to write.
+    def test_gumbel_sample_logits_cache_col(self):
+        """logits_cache_col selects which column (draft step) to write.
 
         Simulates EAGLE with buffer [max_num_reqs, num_steps, vocab_size].
         """
@@ -453,15 +454,15 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=draft_logits,
-            output_processed_logits_col=col_tensor,
+            logits_cache=draft_logits,
+            logits_cache_col=col_tensor,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             # Data should be at draft_logits[req, 1, :]  (column 1)
             actual = draft_logits[req, 1, :]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
@@ -471,12 +472,11 @@ class TestGumbelSampling:
             assert (draft_logits[req, 0, :] == 0).all(), f"Col 0 should be zeros for req {req}"
             assert (draft_logits[req, 2, :] == 0).all(), f"Col 2 should be zeros for req {req}"
 
-    def test_gumbel_sample_processed_logits_mixed_temp(self):
-        """Processed logits with mixed temperature (1:1 token-to-request mapping):
-        - temp=0: stored logits should be raw (no scaling)
-        - temp>0 with apply_temperature=True: stored logits should be logits/temp
+    def test_gumbel_sample_logits_cache_mixed_temp(self):
+        """Cached logits with mixed temperature (1:1 token-to-request mapping):
+        the cache always stores the raw input logits regardless of temperature.
 
-        Note: In practice, output_processed_logits is only used by EAGLE
+        Note: In practice, the logits cache is only used by EAGLE
         speculative decoding, which always has 1:1 token-to-request mapping.
         Multiple tokens per request would cause a write race (undefined order).
         """
@@ -500,20 +500,17 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
-            output_processed_logits=out_logits,
+            logits_cache=out_logits,
         )
         torch.npu.synchronize()
 
         for tok in range(num_tokens):
             req = expanded_idx_mapping[tok].item()
-            temp = temperature[req].item()
-            if temp == 0.0:
-                expected = logits[tok].float()
-            else:
-                expected = logits[tok].float() / temp
+            # The cache stores the pre-temperature logits.
+            expected = logits[tok].float()
             actual = out_logits[req]
             assert torch.allclose(actual.float(), expected, atol=1e-4, rtol=1e-4), (
-                f"Req {req} (tok={tok}, temp={temp:.3f}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
+                f"Req {req} (tok={tok}): max_diff={(actual.float() - expected).abs().max().item():.6f}"
             )
 
     def test_gumbel_sample_single_token(self):
@@ -568,3 +565,65 @@ class TestGumbelSampling:
         s2 = gumbel_sample(logits, expanded_idx_mapping, high_temp, seed, pos, apply_temperature=True)
         torch.npu.synchronize()
         assert (s2 >= 0).all() and (s2 < vocab_size).all()
+
+
+def _float_bits(t: torch.Tensor) -> torch.Tensor:
+    """Reinterpret floats as same-width ints, so equality is truly bitwise."""
+    int_dtype = torch.int32 if t.dtype == torch.float32 else torch.int16
+    return t.view(int_dtype)
+
+
+class TestGumbelSampleLogitsCache:
+    """Regression tests for the draft logits cache (upstream #50910)."""
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @pytest.mark.parametrize("per_token_col", [False, True])
+    def test_logits_cache_stores_input_logits_bitwise(self, dtype: torch.dtype, per_token_col: bool):
+        """`logits_cache` must receive the input logits, pre-temperature and bit-exact.
+
+        The cache is kept in the head's dtype, which is only lossless because the
+        stored value is the input logit itself. Storing `logit / temp` instead would
+        generally not be representable there, and the rejection sampler -- which
+        divides by the same temperature on load -- would then verify against a `q`
+        the draft never sampled from. Temperatures 0.0 and 1.0 are included because
+        both make the divide a no-op and would mask such a bug.
+
+        Both column-addressing modes are covered: a 0-d column (one draft step per
+        call, as MTP/EAGLE do) and a [num_tokens] column (as DFlash does, sampling
+        every step in one call).
+        """
+        torch.manual_seed(0)
+        num_reqs, vocab_size, num_steps = 8, 4099, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE, dtype=dtype)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.tensor([0.0, 0.1, 0.5, 1.0, 1.5, 2.0, 0.7, 1.0], dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        # NPU: pos is cast to int32 inside the kernel.
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+
+        cache = torch.zeros(num_reqs, num_steps, vocab_size, device=DEVICE, dtype=dtype)
+        if per_token_col:
+            # Each token lands in its own column, cycling through the steps.
+            cols = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE) % num_steps
+        else:
+            cols = torch.tensor(1, dtype=torch.int32, device=DEVICE)
+
+        gumbel_sample(
+            logits,
+            idx_mapping,
+            temp,
+            seed,
+            pos,
+            apply_temperature=True,
+            logits_cache=cache,
+            logits_cache_col=cols,
+        )
+        torch.npu.synchronize()
+
+        if per_token_col:
+            stored = cache[torch.arange(num_reqs, device=DEVICE), cols.long()]
+        else:
+            stored = cache[:, 1]
+            # Untouched columns must stay untouched.
+            assert not cache[:, 0].any() and not cache[:, 2].any()
+        assert torch.equal(_float_bits(stored), _float_bits(logits)), "cached logits differ from the input logits"

--- a/tests/ut/sample/a2/test_gumbel_sampling.py
+++ b/tests/ut/sample/a2/test_gumbel_sampling.py
@@ -627,3 +627,66 @@ class TestGumbelSampleLogitsCache:
             # Untouched columns must stay untouched.
             assert not cache[:, 0].any() and not cache[:, 2].any()
         assert torch.equal(_float_bits(stored), _float_bits(logits)), "cached logits differ from the input logits"
+
+    @pytest.mark.parametrize("extra_cache_cols", [0, 1])
+    def test_logits_cache_columns_stay_separate_across_steps(self, extra_cache_cols: int):
+        """Each drafting step must land in its own cache column.
+
+        `extra_cache_cols=1` is the shape a draft produces when it adds an
+        input-only mask/noise row to its embedding table but keeps a full-width
+        output head: N-wide logits cached into N+1-wide rows. Striding cache
+        columns by the logits width instead of the cache's own row width leaves
+        step 0 correct and silently misaligns every step after it.
+        """
+        torch.manual_seed(0)
+        num_reqs, vocab_size, num_steps = 4, 1031, 3
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.ones(num_reqs, dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        # NPU: pos is cast to int32 inside the kernel.
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+
+        cache = torch.zeros(num_reqs, num_steps, vocab_size + extra_cache_cols, device=DEVICE)
+        cols = torch.arange(num_steps, dtype=torch.int32, device=DEVICE)
+        per_step = [torch.randn(num_reqs, vocab_size, device=DEVICE) for _ in range(num_steps)]
+
+        for step, logits in enumerate(per_step):
+            gumbel_sample(
+                logits,
+                idx_mapping,
+                temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                logits_cache=cache,
+                logits_cache_col=cols[step],
+            )
+        torch.npu.synchronize()
+
+        for step, logits in enumerate(per_step):
+            stored = cache[:, step, :vocab_size]
+            assert torch.equal(_float_bits(stored), _float_bits(logits)), f"step {step} was overwritten by a later step"
+        # Columns past the sampled width belong to no step and stay untouched.
+        assert not cache[:, :, vocab_size:].any()
+
+    def test_logits_cache_narrower_than_logits_is_rejected(self):
+        """A cache too narrow to hold a step would silently drop its tail."""
+        num_reqs, vocab_size, num_steps = 2, 64, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.ones(num_reqs, dtype=torch.float32, device=DEVICE)
+        seed = torch.zeros(num_reqs, dtype=torch.int64, device=DEVICE)
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        cache = torch.zeros(num_reqs, num_steps, vocab_size - 1, device=DEVICE)
+
+        with pytest.raises(AssertionError, match="narrower"):
+            gumbel_sample(
+                logits,
+                idx_mapping,
+                temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                logits_cache=cache,
+                logits_cache_col=torch.tensor(0, dtype=torch.int32, device=DEVICE),
+            )

--- a/tests/ut/sample/a2/test_gumbel_sampling.py
+++ b/tests/ut/sample/a2/test_gumbel_sampling.py
@@ -95,7 +95,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -113,8 +115,12 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        s_false = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
-        s_true = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True)
+        s_false = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
+        s_true = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -138,9 +144,13 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        r1 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        r1 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
-        r2 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        r2 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert torch.equal(r1, r2), "gumbel_sample is non-deterministic with same seed"
@@ -159,8 +169,12 @@ class TestGumbelSampling:
         # Ensure seeds differ
         seed2[0] = seed1[0] + 1
 
-        r1 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed1, pos, apply_temperature=False)
-        r2 = gumbel_sample(logits, expanded_idx_mapping, temperature, seed2, pos, apply_temperature=False)
+        r1 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed1, pos, apply_temperature=False, is_drafting=False
+        )
+        r2 = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed2, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         # With 16 tokens and vocab 32000 at temp=1.0, identical results are astronomically unlikely
@@ -183,7 +197,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert sampled.shape == (num_tokens,)
@@ -215,10 +231,22 @@ class TestGumbelSampling:
             pos = torch.tensor([i], dtype=torch.int32, device=DEVICE)
 
             s_low = gumbel_sample(
-                logits_base.clone(), expanded_idx_mapping, low_temp, seed, pos, apply_temperature=True
+                logits_base.clone(),
+                expanded_idx_mapping,
+                low_temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=False,
             )
             s_high = gumbel_sample(
-                logits_base.clone(), expanded_idx_mapping, high_temp, seed, pos, apply_temperature=True
+                logits_base.clone(),
+                expanded_idx_mapping,
+                high_temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=False,
             )
             if s_low.item() == 0:
                 low_temp_winner_count += 1
@@ -255,7 +283,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_tokens,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         greedy = logits.argmax(dim=-1)
@@ -278,7 +308,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_reqs,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -303,7 +335,9 @@ class TestGumbelSampling:
         # Same pos -> same Gumbel noise
         pos = torch.tensor([5, 5], dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert sampled[0].item() == sampled[1].item(), (
@@ -332,6 +366,7 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
+            is_drafting=False,
             logits_cache=out_logits,
         )
         torch.npu.synchronize()
@@ -365,6 +400,7 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=False,
+            is_drafting=False,
             logits_cache=out_logits,
         )
         torch.npu.synchronize()
@@ -406,6 +442,7 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
+            is_drafting=False,
             logits_cache=out_logits,
         )
         torch.npu.synchronize()
@@ -454,6 +491,7 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
+            is_drafting=False,
             logits_cache=draft_logits,
             logits_cache_col=col_tensor,
         )
@@ -500,6 +538,7 @@ class TestGumbelSampling:
             seed,
             pos,
             apply_temperature=True,
+            is_drafting=False,
             logits_cache=out_logits,
         )
         torch.npu.synchronize()
@@ -522,7 +561,9 @@ class TestGumbelSampling:
         seed = torch.tensor([12345], dtype=torch.int64, device=DEVICE)
         pos = torch.tensor([0], dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
 
         assert sampled.shape == (1,)
@@ -539,7 +580,9 @@ class TestGumbelSampling:
         seed = torch.randint(0, 2**31, (num_tokens,), dtype=torch.int64, device=DEVICE)
         pos = torch.arange(num_tokens, dtype=torch.int32, device=DEVICE)
 
-        sampled = gumbel_sample(logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False)
+        sampled = gumbel_sample(
+            logits, expanded_idx_mapping, temperature, seed, pos, apply_temperature=False, is_drafting=False
+        )
         torch.npu.synchronize()
 
         expected = logits.argmax(dim=-1)
@@ -556,13 +599,15 @@ class TestGumbelSampling:
 
         # Very low temperature (near-greedy)
         low_temp = torch.tensor([0.01, 0.01, 0.01, 0.01], dtype=torch.float32, device=DEVICE)
-        s1 = gumbel_sample(logits, expanded_idx_mapping, low_temp, seed, pos, apply_temperature=True)
+        s1 = gumbel_sample(logits, expanded_idx_mapping, low_temp, seed, pos, apply_temperature=True, is_drafting=False)
         torch.npu.synchronize()
         assert (s1 >= 0).all() and (s1 < vocab_size).all()
 
         # Very high temperature (near-uniform)
         high_temp = torch.tensor([100.0, 100.0, 100.0, 100.0], dtype=torch.float32, device=DEVICE)
-        s2 = gumbel_sample(logits, expanded_idx_mapping, high_temp, seed, pos, apply_temperature=True)
+        s2 = gumbel_sample(
+            logits, expanded_idx_mapping, high_temp, seed, pos, apply_temperature=True, is_drafting=False
+        )
         torch.npu.synchronize()
         assert (s2 >= 0).all() and (s2 < vocab_size).all()
 
@@ -615,6 +660,7 @@ class TestGumbelSampleLogitsCache:
             seed,
             pos,
             apply_temperature=True,
+            is_drafting=False,
             logits_cache=cache,
             logits_cache_col=cols,
         )
@@ -658,6 +704,7 @@ class TestGumbelSampleLogitsCache:
                 seed,
                 pos,
                 apply_temperature=True,
+                is_drafting=False,
                 logits_cache=cache,
                 logits_cache_col=cols[step],
             )
@@ -687,6 +734,7 @@ class TestGumbelSampleLogitsCache:
                 seed,
                 pos,
                 apply_temperature=True,
+                is_drafting=False,
                 logits_cache=cache,
                 logits_cache_col=torch.tensor(0, dtype=torch.int32, device=DEVICE),
             )

--- a/tests/ut/sample/a2/test_gumbel_sampling.py
+++ b/tests/ut/sample/a2/test_gumbel_sampling.py
@@ -7,10 +7,14 @@
 # Tests for vllm_ascend.worker.v2.sample.gumbel on Ascend NPU.
 # Validates gumbel_sample and apply_temperature against PyTorch references.
 
+import math
+
 import pytest
 import torch
+from vllm.triton_utils import tl, triton
 
 from vllm_ascend.worker.v2.sample.gumbel import apply_temperature, gumbel_sample
+from vllm_ascend.worker.v2.spec_decode.rejection_sampler_utils import _npu_gumbel_block_argmax
 
 DEVICE = "npu"
 
@@ -660,7 +664,7 @@ class TestGumbelSampleLogitsCache:
             seed,
             pos,
             apply_temperature=True,
-            is_drafting=False,
+            is_drafting=True,
             logits_cache=cache,
             logits_cache_col=cols,
         )
@@ -704,7 +708,7 @@ class TestGumbelSampleLogitsCache:
                 seed,
                 pos,
                 apply_temperature=True,
-                is_drafting=False,
+                is_drafting=True,
                 logits_cache=cache,
                 logits_cache_col=cols[step],
             )
@@ -734,7 +738,293 @@ class TestGumbelSampleLogitsCache:
                 seed,
                 pos,
                 apply_temperature=True,
-                is_drafting=False,
+                is_drafting=True,
                 logits_cache=cache,
                 logits_cache_col=torch.tensor(0, dtype=torch.int32, device=DEVICE),
             )
+
+
+@triton.jit
+def _npu_gumbel_block_argmax_wrapper_kernel(
+    # [num_tokens, V]
+    logits_ptr,
+    # [num_tokens]
+    idx_mapping_ptr,
+    # [max_num_reqs]
+    temp_ptr,
+    # [max_num_reqs]
+    seed_ptr,
+    # [num_tokens]
+    pos_ptr,
+    # [max_num_reqs, num_cols, V]
+    cache_ptr,
+    cache_stride_0,
+    cache_stride_1,
+    # [] (shared column) or [num_tokens] (per-token column)
+    cache_col_ptr,
+    vocab_size,
+    # [num_tokens]
+    value_out_ptr,
+    idx_out_ptr,
+    APPLY_TEMPERATURE: tl.constexpr,
+    PER_TOKEN_COL: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Minimal launcher so _npu_gumbel_block_argmax's cache path can be tested
+    # directly: it is a device function, so a host-side call is impossible.
+    token_idx = tl.program_id(0).to(tl.int64)
+    block = tl.arange(0, BLOCK_SIZE)
+    mask = block < vocab_size
+    logits = tl.load(logits_ptr + token_idx * vocab_size + block, mask=mask, other=float("-inf"))
+    value, idx = _npu_gumbel_block_argmax(
+        logits,
+        block,
+        mask,
+        token_idx,
+        idx_mapping_ptr,
+        temp_ptr,
+        seed_ptr,
+        pos_ptr,
+        cache_ptr,
+        cache_stride_0,
+        cache_stride_1,
+        cache_col_ptr,
+        vocab_size,
+        IS_DRAFTING=False,
+        APPLY_TEMPERATURE=APPLY_TEMPERATURE,
+        USE_FP64=False,
+        PER_TOKEN_COL=PER_TOKEN_COL,
+    )
+    tl.store(value_out_ptr + token_idx, value)
+    tl.store(idx_out_ptr + token_idx, idx)
+
+
+class TestNpuGumbelBlockArgmaxCache:
+    """Direct coverage for _npu_gumbel_block_argmax's logits-cache path.
+
+    In production the rejection sampler's _resample_kernel calls the op with
+    logits_cache_ptr=None, so the cache path only runs when the NPU op is
+    patched into the upstream kernels (draft logits caching, upstream #50910).
+    These tests launch the op through a wrapper kernel (mirroring the
+    TestGumbelSampleLogitsCache assertions for gumbel_sample's cache) so the
+    fork-owned cache path keeps a regression guard.
+    """
+
+    BLOCK_SIZE = 8192
+
+    def _run(
+        self,
+        logits: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        temp: torch.Tensor,
+        seed: torch.Tensor,
+        pos: torch.Tensor,
+        cache: torch.Tensor,
+        cols: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        num_tokens, vocab_size = logits.shape
+        value_out = torch.empty(num_tokens, dtype=torch.float32, device=DEVICE)
+        idx_out = torch.empty(num_tokens, dtype=torch.int64, device=DEVICE)
+        _npu_gumbel_block_argmax_wrapper_kernel[(num_tokens,)](
+            logits,
+            idx_mapping,
+            temp,
+            seed,
+            pos,
+            cache,
+            cache.stride(0),
+            cache.stride(1),
+            cols,
+            vocab_size,
+            value_out,
+            idx_out,
+            APPLY_TEMPERATURE=True,
+            PER_TOKEN_COL=cols.ndim > 0,
+            BLOCK_SIZE=self.BLOCK_SIZE,
+        )
+        torch.npu.synchronize()
+        return value_out, idx_out
+
+    @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+    @pytest.mark.parametrize("per_token_col", [False, True])
+    @torch.inference_mode()
+    def test_cache_path_stores_input_logits_bitwise(self, dtype: torch.dtype, per_token_col: bool):
+        """The op's cache store must be pre-temperature and bit-exact.
+
+        Temps far from 0.0/1.0 make a post-temperature store fail the bitwise
+        check in every dtype. Both column-addressing modes are covered (shared
+        0-d column and per-token column), matching TestGumbelSampleLogitsCache.
+        """
+        torch.manual_seed(0)
+        num_reqs, vocab_size, num_steps = 8, 4099, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE, dtype=dtype)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.tensor([0.1, 0.5, 1.5, 2.0, 0.7, 0.3, 0.9, 1.1], dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        # NPU: pos is cast to int32 inside the kernel.
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+
+        cache = torch.zeros(num_reqs, num_steps, vocab_size, device=DEVICE, dtype=dtype)
+        if per_token_col:
+            # Each token lands in its own column, cycling through the steps.
+            cols = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE) % num_steps
+        else:
+            cols = torch.tensor(1, dtype=torch.int32, device=DEVICE)
+
+        _, idx_out = self._run(logits, idx_mapping, temp, seed, pos, cache, cols)
+        # Same (seed, pos) must reproduce the same noisy draw.
+        _, idx_out_2 = self._run(logits, idx_mapping, temp, seed, pos, cache, cols)
+        assert torch.equal(idx_out, idx_out_2), "same (seed, pos) produced different draws"
+
+        if per_token_col:
+            stored = cache[torch.arange(num_reqs, device=DEVICE), cols.long()]
+        else:
+            stored = cache[:, 1]
+            # Untouched columns must stay untouched.
+            assert not cache[:, 0].any() and not cache[:, 2].any()
+        assert torch.equal(_float_bits(stored), _float_bits(logits)), "cached logits differ from the input logits"
+        assert ((idx_out >= 0) & (idx_out < vocab_size)).all()
+
+    @torch.inference_mode()
+    def test_cache_path_greedy_returns_argmax(self):
+        """temp=0 applies neither temperature nor noise: argmax and raw max."""
+        torch.manual_seed(1)
+        num_reqs, vocab_size, num_steps = 4, 1031, 3
+        logits = torch.randn(num_reqs, vocab_size, device=DEVICE, dtype=torch.float32)
+        idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        temp = torch.zeros(num_reqs, dtype=torch.float32, device=DEVICE)
+        seed = torch.arange(num_reqs, dtype=torch.int64, device=DEVICE)
+        pos = torch.arange(num_reqs, dtype=torch.int32, device=DEVICE)
+        cache = torch.zeros(num_reqs, num_steps, vocab_size, device=DEVICE, dtype=torch.float32)
+        cols = torch.tensor(0, dtype=torch.int32, device=DEVICE)
+
+        value_out, idx_out = self._run(logits, idx_mapping, temp, seed, pos, cache, cols)
+
+        assert torch.equal(idx_out, logits.argmax(dim=-1))
+        assert torch.equal(value_out, logits.max(dim=-1).values)
+        assert torch.equal(cache[:, 0], logits)
+
+
+# --------------------------- Noise streams ---------------------------------
+
+# Adapted from upstream tests/v1/worker/test_gpu_gumbel_sample.py
+# (upstream #54282: decouple the draft's Gumbel noise stream from the
+# target's via a Philox offset salt).
+
+# Dominant token is exp(HEAD_LOG_GAP)x larger than the unit-count tail, so the
+# tail sits ~HEAD_LOG_GAP logits below the top. That tail is the sensitive
+# part: the fp32 Gumbel noise must reach ~18 to ever sample it.
+HEAD_LOG_GAP = 18.0
+# 10-sigma band: a correct sampler effectively never trips it.
+Z_TOLERANCE = 10.0
+# NPU: upstream draws 500K samples in one call; the kernel's int64 argmax
+# scratch is [num_tokens, num_blocks], so draw in chunks to bound memory.
+NOISE_STREAM_VOCAB_SIZE = 200_000
+NOISE_STREAM_CHUNK = 50_000
+NOISE_STREAM_NUM_SAMPLES = 500_000
+
+
+def _make_heavy_tailed_counts(seed: int = 1234) -> torch.Tensor:
+    """Non-negative int64 counts of shape [vocab]; target prob = counts/N."""
+    gen = torch.Generator(device=DEVICE).manual_seed(seed)
+    counts = torch.randint(1, 4, (NOISE_STREAM_VOCAB_SIZE,), generator=gen, dtype=torch.int64, device=DEVICE)
+    counts[0] = round(math.exp(HEAD_LOG_GAP))  # dominant token
+    return counts
+
+
+def _counts_to_logits(counts: torch.Tensor) -> torch.Tensor:
+    # softmax(log(count)) == count / sum(count); count 0 -> logit -inf -> prob 0.
+    return counts.double().log().to(torch.float32)
+
+
+def _sample_noise_stream(
+    logits_1d: torch.Tensor,
+    *,
+    is_drafting: bool,
+) -> torch.Tensor:
+    """Sample NOISE_STREAM_NUM_SAMPLES tokens from one logit vector.
+
+    Fixed seed with a distinct `pos` per sample gives independent draws; the
+    logits are broadcast with a 0-stride view to avoid materializing
+    [num_samples, vocab_size]. NPU: pos is int32 (triton-ascend philox), and
+    draws are chunked to bound the kernel's scratch memory.
+    """
+    vocab_size = logits_1d.shape[0]
+    sampled_parts = []
+    for start in range(0, NOISE_STREAM_NUM_SAMPLES, NOISE_STREAM_CHUNK):
+        size = min(NOISE_STREAM_CHUNK, NOISE_STREAM_NUM_SAMPLES - start)
+        logits = logits_1d.unsqueeze(0).expand(size, vocab_size)
+        idx_mapping = torch.zeros(size, dtype=torch.int32, device=DEVICE)
+        temp = torch.tensor([1.0], dtype=torch.float32, device=DEVICE)
+        seed = torch.tensor([0xABCD], dtype=torch.int64, device=DEVICE)
+        pos = torch.arange(start, start + size, dtype=torch.int32, device=DEVICE)
+        sampled_parts.append(
+            gumbel_sample(
+                logits,
+                idx_mapping,
+                temp,
+                seed,
+                pos,
+                apply_temperature=True,
+                is_drafting=is_drafting,
+            )
+        )
+    return torch.cat(sampled_parts)
+
+
+def _z_score(observed: int, expected: float, num_trials: int) -> float:
+    p = expected / num_trials
+    return (observed - expected) / math.sqrt(num_trials * p * (1 - p))
+
+
+class TestGumbelSampleNoiseStreams:
+    """The draft's Gumbel noise stream must be disjoint from the target's."""
+
+    @torch.inference_mode()
+    def test_drafting_uses_a_separate_noise_stream(self):
+        """is_drafting salts the Philox offset: same inputs, different draws.
+
+        The draft proposal and the residual resample after a rejection must be
+        independent. They key noise by the same (seed, pos), so only the salt
+        keeps them apart -- without it the resample inherits the very noise
+        vector that picked the rejected proposal. See
+        test_gumbel_drafted_rejection_sample_is_unbiased in
+        tests/e2e/nightly/single_node/ops/singlecard_ops/triton/
+        test_rejection_sample_v2.py for the distributional consequence.
+
+        Relocating the offset must not distort the draw either, so both streams
+        are checked against the target's far-tail mass, which sits
+        HEAD_LOG_GAP logits below the head -- the regime where fp32 Gumbel
+        precision matters.
+        """
+        counts = _make_heavy_tailed_counts()
+        total = counts.sum().item()
+        logits = _counts_to_logits(counts)
+        tail_prob = (total - counts[0].item()) / total
+
+        target = _sample_noise_stream(logits, is_drafting=False)
+        draft = _sample_noise_stream(logits, is_drafting=True)
+
+        # The head dominates, so the streams agree on most draws by construction.
+        # Compare instead which draws leave the head: shared noise makes that
+        # identical, independent noise makes them differ on ~2p(1-p) of draws.
+        target_tail = target != 0
+        draft_tail = draft != 0
+        disagree = (target_tail != draft_tail).double().mean().item()
+        assert disagree > tail_prob, (
+            f"streams leave the head on the same draws ({disagree:.3e} disagreement "
+            f"vs tail mass {tail_prob:.3e}); the draft salt is not taking effect"
+        )
+
+        # Both streams must still reproduce the target's tail mass.
+        for name, tail in (("target", target_tail), ("draft", draft_tail)):
+            tail_count = tail.sum().item()
+            z = _z_score(tail_count, NOISE_STREAM_NUM_SAMPLES * tail_prob, NOISE_STREAM_NUM_SAMPLES)
+            assert abs(z) < Z_TOLERANCE, (
+                f"{name} tail mass {tail_count / NOISE_STREAM_NUM_SAMPLES:.3e} != {tail_prob:.3e} (z={z:.2f})"
+            )
+
+        # The draft stream is reproducible.
+        assert torch.equal(draft, _sample_noise_stream(logits, is_drafting=True))
+
+        torch.npu.synchronize()

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -80,7 +80,8 @@ def apply_temperature(
     do_not_specialize=[
         "local_argmax_stride",
         "local_max_stride",
-        "processed_logits_stride",
+        "logits_cache_stride_0",
+        "logits_cache_stride_1",
         "logits_stride",
         "vocab_size",
         "num_blocks",
@@ -91,9 +92,11 @@ def _gumbel_sample_kernel(
     local_argmax_stride,
     local_max_ptr,
     local_max_stride,
-    processed_logits_ptr,
-    processed_logits_stride,
-    processed_logits_col_ptr,
+    # [max_num_reqs, num_cols, vocab_size]
+    logits_cache_ptr,
+    logits_cache_stride_0,
+    logits_cache_stride_1,
+    logits_cache_col_ptr,
     logits_ptr,
     logits_stride,
     expanded_idx_mapping_ptr,
@@ -121,24 +124,28 @@ def _gumbel_sample_kernel(
         )
         logits = logits.to(tl.float32)
 
-        block_temp = temp
-        if block_temp != 0.0 and APPLY_TEMPERATURE:
-            logits = logits / block_temp
-
-        if processed_logits_ptr is not None:
-            # Store the temperature-applied logits.
-            if processed_logits_col_ptr is not None:
+        if logits_cache_ptr is not None:
+            # Store the logits *before* temperature. Dividing first would
+            # produce a value that is generally not representable in the
+            # cache's dtype, forcing it to be fp32. Consumers (the rejection
+            # sampler) divide by the same temperature on load, which
+            # reproduces the value used below bitwise.
+            if logits_cache_col_ptr is not None:
                 if PER_TOKEN_COL:
-                    col = tl.load(processed_logits_col_ptr + token_idx)
+                    col = tl.load(logits_cache_col_ptr + token_idx)
                 else:
-                    col = tl.load(processed_logits_col_ptr)
+                    col = tl.load(logits_cache_col_ptr)
             else:
                 col = 0
             tl.store(
-                processed_logits_ptr + req_state_idx * processed_logits_stride + col * vocab_size + block,
+                logits_cache_ptr + req_state_idx * logits_cache_stride_0 + col * logits_cache_stride_1 + block,
                 logits,
                 mask=mask,
             )
+
+        block_temp = temp
+        if block_temp != 0.0 and APPLY_TEMPERATURE:
+            logits = logits / block_temp
 
         if block_temp != 0.0:
             # Calculate the seed for gumbel noise.
@@ -171,13 +178,21 @@ def gumbel_sample(
     seed: torch.Tensor,  # [max_num_reqs]
     pos: torch.Tensor,  # [num_tokens]
     apply_temperature: bool,
-    output_processed_logits: torch.Tensor | None = None,
-    output_processed_logits_col: torch.Tensor | None = None,
+    logits_cache: torch.Tensor | None = None,  # [max_num_reqs, num_cols, vocab_size]
+    logits_cache_col: torch.Tensor | None = None,  # scalar or [num_tokens]
     use_fp64: bool = False,
 ) -> torch.Tensor:
     if use_fp64:
         raise NotImplementedError("FP64 Gumbel sampling is not supported on NPU.")
+    if logits_cache_col is not None:
+        logits_cache_col = logits_cache_col.contiguous()
     num_tokens, vocab_size = logits.shape
+    if logits_cache is not None:
+        assert logits_cache.size(-1) >= vocab_size, (
+            f"draft logits cache vocab dim ({logits_cache.size(-1)}) is narrower "
+            f"than the sampled logits ({vocab_size}). Cached logits would be "
+            "truncated."
+        )
     BLOCK_SIZE = 1024
     num_blocks = triton.cdiv(vocab_size, BLOCK_SIZE)
     local_argmax = torch.empty(
@@ -192,15 +207,16 @@ def gumbel_sample(
         dtype=torch.float32,
         device=logits.device,
     )
-    per_token_col = output_processed_logits_col is not None and output_processed_logits_col.dim() > 0
+    per_token_col = logits_cache_col is not None and logits_cache_col.dim() > 0
     _gumbel_sample_kernel[(num_tokens,)](
         local_argmax,
         local_argmax.stride(0),
         local_max,
         local_max.stride(0),
-        output_processed_logits,
-        output_processed_logits.stride(0) if output_processed_logits is not None else 0,
-        output_processed_logits_col,
+        logits_cache,
+        logits_cache.stride(0) if logits_cache is not None else 0,
+        logits_cache.stride(1) if logits_cache is not None else 0,
+        logits_cache_col,
         logits,
         logits.stride(0),
         expanded_idx_mapping,

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -20,6 +20,14 @@
 import torch
 from vllm.triton_utils import tl, triton
 
+# Offset salt keeping the draft's Gumbel noise disjoint from the target's
+# (upstream #54282). Verification is a probability-ratio test, not a Gumbel
+# coupling, so a proposal and the residual it is resampled from must not share
+# a noise vector. Positions are well below 2**30, so the streams cannot
+# collide. NPU: pos is cast to int32 before salting, and the salt plus any
+# real position stays within int32 range.
+_DRAFT_NOISE_SALT = tl.constexpr(1 << 30)
+
 
 @triton.jit(do_not_specialize=["logits_stride", "vocab_size"])
 def _temperature_kernel(
@@ -106,6 +114,7 @@ def _gumbel_sample_kernel(
     vocab_size,
     num_blocks,
     BLOCK_SIZE: tl.constexpr,
+    IS_DRAFTING: tl.constexpr,
     APPLY_TEMPERATURE: tl.constexpr,
     PER_TOKEN_COL: tl.constexpr,
 ):
@@ -153,6 +162,14 @@ def _gumbel_sample_kernel(
             # NOTE(Ronald1995): change pos's dtype to tl.int32, because triton-ascend's
             # compiler doesn't support uint64 of pos arg.
             pos = tl.load(pos_ptr + token_idx).to(tl.int32)
+            if IS_DRAFTING:
+                # Offset salt keeping the draft's Gumbel noise disjoint from
+                # the target's (upstream #54282). Verification is a
+                # probability-ratio test, not a Gumbel coupling, so a proposal
+                # and the residual it is resampled from must not share a
+                # noise vector. NPU: pos is int32 here, and the salt (2**30)
+                # plus any real position stays within int32 range.
+                pos = pos + _DRAFT_NOISE_SALT
             gumbel_seed = tl.randint(seed, pos)
 
             # NOTE(Ronald1995): r is tl.float64 in vllm, change it to tl.float32,
@@ -178,6 +195,7 @@ def gumbel_sample(
     seed: torch.Tensor,  # [max_num_reqs]
     pos: torch.Tensor,  # [num_tokens]
     apply_temperature: bool,
+    is_drafting: bool,
     logits_cache: torch.Tensor | None = None,  # [max_num_reqs, num_cols, vocab_size]
     logits_cache_col: torch.Tensor | None = None,  # scalar or [num_tokens]
     use_fp64: bool = False,
@@ -226,6 +244,7 @@ def gumbel_sample(
         vocab_size,
         num_blocks,
         BLOCK_SIZE=BLOCK_SIZE,
+        IS_DRAFTING=is_drafting,
         APPLY_TEMPERATURE=apply_temperature,
         PER_TOKEN_COL=per_token_col,
     )

--- a/vllm_ascend/worker/v2/sample/gumbel.py
+++ b/vllm_ascend/worker/v2/sample/gumbel.py
@@ -30,7 +30,7 @@ def _temperature_kernel(
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
 ):
-    token_idx = tl.program_id(0)
+    token_idx = tl.program_id(0).to(tl.int64)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     temperature = tl.load(temperature_ptr + req_state_idx).to(tl.float32)
     if temperature == 0.0 or temperature == 1.0:
@@ -106,9 +106,9 @@ def _gumbel_sample_kernel(
     APPLY_TEMPERATURE: tl.constexpr,
     PER_TOKEN_COL: tl.constexpr,
 ):
-    token_idx = tl.program_id(0)
+    token_idx = tl.program_id(0).to(tl.int64)
 
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx).to(tl.int64)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
 
     for block_idx in range(num_blocks):

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -51,6 +51,10 @@ def _npu_gumbel_block_argmax(
     vocab_size,
     APPLY_TEMPERATURE: tl.constexpr,
 ):
+    # Convert token_idx to int64 before pointer arithmetic so the offset
+    # does not overflow int32 at large token counts (matches the other
+    # kernels that cast tl.program_id(0) up front).
+    token_idx = token_idx.to(tl.int64)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx).to(tl.int64)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     if temp != 0.0 and APPLY_TEMPERATURE:

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -553,6 +553,10 @@ def rejection_sample(
         # kernel signatures receive valid pointers/strides. The kernels
         # will never read from it when HAS_DRAFT_LOGITS=False.
         draft_logits = target_logits.new_empty(1, 1, 1)
+    else:
+        # In some cases (e.g. MiMo v2.5 Pro + DFlash) the target model's
+        # vocab size is larger than the draft's due to padding.
+        vocab_size = min(vocab_size, draft_logits.size(-1))
 
     # Compute the block-level logits stats, such as target argmax
     # (for greedy requests), and target max + softmax exponential

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -51,6 +51,7 @@ def _npu_gumbel_block_argmax(
     logits_cache_stride_1,
     logits_cache_col_ptr,
     vocab_size,
+    IS_DRAFTING: tl.constexpr,
     APPLY_TEMPERATURE: tl.constexpr,
     USE_FP64: tl.constexpr,
     PER_TOKEN_COL: tl.constexpr = False,
@@ -103,6 +104,11 @@ def _npu_gumbel_block_argmax(
         # NPU: cast pos to int32 to avoid uint64 in philox (NPU umulhi only
         # supports int32/uint32). Position values fit in int32 in practice.
         pos = tl.load(pos_ptr + token_idx).to(tl.int32)
+        # IS_DRAFTING is kept for signature compatibility with upstream
+        # gumbel_block_argmax (upstream #54282). The rejection sampler's
+        # resample is the target side, so callers must always pass False;
+        # salting the noise here would corrupt the target's stream.
+        assert not IS_DRAFTING
         gumbel_seed = tl.randint(seed, pos)
         # NPU: tldevice.log1p (CUDA libdevice extern) is not usable on
         # triton-ascend — the AST frontend infers a NoneType return for the
@@ -264,6 +270,7 @@ def _resample_kernel(
         0,  # logits_cache_stride_1
         None,  # logits_cache_col_ptr
         vocab_size,
+        IS_DRAFTING=False,
         APPLY_TEMPERATURE=False,
         USE_FP64=False,
     )

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -46,7 +46,7 @@ def _npu_gumbel_block_argmax(
     vocab_size,
     APPLY_TEMPERATURE: tl.constexpr,
 ):
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx).to(tl.int64)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     if temp != 0.0 and APPLY_TEMPERATURE:
         logits = logits / temp
@@ -117,10 +117,10 @@ def _resample_kernel(
 ):
     req_idx = tl.program_id(0)
     resample_idx = tl.load(rejected_step_ptr + req_idx)
-    start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
     resample_token_idx = start_idx + resample_idx
-    req_state_idx = tl.load(expanded_idx_mapping_ptr + resample_token_idx)
+    req_state_idx = tl.load(expanded_idx_mapping_ptr + resample_token_idx).to(tl.int64)
 
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     is_bonus = resample_token_idx == end_idx - 1
@@ -241,8 +241,8 @@ def _probabilistic_rejection_kernel(
     SYNTHETIC_MODE: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
-    req_state_idx = tl.load(idx_mapping_ptr + req_idx)
-    start_idx = tl.load(cu_num_logits_ptr + req_idx)
+    req_state_idx = tl.load(idx_mapping_ptr + req_idx).to(tl.int64)
+    start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
     num_tokens = end_idx - start_idx
     seed = tl.load(seed_ptr + req_state_idx)  # noqa: F841

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -45,32 +45,58 @@ def _npu_gumbel_block_argmax(
     temp_ptr,
     seeds_ptr,
     pos_ptr,
-    processed_logits_ptr,
-    processed_logits_stride,
-    processed_logits_col_ptr,
+    # [max_num_reqs, num_cols, vocab_size]
+    logits_cache_ptr,
+    logits_cache_stride_0,
+    logits_cache_stride_1,
+    logits_cache_col_ptr,
     vocab_size,
     APPLY_TEMPERATURE: tl.constexpr,
+    USE_FP64: tl.constexpr,
+    PER_TOKEN_COL: tl.constexpr = False,
 ):
-    # Convert token_idx to int64 before pointer arithmetic so the offset
-    # does not overflow int32 at large token counts (matches the other
-    # kernels that cast tl.program_id(0) up front).
+    # NPU port of the upstream gumbel_block_argmax (vllm/v1/worker/gpu/
+    # sample/gumbel.py). The signature must stay aligned with upstream so
+    # this can be patched into rejection_sampler_utils.gumbel_block_argmax
+    # and resolved by the upstream kernels. NPU adaptations:
+    #   1. token_idx is upcast to int64 before pointer arithmetic so the
+    #      offset does not overflow int32 at large token counts.
+    #   2. pos is cast to int32: triton-ascend's philox (umulhi) only
+    #      supports int32/uint32 operands.
+    #   3. Noise is always fp32 tl.rand clamped away from zero (equivalent
+    #      to upstream tl_rand32 includes_zero=False); fp64 (tl_rand64) is
+    #      unsupported on NPU and guarded at the host level.
+    #   4. Plain scalar loads instead of upstream's mask=is_valid_req
+    #      masked loads: req_state_idx is always valid in the rejection
+    #      sampler path and 0-d masked loads are unverified on
+    #      triton-ascend.
     token_idx = token_idx.to(tl.int64)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx).to(tl.int64)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
-    if temp != 0.0 and APPLY_TEMPERATURE:
-        logits = logits / temp
-
-    if processed_logits_ptr is not None:
-        if processed_logits_col_ptr is not None:
-            col = tl.load(processed_logits_col_ptr)
+    if logits_cache_ptr is not None:
+        # Store the logits *before* temperature. Dividing first would
+        # produce a value that is generally not representable in the
+        # cache's dtype, forcing it to be fp32. Consumers (the rejection
+        # sampler) divide by the same temperature on load, which
+        # reproduces the value used below bitwise.
+        if PER_TOKEN_COL:
+            col = tl.load(logits_cache_col_ptr + token_idx)
         else:
-            col = 0
+            col = tl.load(logits_cache_col_ptr)
         tl.store(
-            processed_logits_ptr + req_state_idx * processed_logits_stride + col * vocab_size + block,
+            logits_cache_ptr + req_state_idx * logits_cache_stride_0 + col * logits_cache_stride_1 + block,
             logits,
             mask=mask,
         )
 
+    if temp != 0.0 and APPLY_TEMPERATURE:
+        # Apply temperature.
+        # NOTE(woosuk): Match the behavior of _temperature_kernel.
+        # E.g., if the kernel uses tl.div_rn, we should use tl.div_rn here too.
+        logits = logits / temp
+
+    # NPU: fp64 is unsupported; always reduce in fp32. USE_FP64 is kept
+    # for signature compatibility and guarded at the host level.
     logits = logits.to(tl.float32)
     if temp != 0.0:
         seed = tl.load(seeds_ptr + req_state_idx)
@@ -78,9 +104,15 @@ def _npu_gumbel_block_argmax(
         # supports int32/uint32). Position values fit in int32 in practice.
         pos = tl.load(pos_ptr + token_idx).to(tl.int32)
         gumbel_seed = tl.randint(seed, pos)
-        # NPU: use tl.rand (float32) instead of tl_rand64 (float64 not supported)
-        r = tl.rand(gumbel_seed, block).to(tl.float32)
-        gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
+        # NPU: tl.rand (fp32) clamped away from zero, matching upstream
+        # tl_rand32(includes_zero=False). Draw the large-noise tail (which
+        # decides the argmax winner) from u -> 0, where fp32 has fine
+        # resolution, instead of u -> 1 (see upstream gumbel.py for the
+        # full log1p rationale).
+        u = tl.rand(gumbel_seed, block).to(tl.float32)
+        u = tl.maximum(u, 4.6566127342e-10)
+        gumbel_noise = -tl.log(-tldevice.log1p(-u))
+        # Apply gumbel noise.
         logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
 
     value, idx = tl.max(logits, axis=0, return_indices=True)
@@ -222,11 +254,13 @@ def _resample_kernel(
         temp_ptr,
         seed_ptr,
         pos_ptr,
-        None,
-        0,
-        None,
+        None,  # logits_cache_ptr
+        0,  # logits_cache_stride_0
+        0,  # logits_cache_stride_1
+        None,  # logits_cache_col_ptr
         vocab_size,
         APPLY_TEMPERATURE=False,
+        USE_FP64=False,
     )
     token_id = block_idx * BLOCK_SIZE + idx
     tl.store(

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -20,13 +20,18 @@
 import torch
 from vllm.triton_utils import tl, tldevice, triton
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
+    _compute_cumulative_log_p_kernel,
+    _compute_global_logprobs_and_logsumexp,
+    _compute_global_residual_mass,
+    _compute_global_target_argmax,
+    _compute_local_residual_mass_kernel,
+    _insert_resampled_kernel,
+)
+from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
     _compute_global_logsumexp as _compute_global_lse,
 )
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
     _compute_local_logits_stats_kernel as _compute_block_stats_kernel,
-)
-from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
-    _insert_resampled_kernel,
 )
 
 
@@ -111,9 +116,12 @@ def _resample_kernel(
     seed_ptr,
     # [num_logits]
     pos_ptr,
+    # [num_logits]
+    cumulative_log_p_ptr,
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
+    USE_BLOCK_VERIFICATION: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     resample_idx = tl.load(rejected_step_ptr + req_idx)
@@ -125,7 +133,18 @@ def _resample_kernel(
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     is_bonus = resample_token_idx == end_idx - 1
     if temp == 0.0 and not is_bonus:
+        # Greedy + non-bonus token. No resampling needed because
+        # the target argmax is already in the sampled tensor.
         return
+
+    # NPU: use `== 0` instead of Python `not` on the scalar tensor so the
+    # mask stays a plain tensor expression.
+    rejected_draft_token = tl.load(
+        draft_sampled_ptr + resample_token_idx + 1,
+        mask=is_bonus == 0,
+        other=0,
+    )
+    is_valid_rejected_draft = rejected_draft_token >= 0
 
     block_idx = tl.program_id(1)
     block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -136,17 +155,33 @@ def _resample_kernel(
         other=float("-inf"),
     ).to(tl.float32)
 
-    if is_bonus:
+    # Compute the residual logits to resample the rejected token from.
+    if is_bonus or not is_valid_rejected_draft:
+        # Bonus token (no rejections) or -1 placeholder token. In either case,
+        # directly use the target logits.
         residual_logits = target_logits
     elif HAS_DRAFT_LOGITS:
-        draft_logits = tl.load(
-            draft_logits_ptr + req_state_idx * draft_logits_stride_0 + resample_idx * draft_logits_stride_1 + block,
-            mask=mask,
-            other=float("-inf"),
-        ).to(tl.float32)
+        # draft_logits is stored pre-temperature, so apply scale first.
+        draft_logits = (
+            tl.load(
+                draft_logits_ptr + req_state_idx * draft_logits_stride_0 + resample_idx * draft_logits_stride_1 + block,
+                mask=mask,
+                other=float("-inf"),
+            ).to(tl.float32)
+            / temp
+        )
         target_lse = tl.load(target_rejected_logsumexp_ptr + req_idx)
         draft_lse = tl.load(draft_rejected_logsumexp_ptr + req_idx)
         target_log_probs = target_logits - target_lse
+        if USE_BLOCK_VERIFICATION:
+            # Block residual is:
+            #   max(p_tau * M_b(x) - M_s(x), 0) / Z.
+            # Scale the target logprobs by log(p_tau). p_0 = 1, so skip
+            # shifting when nothing was accepted (tau == 0).
+            log_p_tau = 0.0
+            if resample_idx > 0:
+                log_p_tau = tl.load(cumulative_log_p_ptr + resample_token_idx - 1).to(tl.float32)
+            target_log_probs += log_p_tau
         draft_log_probs = draft_logits - draft_lse
         # Compute the residual:
         #   r(x) = max(p(x) - q(x), 0)
@@ -161,7 +196,13 @@ def _resample_kernel(
             float("-inf"),
         ).to(tl.float32)
     else:
-        rejected_draft_token = tl.load(draft_sampled_ptr + resample_token_idx + 1)
+        # One-hot draft. The residual is just the target distribution with
+        # the rejected draft token probability zeroed out.
+        # NOTE: During block verification, the residual becomes:
+        #   0                   if x == rejected_draft_token
+        #   p_tau * M_b(x) / Z  otherwise
+        # Therefore p_tau is a constant that cancels under normalization,
+        # and does not need to be applied.
         residual_logits = tl.where(
             block != rejected_draft_token,
             target_logits,
@@ -241,129 +282,181 @@ def _probabilistic_rejection_kernel(
     pos_ptr,
     # [num_speculative_steps]
     synthetic_conditional_rates_ptr,
+    # [num_logits]
+    cumulative_log_p_ptr,
+    # [num_logits, num_blocks]
+    local_residual_mass_ptr,
+    local_residual_mass_stride,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
     SYNTHETIC_MODE: tl.constexpr,
+    USE_BLOCK_VERIFICATION: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx).to(tl.int64)
     start_idx = tl.load(cu_num_logits_ptr + req_idx).to(tl.int64)
     end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
-    num_tokens = end_idx - start_idx
-    seed = tl.load(seed_ptr + req_state_idx)  # noqa: F841
+    num_draft_tokens = end_idx - start_idx - 1
+    seed = tl.load(seed_ptr + req_state_idx)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
+    is_greedy = temp == 0.0
 
-    rejected_step = 0
+    accepted_length = tl.zeros((), tl.int64)
     target_lse = 0.0
     draft_lse = 0.0
-    accepted = True
-    for i in range(num_tokens - 1):
-        if accepted:
-            logit_idx = start_idx + i
-            draft_sampled = tl.load(draft_sampled_ptr + logit_idx + 1)
-            if temp == 0.0:
+    verifying = True
+    for i in range(num_draft_tokens):
+        logit_idx = start_idx + i
+        draft_sampled = tl.load(draft_sampled_ptr + logit_idx + 1).to(tl.int64)
+        # -1 is used for placeholder draft token ids that should be rejected.
+        is_valid_draft = draft_sampled >= 0
+        # Avoid possible OOB ptr access.
+        draft_sampled = tl.maximum(0, draft_sampled)
+        if not is_greedy:
+            # A -1 placeholder ends verification. Greedy is excluded because it
+            # stores the target argmax upon first rejection, so it rejects the
+            # placeholder via `accepted` instead.
+            verifying &= is_valid_draft
+
+        if verifying:
+            # Draw the acceptance threshold u ~ U(0, 1). Upstream uses
+            # tl_rand32(seed, pos, includes_zero=False); NPU Triton lacks
+            # scalar tl.rand, so generate u from a 1-element block + reduction
+            # and clamp away from 0 so that tl.log(u) stays finite.
+            # NPU: cast pos to int32 so philox uses the 32-bit path.
+            # uint64 umulhi is not supported by the Ascend vector core.
+            # Position values fit in int32 in practice.
+            u_pos = tl.load(pos_ptr + logit_idx).to(tl.int32)
+            u_seed = tl.randint(seed, u_pos)
+            u = tl.max(tl.rand(u_seed, tl.arange(0, 1)).to(tl.float32), axis=0)
+            u = tl.maximum(u, 4.6566127342e-10)
+            if is_greedy:
                 # Greedy sampling. Accept IFF draft matches target argmax.
                 # NOTE: Target argmax is stored directly so that resampling
                 # can be skipped upon rejection.
-                target_blocks = tl.arange(0, PADDED_VOCAB_NUM_BLOCKS)
-                target_blocks_mask = target_blocks < vocab_num_blocks
-                target_local_max = tl.load(
-                    target_local_max_ptr + logit_idx * target_local_max_stride + target_blocks,
-                    mask=target_blocks_mask,
-                    other=float("-inf"),
-                )
-                max_target_block_idx = tl.argmax(target_local_max, axis=0)
-                target_argmax = tl.load(
-                    target_local_argmax_ptr + logit_idx * target_local_argmax_stride + max_target_block_idx
-                )
-                if SYNTHETIC_MODE:
-                    # Synthetic acceptance: accept IFF u ~ U(0, 1) < rate.
-                    # Upstream uses tl_rand32(seed, pos, includes_zero=False);
-                    # NPU Triton lacks scalar tl.rand, so reuse the 1-element
-                    # block + reduction pattern from the non-greedy path below.
-                    u_pos = tl.load(pos_ptr + logit_idx).to(tl.int32)
-                    u_seed = tl.randint(seed, u_pos)
-                    u = tl.max(tl.rand(u_seed, tl.arange(0, 1)).to(tl.float32), axis=0)
-                    u = tl.maximum(u, 4.6566127342e-10)
-                    rate = tl.load(synthetic_conditional_rates_ptr + i)
-                    accepted &= u < rate
-                    # -1 placeholder draft tokens can never be accepted.
-                    accepted &= draft_sampled >= 0
-                    # Keep the accepted draft token; store the target argmax
-                    # upon rejection so resampling can be skipped.
-                    token = tl.where(accepted, draft_sampled.to(tl.int64), target_argmax)
-                    tl.store(sampled_ptr + req_idx * sampled_stride + i, token)
-                else:
-                    accepted &= target_argmax == draft_sampled
-                    tl.store(sampled_ptr + req_idx * sampled_stride + i, target_argmax)
-            else:
-                # -1 is used for placeholder draft token ids that should be
-                # rejected.
-                is_valid_draft = draft_sampled >= 0
-                # Avoid possible OOB ptr access.
-                draft_sampled = tl.maximum(0, draft_sampled)
-                target_logit = tl.load(target_logits_ptr + logit_idx * target_logits_stride + draft_sampled).to(
-                    tl.float32
-                )
-                target_lse = _compute_global_lse(
+                target_argmax = _compute_global_target_argmax(
                     target_local_max_ptr,
                     target_local_max_stride,
-                    target_local_sumexp_ptr,
-                    target_local_sumexp_stride,
+                    target_local_argmax_ptr,
+                    target_local_argmax_stride,
                     logit_idx,
                     vocab_num_blocks,
                     PADDED_VOCAB_NUM_BLOCKS,
                 )
-                target_log_prob = target_logit - target_lse
-                # Draw the acceptance threshold u ~ U(0, 1). Upstream uses
-                # tl_rand64/tl_rand32; NPU Triton lacks float64 tl_rand64 and
-                # scalar tl.rand, so generate u from a 1-element block (same
-                # pattern as _npu_gumbel_block_argmax) and clamp away from 0
-                # so that tl.log(u) stays finite.
-                # NPU: cast pos to int32 so philox uses the 32-bit path.
-                # uint64 umulhi is not supported by the Ascend vector core
-                # (matches _npu_gumbel_block_argmax). Position values fit in
-                # int32 in practice.
-                u_pos = tl.load(pos_ptr + logit_idx).to(tl.int32)
-                u_seed = tl.randint(seed, u_pos)
-                u = tl.max(tl.rand(u_seed, tl.arange(0, 1)).to(tl.float32), axis=0)
-                u = tl.maximum(u, 4.6566127342e-10)
-                if HAS_DRAFT_LOGITS:
-                    draft_logit = tl.load(
-                        draft_logits_ptr
-                        + req_state_idx * draft_logits_stride_0
-                        + i * draft_logits_stride_1
-                        + draft_sampled
-                    ).to(tl.float32)
-                    draft_lse = _compute_global_lse(
-                        draft_local_max_ptr,
-                        draft_local_max_stride,
-                        draft_local_sumexp_ptr,
-                        draft_local_sumexp_stride,
-                        logit_idx,
+                if SYNTHETIC_MODE:
+                    # Synthetic acceptance: accept IFF u ~ U(0, 1) < rate.
+                    rate = tl.load(synthetic_conditional_rates_ptr + i)
+                    accepted = u < rate
+                else:
+                    accepted = target_argmax == draft_sampled
+                # -1 placeholder draft tokens can never be accepted.
+                accepted &= is_valid_draft
+                verifying = accepted
+                accepted_length += accepted.to(tl.int64)
+                # Keep the accepted draft token; store the target argmax
+                # upon rejection so resampling can be skipped.
+                token = tl.where(accepted, draft_sampled, target_argmax)
+                tl.store(sampled_ptr + req_idx * sampled_stride + i, token)
+            elif USE_BLOCK_VERIFICATION:
+                # Block verification (Sun et al., 2024): https://arxiv.org/abs/2403.10444
+                prefix_joint_ratio = tl.exp(tl.load(cumulative_log_p_ptr + logit_idx).to(tl.float32))
+                next_draft_token = tl.load(
+                    draft_sampled_ptr + logit_idx + 2,
+                    mask=i < num_draft_tokens - 1,
+                    other=-1,
+                ).to(tl.int64)
+                if next_draft_token >= 0:
+                    residual_mass = _compute_global_residual_mass(
+                        local_residual_mass_ptr,
+                        local_residual_mass_stride,
+                        prefix_joint_ratio,
+                        target_logits_ptr,
+                        target_logits_stride,
+                        target_local_max_ptr,
+                        target_local_max_stride,
+                        target_local_sumexp_ptr,
+                        target_local_sumexp_stride,
+                        next_draft_token,
+                        logit_idx + 1,
                         vocab_num_blocks,
                         PADDED_VOCAB_NUM_BLOCKS,
+                        HAS_DRAFT_LOGITS,
                     )
-                    draft_log_prob = draft_logit - draft_lse
+                    denom = residual_mass + 1.0 - prefix_joint_ratio
+                    h = tl.where(denom > 0.0, residual_mass / denom, 1.0)
                 else:
-                    # One-hot draft: q(draft_token) = 1, log_q = 0.
-                    draft_log_prob = 0
+                    h = prefix_joint_ratio
+                accepted_length = tl.where(u <= h, i + 1, accepted_length)
+                tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
+            else:
+                # Speculative decoding (Leviathan et al., 2023): https://arxiv.org/abs/2211.17192
+                target_log_prob, draft_log_prob, target_lse, draft_lse = _compute_global_logprobs_and_logsumexp(
+                    draft_sampled,
+                    True,  # mask
+                    logit_idx,
+                    req_state_idx,
+                    i,
+                    temp,
+                    target_logits_ptr,
+                    target_logits_stride,
+                    target_local_max_ptr,
+                    target_local_max_stride,
+                    target_local_sumexp_ptr,
+                    target_local_sumexp_stride,
+                    draft_logits_ptr,
+                    draft_logits_stride_0,
+                    draft_logits_stride_1,
+                    draft_local_max_ptr,
+                    draft_local_max_stride,
+                    draft_local_sumexp_ptr,
+                    draft_local_sumexp_stride,
+                    vocab_num_blocks,
+                    PADDED_VOCAB_NUM_BLOCKS,
+                    HAS_DRAFT_LOGITS,
+                )
                 if SYNTHETIC_MODE:
                     # Synthetic acceptance: accept IFF u ~ U(0, 1) < rate.
                     # The logprob/LSE values above are still needed to
                     # resample the rejected token.
                     rate = tl.load(synthetic_conditional_rates_ptr + i)
-                    accepted &= u < rate
+                    accepted = u < rate
                 else:
                     # Probability ratio test: p(x) > u * q(x)
                     # Equivalent log form: log_p(x) > log(u) + log_q(x)
-                    accepted &= target_log_prob > tl.log(u) + draft_log_prob
+                    accepted = target_log_prob > tl.log(u) + draft_log_prob
                 # -1 placeholder draft tokens can never be accepted.
                 accepted &= is_valid_draft
+                verifying = accepted
+                accepted_length += accepted.to(tl.int64)
                 tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
-            rejected_step += accepted
-    tl.store(rejected_steps_ptr + req_idx, rejected_step)
+
+    tl.store(rejected_steps_ptr + req_idx, accepted_length.to(tl.int32))
+    # NPU: parenthesize the tensor-side condition. A flat `constexpr and
+    # tensor and tensor` chain fails to compile on triton-ascend.
+    if USE_BLOCK_VERIFICATION and (not is_greedy and accepted_length < num_draft_tokens):
+        # Compute the target and draft log exponential sums for the
+        # rejected token.
+        rejected_idx = start_idx + accepted_length
+        target_lse = _compute_global_lse(
+            target_local_max_ptr,
+            target_local_max_stride,
+            target_local_sumexp_ptr,
+            target_local_sumexp_stride,
+            rejected_idx,
+            vocab_num_blocks,
+            PADDED_VOCAB_NUM_BLOCKS,
+        )
+        if HAS_DRAFT_LOGITS:
+            draft_lse = _compute_global_lse(
+                draft_local_max_ptr,
+                draft_local_max_stride,
+                draft_local_sumexp_ptr,
+                draft_local_sumexp_stride,
+                rejected_idx,
+                vocab_num_blocks,
+                PADDED_VOCAB_NUM_BLOCKS,
+            )
     tl.store(target_rejected_logsumexp_ptr + req_idx, target_lse)
     tl.store(draft_rejected_logsumexp_ptr + req_idx, draft_lse)
 
@@ -393,9 +486,6 @@ def rejection_sample(
     # [num_speculative_steps]
     synthetic_conditional_rates: torch.Tensor | None = None,
     use_fp64: bool = False,
-    # TODO: refactor speculative decoding functionality in a future PR.
-    # `use_block_verification` is accepted but not yet implemented on NPU;
-    # wire it up when the block verification path is supported.
     use_block_verification: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     if use_fp64:
@@ -447,6 +537,81 @@ def rejection_sample(
         HAS_DRAFT_LOGITS=has_draft_logits,
     )
 
+    # Precompute the running joint ratio and residual mass for block
+    # verification.
+    if use_block_verification:
+        assert synthetic_conditional_rates is None, (
+            "Block verification is incompatible with synthetic acceptance rates."
+        )
+
+        # Compute the log of the running joint ratio, p_i.
+        # cumulative_log_p[start + i] = log(p_{i+1}), the cumulative ratio
+        # after the (i+1)-th draft token.
+        cumulative_log_p = target_logits.new_empty(num_logits, dtype=torch.float32)
+        _compute_cumulative_log_p_kernel[(num_reqs,)](
+            cumulative_log_p,
+            target_logits,
+            target_logits.stride(0),
+            target_local_max,
+            target_local_max.stride(0),
+            target_local_sumexp,
+            target_local_sumexp.stride(0),
+            draft_sampled,
+            draft_logits,
+            draft_logits.stride(0),
+            draft_logits.stride(1),
+            draft_local_max,
+            draft_local_max.stride(0),
+            draft_local_sumexp,
+            draft_local_sumexp.stride(0),
+            cu_num_logits,
+            idx_mapping,
+            temperature,
+            vocab_num_blocks,
+            PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+            HAS_DRAFT_LOGITS=has_draft_logits,
+            num_warps=1,
+        )
+
+        # Compute the per-vocab-block partials of the residual mass, later
+        # reduced to the total by _compute_global_residual_mass. Only
+        # launched for full draft logits distributions. One-hot drafts use a
+        # closed-form residual mass instead.
+        if has_draft_logits:
+            local_residual_mass = target_logits.new_empty(num_logits, vocab_num_blocks, dtype=torch.float32)
+            _compute_local_residual_mass_kernel[(num_logits, vocab_num_blocks)](
+                local_residual_mass,
+                local_residual_mass.stride(0),
+                cumulative_log_p,
+                target_logits,
+                target_logits.stride(0),
+                target_local_max,
+                target_local_max.stride(0),
+                target_local_sumexp,
+                target_local_sumexp.stride(0),
+                draft_logits,
+                draft_logits.stride(0),
+                draft_logits.stride(1),
+                draft_local_max,
+                draft_local_max.stride(0),
+                draft_local_sumexp,
+                draft_local_sumexp.stride(0),
+                draft_sampled,
+                expanded_idx_mapping,
+                expanded_local_pos,
+                temperature,
+                vocab_size,
+                num_speculative_steps,
+                vocab_num_blocks,
+                BLOCK_SIZE=VOCAB_BLOCK_SIZE,
+                PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+            )
+        else:
+            local_residual_mass = None
+    else:
+        cumulative_log_p = None
+        local_residual_mass = None
+
     # Sample up until the first rejected/bonus token, and store
     # the step.
     sampled = draft_sampled.new_empty(num_reqs, num_speculative_steps + 1, dtype=torch.int64)
@@ -481,10 +646,14 @@ def rejection_sample(
         seed,
         pos,
         synthetic_conditional_rates,
+        cumulative_log_p,
+        local_residual_mass,
+        local_residual_mass.stride(0) if local_residual_mass is not None else 0,
         vocab_num_blocks,
         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
         HAS_DRAFT_LOGITS=has_draft_logits,
         SYNTHETIC_MODE=synthetic_conditional_rates is not None,
+        USE_BLOCK_VERIFICATION=use_block_verification,
         num_warps=1,
     )
 
@@ -514,9 +683,11 @@ def rejection_sample(
         temperature,
         seed,
         pos,
+        cumulative_log_p,
         vocab_size,
         BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
         HAS_DRAFT_LOGITS=has_draft_logits,
+        USE_BLOCK_VERIFICATION=use_block_verification,
     )
 
     # Insert the resampled tokens into the output sampled.

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -292,6 +292,11 @@ def _probabilistic_rejection_kernel(
                     accepted &= target_argmax == draft_sampled
                     tl.store(sampled_ptr + req_idx * sampled_stride + i, target_argmax)
             else:
+                # -1 is used for placeholder draft token ids that should be
+                # rejected.
+                is_valid_draft = draft_sampled >= 0
+                # Avoid possible OOB ptr access.
+                draft_sampled = tl.maximum(0, draft_sampled)
                 target_logit = tl.load(target_logits_ptr + logit_idx * target_logits_stride + draft_sampled).to(
                     tl.float32
                 )
@@ -348,6 +353,8 @@ def _probabilistic_rejection_kernel(
                     # Probability ratio test: p(x) > u * q(x)
                     # Equivalent log form: log_p(x) > log(u) + log_q(x)
                     accepted &= target_log_prob > tl.log(u) + draft_log_prob
+                # -1 placeholder draft tokens can never be accepted.
+                accepted &= is_valid_draft
                 tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
             rejected_step += accepted
     tl.store(rejected_steps_ptr + req_idx, rejected_step)

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -18,7 +18,7 @@
 # This file is a part of the vllm-ascend project.
 
 import torch
-from vllm.triton_utils import tl, triton
+from vllm.triton_utils import tl, tldevice, triton
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
     _compute_global_logsumexp as _compute_global_lse,
 )
@@ -148,10 +148,16 @@ def _resample_kernel(
         draft_lse = tl.load(draft_rejected_logsumexp_ptr + req_idx)
         target_log_probs = target_logits - target_lse
         draft_log_probs = draft_logits - draft_lse
+        # Compute the residual:
+        #   r(x) = max(p(x) - q(x), 0)
+        # Gumbel sampling needs logits, so we compute it in log space:
+        #   log(r(x)) = log(max(exp(log_p(x)) - exp(log_q(x)), 0))
+        # The more numerically stable form is:
+        #   log(max(exp(a) - exp(b), 0)) = a + log(max(1 - exp(b - a), 0))
         ratio = tl.exp(draft_log_probs - target_log_probs)
         residual_logits = tl.where(
             ratio < 1.0,
-            target_log_probs + tl.log(1 - ratio),
+            target_log_probs + tldevice.log1p(-ratio),
             float("-inf"),
         ).to(tl.float32)
     else:

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -18,7 +18,7 @@
 # This file is a part of the vllm-ascend project.
 
 import torch
-from vllm.triton_utils import tl, tldevice, triton
+from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.spec_decode.rejection_sampler_utils import (
     _compute_cumulative_log_p_kernel,
     _compute_global_logprobs_and_logsumexp,
@@ -63,9 +63,9 @@ def _npu_gumbel_block_argmax(
     #      offset does not overflow int32 at large token counts.
     #   2. pos is cast to int32: triton-ascend's philox (umulhi) only
     #      supports int32/uint32 operands.
-    #   3. Noise is always fp32 tl.rand clamped away from zero (equivalent
-    #      to upstream tl_rand32 includes_zero=False); fp64 (tl_rand64) is
-    #      unsupported on NPU and guarded at the host level.
+    #   3. Noise uses the same fp32 eps-clamped tl.rand formula as
+    #      gumbel.py::_gumbel_sample_kernel (tldevice.log1p and fp64
+    #      tl_rand64 are unavailable on triton-ascend).
     #   4. Plain scalar loads instead of upstream's mask=is_valid_req
     #      masked loads: req_state_idx is always valid in the rejection
     #      sampler path and 0-d masked loads are unverified on
@@ -104,14 +104,14 @@ def _npu_gumbel_block_argmax(
         # supports int32/uint32). Position values fit in int32 in practice.
         pos = tl.load(pos_ptr + token_idx).to(tl.int32)
         gumbel_seed = tl.randint(seed, pos)
-        # NPU: tl.rand (fp32) clamped away from zero, matching upstream
-        # tl_rand32(includes_zero=False). Draw the large-noise tail (which
-        # decides the argmax winner) from u -> 0, where fp32 has fine
-        # resolution, instead of u -> 1 (see upstream gumbel.py for the
-        # full log1p rationale).
-        u = tl.rand(gumbel_seed, block).to(tl.float32)
-        u = tl.maximum(u, 4.6566127342e-10)
-        gumbel_noise = -tl.log(-tldevice.log1p(-u))
+        # NPU: tldevice.log1p (CUDA libdevice extern) is not usable on
+        # triton-ascend — the AST frontend infers a NoneType return for the
+        # call. Use the same eps-clamped fp32 formula as
+        # gumbel.py::_gumbel_sample_kernel instead (equivalent Gumbel
+        # distribution; slightly coarser resolution in the large-noise tail
+        # that decides the argmax winner).
+        r = tl.rand(gumbel_seed, block).to(tl.float32)
+        gumbel_noise = -tl.log(-tl.log(r + 1e-20) + 1e-20)
         # Apply gumbel noise.
         logits = tl.where(mask, logits + gumbel_noise, float("-inf"))
 
@@ -226,9 +226,14 @@ def _resample_kernel(
         # The more numerically stable form is:
         #   log(max(exp(a) - exp(b), 0)) = a + log(max(1 - exp(b - a), 0))
         ratio = tl.exp(draft_log_probs - target_log_probs)
+        # NPU: upstream uses tldevice.log1p(-ratio) here, but the CUDA
+        # libdevice extern is not usable on triton-ascend. tl.log(1.0 - ratio)
+        # is still exact where it matters: by the Sterbenz lemma,
+        # 1.0 - ratio is exactly representable in fp32 for ratio in [0.5, 1),
+        # so no catastrophic cancellation occurs.
         residual_logits = tl.where(
             ratio < 1.0,
-            target_log_probs + tldevice.log1p(-ratio),
+            target_log_probs + tl.log(1.0 - ratio),
             float("-inf"),
         ).to(tl.float32)
     else:

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -495,6 +495,9 @@ def rejection_sample(
     if use_fp64:
         raise NotImplementedError("FP64 rejection sampling is not supported on NPU.")
 
+    assert target_logits.ndim == 2 and target_logits.stride(-1) == 1
+    assert draft_logits is None or (draft_logits.ndim == 3 and draft_logits.stride(-1) == 1)
+
     num_reqs = cu_num_logits.shape[0] - 1
     num_logits, vocab_size = target_logits.shape
     has_draft_logits = draft_logits is not None

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -233,9 +233,12 @@ def _probabilistic_rejection_kernel(
     seed_ptr,
     # [num_logits]
     pos_ptr,
+    # [num_speculative_steps]
+    synthetic_conditional_rates_ptr,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
     HAS_DRAFT_LOGITS: tl.constexpr,
+    SYNTHETIC_MODE: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx)
@@ -268,8 +271,26 @@ def _probabilistic_rejection_kernel(
                 target_argmax = tl.load(
                     target_local_argmax_ptr + logit_idx * target_local_argmax_stride + max_target_block_idx
                 )
-                accepted &= target_argmax == draft_sampled
-                tl.store(sampled_ptr + req_idx * sampled_stride + i, target_argmax)
+                if SYNTHETIC_MODE:
+                    # Synthetic acceptance: accept IFF u ~ U(0, 1) < rate.
+                    # Upstream uses tl_rand32(seed, pos, includes_zero=False);
+                    # NPU Triton lacks scalar tl.rand, so reuse the 1-element
+                    # block + reduction pattern from the non-greedy path below.
+                    u_pos = tl.load(pos_ptr + logit_idx).to(tl.int32)
+                    u_seed = tl.randint(seed, u_pos)
+                    u = tl.max(tl.rand(u_seed, tl.arange(0, 1)).to(tl.float32), axis=0)
+                    u = tl.maximum(u, 4.6566127342e-10)
+                    rate = tl.load(synthetic_conditional_rates_ptr + i)
+                    accepted &= u < rate
+                    # -1 placeholder draft tokens can never be accepted.
+                    accepted &= draft_sampled >= 0
+                    # Keep the accepted draft token; store the target argmax
+                    # upon rejection so resampling can be skipped.
+                    token = tl.where(accepted, draft_sampled.to(tl.int64), target_argmax)
+                    tl.store(sampled_ptr + req_idx * sampled_stride + i, token)
+                else:
+                    accepted &= target_argmax == draft_sampled
+                    tl.store(sampled_ptr + req_idx * sampled_stride + i, target_argmax)
             else:
                 target_logit = tl.load(target_logits_ptr + logit_idx * target_logits_stride + draft_sampled).to(
                     tl.float32
@@ -317,9 +338,16 @@ def _probabilistic_rejection_kernel(
                 else:
                     # One-hot draft: q(draft_token) = 1, log_q = 0.
                     draft_log_prob = 0
-                # Probability ratio test: p(x) > u * q(x)
-                # Equivalent log form: log_p(x) > log(u) + log_q(x)
-                accepted &= target_log_prob > tl.log(u) + draft_log_prob
+                if SYNTHETIC_MODE:
+                    # Synthetic acceptance: accept IFF u ~ U(0, 1) < rate.
+                    # The logprob/LSE values above are still needed to
+                    # resample the rejected token.
+                    rate = tl.load(synthetic_conditional_rates_ptr + i)
+                    accepted &= u < rate
+                else:
+                    # Probability ratio test: p(x) > u * q(x)
+                    # Equivalent log form: log_p(x) > log(u) + log_q(x)
+                    accepted &= target_log_prob > tl.log(u) + draft_log_prob
                 tl.store(sampled_ptr + req_idx * sampled_stride + i, draft_sampled)
             rejected_step += accepted
     tl.store(rejected_steps_ptr + req_idx, rejected_step)
@@ -360,13 +388,6 @@ def rejection_sample(
     if use_fp64:
         raise NotImplementedError("FP64 rejection sampling is not supported on NPU.")
 
-    if synthetic_conditional_rates is not None:
-        # Synthetic rejection sampling needs tl_rand64, which NPU Triton does
-        # not support. The greedy fallback below would silently use u=0.0 and
-        # produce wrong acceptance — refuse loudly instead.
-        raise NotImplementedError(
-            "Synthetic rejection sampling is not supported on NPU yet; use rejection_sample_method='standard'."
-        )
     num_reqs = cu_num_logits.shape[0] - 1
     num_logits, vocab_size = target_logits.shape
     has_draft_logits = draft_logits is not None
@@ -446,9 +467,11 @@ def rejection_sample(
         temperature,
         seed,
         pos,
+        synthetic_conditional_rates,
         vocab_num_blocks,
         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
         HAS_DRAFT_LOGITS=has_draft_logits,
+        SYNTHETIC_MODE=synthetic_conditional_rates is not None,
         num_warps=1,
     )
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR implements synthetic rejection sampling support on NPU (Ascend) within the speculative decoding framework. It adds the `SYNTHETIC_MODE` path in `_probabilistic_rejection_kernel` using a 1-element block reduction pattern to work around the lack of scalar `tl.rand` in NPU Triton. Additionally, it improves numerical stability in `_resample_kernel` by using `tldevice.log1p` and adds explicit `tl.int64` casts to several index variables.

Feedback: Two potential compilation issues on NPU were identified due to mixed-type operations (comparing or subtracting `tl.int32` and `tl.int64`). It is recommended to also cast `end_idx` to `tl.int64` in both `_resample_kernel` and `_probabilistic_rejection_kernel`.

### Does this PR introduce _any_ user-facing change?
Yes, it enables synthetic rejection sampling on NPU, which was previously unsupported and raised a `NotImplementedError`.

### How was this patch tested?
The changes should be verified using existing speculative decoding integration tests on NPU.


- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
