### PR TITLE
test(ci): test aiframe/mind 800i runners

### DIFF
--- a/.github/workflows/test-aiframe-mind-runner.yml
+++ b/.github/workflows/test-aiframe-mind-runner.yml
@@ -1,0 +1,56 @@
+name: Test AIframe/Mind Runner
+
+on:
+  workflow_dispatch:  # 手动触发
+  pull_request:
+    paths:
+      - '.github/workflows/test-aiframe-mind-runner.yml'
+
+jobs:
+  test-aiframe-2card:
+    runs-on: linux-aarch64-a3-800i-2-aiframe
+    steps:
+      - name: Check runner info
+        run: |
+          echo "=== Runner Information ==="
+          echo "Hostname: $(hostname)"
+          echo "Kernel: $(uname -a)"
+          echo "Date: $(date)"
+
+      - name: Check NPU
+        run: |
+          echo "=== NPU Information ==="
+          npu-smi info || echo "NPU info not available"
+
+      - name: Check resources
+        run: |
+          echo "=== System Resources ==="
+          echo "CPU cores: $(nproc)"
+          echo "Memory:"
+          free -h
+          echo "Disk:"
+          df -h | head -10
+
+  test-mind-4card:
+    runs-on: linux-aarch64-a3-800i-4-mind
+    steps:
+      - name: Check runner info
+        run: |
+          echo "=== Runner Information ==="
+          echo "Hostname: $(hostname)"
+          echo "Kernel: $(uname -a)"
+          echo "Date: $(date)"
+
+      - name: Check NPU
+        run: |
+          echo "=== NPU Information ==="
+          npu-smi info || echo "NPU info not available"
+
+      - name: Check resources
+        run: |
+          echo "=== System Resources ==="
+          echo "CPU cores: $(nproc)"
+          echo "Memory:"
+          free -h
+          echo "Disk:"
+          df -h | head -10


### PR DESCRIPTION
**测试目的**
验证新部署的 aiframe/mind 集群 800i runner 是否能正常接收和执行 GitHub Actions 任务。

**测试 runner**
- `linux-aarch64-a3-800i-2-aiframe` (2卡, aiframe 集群)
- `linux-aarch64-a3-800i-4-mind` (4卡, mind 集群)

**相关部署 PR**
opensourceways/ascend-ci-deployment#1442

**测试内容**
- 检查 runner 主机信息（hostname、kernel）
- 检查 NPU 可用性（npu-smi info）
- 检查系统资源（CPU、内存、磁盘）

这是一个测试 PR，验证完成后会关闭，不会合并。
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
