### PR TITLE
[v0.26.0rc][BugFix][Triton] Guard rejection sampler predecessor loads

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_rejection_sample.py
@@ -147,6 +147,102 @@ def test_sample_recovered_tokens_kernel():
     torch.npu.reset_peak_memory_stats()
 
 
+@torch.inference_mode()
+def test_request_zero_with_no_draft_tokens():
+    """Exercise every predecessor load at the request-zero boundary."""
+    device = "npu"
+    batch_size = 1
+    max_spec_len = 1
+    vocab_size = 4
+    grid, block_size = cal_grid_and_block_size(batch_size)
+
+    cu_num_draft_tokens = torch.zeros(batch_size, dtype=torch.int32, device=device)
+    no_token_ids = torch.empty(0, dtype=torch.int64, device=device)
+    no_probs = torch.empty((0, vocab_size), dtype=torch.float32, device=device)
+    no_uniform_probs = torch.empty(0, dtype=torch.float32, device=device)
+
+    expanded = torch.tensor([17], dtype=torch.int64, device=device)
+    expand_kernel[(grid,)](
+        expanded,
+        torch.tensor([7], dtype=torch.int64, device=device),
+        cu_num_draft_tokens,
+        -1,
+        99,
+        batch_size,
+        MAX_NUM_TOKENS=max_spec_len,
+        BLOCK_SIZE=block_size,
+    )
+
+    recovered = torch.tensor([23], dtype=torch.int64, device=device)
+    sample_recovered_tokens_kernel[(batch_size, max_spec_len)](
+        recovered,
+        cu_num_draft_tokens,
+        no_token_ids,
+        None,
+        no_probs,
+        None,
+        torch.ones((batch_size, vocab_size), dtype=torch.float32, device=device),
+        vocab_size,
+        vocab_size,
+        NO_DRAFT_PROBS=True,
+        ENABLE_REDUCE_SAMPLING=False,
+        SUB_BLOCK=vocab_size,
+        VOCAB_BLOCK_SIZE=vocab_size,
+    )
+
+    greedy_output = torch.full((batch_size, max_spec_len + 1), -1, dtype=torch.int64, device=device)
+    rejection_greedy_sample_triton[(grid,)](
+        greedy_output,
+        cu_num_draft_tokens,
+        no_token_ids,
+        no_token_ids,
+        torch.tensor([[31]], dtype=torch.int64, device=device),
+        torch.ones(batch_size, dtype=torch.bool, device=device),
+        batch_size,
+        max_spec_len,
+        None,
+        None,
+        SYNTHETIC_MODE=False,
+        BLOCK_SIZE=block_size,
+    )
+
+    random_output = torch.full_like(greedy_output, -1)
+    rejection_random_sample_kernel[(grid,)](
+        random_output,
+        cu_num_draft_tokens,
+        no_token_ids,
+        None,
+        no_probs,
+        None,
+        torch.tensor([37], dtype=torch.int64, device=device),
+        no_token_ids,
+        no_uniform_probs,
+        torch.zeros(batch_size, dtype=torch.bool, device=device),
+        max_spec_len,
+        vocab_size,
+        vocab_size,
+        batch_size,
+        None,
+        None,
+        NO_ORI_TARGET_PROBS=True,
+        NO_DRAFT_PROBS=True,
+        ENABLE_REDUCE_SAMPLING=False,
+        SYNTHETIC_MODE=False,
+        ENTROPY_VERIFY=False,
+        BLOCK_SIZE=block_size,
+    )
+
+    torch.npu.synchronize()
+    assert expanded.cpu().tolist() == [17]
+    assert recovered.cpu().tolist() == [23]
+    assert greedy_output.cpu().tolist() == [[31, -1]]
+    assert random_output.cpu().tolist() == [[37, -1]]
+
+    gc.collect()
+    torch.npu.empty_cache()
+    torch.npu.reset_peak_memory_stats()
+
+
 @pytest.mark.parametrize("synthetic_mode", [False, True])
 @pytest.mark.parametrize("max_spec_len", [1, 2, 3])
 @pytest.mark.parametrize("vocab_size", [1024])

