### PR TITLE
[Performance] Cache cos/sin in native MRoPE path for unsupported sections

### DIFF
--- a/vllm_ascend/ops/rotary_embedding.py
+++ b/vllm_ascend/ops/rotary_embedding.py
@@ -494,6 +494,74 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
 
         return q.reshape(query_shape), k.reshape(key_shape)
 
+    def _forward_native_cached(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+    ):
+        # Sections outside the aclnnRopeWithSinCosCacheV2 allowlist (e.g.
+        # Qwen2.5-Omni's [16, 16, 0]) fall back to the eager native path,
+        # whose stock code recomputes the processed cos/sin for every
+        # decoder layer. Cache it keyed by the `positions` object identity
+        # (strong ref kept, so tensor-id reuse cannot alias; the stored
+        # shape + version counter invalidate in-place rewrites). Per-layer
+        # q/k rotation still runs.
+        cache = getattr(self, "_mrope_cos_sin_cache", None)
+        if (
+            cache is not None
+            and cache[0] is positions
+            and cache[3] == positions.shape
+            and cache[4] == positions._version
+        ):
+            cos, sin = cache[1], cache[2]
+        else:
+            cos_sin_cache = self._match_cos_sin_cache_dtype(query)
+            cos_sin = cos_sin_cache[positions]  # type: ignore[index]
+            cos, sin = cos_sin.chunk(2, dim=-1)
+            if positions.ndim == 2:
+                assert self.mrope_section
+                if self.mrope_interleaved:
+                    from vllm.model_executor.layers.rotary_embedding.mrope import (
+                        apply_interleaved_rope,
+                    )
+
+                    cos = apply_interleaved_rope(cos, self.mrope_section)
+                    sin = apply_interleaved_rope(sin, self.mrope_section)
+                else:
+                    cos = torch.cat(
+                        [m[i] for i, m in enumerate(cos.split(self.mrope_section, dim=-1))],
+                        dim=-1,
+                    )
+                    sin = torch.cat(
+                        [m[i] for i, m in enumerate(sin.split(self.mrope_section, dim=-1))],
+                        dim=-1,
+                    )
+            self._mrope_cos_sin_cache = (
+                positions,
+                cos,
+                sin,
+                positions.shape,
+                positions._version,
+            )
+
+        num_tokens = positions.shape[-1]
+
+        query_shape = query.shape
+        query = query.reshape(num_tokens, -1, self.head_size)
+        query_rot = query[..., : self.rotary_dim]
+        query_pass = query[..., self.rotary_dim :]
+        query_rot = self.apply_rotary_emb.forward_native(query_rot, cos, sin)
+        query = torch.cat((query_rot, query_pass), dim=-1).reshape(query_shape)
+
+        key_shape = key.shape
+        key = key.reshape(num_tokens, -1, self.head_size)
+        key_rot = key[..., : self.rotary_dim]
+        key_pass = key[..., self.rotary_dim :]
+        key_rot = self.apply_rotary_emb.forward_native(key_rot, cos, sin)
+        key = torch.cat((key_rot, key_pass), dim=-1).reshape(key_shape)
+        return query, key
+
     def forward_oot(
         self,
         positions: torch.Tensor,
@@ -505,7 +573,7 @@ class AscendMRotaryEmbedding(MRotaryEmbedding):
             return self.forward_triton(positions, query, key)
 
         if self.mrope_section != [16, 24, 24]:
-            return super().forward_oot(positions, query, key)
+            return self._forward_native_cached(positions, query, key)
 
         import torch_npu
 


### PR DESCRIPTION
## 🚀 Motivation

Models using MRoPE sections outside the `npu_mrope` allowlist (e.g. **Qwen2.5-Omni thinker's `[16, 16, 0]`**, rejected by `aclnnRopeWithSinCosCacheV2` with *"mropeSection must be in the supported list"*, verified on CANN 9.1.0) fall back to the stock eager native path in `AscendMRotaryEmbedding.forward_oot`.

Within one model forward the **same `positions` tensor object flows through every decoder layer**, yet the stock `forward_native` recomputes `cos_sin_cache[positions]` + chunk + section-cat **per layer** — pure redundancy, since cos/sin are pure functions of positions.

## 📝 Changes

- Add `AscendMRotaryEmbedding._forward_native_cached`: the processed cos/sin is cached keyed by `positions` object identity. The cache holds a **strong reference** to `positions` so `is` stays exact for the step (tensor-id reuse cannot alias a live object). Per-layer q/k rotation still runs.
- The allowlist fallback branch now calls it instead of `super().forward_oot`.
- Function body verbatim-mirrors the stock `MRotaryEmbedding.forward_native` semantics (incl. the interleaved and 2-D sections paths).

## 📊 Results

Qwen2.5-Omni-3B · vllm 0.18 / vllm-ascend 0.18 / CANN 9.1.0 · 910B2C · 24 decode tokens (median of repeated `generate` calls):

| | before | after | Δ |
|---|---:|---:|---:|
| decode latency | 626.4 ms | **550.3 ms** | **-12.1%** |

- Generated tokens are identical (cos/sin are pure functions of positions).
- torch-profiler attribution: the fragmented `Mul`/`MulSlice`/`Cat`/`Index` kernel families (~27% of decode GPU time for this model) come almost entirely from this per-layer cos/sin recompute path and shrink accordingly.

## 🧪 Tested Scenarios

- [x] Qwen2.5-Omni-3B end-to-end generation on 910B2C (token-level equivalence + latency)
- [x] Qwen2.5-VL style `[16, 24, 24]` path untouched (still goes through `npu_mrope`)

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
