### PR TITLE
[CI] Add nightly core suite gate with commit status propagation

### DIFF
--- a/.github/actions/report-core-suite-status/action.yml
+++ b/.github/actions/report-core-suite-status/action.yml
@@ -1,0 +1,44 @@
+name: Report core suite status
+description: |-
+  Determine core suite test status from nightly run logs and
+  report it to the branch and open PRs (nightly/core-suite commit status).
+
+inputs:
+  vllm_ascend_branch:
+    description: Branch to report status to.
+    required: true
+    type: string
+  ref:
+    description: Git ref to checkout for core_suite.yaml (defaults to vllm_ascend_branch).
+    required: false
+    default: ''
+    type: string
+
+outputs:
+  state:
+    description: Overall state (success or failure).
+    value: ${{ steps.report.outputs.state }}
+  description:
+    description: Status description.
+    value: ${{ steps.report.outputs.description }}
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout core suite config
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.ref || inputs.vllm_ascend_branch }}
+        sparse-checkout: .github/workflows/configs/core_suite.yaml
+        sparse-checkout-cone-mode: false
+        fetch-depth: 1
+
+    - name: Determine and report core suite status
+      id: report
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const report = require('${{ github.action_path }}/report.js');
+          const result = await report({ github, context, core, branch: '${{ inputs.vllm_ascend_branch }}' });
+          core.setOutput('state', result.state);
+          core.setOutput('description', result.description);

