### PR TITLE
[Refactor][DSA] Reuse DynamicQuant output for W8A8 multistream projections

### DIFF
--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -1387,13 +1387,20 @@ class AscendDSAImpl(AttentionImplBase[Any]):
         is_w8a8 = _is_w8a8_dynamic(self.wq_b)
 
         # Part1: q_quant[V] -> q_a_down[C]  ||  kv_quant[V]
+        share_hs_quant = _is_w8a8_dynamic(self.wq_a) and _is_w8a8_dynamic(self.wkv)
         q_quant, q_pertoken_scale = self.cv_wq_a.quantize(hidden_states)
 
         e_q_quant_done = main_stream.record_event()
 
         with npu_stream_switch(aux_stream, enabled=True):
             torch.npu.current_stream().wait_event(e_q_quant_done)
-            kv_quant, kv_pertoken_scale = self.cv_wkv.quantize(hidden_states)
+            if share_hs_quant:
+                # Both W8A8 dynamic projections consume the same hidden_states.
+                # Reuse the exact first quantization result instead of launching
+                # a second, serialized DynamicQuant on the auxiliary stream.
+                kv_quant, kv_pertoken_scale = q_quant, q_pertoken_scale
+            else:
+                kv_quant, kv_pertoken_scale = self.cv_wkv.quantize(hidden_states)
 
         wq_a_result = self.cv_wq_a.matmul(q_quant, q_pertoken_scale)
         main_stream.wait_stream(aux_stream)


### PR DESCRIPTION
### What this PR does / why we need it?
In the DeepSeek-V4 DSA multistream path, wq_a and wkv independently run DynamicQuant on the same hidden_states when both projections use W8A8 dynamic quantization.

This PR reuses wq_a's native quantized activation and per-token scale for wkv, removing the redundant second quantization. All non-W8A8-dynamic paths remain unchanged, and the existing stream-event dependencies and MatMul scheduling are preserved.

Measured benefits:

DynamicQuant calls: 27,821 → 20,844, a 25.1% reduction

DynamicQuant time: 135.6 ms → 91.9 ms, a 32.2% reduction

~1.43x geometric-mean p50 speedup in the operator microbenchmark

### Does this PR introduce _any_ user-facing change?
No API, configuration, or model-output semantic change is introduced.

The change only reuses an existing native quantization result internally. For the W8A8 dynamic path, the reused activation and scale are bitwise identical to the original second torch_npu.npu_dynamic_quant invocation. All other quantization modes retain the original behavior.

### How was this patch tested?
<head></head><p data-pm-slice="1 1 []" style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span>Tested on Ascend NPU with BF16<span class="Apple-converted-space"> </span></span><code><span>[tokens, 4096]</span></code><span><span class="Apple-converted-space"> </span>inputs:</span></p>

| Tokens | Bitwise equal | p50 speedup |
|--------|---------------|-------------|
| 1      | Yes           | 1.49x       |
| 2      | Yes           | 1.27x       |
| 4      | Yes           | 1.26x       |
| 18     | Yes           | 1.75x       |

A post-patch profiler run also confirmed the expected reduction in DynamicQuant call count and cumulative latency.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
