### PR TITLE
[Feature] Add eager KV layer parallelism

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -132,6 +132,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/test_qwen3_vl_30b_a3b_instruct.py: 290
   tests/e2e/pull_request/two_card/test_shared_expert_dp.py: 1060
   tests/e2e/pull_request/two_card/test_hccl_weight_transfer.py: 130
+  tests/e2e/pull_request/two_card/test_kvpp.py: 1100
   tests/e2e/pull_request/two_card/test_xlite.py: 740
   tests/e2e/pull_request/four_card/_310p/test_dense_model_310p.py: 500
   tests/e2e/pull_request/four_card/_310p/test_model_runner_v2_310p.py: 800

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ include(${ASCENDC_CMAKE_DIR}/ascendc.cmake)
 
 file(GLOB KERNEL_FILES
 ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels/*.cpp)
+set(KVPP_MTE_KERNEL
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/kernels/kvpp_mte_copy.cpp)
+list(REMOVE_ITEM KERNEL_FILES ${KVPP_MTE_KERNEL})
 
 set(VLLM_ASCEND_CUSTOM_OP
     ${KERNEL_FILES}
@@ -73,10 +76,37 @@ endif()
 
 if(SOC_VERSION MATCHES "ascend310p.*|ascend950")
     message(STATUS "Hardware ${SOC_VERSION} detected: skip vllm_ascend_kernels compile")
+elseif(VLLM_ASCEND_PREBUILT_KERNELS)
+    message(STATUS "Using prebuilt base kernels: ${VLLM_ASCEND_PREBUILT_KERNELS}")
+    add_library(vllm_ascend_kernels SHARED IMPORTED)
+    set_target_properties(vllm_ascend_kernels PROPERTIES
+        IMPORTED_LOCATION "${VLLM_ASCEND_PREBUILT_KERNELS}")
 else()
-    ascendc_library(vllm_ascend_kernels SHARED
+ascendc_library(vllm_ascend_kernels SHARED
         ${VLLM_ASCEND_CUSTOM_OP}
     )
+endif()
+
+# MemFabric Hybrid exposes the MTE data plane only as an AscendC device API.
+# Build the optional KVPP kernel when the serving image has its headers; normal
+# community builds remain independent of MemFabric.
+file(GLOB MEMFABRIC_HYBRID_INCLUDE_CANDIDATES
+    LIST_DIRECTORIES true
+    "/usr/local/memfabric_hybrid/*/include")
+find_path(MEMFABRIC_MTE_INCLUDE_DIR
+    NAMES smem/device/smem_shm_aicore_base_api.h
+    HINTS "$ENV{MEMFABRIC_HYBRID_HOME_PATH}/include"
+          ${MEMFABRIC_HYBRID_INCLUDE_CANDIDATES})
+if(NOT (SOC_VERSION MATCHES "ascend310p.*") AND
+   MEMFABRIC_MTE_INCLUDE_DIR)
+    message(STATUS "MemFabric Hybrid MTE: enabled from ${MEMFABRIC_MTE_INCLUDE_DIR}")
+    ascendc_library(vllm_ascend_kvpp_mte_kernels SHARED
+        ${KVPP_MTE_KERNEL})
+    ascendc_include_directories(vllm_ascend_kvpp_mte_kernels PRIVATE
+        "${MEMFABRIC_MTE_INCLUDE_DIR}")
+    set(VLLM_ASCEND_ENABLE_MEMFABRIC_MTE ON)
+else()
+    message(STATUS "MemFabric Hybrid MTE: disabled (unsupported SoC or device header not found)")
 endif()
 
 message("TORCH_NPU_PATH is ${TORCH_NPU_PATH}")
@@ -160,6 +190,11 @@ if(NOT (SOC_VERSION MATCHES "ascend310p.*|ascend950"))
     target_compile_definitions(vllm_ascend_C PRIVATE -DVLLM_ENABLE_ATB_AND_DIRECT_KERNELS)
 endif()
 
+if(VLLM_ASCEND_ENABLE_MEMFABRIC_MTE)
+    target_compile_definitions(vllm_ascend_C PRIVATE
+        -DVLLM_ASCEND_ENABLE_MEMFABRIC_MTE)
+endif()
+
 target_link_directories(
   vllm_ascend_C
   PRIVATE
@@ -181,16 +216,26 @@ set(VLLM_ASCEND_C_COMMON_LIBS
 )
 
 if(SOC_VERSION MATCHES "ascend310p.*|ascend950")
+  set(VLLM_ASCEND_PLATFORM_LIBS ${VLLM_ASCEND_C_COMMON_LIBS})
+  if(VLLM_ASCEND_ENABLE_MEMFABRIC_MTE)
+    list(APPEND VLLM_ASCEND_PLATFORM_LIBS
+      vllm_ascend_kvpp_mte_kernels)
+  endif()
   target_link_libraries(
     vllm_ascend_C
     PUBLIC
-    ${VLLM_ASCEND_C_COMMON_LIBS}
+    ${VLLM_ASCEND_PLATFORM_LIBS}
   )
 else()
+  set(VLLM_ASCEND_DIRECT_KERNEL_LIBS vllm_ascend_kernels)
+  if(VLLM_ASCEND_ENABLE_MEMFABRIC_MTE)
+    list(APPEND VLLM_ASCEND_DIRECT_KERNEL_LIBS
+      vllm_ascend_kvpp_mte_kernels)
+  endif()
   target_link_libraries(
     vllm_ascend_C
     PUBLIC
-    vllm_ascend_kernels
+    ${VLLM_ASCEND_DIRECT_KERNEL_LIBS}
     ${VLLM_ASCEND_C_COMMON_LIBS}
   )
 endif()
@@ -198,7 +243,22 @@ endif()
 target_link_options(vllm_ascend_C PRIVATE "-Wl,-rpath,$ORIGIN:$ORIGIN/lib:$ORIGIN/_cann_ops_custom/vendors/custom_transformer/op_api/lib")
 
 if(SOC_VERSION MATCHES "ascend310p.*|ascend950")
-  install(TARGETS vllm_ascend_C DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
+  set(VLLM_ASCEND_INSTALL_TARGETS vllm_ascend_C)
+  if(VLLM_ASCEND_ENABLE_MEMFABRIC_MTE)
+    list(APPEND VLLM_ASCEND_INSTALL_TARGETS
+      vllm_ascend_kvpp_mte_kernels)
+  endif()
+  install(TARGETS ${VLLM_ASCEND_INSTALL_TARGETS}
+    DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
 else()
-  install(TARGETS vllm_ascend_C vllm_ascend_kernels DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
+  set(VLLM_ASCEND_INSTALL_TARGETS vllm_ascend_C)
+  if(NOT VLLM_ASCEND_PREBUILT_KERNELS)
+    list(APPEND VLLM_ASCEND_INSTALL_TARGETS vllm_ascend_kernels)
+  endif()
+  if(VLLM_ASCEND_ENABLE_MEMFABRIC_MTE)
+    list(APPEND VLLM_ASCEND_INSTALL_TARGETS
+      vllm_ascend_kvpp_mte_kernels)
+  endif()
+  install(TARGETS ${VLLM_ASCEND_INSTALL_TARGETS}
+    DESTINATION ${VLLM_ASCEND_INSTALL_PATH})
 endif()

--- a/csrc/kernels/kvpp_mte_copy.cpp
+++ b/csrc/kernels/kvpp_mte_copy.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "kernel_operator.h"
+
+#if __has_include("smem/device/smem_shm_aicore_base_api.h")
+#include "smem/device/smem_shm_aicore_base_api.h"
+
+namespace {
+constexpr uint32_t KVPP_MTE_TILE_BYTES = 64 * 1024;
+constexpr uint32_t KVPP_MTE_MAX_CORES = 32;
+constexpr int32_t KVPP_MTE_EVENT_ID = 0;
+} // namespace
+
+extern "C" __global__ __aicore__ void kvpp_mte_batch_copy_pages(
+    __gm__ uint8_t* local_base_address, __gm__ int64_t* physical_page_ids,
+    __gm__ uint8_t* valid_page_mask, __gm__ int64_t* staging_page_indices,
+    uint64_t page_descriptor_count, uint64_t page_stride_bytes,
+    uint64_t page_length_bytes, uint64_t staging_region_offset_bytes,
+    __gm__ uint8_t* staging_base_address,
+    bool staging_is_source, int32_t staging_group_rank, uint32_t shm_id)
+{
+    const uint64_t symmetric_size = smem_shm_get_symmetric_size(shm_id);
+    AscendC::TPipe pipe;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> buffer;
+    pipe.InitBuffer(buffer, 1, KVPP_MTE_TILE_BYTES);
+    AscendC::LocalTensor<uint8_t> local = buffer.AllocTensor<uint8_t>();
+    __ubuf__ uint8_t* ub_address =
+        reinterpret_cast<__ubuf__ uint8_t*>(local.address_.bufferAddr);
+    AscendC::GlobalTensor<int64_t> page_id_descriptor;
+    AscendC::GlobalTensor<uint8_t> valid_descriptor;
+    AscendC::GlobalTensor<int64_t> staging_page_index_descriptor;
+    page_id_descriptor.SetGlobalBuffer(physical_page_ids,
+                                       page_descriptor_count);
+    valid_descriptor.SetGlobalBuffer(valid_page_mask,
+                                    page_descriptor_count);
+    staging_page_index_descriptor.SetGlobalBuffer(staging_page_indices,
+                                                  page_descriptor_count);
+
+    const uint64_t core_index = AscendC::GetBlockIdx();
+    const uint64_t core_count = AscendC::GetBlockNum();
+    for (uint64_t descriptor = core_index;
+         descriptor < page_descriptor_count;
+         descriptor += core_count) {
+        if (valid_descriptor.GetValue(descriptor) == 0) {
+            continue;
+        }
+        const uint64_t page_id = static_cast<uint64_t>(
+            page_id_descriptor.GetValue(descriptor));
+        const uint64_t staging_page_index = static_cast<uint64_t>(
+            staging_page_index_descriptor.GetValue(descriptor));
+        const uint64_t local_offset = page_id * page_stride_bytes;
+        const uint64_t staging_offset = staging_region_offset_bytes +
+            staging_page_index * page_length_bytes;
+        __gm__ uint8_t* local_gm = local_base_address + local_offset;
+        __gm__ uint8_t* staging_address =
+            staging_base_address + staging_offset;
+        staging_address +=
+            symmetric_size * static_cast<uint64_t>(staging_group_rank);
+
+        uint64_t offset = 0;
+        while (offset < page_length_bytes) {
+            const uint32_t bytes = static_cast<uint32_t>(
+                (page_length_bytes - offset) > KVPP_MTE_TILE_BYTES
+                    ? KVPP_MTE_TILE_BYTES
+                    : (page_length_bytes - offset));
+            __gm__ uint8_t* source = staging_is_source
+                ? staging_address + offset
+                : local_gm + offset;
+            smem_shm_copy_gm2ub<uint8_t>(
+                ub_address, source, bytes, false);
+            AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(
+                KVPP_MTE_EVENT_ID);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(
+                KVPP_MTE_EVENT_ID);
+            __gm__ uint8_t* destination = staging_is_source
+                ? local_gm + offset
+                : staging_address + offset;
+            smem_shm_copy_ub2gm<uint8_t>(
+                destination, ub_address, bytes, false);
+            AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(
+                KVPP_MTE_EVENT_ID);
+            AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(
+                KVPP_MTE_EVENT_ID);
+            offset += bytes;
+        }
+    }
+    buffer.FreeTensor(local);
+}
+
+namespace vllm_ascend {
+void kvpp_mte_batch_copy_pages_impl(
+    void* stream, void* local_base_address, void* physical_page_ids,
+    void* valid_page_mask, void* staging_page_indices,
+    uint64_t page_descriptor_count, uint64_t page_stride_bytes,
+    uint64_t page_length_bytes, uint64_t staging_region_offset_bytes,
+    void* staging_base_address,
+    bool staging_is_source, int32_t staging_group_rank, uint32_t shm_id)
+{
+    const uint32_t block_dim = page_descriptor_count < KVPP_MTE_MAX_CORES
+        ? static_cast<uint32_t>(page_descriptor_count)
+        : KVPP_MTE_MAX_CORES;
+    kvpp_mte_batch_copy_pages<<<block_dim, nullptr, stream>>>(
+        local_base_address, physical_page_ids, valid_page_mask,
+        staging_page_indices, page_descriptor_count, page_stride_bytes,
+        page_length_bytes, staging_region_offset_bytes,
+        staging_base_address,
+        staging_is_source, staging_group_rank, shm_id);
+}
+} // namespace vllm_ascend
+#endif

--- a/csrc/kernels/kvpp_mte_copy.cpp
+++ b/csrc/kernels/kvpp_mte_copy.cpp
@@ -12,15 +12,13 @@ namespace {
 constexpr uint32_t KVPP_MTE_TILE_BYTES = 64 * 1024;
 constexpr uint32_t KVPP_MTE_MAX_CORES = 32;
 constexpr int32_t KVPP_MTE_EVENT_ID = 0;
-} // namespace
+}  // namespace
 
 extern "C" __global__ __aicore__ void kvpp_mte_batch_copy_pages(
-    __gm__ uint8_t* local_base_address, __gm__ int64_t* physical_page_ids,
-    __gm__ uint8_t* valid_page_mask, __gm__ int64_t* staging_page_indices,
-    uint64_t page_descriptor_count, uint64_t page_stride_bytes,
-    uint64_t page_length_bytes, uint64_t staging_region_offset_bytes,
-    __gm__ uint8_t* staging_base_address,
-    bool staging_is_source, int32_t staging_group_rank, uint32_t shm_id)
+    __gm__ uint8_t* local_base, __gm__ int64_t* local_offsets,
+    __gm__ int64_t* staging_offsets, __gm__ int64_t* lengths,
+    uint64_t descriptor_count, __gm__ uint8_t* staging_base,
+    int32_t source_rank, int32_t destination_rank, uint32_t shm_id)
 {
     const uint64_t symmetric_size = smem_shm_get_symmetric_size(shm_id);
     AscendC::TPipe pipe;
@@ -29,57 +27,53 @@ extern "C" __global__ __aicore__ void kvpp_mte_batch_copy_pages(
     AscendC::LocalTensor<uint8_t> local = buffer.AllocTensor<uint8_t>();
     __ubuf__ uint8_t* ub_address =
         reinterpret_cast<__ubuf__ uint8_t*>(local.address_.bufferAddr);
-    AscendC::GlobalTensor<int64_t> page_id_descriptor;
-    AscendC::GlobalTensor<uint8_t> valid_descriptor;
-    AscendC::GlobalTensor<int64_t> staging_page_index_descriptor;
-    page_id_descriptor.SetGlobalBuffer(physical_page_ids,
-                                       page_descriptor_count);
-    valid_descriptor.SetGlobalBuffer(valid_page_mask,
-                                    page_descriptor_count);
-    staging_page_index_descriptor.SetGlobalBuffer(staging_page_indices,
-                                                  page_descriptor_count);
+    AscendC::GlobalTensor<int64_t> local_offset_descriptor;
+    AscendC::GlobalTensor<int64_t> staging_offset_descriptor;
+    AscendC::GlobalTensor<int64_t> length_descriptor;
+    local_offset_descriptor.SetGlobalBuffer(local_offsets, descriptor_count);
+    staging_offset_descriptor.SetGlobalBuffer(staging_offsets,
+                                              descriptor_count);
+    length_descriptor.SetGlobalBuffer(lengths, descriptor_count);
 
     const uint64_t core_index = AscendC::GetBlockIdx();
     const uint64_t core_count = AscendC::GetBlockNum();
-    for (uint64_t descriptor = core_index;
-         descriptor < page_descriptor_count;
+    for (uint64_t descriptor = core_index; descriptor < descriptor_count;
          descriptor += core_count) {
-        if (valid_descriptor.GetValue(descriptor) == 0) {
+        const uint64_t length = static_cast<uint64_t>(
+            length_descriptor.GetValue(descriptor));
+        if (length == 0) {
             continue;
         }
-        const uint64_t page_id = static_cast<uint64_t>(
-            page_id_descriptor.GetValue(descriptor));
-        const uint64_t staging_page_index = static_cast<uint64_t>(
-            staging_page_index_descriptor.GetValue(descriptor));
-        const uint64_t local_offset = page_id * page_stride_bytes;
-        const uint64_t staging_offset = staging_region_offset_bytes +
-            staging_page_index * page_length_bytes;
-        __gm__ uint8_t* local_gm = local_base_address + local_offset;
-        __gm__ uint8_t* staging_address =
-            staging_base_address + staging_offset;
-        staging_address +=
-            symmetric_size * static_cast<uint64_t>(staging_group_rank);
+        const uint64_t local_offset = static_cast<uint64_t>(
+            local_offset_descriptor.GetValue(descriptor));
+        const uint64_t staging_offset = static_cast<uint64_t>(
+            staging_offset_descriptor.GetValue(descriptor));
+        __gm__ uint8_t* local_address = local_base + local_offset;
+        __gm__ uint8_t* staging_address = staging_base + staging_offset;
+        const int32_t staging_rank =
+            source_rank >= 0 ? source_rank : destination_rank;
+        staging_address += symmetric_size *
+            static_cast<uint64_t>(staging_rank);
 
         uint64_t offset = 0;
-        while (offset < page_length_bytes) {
+        while (offset < length) {
             const uint32_t bytes = static_cast<uint32_t>(
-                (page_length_bytes - offset) > KVPP_MTE_TILE_BYTES
+                (length - offset) > KVPP_MTE_TILE_BYTES
                     ? KVPP_MTE_TILE_BYTES
-                    : (page_length_bytes - offset));
-            __gm__ uint8_t* source = staging_is_source
+                    : (length - offset));
+            __gm__ uint8_t* source = source_rank >= 0
                 ? staging_address + offset
-                : local_gm + offset;
-            smem_shm_copy_gm2ub<uint8_t>(
-                ub_address, source, bytes, false);
+                : local_address + offset;
+            smem_shm_copy_gm2ub<uint8_t>(ub_address, source, bytes, false);
             AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(
                 KVPP_MTE_EVENT_ID);
             AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(
                 KVPP_MTE_EVENT_ID);
-            __gm__ uint8_t* destination = staging_is_source
-                ? local_gm + offset
-                : staging_address + offset;
-            smem_shm_copy_ub2gm<uint8_t>(
-                destination, ub_address, bytes, false);
+            __gm__ uint8_t* destination = destination_rank >= 0
+                ? staging_address + offset
+                : local_address + offset;
+            smem_shm_copy_ub2gm<uint8_t>(destination, ub_address, bytes,
+                                         false);
             AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(
                 KVPP_MTE_EVENT_ID);
             AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(
@@ -92,22 +86,18 @@ extern "C" __global__ __aicore__ void kvpp_mte_batch_copy_pages(
 
 namespace vllm_ascend {
 void kvpp_mte_batch_copy_pages_impl(
-    void* stream, void* local_base_address, void* physical_page_ids,
-    void* valid_page_mask, void* staging_page_indices,
-    uint64_t page_descriptor_count, uint64_t page_stride_bytes,
-    uint64_t page_length_bytes, uint64_t staging_region_offset_bytes,
-    void* staging_base_address,
-    bool staging_is_source, int32_t staging_group_rank, uint32_t shm_id)
+    void* stream, void* local_base, void* local_offsets,
+    void* staging_offsets, void* lengths, uint64_t descriptor_count,
+    void* staging_base, int32_t source_rank, int32_t destination_rank,
+    uint32_t shm_id)
 {
-    const uint32_t block_dim = page_descriptor_count < KVPP_MTE_MAX_CORES
-        ? static_cast<uint32_t>(page_descriptor_count)
+    const uint32_t block_dim = descriptor_count < KVPP_MTE_MAX_CORES
+        ? static_cast<uint32_t>(descriptor_count)
         : KVPP_MTE_MAX_CORES;
     kvpp_mte_batch_copy_pages<<<block_dim, nullptr, stream>>>(
-        local_base_address, physical_page_ids, valid_page_mask,
-        staging_page_indices, page_descriptor_count, page_stride_bytes,
-        page_length_bytes, staging_region_offset_bytes,
-        staging_base_address,
-        staging_is_source, staging_group_rank, shm_id);
+        local_base, local_offsets, staging_offsets, lengths,
+        descriptor_count, staging_base, source_rank, destination_rank,
+        shm_id);
 }
-} // namespace vllm_ascend
+}  // namespace vllm_ascend
 #endif

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -27,17 +27,14 @@ namespace vllm_ascend {
 #ifdef VLLM_ASCEND_ENABLE_MEMFABRIC_MTE
     extern void kvpp_mte_batch_copy_pages_impl(
         void* stream,
-        void* local_base_address,
-        void* physical_page_ids,
-        void* valid_page_mask,
-        void* staging_page_indices,
-        uint64_t page_descriptor_count,
-        uint64_t page_stride_bytes,
-        uint64_t page_length_bytes,
-        uint64_t staging_region_offset_bytes,
-        void* staging_base_address,
-        bool staging_is_source,
-        int32_t staging_group_rank,
+        void* local_base,
+        void* local_offsets,
+        void* staging_offsets,
+        void* lengths,
+        uint64_t descriptor_count,
+        void* staging_base,
+        int32_t source_rank,
+        int32_t destination_rank,
         uint32_t shm_id);
 #endif
 

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -24,6 +24,23 @@
 #include "torch_npu/csrc/aten/common/from_blob.h"
 
 namespace vllm_ascend {
+#ifdef VLLM_ASCEND_ENABLE_MEMFABRIC_MTE
+    extern void kvpp_mte_batch_copy_pages_impl(
+        void* stream,
+        void* local_base_address,
+        void* physical_page_ids,
+        void* valid_page_mask,
+        void* staging_page_indices,
+        uint64_t page_descriptor_count,
+        uint64_t page_stride_bytes,
+        uint64_t page_length_bytes,
+        uint64_t staging_region_offset_bytes,
+        void* staging_base_address,
+        bool staging_is_source,
+        int32_t staging_group_rank,
+        uint32_t shm_id);
+#endif
+
   extern void bgmv_shrink_impl(
         AscendType type,
         void *stream,

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -256,74 +256,113 @@ void swap_blocks_batch(const torch::Tensor& src_ptrs,
 }
 
 #ifdef VLLM_ASCEND_ENABLE_MEMFABRIC_MTE
-void kvpp_mte_copy(const torch::Tensor& base_tensor,
-                   const torch::Tensor& physical_page_ids,
-                   const torch::Tensor& valid_page_mask,
-                   const torch::Tensor& staging_page_indices,
-                   int64_t page_stride_bytes,
-                   int64_t page_length_bytes,
-                   int64_t staging_region_offset_bytes,
-                   int64_t staging_base_address,
-                   bool staging_is_source,
-                   int64_t staging_group_rank,
+namespace {
+// MemFabric GVA is a raw device address rather than an aclTensor allocation.
+// Keep the ACLNN-style two phases, but launch the AscendC data plane directly
+// in phase two so the GVA is passed to the kernel without address rebinding.
+struct KvppMteCopyExecutor {
+    void* local_base;
+    void* local_offsets;
+    void* staging_offsets;
+    void* lengths;
+    uint64_t descriptor_count;
+    void* staging_base;
+    int32_t source_rank;
+    int32_t destination_rank;
+    uint32_t shm_id;
+};
+
+aclError aclnnKvppMteCopyGetWorkspaceSize(
+    const torch::Tensor& anchor, const torch::Tensor& local_offsets,
+    const torch::Tensor& staging_offsets, const torch::Tensor& lengths,
+    int64_t staging_base, int64_t source_rank, int64_t destination_rank,
+    int64_t shm_id, uint64_t* workspace_size,
+    KvppMteCopyExecutor* executor)
+{
+    *workspace_size = 0;
+    *executor = KvppMteCopyExecutor{
+        anchor.data_ptr(), local_offsets.data_ptr<int64_t>(),
+        staging_offsets.data_ptr<int64_t>(), lengths.data_ptr<int64_t>(),
+        static_cast<uint64_t>(local_offsets.numel()),
+        reinterpret_cast<void*>(staging_base),
+        static_cast<int32_t>(source_rank),
+        static_cast<int32_t>(destination_rank),
+        static_cast<uint32_t>(shm_id)};
+    return ACL_SUCCESS;
+}
+
+aclError aclnnKvppMteCopy(void* workspace, uint64_t workspace_size,
+                          const KvppMteCopyExecutor* executor,
+                          aclrtStream stream)
+{
+    (void)workspace;
+    (void)workspace_size;
+    kvpp_mte_batch_copy_pages_impl(
+        stream, executor->local_base, executor->local_offsets,
+        executor->staging_offsets, executor->lengths,
+        executor->descriptor_count, executor->staging_base,
+        executor->source_rank, executor->destination_rank,
+        executor->shm_id);
+    return ACL_SUCCESS;
+}
+}  // namespace
+
+void kvpp_mte_copy(const torch::Tensor& anchor,
+                   const torch::Tensor& local_offsets,
+                   const torch::Tensor& staging_offsets,
+                   const torch::Tensor& lengths,
+                   int64_t staging_base,
+                   int64_t source_rank,
+                   int64_t destination_rank,
                    int64_t shm_id)
 {
-    TORCH_CHECK(base_tensor.is_privateuseone(),
-                "base_tensor must be an NPU tensor");
-    TORCH_CHECK(physical_page_ids.is_privateuseone() &&
-                    valid_page_mask.is_privateuseone() &&
-                    staging_page_indices.is_privateuseone(),
-                "KVPP active-page tensors must be NPU tensors");
-    TORCH_CHECK(physical_page_ids.device() == base_tensor.device() &&
-                    valid_page_mask.device() == base_tensor.device() &&
-                    staging_page_indices.device() == base_tensor.device(),
-                "KVPP active-page tensors and base_tensor must share one NPU device");
-    TORCH_CHECK(physical_page_ids.dtype() == torch::kInt64,
-                "physical_page_ids must be int64");
-    TORCH_CHECK(valid_page_mask.dtype() == torch::kBool,
-                "valid_page_mask must be bool");
-    TORCH_CHECK(staging_page_indices.dtype() == torch::kInt64,
-                "staging_page_indices must be int64");
-    TORCH_CHECK(physical_page_ids.dim() == 1 &&
-                    valid_page_mask.dim() == 1 &&
-                    staging_page_indices.dim() == 1,
-                "KVPP active-page tensors must be one-dimensional");
-    const int64_t page_descriptor_count = physical_page_ids.numel();
-    TORCH_CHECK(valid_page_mask.numel() == page_descriptor_count &&
-                    staging_page_indices.numel() == page_descriptor_count,
-                "KVPP active-page tensor lengths must match");
-    TORCH_CHECK(physical_page_ids.is_contiguous() &&
-                    valid_page_mask.is_contiguous() &&
-                    staging_page_indices.is_contiguous(),
-                "KVPP active-page tensors must be contiguous");
-    TORCH_CHECK(page_stride_bytes > 0,
-                "page_stride_bytes must be positive");
-    TORCH_CHECK(page_length_bytes > 0,
-                "page_length_bytes must be positive");
-    TORCH_CHECK(staging_region_offset_bytes >= 0,
-                "staging_region_offset_bytes must be non-negative");
-    TORCH_CHECK(staging_base_address > 0,
-                "staging_base_address must be positive");
-    TORCH_CHECK(staging_group_rank >= 0,
-                "staging_group_rank must be non-negative");
-
-    const c10_npu::OptionalNPUGuard npu_guard(base_tensor.device());
-    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
-    if (page_descriptor_count != 0) {
-        kvpp_mte_batch_copy_pages_impl(
-            stream, base_tensor.data_ptr(),
-            physical_page_ids.data_ptr<int64_t>(),
-            valid_page_mask.data_ptr<bool>(),
-            staging_page_indices.data_ptr<int64_t>(),
-            static_cast<uint64_t>(page_descriptor_count),
-            static_cast<uint64_t>(page_stride_bytes),
-            static_cast<uint64_t>(page_length_bytes),
-            static_cast<uint64_t>(staging_region_offset_bytes),
-            reinterpret_cast<void*>(staging_base_address),
-            staging_is_source,
-            static_cast<int32_t>(staging_group_rank),
-            static_cast<uint32_t>(shm_id));
+    TORCH_CHECK(anchor.is_privateuseone(), "anchor must be an NPU tensor");
+    TORCH_CHECK(local_offsets.is_privateuseone() &&
+                    staging_offsets.is_privateuseone() &&
+                    lengths.is_privateuseone(),
+                "KVPP MTE descriptors must be NPU tensors");
+    TORCH_CHECK(local_offsets.device() == anchor.device() &&
+                    staging_offsets.device() == anchor.device() &&
+                    lengths.device() == anchor.device(),
+                "KVPP MTE descriptors and anchor must share one NPU device");
+    TORCH_CHECK(local_offsets.dtype() == torch::kInt64 &&
+                    staging_offsets.dtype() == torch::kInt64 &&
+                    lengths.dtype() == torch::kInt64,
+                "KVPP MTE descriptors must be int64");
+    TORCH_CHECK(local_offsets.dim() == 1 && staging_offsets.dim() == 1 &&
+                    lengths.dim() == 1,
+                "KVPP MTE descriptors must be one-dimensional");
+    const int64_t descriptor_count = local_offsets.numel();
+    TORCH_CHECK(staging_offsets.numel() == descriptor_count &&
+                    lengths.numel() == descriptor_count,
+                "KVPP MTE descriptor lengths must match");
+    TORCH_CHECK(local_offsets.is_contiguous() &&
+                    staging_offsets.is_contiguous() &&
+                    lengths.is_contiguous(),
+                "KVPP MTE descriptors must be contiguous");
+    TORCH_CHECK(staging_base > 0, "staging_base must be positive");
+    TORCH_CHECK(source_rank >= -1 && destination_rank >= -1 &&
+                    ((source_rank >= 0) != (destination_rank >= 0)),
+                "exactly one KVPP MTE endpoint must be SHM staging");
+    TORCH_CHECK(shm_id >= 0 && shm_id < 64,
+                "KVPP MTE shm_id must be in [0, 64)");
+    if (descriptor_count == 0) {
+        return;
     }
+
+    const c10_npu::OptionalNPUGuard npu_guard(anchor.device());
+    uint64_t workspace_size = 0;
+    KvppMteCopyExecutor executor{};
+    aclError status = aclnnKvppMteCopyGetWorkspaceSize(
+        anchor, local_offsets, staging_offsets, lengths, staging_base,
+        source_rank, destination_rank, shm_id, &workspace_size, &executor);
+    TORCH_CHECK(status == ACL_SUCCESS,
+                "aclnnKvppMteCopyGetWorkspaceSize failed: ", status);
+
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    status = aclnnKvppMteCopy(
+        nullptr, workspace_size, &executor, stream);
+    TORCH_CHECK(status == ACL_SUCCESS, "aclnnKvppMteCopy failed: ", status);
 }
 #endif
 
@@ -2101,11 +2140,9 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
 
 #ifdef VLLM_ASCEND_ENABLE_MEMFABRIC_MTE
     ops.def(
-        "kvpp_mte_copy(Tensor base_tensor, Tensor physical_page_ids, "
-        "Tensor valid_page_mask, Tensor staging_page_indices, "
-        "int page_stride_bytes, int page_length_bytes, "
-        "int staging_region_offset_bytes, int staging_base_address, "
-        "bool staging_is_source, int staging_group_rank, int shm_id) -> ()");
+        "kvpp_mte_copy(Tensor(a!) anchor, Tensor local_offsets, "
+        "Tensor staging_offsets, Tensor lengths, int staging_base, "
+        "int source_rank, int destination_rank, int shm_id) -> ()");
     ops.impl("kvpp_mte_copy", torch::kPrivateUse1,
              &vllm_ascend::kvpp_mte_copy);
 #endif

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -255,6 +255,78 @@ void swap_blocks_batch(const torch::Tensor& src_ptrs,
     }
 }
 
+#ifdef VLLM_ASCEND_ENABLE_MEMFABRIC_MTE
+void kvpp_mte_copy(const torch::Tensor& base_tensor,
+                   const torch::Tensor& physical_page_ids,
+                   const torch::Tensor& valid_page_mask,
+                   const torch::Tensor& staging_page_indices,
+                   int64_t page_stride_bytes,
+                   int64_t page_length_bytes,
+                   int64_t staging_region_offset_bytes,
+                   int64_t staging_base_address,
+                   bool staging_is_source,
+                   int64_t staging_group_rank,
+                   int64_t shm_id)
+{
+    TORCH_CHECK(base_tensor.is_privateuseone(),
+                "base_tensor must be an NPU tensor");
+    TORCH_CHECK(physical_page_ids.is_privateuseone() &&
+                    valid_page_mask.is_privateuseone() &&
+                    staging_page_indices.is_privateuseone(),
+                "KVPP active-page tensors must be NPU tensors");
+    TORCH_CHECK(physical_page_ids.device() == base_tensor.device() &&
+                    valid_page_mask.device() == base_tensor.device() &&
+                    staging_page_indices.device() == base_tensor.device(),
+                "KVPP active-page tensors and base_tensor must share one NPU device");
+    TORCH_CHECK(physical_page_ids.dtype() == torch::kInt64,
+                "physical_page_ids must be int64");
+    TORCH_CHECK(valid_page_mask.dtype() == torch::kBool,
+                "valid_page_mask must be bool");
+    TORCH_CHECK(staging_page_indices.dtype() == torch::kInt64,
+                "staging_page_indices must be int64");
+    TORCH_CHECK(physical_page_ids.dim() == 1 &&
+                    valid_page_mask.dim() == 1 &&
+                    staging_page_indices.dim() == 1,
+                "KVPP active-page tensors must be one-dimensional");
+    const int64_t page_descriptor_count = physical_page_ids.numel();
+    TORCH_CHECK(valid_page_mask.numel() == page_descriptor_count &&
+                    staging_page_indices.numel() == page_descriptor_count,
+                "KVPP active-page tensor lengths must match");
+    TORCH_CHECK(physical_page_ids.is_contiguous() &&
+                    valid_page_mask.is_contiguous() &&
+                    staging_page_indices.is_contiguous(),
+                "KVPP active-page tensors must be contiguous");
+    TORCH_CHECK(page_stride_bytes > 0,
+                "page_stride_bytes must be positive");
+    TORCH_CHECK(page_length_bytes > 0,
+                "page_length_bytes must be positive");
+    TORCH_CHECK(staging_region_offset_bytes >= 0,
+                "staging_region_offset_bytes must be non-negative");
+    TORCH_CHECK(staging_base_address > 0,
+                "staging_base_address must be positive");
+    TORCH_CHECK(staging_group_rank >= 0,
+                "staging_group_rank must be non-negative");
+
+    const c10_npu::OptionalNPUGuard npu_guard(base_tensor.device());
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    if (page_descriptor_count != 0) {
+        kvpp_mte_batch_copy_pages_impl(
+            stream, base_tensor.data_ptr(),
+            physical_page_ids.data_ptr<int64_t>(),
+            valid_page_mask.data_ptr<bool>(),
+            staging_page_indices.data_ptr<int64_t>(),
+            static_cast<uint64_t>(page_descriptor_count),
+            static_cast<uint64_t>(page_stride_bytes),
+            static_cast<uint64_t>(page_length_bytes),
+            static_cast<uint64_t>(staging_region_offset_bytes),
+            reinterpret_cast<void*>(staging_base_address),
+            staging_is_source,
+            static_cast<int32_t>(staging_group_rank),
+            static_cast<uint32_t>(shm_id));
+    }
+}
+#endif
+
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
 // Direct kernel wrappers depend on vllm_ascend_kernels, which is skipped on
 // 310P and A5 builds.
@@ -2027,6 +2099,17 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "                               Tensor? gk=None) -> Tensor");
     ops.impl("npu_recurrent_gated_delta_rule", torch::kPrivateUse1, &vllm_ascend::npu_recurrent_gated_delta_rule);
 
+#ifdef VLLM_ASCEND_ENABLE_MEMFABRIC_MTE
+    ops.def(
+        "kvpp_mte_copy(Tensor base_tensor, Tensor physical_page_ids, "
+        "Tensor valid_page_mask, Tensor staging_page_indices, "
+        "int page_stride_bytes, int page_length_bytes, "
+        "int staging_region_offset_bytes, int staging_base_address, "
+        "bool staging_is_source, int staging_group_rank, int shm_id) -> ()");
+    ops.impl("kvpp_mte_copy", torch::kPrivateUse1,
+             &vllm_ascend::kvpp_mte_copy);
+#endif
+
     ops.def(
         "recurrent_kda(Tensor query, Tensor key, Tensor value, Tensor gate, Tensor beta, "
         "Tensor(a!) initial_state, Tensor cu_seqlens, Tensor ssm_state_indices, Tensor A_log, Tensor dt_bias, *, "
@@ -2057,9 +2140,9 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "              bool activate_left=False, "
         "              int dst_type=36) -> (Tensor y, Tensor mxscale)");
     ops.impl("situ_mx_quant", torch::kPrivateUse1, &vllm_ascend::situ_mx_quant);
-
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
     // Direct kernel custom ops
+
     ops.def("bgmv_shrink(Tensor! x, Tensor! weight, Tensor! indices, Tensor! y, float scale) -> ()");
     ops.impl("bgmv_shrink", torch::kPrivateUse1, &vllm_ascend::bgmv_shrink);
 

--- a/docs/source/developer_guide/Design_Documents/kv_layer_parallel.md
+++ b/docs/source/developer_guide/Design_Documents/kv_layer_parallel.md
@@ -1,0 +1,335 @@
+# KV Layer Parallelism
+
+KV Layer Parallelism (KVPP) partitions persistent KV-cache ownership by
+transformer layer. Each KVPP rank owns a contiguous bundle of layers and keeps
+two alternating scratch caches for layers owned by another rank. Before attention
+executes, the owner pushes only the physical KV pages used by the current batch
+into the corresponding page IDs of each peer's scratch cache.
+
+KVPP is not limited to decode. The same ownership and transfer rules apply to
+prefill, decode, and mixed batches.
+
+This document describes Ascend-owned configuration, worker-local cache
+planning, Model Runner V1 and V2 execution, and active-page transport.
+
+## Goals
+
+KVPP is designed to:
+
+- Reduce per-rank KV-cache memory by distributing persistent layer ownership.
+- Reuse the existing TP/PCP rank layout without expanding the process world.
+- Keep the scheduler's physical block-table and slot-mapping semantics intact.
+- Transfer only pages that the current batch can read.
+- Avoid whole-layer KV broadcasts and whole-layer staging allocations.
+- Keep upstream vLLM unchanged and contain configuration, placement, and
+  transport policy in vLLM Ascend.
+
+The implementation uses exactly two alternating scratch buffers and one fixed
+schedule: while layer N executes, layer N+1 is transferred into the other
+scratch buffer. There is no blocking baseline or runtime overlap-mode switch.
+
+## KVPP, DCP, and PP
+
+KVPP reuses the rank-construction rule used by Decode Context Parallelism
+(DCP), but it has different semantics.
+
+| Property | DCP | KVPP |
+| --- | --- | --- |
+| Partition axis | Token sequence | Transformer layer |
+| Persistent KV ownership | Sequence shard | Contiguous layer bundle |
+| Process world expansion | No | No |
+| Block-table behavior | Sequence-local layout | Original physical page IDs |
+| Limited to decode | No | No |
+
+The Ascend parallel-state module constructs a separate `kvpp`
+`GroupCoordinator`. DCP and KVPP cannot both have a world size greater than
+one. This prevents the KV cache from being partitioned along both layer and
+sequence dimensions by independent paths.
+
+KVPP's contiguous layer assignment resembles Pipeline Parallelism (PP), but
+it partitions cache ownership only within the layers local to each PP stage.
+KVPP does not change activation pipelining. MTP caches that appear in a
+worker's local layer list remain unpartitioned by KVPP and are allocated in
+full on every KVPP rank on that stage. KVPP does not assume those layers live
+only on the last PP rank.
+
+## Configuration and process groups
+
+KVPP is configured with:
+
+```text
+--additional-config '{"enable_kvpp": true}'
+```
+
+`KVPPConfig` is owned by vLLM Ascend. When enabled, the KVPP size is always
+equal to the tensor-parallel size; when disabled, its internal size is one.
+
+`init_ascend_model_parallel()` creates the group and exposes it through
+`vllm_ascend.distributed.parallel_state.get_kvpp_group()`. Ascend destroys it
+together with its other platform-owned communication groups.
+
+The generic vLLM rank layout allows a KVPP group to be disabled, span the PCP
+axis, or span the complete TP x PCP block. PCP plus KVPP is not enabled in the
+initial vLLM Ascend implementation.
+
+## Layer ownership
+
+The vLLM cache planner extracts the layer index from each logical cache name
+and groups cache entries with the same index into one layer bundle. Bundles are
+sorted by layer index and divided into contiguous partitions. If the layer
+count is not divisible by the KVPP size, lower ranks receive one additional
+bundle.
+
+For eight local layers and `TP=KVPP=2`, the ownership is:
+
+```text
+rank 0: layers 0-3
+rank 1: layers 4-7
+```
+
+It is deliberately not interleaved. Contiguous ownership reduces owner
+switches during forward execution and provides a natural basis for future
+next-layer prefetching.
+
+Ownership is deterministic. Each Ascend worker computes its physical cache
+specification from the same model configuration and logical cache names. The
+worker restores the complete logical cache groups before runtime
+initialization, so no KVPP fields are added to upstream `KVCacheConfig`.
+
+The number of layer bundles must be at least the KVPP world size.
+
+## KV-cache allocation
+
+Each rank physically allocates:
+
+- Persistent caches for all layers owned by that rank.
+- Two alternating scratch caches for all non-owned layers in each KV-cache
+  group.
+
+The logical names of non-owned layers are assigned alternately to the two
+scratch tensors through their `shared_by` lists. Consequently, the existing
+cache binding mechanism presents the correct scratch storage without changing
+the model's logical layer names.
+
+All non-owned layers sharing a scratch cache must have identical cache specs.
+The planner rejects a group containing incompatible shapes, dtypes, or cache
+layouts. The initial Ascend implementation further requires exactly one
+KV-cache group and a non-hybrid MLA model.
+
+For `L` uniform layers and a KVPP world size `K`, a rank uses approximately:
+
+```text
+L / K persistent layer caches + 2 scratch layer caches
+```
+
+The final block count is reduced to the minimum block count calculated for any
+worker so that all ranks expose the same physical page address space.
+
+## Metadata invariants
+
+KVPP preserves the scheduler's original physical block table and slot mapping.
+The batch metadata order is:
+
+1. Gather the original block table.
+2. Derive the batch's active physical pages from the CPU block-table mirror.
+3. Pass the original device block table to attention.
+4. Compute slot mapping from the original table and positions.
+5. Pass the original slot mapping to the cache-write operators.
+
+The initial implementation therefore has identity views:
+
+```python
+block_table_view(default) is default
+slot_mapping_view(physical) is physical
+```
+
+An owner page with physical ID `P` is written directly to page `P` of each
+peer's scratch cache. There is no compact block table, page renumbering, or
+KVPP-specific slot-mapping rewrite. This keeps model-specific slot-mapping
+logic isolated from KVPP.
+
+## Active-page selection
+
+KVPP combines the device block table with host-resident sequence lengths to
+build fixed-shape MTE descriptors without a device-to-host synchronization.
+
+For every request:
+
+```text
+pages_in_request = ceil(sequence_length / block_size)
+```
+
+Only block-table entries covered by this range are selected. Invalid page IDs
+are discarded, and the remaining IDs are deduplicated and sorted. Transfers
+therefore exclude unreferenced capacity and do not copy an entire cache layer.
+
+## Architecture boundaries
+
+The implementation has four one-way layers:
+
+1. The common Ascend worker owns `KVPPConfig`, the KVPP process group, owner
+   calculation, physical cache planning, and scratch aliases. It returns the
+   worker-local physical spec to the unmodified vLLM allocator and restores the
+   logical view before model-runner initialization.
+2. The Ascend model runner is the composition root. It discovers executable
+   attention layers, creates the MTE transport, injects it into
+   `KVPPScheduler`, and binds the scheduler through the attention
+   implementation's layerwise cache hook.
+3. `KVPPScheduler` owns active-page selection, forward lifecycle,
+   one-layer-ahead prefetch, scratch lifetime, and cross-rank notifications.
+4. `MemFabricMTEKVPPTransport` owns registration, cache metadata, staging,
+   MTE copies, unpack, and transport completion.
+
+Attention implementations use one layerwise operation: `wait_for_layer`.
+They do not
+import or understand KVPP, MemFabric, ownership, scratch buffers, or MTE. This
+is the stable extension boundary for future layerwise cache services.
+
+The scheduler depends directly on `MemFabricMTEKVPPTransport`; there is no
+unused transport protocol or backend-selection layer. MemFabric MTE is the
+only data plane. Owners
+copy selected persistent pages into each consumer's bounded symmetric staging
+segment; consumers then unpack those pages into the original physical IDs of
+their current scratch buffer.
+
+KVPP-specific placement algorithms are isolated in
+`vllm_ascend/core/kv_cache_placement.py` and invoked by the common Ascend
+worker. Transport and runtime lifecycle code never enter vLLM core.
+
+Before vLLM starts, make the installed MemFabric Hybrid package available and
+configure its store:
+
+```bash
+export MEMFABRIC_HYBRID_HOME_PATH=<installed-memfabric-hybrid-path>
+export MF_CONFIG_STORE_URL=<store-url>
+```
+
+The staging capacity and MTE core count remain configurable through the MTE
+configuration variables. There is no transport-backend selection variable.
+
+## Execution flow
+
+The batch and layer execution flow is:
+
+```mermaid
+sequenceDiagram
+    participant Scheduler
+    participant Compute as Compute stream
+    participant Host as Host / CPU group
+    participant MTE as MemFabric MTE stream
+    participant Attention
+
+    Scheduler->>Compute: Original block table and slot mapping
+    Scheduler->>Host: Fixed-shape active-page descriptors
+    Compute->>Host: Record scratch-safe event
+    Host->>MTE: Prefetch layer N+1 to alternate scratch
+    Compute->>Compute: Execute layer N projections
+    Host->>MTE: Wait for residual transfer of layer N
+    MTE->>Compute: Unpack staging into physical page IDs
+    Compute->>Compute: Project and write current-token KV
+    Compute->>Attention: Execute attention
+```
+
+The first layer starts its transfer in `begin_forward`. Once a
+layer's transfer is remotely visible, KVPP immediately starts the next layer's
+transfer into the alternate scratch buffer. Current-token KV writes and
+attention wait only for the residual part of the current transfer.
+
+All ranks compute the current token's KV values. On the owner, those writes
+land in the layer's persistent cache. On non-owners, they land in the shared
+scratch cache and may be overwritten after the layer completes. Thus only the
+owner retains the layer's long-term KV state.
+
+### SFA cache bundles
+
+Main SFA and Lightning Indexer caches form one transport bundle. MTE assigns
+non-overlapping staging ranges to every tensor in that bundle and uses the
+same layout for owner push and consumer unpack. This prevents the indexer push
+from overwriting Main KV before the consumer receives it.
+
+DSA-CP compatibility is intentionally deferred. Its KVPP lifecycle integration
+cannot be accepted until the prerequisite GLM sequence-parallel path is
+functionally validated. DCP remains unsupported with KVPP.
+
+## Correctness invariants
+
+The implementation maintains the following invariants:
+
+1. Every logical layer has exactly one KVPP owner.
+2. Only the owner's cache is persistent state for that layer.
+3. A non-owner scratch cache is valid only for the current layer execution.
+4. A scratch cache cannot be overwritten until all ranks finish the preceding
+   layer's attention.
+5. Current-token KV writes cannot race with the owner's historical-page push.
+6. Owner and destination use the same physical page ID.
+7. Only pages referenced by the current batch are transferred.
+8. KVPP does not change scheduler block allocation or slot-mapping semantics.
+9. Main and Indexer cache tensors use disjoint ranges in bundle staging.
+
+## Supported configuration
+
+The initial vLLM Ascend implementation requires:
+
+| Capability | Requirement |
+| --- | --- |
+| Model runner | Ascend Model Runner V2 |
+| Attention | Non-hybrid MLA |
+| KV-cache groups | One KVPP-managed Target group; MTP groups are allocated in full on each KVPP rank |
+| Execution mode | Eager |
+| Pipeline parallelism | Disabled |
+| PCP | Disabled |
+| DCP | Disabled when KVPP is enabled |
+| DSA-CP | Deferred pending SP validation |
+| Speculative decoding | Fixed-step MTP in eager mode |
+| KV connectors and offload | Disabled |
+| MemFabric protocol | MTE |
+
+Unsupported combinations fail during configuration or cache initialization
+rather than silently selecting a different cache layout.
+
+## Fixed overlap schedule
+
+Two scratch buffers alternate by transformer-layer index. A compute-stream
+event prevents reuse until the earlier attention consumer has been submitted.
+The communication worker exchanges per-layer ready/done notifications and
+runs MTE staging copy and unpack away from the model execution thread. The
+only supported schedule prefetches exactly one layer ahead.
+
+## Validation coverage
+
+The commits add tests for:
+
+- KVPP and DCP mutual exclusion.
+- KVPP overlay-group construction.
+- Contiguous layer ownership.
+- Owned caches plus two alternating scratch allocations.
+- Rejection of incompatible scratch specs.
+- CPU block-table access.
+- Active-page filtering, deduplication, and ordering.
+- MTE device descriptors for masked pages and multiple cache tensors.
+- Non-overlapping Main/Indexer bundle staging for SFA models.
+- Owner staging and consumer unpack into original physical page IDs.
+- Identity block-table and slot-mapping views.
+
+The supported target is a non-hybrid MLA model with `KVPP=TP`. Model Runner V1
+and V2, pipeline parallelism, fixed-length MTP, chunked prefill, prefix cache,
+expert parallelism, and sparse MLA/SFA cache layouts share the same placement
+model. DCP and PCP remain mutually exclusive with KVPP.
+
+## Related files
+
+vLLM Ascend:
+
+- Configuration: `KVPPConfig` in `vllm_ascend/ascend_config.py`
+- KVPP process group: `vllm_ascend/distributed/parallel_state.py`
+- Placement policy: `vllm_ascend/core/kv_cache_placement.py`
+- Worker integration: `vllm_ascend/worker/worker.py`
+- Feature validation: `vllm_ascend/platform.py`
+- Model Runner V1 integration: `vllm_ascend/worker/model_runner_v1.py`
+- Model Runner V1 KVPP adapter: `vllm_ascend/worker/kvpp_v1.py`
+- Model Runner V2 integration: `vllm_ascend/worker/v2/model_runner.py`
+- KVPP execution plan, batch lifecycle, and scheduler:
+  `vllm_ascend/worker/v2/kvpp.py`
+- MemFabric MTE transport:
+  `vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py`
+- MLA attention integration: `vllm_ascend/attention/mla_v1.py`

--- a/docs/source/developer_guide/Design_Documents/kv_layer_parallel.md
+++ b/docs/source/developer_guide/Design_Documents/kv_layer_parallel.md
@@ -119,11 +119,41 @@ KV-cache group and a non-hybrid MLA model.
 For `L` uniform layers and a KVPP world size `K`, a rank uses approximately:
 
 ```text
-L / K persistent layer caches + 2 scratch layer caches
+L / K persistent layer caches + 2 scratch layer caches + 1 staging layer bundle
 ```
 
 The final block count is reduced to the minimum block count calculated for any
 worker so that all ranks expose the same physical page address space.
+
+Staging is included in the post-profile memory budget, not allocated outside
+`gpu_memory_utilization`. The Ascend worker obtains the physical KV bytes per
+block from the existing allocator (including scratch, MTP and layout padding),
+and reserves one complete largest managed layer bundle per block for staging.
+The bundle includes both MLA KV and indexer caches when applicable. Layers
+reuse the same staging allocation; MTP caches are not transferred.
+Scratch allocation still uses each corresponding layer's original KV spec.
+Different owners may therefore have different scratch layouts or counts.
+The equal-sized MemFabric SHM contribution covers the largest transferable
+bundle in the KVPP group, not the sum of a rank's persistent or scratch caches.
+
+For an available budget `B`, physical KV bytes per block `C`, and staging
+bytes per block `S`, choose the largest integer `N` satisfying
+`N * C + align_up(N * S, 2 MiB) <= B`. Only `N * C` is returned to the upstream
+KV planner. After upstream reduces the block count across workers, the Ascend
+worker derives the aligned staging size from that final count and passes it
+to the transport. No upstream configuration fields or
+scheduler changes are needed. An explicit `kv_cache_memory_bytes` budget also
+includes staging when KVPP is enabled; an oversized block-count override is
+rejected at the worker's budget entry point, before the engine applies it.
+Elastic EP scale-up launches skip this memory-planning entry point and are
+therefore rejected when KVPP is enabled; ordinary EP remains supported.
+
+The transport checks the real cache tensors against this reservation and
+requires identical staging capacities and per-bundle wire layouts within each
+KVPP group before creating shared memory. This is a MemFabric/transfer
+requirement, not a requirement that rank-local scratch allocations match.
+Local tensor addresses and strides may differ. Staging covers all physical pages like one scratch bundle,
+but each transfer still copies only active pages.
 
 ## Metadata invariants
 
@@ -204,8 +234,9 @@ export MEMFABRIC_HYBRID_HOME_PATH=<installed-memfabric-hybrid-path>
 export MF_CONFIG_STORE_URL=<store-url>
 ```
 
-The staging capacity and MTE core count remain configurable through the MTE
-configuration variables. There is no transport-backend selection variable.
+Staging capacity is planned automatically; `ASCEND_KVPP_MTE_STAGING_BYTES`
+has been removed and no longer controls allocation. The MTE core count remains
+configurable. There is no transport-backend selection variable.
 
 ## Execution flow
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -335,6 +335,7 @@ nav:
         - developer_guide/Design_Documents/KV_Cache_Pool_Guide.md
         - developer_guide/Design_Documents/add_custom_aclnn_op.md
         - developer_guide/Design_Documents/context_parallel.md
+        - developer_guide/Design_Documents/kv_layer_parallel.md
         - developer_guide/Design_Documents/balance_schedule_refactor.md
         - developer_guide/Design_Documents/dynamic_chunked_pipeline_parallel.md
         - developer_guide/Design_Documents/quantization.md

--- a/tests/e2e/coverage_taxonomy.py
+++ b/tests/e2e/coverage_taxonomy.py
@@ -74,6 +74,7 @@ ALLOWED_VALUES: dict[str, set[str]] = {
         "dynamic_eplb",
         "multistream_moe",
         "mo_routing_replay",
+        "kvpp",
     },
     "parallel": {
         "TP",

--- a/tests/e2e/pull_request/two_card/test_kvpp.py
+++ b/tests/e2e/pull_request/two_card/test_kvpp.py
@@ -1,0 +1,98 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Eager KV layer parallelism on two NPUs with DeepSeek-V2-Lite-W8A8.
+
+KVPP size equals TP, so this needs at least two cards. MemFabric MTE must be
+installed on the runner; otherwise the test is skipped.
+
+Chunked prefill and prefix caching are both on. Prompts share a long prefix so
+the second+ requests can hit the prefix cache; ``max_num_batched_tokens`` is
+kept below that prefix length so prefill is actually chunked.
+
+Run `pytest tests/e2e/pull_request/two_card/test_kvpp.py`.
+"""
+
+import pytest
+
+from tests.e2e.conftest import ModelName, wait_until_npu_memory_free
+from tests.e2e.pull_request.utils import compare_logprobs
+
+MODEL = ModelName.DEEPSEEK
+
+# Shared prefix is long enough that 128 batched tokens cannot cover it in one
+# prefill chunk. Four suffixes share the prefix so later requests can hit cache.
+_SHARED_PREFIX = (
+    "You are a helpful assistant that answers briefly. Read the following context and continue the sentence. "
+) * 16
+PROMPTS = [
+    _SHARED_PREFIX + "Hello, my name is",
+    _SHARED_PREFIX + "The president of the United States is",
+    _SHARED_PREFIX + "The capital of France is",
+    _SHARED_PREFIX + "The future of AI is",
+]
+
+
+def _require_memfabric_mte() -> None:
+    memfabric_hybrid = pytest.importorskip("memfabric_hybrid")
+    if not hasattr(memfabric_hybrid, "shm"):
+        pytest.skip("KVPP MTE requires memfabric_hybrid.shm")
+
+
+@pytest.mark.e2e_model(MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="kvpp,prefix_caching,chunked_prefill",
+    parallel="TP,EP",
+    deploy="pd_mix",
+    hardware="A2",
+    quantization="W8A8",
+    graph_mode="eager",
+)
+@pytest.mark.parametrize(
+    "use_v2_runner",
+    [False, True],
+    ids=["mrv1", "mrv2"],
+)
+@wait_until_npu_memory_free(0.7)
+def test_deepseek_v2_lite_kvpp_tp2(use_v2_runner: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    _require_memfabric_mte()
+    monkeypatch.delenv("HCCL_OP_EXPANSION_MODE", raising=False)
+    if use_v2_runner:
+        monkeypatch.setenv("VLLM_USE_V2_MODEL_RUNNER", "1")
+    else:
+        monkeypatch.delenv("VLLM_USE_V2_MODEL_RUNNER", raising=False)
+
+    # `additional_config` is excluded from the eager baseline by
+    # compare_logprobs, so the baseline runs without KVPP.
+    compare_logprobs(
+        runner_kwargs={
+            "model_name": MODEL,
+            "max_model_len": 1024,
+            "max_num_batched_tokens": 128,
+            "enforce_eager": True,
+            "tensor_parallel_size": 2,
+            "enable_expert_parallel": True,
+            "enable_chunked_prefill": True,
+            "enable_prefix_caching": True,
+            "quantization": "ascend",
+            "gpu_memory_utilization": 0.7,
+            "distributed_executor_backend": "mp",
+            "additional_config": {"enable_kvpp": True},
+        },
+        prompts=PROMPTS,
+    )

--- a/tests/ut/attention/test_kvpp_attention_lifecycle.py
+++ b/tests/ut/attention/test_kvpp_attention_lifecycle.py
@@ -1,0 +1,43 @@
+import inspect
+
+from vllm_ascend.attention.mla_v1 import AscendMLAImpl
+from vllm_ascend.attention.sfa_v1 import AscendSFAImpl
+
+
+def _ordered(source: str, *markers: str) -> None:
+    positions = [source.index(marker) for marker in markers]
+    assert positions == sorted(positions), dict(zip(markers, positions))
+
+
+def test_attn_01_mla_kvpp_lifecycle_wraps_cache_consumption():
+    forward = inspect.getsource(AscendMLAImpl.forward)
+    preprocess = inspect.getsource(AscendMLAImpl._mla_preprocess)
+
+    assert ".enter_layer(" not in forward
+    assert ".leave_layer(" not in forward
+    _ordered(
+        forward,
+        "self._mla_preprocess(",
+        "self._forward_decode(",
+    )
+    _ordered(
+        preprocess,
+        "self.fused_qkv_a_proj(hidden_states)",
+        ".wait_for_layer(layer_name)",
+        "self.mla_preprocess_decode(",
+    )
+
+
+def test_sfa_01_main_and_indexer_share_one_kvpp_lifecycle():
+    source = inspect.getsource(AscendSFAImpl.forward)
+
+    assert ".enter_layer(" not in source
+    assert ".leave_layer(" not in source
+    assert source.count(".wait_for_layer(layer_name)") == 2
+    _ordered(
+        source,
+        "self.indexer_select_pre_process(",
+        ".wait_for_layer(layer_name)",
+        "self.exec_kv(",
+        "self._execute_sparse_flash_attention_process(",
+    )

--- a/tests/ut/core/test_kvpp_cache_placement.py
+++ b/tests/ut/core/test_kvpp_cache_placement.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+
+import torch
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheTensor,
+    MLAAttentionSpec,
+)
+
+from vllm_ascend.core.kv_cache_placement import (
+    build_cache_allocation_groups,
+    create_kvpp_cache_allocation_plan,
+    map_kvpp_layers_to_owners,
+)
+
+
+def _config(*, mtp: bool = False, layers: int = 5):
+    return SimpleNamespace(
+        additional_config={"enable_kvpp": True},
+        parallel_config=SimpleNamespace(
+            pipeline_parallel_size=1,
+            tensor_parallel_size=2,
+        ),
+        scheduler_config=SimpleNamespace(disable_hybrid_kv_cache_manager=False),
+        speculative_config=SimpleNamespace(method="mtp") if mtp else None,
+        model_config=SimpleNamespace(
+            hf_config=SimpleNamespace(
+                num_hidden_layers=layers,
+                num_nextn_predict_layers=1,
+            )
+        ),
+    )
+
+
+def _spec():
+    return MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=128,
+        dtype=torch.float16,
+    )
+
+
+def _target(index: int) -> str:
+    return f"model.layers.{index}.self_attn.attn"
+
+
+def _indexer(index: int) -> str:
+    return f"model.layers.{index}.self_attn.indexer.k_cache"
+
+
+def test_kvpp_01_owner_is_deterministic_and_bundles_share_owner():
+    names = [name for i in range(5) for name in (_target(i), _indexer(i))]
+
+    forward = map_kvpp_layers_to_owners(_config(), names)
+    reverse = map_kvpp_layers_to_owners(_config(), reversed(names))
+
+    assert forward == reverse
+    assert all(forward[_target(i)] == forward[_indexer(i)] for i in range(5))
+
+
+def test_kvpp_02_remainder_partition_is_three_plus_two():
+    names = [_target(i) for i in range(5)]
+
+    owners = map_kvpp_layers_to_owners(_config(), names)
+
+    assert [owners[name] for name in names] == [0, 0, 0, 1, 1]
+
+
+def test_kvpp_03_keeps_mtp_unpartitioned_and_allocates_it_on_each_rank():
+    targets = [_target(i) for i in range(5)]
+    mtp = "model.layers.5.mtp_block.self_attn.attn"
+    worker_spec = dict.fromkeys([*targets, mtp], _spec())
+    config = _config(mtp=True)
+
+    owners = map_kvpp_layers_to_owners(config, worker_spec)
+    plans = [create_kvpp_cache_allocation_plan(config, worker_spec, rank) for rank in range(2)]
+
+    assert mtp not in owners
+    assert all(mtp in plan.physical_cache_spec for plan in plans)
+
+
+def test_kvpp_04_persistent_and_two_scratch_allocations_alias_round_robin():
+    names = [_target(i) for i in range(5)]
+    spec = _spec()
+    worker_spec = dict.fromkeys(names, spec)
+    group = KVCacheGroupSpec(names, spec)
+    owners = map_kvpp_layers_to_owners(_config(), names)
+
+    groups, scratch_layer_aliases = build_cache_allocation_groups([group], worker_spec, owners, kvpp_rank=1)
+
+    # Rank 1 owns two persistent layers; three foreign layers share exactly
+    # two alternating scratch tensors.
+    # Projection preserves logical group order; the physical set contains the
+    # two scratch tensors (0/1) plus this rank's persistent tensors (3/4).
+    assert groups[0].layer_names == [names[0], names[1], names[3], names[4]]
+    assert scratch_layer_aliases == {
+        names[0]: [names[0], names[2]],
+        names[1]: [names[1]],
+    }
+
+
+def test_kvpp_05_restores_logical_cache_view():
+    names = [_target(i) for i in range(5)]
+    worker_spec = dict.fromkeys(names, _spec())
+    plan = create_kvpp_cache_allocation_plan(_config(), worker_spec, kvpp_rank=1)
+    physical_names = list(plan.physical_cache_spec)
+    config = KVCacheConfig(
+        num_blocks=8,
+        kv_cache_tensors=[KVCacheTensor(size=1024, shared_by=[name]) for name in physical_names],
+        kv_cache_groups=[KVCacheGroupSpec(physical_names, _spec())],
+    )
+
+    plan.restore_logical_cache_view(config)
+
+    logical_tensor_names = {name for tensor in config.kv_cache_tensors for name in tensor.shared_by}
+    assert logical_tensor_names == set(names)
+    assert set(config.kv_cache_groups[0].layer_names) == set(names)

--- a/tests/ut/core/test_kvpp_cache_placement.py
+++ b/tests/ut/core/test_kvpp_cache_placement.py
@@ -1,6 +1,8 @@
 from types import SimpleNamespace
 
+import pytest
 import torch
+from vllm.v1.core.kv_cache_utils import get_kv_cache_config_from_groups
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
@@ -9,8 +11,11 @@ from vllm.v1.kv_cache_interface import (
 )
 
 from vllm_ascend.core.kv_cache_placement import (
+    KVPP_STAGING_ALIGNMENT_BYTES,
+    KVPPCacheMemoryBudget,
     build_cache_allocation_groups,
     create_kvpp_cache_allocation_plan,
+    kvpp_staging_size_bytes,
     map_kvpp_layers_to_owners,
 )
 
@@ -117,3 +122,70 @@ def test_kvpp_05_restores_logical_cache_view():
     logical_tensor_names = {name for tensor in config.kv_cache_tensors for name in tensor.shared_by}
     assert logical_tensor_names == set(names)
     assert set(config.kv_cache_groups[0].layer_names) == set(names)
+
+
+@pytest.mark.parametrize("available_bytes", [0, 1, (2 << 20) - 1, 2 << 20, 17 << 20, (1 << 40) + 17])
+def test_staging_budget_finds_maximum_fitting_block_count(available_bytes):
+    kv_page_bytes, staging_page_bytes = 57344, 12288
+    budget = KVPPCacheMemoryBudget.create(available_bytes, kv_page_bytes, staging_page_bytes)
+    count = budget.max_num_blocks
+    assert count * kv_page_bytes + kvpp_staging_size_bytes(staging_page_bytes, count) <= available_bytes
+    assert (count + 1) * kv_page_bytes + kvpp_staging_size_bytes(staging_page_bytes, count + 1) > available_bytes
+    assert isinstance(count, int)
+
+
+def test_staging_alignment_is_included_in_budget():
+    alignment = KVPP_STAGING_ALIGNMENT_BYTES
+    budget = KVPPCacheMemoryBudget.create(3 * alignment, alignment, alignment + 1)
+    assert budget.max_num_blocks == 1
+    assert kvpp_staging_size_bytes(alignment + 1, 1) == 2 * alignment
+
+
+def test_staging_budget_counts_one_bundle_and_excludes_mtp():
+    config = _config(mtp=True)
+    config.cache_config = SimpleNamespace(num_gpu_blocks_override=None, enable_cross_layers=False)
+    main_spec = _spec()
+    indexer_spec = MLAAttentionSpec(block_size=16, num_kv_heads=1, head_size=32, dtype=torch.float16)
+    worker_spec = {_target(i): main_spec for i in range(5)}
+    worker_spec.update({_indexer(i): indexer_spec for i in range(5)})
+    worker_spec["model.layers.5.mtp_block.self_attn.attn"] = main_spec
+    plan = create_kvpp_cache_allocation_plan(config, worker_spec, kvpp_rank=1)
+    assert plan.staging_page_size_bytes == main_spec.page_size_bytes + indexer_spec.page_size_bytes
+    budget = plan.plan_memory(config, 1 << 30)
+    assert budget.kv_page_size_bytes == sum(spec.page_size_bytes for spec in plan.physical_cache_spec.values())
+    assert config.cache_config.num_gpu_blocks_override is None
+    smaller_budget = plan.plan_memory(config, 1 << 28)
+    assert smaller_budget.max_num_blocks < budget.max_num_blocks
+
+
+def test_final_cross_rank_block_reduction_remains_inside_budget():
+    budget = KVPPCacheMemoryBudget.create(64 << 20, 65536, 16384)
+    for count in (1, budget.max_num_blocks // 2, budget.max_num_blocks):
+        assert count * 65536 + kvpp_staging_size_bytes(16384, count) <= 64 << 20
+
+
+def test_rank_local_scratch_specs_can_differ_without_changing_staging_requirement():
+    config = _config()
+    config.cache_config = SimpleNamespace(num_gpu_blocks_override=9, enable_cross_layers=False)
+    large = _spec()
+    small = MLAAttentionSpec(block_size=16, num_kv_heads=1, head_size=64, dtype=torch.float16)
+    worker_spec = {_target(i): large if i < 3 else small for i in range(5)}
+    plans = [create_kvpp_cache_allocation_plan(config, worker_spec, rank) for rank in range(2)]
+    allocations = [get_kv_cache_config_from_groups(config, plan.physical_cache_groups, 1 << 30) for plan in plans]
+    for rank, plan in enumerate(plans):
+        scratch_spec = small if rank == 0 else large
+        assert len(plan.scratch_layer_aliases) == 2
+        for name in plan.scratch_layer_aliases:
+            assert plan.physical_cache_spec[name] == scratch_spec
+            tensor = next(tensor for tensor in allocations[rank].kv_cache_tensors if name in tensor.shared_by)
+            assert tensor.size == 9 * scratch_spec.page_size_bytes
+        assert plan.staging_page_size_bytes == large.page_size_bytes
+    assert sum(tensor.size for tensor in allocations[0].kv_cache_tensors) != sum(
+        tensor.size for tensor in allocations[1].kv_cache_tensors
+    )
+
+
+def test_fractional_profile_budget_produces_integer_block_count():
+    budget = KVPPCacheMemoryBudget.create((17 << 20) + 0.75, 57344, 12288)
+    assert isinstance(budget.max_num_blocks, int)
+    assert budget == KVPPCacheMemoryBudget.create(17 << 20, 57344, 12288)

--- a/tests/ut/distributed/kv_transfer/test_kvpp_mte_transport.py
+++ b/tests/ut/distributed/kv_transfer/test_kvpp_mte_transport.py
@@ -19,11 +19,13 @@ def _make_active_pages() -> KVPPActivePages:
 
 
 def _make_transport(group_rank: int, copy_pages_op=None):
-    return MemFabricMTEKVPPTransport(
+    transport = MemFabricMTEKVPPTransport(
         SimpleNamespace(rank_in_group=group_rank, world_size=2),
         10,
         copy_pages_op=copy_pages_op or (lambda *args: None),
     )
+    transport._staging_shm_id = 31
+    return transport
 
 
 def _install_transfer_regions(transport):
@@ -61,6 +63,12 @@ def test_mte_02_bundle_staging_regions_are_disjoint():
     # indexer occupies [240, 320).
     assert offsets_by_bundle[("main", "indexer")] == {"main": (0, 160), "indexer": (240,)}
 
+    transport._staging_region_offsets_by_cache_bundle = offsets_by_bundle
+    plan = transport._build_device_transfer_plans((("main", "indexer"),))[("main", "indexer")]
+    assert plan.page_strides.tolist() == [32, 64, 16]
+    assert plan.page_lengths.tolist() == [16, 8, 8]
+    assert plan.staging_region_offsets.tolist() == [0, 160, 240]
+
 
 def test_mte_03_owner_pushes_to_peer_and_consumer_receives_locally(monkeypatch):
     class FakeEvent:
@@ -74,26 +82,23 @@ def test_mte_03_owner_pushes_to_peer_and_consumer_receives_locally(monkeypatch):
     calls = []
 
     def record_copy_pages(
-        base_tensor,
-        physical_page_ids,
-        valid_page_mask,
-        staging_page_indices,
-        page_stride_bytes,
-        page_length_bytes,
-        staging_region_offset_bytes,
-        staging_base_address,
-        staging_is_source,
-        staging_group_rank,
+        anchor,
+        local_offsets,
+        staging_offsets,
+        lengths,
+        staging_base,
+        source_rank,
+        destination_rank,
         shm_id,
     ):
         calls.append(
             (
-                page_stride_bytes,
-                page_length_bytes,
-                staging_region_offset_bytes,
-                staging_is_source,
-                staging_group_rank,
-                staging_base_address,
+                local_offsets.tolist(),
+                staging_offsets.tolist(),
+                lengths.tolist(),
+                source_rank,
+                destination_rank,
+                staging_base,
             )
         )
 
@@ -105,12 +110,33 @@ def test_mte_03_owner_pushes_to_peer_and_consumer_receives_locally(monkeypatch):
         MTEStagingRegion(9000, 320, 1),
     ]
     owner._staging_region_offsets_by_cache_bundle = owner._build_staging_region_offsets((("main", "indexer"),), 10)
+    owner._device_transfer_plans_by_cache_bundle = owner._build_device_transfer_plans((("main", "indexer"),))
 
     owner.copy_active_pages_to_staging(("main", "indexer"), _make_active_pages(), SimpleNamespace())
+    owner_plan = owner._device_transfer_plans_by_cache_bundle[("main", "indexer")]
+    base_offsets = owner_plan.local_base_offsets.tolist()
     assert calls == [
-        (32, 16, 0, False, 1, 9000),
-        (64, 8, 160, False, 1, 9000),
-        (16, 8, 240, False, 1, 9000),
+        (
+            [
+                base_offsets[0] + 64,
+                base_offsets[0] + 64,
+                base_offsets[0] + 224,
+                base_offsets[0] + 320,
+                base_offsets[1] + 128,
+                base_offsets[1] + 128,
+                base_offsets[1] + 448,
+                base_offsets[1] + 640,
+                base_offsets[2] + 32,
+                base_offsets[2] + 32,
+                base_offsets[2] + 112,
+                base_offsets[2] + 160,
+            ],
+            [0, 0, 16, 16, 160, 160, 168, 168, 240, 240, 248, 248],
+            [16, 0, 16, 0, 8, 0, 8, 0, 8, 0, 8, 0],
+            -1,
+            1,
+            9000,
+        )
     ]
 
     calls.clear()
@@ -124,10 +150,31 @@ def test_mte_03_owner_pushes_to_peer_and_consumer_receives_locally(monkeypatch):
     consumer._staging_region_offsets_by_cache_bundle = consumer._build_staging_region_offsets(
         (("main", "indexer"),), 10
     )
+    consumer._device_transfer_plans_by_cache_bundle = consumer._build_device_transfer_plans((("main", "indexer"),))
 
     consumer.copy_active_pages_from_staging(("main", "indexer"), _make_active_pages(), SimpleNamespace())
+    consumer_plan = consumer._device_transfer_plans_by_cache_bundle[("main", "indexer")]
+    base_offsets = consumer_plan.local_base_offsets.tolist()
     assert calls == [
-        (32, 16, 0, True, 1, 9000),
-        (64, 8, 160, True, 1, 9000),
-        (16, 8, 240, True, 1, 9000),
+        (
+            [
+                base_offsets[0] + 64,
+                base_offsets[0] + 64,
+                base_offsets[0] + 224,
+                base_offsets[0] + 320,
+                base_offsets[1] + 128,
+                base_offsets[1] + 128,
+                base_offsets[1] + 448,
+                base_offsets[1] + 640,
+                base_offsets[2] + 32,
+                base_offsets[2] + 32,
+                base_offsets[2] + 112,
+                base_offsets[2] + 160,
+            ],
+            [0, 0, 16, 16, 160, 160, 168, 168, 240, 240, 248, 248],
+            [16, 0, 16, 0, 8, 0, 8, 0, 8, 0, 8, 0],
+            1,
+            -1,
+            9000,
+        )
     ]

--- a/tests/ut/distributed/kv_transfer/test_kvpp_mte_transport.py
+++ b/tests/ut/distributed/kv_transfer/test_kvpp_mte_transport.py
@@ -1,0 +1,133 @@
+from types import SimpleNamespace
+
+import torch
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.memfabric_mte_transport import (
+    KVPPActivePages,
+    MemFabricMTEKVPPTransport,
+    MTEStagingRegion,
+    _MTETransferRegion,
+)
+
+
+def _make_active_pages() -> KVPPActivePages:
+    return KVPPActivePages(
+        torch.tensor([2, 2, 7, 10], dtype=torch.int64),
+        torch.tensor([True, False, True, False]),
+        torch.tensor([0, 0, 1, 1], dtype=torch.int64),
+    )
+
+
+def _make_transport(group_rank: int, copy_pages_op=None):
+    return MemFabricMTEKVPPTransport(
+        SimpleNamespace(rank_in_group=group_rank, world_size=2),
+        10,
+        copy_pages_op=copy_pages_op or (lambda *args: None),
+    )
+
+
+def _install_transfer_regions(transport):
+    transport._transfer_regions_by_cache = {
+        "main": (
+            _MTETransferRegion(base_tensor=torch.empty(1), page_stride_bytes=32, page_length_bytes=16),
+            _MTETransferRegion(base_tensor=torch.empty(1), page_stride_bytes=64, page_length_bytes=8),
+        ),
+        "indexer": (_MTETransferRegion(base_tensor=torch.empty(1), page_stride_bytes=16, page_length_bytes=8),),
+    }
+
+
+def test_mte_01_active_page_ordinals_are_fixed_shape():
+    pages = _make_active_pages()
+
+    assert pages.physical_page_ids.tolist() == [2, 2, 7, 10]
+    assert pages.valid_page_mask.tolist() == [True, False, True, False]
+    assert pages.staging_page_indices.tolist() == [0, 0, 1, 1]
+
+
+def test_mte_02_bundle_staging_regions_are_disjoint():
+    transport = _make_transport(0)
+    _install_transfer_regions(transport)
+    transport._staging_regions_by_rank = [
+        MTEStagingRegion(8000, 320, 0),
+        MTEStagingRegion(9000, 320, 1),
+    ]
+
+    offsets_by_bundle = transport._build_staging_region_offsets(
+        (("main", "indexer"),),
+        max_active_pages=10,
+    )
+
+    # Ten active-page slots: main's regions occupy [0, 240), while the
+    # indexer occupies [240, 320).
+    assert offsets_by_bundle[("main", "indexer")] == {"main": (0, 160), "indexer": (240,)}
+
+
+def test_mte_03_owner_pushes_to_peer_and_consumer_receives_locally(monkeypatch):
+    class FakeEvent:
+        def record(self, stream):
+            self.stream = stream
+
+        def synchronize(self):
+            pass
+
+    monkeypatch.setattr(torch.npu, "Event", FakeEvent)
+    calls = []
+
+    def record_copy_pages(
+        base_tensor,
+        physical_page_ids,
+        valid_page_mask,
+        staging_page_indices,
+        page_stride_bytes,
+        page_length_bytes,
+        staging_region_offset_bytes,
+        staging_base_address,
+        staging_is_source,
+        staging_group_rank,
+        shm_id,
+    ):
+        calls.append(
+            (
+                page_stride_bytes,
+                page_length_bytes,
+                staging_region_offset_bytes,
+                staging_is_source,
+                staging_group_rank,
+                staging_base_address,
+            )
+        )
+
+    owner = _make_transport(0, copy_pages_op=record_copy_pages)
+    _install_transfer_regions(owner)
+    owner._local_staging_region = MTEStagingRegion(8000, 320, 0)
+    owner._staging_regions_by_rank = [
+        owner._local_staging_region,
+        MTEStagingRegion(9000, 320, 1),
+    ]
+    owner._staging_region_offsets_by_cache_bundle = owner._build_staging_region_offsets((("main", "indexer"),), 10)
+
+    owner.copy_active_pages_to_staging(("main", "indexer"), _make_active_pages(), SimpleNamespace())
+    assert calls == [
+        (32, 16, 0, False, 1, 9000),
+        (64, 8, 160, False, 1, 9000),
+        (16, 8, 240, False, 1, 9000),
+    ]
+
+    calls.clear()
+    consumer = _make_transport(1, copy_pages_op=record_copy_pages)
+    _install_transfer_regions(consumer)
+    consumer._local_staging_region = MTEStagingRegion(9000, 320, 1)
+    consumer._staging_regions_by_rank = [
+        MTEStagingRegion(8000, 320, 0),
+        consumer._local_staging_region,
+    ]
+    consumer._staging_region_offsets_by_cache_bundle = consumer._build_staging_region_offsets(
+        (("main", "indexer"),), 10
+    )
+
+    consumer.copy_active_pages_from_staging(("main", "indexer"), _make_active_pages(), SimpleNamespace())
+    assert calls == [
+        (32, 16, 0, True, 1, 9000),
+        (64, 8, 160, True, 1, 9000),
+        (16, 8, 240, True, 1, 9000),
+    ]

--- a/tests/ut/distributed/kv_transfer/test_kvpp_mte_transport.py
+++ b/tests/ut/distributed/kv_transfer/test_kvpp_mte_transport.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from vllm_ascend.distributed.kv_transfer.kv_pool.memfabric_mte_transport import (
@@ -38,6 +39,122 @@ def _install_transfer_regions(transport):
     }
 
 
+def test_staging_automatically_covers_all_physical_pages(monkeypatch):
+    transport = _make_transport(0)
+    transport._num_physical_pages = 100000
+    transport._kvpp_group.cpu_group = object()
+    _install_transfer_regions(transport)
+    monkeypatch.setattr(torch.distributed, "all_gather_object", lambda *_args, **_kwargs: None)
+    # One complete bundle, not all layers and not limited by active requests.
+    plans, required_bytes = transport._build_device_transfer_plans((("main", "indexer"), ("main",)), 4)
+    transport._device_transfer_plans_by_cache_bundle = plans
+    transport._check_staging_layout(required_bytes, required_bytes, 4)
+    assert required_bytes == 4 << 20
+    assert plans[("main", "indexer")].staging_region_offsets.tolist() == [0, 64, 96]
+
+
+@pytest.mark.parametrize("peer_layout", [None, (4 << 20, 2 << 20), (2 << 20, 4 << 20)])
+def test_invalid_staging_layout_never_allocates_shm(monkeypatch, peer_layout):
+    transport = _make_transport(0)
+    transport._kvpp_group.cpu_group = object()
+    transport._kvpp_group.ranks = [0, 1]
+    transport._shared_memory_backend = object()
+    transport._planned_staging_capacity_bytes = 100 if peer_layout is None else 2 << 20
+    _install_transfer_regions(transport)
+    monkeypatch.setenv("MF_CONFIG_STORE_URL", "tcp://127.0.0.1:18291")
+    monkeypatch.setattr(transport, "_build_transfer_regions", lambda _caches: transport._transfer_regions_by_cache)
+
+    def gather(layouts, local, **_kwargs):
+        if peer_layout is not None:
+            required, capacity = peer_layout
+            layouts[1] = (capacity, required, *local[2:])
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather)
+    monkeypatch.setattr(
+        transport, "_create_staging_memory", lambda *_args: pytest.fail("SHM allocated before validation")
+    )
+    with pytest.raises(ValueError, match="does not match"):
+        transport.initialize_transport({}, (("main", "indexer"),), 10)
+
+
+def test_staging_rejects_insufficient_plan_before_shm_allocation(monkeypatch):
+    transport = _make_transport(0)
+    transport._kvpp_group.cpu_group = object()
+    transport._planned_staging_capacity_bytes = 100
+    _install_transfer_regions(transport)
+    monkeypatch.setattr(torch.distributed, "all_gather_object", lambda *_args, **_kwargs: None)
+    _, required_bytes = transport._build_device_transfer_plans((("main", "indexer"),), 10)
+    with pytest.raises(ValueError, match="does not match"):
+        transport._check_staging_layout(required_bytes, 100, 10)
+
+
+def test_staging_rejects_asymmetric_rank_budgets(monkeypatch):
+    transport = _make_transport(0)
+    transport._kvpp_group.cpu_group = object()
+    _install_transfer_regions(transport)
+
+    def gather(layouts, local, **_kwargs):
+        layouts[1] = (4 << 20, 2 << 20, *local[2:])
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather)
+    _, required_bytes = transport._build_device_transfer_plans((("main", "indexer"),), 10)
+    with pytest.raises(ValueError, match="does not match"):
+        transport._check_staging_layout(required_bytes, 2 << 20, 10)
+
+
+@pytest.mark.parametrize("mismatch", ["lengths", "dtype", "page_count", "slots", "names"])
+def test_equal_staging_capacity_does_not_hide_wire_layout_mismatch(monkeypatch, mismatch):
+    transport = _make_transport(0)
+    transport._kvpp_group.cpu_group = object()
+    _install_transfer_regions(transport)
+    transport._device_transfer_plans_by_cache_bundle, required = transport._build_device_transfer_plans(
+        (("main", "indexer"),), 10
+    )
+
+    def gather(layouts, local, **_kwargs):
+        peer = list(local)
+        if mismatch == "page_count":
+            peer[2] += 1
+        elif mismatch == "slots":
+            peer[3] -= 1
+        else:
+            names, regions = local[4][0]
+            if mismatch == "lengths":
+                # Same total payload, but indexer starts at the wrong offset.
+                regions = ((8, torch.float32), (8, torch.float32), (16, torch.float32))
+            elif mismatch == "dtype":
+                regions = tuple((length, torch.int32) for length, _dtype in regions)
+            else:
+                names = tuple(reversed(names))
+            peer[4] = ((names, regions),)
+        layouts[1] = tuple(peer)
+
+    monkeypatch.setattr(torch.distributed, "all_gather_object", gather)
+    with pytest.raises(ValueError, match="wire layout"):
+        transport._check_staging_layout(required, required, 10)
+
+
+def test_rank_local_tensor_strides_need_not_match(monkeypatch):
+    transports = [_make_transport(rank) for rank in range(2)]
+    signatures = []
+    for rank, transport in enumerate(transports):
+        transport._kvpp_group.cpu_group = object()
+        _install_transfer_regions(transport)
+        if rank == 1:
+            transport._transfer_regions_by_cache["main"] = tuple(
+                _MTETransferRegion(torch.empty(1), region.page_stride_bytes * 2, region.page_length_bytes)
+                for region in transport._transfer_regions_by_cache["main"]
+            )
+        transport._device_transfer_plans_by_cache_bundle, required = transport._build_device_transfer_plans(
+            (("main", "indexer"),), 10
+        )
+        monkeypatch.setattr(
+            torch.distributed, "all_gather_object", lambda _out, local, **_kwargs: signatures.append(local)
+        )
+        transport._check_staging_layout(required, required, 10)
+    assert signatures[0] == signatures[1]
+
+
 def test_mte_01_active_page_ordinals_are_fixed_shape():
     pages = _make_active_pages()
 
@@ -49,22 +166,17 @@ def test_mte_01_active_page_ordinals_are_fixed_shape():
 def test_mte_02_bundle_staging_regions_are_disjoint():
     transport = _make_transport(0)
     _install_transfer_regions(transport)
-    transport._staging_regions_by_rank = [
-        MTEStagingRegion(8000, 320, 0),
-        MTEStagingRegion(9000, 320, 1),
-    ]
-
-    offsets_by_bundle = transport._build_staging_region_offsets(
-        (("main", "indexer"),),
+    plans, required_bytes = transport._build_device_transfer_plans(
+        (("main", "indexer"), ("main",), ("main", "indexer")),
         max_active_pages=10,
     )
 
     # Ten active-page slots: main's regions occupy [0, 240), while the
     # indexer occupies [240, 320).
-    assert offsets_by_bundle[("main", "indexer")] == {"main": (0, 160), "indexer": (240,)}
-
-    transport._staging_region_offsets_by_cache_bundle = offsets_by_bundle
-    plan = transport._build_device_transfer_plans((("main", "indexer"),))[("main", "indexer")]
+    assert len(plans) == 2
+    assert required_bytes == 2 << 20
+    assert plans[("main",)].staging_region_offsets.tolist() == [0, 160]
+    plan = plans[("main", "indexer")]
     assert plan.page_strides.tolist() == [32, 64, 16]
     assert plan.page_lengths.tolist() == [16, 8, 8]
     assert plan.staging_region_offsets.tolist() == [0, 160, 240]
@@ -109,8 +221,7 @@ def test_mte_03_owner_pushes_to_peer_and_consumer_receives_locally(monkeypatch):
         owner._local_staging_region,
         MTEStagingRegion(9000, 320, 1),
     ]
-    owner._staging_region_offsets_by_cache_bundle = owner._build_staging_region_offsets((("main", "indexer"),), 10)
-    owner._device_transfer_plans_by_cache_bundle = owner._build_device_transfer_plans((("main", "indexer"),))
+    owner._device_transfer_plans_by_cache_bundle, _ = owner._build_device_transfer_plans((("main", "indexer"),), 10)
 
     owner.copy_active_pages_to_staging(("main", "indexer"), _make_active_pages(), SimpleNamespace())
     owner_plan = owner._device_transfer_plans_by_cache_bundle[("main", "indexer")]
@@ -147,10 +258,9 @@ def test_mte_03_owner_pushes_to_peer_and_consumer_receives_locally(monkeypatch):
         MTEStagingRegion(8000, 320, 0),
         consumer._local_staging_region,
     ]
-    consumer._staging_region_offsets_by_cache_bundle = consumer._build_staging_region_offsets(
+    consumer._device_transfer_plans_by_cache_bundle, _ = consumer._build_device_transfer_plans(
         (("main", "indexer"),), 10
     )
-    consumer._device_transfer_plans_by_cache_bundle = consumer._build_device_transfer_plans((("main", "indexer"),))
 
     consumer.copy_active_pages_from_staging(("main", "indexer"), _make_active_pages(), SimpleNamespace())
     consumer_plan = consumer._device_transfer_plans_by_cache_bundle[("main", "indexer")]

--- a/tests/ut/worker/test_kvpp_memory_budget.py
+++ b/tests/ut/worker/test_kvpp_memory_budget.py
@@ -1,0 +1,61 @@
+"""Exercise actual worker budget hooks without loading a model."""
+
+from types import MethodType, SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from vllm_ascend.core.kv_cache_placement import KVPPCacheMemoryBudget
+from vllm_ascend.worker.worker import NPUWorker
+
+
+def _worker(override=None):
+    return SimpleNamespace(
+        vllm_config=object(),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=override, kv_cache_memory_bytes=8 << 20),
+        _kvpp_cache_allocation_plan=SimpleNamespace(
+            plan_memory=lambda _config, available: KVPPCacheMemoryBudget.create(available, 65536, 16384)
+        ),
+        _apply_kv_offload_decode_memory_constraints=lambda available: available,
+        init_snapshot=SimpleNamespace(free_memory=16 << 20),
+    )
+
+
+@pytest.mark.parametrize("override", [None, 1, 96])
+def test_worker_budget_accepts_fitting_override(override):
+    worker = _worker(override)
+    assert NPUWorker._apply_kvpp_memory_constraints(worker, 8 << 20) == 96 * 65536
+
+
+@pytest.mark.parametrize("override", [-1, 0, 97])
+def test_worker_rejects_invalid_override_before_engine_planning(override):
+    with pytest.raises(ValueError, match="num_gpu_blocks_override"):
+        NPUWorker._apply_kvpp_memory_constraints(_worker(override), 8 << 20)
+
+
+def test_explicit_memory_budget_cannot_skip_staging():
+    worker = _worker()
+    calls = []
+    worker.model_runner = SimpleNamespace(profile_run=lambda: calls.append("profile"))
+    worker._apply_kvpp_memory_constraints = MethodType(NPUWorker._apply_kvpp_memory_constraints, worker)
+    assert NPUWorker.determine_available_memory(worker) == 96 * 65536
+    assert calls == ["profile"]
+
+
+def test_disabled_kvpp_does_not_change_budget_or_override():
+    worker = _worker(999999)
+    worker._kvpp_cache_allocation_plan = None
+    assert NPUWorker._apply_kvpp_memory_constraints(worker, 8 << 20) == 8 << 20
+
+
+def test_elastic_scale_up_cannot_bypass_staging_budget(monkeypatch):
+    worker = _worker()
+    worker.model_runner = SimpleNamespace(get_kv_cache_spec=lambda: {})
+    worker.vllm_config = SimpleNamespace(kv_transfer_config=None)
+    monkeypatch.setenv("VLLM_ELASTIC_EP_SCALE_UP_LAUNCH", "1")
+    with (
+        patch("vllm_ascend.worker.worker.get_gva_layerwise_config", return_value=None),
+        patch("vllm_ascend.worker.worker.KVPPConfig.from_vllm_config", return_value=SimpleNamespace(size=2)),
+        pytest.raises(NotImplementedError, match="elastic EP scale-up"),
+    ):
+        NPUWorker.get_kv_cache_spec(worker)

--- a/tests/ut/worker/test_kvpp_runtime.py
+++ b/tests/ut/worker/test_kvpp_runtime.py
@@ -1,0 +1,168 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import vllm_ascend.worker.v2.kvpp as kvpp_module
+from vllm_ascend.worker.v2.kvpp import (
+    KVPPRuntime,
+    KVPPScheduler,
+    build_layer_cache_bundles,
+    select_active_pages,
+)
+
+
+def _layer(index: int) -> str:
+    return f"model.layers.{index}.self_attn.attn"
+
+
+def _indexer(index: int) -> str:
+    return f"model.layers.{index}.self_attn.indexer.k_cache"
+
+
+def _scheduler(layer_count: int = 2) -> KVPPScheduler:
+    owners = {_layer(index): 0 for index in range(layer_count)}
+    transport = SimpleNamespace(initialize_transport=lambda _caches, _bundles, _max_pages: None)
+    return KVPPScheduler(
+        kvpp_group=SimpleNamespace(rank_in_group=0, world_size=1),
+        layer_owner_ranks=owners,
+        kv_caches={layer_name: object() for layer_name in owners},
+        num_physical_blocks=10,
+        tokens_per_block=4,
+        max_active_pages=10,
+        transport=transport,
+    )
+
+
+def _begin(scheduler: KVPPScheduler) -> None:
+    scheduler.schedule_forward(
+        torch.tensor([[7, 2, -1], [2, 8, 12]], dtype=torch.int32),
+        [5, 9],
+    )
+
+
+def test_kvpp_06_builds_sparse_main_and_indexer_cache_bundles():
+    owners = {
+        _layer(0): 0,
+        _indexer(0): 0,
+        _layer(1): 1,
+        _indexer(1): 1,
+    }
+
+    layer_cache_bundles = build_layer_cache_bundles(owners, (_layer(0), _layer(1)))
+
+    assert layer_cache_bundles == {
+        _layer(0): (_layer(0), _indexer(0)),
+        _layer(1): (_layer(1), _indexer(1)),
+    }
+
+
+def test_kvpp_07_active_pages_are_fixed_shape_deduplicated_and_masked():
+    table = torch.tensor([[7, 2, -1, 0], [2, 8, 12, 0]], dtype=torch.int32)
+    original = table.clone()
+
+    pages = select_active_pages(table, [5, 9], tokens_per_block=4, num_physical_blocks=10)
+
+    assert pages.physical_page_ids.shape == (table.numel(),)
+    assert pages.physical_page_ids.tolist() == [2, 2, 7, 8, 10, 10, 10, 10]
+    assert pages.valid_page_mask.tolist() == [True, False, True, True, False, False, False, False]
+    assert pages.staging_page_indices.tolist() == [0, 0, 1, 2, 2, 2, 2, 2]
+    assert torch.equal(table, original)
+
+
+def test_kvpp_08_prefetch_starts_when_scheduled_and_advances_on_wait():
+    scheduler = _scheduler()
+    _begin(scheduler)
+    assert scheduler._next_attention_layer_index == 0
+
+    scheduler.wait_for_layer(_layer(0))
+    assert scheduler._next_attention_layer_index == 1
+
+    scheduler.wait_for_layer(_layer(1))
+    assert scheduler._next_attention_layer_index == 2
+    scheduler.complete_forward()
+    assert scheduler._active_pages is None
+
+
+def test_kvpp_runtime_disabled_preparation_is_noop():
+    runtime = KVPPRuntime()
+    runtime.prepare_forward((torch.zeros(1, 1, dtype=torch.int32),), [1])
+    runtime.complete_forward()
+    assert runtime.scheduler is None
+
+
+def test_kvpp_09_runtime_binds_cache_and_attention_hook(monkeypatch):
+    target = _layer(0)
+    indexer = _indexer(0)
+    hook = SimpleNamespace(layerwise_kv_cache_hook=None)
+    target_cache = object()
+    indexer_cache = object()
+    context = {
+        target: SimpleNamespace(impl=hook, kv_cache=target_cache),
+        indexer: SimpleNamespace(kv_cache=indexer_cache),
+    }
+    owners = {target: 0, indexer: 0}
+    group = SimpleNamespace(rank_in_group=0, world_size=1)
+    initialized_caches = {}
+
+    class FakeTransport:
+        def __init__(self, *_args):
+            pass
+
+        def initialize_transport(self, caches, _bundles, _max_pages):
+            initialized_caches.update(caches)
+
+    monkeypatch.setattr(
+        kvpp_module.KVPPConfig,
+        "from_vllm_config",
+        lambda _config: SimpleNamespace(size=2),
+    )
+    monkeypatch.setattr(kvpp_module, "map_kvpp_layers_to_owners", lambda *_args: owners)
+    monkeypatch.setattr(kvpp_module, "get_kvpp_group", lambda: group)
+    monkeypatch.setattr(kvpp_module, "MemFabricMTEKVPPTransport", FakeTransport)
+
+    runtime = KVPPRuntime.create_from_kv_cache(
+        vllm_config=SimpleNamespace(
+            model_config=SimpleNamespace(max_model_len=4096),
+            scheduler_config=SimpleNamespace(max_num_seqs=4),
+        ),
+        kv_cache_config=SimpleNamespace(
+            kv_cache_groups=[SimpleNamespace(layer_names=(target, indexer))],
+            num_blocks=8,
+        ),
+        block_tables=SimpleNamespace(
+            blocks_per_kv_block=(2,),
+            kernel_block_sizes=(128,),
+        ),
+        static_forward_context=context,
+    )
+
+    assert initialized_caches == {target: target_cache, indexer: indexer_cache}
+    assert runtime.managed_cache_group_index == 0
+    assert runtime.scheduler.layer_cache_bundles == {target: (target, indexer)}
+    assert hook.layerwise_kv_cache_hook is runtime.scheduler
+
+
+def test_kvpp_10_rejects_managed_layers_from_multiple_cache_groups(monkeypatch):
+    target = _layer(0)
+    indexer = _indexer(0)
+    owners = {target: 0, indexer: 0}
+    monkeypatch.setattr(
+        kvpp_module.KVPPConfig,
+        "from_vllm_config",
+        lambda _config: SimpleNamespace(size=2),
+    )
+    monkeypatch.setattr(kvpp_module, "map_kvpp_layers_to_owners", lambda *_args: owners)
+
+    with pytest.raises(ValueError, match="must belong to one cache group"):
+        KVPPRuntime.create_from_kv_cache(
+            vllm_config=object(),
+            kv_cache_config=SimpleNamespace(
+                kv_cache_groups=[
+                    SimpleNamespace(layer_names=(target,)),
+                    SimpleNamespace(layer_names=(indexer,)),
+                ]
+            ),
+            block_tables=object(),
+            static_forward_context={},
+        )

--- a/tests/ut/worker/test_kvpp_runtime.py
+++ b/tests/ut/worker/test_kvpp_runtime.py
@@ -70,6 +70,16 @@ def test_kvpp_07_active_pages_are_fixed_shape_deduplicated_and_masked():
     assert torch.equal(table, original)
 
 
+def test_kvpp_first_chunk_has_no_computed_pages():
+    table = torch.tensor([[7, 2, 1, 0]], dtype=torch.int32)
+
+    pages = select_active_pages(table, [0], tokens_per_block=4, num_physical_blocks=10)
+
+    assert pages.physical_page_ids.tolist() == [10, 10, 10, 10]
+    assert pages.valid_page_mask.tolist() == [False, False, False, False]
+    assert pages.staging_page_indices.tolist() == [-1, -1, -1, -1]
+
+
 def test_kvpp_08_prefetch_starts_when_scheduled_and_advances_on_wait():
     scheduler = _scheduler()
     _begin(scheduler)

--- a/tests/ut/worker/test_kvpp_runtime.py
+++ b/tests/ut/worker/test_kvpp_runtime.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+from threading import Event, get_ident
 from types import SimpleNamespace
 
 import pytest
@@ -94,6 +96,165 @@ def test_kvpp_08_prefetch_starts_when_scheduled_and_advances_on_wait():
     assert scheduler._active_pages is None
 
 
+@pytest.fixture
+def parallel_scheduler(monkeypatch):
+    calls = []
+    recorded_events = []
+    schedulers = []
+
+    class FakeEvent:
+        def record(self, stream):
+            recorded_events.append(self)
+
+    class FakeStream:
+        def wait_event(self, event):
+            calls.append(("wait", event))
+
+    monkeypatch.setattr(
+        torch,
+        "npu",
+        SimpleNamespace(
+            Event=FakeEvent,
+            Stream=FakeStream,
+            current_device=lambda: 0,
+            current_stream=lambda: "compute",
+            set_device=lambda _device: None,
+            stream=lambda _stream: nullcontext(),
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(kvpp_module.dist, "send", lambda _token, dst, group, tag: calls.append(("send", dst, tag)))
+    monkeypatch.setattr(kvpp_module.dist, "recv", lambda _token, src, group, tag: calls.append(("recv", src, tag)))
+
+    def copy(direction):
+        def enqueue(bundle, pages, stream):
+            calls.append((direction, bundle, pages))
+            return SimpleNamespace(synchronize=lambda: calls.append(("complete", direction)))
+
+        return enqueue
+
+    def make(rank):
+        owners = {_layer(38): 0, _layer(39): 1, _layer(40): 0}
+        scheduler = KVPPScheduler(
+            kvpp_group=SimpleNamespace(rank_in_group=rank, world_size=3, ranks=[16, 17, 18], cpu_group="pp1"),
+            layer_owner_ranks=owners,
+            kv_caches={name: object() for name in owners},
+            num_physical_blocks=10,
+            tokens_per_block=4,
+            max_active_pages=10,
+            transport=SimpleNamespace(
+                initialize_transport=lambda *_args: None,
+                copy_active_pages_to_staging=copy("push"),
+                copy_active_pages_from_staging=copy("pull"),
+            ),
+        )
+        schedulers.append(scheduler)
+        return scheduler, calls, recorded_events
+
+    yield make
+    for scheduler in schedulers:
+        scheduler._prefetch_executor.shutdown(wait=True)
+
+
+@pytest.mark.parametrize(("rank", "layer_index", "peers"), [(0, 38, [17, 18]), (1, 39, [16, 18])])
+def test_owner_sends_after_forward_ready_without_waiting_for_scratch(parallel_scheduler, rank, layer_index, peers):
+    scheduler, calls, _events = parallel_scheduler(rank)
+    pages, forward_ready, scratch_ready = object(), object(), object()
+    layer = _layer(layer_index)
+
+    scheduler.run_layer_prefetch(layer, pages, forward_ready, scratch_ready)
+
+    assert calls == (
+        [("recv", peer, kvpp_module._KVPP_READY_TAG) for peer in peers]
+        + [("wait", forward_ready), ("push", (layer,), pages), ("complete", "push")]
+        + [("send", peer, kvpp_module._KVPP_DONE_TAG) for peer in peers]
+    )
+
+
+@pytest.mark.parametrize(("rank", "layer_index", "owner"), [(1, 38, 16), (0, 39, 17)])
+def test_receiver_requires_send_completion_and_destination_ready(parallel_scheduler, rank, layer_index, owner):
+    scheduler, calls, _events = parallel_scheduler(rank)
+    pages, forward_ready, scratch_ready = object(), object(), object()
+    layer = _layer(layer_index)
+
+    scheduler.run_layer_prefetch(layer, pages, forward_ready, scratch_ready)
+
+    assert calls == [
+        ("send", owner, kvpp_module._KVPP_READY_TAG),
+        ("recv", owner, kvpp_module._KVPP_DONE_TAG),
+        ("wait", forward_ready),
+        ("wait", scratch_ready),
+        ("pull", (layer,), pages),
+        ("complete", "pull"),
+    ]
+
+
+def test_background_receiver_publishes_staging_ready_before_waiting_for_done(parallel_scheduler, monkeypatch):
+    scheduler, calls, events = parallel_scheduler(1)
+    waiting_for_done, send_done = Event(), Event()
+    caller_thread = get_ident()
+    worker_threads = []
+
+    def wait_for_sender(_token, src, group, tag):
+        worker_threads.append(get_ident())
+        assert calls == [("send", src, kvpp_module._KVPP_READY_TAG)]
+        waiting_for_done.set()
+        assert send_done.wait(timeout=5), "Test did not release the sender completion."
+        calls.append(("recv", src, tag))
+
+    monkeypatch.setattr(kvpp_module.dist, "recv", wait_for_sender)
+    _begin(scheduler)
+    try:
+        assert waiting_for_done.wait(timeout=5)
+        assert len(worker_threads) == 1
+        assert worker_threads[0] != caller_thread
+        assert not scheduler._prefetch_future.done()
+        assert not any(call[0] in ("wait", "pull") for call in calls)
+    finally:
+        send_done.set()
+    scheduler._prefetch_future.result(timeout=5)
+    assert ("wait", events[0]) in calls
+    assert ("wait", events[1]) in calls
+    assert calls[-1] == ("complete", "pull")
+
+
+def test_forward_event_is_reused_without_background_advancing_layers(parallel_scheduler):
+    scheduler, calls, events = parallel_scheduler(0)
+    _begin(scheduler)
+    forward_ready = scheduler._forward_ready
+    scheduler._prefetch_future.result(timeout=5)
+    assert scheduler._next_attention_layer_index == 0
+    assert len(events) == 2  # One forward event and the first scratch safe point.
+    assert [call[0] for call in calls].count("push") == 1
+
+    for layer in (38, 39, 40):
+        scheduler.wait_for_layer(_layer(layer))
+        assert scheduler._forward_ready is forward_ready
+    assert len(events) == 4
+    scheduler.complete_forward()
+    assert scheduler._forward_ready is None
+    _begin(scheduler)
+    assert scheduler._forward_ready is not forward_ready
+    scheduler._prefetch_future.result(timeout=5)
+
+
+def test_explicit_scratch_event_is_passed_to_worker_without_an_extra_safe_point(parallel_scheduler):
+    scheduler, calls, events = parallel_scheduler(1)
+    scheduler._active_pages = pages = object()
+    scheduler._forward_ready = forward_ready = object()
+    scratch_ready = object()
+
+    scheduler.start_layer_prefetch(_layer(38), scratch_ready=scratch_ready)
+    scheduler._prefetch_future.result(timeout=5)
+
+    assert events == []
+    assert ("wait", forward_ready) in calls
+    assert ("wait", scratch_ready) in calls
+    assert ("pull", (_layer(38),), pages) in calls
+    with pytest.raises(RuntimeError, match="previous prefetch must be consumed"):
+        scheduler.start_layer_prefetch(_layer(39), scratch_ready=scratch_ready)
+
+
 def test_kvpp_runtime_disabled_preparation_is_noop():
     runtime = KVPPRuntime()
     runtime.prepare_forward((torch.zeros(1, 1, dtype=torch.int32),), [1])
@@ -173,6 +334,6 @@ def test_kvpp_10_rejects_managed_layers_from_multiple_cache_groups(monkeypatch):
                     SimpleNamespace(layer_names=(indexer,)),
                 ]
             ),
-            block_tables=object(),
+            block_tables=SimpleNamespace(blocks_per_kv_block=(1, 1), kernel_block_sizes=(128, 128)),
             static_forward_context={},
         )

--- a/tests/ut/worker/test_kvpp_runtime.py
+++ b/tests/ut/worker/test_kvpp_runtime.py
@@ -277,7 +277,7 @@ def test_kvpp_09_runtime_binds_cache_and_attention_hook(monkeypatch):
     initialized_caches = {}
 
     class FakeTransport:
-        def __init__(self, *_args):
+        def __init__(self, *_args, **_kwargs):
             pass
 
         def initialize_transport(self, caches, _bundles, _max_pages):

--- a/tests/ut/worker/test_kvpp_v1.py
+++ b/tests/ut/worker/test_kvpp_v1.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+import vllm_ascend.worker.kvpp_v1 as kvpp_v1_module
+from vllm_ascend.worker.kvpp_v1 import KVPPV1Runtime
+from vllm_ascend.worker.v2.kvpp import KVPPCacheLayout, KVPPRuntime
+
+
+def test_kvpp_runtime_v1_disabled_prepare_is_noop():
+    KVPPV1Runtime().prepare_forward(SimpleNamespace(), 1, [1])
+
+
+def test_kvpp_runtime_v1_converts_cache_layout(monkeypatch):
+    expected_runtime = KVPPRuntime()
+    captured: dict[str, object] = {}
+
+    def capture_cache_layout(_runtime_cls, **kwargs):
+        captured.update(kwargs)
+        return expected_runtime
+
+    monkeypatch.setattr(
+        KVPPRuntime,
+        "create_from_cache_layout",
+        classmethod(capture_cache_layout),
+    )
+    monkeypatch.setattr(
+        kvpp_v1_module.KVPPConfig,
+        "from_vllm_config",
+        lambda _config: SimpleNamespace(size=2),
+    )
+    vllm_config = object()
+    kv_cache_config = SimpleNamespace(kv_cache_groups=[SimpleNamespace(layer_names=("layer",))])
+    static_forward_context = {"layer": object()}
+    kv_caches = {"layer": object()}
+    block_tables = [SimpleNamespace(blocks_per_phys_block=2, logical_block_size=128)]
+
+    runtime = KVPPV1Runtime.create_from_kv_cache(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        static_forward_context=static_forward_context,
+        kv_caches=kv_caches,
+        block_tables=block_tables,
+    )
+
+    assert runtime._kvpp_runtime is expected_runtime
+    assert captured["vllm_config"] is vllm_config
+    assert captured["kv_cache_config"] is kv_cache_config
+    assert captured["static_forward_context"] is static_forward_context
+    assert captured["cache_layout"] == KVPPCacheLayout(
+        layer_caches=kv_caches,
+        physical_blocks_per_kv_block=(2,),
+        tokens_per_block=(128,),
+    )

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -47,12 +47,65 @@ def is_mega_moe_supported() -> bool:
     return _MEGA_MOE_SUPPORTED
 
 
+_KVPP_COMPATIBLE_CONNECTORS = frozenset(
+    {
+        "MooncakeConnectorV2",
+        "MooncakePullConnector",
+    }
+)
+
+
 def validate_additional_config_bool(value: Any, path: str) -> bool:
     """Apply the same pydantic bool rules to values read before config init."""
     try:
         return TypeAdapter(bool).validate_python(value)
     except ValueError as exc:
         raise ValueError(f"{path} must be a boolean, got {value!r}.") from exc
+
+
+@config(config=ConfigDict(frozen=True))
+class KVPPConfig:
+    """Configuration for KV layer parallelism on Ascend."""
+
+    size: int = 1
+
+    @classmethod
+    def from_vllm_config(cls, vllm_config: VllmConfig) -> KVPPConfig:
+        additional_config = vllm_config.additional_config or {}
+        enabled = additional_config.get("enable_kvpp", False)
+        if not isinstance(enabled, bool):
+            raise ValueError(f"additional_config.enable_kvpp must be a boolean, got {enabled!r}.")
+
+        size = vllm_config.parallel_config.tensor_parallel_size if enabled else 1
+        return cls(size=size)
+
+    def validate(self, vllm_config: VllmConfig) -> None:
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.prefill_context_parallel_size != 1:
+            raise ValueError("KVPP does not support PCP yet.")
+        if parallel_config.decode_context_parallel_size != 1:
+            raise ValueError("KVPP and DCP cannot be enabled at the same time.")
+        kv_transfer_config = vllm_config.kv_transfer_config
+        if kv_transfer_config is not None:
+            connector = kv_transfer_config.kv_connector
+            role = kv_transfer_config.kv_role
+            if connector not in _KVPP_COMPATIBLE_CONNECTORS or role != "kv_producer":
+                raise ValueError(
+                    "KVPP supports KV transfer only with MooncakeConnectorV2 "
+                    f"on a kv_producer, got connector={connector!r}, role={role!r}."
+                )
+
+        model_config = vllm_config.model_config
+        if not getattr(model_config, "enforce_eager", False):
+            raise ValueError("KVPP currently supports eager execution only; set --enforce-eager.")
+        if not model_config.use_mla or model_config.is_hybrid:
+            raise ValueError("KVPP currently supports only non-hybrid MLA models.")
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None:
+            if speculative_config.method != "mtp":
+                raise ValueError("KVPP currently supports speculative decoding only with method='mtp'.")
+            if getattr(speculative_config, "num_speculative_tokens_per_batch_size", None):
+                raise ValueError("KVPP currently supports only a fixed number of MTP speculative tokens.")
 
 
 @config
@@ -430,6 +483,7 @@ class AscendConfig:
     dynamic_spec_config: DynamicSpecConfig = dataclasses.field(default_factory=lambda: DynamicSpecConfig())
     # Still factory-injected: construction depends on vllm_config.
     sparse_kv_offload_config: Any = dataclasses.field(kw_only=True)
+    kvpp_config: KVPPConfig = dataclasses.field(kw_only=True)
 
     # ---- derived fields: sentinel default, after-validator overwrites ----
     enable_shared_expert_dp: bool = False
@@ -1358,6 +1412,7 @@ def init_ascend_config(vllm_config):
     sparse_kv = SparseKVOffloadConfig.from_additional_config(
         vllm_config, additional_config.get("sparse_kv_offload_config", {})
     )
+    kvpp_config = KVPPConfig.from_vllm_config(vllm_config)
     # dump_config: keep the mutual-exclusion / materialize logic as a factory
     # pre-step; the resolved path is passed as the dump_config_path field.
     dump_config_path = AscendConfig._resolve_dump_config_path(additional_config)
@@ -1374,6 +1429,10 @@ def init_ascend_config(vllm_config):
         # injected fields (factory passes explicitly; a copy in additional_config would conflict)
         "scheduler_config",
         "sparse_kv_offload_config",
+        # Factory-injected: derived from additional_config.enable_kvpp + TP.
+        "enable_kvpp",
+        "kvpp_size",
+        "kvpp_config",
         # Factory-only input: materialized by _resolve_dump_config_path and
         # replaced with the validated dump_config_path field below.
         "dump_config",
@@ -1404,6 +1463,7 @@ def init_ascend_config(vllm_config):
     new_config = AscendConfig(  # type: ignore[call-arg]
         scheduler_config=sched,
         sparse_kv_offload_config=sparse_kv,
+        kvpp_config=kvpp_config,
         dump_config_path=dump_config_path,
         **kwargs,
     )

--- a/vllm_ascend/attention/mla_v1.py
+++ b/vllm_ascend/attention/mla_v1.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, NamedTuple, TypeVar
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeVar
 
 import numpy as np
 import torch
@@ -826,6 +826,7 @@ class AscendMLAImpl(MLAAttentionImpl):
         **kwargs,
     ):
         self.vllm_config = get_current_vllm_config()
+        self.layerwise_kv_cache_hook: Any = None
         self.support_fp8_attention = get_current_hardware_profile().supports(HardwareCapability.FP8_ATTENTION)
         self.num_heads = num_heads
         self.head_size = head_size
@@ -1897,6 +1898,12 @@ class AscendMLAImpl(MLAAttentionImpl):
         prefill_preprocess_res = None
         if has_prefill:
             wait_for_kv_layer_from_connector(layer_name)
+        if self.layerwise_kv_cache_hook is not None and (has_decode or has_prefill):
+            # Q/KV projections above run on the compute stream while the
+            # active historical pages are pushed on KVPP's communication
+            # stream. Cache writes wait only at the first point that consumes
+            # the cache.
+            self.layerwise_kv_cache_hook.wait_for_layer(layer_name)
         # Preprocess for decode tokens
         if has_decode:
             decode_preprocess_res = self.mla_preprocess_decode(q_c, kv_no_split, kv_cache, attn_metadata)
@@ -1974,6 +1981,8 @@ class AscendMLAImpl(MLAAttentionImpl):
             and attn_metadata.num_decode_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
             and attn_metadata.num_prefills == 0
         ):
+            if self.layerwise_kv_cache_hook is not None:
+                self.layerwise_kv_cache_hook.wait_for_layer(layer_name)
             decode_preprocess_res, prefill_preprocess_res = self.mla_preprocess_only_decode(
                 hidden_states, kv_cache, attn_metadata
             )

--- a/vllm_ascend/attention/sfa_v1.py
+++ b/vllm_ascend/attention/sfa_v1.py
@@ -451,6 +451,9 @@ class AscendSFAImpl(MLAAttentionImpl):
         self.tp_size = get_tensor_model_parallel_world_size()
         self.skip_topk = kwargs.get("skip_topk", False)
         self.topk_indices_buffer = kwargs.get("topk_indices_buffer")
+        # Optional platform service injected by the model runner. Attention
+        # stays independent of KVPP scheduling and the concrete transport.
+        self.layerwise_kv_cache_hook: Any = None
 
         ascend_config = get_ascend_config()
         self.vllm_config = get_current_vllm_config()
@@ -1551,6 +1554,10 @@ class AscendSFAImpl(MLAAttentionImpl):
             else:
                 k_li, k_li_scale = None, None
             wait_for_kv_layer_from_connector(layer_name)
+            if self.layerwise_kv_cache_hook is not None:
+                # The fused preprocess is the first operation that may read or
+                # update the paged SFA and LI caches.
+                self.layerwise_kv_cache_hook.wait_for_layer(layer_name)
 
             if fused_type == PreprocessType.PROLOG_V3:
                 hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_prolog_v3(
@@ -1591,6 +1598,10 @@ class AscendSFAImpl(MLAAttentionImpl):
                 k_li, k_li_scale = None, None
 
             wait_for_kv_layer_from_connector(layer_name)
+            if self.layerwise_kv_cache_hook is not None:
+                # Q/KV and lightning-indexer projections above overlap the
+                # active-page transfer. Wait only before the first cache write.
+                self.layerwise_kv_cache_hook.wait_for_layer(layer_name)
 
             kv_outputs = self.exec_kv(
                 kv_no_split,

--- a/vllm_ascend/core/kv_cache_placement.py
+++ b/vllm_ascend/core/kv_cache_placement.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from vllm.config import VllmConfig
+from vllm.model_executor.models.utils import extract_layer_index
+from vllm.v1.core.kv_cache_utils import get_kv_cache_groups
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
+
+from vllm_ascend.ascend_config import KVPPConfig
+
+
+@dataclass(frozen=True)
+class KVPPPhysicalCachePlan:
+    """Worker-local physical allocation with a complete logical cache view."""
+
+    logical_cache_spec: dict[str, KVCacheSpec]
+    physical_cache_spec: dict[str, KVCacheSpec]
+    scratch_layer_aliases: dict[str, list[str]]
+
+    def restore_logical_cache_view(self, kv_cache_config: KVCacheConfig) -> None:
+        """Restore logical layer bindings on an upstream physical config."""
+        for tensor in kv_cache_config.kv_cache_tensors:
+            tensor_names: list[str] = []
+            for layer_name in tensor.shared_by:
+                tensor_names.extend(self.scratch_layer_aliases.get(layer_name, [layer_name]))
+            tensor.shared_by = list(dict.fromkeys(tensor_names))
+
+        logical_groups: list[KVCacheGroupSpec] = []
+        for group in kv_cache_config.kv_cache_groups:
+            group_names: list[str] = []
+            for layer_name in group.layer_names:
+                group_names.extend(self.scratch_layer_aliases.get(layer_name, [layer_name]))
+            expanded_names = list(dict.fromkeys(group_names))
+
+            group_spec = group.kv_cache_spec
+            if expanded_names and isinstance(group_spec, UniformTypeKVCacheSpecs):
+                group_spec = UniformTypeKVCacheSpecs(
+                    block_size=group_spec.block_size,
+                    kv_cache_specs={layer_name: self.logical_cache_spec[layer_name] for layer_name in expanded_names},
+                )
+            logical_groups.append(
+                KVCacheGroupSpec(
+                    expanded_names,
+                    group_spec,
+                    is_eagle_group=group.is_eagle_group,
+                )
+            )
+
+        kv_cache_config.kv_cache_groups = logical_groups
+
+
+def project_kv_cache_groups_to_worker(
+    global_groups: list[KVCacheGroupSpec],
+    worker_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    """Project global logical groups onto one worker's PP-local layers.
+
+    The projected list keeps one entry per global group so logical group
+    indices stay aligned with the global topology; groups without local
+    layers become empty entries instead of being compacted away.
+    """
+    projected_groups: list[KVCacheGroupSpec] = []
+    for group in global_groups:
+        worker_layer_names = [layer_name for layer_name in group.layer_names if layer_name in worker_spec]
+        group_spec = group.kv_cache_spec
+        if worker_layer_names and isinstance(group_spec, UniformTypeKVCacheSpecs):
+            group_spec = UniformTypeKVCacheSpecs(
+                block_size=group_spec.block_size,
+                kv_cache_specs={layer_name: group_spec.kv_cache_specs[layer_name] for layer_name in worker_layer_names},
+            )
+        projected_groups.append(
+            KVCacheGroupSpec(
+                worker_layer_names,
+                group_spec,
+                is_eagle_group=group.is_eagle_group and bool(worker_layer_names),
+            )
+        )
+    return projected_groups
+
+
+def find_mtp_layers(
+    vllm_config: VllmConfig,
+    local_layer_names: Iterable[str],
+) -> set[str]:
+    """Find MTP KV-cache layers among this worker's PP-local cache names.
+
+    Only names present in ``local_layer_names`` are returned. A PP stage
+    without MTP caches yields an empty set; KVPP does not assume MTP lives
+    on the last pipeline rank.
+    """
+    speculative_config = vllm_config.speculative_config
+    if speculative_config is None or speculative_config.method != "mtp":
+        return set()
+
+    hf_config = vllm_config.model_config.hf_config
+    mtp_start = hf_config.num_hidden_layers
+    num_mtp_layers = hf_config.num_nextn_predict_layers
+    mtp_end = mtp_start + num_mtp_layers
+    return {layer_name for layer_name in local_layer_names if mtp_start <= extract_layer_index(layer_name) < mtp_end}
+
+
+def map_kvpp_layers_to_owners(vllm_config: VllmConfig, local_layer_names: Iterable[str]) -> dict[str, int]:
+    """Partition PP-local Target KV layers across KVPP ranks.
+
+    ``local_layer_names`` must already be PP-local (typically the keys of the
+    current worker's cache spec). MTP layers remain fully allocated on every
+    KVPP rank and are therefore absent from the returned owner mapping.
+    """
+    kvpp_size = KVPPConfig.from_vllm_config(vllm_config).size
+    # Workers are separate Python processes and may receive layer names from
+    # sets or differently ordered dictionaries. Keep both owner insertion
+    # order and per-layer cache-bundle order identical on every rank.
+    local_layer_names = tuple(sorted(local_layer_names, key=lambda name: (extract_layer_index(name), name)))
+    mtp_layers = find_mtp_layers(
+        vllm_config,
+        local_layer_names,
+    )
+    layers_by_index: dict[int, list[str]] = defaultdict(list)
+    for layer_name in local_layer_names:
+        if layer_name not in mtp_layers:
+            layers_by_index[extract_layer_index(layer_name)].append(layer_name)
+
+    layer_indices = sorted(layers_by_index)
+    if len(layer_indices) < kvpp_size:
+        raise ValueError(
+            f"KVPP size ({kvpp_size}) exceeds the number of KV cache layer bundles ({len(layer_indices)})."
+        )
+    base, remainder = divmod(len(layer_indices), kvpp_size)
+    layer_owner_ranks: dict[str, int] = {}
+    offset = 0
+    for owner_rank in range(kvpp_size):
+        partition_size = base + int(owner_rank < remainder)
+        for layer_index in layer_indices[offset : offset + partition_size]:
+            for layer_name in layers_by_index[layer_index]:
+                layer_owner_ranks[layer_name] = owner_rank
+        offset += partition_size
+    return layer_owner_ranks
+
+
+def build_cache_allocation_groups(
+    logical_groups: list[KVCacheGroupSpec],
+    worker_spec: dict[str, KVCacheSpec],
+    layer_owner_ranks: dict[str, int],
+    kvpp_rank: int,
+) -> tuple[list[KVCacheGroupSpec], dict[str, list[str]]]:
+    """Per-KVPP-rank allocation view over PP-local logical groups.
+
+    Target layers owned by this rank stay persistent; other owners' layers map
+    onto two alternating scratch caches per layout. MTP layers remain
+    unpartitioned by KVPP and are allocated in full on every KVPP rank.
+    """
+    allocation_spec: dict[str, KVCacheSpec] = {}
+    scratch_layer_aliases: dict[str, list[str]] = {}
+
+    for group in logical_groups:
+        local_names = list(group.layer_names)
+        managed_names = [name for name in local_names if name in layer_owner_ranks]
+        allocation_names = [
+            name for name in local_names if name not in layer_owner_ranks or layer_owner_ranks[name] == kvpp_rank
+        ]
+        scratch_layout_groups: list[list[str]] = []
+        for name in managed_names:
+            if layer_owner_ranks[name] == kvpp_rank:
+                continue
+            for layout_names in scratch_layout_groups:
+                if worker_spec[name] == worker_spec[layout_names[0]]:
+                    layout_names.append(name)
+                    break
+            else:
+                scratch_layout_groups.append([name])
+        for layout_names in scratch_layout_groups:
+            scratch_names = layout_names[:2]
+            allocation_names.extend(scratch_names)
+            for scratch_index, scratch_name in enumerate(scratch_names):
+                scratch_layer_aliases[scratch_name] = layout_names[scratch_index :: len(scratch_names)]
+        for layer_name in allocation_names:
+            allocation_spec[layer_name] = worker_spec[layer_name]
+
+    return (
+        project_kv_cache_groups_to_worker(logical_groups, allocation_spec),
+        scratch_layer_aliases,
+    )
+
+
+def create_kvpp_cache_allocation_plan(
+    vllm_config: VllmConfig,
+    worker_spec: dict[str, KVCacheSpec],
+    kvpp_rank: int,
+) -> KVPPPhysicalCachePlan:
+    """Create the KV cache allocation plan reported by one worker.
+
+    The union of owner specs across KVPP ranks still contains every logical
+    layer, so upstream can build the global logical topology normally. Each
+    worker only reports its persistent layers, two scratch layers per cache
+    layout, and a full MTP cache on each rank; upstream therefore computes
+    the desired physical allocation without any KVPP-specific hook.
+    """
+    kvpp_size = KVPPConfig.from_vllm_config(vllm_config).size
+    if not 0 <= kvpp_rank < kvpp_size:
+        raise ValueError(f"KVPP rank must be in [0, {kvpp_size}), got {kvpp_rank}.")
+
+    logical_cache_spec = dict(worker_spec)
+    # get_kv_cache_groups may normalize its input in place, so keep the spec
+    # returned to the engine and the spec retained for logical restoration
+    # independent from its working copy.
+    logical_cache_groups = get_kv_cache_groups(vllm_config, dict(logical_cache_spec))
+    layer_owner_ranks = map_kvpp_layers_to_owners(vllm_config, worker_spec)
+    physical_cache_groups, scratch_layer_aliases = build_cache_allocation_groups(
+        logical_cache_groups,
+        worker_spec,
+        layer_owner_ranks,
+        kvpp_rank,
+    )
+    physical_layer_names = {layer_name for group in physical_cache_groups for layer_name in group.layer_names}
+    physical_cache_spec = {
+        layer_name: logical_cache_spec[layer_name]
+        for layer_name in logical_cache_spec
+        if layer_name in physical_layer_names
+    }
+    return KVPPPhysicalCachePlan(
+        logical_cache_spec=logical_cache_spec,
+        physical_cache_spec=physical_cache_spec,
+        scratch_layer_aliases=scratch_layer_aliases,
+    )

--- a/vllm_ascend/core/kv_cache_placement.py
+++ b/vllm_ascend/core/kv_cache_placement.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
+import copy
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
 
 from vllm.config import VllmConfig
 from vllm.model_executor.models.utils import extract_layer_index
-from vllm.v1.core.kv_cache_utils import get_kv_cache_groups
+from vllm.v1.core.kv_cache_utils import get_kv_cache_config_from_groups, get_kv_cache_groups
 from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
@@ -15,6 +16,37 @@ from vllm.v1.kv_cache_interface import (
 
 from vllm_ascend.ascend_config import KVPPConfig
 
+# MemFabric device slices must be aligned to HYBM_LARGE_PAGE_SIZE (2 MiB).
+KVPP_STAGING_ALIGNMENT_BYTES = 2 << 20
+
+
+def kvpp_staging_size_bytes(page_size_bytes: int, num_blocks: int) -> int:
+    """Capacity of one complete scratch bundle, aligned for MemFabric."""
+    size = page_size_bytes * num_blocks
+    return (size + KVPP_STAGING_ALIGNMENT_BYTES - 1) // KVPP_STAGING_ALIGNMENT_BYTES * KVPP_STAGING_ALIGNMENT_BYTES
+
+
+@dataclass(frozen=True)
+class KVPPCacheMemoryBudget:
+    """KV and staging share the same post-profile device memory budget."""
+
+    kv_page_size_bytes: int
+    staging_page_size_bytes: int
+    max_num_blocks: int
+
+    @classmethod
+    def create(cls, available_bytes: int, kv_page_size_bytes: int, staging_page_size_bytes: int):
+        if kv_page_size_bytes <= 0 or staging_page_size_bytes <= 0:
+            raise ValueError("KVPP KV and staging page sizes must be positive.")
+        available_bytes = int(available_bytes)
+        num_blocks = max(0, available_bytes // (kv_page_size_bytes + staging_page_size_bytes))
+        while num_blocks > 0:
+            required = num_blocks * kv_page_size_bytes + kvpp_staging_size_bytes(staging_page_size_bytes, num_blocks)
+            if required <= available_bytes:
+                break
+            num_blocks -= 1
+        return cls(kv_page_size_bytes, staging_page_size_bytes, num_blocks)
+
 
 @dataclass(frozen=True)
 class KVPPPhysicalCachePlan:
@@ -23,6 +55,21 @@ class KVPPPhysicalCachePlan:
     logical_cache_spec: dict[str, KVCacheSpec]
     physical_cache_spec: dict[str, KVCacheSpec]
     scratch_layer_aliases: dict[str, list[str]]
+    physical_cache_groups: list[KVCacheGroupSpec]
+    staging_page_size_bytes: int
+
+    def plan_memory(self, vllm_config: VllmConfig, available_bytes: int) -> KVPPCacheMemoryBudget:
+        # Reuse the upstream allocator's actual per-block cost, including
+        # scratch, MTP and group padding; never count logical aliases again.
+        sizing_config = copy.copy(vllm_config)
+        sizing_config.cache_config = copy.copy(vllm_config.cache_config)
+        sizing_config.cache_config.num_gpu_blocks_override = 1
+        one_block = get_kv_cache_config_from_groups(sizing_config, self.physical_cache_groups, 0)
+        return KVPPCacheMemoryBudget.create(
+            available_bytes,
+            sum(tensor.size for tensor in one_block.kv_cache_tensors),
+            self.staging_page_size_bytes,
+        )
 
     def restore_logical_cache_view(self, kv_cache_config: KVCacheConfig) -> None:
         """Restore logical layer bindings on an upstream physical config."""
@@ -224,8 +271,17 @@ def create_kvpp_cache_allocation_plan(
         for layer_name in logical_cache_spec
         if layer_name in physical_layer_names
     }
+    staging_bytes_by_layer: dict[int, int] = defaultdict(int)
+    # Scratch specs remain unchanged. Each managed layer is received by some
+    # non-owner, so the largest logical bundle covers the group's largest
+    # scratch requirement, even when individual ranks have different scratch
+    # layouts. MemFabric requires equal SHM contributions within the group.
+    for layer_name in layer_owner_ranks:
+        staging_bytes_by_layer[extract_layer_index(layer_name)] += logical_cache_spec[layer_name].page_size_bytes
     return KVPPPhysicalCachePlan(
         logical_cache_spec=logical_cache_spec,
         physical_cache_spec=physical_cache_spec,
         scratch_layer_aliases=scratch_layer_aliases,
+        physical_cache_groups=physical_cache_groups,
+        staging_page_size_bytes=max(staging_bytes_by_layer.values()),
     )

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
@@ -1,0 +1,346 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MemFabric Hybrid MTE backend for KV layer parallelism.
+
+MemFabric Hybrid 1.2 cannot export an existing KV tensor as a remote MTE GVA.
+This backend therefore allocates one bounded symmetric active-page staging
+segment per rank. Layer owners copy selected persistent pages directly to each
+consumer's segment with batched AscendC GM->UB->remote-GM launches. Consumers
+unpack the same device-resident page descriptors into their existing scratch
+cache before attention. No full layer cache is copied or staged.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, cast
+from urllib.parse import urlsplit, urlunsplit
+
+import torch
+import torch.distributed as dist
+from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.logger import logger
+
+from vllm_ascend import envs
+
+
+def _build_group_store_url(store_url: str, kvpp_group: GroupCoordinator) -> str:
+    """Give each KVPP process group its own MemFabric config store.
+
+    A PP deployment has one KVPP group per pipeline stage. MemFabric's SHM
+    initializer identifies participants only by ``(store_url, world_size,
+    rank_id)``; reusing one URL would therefore merge stage-local ranks from
+    different PP stages. KVPP groups are contiguous slices of the global rank
+    grid, so their ordinal can safely select a stage-local TCP port.
+    """
+    group_index = min(kvpp_group.ranks) // kvpp_group.world_size
+    if group_index == 0:
+        return store_url
+
+    parsed = urlsplit(store_url)
+    port = cast(int, parsed.port) + group_index
+    host = cast(str, parsed.hostname)
+    if ":" in host:
+        host = f"[{host}]"
+    netloc = f"{host}:{port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+
+
+@dataclass(frozen=True)
+class KVPPActivePages:
+    """Fixed-shape device page IDs and their compact staging slots."""
+
+    physical_page_ids: torch.Tensor
+    valid_page_mask: torch.Tensor
+    staging_page_indices: torch.Tensor
+
+
+@dataclass(frozen=True)
+class MTEStagingRegion:
+    """One rank's remotely addressable staging region."""
+
+    base_address: int
+    capacity_bytes: int
+    kvpp_group_rank: int
+
+
+@dataclass(frozen=True)
+class _MTETransferRegion:
+    """One base address and its logical-page layout."""
+
+    base_tensor: torch.Tensor
+    page_stride_bytes: int
+    page_length_bytes: int
+
+
+class MemFabricMTEKVPPTransport:
+    """Move active physical pages through bounded symmetric MTE staging."""
+
+    def __init__(
+        self,
+        kvpp_group: GroupCoordinator,
+        num_physical_pages: int,
+        *,
+        shared_memory_backend: Any | None = None,
+        copy_pages_op: Callable[..., None] | None = None,
+    ) -> None:
+        self._kvpp_group = kvpp_group
+        self._num_physical_pages = num_physical_pages
+        self._shared_memory_backend = shared_memory_backend
+        self._copy_pages_op = copy_pages_op
+        self._staging_memory: Any | None = None
+        self._local_staging_region: MTEStagingRegion | None = None
+        self._staging_regions_by_rank: list[MTEStagingRegion] = []
+        self._transfer_regions_by_cache: dict[str, tuple[_MTETransferRegion, ...]] = {}
+        self._staging_region_offsets_by_cache_bundle: dict[tuple[str, ...], dict[str, tuple[int, ...]]] = {}
+        self._staging_shm_id: int
+
+    def initialize_transport(
+        self,
+        kv_caches_by_name: dict[str, Any],
+        cache_bundles: tuple[tuple[str, ...], ...],
+        max_active_pages: int,
+    ) -> None:
+        memfabric_backend = None
+        if self._shared_memory_backend is None:
+            import memfabric_hybrid  # type: ignore
+
+            memfabric_backend = memfabric_hybrid
+            self._shared_memory_backend = memfabric_hybrid.shm
+        shared_memory_backend = cast(Any, self._shared_memory_backend)
+        if self._copy_pages_op is None:
+            # Load the extension lazily to avoid early RTS initialization.
+            import vllm_ascend.vllm_ascend_C  # type: ignore # noqa: F401
+
+            self._copy_pages_op = torch.ops._C_ascend.kvpp_mte_copy
+
+        store_url = os.getenv("MF_CONFIG_STORE_URL") or os.environ["ASCEND_MF_STORE_URL"]
+        store_url = _build_group_store_url(store_url, self._kvpp_group)
+        staging_capacity_bytes = envs.ASCEND_KVPP_MTE_STAGING_BYTES
+        self._staging_shm_id = envs.ASCEND_KVPP_MTE_SHM_ID
+        staging_memory = self._create_staging_memory(
+            shared_memory_backend,
+            memfabric_backend,
+            store_url,
+            staging_capacity_bytes,
+        )
+        self._transfer_regions_by_cache = self._build_transfer_regions(kv_caches_by_name)
+        local_staging_region = self._gather_staging_regions(staging_memory, staging_capacity_bytes)
+        self._staging_region_offsets_by_cache_bundle = self._build_staging_region_offsets(
+            cache_bundles,
+            max_active_pages,
+        )
+
+        logger.info(
+            "KVPP MemFabric MTE initialized: rank=%d, gva=%#x, staging_capacity_bytes=%d, shm_id=%d, store_url=%s",
+            self._kvpp_group.rank_in_group,
+            local_staging_region.base_address,
+            staging_capacity_bytes,
+            self._staging_shm_id,
+            store_url,
+        )
+
+    def _create_staging_memory(
+        self,
+        shared_memory_backend: Any,
+        memfabric_backend: Any | None,
+        store_url: str,
+        staging_capacity_bytes: int,
+    ) -> Any:
+        shm_config = shared_memory_backend.ShmConfig()
+        shm_config.start_store = self._kvpp_group.rank_in_group == 0
+        timeout_seconds = envs.ASCEND_KVPP_MTE_TIMEOUT_SECONDS
+        shm_config.init_timeout = timeout_seconds
+        shm_config.create_timeout = timeout_seconds
+        shm_config.operation_timeout = timeout_seconds
+        device_id = torch.npu.current_device()
+        if memfabric_backend is not None:
+            return_code = memfabric_backend.initialize(0)
+            if return_code != 0:
+                raise RuntimeError(f"KVPP MemFabric global initialization failed: error={return_code}.")
+        return_code = shared_memory_backend.initialize(
+            store_url,
+            self._kvpp_group.world_size,
+            self._kvpp_group.rank_in_group,
+            device_id,
+            shm_config,
+        )
+        if return_code != 0:
+            raise RuntimeError(f"KVPP MemFabric SHM initialization failed: error={return_code}.")
+        staging_memory = shared_memory_backend.create(
+            self._staging_shm_id,
+            self._kvpp_group.world_size,
+            self._kvpp_group.rank_in_group,
+            staging_capacity_bytes,
+            shared_memory_backend.ShmDataOpType.MTE,
+        )
+        if staging_memory is None:
+            raise RuntimeError("KVPP MemFabric SHM creation returned no memory.")
+        # ``create`` publishes the symmetric address before every rank's
+        # device-side mapping is necessarily ready. The SHM barrier completes
+        # that setup; a process-group barrier is not an equivalent substitute.
+        staging_memory.barrier()
+        self._staging_memory = staging_memory
+        return staging_memory
+
+    def _build_transfer_regions(
+        self,
+        kv_caches_by_name: dict[str, Any],
+    ) -> dict[str, tuple[_MTETransferRegion, ...]]:
+        transfer_regions_by_cache: dict[str, tuple[_MTETransferRegion, ...]] = {}
+        for cache_name, cache in kv_caches_by_name.items():
+            cache_tensors = (cache,) if isinstance(cache, torch.Tensor) else tuple(cache)
+            if not cache_tensors:
+                raise ValueError(f"KVPP cache group {cache_name} cannot be empty.")
+
+            transfer_regions: list[_MTETransferRegion] = []
+            for cache_tensor in cache_tensors:
+                if cache_tensor.ndim == 0 or cache_tensor.shape[0] % self._num_physical_pages != 0:
+                    raise RuntimeError(
+                        f"KVPP cache {cache_name} shape {tuple(cache_tensor.shape)} "
+                        f"cannot be divided into {self._num_physical_pages} pages."
+                    )
+                rows_per_page = cache_tensor.shape[0] // self._num_physical_pages
+                page = cache_tensor[0:rows_per_page]
+                if not page.is_contiguous():
+                    raise RuntimeError(f"KVPP cache {cache_name} page is not contiguous.")
+
+                page_stride_bytes = cache_tensor.stride(0) * cache_tensor.element_size() * rows_per_page
+                page_length_bytes = page.numel() * cache_tensor.element_size()
+                if page_length_bytes > page_stride_bytes:
+                    raise RuntimeError(
+                        f"KVPP cache {cache_name} pages overlap: "
+                        f"length={page_length_bytes}, stride={page_stride_bytes}."
+                    )
+                transfer_regions.append(
+                    _MTETransferRegion(
+                        base_tensor=cache_tensor,
+                        page_stride_bytes=page_stride_bytes,
+                        page_length_bytes=page_length_bytes,
+                    )
+                )
+            transfer_regions_by_cache[cache_name] = tuple(transfer_regions)
+        return transfer_regions_by_cache
+
+    def _gather_staging_regions(
+        self,
+        staging_memory: Any,
+        staging_capacity_bytes: int,
+    ) -> MTEStagingRegion:
+        # ``gva`` is the common symmetric base. MemFabric may align each
+        # rank's segment to an internal symmetric size larger than the local
+        # contribution. That size is intentionally queried inside the
+        # AscendC kernel; the Python binding does not expose it.
+        self._local_staging_region = MTEStagingRegion(
+            base_address=int(staging_memory.gva),
+            capacity_bytes=staging_capacity_bytes,
+            kvpp_group_rank=self._kvpp_group.rank_in_group,
+        )
+        peer_staging_regions = [self._local_staging_region] * self._kvpp_group.world_size
+        dist.all_gather_object(
+            peer_staging_regions,
+            self._local_staging_region,
+            group=self._kvpp_group.cpu_group,
+        )
+        self._staging_regions_by_rank = peer_staging_regions
+        return self._local_staging_region
+
+    def _build_staging_region_offsets(
+        self,
+        cache_bundles: tuple[tuple[str, ...], ...],
+        max_active_pages: int,
+    ) -> dict[tuple[str, ...], dict[str, tuple[int, ...]]]:
+        """Assign every cache bundle disjoint regions in staging."""
+        staging_capacity_bytes = min(staging_region.capacity_bytes for staging_region in self._staging_regions_by_rank)
+        offsets_by_cache_bundle: dict[tuple[str, ...], dict[str, tuple[int, ...]]] = {}
+        for cache_names in cache_bundles:
+            if cache_names in offsets_by_cache_bundle:
+                continue
+
+            offsets_by_cache: dict[str, tuple[int, ...]] = {}
+            next_offset_bytes = 0
+            for cache_name in cache_names:
+                cache_offsets: list[int] = []
+                for transfer_region in self._transfer_regions_by_cache[cache_name]:
+                    cache_offsets.append(next_offset_bytes)
+                    next_offset_bytes += transfer_region.page_length_bytes * max_active_pages
+                offsets_by_cache[cache_name] = tuple(cache_offsets)
+
+            if next_offset_bytes > staging_capacity_bytes:
+                raise RuntimeError(
+                    "KVPP MTE staging capacity is insufficient for the configured batch: "
+                    f"required_bytes={next_offset_bytes}, capacity_bytes={staging_capacity_bytes}, "
+                    f"max_active_pages={max_active_pages}. Increase ASCEND_KVPP_MTE_STAGING_BYTES."
+                )
+            offsets_by_cache_bundle[cache_names] = offsets_by_cache
+        return offsets_by_cache_bundle
+
+    def copy_active_pages_to_staging(
+        self,
+        cache_names: tuple[str, ...],
+        active_pages: KVPPActivePages,
+        stream: Any,
+    ) -> Any:
+        if self._local_staging_region is None or not self._staging_regions_by_rank:
+            raise RuntimeError("KVPP MTE transport was not initialized.")
+
+        copy_pages_op = cast(Callable[..., None], self._copy_pages_op)
+        staging_region_offsets = self._staging_region_offsets_by_cache_bundle[cache_names]
+        for peer_staging_region in self._staging_regions_by_rank:
+            if peer_staging_region.kvpp_group_rank == self._kvpp_group.rank_in_group:
+                continue
+            for cache_name in cache_names:
+                for transfer_region, staging_region_offset_bytes in zip(
+                    self._transfer_regions_by_cache[cache_name],
+                    staging_region_offsets[cache_name],
+                ):
+                    copy_pages_op(
+                        transfer_region.base_tensor,
+                        active_pages.physical_page_ids,
+                        active_pages.valid_page_mask,
+                        active_pages.staging_page_indices,
+                        transfer_region.page_stride_bytes,
+                        transfer_region.page_length_bytes,
+                        staging_region_offset_bytes,
+                        peer_staging_region.base_address,
+                        False,
+                        peer_staging_region.kvpp_group_rank,
+                        self._staging_shm_id,
+                    )
+        completion_event = torch.npu.Event()
+        completion_event.record(stream)
+        return completion_event
+
+    def copy_active_pages_from_staging(
+        self,
+        cache_names: tuple[str, ...],
+        active_pages: KVPPActivePages,
+        stream: Any,
+    ) -> Any:
+        if self._local_staging_region is None:
+            raise RuntimeError("KVPP MTE transport was not initialized.")
+
+        copy_pages_op = cast(Callable[..., None], self._copy_pages_op)
+        staging_region_offsets = self._staging_region_offsets_by_cache_bundle[cache_names]
+        for cache_name in cache_names:
+            for transfer_region, staging_region_offset_bytes in zip(
+                self._transfer_regions_by_cache[cache_name],
+                staging_region_offsets[cache_name],
+            ):
+                copy_pages_op(
+                    transfer_region.base_tensor,
+                    active_pages.physical_page_ids,
+                    active_pages.valid_page_mask,
+                    active_pages.staging_page_indices,
+                    transfer_region.page_stride_bytes,
+                    transfer_region.page_length_bytes,
+                    staging_region_offset_bytes,
+                    self._local_staging_region.base_address,
+                    True,
+                    self._local_staging_region.kvpp_group_rank,
+                    self._staging_shm_id,
+                )
+        completion_event = torch.npu.Event()
+        completion_event.record(stream)
+        return completion_event

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
@@ -74,6 +74,17 @@ class _MTETransferRegion:
     page_length_bytes: int
 
 
+@dataclass(frozen=True)
+class _MTEDeviceTransferPlan:
+    """Static device metadata shared by every transfer of one cache bundle."""
+
+    anchor: torch.Tensor
+    local_base_offsets: torch.Tensor
+    page_strides: torch.Tensor
+    page_lengths: torch.Tensor
+    staging_region_offsets: torch.Tensor
+
+
 class MemFabricMTEKVPPTransport:
     """Move active physical pages through bounded symmetric MTE staging."""
 
@@ -94,6 +105,7 @@ class MemFabricMTEKVPPTransport:
         self._staging_regions_by_rank: list[MTEStagingRegion] = []
         self._transfer_regions_by_cache: dict[str, tuple[_MTETransferRegion, ...]] = {}
         self._staging_region_offsets_by_cache_bundle: dict[tuple[str, ...], dict[str, tuple[int, ...]]] = {}
+        self._device_transfer_plans_by_cache_bundle: dict[tuple[str, ...], _MTEDeviceTransferPlan] = {}
         self._staging_shm_id: int
 
     def initialize_transport(
@@ -131,6 +143,7 @@ class MemFabricMTEKVPPTransport:
             cache_bundles,
             max_active_pages,
         )
+        self._device_transfer_plans_by_cache_bundle = self._build_device_transfer_plans(cache_bundles)
 
         logger.info(
             "KVPP MemFabric MTE initialized: rank=%d, gva=%#x, staging_capacity_bytes=%d, shm_id=%d, store_url=%s",
@@ -276,6 +289,83 @@ class MemFabricMTEKVPPTransport:
             offsets_by_cache_bundle[cache_names] = offsets_by_cache
         return offsets_by_cache_bundle
 
+    def _build_device_transfer_plans(
+        self,
+        cache_bundles: tuple[tuple[str, ...], ...],
+    ) -> dict[tuple[str, ...], _MTEDeviceTransferPlan]:
+        """Materialize all address/layout data that is invariant across forwards."""
+        plans: dict[tuple[str, ...], _MTEDeviceTransferPlan] = {}
+        for cache_names in cache_bundles:
+            if cache_names in plans:
+                continue
+
+            regions: list[_MTETransferRegion] = []
+            staging_offsets: list[int] = []
+            offsets_by_cache = self._staging_region_offsets_by_cache_bundle[cache_names]
+            for cache_name in cache_names:
+                cache_regions = self._transfer_regions_by_cache[cache_name]
+                regions.extend(cache_regions)
+                staging_offsets.extend(offsets_by_cache[cache_name])
+            if not regions:
+                raise ValueError("KVPP MTE cache bundle cannot be empty.")
+
+            anchor = regions[0].base_tensor
+            if any(region.base_tensor.device != anchor.device for region in regions):
+                raise RuntimeError("KVPP MTE cache bundle tensors must share one device.")
+            anchor_address = anchor.data_ptr()
+            plans[cache_names] = _MTEDeviceTransferPlan(
+                anchor=anchor,
+                local_base_offsets=torch.tensor(
+                    [region.base_tensor.data_ptr() - anchor_address for region in regions],
+                    dtype=torch.int64,
+                    device=anchor.device,
+                ),
+                page_strides=torch.tensor(
+                    [region.page_stride_bytes for region in regions],
+                    dtype=torch.int64,
+                    device=anchor.device,
+                ),
+                page_lengths=torch.tensor(
+                    [region.page_length_bytes for region in regions],
+                    dtype=torch.int64,
+                    device=anchor.device,
+                ),
+                staging_region_offsets=torch.tensor(
+                    staging_offsets,
+                    dtype=torch.int64,
+                    device=anchor.device,
+                ),
+            )
+        return plans
+
+    def _build_active_page_descriptors(
+        self,
+        cache_names: tuple[str, ...],
+        active_pages: KVPPActivePages,
+    ) -> tuple[_MTEDeviceTransferPlan, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Combine cached layout metadata with this forward's active pages."""
+        plan = self._device_transfer_plans_by_cache_bundle[cache_names]
+        page_ids = active_pages.physical_page_ids.to(dtype=torch.int64)
+        staging_page_indices = active_pages.staging_page_indices.to(dtype=torch.int64)
+        valid_page_mask = active_pages.valid_page_mask
+        if (
+            page_ids.device != plan.anchor.device
+            or staging_page_indices.device != plan.anchor.device
+            or valid_page_mask.device != plan.anchor.device
+        ):
+            raise RuntimeError("KVPP MTE active pages and transfer plan must share one device.")
+
+        local_offsets = (plan.local_base_offsets[:, None] + page_ids[None, :] * plan.page_strides[:, None]).flatten()
+        staging_offsets = (
+            plan.staging_region_offsets[:, None] + staging_page_indices[None, :] * plan.page_lengths[:, None]
+        ).flatten()
+        lengths = torch.where(
+            valid_page_mask[None, :],
+            plan.page_lengths[:, None],
+            torch.zeros((), dtype=torch.int64, device=plan.anchor.device),
+        ).flatten()
+        return plan, local_offsets, staging_offsets, lengths
+
     def copy_active_pages_to_staging(
         self,
         cache_names: tuple[str, ...],
@@ -286,28 +376,23 @@ class MemFabricMTEKVPPTransport:
             raise RuntimeError("KVPP MTE transport was not initialized.")
 
         copy_pages_op = cast(Callable[..., None], self._copy_pages_op)
-        staging_region_offsets = self._staging_region_offsets_by_cache_bundle[cache_names]
+        plan, local_offsets, staging_offsets, lengths = self._build_active_page_descriptors(
+            cache_names,
+            active_pages,
+        )
         for peer_staging_region in self._staging_regions_by_rank:
             if peer_staging_region.kvpp_group_rank == self._kvpp_group.rank_in_group:
                 continue
-            for cache_name in cache_names:
-                for transfer_region, staging_region_offset_bytes in zip(
-                    self._transfer_regions_by_cache[cache_name],
-                    staging_region_offsets[cache_name],
-                ):
-                    copy_pages_op(
-                        transfer_region.base_tensor,
-                        active_pages.physical_page_ids,
-                        active_pages.valid_page_mask,
-                        active_pages.staging_page_indices,
-                        transfer_region.page_stride_bytes,
-                        transfer_region.page_length_bytes,
-                        staging_region_offset_bytes,
-                        peer_staging_region.base_address,
-                        False,
-                        peer_staging_region.kvpp_group_rank,
-                        self._staging_shm_id,
-                    )
+            copy_pages_op(
+                plan.anchor,
+                local_offsets,
+                staging_offsets,
+                lengths,
+                peer_staging_region.base_address,
+                -1,
+                peer_staging_region.kvpp_group_rank,
+                self._staging_shm_id,
+            )
         completion_event = torch.npu.Event()
         completion_event.record(stream)
         return completion_event
@@ -322,25 +407,20 @@ class MemFabricMTEKVPPTransport:
             raise RuntimeError("KVPP MTE transport was not initialized.")
 
         copy_pages_op = cast(Callable[..., None], self._copy_pages_op)
-        staging_region_offsets = self._staging_region_offsets_by_cache_bundle[cache_names]
-        for cache_name in cache_names:
-            for transfer_region, staging_region_offset_bytes in zip(
-                self._transfer_regions_by_cache[cache_name],
-                staging_region_offsets[cache_name],
-            ):
-                copy_pages_op(
-                    transfer_region.base_tensor,
-                    active_pages.physical_page_ids,
-                    active_pages.valid_page_mask,
-                    active_pages.staging_page_indices,
-                    transfer_region.page_stride_bytes,
-                    transfer_region.page_length_bytes,
-                    staging_region_offset_bytes,
-                    self._local_staging_region.base_address,
-                    True,
-                    self._local_staging_region.kvpp_group_rank,
-                    self._staging_shm_id,
-                )
+        plan, local_offsets, staging_offsets, lengths = self._build_active_page_descriptors(
+            cache_names,
+            active_pages,
+        )
+        copy_pages_op(
+            plan.anchor,
+            local_offsets,
+            staging_offsets,
+            lengths,
+            self._local_staging_region.base_address,
+            self._local_staging_region.kvpp_group_rank,
+            -1,
+            self._staging_shm_id,
+        )
         completion_event = torch.npu.Event()
         completion_event.record(stream)
         return completion_event

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
@@ -23,6 +23,7 @@ from vllm.distributed.parallel_state import GroupCoordinator
 from vllm.logger import logger
 
 from vllm_ascend import envs
+from vllm_ascend.core.kv_cache_placement import kvpp_staging_size_bytes
 
 
 def _build_group_store_url(store_url: str, kvpp_group: GroupCoordinator) -> str:
@@ -106,16 +107,17 @@ class MemFabricMTEKVPPTransport:
         *,
         shared_memory_backend: Any | None = None,
         copy_pages_op: Callable[..., None] | None = None,
+        staging_capacity_bytes: int | None = None,
     ) -> None:
         self._kvpp_group = kvpp_group
         self._num_physical_pages = num_physical_pages
         self._shared_memory_backend = shared_memory_backend
         self._copy_pages_op = copy_pages_op
+        self._planned_staging_capacity_bytes = staging_capacity_bytes
         self._staging_memory: Any | None = None
         self._local_staging_region: MTEStagingRegion | None = None
         self._staging_regions_by_rank: list[MTEStagingRegion] = []
         self._transfer_regions_by_cache: dict[str, tuple[_MTETransferRegion, ...]] = {}
-        self._staging_region_offsets_by_cache_bundle: dict[tuple[str, ...], dict[str, tuple[int, ...]]] = {}
         self._device_transfer_plans_by_cache_bundle: dict[tuple[str, ...], _MTEDeviceTransferPlan] = {}
         self._staging_shm_id: int
 
@@ -140,7 +142,16 @@ class MemFabricMTEKVPPTransport:
 
         store_url = os.getenv("MF_CONFIG_STORE_URL") or os.environ["ASCEND_MF_STORE_URL"]
         store_url = _build_group_store_url(store_url, self._kvpp_group)
-        staging_capacity_bytes = envs.ASCEND_KVPP_MTE_STAGING_BYTES
+        self._transfer_regions_by_cache = self._build_transfer_regions(kv_caches_by_name)
+        self._device_transfer_plans_by_cache_bundle, required_bytes = self._build_device_transfer_plans(
+            cache_bundles, max_active_pages
+        )
+        # Standalone transport callers have no worker budget. Production uses
+        # the capacity already included in the worker's memory plan.
+        staging_capacity_bytes = self._planned_staging_capacity_bytes
+        if staging_capacity_bytes is None:
+            staging_capacity_bytes = required_bytes
+        self._check_staging_layout(required_bytes, staging_capacity_bytes, max_active_pages)
         self._staging_shm_id = envs.ASCEND_KVPP_MTE_SHM_ID
         staging_memory = self._create_staging_memory(
             shared_memory_backend,
@@ -148,13 +159,7 @@ class MemFabricMTEKVPPTransport:
             store_url,
             staging_capacity_bytes,
         )
-        self._transfer_regions_by_cache = self._build_transfer_regions(kv_caches_by_name)
         local_staging_region = self._gather_staging_regions(staging_memory, staging_capacity_bytes)
-        self._staging_region_offsets_by_cache_bundle = self._build_staging_region_offsets(
-            cache_bundles,
-            max_active_pages,
-        )
-        self._device_transfer_plans_by_cache_bundle = self._build_device_transfer_plans(cache_bundles)
 
         logger.info(
             "KVPP MemFabric MTE initialized: rank=%d, gva=%#x, staging_capacity_bytes=%d, shm_id=%d, store_url=%s",
@@ -164,6 +169,34 @@ class MemFabricMTEKVPPTransport:
             self._staging_shm_id,
             store_url,
         )
+
+    def _check_staging_layout(self, required_bytes: int, capacity_bytes: int, max_active_pages: int) -> None:
+        """Check the wire layout, not equality of rank-local scratch allocations."""
+        # Equal total sizes alone do not ensure the owner and receiver agree
+        # on segment offsets or data types. Local base addresses and strides
+        # may differ and are deliberately excluded from the wire signature.
+        bundles = tuple(
+            (
+                names,
+                tuple(
+                    (r.page_length_bytes, r.base_tensor.dtype)
+                    for name in names
+                    for r in self._transfer_regions_by_cache[name]
+                ),
+            )
+            for names in sorted(self._device_transfer_plans_by_cache_bundle)
+        )
+        local = (capacity_bytes, required_bytes, self._num_physical_pages, max_active_pages, bundles)
+        layouts = [local] * self._kvpp_group.world_size
+        dist.all_gather_object(layouts, local, group=self._kvpp_group.cpu_group)
+        if any(
+            capacity != capacity_bytes
+            or required > capacity
+            or not 0 < slots <= pages
+            or (pages, slots, peer_bundles) != local[2:]
+            for capacity, required, pages, slots, peer_bundles in layouts
+        ):
+            raise ValueError("KVPP staging capacity or wire layout does not match across ranks; SHM was not allocated.")
 
     def _create_staging_memory(
         self,
@@ -270,53 +303,27 @@ class MemFabricMTEKVPPTransport:
         self._staging_regions_by_rank = peer_staging_regions
         return self._local_staging_region
 
-    def _build_staging_region_offsets(
-        self,
-        cache_bundles: tuple[tuple[str, ...], ...],
-        max_active_pages: int,
-    ) -> dict[tuple[str, ...], dict[str, tuple[int, ...]]]:
-        """Assign every cache bundle disjoint regions in staging."""
-        staging_capacity_bytes = min(staging_region.capacity_bytes for staging_region in self._staging_regions_by_rank)
-        offsets_by_cache_bundle: dict[tuple[str, ...], dict[str, tuple[int, ...]]] = {}
-        for cache_names in cache_bundles:
-            if cache_names in offsets_by_cache_bundle:
-                continue
-
-            offsets_by_cache: dict[str, tuple[int, ...]] = {}
-            next_offset_bytes = 0
-            for cache_name in cache_names:
-                cache_offsets: list[int] = []
-                for transfer_region in self._transfer_regions_by_cache[cache_name]:
-                    cache_offsets.append(next_offset_bytes)
-                    next_offset_bytes += transfer_region.page_length_bytes * max_active_pages
-                offsets_by_cache[cache_name] = tuple(cache_offsets)
-
-            if next_offset_bytes > staging_capacity_bytes:
-                raise RuntimeError(
-                    "KVPP MTE staging capacity is insufficient for the configured batch: "
-                    f"required_bytes={next_offset_bytes}, capacity_bytes={staging_capacity_bytes}, "
-                    f"max_active_pages={max_active_pages}. Increase ASCEND_KVPP_MTE_STAGING_BYTES."
-                )
-            offsets_by_cache_bundle[cache_names] = offsets_by_cache
-        return offsets_by_cache_bundle
-
     def _build_device_transfer_plans(
         self,
         cache_bundles: tuple[tuple[str, ...], ...],
-    ) -> dict[tuple[str, ...], _MTEDeviceTransferPlan]:
-        """Materialize all address/layout data that is invariant across forwards."""
+        max_active_pages: int,
+    ) -> tuple[dict[tuple[str, ...], _MTEDeviceTransferPlan], int]:
+        """Build static descriptors and their staging requirement in one pass."""
         plans: dict[tuple[str, ...], _MTEDeviceTransferPlan] = {}
+        required_page_bytes = 0
         for cache_names in cache_bundles:
             if cache_names in plans:
                 continue
 
             regions: list[_MTETransferRegion] = []
             staging_offsets: list[int] = []
-            offsets_by_cache = self._staging_region_offsets_by_cache_bundle[cache_names]
+            page_offset = 0
             for cache_name in cache_names:
-                cache_regions = self._transfer_regions_by_cache[cache_name]
-                regions.extend(cache_regions)
-                staging_offsets.extend(offsets_by_cache[cache_name])
+                for region in self._transfer_regions_by_cache[cache_name]:
+                    regions.append(region)
+                    staging_offsets.append(page_offset * max_active_pages)
+                    page_offset += region.page_length_bytes
+            required_page_bytes = max(required_page_bytes, page_offset)
             if not regions:
                 raise ValueError("KVPP MTE cache bundle cannot be empty.")
 
@@ -347,7 +354,7 @@ class MemFabricMTEKVPPTransport:
                     device=anchor.device,
                 ),
             )
-        return plans
+        return plans, kvpp_staging_size_bytes(required_page_bytes, self._num_physical_pages)
 
     def _build_active_page_descriptors(
         self,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/memfabric_mte_transport.py
@@ -66,6 +66,17 @@ class MTEStagingRegion:
 
 
 @dataclass(frozen=True)
+class _MTECompletion:
+    """Completion event that keeps asynchronous descriptor tensors alive."""
+
+    event: Any
+    retained_resources: tuple[torch.Tensor, ...]
+
+    def synchronize(self) -> None:
+        self.event.synchronize()
+
+
+@dataclass(frozen=True)
 class _MTETransferRegion:
     """One base address and its logical-page layout."""
 
@@ -395,7 +406,7 @@ class MemFabricMTEKVPPTransport:
             )
         completion_event = torch.npu.Event()
         completion_event.record(stream)
-        return completion_event
+        return _MTECompletion(completion_event, (local_offsets, staging_offsets, lengths))
 
     def copy_active_pages_from_staging(
         self,
@@ -423,4 +434,4 @@ class MemFabricMTEKVPPTransport:
         )
         completion_event = torch.npu.Event()
         completion_event.record(stream)
-        return completion_event
+        return _MTECompletion(completion_event, (local_offsets, staging_offsets, lengths))

--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -16,6 +16,7 @@ _EMBED_TP: GroupCoordinator | None = None
 _P_TP: GroupCoordinator | None = None
 
 _DYNAMIC_EPLB: GroupCoordinator | None = None
+_KVPP: GroupCoordinator | None = None
 
 
 def init_ascend_model_parallel(
@@ -40,6 +41,17 @@ def init_ascend_model_parallel(
         global_pp_size,
         global_pcp_size,
         global_tp_size,
+    )
+
+    kvpp_size = get_ascend_config().kvpp_config.size
+    global _KVPP
+    assert _KVPP is None, "KV layer parallel group is already initialized"
+    kvpp_group_ranks = all_ranks.reshape(-1, kvpp_size).unbind(0)
+    _KVPP = init_model_parallel_group(
+        [ranks.tolist() for ranks in kvpp_group_ranks],
+        get_world_group().local_rank,
+        backend,
+        group_name="kvpp",
     )
 
     pd_tp_ratio = get_ascend_config().pd_tp_ratio
@@ -173,7 +185,17 @@ def get_dynamic_eplb_group() -> GroupCoordinator:
     return _DYNAMIC_EPLB
 
 
+def get_kvpp_group() -> GroupCoordinator:
+    assert _KVPP is not None, "KV layer parallel group is not initialized"
+    return _KVPP
+
+
 def destroy_ascend_model_parallel():
+    global _KVPP
+    if _KVPP:
+        _KVPP.destroy()
+    _KVPP = None
+
     global _MC2
     if _MC2:
         _MC2.destroy()

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,11 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Per-rank bounded symmetric staging capacity used by KVPP MTE.
+    "ASCEND_KVPP_MTE_STAGING_BYTES": lambda: int(os.getenv("ASCEND_KVPP_MTE_STAGING_BYTES", str(256 << 20))),
+    # MemFabric SHM object IDs are process-global and restricted to [0, 64).
+    "ASCEND_KVPP_MTE_SHM_ID": lambda: int(os.getenv("ASCEND_KVPP_MTE_SHM_ID", "31")),
+    "ASCEND_KVPP_MTE_TIMEOUT_SECONDS": lambda: int(os.getenv("ASCEND_KVPP_MTE_TIMEOUT_SECONDS", "120")),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,8 +71,6 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
-    # Per-rank bounded symmetric staging capacity used by KVPP MTE.
-    "ASCEND_KVPP_MTE_STAGING_BYTES": lambda: int(os.getenv("ASCEND_KVPP_MTE_STAGING_BYTES", str(256 << 20))),
     # MemFabric SHM object IDs are process-global and restricted to [0, 64).
     "ASCEND_KVPP_MTE_SHM_ID": lambda: int(os.getenv("ASCEND_KVPP_MTE_SHM_ID", "31")),
     "ASCEND_KVPP_MTE_TIMEOUT_SECONDS": lambda: int(os.getenv("ASCEND_KVPP_MTE_TIMEOUT_SECONDS", "120")),

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -31,8 +31,7 @@ from vllm.platforms import Platform, PlatformEnum
 # todo: please remove it when solve cuda hard code in vllm
 os.environ["VLLM_DISABLE_SHARED_EXPERTS_STREAM"] = "1"
 
-
-from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.ascend_config import KVPPConfig, get_ascend_config, init_ascend_config
 from vllm_ascend.device.hardware_profile import (
     AttentionBackendFamily,
     HardwareCapability,
@@ -1460,6 +1459,10 @@ def _validate_parallel_config(vllm_config: VllmConfig) -> None:
             "Please set --prefill-context-parallel-size to 1. "
             f"Got prefill_context_parallel_size={parallel_config.prefill_context_parallel_size}."
         )
+
+    kvpp_config = KVPPConfig.from_vllm_config(vllm_config)
+    if kvpp_config.size > 1:
+        kvpp_config.validate(vllm_config)
 
     sfa_dcp_replicated_indexer = enable_sfa_dcp_replicated_indexer(vllm_config)
     if sfa_dcp_replicated_indexer:

--- a/vllm_ascend/worker/kvpp_v1.py
+++ b/vllm_ascend/worker/kvpp_v1.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import Any
+
+from vllm_ascend.ascend_config import KVPPConfig
+from vllm_ascend.worker.v2.kvpp import KVPPCacheLayout, KVPPRuntime
+
+
+class KVPPV1Runtime:
+    """Model Runner V1 adapter around the shared KVPP scheduler."""
+
+    def __init__(self, runtime: KVPPRuntime | None = None) -> None:
+        self._kvpp_runtime = runtime if runtime is not None else KVPPRuntime()
+
+    @classmethod
+    def create_from_kv_cache(
+        cls,
+        *,
+        vllm_config: Any,
+        kv_cache_config: Any,
+        static_forward_context: dict[str, Any],
+        kv_caches: dict[str, Any],
+        block_tables: Any,
+    ) -> KVPPV1Runtime:
+        if KVPPConfig.from_vllm_config(vllm_config).size <= 1:
+            return cls()
+
+        cache_group_count = len(kv_cache_config.kv_cache_groups)
+        return cls(
+            KVPPRuntime.create_from_cache_layout(
+                vllm_config=vllm_config,
+                kv_cache_config=kv_cache_config,
+                static_forward_context=static_forward_context,
+                cache_layout=KVPPCacheLayout(
+                    layer_caches=kv_caches,
+                    physical_blocks_per_kv_block=tuple(
+                        block_tables[index].blocks_per_phys_block for index in range(cache_group_count)
+                    ),
+                    tokens_per_block=tuple(
+                        block_tables[index].logical_block_size for index in range(cache_group_count)
+                    ),
+                ),
+            ),
+        )
+
+    def prepare_forward(
+        self,
+        input_batch: Any,
+        num_reqs: int,
+        seq_lens: Any,
+    ) -> None:
+        runtime = self._kvpp_runtime
+        if runtime.scheduler is None:
+            return
+        block_table = input_batch.block_table[runtime.managed_cache_group_index]
+        runtime.scheduler.schedule_forward(
+            block_table.get_device_tensor(num_reqs),
+            seq_lens,
+        )
+
+    def complete_forward(self) -> None:
+        self._kvpp_runtime.complete_forward()

--- a/vllm_ascend/worker/kvpp_v1.py
+++ b/vllm_ascend/worker/kvpp_v1.py
@@ -48,7 +48,7 @@ class KVPPV1Runtime:
         self,
         input_batch: Any,
         num_reqs: int,
-        seq_lens: Any,
+        num_computed_tokens: Any,
     ) -> None:
         runtime = self._kvpp_runtime
         if runtime.scheduler is None:
@@ -56,7 +56,7 @@ class KVPPV1Runtime:
         block_table = input_batch.block_table[runtime.managed_cache_group_index]
         runtime.scheduler.schedule_forward(
             block_table.get_device_tensor(num_reqs),
-            seq_lens,
+            num_computed_tokens,
         )
 
     def complete_forward(self) -> None:

--- a/vllm_ascend/worker/kvpp_v1.py
+++ b/vllm_ascend/worker/kvpp_v1.py
@@ -22,6 +22,7 @@ class KVPPV1Runtime:
         static_forward_context: dict[str, Any],
         kv_caches: dict[str, Any],
         block_tables: Any,
+        staging_capacity_bytes: int | None = None,
     ) -> KVPPV1Runtime:
         if KVPPConfig.from_vllm_config(vllm_config).size <= 1:
             return cls()
@@ -32,6 +33,7 @@ class KVPPV1Runtime:
                 vllm_config=vllm_config,
                 kv_cache_config=kv_cache_config,
                 static_forward_context=static_forward_context,
+                staging_capacity_bytes=staging_capacity_bytes,
                 cache_layout=KVPPCacheLayout(
                     layer_caches=kv_caches,
                     physical_blocks_per_kv_block=tuple(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -192,6 +192,7 @@ from vllm_ascend.utils import (
     weak_ref_tensors,
 )
 from vllm_ascend.worker.dcp_utils import DCPAsyncSpecDecodeRebuildResult, DCPManager
+from vllm_ascend.worker.kvpp_v1 import KVPPV1Runtime
 from vllm_ascend.worker.npu_input_batch import NPUInputBatch
 from vllm_ascend.worker.utils import AscendKVBlockZeroer
 
@@ -347,6 +348,8 @@ class NPUModelRunner(GPUModelRunner):
         # Ascend-specific configurations
         self.ascend_config = get_ascend_config()
         self.use_score_encoder_cache = is_score_encoder_cache_manager(self.vllm_config)
+
+        self.kvpp = KVPPV1Runtime()
 
         # Dump / PrecisionDebugger configuration now comes from AscendConfig
         dump_cfg = self.ascend_config.dump_config_path
@@ -2330,6 +2333,12 @@ class NPUModelRunner(GPUModelRunner):
             # update global cos, sin
             update_cos_sin(positions)
 
+        self.kvpp.prepare_forward(
+            self.input_batch,
+            num_reqs,
+            self.optimistic_seq_lens_cpu[:num_reqs],
+        )
+
         if self.dynamic_eplb:
             self.eplb_updator.forward_before()
 
@@ -2378,6 +2387,9 @@ class NPUModelRunner(GPUModelRunner):
             hidden_states = self._model_forward(
                 num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds, **model_kwargs
             )
+
+        self.kvpp.complete_forward()
+
         with record_function_or_nullcontext("post process"):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
@@ -3646,6 +3658,13 @@ class NPUModelRunner(GPUModelRunner):
                 if hasattr(self.drafter, "model") and hasattr(self.drafter.model, "compute_logits"):
                     return self.drafter.model.compute_logits(hidden_states[dummy_indices])
 
+            if attn_metadata is not None:
+                self.kvpp.prepare_forward(
+                    self.input_batch,
+                    num_reqs,
+                    self.optimistic_seq_lens_cpu[:num_reqs],
+                )
+
             with set_ascend_forward_context(
                 attn_metadata,
                 self.vllm_config,
@@ -3662,6 +3681,8 @@ class NPUModelRunner(GPUModelRunner):
                 outputs = self._model_forward(
                     num_tokens_padded, input_ids, positions, intermediate_tensors, inputs_embeds
                 )
+
+            self.kvpp.complete_forward()
             if self.use_aux_hidden_state_outputs:
                 hidden_states, _ = outputs
             else:
@@ -3975,6 +3996,14 @@ class NPUModelRunner(GPUModelRunner):
 
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
+
+        self.kvpp = KVPPV1Runtime.create_from_kv_cache(
+            vllm_config=self.vllm_config,
+            kv_cache_config=self.kv_cache_config,
+            static_forward_context=self.compilation_config.static_forward_context,
+            kv_caches=kv_caches,
+            block_tables=self.input_batch.block_table,
+        )
 
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:
         data_ptr = tensor.data_ptr()

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2336,7 +2336,7 @@ class NPUModelRunner(GPUModelRunner):
         self.kvpp.prepare_forward(
             self.input_batch,
             num_reqs,
-            self.optimistic_seq_lens_cpu[:num_reqs],
+            self.num_computed_tokens[:num_reqs],
         )
 
         if self.dynamic_eplb:
@@ -3662,7 +3662,7 @@ class NPUModelRunner(GPUModelRunner):
                 self.kvpp.prepare_forward(
                     self.input_batch,
                     num_reqs,
-                    self.optimistic_seq_lens_cpu[:num_reqs],
+                    self.num_computed_tokens[:num_reqs],
                 )
 
             with set_ascend_forward_context(

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -3927,7 +3927,9 @@ class NPUModelRunner(GPUModelRunner):
 
         self.debugger.step(**kwargs)
 
-    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+    def initialize_kv_cache(
+        self, kv_cache_config: KVCacheConfig, *, kvpp_staging_capacity_bytes: int | None = None
+    ) -> None:
         """
         Initialize KV cache based on `kv_cache_config`.
         Args:
@@ -4003,6 +4005,7 @@ class NPUModelRunner(GPUModelRunner):
             static_forward_context=self.compilation_config.static_forward_context,
             kv_caches=kv_caches,
             block_tables=self.input_batch.block_table,
+            staging_capacity_bytes=kvpp_staging_capacity_bytes,
         )
 
     def _align_memory(self, tensor: torch.Tensor, alignment: int) -> torch.Tensor:

--- a/vllm_ascend/worker/v2/kvpp.py
+++ b/vllm_ascend/worker/v2/kvpp.py
@@ -181,11 +181,14 @@ class KVPPRuntime:
     def prepare_forward(
         self,
         block_tables: tuple[torch.Tensor, ...],
-        seq_lens: Any,
+        num_computed_tokens: Any,
     ) -> None:
         if self.scheduler is None:
             return
-        self.scheduler.schedule_forward(block_tables[self.managed_cache_group_index], seq_lens)
+        self.scheduler.schedule_forward(
+            block_tables[self.managed_cache_group_index],
+            num_computed_tokens,
+        )
 
     def complete_forward(self) -> None:
         if self.scheduler is None:
@@ -195,27 +198,28 @@ class KVPPRuntime:
 
 def select_active_pages(
     block_table: torch.Tensor,
-    seq_lens: Any,
+    num_computed_tokens: Any,
     tokens_per_block: int,
     num_physical_blocks: int,
 ) -> KVPPActivePages:
-    """Return fixed-shape device pages read by the current batch.
+    """Return fixed-shape device pages containing computed KV cache.
 
     The original block table is read only. Invalid columns and duplicate page
     IDs become masked slots instead of being compacted through the host.
     """
-    if isinstance(seq_lens, torch.Tensor) and seq_lens.device.type != "cpu":
-        raise ValueError("KVPP sequence lengths must stay on the host.")
-    sequence_lengths_host = torch.as_tensor(seq_lens, dtype=torch.int64, device="cpu").flatten()
-    sequence_lengths_device = sequence_lengths_host.to(device=block_table.device)
-    active_block_table = block_table[: sequence_lengths_device.shape[0]].to(dtype=torch.int64)
+    computed_token_counts = torch.as_tensor(
+        num_computed_tokens,
+        dtype=torch.int64,
+        device=block_table.device,
+    ).flatten()
+    active_block_table = block_table[: computed_token_counts.shape[0]].to(dtype=torch.int64)
     block_columns = torch.arange(
         active_block_table.shape[1],
         dtype=torch.int64,
         device=block_table.device,
     )
     pages_per_request = torch.div(
-        sequence_lengths_device + tokens_per_block - 1,
+        computed_token_counts + tokens_per_block - 1,
         tokens_per_block,
         rounding_mode="floor",
     )
@@ -287,13 +291,13 @@ class KVPPScheduler:
     def schedule_forward(
         self,
         block_table: torch.Tensor,
-        seq_lens: Any,
+        num_computed_tokens: Any,
     ) -> None:
         if self._active_pages is not None:
             raise RuntimeError("KVPP cannot schedule a new forward while the previous forward is active.")
         self._active_pages = select_active_pages(
             block_table,
-            seq_lens,
+            num_computed_tokens,
             self.tokens_per_block,
             self.num_physical_blocks,
         )

--- a/vllm_ascend/worker/v2/kvpp.py
+++ b/vllm_ascend/worker/v2/kvpp.py
@@ -19,7 +19,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.memfabric_mte_transport import 
 from vllm_ascend.distributed.parallel_state import get_kvpp_group
 
 # Dedicated kvpp CPU group: one in-flight prefetch, so tags only distinguish
-# the ready/done handshake, not the transformer layer.
+# the staging-ready/data-ready handshake, not the transformer layer.
 _KVPP_READY_TAG = 0
 _KVPP_DONE_TAG = 1
 
@@ -371,9 +371,10 @@ class KVPPScheduler:
         token = torch.ones(1, dtype=torch.uint8, device="cpu")
 
         with torch.profiler.record_function(f"kvpp.comm_total.layer_{layer_index}"):
-            scratch_ready.synchronize()
-
             if local_kvpp_rank != owner_kvpp_rank:
+                # The previous prefetch future completed before this task was
+                # submitted, so this rank's staging region can be overwritten.
+                # Scratch reuse is a separate device-stream dependency below.
                 dist.send(
                     token,
                     dst=owner_global_rank,
@@ -388,6 +389,7 @@ class KVPPScheduler:
                 )
                 with torch.profiler.record_function(f"kvpp.transport_receive.layer_{layer_index}"):
                     with torch.npu.stream(self._kv_transfer_stream):
+                        self._kv_transfer_stream.wait_event(scratch_ready)
                         receive_completion = self.transport.copy_active_pages_from_staging(
                             self.layer_cache_bundles[layer_name],
                             active_pages,

--- a/vllm_ascend/worker/v2/kvpp.py
+++ b/vllm_ascend/worker/v2/kvpp.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from vllm.distributed.parallel_state import GroupCoordinator
+from vllm.model_executor.models.utils import extract_layer_index
+
+from vllm_ascend.ascend_config import KVPPConfig
+from vllm_ascend.core.kv_cache_placement import map_kvpp_layers_to_owners
+from vllm_ascend.distributed.kv_transfer.kv_pool.memfabric_mte_transport import (
+    KVPPActivePages,
+    MemFabricMTEKVPPTransport,
+)
+from vllm_ascend.distributed.parallel_state import get_kvpp_group
+
+# Dedicated kvpp CPU group: one in-flight prefetch, so tags only distinguish
+# the ready/done handshake, not the transformer layer.
+_KVPP_READY_TAG = 0
+_KVPP_DONE_TAG = 1
+
+
+def build_layer_cache_bundles(
+    layer_owner_ranks: dict[str, int],
+    attention_layer_names: tuple[str, ...] | None,
+) -> dict[str, tuple[str, ...]]:
+    """Group the KV caches consumed by each executable attention layer.
+
+    For example, if layer 0 has a Target KV cache and an indexer cache, both
+    are transferred when its attention implementation runs::
+
+        {
+            "model.layers.0.self_attn.attn": (
+                "model.layers.0.self_attn.attn",
+                "model.layers.0.self_attn.indexer.k_cache",
+            )
+        }
+    """
+    layers = tuple(attention_layer_names or layer_owner_ranks)
+    if attention_layer_names is None:
+        return {layer_name: (layer_name,) for layer_name in layers}
+
+    cache_layers_by_index: dict[int, list[str]] = {}
+    for cache_layer_name in sorted(
+        layer_owner_ranks,
+        key=lambda name: (extract_layer_index(name), name),
+    ):
+        cache_layers_by_index.setdefault(extract_layer_index(cache_layer_name), []).append(cache_layer_name)
+
+    return {
+        layer_name: tuple(cache_layers_by_index[extract_layer_index(layer_name)])
+        for layer_name in attention_layer_names
+    }
+
+
+@dataclass(frozen=True)
+class KVPPCacheLayout:
+    """Model-runner cache objects and their physical block layout."""
+
+    layer_caches: dict[str, Any]
+    physical_blocks_per_kv_block: Sequence[int]
+    tokens_per_block: Sequence[int]
+
+
+class KVPPRuntime:
+    """Model-runner facing KVPP placement and scheduling glue."""
+
+    def __init__(
+        self,
+        scheduler: KVPPScheduler | None = None,
+        managed_cache_group_index: int = 0,
+    ) -> None:
+        self.scheduler = scheduler
+        self.managed_cache_group_index = managed_cache_group_index
+
+    @classmethod
+    def create_from_kv_cache(
+        cls,
+        *,
+        vllm_config: Any,
+        kv_cache_config: Any,
+        block_tables: Any,
+        static_forward_context: dict[str, Any],
+    ) -> KVPPRuntime:
+        if KVPPConfig.from_vllm_config(vllm_config).size <= 1:
+            return cls()
+
+        layer_caches: dict[str, Any] = {}
+        for cache_group in kv_cache_config.kv_cache_groups:
+            for layer_name in cache_group.layer_names:
+                module = static_forward_context.get(layer_name)
+                if module is not None and hasattr(module, "kv_cache"):
+                    layer_caches[layer_name] = module.kv_cache
+        return cls.create_from_cache_layout(
+            vllm_config=vllm_config,
+            kv_cache_config=kv_cache_config,
+            static_forward_context=static_forward_context,
+            cache_layout=KVPPCacheLayout(
+                layer_caches=layer_caches,
+                physical_blocks_per_kv_block=block_tables.blocks_per_kv_block,
+                tokens_per_block=block_tables.kernel_block_sizes,
+            ),
+        )
+
+    @classmethod
+    def create_from_cache_layout(
+        cls,
+        *,
+        vllm_config: Any,
+        kv_cache_config: Any,
+        static_forward_context: dict[str, Any],
+        cache_layout: KVPPCacheLayout,
+    ) -> KVPPRuntime:
+        """Create the runtime after a model runner has normalized its cache layout."""
+        layer_names = tuple(
+            dict.fromkeys(
+                layer_name for cache_group in kv_cache_config.kv_cache_groups for layer_name in cache_group.layer_names
+            )
+        )
+        layer_owner_ranks = map_kvpp_layers_to_owners(vllm_config, layer_names)
+
+        managed_layer_names = set(layer_owner_ranks)
+        managed_cache_group_indices = {
+            group_index
+            for group_index, cache_group in enumerate(kv_cache_config.kv_cache_groups)
+            if managed_layer_names.intersection(cache_group.layer_names)
+        }
+        if len(managed_cache_group_indices) != 1:
+            raise ValueError(
+                f"KVPP managed layers must belong to one cache group, got {sorted(managed_cache_group_indices)}."
+            )
+        managed_cache_group_index = managed_cache_group_indices.pop()
+
+        attention_impls: dict[str, Any] = {}
+        managed_kv_caches: dict[str, Any] = {}
+        for layer_name in layer_owner_ranks:
+            if layer_name not in cache_layout.layer_caches:
+                raise RuntimeError(f"KVPP could not find the cache bound to layer {layer_name!r}.")
+            managed_kv_caches[layer_name] = cache_layout.layer_caches[layer_name]
+            module = static_forward_context.get(layer_name)
+            impl = getattr(module, "impl", None)
+            if impl is not None and hasattr(impl, "layerwise_kv_cache_hook"):
+                attention_impls[layer_name] = impl
+        if not attention_impls:
+            raise RuntimeError("KVPP requires an MLA or SFA attention implementation with a layer cache hook.")
+
+        num_physical_blocks = (
+            kv_cache_config.num_blocks * cache_layout.physical_blocks_per_kv_block[managed_cache_group_index]
+        )
+        tokens_per_block = cache_layout.tokens_per_block[managed_cache_group_index]
+        max_blocks_per_request = (vllm_config.model_config.max_model_len + tokens_per_block - 1) // tokens_per_block
+        max_active_pages = min(
+            num_physical_blocks,
+            vllm_config.scheduler_config.max_num_seqs * max_blocks_per_request,
+        )
+        kvpp_group = get_kvpp_group()
+        scheduler = KVPPScheduler(
+            kvpp_group=kvpp_group,
+            layer_owner_ranks=layer_owner_ranks,
+            kv_caches=managed_kv_caches,
+            tokens_per_block=tokens_per_block,
+            num_physical_blocks=num_physical_blocks,
+            max_active_pages=max_active_pages,
+            transport=MemFabricMTEKVPPTransport(
+                kvpp_group,
+                num_physical_blocks,
+            ),
+            attention_layer_names=tuple(attention_impls),
+        )
+        for impl in attention_impls.values():
+            impl.layerwise_kv_cache_hook = scheduler
+        return cls(
+            scheduler=scheduler,
+            managed_cache_group_index=managed_cache_group_index,
+        )
+
+    def prepare_forward(
+        self,
+        block_tables: tuple[torch.Tensor, ...],
+        seq_lens: Any,
+    ) -> None:
+        if self.scheduler is None:
+            return
+        self.scheduler.schedule_forward(block_tables[self.managed_cache_group_index], seq_lens)
+
+    def complete_forward(self) -> None:
+        if self.scheduler is None:
+            return
+        self.scheduler.complete_forward()
+
+
+def select_active_pages(
+    block_table: torch.Tensor,
+    seq_lens: Any,
+    tokens_per_block: int,
+    num_physical_blocks: int,
+) -> KVPPActivePages:
+    """Return fixed-shape device pages read by the current batch.
+
+    The original block table is read only. Invalid columns and duplicate page
+    IDs become masked slots instead of being compacted through the host.
+    """
+    if isinstance(seq_lens, torch.Tensor) and seq_lens.device.type != "cpu":
+        raise ValueError("KVPP sequence lengths must stay on the host.")
+    sequence_lengths_host = torch.as_tensor(seq_lens, dtype=torch.int64, device="cpu").flatten()
+    sequence_lengths_device = sequence_lengths_host.to(device=block_table.device)
+    active_block_table = block_table[: sequence_lengths_device.shape[0]].to(dtype=torch.int64)
+    block_columns = torch.arange(
+        active_block_table.shape[1],
+        dtype=torch.int64,
+        device=block_table.device,
+    )
+    pages_per_request = torch.div(
+        sequence_lengths_device + tokens_per_block - 1,
+        tokens_per_block,
+        rounding_mode="floor",
+    )
+    covered_slots = block_columns.unsqueeze(0) < pages_per_request.unsqueeze(1)
+    valid_slots = covered_slots & (active_block_table >= 0) & (active_block_table < num_physical_blocks)
+    invalid_page_id = torch.full_like(active_block_table, num_physical_blocks)
+    physical_page_ids = torch.sort(torch.where(valid_slots, active_block_table, invalid_page_id).flatten()).values
+    first_occurrence_mask = torch.ones_like(physical_page_ids, dtype=torch.bool)
+    if physical_page_ids.numel() > 1:
+        first_occurrence_mask[1:] = physical_page_ids[1:] != physical_page_ids[:-1]
+    valid_page_mask = first_occurrence_mask & (physical_page_ids < num_physical_blocks)
+    staging_page_indices = torch.cumsum(valid_page_mask.to(dtype=torch.int64), dim=0) - 1
+    return KVPPActivePages(
+        physical_page_ids=physical_page_ids,
+        valid_page_mask=valid_page_mask,
+        staging_page_indices=staging_page_indices,
+    )
+
+
+class KVPPScheduler:
+    """Schedule stream-ordered layer prefetch over an injected transport.
+
+    Owned layers use persistent KV caches. Non-owned layers are already bound
+    by vLLM's planner to one of two alternating full-size scratch caches.
+    Active pages are pushed into the same physical block IDs, preserving the
+    original block table and slot mapping. The dual buffers let layer N+1 be
+    filled while layer N attention still reads its own scratch cache.
+    """
+
+    def __init__(
+        self,
+        kvpp_group: GroupCoordinator,
+        layer_owner_ranks: dict[str, int],
+        kv_caches: dict[str, Any],
+        num_physical_blocks: int,
+        tokens_per_block: int,
+        max_active_pages: int,
+        transport: MemFabricMTEKVPPTransport,
+        attention_layer_names: tuple[str, ...] | None = None,
+    ) -> None:
+        self.kvpp_group = kvpp_group
+        self.layer_owner_ranks = layer_owner_ranks
+        self.num_physical_blocks = num_physical_blocks
+        self.tokens_per_block = tokens_per_block
+        self.transport = transport
+        self.layer_cache_bundles = build_layer_cache_bundles(
+            self.layer_owner_ranks,
+            attention_layer_names,
+        )
+        self.attention_layer_names = tuple(self.layer_cache_bundles)
+        self._next_attention_layer_index = 0
+        self._active_pages: KVPPActivePages | None = None
+        self._kv_transfer_stream: Any | None = None
+        self._prefetch_executor: ThreadPoolExecutor | None = None
+        self._prefetch_future: Future[None] | None = None
+        self._npu_device_id: int | None = None
+        self.transport.initialize_transport(
+            kv_caches,
+            tuple(self.layer_cache_bundles.values()),
+            max_active_pages,
+        )
+        if self.kvpp_group.world_size > 1:
+            self._npu_device_id = torch.npu.current_device()
+            self._kv_transfer_stream = torch.npu.Stream()
+            # One transfer may be in flight. Serializing jobs also preserves
+            # point-to-point notification order when layer ownership changes.
+            self._prefetch_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="kvpp-prefetch")
+
+    def schedule_forward(
+        self,
+        block_table: torch.Tensor,
+        seq_lens: Any,
+    ) -> None:
+        if self._active_pages is not None:
+            raise RuntimeError("KVPP cannot schedule a new forward while the previous forward is active.")
+        self._active_pages = select_active_pages(
+            block_table,
+            seq_lens,
+            self.tokens_per_block,
+            self.num_physical_blocks,
+        )
+        self._next_attention_layer_index = 0
+        self.start_layer_prefetch(self.attention_layer_names[0])
+
+    def complete_forward(self) -> None:
+        if self._active_pages is None:
+            return
+        self._active_pages = None
+        self._next_attention_layer_index = 0
+
+    def wait_for_layer(self, layer_name: str) -> None:
+        """Order cache use, then prefetch the next layer before attention."""
+        if self._active_pages is None:
+            raise RuntimeError("KVPP batch metadata was not prepared before attention.")
+        if self._next_attention_layer_index >= len(self.attention_layer_names):
+            raise RuntimeError(f"KVPP received an extra attention layer {layer_name!r}.")
+        expected_layer = self.attention_layer_names[self._next_attention_layer_index]
+        if layer_name != expected_layer:
+            raise RuntimeError(f"KVPP expected attention layer {expected_layer!r}, got {layer_name!r}.")
+        if self._prefetch_future is not None:
+            # Eager path: this blocks only for the residual transfer time
+            # because this layer was prefetched while earlier work executed.
+            layer_index = extract_layer_index(layer_name)
+            with torch.profiler.record_function(f"kvpp.wait.previous_layer.layer_{layer_index}"):
+                self._prefetch_future.result()
+        self._prefetch_future = None
+        self._next_attention_layer_index += 1
+        if self._next_attention_layer_index < len(self.attention_layer_names):
+            self.start_layer_prefetch(self.attention_layer_names[self._next_attention_layer_index])
+
+    def start_layer_prefetch(self, layer_name: str) -> None:
+        self._prefetch_future = None
+        if self.kvpp_group.world_size <= 1:
+            return
+        if self._prefetch_executor is None or self._kv_transfer_stream is None:
+            raise RuntimeError("KVPP prefetch resources were not initialized.")
+        # All ranks publish a local safe point. Alternating layers use distinct
+        # buffers. When a buffer cycles back after two layers, this event is
+        # ordered after all earlier attention work on the compute stream, so
+        # the owner cannot overwrite a buffer that is still being read.
+        scratch_ready = torch.npu.Event()
+        scratch_ready.record(torch.npu.current_stream())
+        pages = self._active_pages
+        if pages is None:
+            raise RuntimeError("KVPP active pages were not prepared before prefetch.")
+        self._prefetch_future = self._prefetch_executor.submit(
+            self.run_layer_prefetch,
+            layer_name,
+            pages,
+            scratch_ready,
+        )
+
+    def run_layer_prefetch(
+        self,
+        layer_name: str,
+        active_pages: KVPPActivePages,
+        scratch_ready: Any,
+    ) -> None:
+        """Run safe-point and completion notification off the compute thread."""
+        if self._kv_transfer_stream is None:
+            raise RuntimeError("KVPP communication stream was not initialized.")
+        if self._npu_device_id is not None:
+            torch.npu.set_device(self._npu_device_id)
+
+        owner_kvpp_rank = self.layer_owner_ranks[layer_name]
+        local_kvpp_rank = self.kvpp_group.rank_in_group
+        owner_global_rank = self.kvpp_group.ranks[owner_kvpp_rank]
+        layer_index = extract_layer_index(layer_name)
+        token = torch.ones(1, dtype=torch.uint8, device="cpu")
+
+        with torch.profiler.record_function(f"kvpp.comm_total.layer_{layer_index}"):
+            scratch_ready.synchronize()
+
+            if local_kvpp_rank != owner_kvpp_rank:
+                dist.send(
+                    token,
+                    dst=owner_global_rank,
+                    group=self.kvpp_group.cpu_group,
+                    tag=_KVPP_READY_TAG,
+                )
+                dist.recv(
+                    token,
+                    src=owner_global_rank,
+                    group=self.kvpp_group.cpu_group,
+                    tag=_KVPP_DONE_TAG,
+                )
+                with torch.profiler.record_function(f"kvpp.transport_receive.layer_{layer_index}"):
+                    with torch.npu.stream(self._kv_transfer_stream):
+                        receive_completion = self.transport.copy_active_pages_from_staging(
+                            self.layer_cache_bundles[layer_name],
+                            active_pages,
+                            self._kv_transfer_stream,
+                        )
+                    receive_completion.synchronize()
+                return
+
+            for peer_kvpp_rank, peer_global_rank in enumerate(self.kvpp_group.ranks):
+                if peer_kvpp_rank == owner_kvpp_rank:
+                    continue
+                dist.recv(
+                    token,
+                    src=peer_global_rank,
+                    group=self.kvpp_group.cpu_group,
+                    tag=_KVPP_READY_TAG,
+                )
+
+            with torch.profiler.record_function(f"kvpp.transport_push.layer_{layer_index}"):
+                with torch.npu.stream(self._kv_transfer_stream):
+                    completion = self.transport.copy_active_pages_to_staging(
+                        self.layer_cache_bundles[layer_name],
+                        active_pages,
+                        self._kv_transfer_stream,
+                    )
+                # Only the communication worker waits on the host. The compute
+                # thread continues until this layer first writes/reads its
+                # paged KV cache.
+                completion.synchronize()
+
+            for peer_kvpp_rank, peer_global_rank in enumerate(self.kvpp_group.ranks):
+                if peer_kvpp_rank == owner_kvpp_rank:
+                    continue
+                dist.send(
+                    token,
+                    dst=peer_global_rank,
+                    group=self.kvpp_group.cpu_group,
+                    tag=_KVPP_DONE_TAG,
+                )

--- a/vllm_ascend/worker/v2/kvpp.py
+++ b/vllm_ascend/worker/v2/kvpp.py
@@ -272,6 +272,7 @@ class KVPPScheduler:
         self.attention_layer_names = tuple(self.layer_cache_bundles)
         self._next_attention_layer_index = 0
         self._active_pages: KVPPActivePages | None = None
+        self._forward_ready: Any | None = None
         self._kv_transfer_stream: Any | None = None
         self._prefetch_executor: ThreadPoolExecutor | None = None
         self._prefetch_future: Future[None] | None = None
@@ -301,6 +302,11 @@ class KVPPScheduler:
             self.tokens_per_block,
             self.num_physical_blocks,
         )
+        if self.kvpp_group.world_size > 1:
+            # Covers this forward's metadata and earlier persistent KV writes
+            # on the compute stream, independently of per-layer scratch reuse.
+            self._forward_ready = torch.npu.Event()
+            self._forward_ready.record(torch.npu.current_stream())
         self._next_attention_layer_index = 0
         self.start_layer_prefetch(self.attention_layer_names[0])
 
@@ -308,6 +314,7 @@ class KVPPScheduler:
         if self._active_pages is None:
             return
         self._active_pages = None
+        self._forward_ready = None
         self._next_attention_layer_index = 0
 
     def wait_for_layer(self, layer_name: str) -> None:
@@ -330,25 +337,32 @@ class KVPPScheduler:
         if self._next_attention_layer_index < len(self.attention_layer_names):
             self.start_layer_prefetch(self.attention_layer_names[self._next_attention_layer_index])
 
-    def start_layer_prefetch(self, layer_name: str) -> None:
-        self._prefetch_future = None
+    def start_layer_prefetch(self, layer_name: str, scratch_ready: Any | None = None) -> None:
+        """Launch at the caller's chosen point, without advancing in the worker.
+
+        A supplied scratch event must already be recorded after the target
+        buffer's last use. Otherwise use the current compute-stream safe point.
+        """
         if self.kvpp_group.world_size <= 1:
             return
+        if self._prefetch_future is not None:
+            raise RuntimeError("KVPP previous prefetch must be consumed before starting another layer.")
         if self._prefetch_executor is None or self._kv_transfer_stream is None:
             raise RuntimeError("KVPP prefetch resources were not initialized.")
-        # All ranks publish a local safe point. Alternating layers use distinct
-        # buffers. When a buffer cycles back after two layers, this event is
-        # ordered after all earlier attention work on the compute stream, so
-        # the owner cannot overwrite a buffer that is still being read.
-        scratch_ready = torch.npu.Event()
-        scratch_ready.record(torch.npu.current_stream())
+        forward_ready = self._forward_ready
+        if forward_ready is None:
+            raise RuntimeError("KVPP forward readiness was not prepared before prefetch.")
         pages = self._active_pages
         if pages is None:
             raise RuntimeError("KVPP active pages were not prepared before prefetch.")
+        if scratch_ready is None:
+            scratch_ready = torch.npu.Event()
+            scratch_ready.record(torch.npu.current_stream())
         self._prefetch_future = self._prefetch_executor.submit(
             self.run_layer_prefetch,
             layer_name,
             pages,
+            forward_ready,
             scratch_ready,
         )
 
@@ -356,81 +370,71 @@ class KVPPScheduler:
         self,
         layer_name: str,
         active_pages: KVPPActivePages,
+        forward_ready: Any,
         scratch_ready: Any,
     ) -> None:
-        """Run safe-point and completion notification off the compute thread."""
+        """Run both phases in order on the existing communication worker."""
         if self._kv_transfer_stream is None:
             raise RuntimeError("KVPP communication stream was not initialized.")
         if self._npu_device_id is not None:
             torch.npu.set_device(self._npu_device_id)
 
-        owner_kvpp_rank = self.layer_owner_ranks[layer_name]
-        local_kvpp_rank = self.kvpp_group.rank_in_group
-        owner_global_rank = self.kvpp_group.ranks[owner_kvpp_rank]
         layer_index = extract_layer_index(layer_name)
-        token = torch.ones(1, dtype=torch.uint8, device="cpu")
-
         with torch.profiler.record_function(f"kvpp.comm_total.layer_{layer_index}"):
-            if local_kvpp_rank != owner_kvpp_rank:
-                # The previous prefetch future completed before this task was
-                # submitted, so this rank's staging region can be overwritten.
-                # Scratch reuse is a separate device-stream dependency below.
-                dist.send(
-                    token,
-                    dst=owner_global_rank,
-                    group=self.kvpp_group.cpu_group,
-                    tag=_KVPP_READY_TAG,
-                )
-                dist.recv(
-                    token,
-                    src=owner_global_rank,
-                    group=self.kvpp_group.cpu_group,
-                    tag=_KVPP_DONE_TAG,
-                )
-                with torch.profiler.record_function(f"kvpp.transport_receive.layer_{layer_index}"):
-                    with torch.npu.stream(self._kv_transfer_stream):
-                        self._kv_transfer_stream.wait_event(scratch_ready)
-                        receive_completion = self.transport.copy_active_pages_from_staging(
-                            self.layer_cache_bundles[layer_name],
-                            active_pages,
-                            self._kv_transfer_stream,
-                        )
-                    receive_completion.synchronize()
-                return
+            self.run_layer_send(layer_name, active_pages, forward_ready)
+            self.run_layer_receive(layer_name, active_pages, forward_ready, scratch_ready)
 
-            for peer_kvpp_rank, peer_global_rank in enumerate(self.kvpp_group.ranks):
-                if peer_kvpp_rank == owner_kvpp_rank:
-                    continue
-                dist.recv(
-                    token,
-                    src=peer_global_rank,
-                    group=self.kvpp_group.cpu_group,
-                    tag=_KVPP_READY_TAG,
-                )
+    def run_layer_send(self, layer_name: str, active_pages: KVPPActivePages, forward_ready: Any) -> None:
+        """Publish free staging, or push as its owner; never wait for scratch.
 
-            with torch.profiler.record_function(f"kvpp.transport_push.layer_{layer_index}"):
-                with torch.npu.stream(self._kv_transfer_stream):
-                    # ``active_pages`` is materialized on the compute stream in
-                    # schedule_forward().  The owner reads those tensors from
-                    # the transfer stream as MTE descriptors, so it needs the
-                    # same cross-stream dependency as the consumer path above.
-                    self._kv_transfer_stream.wait_event(scratch_ready)
-                    completion = self.transport.copy_active_pages_to_staging(
-                        self.layer_cache_bundles[layer_name],
-                        active_pages,
-                        self._kv_transfer_stream,
-                    )
-                # Only the communication worker waits on the host. The compute
-                # thread continues until this layer first writes/reads its
-                # paged KV cache.
-                completion.synchronize()
+        Called on the communication worker after the previous prefetch has
+        completed, so no preceding unpack still reads the local staging slot.
+        """
+        owner_kvpp_rank = self.layer_owner_ranks[layer_name]
+        owner_global_rank = self.kvpp_group.ranks[owner_kvpp_rank]
+        token = torch.ones(1, dtype=torch.uint8, device="cpu")
+        if self.kvpp_group.rank_in_group != owner_kvpp_rank:
+            dist.send(token, dst=owner_global_rank, group=self.kvpp_group.cpu_group, tag=_KVPP_READY_TAG)
+            return
 
-            for peer_kvpp_rank, peer_global_rank in enumerate(self.kvpp_group.ranks):
-                if peer_kvpp_rank == owner_kvpp_rank:
-                    continue
-                dist.send(
-                    token,
-                    dst=peer_global_rank,
-                    group=self.kvpp_group.cpu_group,
-                    tag=_KVPP_DONE_TAG,
+        for peer_kvpp_rank, peer_global_rank in enumerate(self.kvpp_group.ranks):
+            if peer_kvpp_rank != owner_kvpp_rank:
+                dist.recv(token, src=peer_global_rank, group=self.kvpp_group.cpu_group, tag=_KVPP_READY_TAG)
+
+        layer_index = extract_layer_index(layer_name)
+        with torch.profiler.record_function(f"kvpp.transport_push.layer_{layer_index}"):
+            with torch.npu.stream(self._kv_transfer_stream):
+                self._kv_transfer_stream.wait_event(forward_ready)
+                completion = self.transport.copy_active_pages_to_staging(
+                    self.layer_cache_bundles[layer_name], active_pages, self._kv_transfer_stream
                 )
+            completion.synchronize()
+
+        for peer_kvpp_rank, peer_global_rank in enumerate(self.kvpp_group.ranks):
+            if peer_kvpp_rank != owner_kvpp_rank:
+                dist.send(token, dst=peer_global_rank, group=self.kvpp_group.cpu_group, tag=_KVPP_DONE_TAG)
+
+    def run_layer_receive(
+        self,
+        layer_name: str,
+        active_pages: KVPPActivePages,
+        forward_ready: Any,
+        scratch_ready: Any,
+    ) -> None:
+        """Unpack on the communication worker after DONE and scratch readiness."""
+        owner_kvpp_rank = self.layer_owner_ranks[layer_name]
+        if self.kvpp_group.rank_in_group == owner_kvpp_rank:
+            return
+
+        owner_global_rank = self.kvpp_group.ranks[owner_kvpp_rank]
+        token = torch.ones(1, dtype=torch.uint8, device="cpu")
+        dist.recv(token, src=owner_global_rank, group=self.kvpp_group.cpu_group, tag=_KVPP_DONE_TAG)
+        layer_index = extract_layer_index(layer_name)
+        with torch.profiler.record_function(f"kvpp.transport_receive.layer_{layer_index}"):
+            with torch.npu.stream(self._kv_transfer_stream):
+                self._kv_transfer_stream.wait_event(forward_ready)
+                self._kv_transfer_stream.wait_event(scratch_ready)
+                completion = self.transport.copy_active_pages_from_staging(
+                    self.layer_cache_bundles[layer_name], active_pages, self._kv_transfer_stream
+                )
+            completion.synchronize()

--- a/vllm_ascend/worker/v2/kvpp.py
+++ b/vllm_ascend/worker/v2/kvpp.py
@@ -410,6 +410,11 @@ class KVPPScheduler:
 
             with torch.profiler.record_function(f"kvpp.transport_push.layer_{layer_index}"):
                 with torch.npu.stream(self._kv_transfer_stream):
+                    # ``active_pages`` is materialized on the compute stream in
+                    # schedule_forward().  The owner reads those tensors from
+                    # the transfer stream as MTE descriptors, so it needs the
+                    # same cross-stream dependency as the consumer path above.
+                    self._kv_transfer_stream.wait_event(scratch_ready)
                     completion = self.transport.copy_active_pages_to_staging(
                         self.layer_cache_bundles[layer_name],
                         active_pages,

--- a/vllm_ascend/worker/v2/kvpp.py
+++ b/vllm_ascend/worker/v2/kvpp.py
@@ -85,6 +85,7 @@ class KVPPRuntime:
         kv_cache_config: Any,
         block_tables: Any,
         static_forward_context: dict[str, Any],
+        staging_capacity_bytes: int | None = None,
     ) -> KVPPRuntime:
         if KVPPConfig.from_vllm_config(vllm_config).size <= 1:
             return cls()
@@ -99,6 +100,7 @@ class KVPPRuntime:
             vllm_config=vllm_config,
             kv_cache_config=kv_cache_config,
             static_forward_context=static_forward_context,
+            staging_capacity_bytes=staging_capacity_bytes,
             cache_layout=KVPPCacheLayout(
                 layer_caches=layer_caches,
                 physical_blocks_per_kv_block=block_tables.blocks_per_kv_block,
@@ -114,6 +116,7 @@ class KVPPRuntime:
         kv_cache_config: Any,
         static_forward_context: dict[str, Any],
         cache_layout: KVPPCacheLayout,
+        staging_capacity_bytes: int | None = None,
     ) -> KVPPRuntime:
         """Create the runtime after a model runner has normalized its cache layout."""
         layer_names = tuple(
@@ -152,11 +155,6 @@ class KVPPRuntime:
             kv_cache_config.num_blocks * cache_layout.physical_blocks_per_kv_block[managed_cache_group_index]
         )
         tokens_per_block = cache_layout.tokens_per_block[managed_cache_group_index]
-        max_blocks_per_request = (vllm_config.model_config.max_model_len + tokens_per_block - 1) // tokens_per_block
-        max_active_pages = min(
-            num_physical_blocks,
-            vllm_config.scheduler_config.max_num_seqs * max_blocks_per_request,
-        )
         kvpp_group = get_kvpp_group()
         scheduler = KVPPScheduler(
             kvpp_group=kvpp_group,
@@ -164,10 +162,11 @@ class KVPPRuntime:
             kv_caches=managed_kv_caches,
             tokens_per_block=tokens_per_block,
             num_physical_blocks=num_physical_blocks,
-            max_active_pages=max_active_pages,
+            max_active_pages=num_physical_blocks,
             transport=MemFabricMTEKVPPTransport(
                 kvpp_group,
                 num_physical_blocks,
+                staging_capacity_bytes=staging_capacity_bytes,
             ),
             attention_layer_names=tuple(attention_impls),
         )

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -66,6 +66,7 @@ from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
 from vllm_ascend.worker.v2.eplb import AscendEPLBController
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
+from vllm_ascend.worker.v2.kvpp import KVPPRuntime
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 from vllm_ascend.worker.v2.spec_decode import init_speculator
 from vllm_ascend.worker.v2.spec_decode.eagle.speculator import AscendEagleSpeculator
@@ -105,6 +106,7 @@ class NPUModelRunner(GPUModelRunner):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         # Ascend-specific configurations
         self.ascend_config = get_ascend_config()
+        self.kvpp = KVPPRuntime()
         # FusedMoE can be constructed by the parent initializer and reads this
         # capacity while setting up MC2 communication.
         set_potential_max_tokens(vllm_config)
@@ -222,6 +224,14 @@ class NPUModelRunner(GPUModelRunner):
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
 
+        self.kvpp = KVPPRuntime.create_from_kv_cache(
+            vllm_config=self.vllm_config,
+            kv_cache_config=self.kv_cache_config,
+            block_tables=self.block_tables,
+            static_forward_context=self.compilation_config.static_forward_context,
+        )
+        self.model_state.kvpp_runtime = self.kvpp
+
     @torch.inference_mode()
     def execute_model(
         self,
@@ -256,6 +266,8 @@ class NPUModelRunner(GPUModelRunner):
                 is_profile=is_profile,
                 context_len=context_len,
             )
+
+        self.kvpp.complete_forward()
 
         self._cpp_execution_time_ms = _finish_profiling_chunk_timing(
             profiling_config,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -214,7 +214,9 @@ class NPUModelRunner(GPUModelRunner):
             self.pp_handler.broadcast_draft_tokens()
         return output
 
-    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+    def initialize_kv_cache(
+        self, kv_cache_config: KVCacheConfig, *, kvpp_staging_capacity_bytes: int | None = None
+    ) -> None:
         with graph_manager_wrapper(self), _use_ascend_pcp_manager_for_vllm_0271():
             super().initialize_kv_cache(kv_cache_config)
             if self.pcp_manager is not None:
@@ -229,6 +231,7 @@ class NPUModelRunner(GPUModelRunner):
             kv_cache_config=self.kv_cache_config,
             block_tables=self.block_tables,
             static_forward_context=self.compilation_config.static_forward_context,
+            staging_capacity_bytes=kvpp_staging_capacity_bytes,
         )
         self.model_state.kvpp_runtime = self.kvpp
 

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -29,6 +29,7 @@ from vllm_ascend.worker.v2.attn_utils import build_attn_metadata
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 
 if TYPE_CHECKING:
+    from vllm_ascend.worker.v2.kvpp import KVPPRuntime
     from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 
@@ -36,6 +37,7 @@ class AscendModelState(DefaultModelState):
     """Model state for Ascend NPUs."""
 
     pcp_manager: "AscendPCPManager | None" = None
+    kvpp_runtime: "KVPPRuntime | None" = None
 
     def prepare_attn(
         self,
@@ -65,6 +67,11 @@ class AscendModelState(DefaultModelState):
 
         num_actual_reqs = input_batch.num_reqs
         num_actual_tokens = input_batch.num_tokens
+        if self.kvpp_runtime is not None:
+            self.kvpp_runtime.prepare_forward(
+                block_tables,
+                input_batch.seq_lens_np[:num_actual_reqs],
+            )
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)
         max_query_len = input_batch.num_scheduled_tokens.max().item()

--- a/vllm_ascend/worker/v2/model_states/default.py
+++ b/vllm_ascend/worker/v2/model_states/default.py
@@ -70,7 +70,7 @@ class AscendModelState(DefaultModelState):
         if self.kvpp_runtime is not None:
             self.kvpp_runtime.prepare_forward(
                 block_tables,
-                input_batch.seq_lens_np[:num_actual_reqs],
+                input_batch.num_computed_tokens_np[:num_actual_reqs],
             )
         query_start_loc_cpu = torch.from_numpy(input_batch.query_start_loc_np)
         is_prefilling = torch.from_numpy(input_batch.is_prefilling_np)

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -57,8 +57,12 @@ from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
 
 import vllm_ascend.envs as envs_ascend
-from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.ascend_config import KVPPConfig, get_ascend_config, init_ascend_config
 from vllm_ascend.batch_invariant import init_batch_invariance
+from vllm_ascend.core.kv_cache_placement import (
+    KVPPPhysicalCachePlan,
+    create_kvpp_cache_allocation_plan,
+)
 from vllm_ascend.core.profiling_chunk_predictor import (
     _attach_profiling_chunk_execution_time,
 )
@@ -178,6 +182,7 @@ class NPUWorker(WorkerBase):
             WEIGHT_LOADER_V2_SUPPORTED.remove("UnquantizedLinearMethod")
 
         self.use_v2_model_runner = self.vllm_config.use_v2_model_runner
+        self._kvpp_cache_allocation_plan: KVPPPhysicalCachePlan | None = None
         self._pp_send_work: list[Handle] = []
 
         ascend_compilation_config = get_ascend_config().ascend_compilation_config
@@ -987,6 +992,15 @@ class NPUWorker(WorkerBase):
                 kv_cache_spec,
                 extra_config,
             )
+        kvpp_config = KVPPConfig.from_vllm_config(self.vllm_config)
+        if kvpp_config.size > 1:
+            kvpp_rank = get_tp_group().rank_in_group % kvpp_config.size
+            self._kvpp_cache_allocation_plan = create_kvpp_cache_allocation_plan(
+                self.vllm_config,
+                kv_cache_spec,
+                kvpp_rank,
+            )
+            kv_cache_spec = self._kvpp_cache_allocation_plan.physical_cache_spec
         if get_ascend_config().sparse_kv_offload_config.enabled:
             # reserve kv_cache_spec for sparse kv offload memory profile usage.
             self.kv_cache_spec = kv_cache_spec
@@ -1007,6 +1021,9 @@ class NPUWorker(WorkerBase):
 
     def initialize_from_config(self, kv_cache_config: KVCacheConfig) -> None:
         """Allocate NPU KV cache with the specified kv_cache_config."""
+        if self._kvpp_cache_allocation_plan is not None:
+            kv_cache_config = copy.deepcopy(kv_cache_config)
+            self._kvpp_cache_allocation_plan.restore_logical_cache_view(kv_cache_config)
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
         if self.vllm_config.model_config.enable_sleep_mode:
             allocator = CaMemAllocator.get_instance()

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -29,6 +29,7 @@ import torch.nn as nn
 import torch_npu
 from torch_npu.op_plugin.atb._atb_ops import _register_atb_extensions
 from torch_npu.profiler import dynamic_profile as dp
+from vllm import envs as vllm_envs
 from vllm.config import CUDAGraphMode, VllmConfig, set_current_vllm_config
 from vllm.distributed import ensure_model_parallel_initialized, get_pcp_group, init_distributed_environment
 from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
@@ -62,6 +63,7 @@ from vllm_ascend.batch_invariant import init_batch_invariance
 from vllm_ascend.core.kv_cache_placement import (
     KVPPPhysicalCachePlan,
     create_kvpp_cache_allocation_plan,
+    kvpp_staging_size_bytes,
 )
 from vllm_ascend.core.profiling_chunk_predictor import (
     _attach_profiling_chunk_execution_time,
@@ -564,7 +566,9 @@ class NPUWorker(WorkerBase):
                 GiB(self.init_snapshot.free_memory),
                 GiB(kv_cache_memory_bytes),
             )
-            return self._apply_kv_offload_decode_memory_constraints(kv_cache_memory_bytes)
+            return self._apply_kvpp_memory_constraints(
+                self._apply_kv_offload_decode_memory_constraints(kv_cache_memory_bytes)
+            )
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
@@ -630,8 +634,34 @@ class NPUWorker(WorkerBase):
         self.available_kv_cache_memory_bytes = self._apply_kv_offload_decode_memory_constraints(
             self.available_kv_cache_memory_bytes
         )
+        self.available_kv_cache_memory_bytes = self._apply_kvpp_memory_constraints(self.available_kv_cache_memory_bytes)
 
         return int(self.available_kv_cache_memory_bytes)
+
+    def _apply_kvpp_memory_constraints(self, available_bytes: int) -> int:
+        plan = self._kvpp_cache_allocation_plan
+        if plan is None:
+            return available_bytes
+        budget = plan.plan_memory(self.vllm_config, available_bytes)
+        # The engine treats an override as authoritative, even above its
+        # memory-derived limit. Reject that escape here, not during allocation.
+        override = self.cache_config.num_gpu_blocks_override
+        if override is not None and not 0 < override <= budget.max_num_blocks:
+            raise ValueError(
+                f"KVPP num_gpu_blocks_override={override} must be between 1 and {budget.max_num_blocks} "
+                "to fit KV cache and staging in the memory budget."
+            )
+        kv_budget_bytes = budget.max_num_blocks * budget.kv_page_size_bytes
+        logger.info(
+            "KVPP memory budget: available_bytes=%d, kv_page_bytes=%d, staging_page_bytes=%d, "
+            "max_num_blocks=%d, kv_budget_bytes=%d (staging included in the original budget)",
+            available_bytes,
+            budget.kv_page_size_bytes,
+            budget.staging_page_size_bytes,
+            budget.max_num_blocks,
+            kv_budget_bytes,
+        )
+        return kv_budget_bytes
 
     def log_memory_stats(self) -> None:
         """Profiles the torch reserved memory, torch allocated memory in execute_model()."""
@@ -994,6 +1024,8 @@ class NPUWorker(WorkerBase):
             )
         kvpp_config = KVPPConfig.from_vllm_config(self.vllm_config)
         if kvpp_config.size > 1:
+            if vllm_envs.VLLM_ELASTIC_EP_SCALE_UP_LAUNCH:
+                raise NotImplementedError("KVPP staging budgeting does not support elastic EP scale-up launches.")
             kvpp_rank = get_tp_group().rank_in_group % kvpp_config.size
             self._kvpp_cache_allocation_plan = create_kvpp_cache_allocation_plan(
                 self.vllm_config,
@@ -1021,9 +1053,20 @@ class NPUWorker(WorkerBase):
 
     def initialize_from_config(self, kv_cache_config: KVCacheConfig) -> None:
         """Allocate NPU KV cache with the specified kv_cache_config."""
-        if self._kvpp_cache_allocation_plan is not None:
+        kvpp_staging_capacity_bytes = None
+        plan = self._kvpp_cache_allocation_plan
+        if plan is not None:
+            kvpp_staging_capacity_bytes = kvpp_staging_size_bytes(
+                plan.staging_page_size_bytes, kv_cache_config.num_blocks
+            )
+            logger.info(
+                "KVPP final allocation: num_blocks=%d, kv_bytes=%d, staging_bytes=%d",
+                kv_cache_config.num_blocks,
+                sum(tensor.size for tensor in kv_cache_config.kv_cache_tensors),
+                kvpp_staging_capacity_bytes,
+            )
             kv_cache_config = copy.deepcopy(kv_cache_config)
-            self._kvpp_cache_allocation_plan.restore_logical_cache_view(kv_cache_config)
+            plan.restore_logical_cache_view(kv_cache_config)
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
         if self.vllm_config.model_config.enable_sleep_mode:
             allocator = CaMemAllocator.get_instance()
@@ -1033,7 +1076,12 @@ class NPUWorker(WorkerBase):
 
             context = nullcontext()  # type: ignore
         with context:
-            self.model_runner.initialize_kv_cache(kv_cache_config)
+            if kvpp_staging_capacity_bytes is None:
+                self.model_runner.initialize_kv_cache(kv_cache_config)
+            else:
+                self.model_runner.initialize_kv_cache(
+                    kv_cache_config, kvpp_staging_capacity_bytes=kvpp_staging_capacity_bytes
+                )
 
         # MRV2's scheduler emits new_block_ids_to_zero whenever this flag is
         # set, so its worker-side consumer must use the same condition. Keep the


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces eager KV Layer Parallelism (KVPP) for Ascend NPU.

KVPP partitions persistent KV-cache ownership by transformer layer. Each rank
keeps persistent caches only for its owned layers and reuses two alternating
scratch caches for non-owned layers. Before a layer executes, the owner transfers
the current batch's active physical pages to peer staging regions through
MemFabric MTE.

The implementation:

- Supports both Model Runner V1 and V2.
- Preserves the original physical block table and slot mapping.
- Transfers raw contiguous cache regions independently for each cache tensor.
- Bundles MLA/SFA and indexer cache tensors belonging to the same layer.
- Keeps MTP cache layers replicated instead of partitioning them.
- Validates staging capacity once during runtime initialization.
- Supports KVPP inside each local PP stage.

Current limitations:

- Eager execution only.
- Non-hybrid MLA models only.
- KVPP size equals tensor-parallel size.
- PCP and DCP cannot be enabled with KVPP.
- Speculative decoding currently supports fixed-token MTP only.

This PR does not add the MooncakeConnectorV2 PD-disaggregation adapter itself;
it only preserves the supported KV producer configuration.

### Does this PR introduce _any_ user-facing change?

Yes.

KVPP can be enabled with:

`--additional-config '{"enable_kvpp": true}'`

The following environment variables configure the MemFabric MTE transport:

- `ASCEND_KVPP_MTE_STAGING_BYTES`
- `ASCEND_KVPP_MTE_SHM_ID`
- `ASCEND_KVPP_MTE_TIMEOUT_SECONDS`

### How was this patch tested?

- Added unit tests for cache placement, Model Runner V1/V2 runtime scheduling,
  attention lifecycle hooks, and MemFabric MTE transport.
- Added a two-NPU DeepSeek-V2-Lite E2E test covering both Model Runner V1 and
  V2, TP2, EP, chunked prefill, prefix caching, and KVPP.
- Manually validated service startup and single/batched requests on A3 with:
  PP2 + TP8 + EP + FlashComm1 + KVPP + chunked prefill + prefix caching +
  SFA_C8 + LI_C8 + MTP3 + asynchronous scheduling.
- Confirmed chunked prefill was triggered, prefix-cache hits occurred, MTP
  decoding executed, and requests completed successfully.

vLLM main: vllm-project/vllm@[`ba07e4a`](https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3)

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
