### PR TITLE
[Performance][MoE] Skip padded A5 SiTU MX quant rows

### DIFF
--- a/csrc/moe/situ_mx_quant/op_host/arch35/situ_mx_quant_tiling_arch35.cpp
+++ b/csrc/moe/situ_mx_quant/op_host/arch35/situ_mx_quant_tiling_arch35.cpp
@@ -35,6 +35,7 @@ constexpr int64_t INDEX_ATTR_LINEAR_BETA = 1;
 constexpr int64_t INDEX_ATTR_ACTIVATE_LEFT = 2;
 constexpr int64_t INDEX_ATTR_AXIS = 3;
 constexpr int64_t INDEX_ATTR_DST_TYPE = 4;
+constexpr int64_t INDEX_INPUT_GROUP_LIST = 1;
 
 constexpr int64_t BYTES_OF_BF16 = 2;
 constexpr int64_t BYTES_OF_FP8 = 1;
@@ -146,6 +147,21 @@ ge::graphStatus SituMxQuantRegbaseTiling::ValidateInput()
                 OP_LOGE(context_->GetNodeName(), "Last dimension must be divisible by 2, but got %ld.",
                         inputInfo_.inputDim2),
                 return ge::GRAPH_FAILED);
+
+    auto groupListDesc = context_->GetOptionalInputDesc(INDEX_INPUT_GROUP_LIST);
+    inputInfo_.hasGroupList = groupListDesc != nullptr;
+    if (inputInfo_.hasGroupList) {
+        OP_CHECK_IF(groupListDesc->GetDataType() != ge::DT_INT64,
+                    OP_LOGE(context_->GetNodeName(), "group_list must have int64 dtype"),
+                    return ge::GRAPH_FAILED);
+        auto groupListShape = context_->GetOptionalInputShape(INDEX_INPUT_GROUP_LIST);
+        OP_CHECK_NULL_WITH_CONTEXT(context_, groupListShape);
+        const auto storageShape = groupListShape->GetStorageShape();
+        OP_CHECK_IF(storageShape.GetDimNum() != 1 || storageShape.GetDim(0) <= 0,
+                    OP_LOGE(context_->GetNodeName(), "group_list must be a non-empty 1-D tensor"),
+                    return ge::GRAPH_FAILED);
+        inputInfo_.groupListSize = storageShape.GetDim(0);
+    }
     return ge::GRAPH_SUCCESS;
 }
 
@@ -267,6 +283,8 @@ ge::graphStatus SituMxQuantRegbaseTiling::FillTilingData()
     tilingData_->beta = attrParam_.beta;
     tilingData_->linearBeta = attrParam_.linearBeta;
     tilingData_->hasLinearBeta = attrParam_.hasLinearBeta ? 1 : 0;
+    tilingData_->hasGroupList = inputInfo_.hasGroupList ? 1 : 0;
+    tilingData_->groupListSize = inputInfo_.groupListSize;
     return ge::GRAPH_SUCCESS;
 }
 
@@ -287,11 +305,11 @@ void SituMxQuantRegbaseTiling::PrintTilingData() const
     OP_LOGI(context_->GetNodeName(),
             "TilingData: usedCoreNum=%ld, inputDim1=%ld, inputDim2=%ld, dimNBlockNum=%ld, "
             "maxBasicNumUbDim2=%ld, maxBasicNumUbDim1=%ld, nCoreNum=%ld, mCorePerB=%ld, "
-            "beta=%f, linearBeta=%f, hasLinearBeta=%ld",
+            "beta=%f, linearBeta=%f, hasLinearBeta=%ld, hasGroupList=%ld, groupListSize=%ld",
             tilingData_->usedCoreNum, tilingData_->inputDim1, tilingData_->inputDim2,
             tilingData_->dimNBlockNum, tilingData_->maxBasicNumUbDim2, tilingData_->maxBasicNumUbDim1,
             tilingData_->nCoreNum, tilingData_->mCorePerB, tilingData_->beta, tilingData_->linearBeta,
-            tilingData_->hasLinearBeta);
+            tilingData_->hasLinearBeta, tilingData_->hasGroupList, tilingData_->groupListSize);
 }
 
 // ==================== Entry Functions ====================

