### PR TITLE
[Refactor][KV Cache] Reduce Mamba manager patch scope

### DIFF
--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -415,6 +415,93 @@ def test_ascend_mamba_manager_uses_logical_block_size_with_prefix_caching() -> N
     assert manager.block_size == mamba_spec.block_size
 
 
+@pytest.mark.parametrize(
+    ("total_computed_tokens", "num_tokens_main_model", "expected_blocks"),
+    [
+        pytest.param(0, 16, 1, id="new-tokens-only"),
+        pytest.param(32, 32, 1, id="external-cache-only"),
+        pytest.param(32, 48, 2, id="external-cache-with-new-tokens"),
+    ],
+)
+def test_ascend_mamba_manager_external_cache_block_count(
+    total_computed_tokens: int,
+    num_tokens_main_model: int,
+    expected_blocks: int,
+) -> None:
+    """Account for the external state block during synchronous loading."""
+    block_size = 16
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    block_pool = BlockPool(
+        10,
+        True,
+        block_size,
+        False,
+        MagicMock(),
+    )
+    manager = AscendMambaManager(
+        kv_cache_spec=mamba_spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=1,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        scheduler_block_size=block_size,
+    )
+
+    num_blocks = manager.get_num_blocks_to_allocate(
+        request_id="request",
+        num_tokens=num_tokens_main_model,
+        new_computed_blocks=(),
+        total_computed_tokens=total_computed_tokens,
+        num_local_computed_tokens=0,
+        num_tokens_main_model=num_tokens_main_model,
+    )
+
+    assert num_blocks == expected_blocks
+
+
+def test_ascend_mamba_manager_does_not_overcount_non_align_cache() -> None:
+    block_size = 16
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    block_pool = BlockPool(
+        10,
+        True,
+        block_size,
+        False,
+        MagicMock(),
+    )
+    manager = AscendMambaManager(
+        kv_cache_spec=mamba_spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=1,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        scheduler_block_size=block_size,
+    )
+
+    num_blocks = manager.get_num_blocks_to_allocate(
+        request_id="request",
+        num_tokens=48,
+        new_computed_blocks=(),
+        total_computed_tokens=32,
+        num_local_computed_tokens=0,
+        num_tokens_main_model=48,
+    )
+
+    assert num_blocks == 3
+
+
 def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:
     """Regression: when ``scheduler_block_size`` is aligned to ``lcm_block_size``
     (instead of the raw-block-size LCM), ``SlidingWindowManager.reachable_block_mask``

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -504,6 +504,43 @@ def test_ascend_mamba_manager_does_not_overcount_non_align_cache() -> None:
     assert num_blocks == 2
 
 
+def test_ascend_mamba_manager_preserves_optional_main_model_tokens() -> None:
+    """Keep compatibility with callers using the historical method shape."""
+    block_size = 16
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    block_pool = BlockPool(
+        10,
+        True,
+        block_size,
+        False,
+        MagicMock(),
+    )
+    manager = AscendMambaManager(
+        kv_cache_spec=mamba_spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=1,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        scheduler_block_size=block_size,
+    )
+
+    num_blocks = manager.get_num_blocks_to_allocate(
+        request_id="request",
+        num_tokens=block_size,
+        new_computed_blocks=(),
+        total_computed_tokens=0,
+        num_local_computed_tokens=block_size,
+    )
+
+    assert num_blocks == 1
+
+
 def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:
     """Regression: when ``scheduler_block_size`` is aligned to ``lcm_block_size``
     (instead of the raw-block-size LCM), ``SlidingWindowManager.reachable_block_mask``

--- a/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
+++ b/tests/ut/patch/platform/test_prefix_cache_cp_patches.py
@@ -499,7 +499,9 @@ def test_ascend_mamba_manager_does_not_overcount_non_align_cache() -> None:
         num_tokens_main_model=48,
     )
 