--- a/tests/ut/ops/triton/test_reject_sample_source.py
+++ b/tests/ut/ops/triton/test_reject_sample_source.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import TypeGuard
 
 ROOT = Path(__file__).resolve().parents[4]
 KERNEL = ROOT / "vllm_ascend" / "ops" / "triton" / "reject_sample.py"
@@ -23,7 +24,7 @@ def _function(name: str) -> ast.FunctionDef:
     raise AssertionError(f"function {name} not found in {KERNEL}")
 
 
-def _is_tl_call(node: ast.AST, name: str) -> bool:
+def _is_tl_call(node: ast.AST, name: str) -> TypeGuard[ast.Call]:
     return (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
@@ -134,7 +135,9 @@ def test_expand_kernel_masks_padded_lane_reads_and_writes() -> None:
         if _is_tl_call(node, "load") and node.args and "input_ptr" in _names(node.args[0])
     ]
     assert len(input_loads) == 1
-    assert ast.unparse(_keyword(input_loads[0], "mask")) == "len_mask"
+    input_mask = _keyword(input_loads[0], "mask")
+    assert input_mask is not None
+    assert ast.unparse(input_mask) == "len_mask"
     input_other = _keyword(input_loads[0], "other")
     assert isinstance(input_other, ast.Constant) and input_other.value == 0
 

--- a/tests/ut/ops/triton/test_reject_sample_source.py
+++ b/tests/ut/ops/triton/test_reject_sample_source.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level memory-safety regressions for rejection-sampler kernels.
+
+The invalid predecessor read is allocator-dependent at runtime: a numerically
+correct result does not prove that ``ptr[-1]`` was not evaluated.  Keep an
+import-free source check alongside the NPU test so CI deterministically guards
+the load masks without initializing a device runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[4]
+KERNEL = ROOT / "vllm_ascend" / "ops" / "triton" / "reject_sample.py"
+
+
+def _function(name: str) -> ast.FunctionDef:
+    for node in ast.parse(KERNEL.read_text()).body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name} not found in {KERNEL}")
+
+
+def _is_tl_call(node: ast.AST, name: str) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "tl"
+        and node.func.attr == name
+    )
+
+
+def _keyword(call: ast.Call, name: str) -> ast.AST | None:
+    return next((keyword.value for keyword in call.keywords if keyword.arg == name), None)
+
+
+def _assignment(function: ast.FunctionDef, name: str) -> ast.AST:
+    values = [
+        node.value
+        for node in ast.walk(function)
+        if isinstance(node, ast.Assign)
+        and len(node.targets) == 1
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id == name
+    ]
+    assert len(values) == 1, f"expected one assignment to {name}, found {len(values)}"
+    return values[0]
+
+
+def _resolve_name(function: ast.FunctionDef, node: ast.AST) -> ast.AST:
+    return _assignment(function, node.id) if isinstance(node, ast.Name) else node
+
+
+def _names(node: ast.AST) -> set[str]:
+    return {child.id for child in ast.walk(node) if isinstance(child, ast.Name)}
+
+
+def _has_positive_index_guard(node: ast.AST, index_name: str) -> bool:
+    return any(
+        isinstance(child, ast.Compare)
+        and isinstance(child.left, ast.Name)
+        and child.left.id == index_name
+        and len(child.ops) == 1
+        and isinstance(child.ops[0], ast.Gt)
+        and len(child.comparators) == 1
+        and isinstance(child.comparators[0], ast.Constant)
+        and child.comparators[0].value == 0
+        for child in ast.walk(node)
+    )
+
+
+def _predecessor_load(function: ast.FunctionDef, pointer_name: str) -> ast.Call:
+    loads = [
+        node
+        for node in ast.walk(function)
+        if _is_tl_call(node, "load")
+        and node.args
+        and pointer_name in _names(node.args[0])
+        and "- 1" in ast.unparse(node.args[0])
+    ]
+    assert len(loads) == 1, f"expected one predecessor load in {function.name}, found {len(loads)}"
+    return loads[0]
+
+
+def test_predecessor_loads_mask_request_zero_and_padded_lanes() -> None:
+    cases = {
+        "rejection_greedy_sample_triton": (
+            "cu_num_draft_tokens_ptr",
+            "offset",
+            "is_greedy_mask",
+        ),
+        "rejection_random_sample_kernel": (
+            "cu_num_draft_tokens_ptr",
+            "offsets",
+            "not_greedy_mask",
+        ),
+        "expand_kernel": ("cu_num_tokens_ptr", "offset", "len_mask"),
+        "sample_recovered_tokens_kernel": (
+            "cu_num_draft_tokens_ptr",
+            "req_idx",
+            None,
+        ),
+    }
+
+    for function_name, (pointer_name, index_name, lane_mask_name) in cases.items():
+        function = _function(function_name)
+        load = _predecessor_load(function, pointer_name)
+        mask = _keyword(load, "mask")
+        other = _keyword(load, "other")
+
+        assert mask is not None, f"{function_name} predecessor load must be masked"
+        resolved_mask = _resolve_name(function, mask)
+        assert _has_positive_index_guard(resolved_mask, index_name), (
+            f"{function_name} predecessor mask must reject index zero"
+        )
+        if lane_mask_name is not None:
+            assert lane_mask_name in _names(resolved_mask), (
+                f"{function_name} predecessor mask must reject padded/non-target lanes"
+            )
+        assert isinstance(other, ast.Constant) and other.value == 0, (
+            f"{function_name} predecessor load must use neutral other=0"
+        )
+
+
+def test_expand_kernel_masks_padded_lane_reads_and_writes() -> None:
+    function = _function("expand_kernel")
+
+    input_loads = [
+        node
+        for node in ast.walk(function)
+        if _is_tl_call(node, "load") and node.args and "input_ptr" in _names(node.args[0])
+    ]
+    assert len(input_loads) == 1
+    assert ast.unparse(_keyword(input_loads[0], "mask")) == "len_mask"
+    input_other = _keyword(input_loads[0], "other")
+    assert isinstance(input_other, ast.Constant) and input_other.value == 0
+
+    stores = [node for node in ast.walk(function) if _is_tl_call(node, "store")]
+    assert len(stores) == 1
+    store_mask = _keyword(stores[0], "mask")
+    assert store_mask is not None
+    assert "valid_req" in _names(store_mask)
+
+    valid_req = _assignment(function, "valid_req")
+    assert isinstance(valid_req, ast.Call)
+    assert "len_mask" in _names(valid_req)