--- a/.github/actions/report-core-suite-status/report.js
+++ b/.github/actions/report-core-suite-status/report.js
@@ -1,0 +1,118 @@
+module.exports = async function report({ github, core, context, branch }) {
+  const fs = require('fs');
+  const { owner, repo } = context.repo;
+  const runId = context.runId;
+
+  // Read core suite test names from config (strip comments and quotes for robustness).
+  const configContent = fs.readFileSync('.github/workflows/configs/core_suite.yaml', 'utf8');
+  const coreTests = configContent
+    .split('\n')
+    .map(l => l.split('#')[0].trim())
+    .filter(l => l.startsWith('- '))
+    .map(l => l.slice(2).trim().replace(/^['"]|['"]$/g, ''));
+  core.info(`Core suite tests: ${JSON.stringify(coreTests)}`);
+
+  // List all jobs in the current workflow run (with empty-page and max-page safety).
+  let allJobs = [];
+  let page = 1;
+  const MAX_JOB_PAGES = 50;
+  while (page <= MAX_JOB_PAGES) {
+    const resp = await github.rest.actions.listJobsForWorkflowRun({
+      owner, repo, run_id: runId, per_page: 100, page,
+    });
+    if (!resp.data.jobs || resp.data.jobs.length === 0) break;
+    allJobs = allJobs.concat(resp.data.jobs);
+    if (allJobs.length >= resp.data.total_count) break;
+    page++;
+  }
+
+  // Download job logs once per job (avoids redundant API calls).
+  const fetchJobLogs = async (job) => {
+    try {
+      const resp = await github.rest.actions.downloadJobLogsForWorkflowRun({
+        owner, repo, job_id: job.id,
+      });
+      return Buffer.isBuffer(resp.data) ? resp.data.toString('utf8') : String(resp.data);
+    } catch (e) {
+      core.warning(`Failed to download logs for job "${job.name}": ${e.message}`);
+      return null;
+    }
+  };
+
+  // Match core tests against job names.
+  const results = [];
+  for (const test of coreTests) {
+    const matched = allJobs.filter(j => j.name.includes(test));
+    if (matched.length === 0) {
+      core.info(`Core test "${test}" not found in this run, skipped.`);
+      continue;
+    }
+    for (const job of matched) {
+      const conclusion = job.conclusion;
+      core.info(`Core test "${test}" -> job "${job.name}": conclusion=${conclusion}`);
+      if (conclusion === 'success') {
+        results.push({ test, status: 'pass' });
+      } else if (conclusion === 'failure') {
+        const logText = await fetchJobLogs(job);
+        if (logText && logText.includes('Application startup complete')) {
+          core.info('  -> Has "Application startup complete" -> non-core issue, pass');
+          results.push({ test, status: 'pass' });
+        } else if (logText && logText.includes('test session starts')) {
+          core.info('  -> No "Application startup complete" but test session ran -> startup failure');
+          results.push({ test, status: 'fail' });
+        } else {
+          core.info('  -> No "Application startup complete" and no test session -> env/resource issue, ignored');
+          results.push({ test, status: 'pass' });
+        }
+      } else {
+        core.info(`  -> conclusion=${conclusion}, ignored`);
+        results.push({ test, status: 'pass' });
+      }
+    }
+  }
+
+  const anyFail = results.some(r => r.status === 'fail');
+  const state = anyFail ? 'failure' : 'success';
+  const description = anyFail
+    ? `Core suite failed: ${results.filter(r => r.status === 'fail').map(r => r.test).join(', ')}`
+    : 'Core suite passed';
+  core.info(`Overall status: ${state} (${description})`);
+
+  // Write to branch HEAD.
+  const refData = await github.rest.git.getRef({
+    owner, repo, ref: `heads/${branch}`,
+  });
+  const branchHeadSha = refData.data.object.sha;
+  await github.rest.repos.createCommitStatus({
+    owner, repo, sha: branchHeadSha,
+    context: 'nightly/core-suite', state, description,
+  });
+  core.info(`Wrote nightly/core-suite=${state} on ${branch} HEAD ${branchHeadSha}`);
+
+  // Propagate to all open PRs targeting this branch.
+  let prPage = 1;
+  let propagated = 0;
+  const MAX_PR_PAGES = 50;
+  while (prPage <= MAX_PR_PAGES) {
+    const prs = await github.rest.pulls.list({
+      owner, repo, state: 'open', base: branch, per_page: 100, page: prPage,
+    });
+    if (prs.data.length === 0) break;
+    for (const pr of prs.data) {
+      try {
+        await github.rest.repos.createCommitStatus({
+          owner, repo, sha: pr.head.sha,
+          context: 'nightly/core-suite', state, description,
+        });
+        propagated++;
+      } catch (e) {
+        core.warning(`Failed to propagate to PR #${pr.number}: ${e.message}`);
+      }
+    }
+    if (prs.data.length < 100) break;
+    prPage++;
+  }
+  core.info(`Propagated nightly/core-suite to ${propagated} open PRs`);
+
+  return { state, description };
+};

--- a/.github/workflows/_e2e_nightly_multi_node.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node.yaml
@@ -153,7 +153,7 @@ concurrency:
 
 jobs:
   e2e:
-    name: ${{ inputs.config_file_path }}
+    name: ${{ inputs.name || inputs.config_file_path }}
     timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
     # This is the runner with no NPU for k8s controller
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/_e2e_nightly_multi_node_560t.yaml
+++ b/.github/workflows/_e2e_nightly_multi_node_560t.yaml
@@ -181,7 +181,7 @@ concurrency:
 
 jobs:
   e2e:
-    name: ${{ inputs.config_file_path }}
+    name: ${{ inputs.name || inputs.config_file_path }}
     timeout-minutes: ${{ inputs.request_id != '' && 240 || fromJSON(inputs.testcase_timeout) }}
     runs-on: ${{ inputs.runner }}
     if: ${{ inputs.should_run }}

--- a/.github/workflows/check_trunk_health.yaml
+++ b/.github/workflows/check_trunk_health.yaml
@@ -1,0 +1,154 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# Maintains the `nightly/core-suite` commit status on PR head commits.
+#
+# Branch protection requires `nightly/core-suite` to pass on every PR.
+# The status is normally written by the nightly `report-core-suite-status`
+# job (propagation) or by `reset_core_suite_status` / `/exempt`. This workflow
+# covers two gaps that propagation cannot reach:
+#
+#   1. Newly opened (or re-pushed) PRs whose head commit has no
+#      `nightly/core-suite` status yet -> fall back to the base branch HEAD.
+#   2. Non-source PRs (no vllm_ascend/ csrc/ or root py/build files changed)
+#      -> auto-exempt by writing a success status.
+#
+# pull_request_target is required because GITHUB_TOKEN is read-only and repo
+# secrets are unavailable for fork PRs under the plain `pull_request` event.
+# This workflow only calls the GitHub API - it never checks out or executes
+# PR code, so it is safe to run with write permissions.
+name: Check Trunk Health
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - 'main'
+      - '*-dev'
+      - 'releases/v*'
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  check-trunk-health:
+    name: Check trunk health
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - name: Maintain nightly/core-suite status on PR head
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const payload = context.payload.pull_request;
+            const prNumber = payload.number;
+            const prHeadSha = payload.head.sha;
+            const baseBranch = payload.base.ref;
+
+            const SOURCE_PATTERNS = [
+              'vllm_ascend/',
+              'csrc/',
+              'pyproject.toml',
+              'setup.py',
+              'setup.cfg',
+              'requirements.txt',
+              'requirements-dev.txt',
+              'CMakeLists.txt',
+            ];
+
+            const writeStatus = async (state, description) => {
+              await github.rest.repos.createCommitStatus({
+                owner, repo, sha: prHeadSha,
+                context: 'nightly/core-suite',
+                state,
+                description,
+              });
+              core.info(`Wrote nightly/core-suite=${state} on ${prHeadSha}: ${description}`);
+            };
+
+            // 1. List changed files of the PR.
+            let changedFiles = [];
+            let page = 1;
+            while (true) {
+              try {
+                const resp = await github.rest.pulls.listFiles({
+                  owner, repo, pull_number: prNumber, per_page: 100, page,
+                });
+                changedFiles = changedFiles.concat(resp.data.map(f => f.filename));
+                if (resp.data.length < 100) break;
+                page++;
+              } catch (e) {
+                core.warning(`Failed to list changed files (page ${page}): ${e.message}`);
+                break;
+              }
+            }
+            core.info(`Changed files: ${JSON.stringify(changedFiles)}`);
+
+            // 2. Non-source PR -> auto-exempt (no comment, to avoid noise).
+            const isSourcePR = changedFiles.some(f => SOURCE_PATTERNS.some(p => f.startsWith(p)));
+            if (!isSourcePR) {
+              await writeStatus('success', 'Auto-exempted: non-source PR');
+              return;
+            }
+
+            // 3. Source PR: reuse the status already present on the PR head
+            //    (written by nightly propagation / reset / /exempt).
+            try {
+              const existing = await github.rest.repos.listCommitStatusesForRef({
+                owner, repo, ref: prHeadSha,
+              });
+              const coreStatus = existing.data.find(s => s.context === 'nightly/core-suite');
+              if (coreStatus) {
+                core.info(`Reusing existing status on PR head: ${coreStatus.state}`);
+                return;
+              }
+            } catch (e) {
+              core.warning(`Failed to read PR head statuses: ${e.message}`);
+            }
+
+            // 4. No status on PR head -> fall back to the base branch HEAD.
+            let baseSha;
+            try {
+              const refData = await github.rest.git.getRef({
+                owner, repo, ref: `heads/${baseBranch}`,
+              });
+              baseSha = refData.data.object.sha;
+            } catch (e) {
+              core.warning(`Failed to resolve ${baseBranch} HEAD: ${e.message}`);
+              return;
+            }
+
+            try {
+              const branchStatuses = await github.rest.repos.listCommitStatusesForRef({
+                owner, repo, ref: baseSha,
+              });
+              const branchStatus = branchStatuses.data.find(s => s.context === 'nightly/core-suite');
+              if (branchStatus) {
+                const state = branchStatus.state === 'failure' ? 'failure' : 'success';
+                const description = branchStatus.state === 'failure'
+                  ? `Trunk ${baseBranch} core suite failed`
+                  : `Trunk ${baseBranch} core suite passed`;
+                await writeStatus(state, description);
+              } else {
+                // No nightly signal on the base branch -> no gate signal.
+                core.info(`No nightly/core-suite status found on ${baseBranch} HEAD; leaving PR status unset.`);
+              }
+            } catch (e) {
+              core.warning(`Failed to read ${baseBranch} HEAD statuses: ${e.message}`);
+            }

--- a/.github/workflows/configs/core_suite.yaml
+++ b/.github/workflows/configs/core_suite.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# Core suite tests used as the L1 gating signal for PR merges.
+#
+# The `report-core-suite-status` job in the nightly workflows matches these
+# test names against the job names of the current workflow run. A SOC only
+# reports the tests it actually ran, so this list is intentionally a flat set
+# of test names without SOC differentiation.
+#
+# The core suite is currently a provisional selection and will be refined later.
+core_suite:
+  tests:
+    - qwen3-32b-int8
+    - multi-node-qwen3-dp
+    - qwen3-235b-a22b-w8a8

--- a/.github/workflows/pr_exempt_command.yml
+++ b/.github/workflows/pr_exempt_command.yml
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# Handles the /exempt slash command.
+#
+# Writes a `nightly/core-suite` success status to a single PR head commit so
+# that branch protection allows the PR to merge even when the trunk core suite
+# is failing. This is an emergency per-PR bypass: it does NOT change the branch
+# HEAD health signal, and it does NOT propagate to other PRs.
+#
+# Because the status is bound to the PR head SHA, a new push to the PR
+# automatically invalidates the exemption.
+#
+# Authorization is restricted to maintain/admin only (NOT triage), otherwise
+# the L1 circuit breaker would lose its meaning.
+name: Handle /exempt Command
+
+on:
+  repository_dispatch:
+    types: [exempt-command]
+
+defaults:
+  run:
+    shell: bash -el {0}
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  exempt:
+    name: Exempt PR from core-suite gate
+    runs-on: linux-amd64-cpu-4-hk
+    container:
+      image: swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend/act-environments-ubuntu:act-22.04
+    steps:
+      - name: Install system dependencies
+        run: |
+          sudo mkdir -p -m 755 /etc/apt/keyrings
+          curl -sL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null
+          sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt-get update -y
+          sudo apt-get install gh -y
+
+      - name: Check user authorization (maintain/admin only)
+        id: auth
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          ACTOR: ${{ github.event.client_payload.github.payload.comment.user.login }}
+          REPO: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        run: |
+          ROLE_NAME=$(gh api "repos/$REPO/collaborators/$ACTOR/permission" --jq '.role_name' 2>/dev/null || true)
+          case "$ROLE_NAME" in
+            maintain|admin)
+              echo "User $ACTOR has $ROLE_NAME role, authorized."
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::User $ACTOR does not have maintain/admin permission and cannot trigger /exempt."
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Post unauthorized comment
+        if: steps.auth.outputs.authorized == 'false'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            [Bot]: exempt command failed: you do not have permission. Only users with maintain/admin permission can trigger /exempt.
+          reactions: confused
+
+      - name: Fail if unauthorized
+        if: steps.auth.outputs.authorized == 'false'
+        run: exit 1
+
+      - name: Write success status to PR head
+        id: exempt
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const repo = context.payload.client_payload.github.payload.repository.full_name;
+            const prNumber = context.payload.client_payload.github.payload.issue.number;
+            const actor = context.payload.client_payload.github.payload.comment.user.login;
+            const reason = (context.payload.client_payload.slash_command.args.all || '').trim();
+
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const prHeadSha = pr.data.head.sha;
+            const timestamp = new Date().toISOString();
+
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: prHeadSha,
+              context: 'nightly/core-suite',
+              state: 'success',
+              description: `Exempted by ${actor}${reason ? ` (${reason})` : ''}`,
+            });
+
+            core.info(`Wrote nightly/core-suite=success on ${prHeadSha} for PR #${prNumber}`);
+            core.setOutput('pr_head_sha', prHeadSha);
+            core.setOutput('actor', actor);
+            core.setOutput('reason', reason);
+            core.setOutput('timestamp', timestamp);
+
+      - name: Post exemption audit comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          body: |
+            [Bot]: :white_check_mark: `nightly/core-suite` exempted for PR head `${{ steps.exempt.outputs.pr_head_sha }}`.
+            - Operator: @${{ steps.exempt.outputs.actor }}
+            - Time: ${{ steps.exempt.outputs.timestamp }}
+            - Reason: ${{ steps.exempt.outputs.reason || '(not provided)' }}
+          reactions: rocket

