### PR TITLE
[Feature][Model] Support text-only Qwen3.5 checkpoints

### DIFF
--- a/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
+++ b/tests/ut/patch/worker/test_patch_qwen3_5_mtp.py
@@ -10,6 +10,22 @@ from vllm.sequence import IntermediateTensors
 from vllm_ascend.patch.worker import patch_qwen3_5
 
 
+def test_qwen3_5_text_attention_uses_standard_rope():
+    attention = SimpleNamespace(
+        config=SimpleNamespace(model_type="qwen3_5_moe_text"),
+        rotary_emb=SimpleNamespace(),
+    )
+    assert not patch_qwen3_5._uses_multimodal_rope(attention)
+
+
+def test_qwen3_5_multimodal_attention_uses_mrope():
+    attention = SimpleNamespace(
+        config=SimpleNamespace(model_type="qwen3_5_moe"),
+        rotary_emb=SimpleNamespace(mrope_section=[11, 11, 10]),
+    )
+    assert patch_qwen3_5._uses_multimodal_rope(attention)
+
+
 @pytest.mark.skipif(
     patch_qwen3_5.Qwen3_5MultiTokenPredictor is None,
     reason="Qwen3.5 MTP model is not available in this vLLM version.",

--- a/tests/ut/quantization/test_modelslim_config.py
+++ b/tests/ut/quantization/test_modelslim_config.py
@@ -486,6 +486,15 @@ class TestApplyVllmMapper(TestBase):
 
 
 class TestQuantPrefixMapper(TestBase):
+    def test_qwen3_5_text_backbones_use_packed_module_mappings(self):
+        dense_mapping = get_packed_modules_mapping("qwen3_5_text")
+        moe_mapping = get_packed_modules_mapping("qwen3_5_moe_text")
+        self.assertEqual(dense_mapping["qkv_proj"], ["q_proj", "k_proj", "v_proj"])
+        self.assertEqual(
+            moe_mapping["experts"],
+            ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+        )
+
     def test_lm_head_maps_to_language_model_lm_head_when_quant_key_exists(self):
         config = AscendModelSlimConfig({"language_model.lm_head.weight": "FLOAT"})
 

--- a/vllm_ascend/patch/worker/patch_qwen3_5.py
+++ b/vllm_ascend/patch/worker/patch_qwen3_5.py
@@ -56,10 +56,15 @@ if vllm_version_is("0.27.1"):
 _GDN_PATCH_TARGET = _GDNBaseCls
 
 
+def _uses_multimodal_rope(attention: Qwen3NextAttention) -> bool:
+    """Return whether a Qwen3.5 attention layer exposes multimodal RoPE."""
+    return "qwen3_5" in attention.config.model_type and hasattr(attention.rotary_emb, "mrope_section")
+
+
 class AscendQwen3NextAttention(Qwen3NextAttention):
     def forward(self, positions: torch.Tensor, hidden_states: torch.Tensor, output: torch.Tensor = None):
         qkv, _ = self.qkv_proj(hidden_states)
-        if "qwen3_5" in self.config.model_type:
+        if _uses_multimodal_rope(self):
             cos_sin = self.rotary_emb.cos_sin_cache[positions]
             if cos_sin.device != qkv.device:
                 cos_sin = cos_sin.to(qkv.device)

--- a/vllm_ascend/quantization/modelslim_config.py
+++ b/vllm_ascend/quantization/modelslim_config.py
@@ -123,7 +123,20 @@ packed_modules_model_mapping: dict[str, dict[str, list[str]]] = {
         "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
         "in_proj_ba": ["in_proj_b", "in_proj_a"],
     },
+    "qwen3_5_text": {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+    },
     "qwen3_5_moe": {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "experts": ["experts.0.gate_proj", "experts.0.up_proj", "experts.0.down_proj"],
+    },
+    "qwen3_5_moe_text": {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
         "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],


### PR DESCRIPTION
### What this PR does / why we need it?
This PR backports the Qwen3.5 text-only RoPE handling and ModelSlim packed-module mappings from [vLLM PR #50734](https://github.com/vllm-project/vllm/pull/50734).
Text-only Qwen3.5-family checkpoints use the model types qwen3_5_text or qwen3_5_moe_text. Unlike multimodal Qwen3.5 checkpoints, they do not expose multimodal RoPE fields such as mrope_section.
Before this change, the Ascend Qwen3.5 attention patch selected the multimodal RoPE path based only on the qwen3_5 model-type prefix. This could cause text-only checkpoints to access missing multimodal RoPE attributes. ModelSlim also lacked packed-module mappings for the text-only dense and MoE model types.
The change:
- selects the multimodal RoPE path only when mrope_section is available;
- keeps text-only Qwen3.5 checkpoints on the standard RoPE path;
- adds ModelSlim packed-module mappings for qwen3_5_text;
- adds ModelSlim packed-module and expert mappings for qwen3_5_moe_text;
- adds focused unit coverage for RoPE selection and ModelSlim mappings.
This is a scoped backport. It does not include the model registration, hybrid-cache wrappers, MTP configuration conversion, or documentation changes from the source PR.
Related PR: [vllm-project/vllm#50734](https://github.com/vllm-project/vllm/pull/50734)

### Does this PR introduce _any_ user-facing change?
Yes.
When the corresponding text-only Qwen3.5 model integration is available, checkpoints using qwen3_5_text or qwen3_5_moe_text no longer incorrectly enter the multimodal RoPE path.
ModelSlim W8A8 checkpoints using these model types can also resolve the existing packed QKV, gate/up projection, GDN projection, and MoE expert mappings.

### How was this patch tested?
Added unit coverage for:
- standard RoPE selection for qwen3_5_moe_text;
- multimodal RoPE selection when mrope_section exists;
- ModelSlim packed-module mappings for qwen3_5_text;
- ModelSlim expert mappings for qwen3_5_moe_text.

git diff --check passed.

Python syntax compilation passed for all four changed files.

Targeted pytest execution was not available in the local environment because pytest is not installed.

Ruff was not available in the local environment, so no Ruff result is claimed.

No real Ascend NPU or checkpoint inference validation was performed for this scoped backport.

vLLM version: current branch dependency

vLLM main: current branch dependency

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