-    assert num_blocks == 3
+    # Preserve the upstream non-align result: the extra synchronous-load
+    # state block is specific to ``mamba_cache_mode="align"``.
+    assert num_blocks == 2
 
 
 def test_swa_reachable_block_mask_sparse_with_lcm_alignment() -> None:

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -224,21 +224,16 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.v1.core.single_type_kv_cache_manager.MambaManager`
 #    Why:
-#       1. Upstream hybrid prefix cache lookup does not support DCP.
-#       2. Upstream MambaManager#get_num_blocks_to_allocate give the
+#       1. Upstream MambaManager#get_num_blocks_to_allocate gives the
 #          wrong number of blocks when an external cache hit occurred
 #    How:
-#       1. Replace MambaManager with AscendMambaManager for prefix cache hit lookup
-#          on hybrid Mamba paths (logical mamba block_size when caching is enabled).
-#       2. Override the get_num_blocks_to_allocate method to fix the number of blocks
+#       1. Override the get_num_blocks_to_allocate method to fix the number of blocks
 #          when hitting the external cache and loading synchronously
 #    Related PR (if no, explain why):
-#       1. https://github.com/vllm-project/vllm/pull/40996
-#       2. https://github.com/vllm-project/vllm/pull/46892
+#       1. https://github.com/vllm-project/vllm/pull/46892
 #    Future Plan:
-#       1. Remove this patch once the supported upstream revision includes
-#          hybrid prefix cache lookup for DCP.
-#       2. Remove this patch once upstream accept 46892 pr or fixed the bug by other pr.
+#       1. Remove this patch once upstream accepts PR #46892 (or fixes the bug
+#          another way) and the supported vLLM revision includes the fix.
 #
 # ** 13. File: platform/patch_minimax_m2_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_mamba_manager.py
+++ b/vllm_ascend/patch/platform/patch_mamba_manager.py
@@ -8,44 +8,18 @@ from collections.abc import Sequence
 
 import vllm.v1.core.single_type_kv_cache_manager as single_type_kv_cache_manager
 from vllm.v1.core.single_type_kv_cache_manager import (
-    BlockHashList,
-    BlockPool,
     KVCacheBlock,
-    KVCacheSpec,
     MambaManager,
-    MambaSpec,
 )
 
 
 class AscendMambaManager(MambaManager):
-    def __init__(self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs) -> None:
-        super().__init__(kv_cache_spec, block_pool, **kwargs)
-        self.block_size = kv_cache_spec.block_size
+    """Temporary compatibility for synchronous external Mamba cache loads.
 
-    @classmethod
-    def find_longest_cache_hit(
-        cls,
-        block_hashes: BlockHashList,
-        max_length: int,
-        kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
-        kv_cache_spec: KVCacheSpec,
-        alignment_tokens: int,
-        dcp_world_size: int = 1,
-        pcp_world_size: int = 1,
-        drop_eagle_block: bool = False,
-    ) -> tuple[list[KVCacheBlock], ...] | tuple[tuple[list[KVCacheBlock], ...], int]:
-        return super().find_longest_cache_hit(
-            block_hashes=block_hashes,
-            max_length=max_length,
-            kv_cache_group_ids=kv_cache_group_ids,
-            block_pool=block_pool,
-            kv_cache_spec=kv_cache_spec,
-            alignment_tokens=alignment_tokens,
-            dcp_world_size=dcp_world_size,
-            pcp_world_size=pcp_world_size,
-            drop_eagle_block=drop_eagle_block,
-        )
+    Upstream already owns Mamba block sizing and prefix-cache lookup. Keep only
+    the allocation fix from vLLM PR #46892 until that change is merged and the
+    pinned vLLM revision contains it.
+    """
 
     def get_num_blocks_to_allocate(
         self,
@@ -53,13 +27,10 @@ class AscendMambaManager(MambaManager):
         num_tokens: int,
         new_computed_blocks: Sequence[KVCacheBlock],
         total_computed_tokens: int,
-        num_local_computed_tokens: int | None = None,
-        num_tokens_main_model: int | None = None,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
         apply_admission_cap: bool = False,
     ) -> int:
-        if num_tokens_main_model is None:
-            assert num_local_computed_tokens is not None
-            num_tokens_main_model = num_local_computed_tokens
         local_hit_tokens = len(new_computed_blocks) * self.block_size
         num_new_blocks = super().get_num_blocks_to_allocate(
             request_id,
@@ -79,8 +50,7 @@ class AscendMambaManager(MambaManager):
         # num_tokens_main_model exceeds total_computed_tokens.)
         has_external_tokens = total_computed_tokens > local_hit_tokens
         has_new_scheduled_tokens = num_tokens_main_model > total_computed_tokens
-        if has_external_tokens and has_new_scheduled_tokens:
-            # one more block for external computed tokens
+        if self.mamba_cache_mode == "align" and has_external_tokens and has_new_scheduled_tokens:
             num_new_blocks += 1
         return num_new_blocks
 

--- a/vllm_ascend/patch/platform/patch_mamba_manager.py
+++ b/vllm_ascend/patch/platform/patch_mamba_manager.py
@@ -27,10 +27,13 @@ class AscendMambaManager(MambaManager):
         num_tokens: int,
         new_computed_blocks: Sequence[KVCacheBlock],
         total_computed_tokens: int,
-        num_local_computed_tokens: int,
-        num_tokens_main_model: int,
+        num_local_computed_tokens: int | None = None,
+        num_tokens_main_model: int | None = None,
         apply_admission_cap: bool = False,
     ) -> int:
+        if num_tokens_main_model is None:
+            assert num_local_computed_tokens is not None
+            num_tokens_main_model = num_local_computed_tokens
         local_hit_tokens = len(new_computed_blocks) * self.block_size
         num_new_blocks = super().get_num_blocks_to_allocate(
             request_id,


### PR DESCRIPTION
### What this PR does / why we need it?

This draft reduces platform/patch_mamba_manager.py to the one behavior that is still missing upstream.

- Remove the redundant custom constructor and prefix-cache lookup override.
- Use the upstream MambaManager for block sizing and cache-hit lookup.
- Retain only the synchronous external-cache allocation correction for mamba_cache_mode=align until vLLM PR #46892, or an equivalent fix, is available in the pinned revision.
- Add regression cases for new tokens, external-cache-only hits, external hits followed by new tokens, and non-align mode.

### Does this PR introduce any user-facing change?

No intended user-facing change. This only reduces the monkey-patch surface.

### How was this patch tested?

- ruff check: passed for changed files.
- ruff format --check: passed for changed files.
- pytest -q tests/ut/patch/platform/test_prefix_cache_cp_patches.py: not collected locally because the Windows Python environment does not contain torch.

Before marking ready for review:

- Run the focused unit test in the vLLM-Ascend development environment.
- Validate Hybrid Mamba prefix caching and synchronous external cache loading on A2/A3 hardware.
- Recheck the implementation after vLLM PR #46892 changes state.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