--- a/vllm_ascend/ops/triton/reject_sample.py
+++ b/vllm_ascend/ops/triton/reject_sample.py
@@ -108,8 +108,10 @@ def rejection_greedy_sample_triton(
         is_greedy = tl.load(is_greedy_ptr + offset, mask=mask, other=0)
         is_greedy_mask = mask & (is_greedy != 0)
 
-    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_draft_tokens_ptr + offset - 1, is_greedy_mask))
-    end_idx = tl.load(cu_num_draft_tokens_ptr + offset, is_greedy_mask)
+    prev_mask = is_greedy_mask & (offset > 0)
+    prev_end_idx = tl.load(cu_num_draft_tokens_ptr + offset - 1, mask=prev_mask, other=0)
+    start_idx = tl.where(offset == 0, 0, prev_end_idx)
+    end_idx = tl.load(cu_num_draft_tokens_ptr + offset, mask=is_greedy_mask, other=0)
     num_draft_tokens = end_idx - start_idx
 
     for pos in tl.range(0, BLOCK_SIZE):
@@ -203,8 +205,10 @@ def rejection_random_sample_kernel(
     mask = offsets < vec_len
     is_greedy = tl.load(is_greedy_ptr + offsets, mask, other=1)
     not_greedy_mask = is_greedy == 0
-    start_idxs = tl.where(offsets == 0, 0, tl.load(cu_num_draft_tokens_ptr + offsets - 1, not_greedy_mask))
-    end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets, not_greedy_mask)
+    prev_mask = not_greedy_mask & (offsets > 0)
+    prev_end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets - 1, mask=prev_mask, other=0)
+    start_idxs = tl.where(offsets == 0, 0, prev_end_idxs)
+    end_idxs = tl.load(cu_num_draft_tokens_ptr + offsets, mask=not_greedy_mask, other=0)
     n_num_draft_tokens = end_idxs - start_idxs
 
     for req_i in range(BLOCK_SIZE):
