### PR TITLE
[Performance][SpecDecode] Fuse padded next-token preparation

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py
@@ -4,7 +4,7 @@ import pytest
 import torch
 from vllm.triton_utils import triton
 
-from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
+from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel, prepare_next_token_ids_padded
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.spec_decode.llm_base_proposer import _PREPARE_INPUTS_BLOCK_SIZE as BLOCK_SIZE
 
@@ -74,3 +74,24 @@ def test_prepare_inputs_padded(num_reqs):
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()
+
+
+@pytest.mark.parametrize("num_reqs", [1, 128])
+def test_prepare_next_token_ids_padded(num_reqs):
+    vocab_size, num_tokens = 1000, 5
+    sampled = torch.randint(0, vocab_size, (num_reqs, num_tokens), device="npu")
+    valid_lens = torch.arange(num_reqs, device="npu") % (num_tokens + 1)
+    sampled[torch.arange(num_tokens, device="npu") >= valid_lens[:, None]] = -1
+    backup = torch.arange(num_reqs, dtype=torch.int64, device="npu")
+    discard = torch.arange(num_reqs, device="npu") % 3 == 0
+
+    expected_count = ((sampled != -1) & (sampled < vocab_size)).sum(1)
+    expected_count[discard] = 0
+    expected = torch.where(
+        expected_count > 0,
+        sampled.gather(1, (expected_count - 1).clamp_min(0).unsqueeze(1)).squeeze(1),
+        backup,
+    )
+    actual, actual_count = prepare_next_token_ids_padded(sampled, backup, discard, vocab_size)
+    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual_count, expected_count)

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -15,7 +15,66 @@
 #
 # Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/v1/spec_decode/utils.py
 
+import torch
 from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+
+@triton.jit(do_not_specialize=["vocab_size", "num_reqs"])
+def prepare_next_token_ids_padded_kernel(
+    sampled_ptr,
+    backup_ptr,
+    discard_ptr,
+    next_ptr,
+    count_ptr,
+    sampled_stride,
+    vocab_size,
+    num_reqs,
+    NUM_TOKENS: tl.constexpr,
+    TOKEN_BLOCK: tl.constexpr,
+    REQUEST_BLOCK: tl.constexpr,
+):
+    block = tl.program_id(0) * REQUEST_BLOCK
+    step = tl.num_programs(0) * REQUEST_BLOCK
+    while block < num_reqs:
+        req = block + tl.arange(0, REQUEST_BLOCK)
+        req_mask = req < num_reqs
+        offsets = tl.arange(0, TOKEN_BLOCK)
+        mask = req_mask[:, None] & (offsets[None, :] < NUM_TOKENS)
+        tokens = tl.load(sampled_ptr + req[:, None] * sampled_stride + offsets[None, :], mask=mask, other=-1)
+        count = tl.sum((mask & (tokens != -1) & (tokens < vocab_size)).to(tl.int32), axis=1)
+        count = tl.where(tl.load(discard_ptr + req, mask=req_mask, other=1), 0, count)
+        selected = tl.load(
+            sampled_ptr + req * sampled_stride + tl.where(count > 0, count - 1, 0), mask=req_mask, other=-1
+        )
+        backup = tl.load(backup_ptr + req, mask=req_mask, other=-1)
+        tl.store(next_ptr + req, tl.where(count > 0, selected, backup), mask=req_mask)
+        tl.store(count_ptr + req, count, mask=req_mask)
+        block += step
+
+
+def prepare_next_token_ids_padded(sampled, backup, discard, vocab_size):
+    num_reqs, num_tokens = sampled.shape
+    next_tokens = torch.empty_like(backup)
+    counts = torch.empty(num_reqs, dtype=torch.int64, device=sampled.device)
+    if num_reqs:
+        request_block = 4
+        grid = (min(triton.cdiv(num_reqs, request_block), get_vectorcore_num()),)
+        prepare_next_token_ids_padded_kernel[grid](
+            sampled,
+            backup,
+            discard,
+            next_tokens,
+            counts,
+            sampled.stride(0),
+            vocab_size,
+            num_reqs,
+            NUM_TOKENS=num_tokens,
+            TOKEN_BLOCK=triton.next_power_of_2(num_tokens),
+            REQUEST_BLOCK=request_block,
+        )
+    return next_tokens, counts
 
 
 @triton.jit(do_not_specialize=["num_reqs"])

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -53,7 +53,7 @@ from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_man
 from vllm_ascend.distributed.parallel_state import get_lmhead_tp_group
 from vllm_ascend.models.deepseek_v4.dspark import DSparkDeepseekV4ForCausalLM
 from vllm_ascend.models.llama_eagle3_vwn import Eagle3VwnLlamaForCausalLM
