### PR TITLE
[CI] Raise image build parallelism to 4 and prioritize Ubuntu variants

### DIFF
--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -171,7 +171,6 @@ jobs:
 
     strategy:
       max-parallel: 2
-      fail-fast: false
       matrix:
         runner_info:
           - {runner: linux-aarch64-cpu-4, tag: arm64}

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -11,9 +11,6 @@
 #   - is for final release image
 #   - Publish when tag with v* (pep440 version)  ===>  vllm-ascend:v1.2.3 / vllm-ascend:v1.2.3rc1
 name: Image Build and Push
-concurrency:
-  group: image-build-${{ github.ref }}
-  cancel-in-progress: false
 on:
   push:
     tags:
@@ -109,30 +106,30 @@ jobs:
         && !(github.event_name == 'workflow_dispatch' && inputs.vllm_commit != '' && inputs.vllm_ascend_commit != '') }}
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         build_meta:
           - name: A2 Ubuntu
             dockerfile: Dockerfile
-            suffix: ''
-          - name: A2 openeuler
-            dockerfile: Dockerfile.openEuler
-            suffix: 'openeuler'
+            suffix: ''        
           - name: A3 Ubuntu
             dockerfile: Dockerfile.a3
             suffix: 'a3'
-          - name: A3 openEuler
-            dockerfile: Dockerfile.a3.openEuler
-            suffix: 'a3-openeuler'
           - name: 310P Ubuntu
             dockerfile: Dockerfile.310p
             suffix: '310p'
-          - name: 310P openEuler
-            dockerfile: Dockerfile.310p.openEuler
-            suffix: '310p-openeuler'
           - name: A5 Ubuntu
             dockerfile: Dockerfile.a5
             suffix: 'a5'
+          - name: A2 openeuler
+            dockerfile: Dockerfile.openEuler
+            suffix: 'openeuler'
+          - name: A3 openEuler
+            dockerfile: Dockerfile.a3.openEuler
+            suffix: 'a3-openeuler'        
+          - name: 310P openEuler
+            dockerfile: Dockerfile.310p.openEuler
+            suffix: '310p-openeuler'
           - name: A5 openEuler
             dockerfile: Dockerfile.a5.openEuler
             suffix: 'a5-openeuler'
@@ -184,30 +181,30 @@ jobs:
         && inputs.branch == 'none' }}
     strategy:
       fail-fast: false
-      max-parallel: 3
+      max-parallel: 4
       matrix:
         build_meta:
           - name: A2 Ubuntu
             dockerfile: Dockerfile
-            suffix: ''
-          - name: A2 openeuler
-            dockerfile: Dockerfile.openEuler
-            suffix: 'openeuler'
+            suffix: ''        
           - name: A3 Ubuntu
             dockerfile: Dockerfile.a3
             suffix: 'a3'
-          - name: A3 openEuler
-            dockerfile: Dockerfile.a3.openEuler
-            suffix: 'a3-openeuler'
           - name: 310P Ubuntu
             dockerfile: Dockerfile.310p
             suffix: '310p'
-          - name: 310P openEuler
-            dockerfile: Dockerfile.310p.openEuler
-            suffix: '310p-openeuler'
           - name: A5 Ubuntu
             dockerfile: Dockerfile.a5
             suffix: 'a5'
+          - name: A2 openeuler
+            dockerfile: Dockerfile.openEuler
+            suffix: 'openeuler'
+          - name: A3 openEuler
+            dockerfile: Dockerfile.a3.openEuler
+            suffix: 'a3-openeuler'        
+          - name: 310P openEuler
+            dockerfile: Dockerfile.310p.openEuler
+            suffix: '310p-openeuler'
           - name: A5 openEuler
             dockerfile: Dockerfile.a5.openEuler
             suffix: 'a5-openeuler'


### PR DESCRIPTION
## What this PR does / why we need it?

- Raises `max-parallel` from 3 to 4 for both `image_build` and
  `image_build_by_commit` matrix jobs, so more variants build
  concurrently and total wall time drops when runners are available.
- Reorders the matrix entries to list Ubuntu variants (A2, A3, 310P, A5)
  before openEuler variants. With limited parallelism, the most widely
  used Ubuntu images now finish first instead of being queued behind
  openEuler builds.

## Does this PR introduce _any_ user-facing change?

- No. CI-only change; no runtime behavior is affected.

## How was this patch tested?

- CI verification only (workflow syntax checked by GitHub Actions
  linter; no unit tests apply to workflow files).

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