--- a/.github/workflows/pr_nightly_command.yml
+++ b/.github/workflows/pr_nightly_command.yml
@@ -370,6 +370,7 @@ jobs:
             -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
+            -f enable_core_suite=false \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
             -f bisect_args_json="$BISECT_ARGS_JSON"
@@ -413,6 +414,7 @@ jobs:
             -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
+            -f enable_core_suite=false \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
             -f bisect_args_json="$BISECT_ARGS_JSON"
@@ -456,6 +458,7 @@ jobs:
             -f vllm_ascend_branch='${{ needs.authorize.outputs.branch }}' \
             -f request_id="$REQUEST_ID" \
             -f skip_build_image=true \
+            -f enable_core_suite=false \
             -f vllm_ascend_ref='${{ needs.authorize.outputs.vllm_ascend_ref }}' \
             -f aop_enabled='${{ needs.authorize.outputs.aop_enabled }}' \
             -f bisect_args_json="$BISECT_ARGS_JSON"

--- a/.github/workflows/reset_core_suite_status.yaml
+++ b/.github/workflows/reset_core_suite_status.yaml
@@ -1,0 +1,112 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+# Manually sets the branch-level `nightly/core-suite` health signal.
+#
+# Intended for maintainers who fixed a broken trunk and do not want to wait
+# for the next scheduled nightly run, or who need to force a failure when a
+# nightly false-reports success.
+#
+# The status is written to the branch HEAD AND propagated to every open PR
+# targeting that branch, so PRs are updated immediately without requiring a
+# re-push (see the propagation mechanism in report-core-suite-status).
+name: Reset Core Suite Status
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to set the core suite status on'
+        required: true
+        default: 'main'
+        type: string
+      state:
+        description: 'Target status state'
+        required: true
+        default: 'success'
+        type: choice
+        options:
+          - success
+          - failure
+      reason:
+        description: 'Reason for the manual status change'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  reset:
+    name: Reset core suite status
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - name: Set branch HEAD and propagate to open PRs
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const branch = '${{ inputs.branch }}';
+            const state = '${{ inputs.state }}';
+            const reason = '${{ inputs.reason }}';
+            const actor = context.actor;
+            const description = `Manual reset by ${actor}: ${reason}`;
+
+            const refData = await github.rest.git.getRef({
+              owner, repo, ref: `heads/${branch}`,
+            });
+            const branchHeadSha = refData.data.object.sha;
+
+            await github.rest.repos.createCommitStatus({
+              owner, repo, sha: branchHeadSha,
+              context: 'nightly/core-suite',
+              state,
+              description,
+            });
+            core.info(`Wrote nightly/core-suite=${state} on ${branch} HEAD ${branchHeadSha}`);
+
+            // Propagate to all open PRs targeting this branch.
+            let page = 1;
+            let propagated = 0;
+            let failed = 0;
+            while (true) {
+              const prs = await github.rest.pulls.list({
+                owner, repo, state: 'open', base: branch, per_page: 100, page,
+              });
+              if (prs.data.length === 0) break;
+              for (const pr of prs.data) {
+                try {
+                  await github.rest.repos.createCommitStatus({
+                    owner, repo, sha: pr.head.sha,
+                    context: 'nightly/core-suite',
+                    state,
+                    description,
+                  });
+                  propagated++;
+                } catch (e) {
+                  core.warning(`Failed to propagate to PR #${pr.number}: ${e.message}`);
+                  failed++;
+                }
+              }
+              if (prs.data.length < 100) break;
+              page++;
+            }
+            core.info(`Propagated to ${propagated} open PRs (${failed} failed)`);
+            core.setOutput('branch_head_sha', branchHeadSha);
+            core.setOutput('propagated', String(propagated));

