### PR TITLE
[Performance]Support IndexCache TopK reuse

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1629,25 +1629,34 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             assert compressor_attn_metadata.req_metadata is not None
             assert compressor_kv_state_metadata.req_metadata is not None
             if self.compress_ratio == 4:
-                assert layer_metadata.indexer_cache is not None
-                assert layer_metadata.indexer_state is not None
-                self._update_indexer_cache(
-                    x=hidden_states_cache,
-                    kv_cache=kv_cache,
-                    metadata=layer_metadata,
-                    actual_seq_lengths_query=actual_seq_lengths_query,
-                )
-                compress_topk_idxs = self._indexer_select_topk(
-                    x=hidden_states_local,
-                    qr=qr_local,
-                    kv_cache=kv_cache,
-                    metadata=layer_metadata,
-                    cos=local_cos,
-                    sin=local_sin,
-                    actual_seq_lengths_query=local_seq_lengths_query,
-                    actual_seq_lengths_key=local_seq_lengths_key,
-                    qr_pertoken_scale=qr_pertoken_scale_local,
-                )
+                assert self.indexer is not None
+                if self.indexer.skip_topk:
+                    compress_topk_idxs = self.indexer._get_cached_topk_indices(
+                        num_tokens=hidden_states_local.shape[0],
+                    )
+                else:
+                    assert layer_metadata.indexer_cache is not None
+                    assert layer_metadata.indexer_state is not None
+                    self._update_indexer_cache(
+                        x=hidden_states_cache,
+                        kv_cache=kv_cache,
+                        metadata=layer_metadata,
+                        actual_seq_lengths_query=actual_seq_lengths_query,
+                    )
+                    compress_topk_idxs = self._indexer_select_topk(
+                        x=hidden_states_local,
+                        qr=qr_local,
+                        kv_cache=kv_cache,
+                        metadata=layer_metadata,
+                        cos=local_cos,
+                        sin=local_sin,
+                        actual_seq_lengths_query=local_seq_lengths_query,
+                        actual_seq_lengths_key=local_seq_lengths_key,
+                        qr_pertoken_scale=qr_pertoken_scale_local,
+                    )
+
+                    if self.indexer.use_index_cache:
+                        self.indexer._update_cached_topk_indices(compress_topk_idxs)
 
             coff = 2 if self.compressor_overlap else 1
             compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(


### PR DESCRIPTION
### What this PR does / why we need it?
This PR enables IndexCache TopK index reuse in the legacy DSA-CP path (AscendDSACPImpl).

The model and DeepseekV4Indexer already assign each C4 layer an F/S role through skip_topk:

- F layers compute TopK indices and store them in the shared topk_indices_buffer.

- S layers reuse the indices generated by the preceding F layer.

However, AscendDSACPImpl directly called _update_indexer_cache() and _indexer_select_topk() for every C4 layer, bypassing the existing IndexCache handling in DeepseekV4Indexer.forward(). As a result, S layers still updated their Indexer caches and recomputed TopK under DSA-CP.

This PR updates the DSA-CP C4 path so that:

- F layers update the Indexer cache and compute TopK as before.

- F layers store the computed TopK indices when use_index_cache is enabled.

- S layers read TopK indices from the shared topk_indices_buffer.

- S layers skip both _update_indexer_cache() and _indexer_select_topk().

- Every layer still updates its own attention compressed KV cache.

The reused data is only the TopK token-position indices. Per-layer attention KV cache contents are not shared.
This reduces redundant Indexer cache updates and TopK computation for S layers while preserving the existing F/S layer pattern.

### Does this PR introduce _any_ user-facing change?
No API or configuration changes are introduced.

### How was this patch tested?
This change was performance-tested with DeepSeek-V4 on a four-card Ascend 910B platform. Profiling results show that the _forward function took approximately 3.7 ms on the original execution path. After the optimization, _forward took approximately 4.1 ms for F layers and 2.0 ms for S layers. Accuracy was also evaluated on the GSM8K dataset, achieving a score of 0.9682.
<img width="548" height="143" alt="acc_result" src="https://github.com/user-attachments/assets/bd0154c1-c001-4276-a1bd-7fa1234851d6" />

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
