### PR TITLE
[Refactor][MTP] Move PP draft metadata to Ascend output

### DIFF
--- a/tests/ut/patch/platform/test_patch_pp_mtp.py
+++ b/tests/ut/patch/platform/test_patch_pp_mtp.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import pickle
 from types import SimpleNamespace
 
 import numpy as np
@@ -7,27 +8,57 @@ import pytest
 import torch
 from vllm.config.model import ModelConfig
 from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, ModelRunnerOutput
 from vllm.v1.sample.rejection_sampler import PLACEHOLDER_TOKEN_ID
 
 from vllm_ascend.patch.platform.patch_pp_mtp import (
-    _update_pp_mtp_spec_token_ids,
+    _update_pp_mtp_draft_token_ids,
     _use_pp_ipc_runtime_patch,
 )
+from vllm_ascend.worker.model_runner_output import AscendModelRunnerOutput
 from vllm_ascend.worker.model_runner_v1 import NPUModelRunner
 
 
-def test_model_config_validates_local_mtp_drafter_as_single_pp_rank(monkeypatch):
+def test_ascend_model_runner_output_owns_pp_mtp_metadata():
+    assert "draft_token_ids" not in ModelRunnerOutput.__dataclass_fields__
+    assert not hasattr(EMPTY_MODEL_RUNNER_OUTPUT, "draft_token_ids")
+    assert "draft_token_ids" in AscendModelRunnerOutput.__dataclass_fields__
+
+    output = AscendModelRunnerOutput(
+        req_ids=["req-0"],
+        req_id_to_index={"req-0": 0},
+        sampled_token_ids=[[101]],
+        draft_token_ids=[[201, 202]],
+    )
+    restored = pickle.loads(pickle.dumps(output))
+
+    assert isinstance(restored, ModelRunnerOutput)
+    assert restored.draft_token_ids == [[201, 202]]
+
+
+@pytest.mark.parametrize(
+    ("model_type", "architectures"),
+    [
+        ("qwen3_5_mtp", ["Qwen3_5MTP"]),
+        ("eagle", ["EagleLlamaForCausalLM"]),
+    ],
+)
+def test_model_config_validates_local_drafter_as_single_pp_rank(
+    monkeypatch,
+    model_type,
+    architectures,
+):
     fake_registry = SimpleNamespace(
         is_pp_supported_model=lambda _architectures, _model_config: False,
     )
     monkeypatch.setattr(ModelConfig, "registry", property(lambda _self: fake_registry))
 
     model_config = ModelConfig.__new__(ModelConfig)
-    model_config.hf_config = SimpleNamespace(model_type="qwen3_5_mtp")
+    model_config.hf_config = SimpleNamespace(model_type=model_type)
     model_config.runner = "draft"
     model_config.model_arch_config = SimpleNamespace(
         total_num_attention_heads=1,
-        architectures=["Qwen3_5MTP"],
+        architectures=architectures,
     )
     model_config.multimodal_config = None
 
@@ -311,13 +342,100 @@ def test_pp_mtp_spec_tokens_are_written_from_model_runner_output_for_sync_and_as
     model_runner_output = SimpleNamespace(
         req_id_to_index={"req-0": 0},
         sampled_token_ids=[[200]],
-        spec_token_ids=[[301, 302]],
+        draft_token_ids=[[301, 302]],
     )
 
