### PR TITLE
[Doc][Misc] Update GLM-5/5.2 A3 PD deployment commands and proxy config

### DIFF
--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -326,6 +326,8 @@ Run the following scripts on two nodes respectively.
 
 We'd like to show the deployment guide of `GLM-5.2` on multi-node environment with Prefill-Decode (PD) disaggregation for better performance.
 
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [Prefill-Decode Disaggregation with Mooncake](../features/pd_disaggregation_mooncake_multi_node.md) for the Mooncake configuration.
+
 Before you start, please
 
 1. prepare the script `launch_online_dp.py` on each node:

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -558,6 +558,11 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
+        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
+        KV_PORT=$((30200 + $4 % 4))
+        ENGINE_ID=$((100 + $4))
+
         export HCCL_OP_EXPANSION_MODE="AIV"
 
         export HCCL_IF_IP=$local_ip
@@ -612,8 +617,8 @@ Before you start, please
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30200",
-            "engine_id": "2",
+            "kv_port": "'"$KV_PORT"'",
+            "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,
                 "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
@@ -628,6 +633,11 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
+        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
+        KV_PORT=$((30200 + $4 % 4))
+        ENGINE_ID=$((100 + $4))
+
         export HCCL_OP_EXPANSION_MODE="AIV"
 
         export HCCL_IF_IP=$local_ip
@@ -682,8 +692,8 @@ Before you start, please
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30200",
-            "engine_id": "2",
+            "kv_port": "'"$KV_PORT"'",
+            "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,
                 "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -339,53 +339,20 @@ Before you start, please
 
     def parse_args():
         parser = argparse.ArgumentParser()
-        parser.add_argument(
-            "--dp-size",
-            type=int,
-            required=True,
-            help="Data parallel size."
-        )
-        parser.add_argument(
-            "--tp-size",
-            type=int,
-            default=1,
-            help="Tensor parallel size."
-        )
-        parser.add_argument(
-            "--dp-size-local",
-            type=int,
-            default=-1,
-            help="Local data parallel size."
-        )
-        parser.add_argument(
-            "--dp-rank-start",
-            type=int,
-            default=0,
-            help="Starting rank for data parallel."
-        )
-        parser.add_argument(
-            "--dp-address",
-            type=str,
-            required=True,
-            help="IP address for data parallel master node."
-        )
-        parser.add_argument(
-            "--dp-rpc-port",
-            type=str,
-            default=12345,
-            help="Port for data parallel master node."
-        )
-        parser.add_argument(
-            "--vllm-start-port",
-            type=int,
-            default=9000,
-            help="Starting port for the engine."
-        )
+        parser.add_argument("--dp-size", type=int, required=True, help="Data parallel size.")
+        parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size.")
+        parser.add_argument("--pp-size", type=int, default=1, help="Pipeline parallel size.")
+        parser.add_argument("--dp-size-local", type=int, default=-1, help="Local data parallel size.")
+        parser.add_argument("--dp-rank-start", type=int, default=0, help="Starting rank for data parallel.")
+        parser.add_argument("--dp-address", type=str, required=True, help="IP address for data parallel master node.")
+        parser.add_argument("--dp-rpc-port", type=str, default="12321", help="Port for data parallel master node.")
+        parser.add_argument("--vllm-start-port", type=int, default=8000, help="Starting port for the engine.")
         return parser.parse_args()
 
     args = parse_args()
     dp_size = args.dp_size
     tp_size = args.tp_size
+    pp_size = args.pp_size
     dp_size_local = args.dp_size_local
     if dp_size_local == -1:
         dp_size_local = dp_size
@@ -393,6 +360,8 @@ Before you start, please
     dp_address = args.dp_address
     dp_rpc_port = args.dp_rpc_port
     vllm_start_port = args.vllm_start_port