--- a/csrc/moe/situ_mx_quant/op_host/arch35/situ_mx_quant_tiling_arch35.h
+++ b/csrc/moe/situ_mx_quant/op_host/arch35/situ_mx_quant_tiling_arch35.h
@@ -41,6 +41,8 @@ struct SituMxQuantInputInfo {
     int64_t inputDim0{1};   // batch dim (collapsed)
     int64_t inputDim1{1};   // row dim (collapsed)
     int64_t inputDim2{0};   // 2H (input last dim)
+    int64_t groupListSize{0};
+    bool hasGroupList{false};
 };
 
 // ==================== Output Info ====================

--- a/csrc/moe/situ_mx_quant/op_host/config/ascend950/situ_mx_quant_binary.json
+++ b/csrc/moe/situ_mx_quant/op_host/config/ascend950/situ_mx_quant_binary.json
@@ -12,6 +12,15 @@
           "paramType": "required",
           "shape": [-2],
           "format_match_mode": "FormatAgnostic"
+        },
+        {
+          "name": "group_list",
+          "index": 1,
+          "dtype": "int64",
+          "format": "ND",
+          "paramType": "optional",
+          "shape": [-2],
+          "format_match_mode": "FormatAgnostic"
         }
       ],
       "outputs": [
@@ -51,6 +60,15 @@
           "dtype": "bfloat16",
           "format": "ND",
           "paramType": "required",
+          "shape": [-2],
+          "format_match_mode": "FormatAgnostic"
+        },
+        {
+          "name": "group_list",
+          "index": 1,
+          "dtype": "int64",
+          "format": "ND",
+          "paramType": "optional",
           "shape": [-2],
           "format_match_mode": "FormatAgnostic"
         }

--- a/csrc/moe/situ_mx_quant/op_host/situ_mx_quant_def.cpp
+++ b/csrc/moe/situ_mx_quant/op_host/situ_mx_quant_def.cpp
@@ -34,7 +34,8 @@ public:
             .ParamType(OPTIONAL)
             .DataType({ge::DT_INT64, ge::DT_INT64})
             .Format({ge::FORMAT_ND, ge::FORMAT_ND})
-            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND})
+            .AutoContiguous();
 
         this->Output("y")
             .ParamType(REQUIRED)

--- a/csrc/moe/situ_mx_quant/op_host/situ_mx_quant_def.cpp
+++ b/csrc/moe/situ_mx_quant/op_host/situ_mx_quant_def.cpp
@@ -30,6 +30,11 @@ public:
             .Format({ge::FORMAT_ND, ge::FORMAT_ND})
             .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND})
             .AutoContiguous();
+        this->Input("group_list")
+            .ParamType(OPTIONAL)
+            .DataType({ge::DT_INT64, ge::DT_INT64})
+            .Format({ge::FORMAT_ND, ge::FORMAT_ND})
+            .UnknownShapeFormat({ge::FORMAT_ND, ge::FORMAT_ND});
 
         this->Output("y")
             .ParamType(REQUIRED)

--- a/csrc/moe/situ_mx_quant/op_kernel/arch35/situ_mx_quant_axis_last.h
+++ b/csrc/moe/situ_mx_quant/op_kernel/arch35/situ_mx_quant_axis_last.h
@@ -29,7 +29,8 @@ public:
     __aicore__ inline SituMxQuantAxisLast(){};
 
     __aicore__ inline void Init(GM_ADDR x, GM_ADDR y, GM_ADDR mxscale, GM_ADDR workspace,
-                                const SituMxQuantTilingData* __restrict tilingData, AscendC::TPipe* pipe);
+                                GM_ADDR groupList, const SituMxQuantTilingData* __restrict tilingData,
+                                AscendC::TPipe* pipe);
     __aicore__ inline void Process();
 
 private:
@@ -42,6 +43,7 @@ private:
     GlobalTensor<T> xGm_;
     GlobalTensor<uint8_t> yGm_;
     GlobalTensor<uint8_t> scaleGm_;
+    GlobalTensor<int64_t> groupListGm_;
     const SituMxQuantTilingData* tiling_;
     AscendC::TPipe* pipe_;
     int32_t blockIdx_ = 0;