-    _update_pp_mtp_spec_token_ids(
+    _update_pp_mtp_draft_token_ids(
         scheduler,
         scheduler_output,
         model_runner_output,
     )
 
     assert request.spec_token_ids == [301, 302]
+
+
+def test_pp_mtp_draft_tokens_follow_output_request_mapping():
+    request = SimpleNamespace(
+        spec_token_ids=[],
+        structured_output_request=None,
+        is_finished=lambda: False,
+    )
+    scheduler = SimpleNamespace(
+        requests={"req-1": request},
+        structured_output_manager=SimpleNamespace(
+            should_advance=lambda _request: False,
+        ),
+    )
+    scheduler_output = SimpleNamespace(num_scheduled_tokens={"req-1": 1})
+    model_runner_output = SimpleNamespace(
+        req_id_to_index={"req-0": 0, "req-1": 1},
+        sampled_token_ids=[[100], [200]],
+        draft_token_ids=[[301], [401, 402]],
+    )
+
+    _update_pp_mtp_draft_token_ids(
+        scheduler,
+        scheduler_output,
+        model_runner_output,
+    )
+
+    assert request.spec_token_ids == [401, 402]
+
+
+def test_pp_mtp_draft_tokens_are_validated_for_structured_output():
+    grammar = SimpleNamespace(
+        validate_tokens=lambda token_ids: [token_id for token_id in token_ids if token_id != 302],
+    )
+    request = SimpleNamespace(
+        spec_token_ids=[],
+        structured_output_request=SimpleNamespace(grammar=grammar),
+        is_finished=lambda: False,
+    )
+    scheduler = SimpleNamespace(
+        requests={"req-0": request},
+        structured_output_manager=SimpleNamespace(
+            should_advance=lambda _request: True,
+        ),
+    )
+    scheduler_output = SimpleNamespace(num_scheduled_tokens={"req-0": 1})
+    model_runner_output = SimpleNamespace(
+        req_id_to_index={"req-0": 0},
+        sampled_token_ids=[[200]],
+        draft_token_ids=[[301, 302]],
+    )
+
+    _update_pp_mtp_draft_token_ids(
+        scheduler,
+        scheduler_output,
+        model_runner_output,
+    )
+
+    assert request.spec_token_ids == [301]
+
+
+def test_pp_mtp_draft_tokens_are_cleared_without_sampled_output():
+    request = SimpleNamespace(
+        spec_token_ids=[999],
+        structured_output_request=None,
+        is_finished=lambda: False,
+    )
+    scheduler = SimpleNamespace(
+        requests={"req-0": request},
+        structured_output_manager=SimpleNamespace(
+            should_advance=lambda _request: False,
+        ),
+    )
+    scheduler_output = SimpleNamespace(num_scheduled_tokens={"req-0": 1})
+    model_runner_output = SimpleNamespace(
+        req_id_to_index={"req-0": 0},
+        sampled_token_ids=[[]],
+        draft_token_ids=[[301, 302]],
+    )
+
+    _update_pp_mtp_draft_token_ids(
+        scheduler,
+        scheduler_output,
+        model_runner_output,
+    )
+
+    assert request.spec_token_ids == []

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -338,21 +338,7 @@
 #
 # ** 16. File: platform/patch_pp_mtp.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-#   1. `vllm.v1.outputs.ModelRunnerOutput`
-#    Why:
-#       PP + MTP mixed deployment needs the model runner to return the draft
-#       tokens produced for the same scheduler output. Upstream output objects
-#       do not carry `spec_token_ids` on all supported vLLM revisions.
-#    How：
-#       Add a backward-compatible `spec_token_ids` field to `ModelRunnerOutput`
-#       and `EMPTY_MODEL_RUNNER_OUTPUT` when the field is missing.
-#    Related PR (if no, explain why):
-#       Backport of local vLLM PP+MTP branch changes.
-#    Future Plan:
-#       Remove this patch once the supported vLLM version carries PP-safe
-#       speculative token metadata in `ModelRunnerOutput`.
-#
-#   2. `vllm.v1.engine.core.EngineCore.post_step`
+#   1. `vllm.v1.engine.core.EngineCore.post_step`
 #    Why:
 #       With PP batch queue, synchronous scheduling can schedule the next batch
 #       before the previous model output is consumed. Calling `post_step` in that
@@ -361,14 +347,14 @@
 #    How：
 #       In PP + MTP + batch queue + sync scheduling, skip `post_step` after model
 #       execution and let scheduler output processing perform the spec token
-#       writeback from the corresponding `ModelRunnerOutput`.
+#       writeback from the corresponding `AscendModelRunnerOutput`.
 #    Related PR (if no, explain why):
-#       Backport of local vLLM PP+MTP branch changes.
+#       vLLM #44698 (V1) and #46994 (V2) are still open.
 #    Future Plan:
 #       Remove this patch when upstream makes spec token writeback output-owned
 #       for PP batch queue.
 #
-#   3. `vllm.v1.core.sched.scheduler.Scheduler._update_after_schedule`
+#   2. `vllm.v1.core.sched.scheduler.Scheduler._update_after_schedule`
 #      `vllm.v1.core.sched.scheduler.Scheduler.update_from_output`
 #    Why:
 #       PP async scheduling must not schedule the same decode request again
@@ -382,14 +368,15 @@
 #       chunks in PP IPC mode. Release the fence in `update_from_output` after
 #       the matching output is processed. For PP + MTP, also filter zero-token
 #       placeholder requests before delegating to upstream scheduler accounting,
-#       then write `request.spec_token_ids` from `model_runner_output.spec_token_ids`.
+#       then write `request.spec_token_ids` from the matching output's
+#       `draft_token_ids`.
 #    Related PR (if no, explain why):
-#       Backport of local vLLM PP+MTP branch changes.
+#       vLLM #44698 (V1) and #46994 (V2) are still open.
 #    Future Plan:
 #       Remove this patch once upstream supports request-level PP async fences
 #       and output-owned spec token writeback.
 #
-#   4. `vllm.v1.core.sched.scheduler.Scheduler._make_cached_request_data`
+#   3. `vllm.v1.core.sched.scheduler.Scheduler._make_cached_request_data`
 #    Why:
 #       Upstream PP async scheduling relies on direct PP-rank GPU broadcast for
 #       sampled-token handoff and omits `new_token_ids` from cached request data.
@@ -402,12 +389,12 @@
 #       mode, then fill the last confirmed output token for requests whose
 #       clamped upstream slice is empty.
 #    Related PR (if no, explain why):
-#       Backport of local vLLM PP+MTP branch changes.
+#       vLLM #44698 (V1) and #46994 (V2) are still open.
 #    Future Plan:
 #       Remove this patch once upstream provides a scheduler-owned PP sampled
 #       token handoff path that works for both sync and async scheduling.
 #
-#   5. `vllm.config.model.ModelConfig.verify_with_parallel_config`
+#   4. `vllm.config.model.ModelConfig.verify_with_parallel_config`
 #    Why:
 #       Local Eagle/MTP drafters are loaded on the last PP stage rather than
 #       partitioned across all PP ranks. Upstream `ModelConfig.verify_with_parallel_config`
@@ -420,7 +407,7 @@
 #       with a patched `pipeline_parallel_size=1` copy, preserving normal target-model
 #       validation for non-drafter models.
 #    Related PR (if no, explain why):
-#       Backport of local vLLM PP+MTP branch changes.
+#       vLLM #52069 tracks the missing upstream draft-model validation path.
 #    Future Plan:
 #       Remove this patch once upstream vLLM's `ModelConfig.verify_with_parallel_config`
 #       supports local drafter models with PP > 1, or moves the PP validation to a

--- a/vllm_ascend/patch/platform/patch_pp_mtp.py
+++ b/vllm_ascend/patch/platform/patch_pp_mtp.py
@@ -14,12 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Backport vLLM PP + MTP runtime support.
+"""Compatibility shims for vLLM PP + MTP runtime support.
 
 The local Eagle/MTP drafter returns the draft tokens that belong to the model
 output being processed. With PP batch_queue, EngineCore schedules a newer batch
 before consuming the older output, so updating ``request.spec_token_ids`` from
 ``post_step`` observes live Request state from the newer schedule step.
+
+Ascend-owned output metadata lives in ``AscendModelRunnerOutput``. The shims in
+this module can be removed after upstream's PP speculative-decoding protocol is
+available in the pinned vLLM revision.
 """
 
 from __future__ import annotations
@@ -59,30 +63,6 @@ def _use_pp_ipc_runtime_patch(vllm_config, use_pp: bool) -> bool:
     if not use_pp or _is_pd_prefill_node(vllm_config):
         return False
     return not getattr(vllm_config, "use_v2_model_runner", False)
-
-
-def _patch_model_runner_output() -> None:
-    from vllm.v1 import outputs as outputs_mod
-
-    model_runner_output_cls = outputs_mod.ModelRunnerOutput
-    fields = getattr(model_runner_output_cls, "__dataclass_fields__", {})
-    if "spec_token_ids" not in fields:
-        model_runner_output_cls.spec_token_ids = None
-        original_init = model_runner_output_cls.__init__
-        if getattr(original_init, "_vllm_ascend_pp_mtp_patched", False):
-            return
-
-        @wraps(original_init)
-        def _patched_init(self, *args, spec_token_ids=None, **kwargs):
-            original_init(self, *args, **kwargs)
-            self.spec_token_ids = spec_token_ids
-
-        _patched_init._vllm_ascend_pp_mtp_patched = True  # type: ignore[attr-defined]
-        model_runner_output_cls.__init__ = _patched_init
-
-    empty_output = outputs_mod.EMPTY_MODEL_RUNNER_OUTPUT
-    if not hasattr(empty_output, "spec_token_ids"):
-        empty_output.spec_token_ids = None
 
 
 def _patch_engine_core() -> None:
@@ -206,9 +186,9 @@ def _patch_scheduler_make_cached_request_data() -> None:
     Scheduler._make_cached_request_data = _patched_make_cached_request_data
 
 
-def _update_pp_mtp_spec_token_ids(scheduler, scheduler_output, model_runner_output) -> None:
-    spec_token_ids = getattr(model_runner_output, "spec_token_ids", None)
-    if spec_token_ids is None:
+def _update_pp_mtp_draft_token_ids(scheduler, scheduler_output, model_runner_output) -> None:
+    draft_token_ids = getattr(model_runner_output, "draft_token_ids", None)
+    if draft_token_ids is None:
         return
 
     sampled_token_ids = getattr(model_runner_output, "sampled_token_ids", None)
@@ -222,11 +202,11 @@ def _update_pp_mtp_spec_token_ids(scheduler, scheduler_output, model_runner_outp
             continue
 
         new_token_ids = sampled_token_ids[req_index] if sampled_token_ids else []
-        if not new_token_ids or req_index >= len(spec_token_ids):
+        if not new_token_ids or req_index >= len(draft_token_ids):
             request.spec_token_ids = []
             continue
 
-        next_spec_token_ids = spec_token_ids[req_index]
+        next_spec_token_ids = draft_token_ids[req_index]
         if scheduler.structured_output_manager.should_advance(request):
             metadata = request.structured_output_request
             assert metadata is not None and metadata.grammar is not None
@@ -283,7 +263,7 @@ def _patch_scheduler_update_from_output() -> None:
         if not use_pp_mtp_runtime_patch:
             return engine_core_outputs
 
-        _update_pp_mtp_spec_token_ids(self, scheduler_output, model_runner_output)
+        _update_pp_mtp_draft_token_ids(self, scheduler_output, model_runner_output)
         return engine_core_outputs
 
     _patched_update_from_output._vllm_ascend_pp_mtp_patched = True  # type: ignore[attr-defined]
@@ -336,7 +316,6 @@ def _apply_patch() -> None:
     if _PATCHED:
         return
     _PATCHED = True
-    _patch_model_runner_output()
     _patch_engine_core()
     _patch_scheduler_update_after_schedule()
     _patch_scheduler_make_cached_request_data()

--- a/vllm_ascend/worker/model_runner_output.py
+++ b/vllm_ascend/worker/model_runner_output.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+from vllm.v1.outputs import ModelRunnerOutput
+
+
+@dataclass
+class AscendModelRunnerOutput(ModelRunnerOutput):
+    """Ascend V1 output metadata needed by the PP + spec-decode protocol.
+
+    The field stays on the Ascend-owned output type instead of being injected
+    into vLLM's process-wide ``ModelRunnerOutput`` class.
+    """
+
+    draft_token_ids: list[list[int]] | None = None

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -190,6 +190,7 @@ from vllm_ascend.utils import (
     vllm_version_is,
 )
 from vllm_ascend.worker.dcp_utils import DCPAsyncSpecDecodeRebuildResult, DCPManager
+from vllm_ascend.worker.model_runner_output import AscendModelRunnerOutput
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.utils import AscendKVBlockZeroer
 
@@ -2281,7 +2282,7 @@ class NPUModelRunner(GPUModelRunner):
             )
             self._copy_draft_token_ids_to_cpu(scheduler_output)
 
-        output_spec_token_ids = None
+        output_draft_token_ids = None
         use_padded_batch = False
         early_pp_padded_drafter = False
         if self.speculative_config:
@@ -2349,16 +2350,16 @@ class NPUModelRunner(GPUModelRunner):
                     draft_req_ids = self.input_batch.req_ids
                 if draft_ids_list and draft_req_ids:
                     draft_by_req_id = dict(zip(draft_req_ids, draft_ids_list))
-                    output_spec_token_ids = [
+                    output_draft_token_ids = [
                         draft_by_req_id.get(req_id, [])
                         for req_id in req_ids_output_copy
                     ]
 
-        model_runner_output = ModelRunnerOutput(
+        model_runner_output = AscendModelRunnerOutput(
             req_ids=req_ids_output_copy,
             req_id_to_index=req_id_to_index_output_copy,
             sampled_token_ids=valid_sampled_token_ids,
-            spec_token_ids=output_spec_token_ids,
+            draft_token_ids=output_draft_token_ids,
             logprobs=logprobs_lists,
             prompt_logprobs_dict=prompt_logprobs_dict,
             kv_connector_output=kv_connector_output,


### PR DESCRIPTION
### What this PR does / why we need it?

This draft removes the process-wide ModelRunnerOutput mutation from platform/patch_pp_mtp.py.

- Add AscendModelRunnerOutput as an Ascend-owned ModelRunnerOutput subtype.
- Carry draft_token_ids on the output that produced them instead of injecting spec_token_ids into the upstream dataclass and EMPTY_MODEL_RUNNER_OUTPUT singleton.
- Update PP+MTP scheduler writeback to use the output request mapping and draft_token_ids.
- Add serialization, request mapping, structured-output filtering, and empty-output regression coverage.

The remaining PP scheduling shims stay in place until the upstream PP speculative-decoding protocol is available. This is therefore a partial sunset PR.

### Does this PR introduce any user-facing change?

No intended user-facing change. The metadata ownership changes, while PP+MTP/EAGLE behavior should remain the same.

### How was this patch tested?

- ruff check: passed for changed files.
- ruff format --check: passed for changed files.
- pytest -q tests/ut/patch/platform/test_patch_pp_mtp.py: not collected locally because the Windows Python environment does not contain torch.

Before marking ready for review:

- Run the focused unit test in the vLLM-Ascend development environment.
- Validate PP=2 or greater with MTP and EAGLE under sync and async scheduling.
- Verify batch_queue request/output association and structured-output decoding.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