--- a/.github/workflows/schedule_nightly_test_310p.yaml
+++ b/.github/workflows/schedule_nightly_test_310p.yaml
@@ -66,11 +66,18 @@ on:
         required: false
         default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
+      enable_core_suite:
+        description: 'Enable core suite gate for nightly status reporting'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write
+  actions: read
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -245,3 +252,20 @@ jobs:
           pattern: nightly-test-benchmark-results-*
           compression-level: 0
           delete-merged: true
+
+  report-core-suite-status:
+    name: Report core suite status
+    needs: [parse-trigger, single-node-tests]
+    if: >-
+      always() &&
+      inputs.enable_core_suite &&
+      needs.parse-trigger.result == 'success'
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_branch }}
+      - uses: ./.github/actions/report-core-suite-status
+        with:
+          vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -65,17 +65,22 @@ on:
         required: false
         default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
         default: '{}'
         type: string
+      enable_core_suite:
+        description: 'Enable core suite gate for nightly status reporting'
+        required: false
+        default: false
+        type: boolean
 permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write
+  actions: read
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -442,3 +447,20 @@ jobs:
           pattern: nightly-test-benchmark-results-*
           compression-level: 0
           delete-merged: true
+
+  report-core-suite-status:
+    name: Report core suite status
+    needs: [parse-trigger, single-node-tests, multi-node-tests, single-node-accuracy-tests, single-node-accuracy-tests-pr-only]
+    if: >-
+      always() &&
+      inputs.enable_core_suite &&
+      needs.parse-trigger.result == 'success'
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_branch }}
+      - uses: ./.github/actions/report-core-suite-status
+        with:
+          vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -66,17 +66,22 @@ on:
         required: false
         default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
         default: '{}'
         type: string