-from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel
+from vllm_ascend.ops.triton.spec_decode.utils import prepare_inputs_padded_kernel, prepare_next_token_ids_padded
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 from vllm_ascend.ops.vocab_parallel_embedding import lmhead_all_to_all
 from vllm_ascend.spec_decode.utils import (
@@ -1874,6 +1874,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         gpu_input_batch: InputBatch,
         discard_request_indices: torch.Tensor,
         num_discarded_requests: int,
+        discard_request_mask: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """
         This function is used to prepare the inputs for speculative decoding.
@@ -1884,8 +1885,6 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         This function must use device functions to operate on the inputs, and
         should not introduce any blocking CPU-GPU synchronization.
         """
-        # TODO(Ben): Combine this into a custom fused kernel
-
         # Precompute get_token_id for when there is no valid next token
         num_reqs = gpu_input_batch.num_reqs
         seq_lens_list = (gpu_input_batch.num_tokens_no_spec[:num_reqs] - 1).tolist()
@@ -1893,6 +1892,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             [requests[gpu_input_batch.req_ids[i]].get_token_id(seq_lens_list[i]) for i in range(num_reqs)]
         )
         self.backup_next_token_ids.copy_to_gpu(num_reqs)
+
+        if HAS_TRITON and sampled_token_ids.device.type != "cpu" and discard_request_mask is not None:
+            return prepare_next_token_ids_padded(
+                sampled_token_ids,
+                self.backup_next_token_ids.gpu[:num_reqs],
+                discard_request_mask,
+                gpu_input_batch.vocab_size,
+            )
 
         # Mask out the sampled tokens indices that should not be sampled.
         discard_sampled_tokens_req_indices = discard_request_indices[:num_discarded_requests]

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -1589,13 +1589,14 @@ class NPUModelRunner(GPUModelRunner):
                 assert isinstance(sampled_token_ids, torch.Tensor), (
                     "sampled_token_ids should be a torch.Tensor whenpadded-batch is enabled."
                 )
-                assert self.drafter is not None
+                assert isinstance(self.drafter, AscendEagleProposer | AscendDraftModelProposer)
                 next_token_ids, valid_sampled_tokens_count = self.drafter.prepare_next_token_ids_padded(
                     sampled_token_ids,
                     self.requests,
                     self.input_batch,
                     self.discard_request_indices.gpu,
                     self.num_discarded_requests,
+                    self.discard_request_mask.gpu[: self.input_batch.num_reqs],
                 )
                 self._copy_valid_sampled_token_count(next_token_ids, valid_sampled_tokens_count)
 


### PR DESCRIPTION
### What this PR does / why we need it?

Padded MTP/Eagle decoding currently prepares the next token with multiple device operations (`clone`, `index_fill`, comparisons, reduction, gather, and `where`) on every speculative decoding step.

This PR replaces that sequence with one Triton kernel. It reuses the existing device-side discard mask, processes four requests per block, and caps the grid at the available VectorCore count. The original CPU/no-mask path remains as the fallback.

The change is intentionally small: 4 files, 93 additions, and 5 deletions. The kernel is kept in the existing speculative-decoding Triton utility module, and correctness coverage is added to the existing padded-input test.

### Does this PR introduce _any_ user-facing change?

No. This is an internal speculative-decoding performance optimization.

### How was this patch tested?

Environment: Ascend 910B1, PyTorch 2.10.0, torch-npu 2.10.0.post4, Triton-Ascend 3.2.2.

Focused proposer regression:

```bash
pytest -q tests/ut/spec_decode/test_llm_base_proposer.py \
  tests/ut/spec_decode/a2/test_eagle_proposer.py::TestPrepareNextTokenIdsPadded
```

Result: `31 passed`.

During development, the same four-request VectorCore-capped grid-stride kernel passed a 127-case NPU matrix covering batch sizes 1/7/32/128/2048, sampled widths 1/4/5/9, int32/int64, and none/some/all discard modes. The PR keeps a compact PyTorch-reference test for batch sizes 1 and 128:

```bash
pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_prepare_inputs_padded.py \
  -k prepare_next_token_ids_padded
```

Operator benchmark used the production fallback against the fused kernel, with 20 warmups and 200 measured iterations per path. Across two low-noise 20-shape runs (`B=1/8/16/32/64`, `K=1/4/5/9`), the conservative worst-shape speedup was `1.588x`; median speedups were `1.608x` and `1.614x`.

Representative `K=4` latency:

| Batch | Existing path (us) | Fused kernel (us) | Speedup |
|---:|---:|---:|---:|
| 1 | 465.52 | 283.44 | 1.642x |
| 8 | 462.10 | 291.07 | 1.588x |
| 16 | 469.76 | 291.65 | 1.611x |
| 32 | 473.35 | 291.49 | 1.624x |
| 64 | 474.98 | 292.62 | 1.623x |

This PR makes an operator-latency claim only; it does not claim a TTFT or TPOT improvement.