@@ -80,7 +82,7 @@ private:
 template <typename T, typename U, bool hasLinearBeta>
 __aicore__ inline void SituMxQuantAxisLast<T, U, hasLinearBeta>::Init(
     GM_ADDR x, GM_ADDR y, GM_ADDR mxscale, GM_ADDR workspace,
-    const SituMxQuantTilingData* __restrict tilingData, AscendC::TPipe* pipe)
+    GM_ADDR groupList, const SituMxQuantTilingData* __restrict tilingData, AscendC::TPipe* pipe)
 {
 #if (__NPU_ARCH__ == 3510)
     AscendC::SetCtrlSpr<FLOAT_OVERFLOW_MODE_CTRL, FLOAT_OVERFLOW_MODE_CTRL>(0);
@@ -93,6 +95,18 @@ __aicore__ inline void SituMxQuantAxisLast<T, U, hasLinearBeta>::Init(
     scaleGm_.SetGlobalBuffer((__gm__ uint8_t*)mxscale);
 
     dimM_ = tiling_->inputDim1;
+    if (tiling_->hasGroupList != 0) {
+        groupListGm_.SetGlobalBuffer((__gm__ int64_t*)groupList, tiling_->groupListSize);
+        int64_t activeRows = 0;
+        for (int64_t expertIdx = 0; expertIdx < tiling_->groupListSize && activeRows < dimM_; ++expertIdx) {
+            const int64_t requestedRows = groupListGm_.GetValue(expertIdx);
+            const int64_t remainingRows = dimM_ - activeRows;
+            if (requestedRows > 0) {
+                activeRows += requestedRows > remainingRows ? remainingRows : requestedRows;
+            }
+        }
+        dimM_ = activeRows;
+    }
     dimN_ = tiling_->inputDim2;
     dim2N_ = dimN_ * CONST_2;
 

--- a/csrc/moe/situ_mx_quant/op_kernel/arch35/situ_mx_quant_tiling_data.h
+++ b/csrc/moe/situ_mx_quant/op_kernel/arch35/situ_mx_quant_tiling_data.h
@@ -48,5 +48,7 @@ struct SituMxQuantTilingData {
     float beta;
     float linearBeta;
     int64_t hasLinearBeta;      // 0 or 1
+    int64_t hasGroupList;       // 0 or 1
+    int64_t groupListSize;      // per-expert count tensor length
 };
 #endif // SITU_MX_QUANT_TILING_DATA_H

--- a/csrc/moe/situ_mx_quant/op_kernel/situ_mx_quant_apt.cpp
+++ b/csrc/moe/situ_mx_quant/op_kernel/situ_mx_quant_apt.cpp
@@ -24,7 +24,8 @@ using namespace AscendC;
 using namespace SituMxQuantOp;
 
 template <uint64_t hasLinearBeta, uint64_t dstTypeIndex>
-__global__ __aicore__ void situ_mx_quant(GM_ADDR x, GM_ADDR y, GM_ADDR mxscale, GM_ADDR workspace, GM_ADDR tiling)
+__global__ __aicore__ void situ_mx_quant(
+    GM_ADDR x, GM_ADDR groupList, GM_ADDR y, GM_ADDR mxscale, GM_ADDR workspace, GM_ADDR tiling)
 {
     KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
     REGISTER_TILING_DEFAULT(SituMxQuantTilingData);
@@ -38,12 +39,12 @@ __global__ __aicore__ void situ_mx_quant(GM_ADDR x, GM_ADDR y, GM_ADDR mxscale, 
     if constexpr (dstTypeIndex == TPL_DST_E4M3FN) {
         constexpr bool useLinearBeta = (hasLinearBeta == TPL_HAS_LINEAR_BETA);
         SituMxQuant::SituMxQuantAxisLast<bfloat16_t, fp8_e4m3fn_t, useLinearBeta> op;
-        op.Init(x, y, mxscale, usrWorkspace, &tilingData, &pipe);
+        op.Init(x, y, mxscale, usrWorkspace, groupList, &tilingData, &pipe);
         op.Process();
     } else {
         constexpr bool useLinearBeta = (hasLinearBeta == TPL_HAS_LINEAR_BETA);
         SituMxQuant::SituMxQuantAxisLast<bfloat16_t, fp8_e5m2_t, useLinearBeta> op;
-        op.Init(x, y, mxscale, usrWorkspace, &tilingData, &pipe);
+        op.Init(x, y, mxscale, usrWorkspace, groupList, &tilingData, &pipe);
         op.Process();
     }
 

--- a/csrc/moe/situ_mx_quant/situ_mx_quant_torch_adpt.h
+++ b/csrc/moe/situ_mx_quant/situ_mx_quant_torch_adpt.h
@@ -21,6 +21,7 @@ namespace vllm_ascend {
 
 std::tuple<at::Tensor, at::Tensor> situ_mx_quant(
     const at::Tensor& x,
+    const c10::optional<at::Tensor>& group_list,
     double beta,
     double linear_beta,
     bool activate_left,
@@ -43,6 +44,13 @@ std::tuple<at::Tensor, at::Tensor> situ_mx_quant(
     TORCH_CHECK(dst_type == DST_TYPE_E4M3FN || dst_type == DST_TYPE_E5M2,
                 "situ_mx_quant: dst_type must be 36 (E4M3FN) or 35 (E5M2), but got ",
                 dst_type);
+    if (group_list.has_value()) {
+        TORCH_CHECK(group_list->dim() == 1 && group_list->numel() > 0,
+                    "situ_mx_quant: group_list must be a non-empty 1-D tensor");
+        TORCH_CHECK(group_list->scalar_type() == at::kLong,
+                    "situ_mx_quant: group_list must have int64 dtype, but got ",
+                    group_list->scalar_type());
+    }
 
     std::vector<int64_t> y_shape(x.sizes().begin(), x.sizes().end());
     y_shape.back() /= 2;
@@ -53,10 +61,12 @@ std::tuple<at::Tensor, at::Tensor> situ_mx_quant(
     auto y_dtype = dst_type == DST_TYPE_E5M2 ? at::kFloat8_e5m2 : at::kFloat8_e4m3fn;
     at::Tensor y = at::empty(y_shape, x.options().dtype(y_dtype));
     at::Tensor mxscale = at::empty(mxscale_shape, x.options().dtype(at::kFloat8_e8m0fnu));
+    const at::Tensor group_list_value = group_list.value_or(at::Tensor());
 
     constexpr int64_t AXIS = -1;
     EXEC_NPU_CMD(aclnnSituMxQuant,
                  x,
+                 group_list_value,
                  beta,
                  linear_beta,
                  activate_left,

--- a/csrc/moe/situ_mx_quant/situ_mx_quant_torch_adpt.h
+++ b/csrc/moe/situ_mx_quant/situ_mx_quant_torch_adpt.h
@@ -45,6 +45,8 @@ std::tuple<at::Tensor, at::Tensor> situ_mx_quant(
                 "situ_mx_quant: dst_type must be 36 (E4M3FN) or 35 (E5M2), but got ",
                 dst_type);
     if (group_list.has_value()) {
+        TORCH_CHECK(group_list->device() == x.device(),
+                    "situ_mx_quant: group_list must be on the same device as x");
         TORCH_CHECK(group_list->dim() == 1 && group_list->numel() > 0,
                     "situ_mx_quant: group_list must be a non-empty 1-D tensor");
         TORCH_CHECK(group_list->scalar_type() == at::kLong,

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -2481,6 +2481,7 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
 
     ops.def(
         "situ_mx_quant(Tensor x, "
+        "              *, Tensor? group_list=None, "
         "              float beta=1.0, "
         "              float linear_beta=0.0, "
         "              bool activate_left=False, "

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -1881,6 +1881,7 @@ std::tuple<at::Tensor, at::Tensor> dequant_situ_quant_meta(
 
 std::tuple<at::Tensor, at::Tensor> situ_mx_quant_meta(
     const at::Tensor& x,
+    const c10::optional<at::Tensor>& group_list,
     double beta,
     double linear_beta,
     bool activate_left,
@@ -1904,6 +1905,7 @@ std::tuple<at::Tensor, at::Tensor> situ_mx_quant_meta(
 
     (void)linear_beta;
     (void)activate_left;
+    (void)group_list;
 
     c10::SymDimVector y_shape(x.sym_sizes().begin(), x.sym_sizes().end());
     y_shape.back() = y_shape.back() / 2;

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_situ_mx_quant_group_list.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_situ_mx_quant_group_list.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import AscendDeviceType, bootstrap_custom_op_env, get_ascend_device_type
+
+K3_INPUT_WIDTH = 6144
+K3_SITU_BETA = 4.0
+K3_SITU_LINEAR_BETA = 25.0
+SITU_MX_DST_TYPE_E4M3FN = 36
+GROUP_LIST_64 = [5, 5, 5, 5, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4]
+GROUP_LIST_128 = [10, 10, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9]
+
+
+def _register_custom_op() -> None:
+    if get_ascend_device_type() != AscendDeviceType.A5:
+        pytest.skip("requires Ascend 950")
+    bootstrap_custom_op_env()
+    import vllm_ascend.vllm_ascend_C  # type: ignore[import-untyped]  # noqa: F401
+
+
+def _run(x: torch.Tensor, group_list: torch.Tensor | None):
+    situ_group_list = None if group_list is None else group_list.to(torch.int64)
+    return torch.ops._C_ascend.situ_mx_quant(
+        x=x,
+        group_list=situ_group_list,
+        beta=K3_SITU_BETA,
+        linear_beta=K3_SITU_LINEAR_BETA,
+        activate_left=True,
+        dst_type=SITU_MX_DST_TYPE_E4M3FN,
+    )
+
+
+@pytest.mark.skip_global_cleanup
+@torch.inference_mode()
+def test_situ_mx_quant_group_list_eager_and_graph():
+    _register_custom_op()
+    capacity_rows = 128
+    group_64 = torch.tensor(GROUP_LIST_64, dtype=torch.int32, device="npu")
+    group_full = torch.tensor(GROUP_LIST_128, dtype=torch.int32, device="npu")
+    x = torch.randn(capacity_rows, K3_INPUT_WIDTH, dtype=torch.bfloat16, device="npu")
+
+    baseline_y, baseline_scale = _run(x, None)
+    full_group_y, full_group_scale = _run(x, group_full)
+    optimized_y, optimized_scale = _run(x, group_64)
+    direct_y, direct_scale = _run(x[:64], group_64)
+    torch.npu.synchronize()
+
+    assert tuple(optimized_y.shape) == tuple(baseline_y.shape)
+    assert tuple(optimized_scale.shape) == tuple(baseline_scale.shape)
+    torch.testing.assert_close(full_group_y.cpu(), baseline_y.cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(full_group_scale.cpu(), baseline_scale.cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(optimized_y[:64].cpu(), baseline_y[:64].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(optimized_scale[:64].cpu(), baseline_scale[:64].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(optimized_y[:64].cpu(), direct_y.cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(optimized_scale[:64].cpu(), direct_scale.cpu(), rtol=0, atol=0)
+
+    graph_group = group_full.clone()
+    graph = torch.npu.NPUGraph()
+    with torch.npu.graph(graph, capture_error_mode="thread_local", auto_dispatch_capture=True):
+        graph_y, graph_scale = _run(x, graph_group)
+    torch.npu.synchronize()
+
+    graph_group.copy_(group_64)
+    graph.replay()
+    torch.npu.synchronize()
+    torch.testing.assert_close(graph_y[:64].cpu(), optimized_y[:64].cpu(), rtol=0, atol=0)
+    torch.testing.assert_close(graph_scale[:64].cpu(), optimized_scale[:64].cpu(), rtol=0, atol=0)

--- a/tests/ut/ops/test_moe_mlp.py
+++ b/tests/ut/ops/test_moe_mlp.py
@@ -215,6 +215,56 @@ class TestUnifiedApplyMlpRequest(unittest.TestCase):
         custom_ops.grouped_matmul_swiglu_quant_weight_nz_tensor_list.assert_not_called()
         custom_ops.npu_dequant_swiglu_quant.assert_not_called()
 
+    def test_w4a8_mxfp_situ_forwards_dispatch_counts(self):
+        hidden_states = torch.randn(3, 4, dtype=torch.bfloat16)
+        gate_up_out = torch.randn(3, 4, dtype=torch.bfloat16)
+        quantized_situ = torch.ones(3, 2)
+        situ_scale = torch.ones(3, 1)
+        down_out = torch.randn(3, 4, dtype=torch.bfloat16)
+        custom_ops = SimpleNamespace(
+            situ_mx_quant=MagicMock(return_value=(quantized_situ, situ_scale)),
+        )
+
+        with (
+            patch.object(moe_mlp_module.torch.ops, "_C_ascend", custom_ops),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.maybe_normalize_mxfp_scale_layout",
+                side_effect=lambda scale: scale,
+            ),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch_npu.npu_grouped_matmul",
+                return_value=[gate_up_out],
+                create=True,
+            ),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.DeviceOperator.npu_grouped_matmul_gmm2",
+                return_value=down_out,
+            ),
+            patch("vllm_ascend.ops.fused_moe.moe_mlp.dispose_tensor"),
+            patch(
+                "vllm_ascend.ops.fused_moe.moe_mlp.torch.npu.current_stream",
+                return_value=MagicMock(record_event=MagicMock()),
+            ),
+        ):
+            output, _ = quant_apply_mlp(
+                hidden_states=hidden_states,
+                w1=torch.ones(2, 4, 4),
+                w1_scale=torch.ones(2, 4),
+                w2=torch.ones(2, 2, 4),
+                w2_scale=torch.ones(2, 4),
+                group_list=torch.tensor([1, 3], dtype=torch.int32),
+                group_list_type=0,
+                dynamic_scale=torch.ones(3, 1),
+                activation=SituActivationConfig(beta=4.0, linear_beta=25.0),
+                use_mxfp_quant=True,
+                mxfp_quant_dtype=QuantType.W4A8MXFP,
+            )
+
+        self.assertIs(output, down_out)
+        situ_call = custom_ops.situ_mx_quant.call_args.kwargs
+        self.assertIs(situ_call["x"], gate_up_out)
+        torch.testing.assert_close(situ_call["group_list"], torch.tensor([1, 2], dtype=torch.int64))
+
     def test_w4a8_swiglu_stays_on_existing_fused_path(self):
         hidden_states = torch.randn(2, 4, dtype=torch.bfloat16)
         quantized_input = torch.ones(2, 4, dtype=torch.int8)

--- a/vllm_ascend/ops/fused_moe/moe_mlp.py
+++ b/vllm_ascend/ops/fused_moe/moe_mlp.py
@@ -226,8 +226,10 @@ def _w4a8_situ_apply_mlp(
         dispose_tensor(externally_quantized_hidden_states)
 
     if use_mxfp_quant:
+        situ_group_list = cumsum_group_list(group_list, group_list_type, 1).to(torch.int64)
         hidden_states, situ_out_scale = torch.ops._C_ascend.situ_mx_quant(
             x=gate_up_out,
+            group_list=situ_group_list,
             beta=activation.beta,
             linear_beta=activation.linear_beta or 0.0,
             activate_left=True,


### PR DESCRIPTION
### What this PR does / why we need it?

Kimi K3 W4A8MXFP on Ascend 950 uses `SituMxQuant` after the routed GMM1. The GMM1 output keeps the dispatch-capacity shape, but only the leading rows described by dispatch `group_list` contain routed tokens. Quantizing every capacity row wastes activation work.

This A5-only change:

- converts dispatch cumulative/count metadata to INT64 per-expert counts;
- adds an optional `group_list` input to the Ascend 950 `SituMxQuant` schema, ACLNN/PyTorch bindings and binary configuration;
- sums the counts in the A5 device kernel and processes only the valid leading rows;
- preserves the original capacity-shaped `y` and `mxscale` outputs for GMM2;
- keeps shapes and addresses static for eager and NPU graph capture/replay, with no `.item()` or device-to-host synchronization;
- leaves the A2/A3 `DequantSituQuant` path unchanged.

This is the A5 counterpart to #14901; it is intentionally split because A5 uses `SituMxQuant` rather than `DequantSituQuant`.

### Does this PR introduce any user-facing change?

No. It is an internal Kimi K3 MoE performance optimization. Output shapes and model semantics are unchanged.

### How was this patch tested?

Static/local checks:

- Python `compileall` for the modified Python wiring and tests
- JSON parse of `situ_mx_quant_binary.json`
- `git diff --check`

Target UT on `green-52-191 / zjb_0824_0822`:

- `test_w4a8_mxfp_situ_forwards_dispatch_counts`: 1 passed
- `tests/ut/ops/test_moe_mlp.py`: 23 passed; one unrelated existing SWIGLUSTEP tiny-shape alignment failure

Ascend 950 single-op validation on physical NPU 1:

- rebuilt and installed the modified `SituMxQuant` package and PyTorch binding successfully;
- eager and `torch.npu.NPUGraph` replay both passed with static `[2048, 6144]` input;
- `group_list` content changed from sum 2048 to sum 64 without changing its shape or graph addresses;
- the valid 64 rows matched the full baseline, direct `[64, 6144]` reference and graph replay element-for-element;
- output shapes remained `y=[2048, 3072]` and `mxscale=[2048, 48, 2]`;
- 20 warmups and 5 groups x 100 iterations measured about 2.05x eager device-time speedup (2.07x wall) and 2.00x graph-replay device-time speedup (1.97x wall).

The 191 test worktree used repository ancestor `b95f94ee0` plus the A5 patch because that node could not reach GitHub. This PR itself is based on the current `releases/v0.26.0rc` head `3ed71abf4`.

- vLLM version: 
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
