### PR TITLE
[BugFix][310P] Fix Moe aclgraph error caued by routing to aclop on 310p

### DIFF
--- a/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
+++ b/tests/ut/_310p/fused_moe/test_shared_fused_moe_310.py
@@ -98,6 +98,7 @@ def test_runner_310_installs_specialized_comm():
     runner = _build_runner()
     moe_config = MagicMock()
     runner.moe_config = moe_config
+    runner.gate = None
     routed_experts = SimpleNamespace(quant_config=None, quant_method=None)
     runner.ascend_shared_experts = SimpleNamespace(multistream_overlap=True)
     comm_method = object()

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -25,7 +25,7 @@ from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
 from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import maybe_trans_nz
+from vllm_ascend.utils import maybe_trans_nz, vllm_version_is
 
 from .moe_comm_method import AllGatherCommImpl310
 
@@ -116,6 +116,10 @@ class AscendMoERunner310(AscendMoERunner):
         tid2eid=None,
         n_shared_experts: int = 0,
     ):
+        if not vllm_version_is("0.27.1") and gate is not None:
+            # Pre-cast the internal router weight during model loading. A
+            # forward-time Cast cannot be captured by ACLGraph on 310P.
+            gate.precast_fp32_weight = True
         super().__init__(
             layer_name=layer_name,
             moe_config=moe_config,

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -25,7 +25,7 @@ from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
 from vllm_ascend.ops.fused_moe.moe_comm_method import _MoECommMethods
 from vllm_ascend.ops.fused_moe.routed_experts import AscendRoutedExperts
 from vllm_ascend.quantization.quant_type import QuantType
-from vllm_ascend.utils import maybe_trans_nz, vllm_version_is
+from vllm_ascend.utils import maybe_trans_nz
 
 from .moe_comm_method import AllGatherCommImpl310
 
@@ -116,10 +116,6 @@ class AscendMoERunner310(AscendMoERunner):
         tid2eid=None,
         n_shared_experts: int = 0,
     ):
-        if not vllm_version_is("0.27.1") and gate is not None:
-            # Pre-cast the internal router weight during model loading. A
-            # forward-time Cast cannot be captured by ACLGraph on 310P.
-            gate.precast_fp32_weight = True
         super().__init__(
             layer_name=layer_name,
             moe_config=moe_config,
@@ -133,6 +129,10 @@ class AscendMoERunner310(AscendMoERunner):
             routed_output_transform=routed_output_transform,
             routed_scaling_factor=routed_scaling_factor,
         )
+        if self.is_internal_router and self.gate is not None and not hasattr(self.gate, "weight_fp32"):
+            # Pre-cast the internal router weight during model loading. A
+            # forward-time Cast cannot be captured by ACLGraph on 310P.
+            self.gate.precast_fp32_weight = True
 
         ascend_shared_experts = getattr(self, "ascend_shared_experts", None)
         if ascend_shared_experts is not None:


### PR DESCRIPTION
### What this PR does / why we need it?
ACLGraph Compatibility: Implemented a pre-casting mechanism for router weights to prevent unsupported forward-time Cast operations on 310P hardware.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