+      enable_core_suite:
+        description: 'Enable core suite gate for nightly status reporting'
+        required: false
+        default: false
+        type: boolean
 permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write
+  actions: read
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -437,3 +442,20 @@ jobs:
       - name: Remove dedicated taint from test nodes
         run: |
           kubectl taint nodes ${{ vars.A3_TAINT_NODES }} dedicated- || true
+
+  report-core-suite-status:
+    name: Report core suite status
+    needs: [parse-trigger, single-node-tests, multi-node-tests, double-node-tests, multi-card-tests]
+    if: >-
+      always() &&
+      inputs.enable_core_suite &&
+      needs.parse-trigger.result == 'success'
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_branch }}
+      - uses: ./.github/actions/report-core-suite-status
+        with:
+          vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -66,18 +66,22 @@ on:
         required: false
         default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
         default: '{}'
         type: string
+      enable_core_suite:
+        description: 'Enable core suite gate for nightly status reporting'
+        required: false
+        default: false
+        type: boolean
 permissions:
   contents: read
   pull-requests: read
   issues: read
   statuses: write
+  actions: read
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -454,3 +458,20 @@ jobs:
       - name: Remove dedicated taint from test nodes
         run: |
           kubectl taint nodes ${{ vars.A3_560T_TAINT_NODES }} dedicated- || true