+    # 一个 DP 副本占 tp×pp 张连续卡（pp=1 时退化为现状的 tp）
+    gpus_per_dp_rank = tp_size * pp_size
 
     def run_command(visible_devices, dp_rank, vllm_engine_port):
         command = [
@@ -405,6 +374,7 @@ Before you start, please
             dp_address,
             dp_rpc_port,
             str(tp_size),
+            str(pp_size),
         ]
         subprocess.run(command, check=True)
 
@@ -415,14 +385,16 @@ Before you start, please
             sys.exit(1)
 
         processes = []
-        num_cards = dp_size_local * tp_size
+        num_cards = dp_size_local * gpus_per_dp_rank
+
         for i in range(dp_size_local):
             dp_rank = dp_rank_start + i
             vllm_engine_port = vllm_start_port + i
-            visible_devices = ",".join(str(x) for x in range(i * tp_size, (i + 1) * tp_size))
-            process = multiprocessing.Process(target=run_command,
-                                            args=(visible_devices, dp_rank,
-                                                    vllm_engine_port))
+            visible_devices = ",".join(str(x) for x in range(i * gpus_per_dp_rank, (i + 1) * gpus_per_dp_rank))
+            process = multiprocessing.Process(
+                target=run_command,
+                args=(visible_devices, dp_rank, vllm_engine_port)
+            )
             processes.append(process)
             process.start()
 
@@ -435,12 +407,11 @@ Before you start, please
 
 `GLM-5.2-w8a8c8` PD disaggregation can be deployed on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node).
 
-**Prefill node 0** (`run_dp_template.sh`): `node_rank=0`, engine port `9081`. The value of `node_p0_ip` must be consistent with the `local_ip` set on prefill node 0 (PP master node).
+**Prefill node 0** (`run_dp_template.sh`): `node_rank=0`, engine port `9081` (PP master node, `--master-addr` uses `$local_ip`).
 
 ```shell
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
-        node_p0_ip="xxxx" # ip of prefill node 0 (PP master node)
         # pp=2
         export VLLM_PP_LAYER_PARTITION="41,37"
         node_rank=0
@@ -473,7 +444,7 @@ Before you start, please
             --port 9081 \
             --pipeline-parallel-size 2 \
             --distributed-executor-backend mp \
-            --master-addr $node_p0_ip \
+            --master-addr $local_ip \
             --master-port 7060 \
             --nnodes 2 \
             --node-rank 0 \
@@ -508,7 +479,7 @@ Before you start, please
         }'
 ```
 
-**Prefill node 1** (`run_dp_template.sh`): `node_rank=1`, engine port `9082`. Both prefill nodes form a single PP2 engine, so `--master-addr` points to prefill node 0 and the KV transfer `engine_id` stays `0`.
+**Prefill node 1** (`run_dp_template.sh`): `node_rank=1`, non-master node running with `--headless` (no API server). Both prefill nodes form a single PP2 engine, so `--master-addr` points to prefill node 0 and the KV transfer `engine_id` stays `0`.
 
 ```shell
         nic_name="xxxx" # change to your own nic name
@@ -543,13 +514,13 @@ Before you start, please
 
         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.2-w8a8c8 \
             --host 0.0.0.0 \
-            --port 9082 \
             --pipeline-parallel-size 2 \
             --distributed-executor-backend mp \
             --master-addr $node_p0_ip \
             --master-port 7060 \
             --nnodes 2 \
             --node-rank 1 \
+            --headless \
             --tensor-parallel-size 16 \
             --enable-expert-parallel \
             --speculative-config '{"num_speculative_tokens": 1, "method":"deepseek_mtp","enforce_eager":true}' \
@@ -739,14 +710,14 @@ Once the preparation is done, start the server on each node:
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
 4. Decode node 1:
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
 To set up request forwarding, run the following script on any machine. You can get the proxy program in the repository's examples: [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py)
@@ -756,14 +727,12 @@ unset http_proxy
 unset https_proxy
 
 python load_balance_proxy_server_example.py \
-    --port 8000 \
+    --port 9000 \
     --host 0.0.0.0 \
     --prefiller-hosts \
       $node_p0_ip \
-      $node_p1_ip \
     --prefiller-ports \
       9081 \
-      9082 \
     --decoder-hosts \
       $node_d0_ip \
       $node_d0_ip \
@@ -774,8 +743,8 @@ python load_balance_proxy_server_example.py \
       $node_d1_ip \
       $node_d1_ip \
     --decoder-ports \
-      9900 9901 9902 9903 \
-      9900 9901 9902 9903
+      8000 8001 8002 8003 \
+      8000 8001 8002 8003
 ```
 
 **Notice:**
