### PR TITLE
[v0.26.0rc][BugFix] Fix dispatch_v2 tokens capacity to follow normal MC2 branch logic

### DIFF
--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -246,7 +246,18 @@ def set_mc2_tokens_capacity(vllm_config, max_num_reqs, uniform_decode_query_len)
         else:
             num_tokens_per_tp_rank = min(num_tokens_per_tp_rank, _DISPATCH_FFN_COMBINE_TOKENS_PER_RANK_LIMIT)
         global _dispatch_v2_tokens_capacity
-        _dispatch_v2_tokens_capacity = min(num_tokens_per_tp_rank, _MC2_TOKENS_PER_RANK_LIMIT) * tp_size
+        # Compute dispatch_v2 (normal MC2) tokens capacity independently from the
+        # fused_mc2 path above. When enable_prefill_mc2 or use_mega_moe is true,
+        # max_num_tokens is based on max_num_batched_tokens (prefill+decode unified
+        # batch), which is too large for the normal MC2 decode path. Recompute the
+        # token count from the decode-only configuration so that
+        # _dispatch_v2_tokens_capacity follows the normal MC2 branch logic.
+        if vllm_config.compilation_config.cudagraph_capture_sizes:
+            dispatch_v2_max_num_tokens = vllm_config.compilation_config.max_cudagraph_capture_size
+        else:
+            dispatch_v2_max_num_tokens = max_num_reqs * uniform_decode_query_len
+        dispatch_v2_tokens_per_tp_rank = (dispatch_v2_max_num_tokens + tp_size - 1) // tp_size
+        _dispatch_v2_tokens_capacity = min(dispatch_v2_tokens_per_tp_rank, _MC2_TOKENS_PER_RANK_LIMIT) * tp_size
 
     # keep the num_tokens_per_tp_rank less than mc2 tokens per rank limit
     else:


### PR DESCRIPTION

### What this PR does / why we need it?
Follow-up modifications for PR #14747
This PR fixes the calculation of `_dispatch_v2_tokens_capacity` (normal MC2 tokens capacity) to follow the normal MC2 branch logic.
Previously, when `enable_prefill_mc2` or `use_mega_moe` was true, `max_num_tokens` was based on `max_num_batched_tokens` (prefill+decode unified batch), which is too large for the normal MC2 decode path.
This PR recomputes the token count from the decode-only configuration so that `_dispatch_v2_tokens_capacity` is computed independently from the fused MC2 path.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
/nightly Qwen3.5-397B-A17B-w8a8-mtp --branch releases/v0.26.0rc

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
