### PR TITLE
[Performance][MoE] Skip padded K3 SiTU quant rows

### DIFF
--- a/csrc/moe/dequant_situ_quant/op_graph/dequant_situ_quant_proto.h
+++ b/csrc/moe/dequant_situ_quant/op_graph/dequant_situ_quant_proto.h
@@ -35,10 +35,11 @@ namespace ge {
 * @li quant_scale: Reserved optional input. It must be absent.
 * @li quant_offset: Reserved optional input. It must be absent.
 * @li group_index: Optional INT64 1-D tensor with shape [experts]. Each value
-* is the number of consecutive routed rows belonging to that expert. None
-* selects the single-group shared-expert path.
+* is the number of consecutive valid routed rows belonging to that expert.
+* For a pre-dequantized BF16 input, the counts are used to skip trailing
+* dispatch-capacity rows. None selects the single-group shared-expert path.
 * For BF16 x, GMM has already applied dequantization; weight_scale,
-* activation_scale, bias, and group_index must all be absent.
+* activation_scale, and bias must all be absent.
 
 * @par Outputs:
 * @li y: INT8 tensor with shape [rows, x.shape[-1] / 2].

--- a/csrc/moe/dequant_situ_quant/op_host/dequant_situ_quant_tiling.cpp
+++ b/csrc/moe/dequant_situ_quant/op_host/dequant_situ_quant_tiling.cpp
@@ -375,9 +375,16 @@ ge::graphStatus DequantSituQuantTiling::CheckInputShapesBF16()
     OP_CHECK_IF(context_->GetOptionalInputShape(INDEX_IN_QUANT_OFFSET) != nullptr,
                 OP_LOGE(context_->GetNodeName(), "quant_offset must be absent for bfloat16 x"),
                 return ge::GRAPH_FAILED);
-    OP_CHECK_IF(context_->GetOptionalInputShape(INDEX_IN_GROUP_INDEX) != nullptr,
-                OP_LOGE(context_->GetNodeName(), "group_index must be absent for bfloat16 x"),
-                return ge::GRAPH_FAILED);
+    auto groupIndexShapePtr = context_->GetOptionalInputShape(INDEX_IN_GROUP_INDEX);
+    hasGroupIndex_ = (groupIndexShapePtr != nullptr);
+    expertNum_ = 1;
+    if (hasGroupIndex_) {
+        const gert::Shape groupIndexShape = groupIndexShapePtr->GetStorageShape();
+        OP_CHECK_IF(groupIndexShape.GetDimNum() != 1 || groupIndexShape.GetDim(0) <= 0,
+                    OP_LOGE(context_->GetNodeName(), "group_index must be a non-empty 1-D tensor"),
+                    return ge::GRAPH_FAILED);
+        expertNum_ = static_cast<uint32_t>(groupIndexShape.GetDim(0));
+    }
 
     // check output shapes
     auto yShapePtr = context_->GetOutputShape(0);
@@ -410,8 +417,8 @@ ge::graphStatus DequantSituQuantTiling::CheckInputShapesBF16()
     tilingData.set_quantScaleIsEmpty(1);
     tilingData.set_quantOffsetIsEmpty(1);
     tilingData.set_quantIsOne(0);
-    tilingData.set_expertNum(1);
-    tilingData.set_hasGroupIndex(0);
+    tilingData.set_expertNum(expertNum_);
+    tilingData.set_hasGroupIndex(hasGroupIndex_ ? 1 : 0);
     tilingData.set_hasActivationScale(0);
     tilingData.set_isPreDequantized(1);
     tilingData.set_inputWidth(static_cast<uint32_t>(inDimy));

--- a/csrc/moe/dequant_situ_quant/op_kernel/dequant_situ_quant.h
+++ b/csrc/moe/dequant_situ_quant/op_kernel/dequant_situ_quant.h
@@ -755,9 +755,9 @@ public:
             if (hasBias_) {
                 biasGm_.SetGlobalBuffer((__gm__ float*)bias, expertNum_ * inputWidth_);
             }
-            if (hasGroupIndex_) {
-                groupIndexGm_.SetGlobalBuffer((__gm__ int64_t*)groupIndex, expertNum_);
-            }
+        }
+        if (hasGroupIndex_) {
+            groupIndexGm_.SetGlobalBuffer((__gm__ int64_t*)groupIndex, expertNum_);
         }
         yGm_.SetGlobalBuffer((__gm__ int8_t*)y, rowLen_ * outputWidth_);
         scaleGm_.SetGlobalBuffer((__gm__ float*)scale, rowLen_);