+
+  report-core-suite-status:
+    name: Report core suite status
+    needs: [parse-trigger, single-node-tests, multi-node-tests, double-node-tests, double-node-pods-started, multi-card-tests]
+    if: >-
+      always() &&
+      inputs.enable_core_suite &&
+      needs.parse-trigger.result == 'success'
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_branch }}
+      - uses: ./.github/actions/report-core-suite-status
+        with:
+          vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}

--- a/.github/workflows/schedule_nightly_test_a5.yaml
+++ b/.github/workflows/schedule_nightly_test_a5.yaml
@@ -64,17 +64,22 @@ on:
         required: false
         default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
         type: string
-      bisect_good_commit:
-        description: 'explicit good commit for bisect (overrides good_table lookup)'
       bisect_args_json:
         description: 'JSON object containing optional bisect parameters'
         required: false
         default: '{}'
-        
+      enable_core_suite:
+        description: 'Enable core suite gate for nightly status reporting'
+        required: false
+        default: false
+        type: boolean
+
 permissions:
   contents: read
   pull-requests: read
   issues: read
+  statuses: write
+  actions: read
 
 # Bash shells do not use ~/.profile or ~/.bashrc so these shells need to be explicitly
 # declared as "shell: bash -el {0}" on steps that need to be properly activated.