@@ -368,19 +372,22 @@ def expand_kernel(
     offset = req_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     len_mask = offset < vec_len
 
-    start_idx = tl.where(offset == 0, 0, tl.load(cu_num_tokens_ptr + offset - 1, len_mask))
-    end_idx = tl.load(cu_num_tokens_ptr + offset, len_mask)
+    prev_mask = len_mask & (offset > 0)
+    prev_end_idx = tl.load(cu_num_tokens_ptr + offset - 1, mask=prev_mask, other=0)
+    start_idx = tl.where(offset == 0, 0, prev_end_idx)
+    end_idx = tl.load(cu_num_tokens_ptr + offset, mask=len_mask, other=0)
     num_tokens = end_idx - start_idx
 
-    src_val = tl.load(input_ptr + offset, len_mask)
+    src_val = tl.load(input_ptr + offset, mask=len_mask, other=0)
     src_val = tl.where(src_val == replace_from, replace_to, src_val)
 
     for i in tl.range(0, BLOCK_SIZE):
+        valid_req = get_element(len_mask, (i,))
         num_tokens1 = get_element(num_tokens, (i,))
         start_idx1 = get_element(start_idx, (i,))
         src_val1 = get_element(src_val, (i,))
         offset1 = tl.arange(0, MAX_NUM_TOKENS)
-        tl.store(output_ptr + start_idx1 + offset1, src_val1, mask=offset1 < num_tokens1)
+        tl.store(output_ptr + start_idx1 + offset1, src_val1, mask=valid_req & (offset1 < num_tokens1))
 
 
 @triton.jit
@@ -403,7 +410,8 @@ def sample_recovered_tokens_kernel(
     pos = tl.program_id(1)
 
     # Compute token index
-    start_idx = tl.where(req_idx == 0, 0, tl.load(cu_num_draft_tokens_ptr + req_idx - 1))
+    prev_end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx - 1, mask=req_idx > 0, other=0)
+    start_idx = tl.where(req_idx == 0, 0, prev_end_idx)
     end_idx = tl.load(cu_num_draft_tokens_ptr + req_idx)
     num_draft_tokens = end_idx - start_idx
 


### PR DESCRIPTION
### What this PR does / why we need it?

Backport of #14902 to `releases/v0.26.0rc`.

The rejection sampler computes each request's start offset from the previous
entry of a cumulative-token buffer. Four Triton kernels use
`tl.where(index == 0, 0, tl.load(ptr + index - 1))`.

`tl.where` evaluates both operands, so request zero still issues the
predecessor load from `ptr[-1]`. Whether this faults depends on the allocator
mapping immediately before the tensor, which can turn the bug into an
intermittent MTE DDR out-of-range error during startup kernel warmup or the
first speculative-decode request.

This patch masks predecessor loads directly in the greedy, random, expand,
and recovered-token kernels, supplies neutral values for masked lanes, and
guards expand stores for padded request lanes.

Triton documents that both `tl.where` operands are evaluated and recommends
using load/store masks to avoid unintended memory operations:
https://triton-lang.org/main/python-api/generated/triton.language.where.html

### Does this PR introduce _any_ user-facing change?

No API or model-semantic change. It prevents nondeterministic out-of-bounds
memory accesses in speculative-decoding rejection-sampler kernels.

### How was this patch tested?

- `python -m py_compile vllm_ascend/ops/triton/reject_sample.py`
- `TORCH_DEVICE_BACKEND_AUTOLOAD=0 python -m pytest -q tests/ut/model_executor/warmup/test_rejection_sampler_triton_warmup.py tests/ut/model_executor/warmup/test_kernel_warmup.py` (3 passed)
- `git diff --check origin/releases/v0.26.0rc...HEAD`
- Existing single-card NPU rejection-sampler tests exercise request zero in all affected kernels; NPU execution is left to CI.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
