### PR TITLE
[Feature][Ascend 950] Unify sparse attention score operator

### DIFF
--- a/csrc/attention/sparse_attention_score/op_host/op_api/aclnn_sparse_attention_score.cpp
+++ b/csrc/attention/sparse_attention_score/op_host/op_api/aclnn_sparse_attention_score.cpp
@@ -37,6 +37,9 @@ static aclnnStatus MakeContiguous(const aclTensor *&query,
                                   const aclTensor *&selectNumIdxOptional,
                                   const aclTensor *&actualSeqLengthsOptional,
                                   const aclTensor *&actualSeqLengthsKvOptional,
+                                  const aclTensor *&qDequantScaleOptional,
+                                  const aclTensor *&kDequantScaleOptional,
+                                  const aclTensor *&vDequantScaleOptional,
                                   aclOpExecutor *executor)
 {
     query = l0op::Contiguous(query, executor);
@@ -67,6 +70,21 @@ static aclnnStatus MakeContiguous(const aclTensor *&query,
     if (actualSeqLengthsKvOptional != nullptr) {
         actualSeqLengthsKvOptional = l0op::Contiguous(actualSeqLengthsKvOptional, executor);
         CHECK_RET(actualSeqLengthsKvOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    if (qDequantScaleOptional != nullptr) {
+        qDequantScaleOptional = l0op::Contiguous(qDequantScaleOptional, executor);
+        CHECK_RET(qDequantScaleOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    if (kDequantScaleOptional != nullptr) {
+        kDequantScaleOptional = l0op::Contiguous(kDequantScaleOptional, executor);
+        CHECK_RET(kDequantScaleOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
+    }
+
+    if (vDequantScaleOptional != nullptr) {
+        vDequantScaleOptional = l0op::Contiguous(vDequantScaleOptional, executor);
+        CHECK_RET(vDequantScaleOptional != nullptr, ACLNN_ERR_INNER_NULLPTR);
     }
 
     return ACLNN_SUCCESS;
@@ -119,6 +137,7 @@ __attribute__((visibility("default"))) aclnnStatus aclnnSparseAttentionScoreGetW
     aclnnStatus ret = MakeContiguous(query, key, value, selectIdx, blockTable,
                                      selectNumIdxOptional,
                                      actualSeqLengthsOptional, actualSeqLengthsKvOptional,
+                                     qDequantScaleOptional, kDequantScaleOptional, vDequantScaleOptional,
                                      executorImpl);
     if (ret != ACLNN_SUCCESS) {
         return ret;

--- a/csrc/attention/sparse_attention_score/op_host/sparse_attention_score_tiling.cpp
+++ b/csrc/attention/sparse_attention_score/op_host/sparse_attention_score_tiling.cpp
@@ -416,7 +416,13 @@ ge::graphStatus SASATiling::CalculateWorkSpace(gert::TilingContext *context)
             uint32_t dtypeSize = (dataType_ == ge::DT_FLOAT8_E4M3FN) ? 1 : 2;
             uint64_t perTaskWorkspace = static_cast<uint64_t>(topK_) * blockSize_ * embeddingSize_ * dtypeSize * 2;
             uint64_t identityIdxSize = static_cast<uint64_t>(topK_) * sizeof(int32_t);
-            workSpaceSize_ = libapiSize_ + identityIdxSize + static_cast<uint64_t>(blockDim_) * perTaskWorkspace;
+            const uint64_t sparseWorkspaceSize =
+                identityIdxSize + static_cast<uint64_t>(blockDim_) * perTaskWorkspace;
+            if (sparseWorkspaceSize > std::numeric_limits<size_t>::max() - libapiSize_) {
+                OP_LOGE(context->GetNodeName(), "Sparse workspace size overflow.");
+                return ge::GRAPH_FAILED;
+            }
+            workSpaceSize_ = libapiSize_ + sparseWorkspaceSize;
         }
     }
 

--- a/csrc/attention/sparse_attention_score/op_kernel/arch35/sparse_attention_score_fd_combine_arch35.h
+++ b/csrc/attention/sparse_attention_score/op_kernel/arch35/sparse_attention_score_fd_combine_arch35.h
@@ -20,7 +20,7 @@ namespace SasaKernelArch35 {
 template <class ElementO, class Resource>
 class SparseAttentionScoreFdCombineArch35 {
 public:
-    static constexpr uint32_t MAX_SPLIT_NUM = 16;
+    static constexpr uint32_t MAX_SPLIT_NUM = SparseAttn::SASA_FD_MAX_AIC;
     static constexpr uint32_t MAX_ROW_TILE = 8;
     static constexpr uint32_t FLOATS_PER_BLOCK = 8;
     static constexpr uint32_t HEAD_DIM = 128;
@@ -63,16 +63,19 @@ public:
         AscendC::SetVectorMask<int8_t>(static_cast<uint64_t>(-1), static_cast<uint64_t>(-1));
 
         const uint32_t subBlockNum = AscendC::GetSubBlockNum();
+        const uint32_t combineTaskNum = tilingData->fdCombineTaskNum;
+        if (subBlockNum == 0U || combineTaskNum == 0U) {
+            return;
+        }
         const uint32_t aivIdx = AscendC::GetBlockIdx();
         const uint32_t aivNum = AscendC::GetBlockNum() * subBlockNum;
+        if (aivNum == 0U) {
+            return;
+        }
         const uint32_t groupSize = tilingData->groupSize;
         const uint32_t rowSplit = Min(groupSize, RoundUp(groupSize, FLOATS_PER_BLOCK) / subBlockNum);
         const uint32_t sub0Rows = rowSplit;
         const uint32_t sub1Rows = groupSize - rowSplit;
-        const uint32_t combineTaskNum = tilingData->fdCombineTaskNum;
-        if (aivNum == 0 || combineTaskNum == 0) {
-            return;
-        }
 
         const uint32_t totalRows = combineTaskNum * groupSize;
         const uint32_t rowTile = Min(MAX_ROW_TILE, Max(1U, CeilDiv(totalRows, aivNum)));

--- a/csrc/attention/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h
+++ b/csrc/attention/sparse_attention_score/op_kernel/arch35/sparse_attention_score_kernel_arch35_full_quant.h
@@ -188,10 +188,12 @@ public:
             uint32_t validTopK = topK_;
             if (params.selectNumIdx != nullptr) {
                 int64_t selectNumOffset = static_cast<int64_t>(kvHeadIdx) * maxQSeqlen_ + qToken;
-                validTopK = static_cast<uint32_t>(gSelectNumIdx.GetValue(selectNumOffset));
+                const int32_t selectNum = gSelectNumIdx.GetValue(selectNumOffset);
+                validTopK = selectNum <= 0 ? 0U :
+                    Min(static_cast<uint32_t>(selectNum), topK_);
             }
             if constexpr (!IS_FD) {
-                if (validTopK == 0) continue;
+                if (validTopK == 0U) continue;
                 rawEnd = validTopK;
             } else {
                 rawBegin = rawBegin < validTopK ? rawBegin : validTopK;
@@ -201,21 +203,22 @@ public:
             uint32_t kvSeqlen = static_cast<uint32_t>(gActualKvseqlen.GetValue(batchIdx));
             uint32_t qSeqlen = static_cast<uint32_t>(gActualQseqlen.GetValue(batchIdx));
             uint32_t historyLen = kvSeqlen - qSeqlen;
-            uint32_t lastBlockTileSize = (historyLen + qTokenInBatch) % blockSize_ + 1;
+            uint32_t visibleKvLen = historyLen + qTokenInBatch + 1U;
+            uint32_t validLogicalBlockNum = CeilDiv(visibleKvLen, blockSize_);
 
             uint32_t kvSLoopNum = rawEnd - rawBegin;
             int32_t validPhysicalIds[16];
             uint32_t validTileSize[16];
-            uint32_t lastLogicalBlockId = (historyLen + qTokenInBatch) / blockSize_;
             uint32_t actualLoopNum = 0;
             for (uint32_t i = rawBegin; i < rawEnd && i < topK_; i++) {
                 int32_t logicalId = gSelectIdx.GetValue(selectIdxBase + i);
-                if (logicalId < 0) continue;
+                if (logicalId < 0 || static_cast<uint32_t>(logicalId) >= validLogicalBlockNum) continue;
                 int64_t btOffset = static_cast<int64_t>(batchIdx) * maxBlocksPerBatch_ + logicalId;
                 int32_t physicalId = gBlockTable.GetValue(btOffset);
                 validPhysicalIds[actualLoopNum] = physicalId;
-                validTileSize[actualLoopNum] = (static_cast<uint32_t>(logicalId) == lastLogicalBlockId) ?
-                    lastBlockTileSize : blockSize_;
+                const uint32_t blockStartToken = static_cast<uint32_t>(logicalId) * blockSize_;
+                const uint32_t remainingTokens = visibleKvLen - blockStartToken;
+                validTileSize[actualLoopNum] = Min(remainingTokens, blockSize_);
                 actualLoopNum++;
             }
             kvSLoopNum = actualLoopNum;

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -208,6 +208,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend950 ]]; then
         "store_kv_block"
         "store_kv_block_metadata"
         "k2q_csr"
+        "sparse_attention_score"
     )
 
     CUSTOM_OPS=$(IFS=';'; echo "${CUSTOM_OPS_ARRAY[*]}")


### PR DESCRIPTION
### What this PR does / why we need it?

This PR provides Ascend 950 support for `sparse_attention_score` without maintaining a duplicated `sparse_attention_score_950` operator tree.

- builds the existing multi-architecture `sparse_attention_score` operator on Ascend 950;
- keeps one public ACLNN / torch interface and selects `arch22` or `arch35` through the existing AICore compile-time dispatch;
- leaves the A2/A3 `arch22` kernel unchanged;
- keeps the existing Flash Decoding tests, including the stability coverage removed by #14642;
- hardens optional dequant-scale contiguity, workspace-size overflow handling, A5 Flash Decoding zero-divisor handling, and full-quant sparse-block bounds.

This is a consolidated alternative to #14642 following the review suggestion to avoid duplicating the entire operator implementation.

### Does this PR introduce _any_ user-facing change?

Yes. Ascend 950 builds now package the existing `sparse_attention_score` operator. The vLLM-facing and ACLNN interfaces remain unchanged.

### How was this patch tested?

The following static checks passed locally:

```bash
git diff --check origin/main...HEAD
```

The branch was also checked to confirm:

- no `csrc/attention/sparse_attention_score_950` directory is introduced;
- no files under `csrc/attention/sparse_attention_score/op_kernel/arch22` are changed;
- Ascend 950 dispatches to the existing `arch35` implementation through `__CCE_AICORE__ == 310`.

CANN compilation and NPU accuracy tests require an Ascend environment and will be run separately.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