@@ -784,13 +784,25 @@ public:
             return;
         }
 
-        if constexpr (!std::is_same_v<XType, int32_t>) {
+        if (!hasGroupIndex_) {
             ProcessGroup(0, rowLen_, 0);
             return;
         }
 
-        if (!hasGroupIndex_) {
-            ProcessGroup(0, rowLen_, 0);
+        if constexpr (!std::is_same_v<XType, int32_t>) {
+            // BF16 GMM output may retain the dispatch buffer capacity. Only
+            // the leading sum(group_index) rows contain routed tokens.
+            int64_t validRows = 0;
+            for (int64_t expertIdx = 0; expertIdx < expertNum_ && validRows < rowLen_; ++expertIdx) {
+                const int64_t requestedRows = groupIndexGm_.GetValue(expertIdx);
+                const int64_t remainingRows = rowLen_ - validRows;
+                if (requestedRows > 0) {
+                    validRows += requestedRows > remainingRows ? remainingRows : requestedRows;
+                }
+            }
+            if (validRows > 0) {
+                ProcessGroup(0, validRows, 0);
+            }
             return;
         }
 

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_situ_quant.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_situ_quant.py
@@ -158,6 +158,31 @@ def test_kimi_k3_predequantized_bf16_situ_quant(rows: int):
 
 
 @pytest.mark.skip_global_cleanup
+@torch.inference_mode()
+def test_kimi_k3_predequantized_bf16_group_list_skips_dispatch_padding():
+    if not hasattr(torch.ops._C_ascend, "dequant_situ_quant"):
+        pytest.skip("requires the DequantSituQuant custom operator")
+
+    valid_rows = 5
+    capacity_rows = 16
+    group_index = torch.tensor([2, 0, 1, 2], dtype=torch.int64)
+    values = torch.linspace(
+        -32.0,
+        32.0,
+        capacity_rows * K3_ROUTED_INPUT_WIDTH,
+        dtype=torch.float32,
+    )
+    x = values.to(torch.bfloat16).reshape(capacity_rows, K3_ROUTED_INPUT_WIDTH)
+    expected_y, expected_scale = _kimi_k3_predequantized_reference(x[:valid_rows])
+    actual_y, actual_scale = _run_dequant_situ_quant(x, None, None, None, group_index)
+
+    assert tuple(actual_y.shape) == (capacity_rows, K3_ROUTED_INPUT_WIDTH // 2)
+    assert tuple(actual_scale.shape) == (capacity_rows,)
+    torch.testing.assert_close(actual_y[:valid_rows].cpu(), expected_y, rtol=0, atol=1)
+    torch.testing.assert_close(actual_scale[:valid_rows].cpu(), expected_scale, rtol=5e-3, atol=1e-5)
+
+
+@pytest.mark.skip_global_cleanup
 @pytest.mark.parametrize(
     ("tp_size", "input_width"),
     K3_SHARED_TP_CASES,

--- a/tests/ut/ops/test_fused_moe.py
+++ b/tests/ut/ops/test_fused_moe.py
@@ -522,6 +522,7 @@ def test_w8a8_shared_situ_uses_dequant_situ_quant(monkeypatch):
     assert situ_call["x"] is gate_up
     assert situ_call["weight_scale"] is gate_up_proj.weight_scale_fp32
     assert situ_call["activation_scale"] is input_scale
+    assert situ_call["group_index"] is None
     assert situ_call["beta"] == 4.0
     assert situ_call["linear_beta"] == 25.0
 

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -202,6 +202,7 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         self.assertIs(situ_call["x"], gate_up_out)
         self.assertIsNone(situ_call["weight_scale"])
         self.assertIsNone(situ_call["activation_scale"])
+        torch.testing.assert_close(situ_call["group_index"], torch.tensor([2]))
         self.assertEqual(situ_call["beta"], 4.0)
         self.assertEqual(situ_call["linear_beta"], 25.0)
         self.assertIs(mock_gmm2.call_args.kwargs["bias"], w2_scale_bias)
@@ -214,6 +215,51 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         custom_ops.grouped_matmul_swiglu_quant_v2.assert_not_called()
         custom_ops.grouped_matmul_swiglu_quant_weight_nz_tensor_list.assert_not_called()
         custom_ops.npu_dequant_swiglu_quant.assert_not_called()
+
+    def test_w4a8_situ_converts_cumulative_group_list_to_counts(self):
+        hidden_states = torch.randn(3, 4, dtype=torch.bfloat16)
+        gate_up_out = torch.randn(3, 4, dtype=torch.bfloat16)
+        quantized_situ = torch.ones(3, 2, dtype=torch.int8)
+        situ_scale = torch.ones(3, dtype=torch.float32)
+        custom_ops = SimpleNamespace(
+            dequant_situ_quant=MagicMock(return_value=(quantized_situ, situ_scale)),
+        )
+
+        with (
+            patch.object(moe_mlp_module.torch.ops, "_C_ascend", custom_ops),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_dynamic_quant",
+                return_value=(torch.ones(3, 4, dtype=torch.int8), torch.ones(3, 1)),
+            ),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul",
+                return_value=[gate_up_out],
+                create=True,
+            ),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                return_value=hidden_states,
+            ),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.dispose_tensor"),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch.npu.current_stream",
+                return_value=MagicMock(record_event=MagicMock()),
+            ),
+        ):
+            quant_apply_mlp(
+                hidden_states=hidden_states,
+                w1=torch.ones(2, 4, 4),
+                w1_scale=torch.ones(2, 4),
+                w2=torch.ones(2, 2, 4),
+                w2_scale=torch.ones(2, 4),
+                group_list=torch.tensor([1, 3]),
+                group_list_type=0,
+                activation=SituActivationConfig(beta=4.0, linear_beta=25.0),
+                mxfp_quant_dtype=QuantType.W4A8,
+            )
+
+        situ_group_list = custom_ops.dequant_situ_quant.call_args.kwargs["group_index"]
+        torch.testing.assert_close(situ_group_list, torch.tensor([1, 2]))
 
     def test_w4a8_swiglu_stays_on_existing_fused_path(self):
         hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -234,6 +234,9 @@ def _w4a8_situ_apply_mlp(
             dst_type=SITU_MX_DST_TYPE_E4M3FN,
         )
     else:
+        # SiTU only needs active routed rows. Pass counts so the custom op can
+        # skip the unused tail of the dispatch-capacity buffer.
+        situ_group_list = cumsum_group_list(group_list, group_list_type, 1)
         hidden_states, situ_out_scale = torch.ops._C_ascend.dequant_situ_quant(
             x=gate_up_out,
             weight_scale=None,
@@ -241,7 +244,7 @@ def _w4a8_situ_apply_mlp(
             bias=None,
             quant_scale=None,
             quant_offset=None,
-            group_index=None,
+            group_index=situ_group_list,
             beta=activation.beta,
             linear_beta=activation.linear_beta,
             activate_left=True,


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3 routed MoE can keep a dispatch-capacity tail in the BF16 GMM1 output. The SiTU quantization path previously processed every capacity row even though GMM2 consumes only the routed rows described by `group_list`.

This PR:

- converts cumulative dispatch metadata to per-expert counts when needed and forwards it to `DequantSituQuant`;
- allows BF16 `DequantSituQuant` to consume the count tensor;
- sums the counts in the device kernel and processes only the valid leading rows while preserving the capacity-shaped outputs;
- leaves the shared-expert path unchanged;
- adds Python wiring coverage and an NPU numerical case for padded dispatch buffers.

The hot path does not call `.item()` or introduce a device-to-host synchronization.

### Does this PR introduce _any_ user-facing change?

No. This is an internal Kimi K3 MoE performance optimization; output shapes and model semantics are unchanged.

### How was this patch tested?

- `python3 -m pytest tests/ut/ops/test_moe_mlp.py::TestUnifiedApplyMlpRequest::test_w4a8_situ_preserves_packed_weight_scale_view_and_bias tests/ut/ops/test_moe_mlp.py::TestUnifiedApplyMlpRequest::test_w4a8_situ_converts_cumulative_group_list_to_counts -q` (2 passed)
- `python3 -m pytest tests/ut/ops/test_moe_mlp.py -q` (23 passed; one unrelated existing SWIGLUSTEP tiny-shape alignment failure in the available development container)
- `python -m compileall -q vllm_ascend/ops/fused_moe/moe_mlp.py tests/ut/ops/test_moe_mlp.py tests/e2e/nightly/single_node/ops/singlecard_ops/test_dequant_situ_quant.py`
- `git diff --check`

The added NPU single-op regression case requires rebuilding the custom operator and is left for CI/NPU validation.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