@@ -791,11 +760,12 @@ Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single
 |---------|----|--------|-------|-----------|
 |`--dp-size`|int|Yes|-|Data parallel size (total number of DP ranks across all nodes).|
 |`--tp-size`|int|No|1|Tensor parallel size within each DP rank.|
+|`--pp-size`|int|No|1|Pipeline parallel size within each DP rank.|
 |`--dp-size-local`|int|No|(same as `--dp-size`)|Number of DP ranks on the current node. If not set, defaults to `--dp-size`.|
 |`--dp-rank-start`|int|No|0|Starting rank offset for data parallel ranks on this node.|
 |`--dp-address`|str|Yes|-|IP address of the data parallel master node (node 0).|
-|`--dp-rpc-port`|str|No|12345|RPC port for data parallel master communication.|
-|`--vllm-start-port`|int|No|9000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
+|`--dp-rpc-port`|str|No|12321|RPC port for data parallel master communication.|
+|`--vllm-start-port`|int|No|8000|Starting port for each vLLM engine instance on this node. Each DP rank's engine port = `vllm_start_port` + local rank index.|
 
 **Prefill node-specific configurations (PP2):**
 
@@ -822,7 +792,7 @@ Key Parameter Descriptions (in addition to [Single-Node Deployment](#5111-single
 
 **Request forwarding (proxy):**
 
-- The proxy command maps every prefill engine endpoint (2 prefiller hosts/ports) and every decode engine endpoint (8 decoder hosts/ports) to a single entry point on port `8000`.
+- The proxy command maps every prefill engine endpoint (1 prefiller host/port) and every decode engine endpoint (8 decoder hosts/ports) to a single entry point on port `9000`.
 - The proxy program can be found in [load_balance_proxy_server_example.py](https://github.com/vllm-project/vllm-ascend/blob/main/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py).
 
 Please refer to [envs.py](https://github.com/vllm-project/vllm-ascend/blob/main/vllm_ascend/envs.py) for further explanation and restrictions of the environment variables above.

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -326,7 +326,7 @@ Run the following scripts on two nodes respectively.
 
 We'd like to show the deployment guide of `GLM-5.2` on multi-node environment with Prefill-Decode (PD) disaggregation for better performance.
 
-In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [Prefill-Decode Disaggregation with Mooncake](../features/pd_disaggregation_mooncake_multi_node.md) for the Mooncake configuration.
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [KV Cache Pool (Ascend Store) Deployment Guide](https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/kv_pool.md) for the Mooncake configuration.
 
 Before you start, please
 

--- a/docs/source/tutorials/models/GLM5.2.md
+++ b/docs/source/tutorials/models/GLM5.2.md
@@ -560,9 +560,8 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
-        KV_PORT=$((30200 + $4 % 4))
+        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -619,7 +618,7 @@ Before you start, please
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "'"$KV_PORT"'",
+            "kv_port": "30200",
             "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,
@@ -635,9 +634,8 @@ Before you start, please
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
-        KV_PORT=$((30200 + $4 % 4))
+        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -694,7 +692,7 @@ Before you start, please
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "'"$KV_PORT"'",
+            "kv_port": "30200",
             "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -1289,9 +1289,8 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
-        KV_PORT=$((30200 + $4 % 4))
+        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -1348,7 +1347,7 @@ if __name__ == "__main__":
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "'"$KV_PORT"'",
+            "kv_port": "30200",
             "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,
@@ -1366,9 +1365,8 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
-        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
-        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
-        KV_PORT=$((30200 + $4 % 4))
+        # 每个 DP rank 使用独立的 engine_id,避免 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → engine_id 100-103
         ENGINE_ID=$((100 + $4))
 
         export HCCL_OP_EXPANSION_MODE="AIV"
@@ -1425,7 +1423,7 @@ if __name__ == "__main__":
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "'"$KV_PORT"'",
+            "kv_port": "30200",
             "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -633,6 +633,8 @@ In addition to all single-node parameters described in [Single-Node Online Deplo
 
 We'd like to show the deployment guide of `GLM-5` on multi-node environment with Prefill-Decode (PD) disaggregation for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
 
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [Prefill-Decode Disaggregation with Mooncake](../features/pd_disaggregation_mooncake_multi_node.md) for the Mooncake configuration.
+
 #### 5.3.1 Prefill-Decode Disaggregation (Ascend950DT series)
 
 Before you start, please

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -633,7 +633,7 @@ In addition to all single-node parameters described in [Single-Node Online Deplo
 
 We'd like to show the deployment guide of `GLM-5` on multi-node environment with Prefill-Decode (PD) disaggregation for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
 
-In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [Prefill-Decode Disaggregation with Mooncake](../features/pd_disaggregation_mooncake_multi_node.md) for the Mooncake configuration.
+In the PD disaggregation scenario, Mooncake is used as the KV cache transfer connector between the prefill and decode nodes. Please refer to [KV Cache Pool (Ascend Store) Deployment Guide](https://github.com/vllm-project/vllm-ascend/blob/main/docs/source/user_guide/feature_guide/kv_pool.md) for the Mooncake configuration.
 
 #### 5.3.1 Prefill-Decode Disaggregation (Ascend950DT series)
 

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -1287,6 +1287,11 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
+        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
+        KV_PORT=$((30200 + $4 % 4))
+        ENGINE_ID=$((100 + $4))
+
         export HCCL_OP_EXPANSION_MODE="AIV"
         export HCCL_TRANSFER_TIMEOUT=600
         export HCCL_EXEC_TIMEOUT=3600
@@ -1341,8 +1346,8 @@ if __name__ == "__main__":
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30200",
-            "engine_id": "2",
+            "kv_port": "'"$KV_PORT"'",
+            "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,
                 "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},
@@ -1359,6 +1364,11 @@ if __name__ == "__main__":
         nic_name="xxxx" # change to your own nic name
         local_ip="xxxx" # change to your own ip
 
+        # 每个 DP rank 使用独立的 KV 端口与 engine_id,避免端口冲突与 KV 路由混淆
+        # $4 = data-parallel-rank; 节点内 rank 偏移 0-3 → KV 端口 30200-30203
+        KV_PORT=$((30200 + $4 % 4))
+        ENGINE_ID=$((100 + $4))
+
         export HCCL_OP_EXPANSION_MODE="AIV"
         export HCCL_TRANSFER_TIMEOUT=600
         export HCCL_EXEC_TIMEOUT=3600
@@ -1413,8 +1423,8 @@ if __name__ == "__main__":
             --kv-transfer-config \
             '{"kv_connector": "MooncakeConnectorV1",
             "kv_role": "kv_consumer",
-            "kv_port": "30200",
-            "engine_id": "2",
+            "kv_port": "'"$KV_PORT"'",
+            "engine_id": "'"$ENGINE_ID"'",
             "kv_connector_extra_config": {
                 "use_ascend_direct": true,
                 "prefill": {"dp_size": 1, "pp_size": 2, "tp_size": 16, "pp_layer_partition": "41,37"},

--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -633,6 +633,8 @@ In addition to all single-node parameters described in [Single-Node Online Deplo
 
 We'd like to show the deployment guide of `GLM-5` on multi-node environment with Prefill-Decode (PD) disaggregation for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
 
+#### 5.3.1 Prefill-Decode Disaggregation (Ascend950DT series)
+
 Before you start, please
 
 prepare the script `launch_online_dp.py` on each node:
@@ -730,10 +732,6 @@ if __name__ == "__main__":
     for process in processes:
         process.join()
 ```
-
-#### 5.3.1 Prefill-Decode Disaggregation (Ascend950DT series)
-
-We'd like to show the deployment guide of `GLM-5` on multi-node environment with 2P1D for better performance. *Prefill-Decode Disaggregation* refers to the separation of the prefill stage and the decode stage across different nodes to improve throughput and latency.
 
 1. prepare the script `run_dp_template.sh` on each node.
 
@@ -1055,11 +1053,87 @@ Once the preparation is done, you can start the server with the following comman
 
 The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (128GB × 8): 2 prefill nodes (`PP2 TP16`, 78 layers partitioned as `41/37`, one PP rank per node) and 2 decode nodes (`DP8 TP4`, 4 DP ranks per node). The same scripts serve both the high-throughput and low-latency cases.
 
+Before you start, please
+
+prepare the script `launch_online_dp.py` on each node:
+
+```python
+import argparse
+import multiprocessing
+import os
+import subprocess
+import sys
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dp-size", type=int, required=True, help="Data parallel size.")
+    parser.add_argument("--tp-size", type=int, default=1, help="Tensor parallel size.")
+    parser.add_argument("--pp-size", type=int, default=1, help="Pipeline parallel size.")
+    parser.add_argument("--dp-size-local", type=int, default=-1, help="Local data parallel size.")
+    parser.add_argument("--dp-rank-start", type=int, default=0, help="Starting rank for data parallel.")
+    parser.add_argument("--dp-address", type=str, required=True, help="IP address for data parallel master node.")
+    parser.add_argument("--dp-rpc-port", type=str, default="12321", help="Port for data parallel master node.")
+    parser.add_argument("--vllm-start-port", type=int, default=8000, help="Starting port for the engine.")
+    return parser.parse_args()
+
+args = parse_args()
+dp_size = args.dp_size
+tp_size = args.tp_size
+pp_size = args.pp_size
+dp_size_local = args.dp_size_local
+if dp_size_local == -1:
+    dp_size_local = dp_size
+dp_rank_start = args.dp_rank_start
+dp_address = args.dp_address
+dp_rpc_port = args.dp_rpc_port
+vllm_start_port = args.vllm_start_port
+# 一个 DP 副本占 tp×pp 张连续卡（pp=1 时退化为现状的 tp）
+gpus_per_dp_rank = tp_size * pp_size
+
+def run_command(visible_devices, dp_rank, vllm_engine_port):
+    command = [
+        "bash",
+        "./run_dp_template.sh",
+        visible_devices,
+        str(vllm_engine_port),
+        str(dp_size),
+        str(dp_rank),
+        dp_address,
+        dp_rpc_port,
+        str(tp_size),
+        str(pp_size),
+    ]
+    subprocess.run(command, check=True)
+
+if __name__ == "__main__":
+    template_path = "./run_dp_template.sh"
+    if not os.path.exists(template_path):
+        print(f"Template file {template_path} does not exist.")
+        sys.exit(1)
+
+    processes = []
+    num_cards = dp_size_local * gpus_per_dp_rank
+
+    for i in range(dp_size_local):
+        dp_rank = dp_rank_start + i
+        vllm_engine_port = vllm_start_port + i
+        visible_devices = ",".join(str(x) for x in range(i * gpus_per_dp_rank, (i + 1) * gpus_per_dp_rank))
+        process = multiprocessing.Process(
+            target=run_command,
+            args=(visible_devices, dp_rank, vllm_engine_port)
+        )
+        processes.append(process)
+        process.start()
+
+    for process in processes:
+        process.join()
+```
+
 1. prepare the script `run_dp_template.sh` on each node.
 
     1. Prefill node 0
 
-        The prefill script selects the node via `node_rank`: set `node_rank=0` on prefill node 0 and `node_rank=1` on prefill node 1. `$2` is the engine port.
+        The prefill script selects the node via `node_rank`: set `node_rank=0` on prefill node 0 (PP master node, engine port `9081`) and `node_rank=1` on prefill node 1 (non-master node, `--headless`, no API server).
 
         ```shell
         nic_name="xxxx" # change to your own nic name
@@ -1093,10 +1167,10 @@ The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (128G
 
         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
             --host 0.0.0.0 \
-            --port $2 \
+            --port 9081 \
             --pipeline-parallel-size 2 \
             --distributed-executor-backend mp \
-            --master-addr $node_p0_ip \
+            --master-addr $local_ip \
             --master-port 7060 \
             --nnodes 2 \
             --node-rank $node_rank \
@@ -1167,13 +1241,13 @@ The high-throughput (198K context) scenario is validated on 4 Atlas 800 A3 (128G
 
         vllm serve /root/.cache/modelscope/hub/models/vllm-ascend/GLM-5.1-W8A8C8-MTP \
             --host 0.0.0.0 \
-            --port $2 \
             --pipeline-parallel-size 2 \
             --distributed-executor-backend mp \
-            --master-addr $local_ip \
+            --master-addr $node_p0_ip \
             --master-port 7060 \
             --nnodes 2 \
             --node-rank $node_rank \
+            --headless \
             --tensor-parallel-size 16 \
             --enable-expert-parallel \
             --speculative-config '{"num_speculative_tokens": 3, "method":"deepseek_mtp","enforce_eager":true}' \
@@ -1367,14 +1441,14 @@ Once the preparation is done, you can start the server with the following comman
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 0 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
 4. Decode node 1
 
     ```shell
     # change ip to your own
-    python launch_online_dp.py --dp-size 8 --tp-size 4 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 16600 --vllm-start-port 9900
+    python launch_online_dp.py --dp-size 8 --tp-size 4 --pp-size 1 --dp-size-local 4 --dp-rank-start 4 --dp-address $node_d0_ip --dp-rpc-port 12321 --vllm-start-port 8000
     ```
 
 **Notice:**
@@ -1430,14 +1504,12 @@ unset http_proxy
 unset https_proxy
 
 python load_balance_proxy_server_example.py \
-    --port 8000 \
+    --port 9000 \
     --host 0.0.0.0 \
     --prefiller-hosts \
     $node_p0_ip \
-    $node_p1_ip \
     --prefiller-ports \
     9081 \
-    9082 \
     --decoder-hosts \
     $node_d0_ip \
     $node_d0_ip \
@@ -1448,8 +1520,8 @@ python load_balance_proxy_server_example.py \
     $node_d1_ip \
     $node_d1_ip \
     --decoder-ports \
-    9900 9901 9902 9903 \
-    9900 9901 9902 9903
+    8000 8001 8002 8003 \
+    8000 8001 8002 8003
 ```
 
 Key Parameter Descriptions for PD separation deployment:


### PR DESCRIPTION
  ### What this PR does / why we need it?                                                                                 - Update `launch_online_dp.py` in the GLM-5/5.2 PD deployment guides to the version supporting `--pp-size` (each DP
  replica occupies tp×pp cards)
  - Hardcode prefill engine ports (P0: 9081, P1: 9082) and add `--headless` to prefill node 1 (non-master node)
  - Fix `--master-addr` in prefill templates: prefill node 0 uses `$local_ip`, prefill node 1 uses `$node_p0_ip`
  - Update decode node 0/1 launch commands: add `--pp-size 1`, `--dp-rpc-port 12321`, `--vllm-start-port 8000`
  - Update the proxy config: keep only prefill node 0, align decoder ports to the new start port (8000-8003), move the    proxy listening port to 9000 to avoid conflicts                                                                         - Sync the same changes to the GLM-5.2 deployment guide (section 5.1.1.3)                                             
  ### Does this PR introduce _any_ user-facing change?
  No. Documentation-only update.

  ### How was this patch tested?
  - Docs built successfully with `make html` and previewed locally.

- vLLM version: v0.23.0
- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