@@ -316,3 +321,20 @@ jobs:
           pattern: nightly-test-benchmark-results-*
           compression-level: 0
           delete-merged: true
+
+  report-core-suite-status:
+    name: Report core suite status
+    needs: [parse-trigger, multi-node-tests, single-node-tests]
+    if: >-
+      always() &&
+      inputs.enable_core_suite &&
+      needs.parse-trigger.result == 'success'
+    runs-on: linux-amd64-cpu-2-hk
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.vllm_ascend_branch }}
+      - uses: ./.github/actions/report-core-suite-status
+        with:
+          vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}

--- a/.github/workflows/slash_command_dispatch.yml
+++ b/.github/workflows/slash_command_dispatch.yml
@@ -40,6 +40,7 @@ jobs:
             revert
             weekly
             wait-feedback
+            exempt
           permission: none
           issue-type: both
           dispatch-type: repository
@@ -84,5 +85,10 @@ jobs:
                 "command": "wait-feedback",
                 "permission": "none",
                 "issue_type": "issue"
+              },
+              {
+                "command": "exempt",
+                "permission": "none",
+                "issue_type": "pull-request"
               }
             ]


### PR DESCRIPTION

### What this PR does / why we need it?

[[RFC]: PR Merge Tiered Governance (L1 Circuit Breaker + Exemption)
](https://github.com/vllm-project/vllm-ascend/issues/14859)

Introduce a tiered governance model with L1 circuit breaker and exemption mechanism to prevent PRs from merging when the trunk core suite is broken.

Components:
- core_suite.yaml: defines core suite test names (flat list, no SOC differentiation)
- report-core-suite-status: reusable action that judges core suite status from nightly job logs, writes nightly/core-suite commit
  status to branch HEAD and propagates to all open PRs
- check_trunk_health: pull_request_target workflow for auto-exempting non-source PRs and falling back new PRs to branch HEAD status
- /exempt command: maintainer-only per-PR exemption (commit-bound,  auto-invalidated on push)
- reset_core_suite_status: manual workflow_dispatch to reset branch HEAD status with bidirectional success/failure support

The failure detection uses two-level log filtering:
- 'Application startup complete' found -> non-core issue (precision drift), treated as pass
- not found but 'test session starts' -> real startup failure
- neither found -> resource/env issue, ignored

The trigger is controlled by enable_core_suite boolean (default false), set to true by 3rd-party scheduled dispatch. PR /nightly commands pass enable_core_suite=false to avoid polluting the trunk health signal.

### Does this PR introduce _any_ user-facing change?

Yes. This PR introduces the following user-facing changes:

- **New `/exempt` slash command**: Maintainers can comment `/exempt` on a PR to bypass the `nightly/core-suite` gate. The exemption is commit-bound and auto-invalidated on push. Only users with `maintain` or `admin` permission can use this command.
- **New `nightly/core-suite` required status check**: All source PRs (those modifying `vllm_ascend/`, `csrc/`, or root build files) must pass the `nightly/core-suite` check before merging. Non-source PRs are auto-exempted.
- **New `reset_core_suite_status` workflow**: Maintainers can manually reset the branch-level `nightly/core-suite` status via the Actions tab (`workflow_dispatch`), supporting both `success` and `failure` states with a required reason field.

### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
