### PR TITLE
[Bugfix][KV Offload] Bound sparse KV offload memory by NPU, DRAM and workload limits

### DIFF
--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -1,15 +1,376 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
-from vllm.v1.kv_cache_interface import KVCacheSpec
+from vllm.v1.kv_cache_interface import KVCacheSpec, UniformTypeKVCacheSpecs
 
 from vllm_ascend.core.kv_cache_interface import (
     AscendMLAAttentionSpec,
     AscendSFAIndexerCacheSpec,
 )
-from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
-    get_host_device_memory_usage_ratio,
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
+    sparse_kv_offload_manager as manager_module,
 )
+from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
+    SparseKVOffloadManager,
+    get_host_device_memory_usage_ratio,
+    get_sparse_kv_offload_cpu_pool_size_bytes,
+    plan_sparse_kv_offload_memory,
+)
+
+
+class _FakeKVCacheSpec:
+    def __init__(
+        self,
+        *,
+        page_size_bytes,
+        max_blocks_per_request,
+        store_on_host,
+        block_size=128,
+    ):
+        self.page_size_bytes = page_size_bytes
+        self.max_blocks_per_request = max_blocks_per_request
+        self.store_on_host = store_on_host
+        self.block_size = block_size
+
+    def max_memory_usage_bytes(self, _vllm_config):
+        return self.max_blocks_per_request * self.page_size_bytes
+
+
+def _make_memory_plan_inputs(max_num_seqs=2):
+    specs = {
+        "host.0": _FakeKVCacheSpec(
+            page_size_bytes=1024,
+            max_blocks_per_request=100,
+            store_on_host=True,
+        ),
+        "host.1": _FakeKVCacheSpec(
+            page_size_bytes=1024,
+            max_blocks_per_request=100,
+            store_on_host=True,
+        ),
+        "device.0": _FakeKVCacheSpec(
+            page_size_bytes=512,
+            max_blocks_per_request=100,
+            store_on_host=False,
+        ),
+    }
+    vllm_config = SimpleNamespace(
+        scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs)
+    )
+    alignment_reserve = (
+        2 * manager_module._CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
+    )
+    return specs, vllm_config, alignment_reserve
+
+
+class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
+    def test_memory_plan_is_limited_by_active_workload(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+
+        budget = plan_sparse_kv_offload_memory(
+            kv_cache_spec=specs,
+            vllm_config=vllm_config,
+            available_device_memory_bytes=1000 * 512,
+            dram_limit_bytes=alignment_reserve + 1000 * 2048,
+            keep_device_kv_cache=False,
+        )
+
+        self.assertEqual(budget.npu_limit_blocks, 1000)
+        self.assertEqual(budget.dram_limit_blocks, 1000)
+        self.assertEqual(budget.workload_limit_blocks, 201)
+        self.assertEqual(budget.final_num_blocks, 201)
+        self.assertEqual(budget.final_planner_bytes, 201 * (2048 + 512))
+        self.assertEqual(budget.planned_host_bytes, 201 * 2048)
+        self.assertEqual(budget.planned_device_bytes, 201 * 512)
+        self.assertEqual(budget.limiting_factor, "workload")
+
+    def test_memory_plan_is_limited_by_dram_capacity(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+
+        budget = plan_sparse_kv_offload_memory(
+            kv_cache_spec=specs,
+            vllm_config=vllm_config,
+            available_device_memory_bytes=1000 * 512,
+            dram_limit_bytes=alignment_reserve + 150 * 2048,
+            keep_device_kv_cache=False,
+        )
+
+        self.assertEqual(budget.dram_limit_blocks, 150)
+        self.assertEqual(budget.final_num_blocks, 150)
+        self.assertEqual(budget.limiting_factor, "dram")
+
+    def test_keep_device_cache_counts_full_npu_page(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+        total_page_size = 2048 + 512
+
+        budget = plan_sparse_kv_offload_memory(
+            kv_cache_spec=specs,
+            vllm_config=vllm_config,
+            available_device_memory_bytes=125 * total_page_size,
+            dram_limit_bytes=alignment_reserve + 1000 * 2048,
+            keep_device_kv_cache=True,
+        )
+
+        self.assertEqual(budget.npu_limit_blocks, 125)
+        self.assertEqual(budget.final_num_blocks, 125)
+        self.assertEqual(budget.planned_device_bytes, 125 * total_page_size)
+        self.assertEqual(budget.limiting_factor, "npu")
+
+    def test_non_positive_capacity_produces_zero_blocks(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+
+        for available_device_memory, dram_limit, limiting_factor in (
+            (-1, alignment_reserve + 1000 * 2048, "npu"),
+            (1000 * 512, alignment_reserve - 1, "dram"),
+        ):
+            with self.subTest(limiting_factor=limiting_factor):
+                budget = plan_sparse_kv_offload_memory(
+                    kv_cache_spec=specs,
+                    vllm_config=vllm_config,
+                    available_device_memory_bytes=available_device_memory,
+                    dram_limit_bytes=dram_limit,
+                    keep_device_kv_cache=False,
+                )
+                self.assertEqual(budget.final_num_blocks, 0)
+                self.assertEqual(budget.final_planner_bytes, 0)
+                self.assertEqual(budget.limiting_factor, limiting_factor)
+
+    def test_memory_plan_rejects_invalid_spec_layouts(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+        invalid_cases = (
+            ({"device.0": specs["device.0"]}, "at least one host"),
+            ({"host.0": specs["host.0"]}, "at least one device"),
+            (
+                {
+                    **specs,
+                    "device.1": _FakeKVCacheSpec(
+                        page_size_bytes=512,
+                        max_blocks_per_request=100,
+                        store_on_host=False,
+                        block_size=64,
+                    ),
+                },
+                "one shared block size",
+            ),
+        )
+
+        for invalid_specs, message in invalid_cases:
+            with self.subTest(message=message), self.assertRaisesRegex(
+                ValueError, message
+            ):
+                plan_sparse_kv_offload_memory(
+                    kv_cache_spec=invalid_specs,
+                    vllm_config=vllm_config,
+                    available_device_memory_bytes=1000 * 512,
+                    dram_limit_bytes=alignment_reserve + 1000 * 2048,
+                    keep_device_kv_cache=False,
+                )
+
+    def test_cpu_pool_size_includes_per_layer_alignment_reserve(self):
+        specs, _, alignment_reserve = _make_memory_plan_inputs()
+        kv_cache_config = SimpleNamespace(
+            num_blocks=200,
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=[name],
+                    kv_cache_spec=spec,
+                )
+                for name, spec in specs.items()
+            ],
+        )
+
+        self.assertEqual(
+            get_sparse_kv_offload_cpu_pool_size_bytes(kv_cache_config),
+            200 * 2048 + alignment_reserve,
+        )
+
+    def test_cpu_pool_size_supports_uniform_specs(self):
+        specs, _, alignment_reserve = _make_memory_plan_inputs()
+        uniform_specs = UniformTypeKVCacheSpecs(
+            block_size=128,
+            kv_cache_specs=specs,
+        )
+        kv_cache_config = SimpleNamespace(
+            num_blocks=200,
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=list(specs),
+                    kv_cache_spec=uniform_specs,
+                )
+            ],
+        )
+
+        self.assertEqual(
+            get_sparse_kv_offload_cpu_pool_size_bytes(kv_cache_config),
+            200 * 2048 + alignment_reserve,
+        )
+
+    def test_cpu_pool_size_rejects_missing_host_specs(self):
+        specs, _, _ = _make_memory_plan_inputs()
+        kv_cache_config = SimpleNamespace(
+            num_blocks=200,
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=["device.0"],
+                    kv_cache_spec=specs["device.0"],
+                )
+            ],
+        )
+
+        with self.assertRaisesRegex(ValueError, "host-resident"):
+            get_sparse_kv_offload_cpu_pool_size_bytes(kv_cache_config)
+
+    def _make_manager_init_inputs(self, dram_size_per_dp_gb=1):
+        spec = _FakeKVCacheSpec(
+            page_size_bytes=1024,
+            max_blocks_per_request=100,
+            store_on_host=True,
+        )
+        kv_cache_config = SimpleNamespace(
+            num_blocks=200,
+            kv_cache_groups=[
+                SimpleNamespace(layer_names=["host.0"], kv_cache_spec=spec)
+            ],
+        )
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                get_num_layers=MagicMock(return_value=1),
+                max_model_len=128,
+            ),
+            parallel_config=SimpleNamespace(),
+            scheduler_config=SimpleNamespace(
+                max_num_seqs=1,
+                max_num_batched_tokens=1,
+            ),
+            speculative_config=None,
+        )
+        offload_config = SimpleNamespace(
+            topk_buffer_size=1,
+            topk=1,
+            use_fused_overlap=False,
+            dram_size_per_dp_GB=dram_size_per_dp_gb,
+        )
+        return vllm_config, kv_cache_config, offload_config
+
+    def test_manager_initializes_offload_with_planned_pool_size(self):
+        vllm_config, kv_cache_config, offload_config = (
+            self._make_manager_init_inputs()
+        )
+        planned_pool_size = 4096
+        for rank, expected_alloc_size in ((0, planned_pool_size), (1, 0)):
+            with self.subTest(rank=rank):
+                offload_backend = SimpleNamespace(
+                    OffloadConfig=lambda: SimpleNamespace(),
+                    Scene=SimpleNamespace(SHARED="shared"),
+                    initialize=MagicMock(return_value=0),
+                )
+                tp_group = SimpleNamespace(barrier=MagicMock())
+
+                with (
+                    patch.object(
+                        manager_module,
+                        "get_tensor_model_parallel_rank",
+                        return_value=rank,
+                    ),
+                    patch.object(
+                        manager_module,
+                        "get_tensor_model_parallel_world_size",
+                        return_value=2,
+                    ),
+                    patch.object(
+                        manager_module,
+                        "get_tp_group",
+                        return_value=tp_group,
+                    ),
+                    patch.object(
+                        manager_module,
+                        "get_sparse_kv_offload_cpu_pool_size_bytes",
+                        return_value=planned_pool_size,
+                    ),
+                    patch.object(
+                        manager_module,
+                        "offload",
+                        offload_backend,
+                        create=True,
+                    ),
+                    patch.object(
+                        manager_module.torch,
+                        "zeros",
+                        return_value=MagicMock(),
+                    ),
+                    patch.object(
+                        manager_module.torch,
+                        "empty",
+                        return_value=MagicMock(),
+                    ),
+                    patch.object(SparseKVOffloadManager, "_build_cpp"),
+                ):
+                    SparseKVOffloadManager(
+                        vllm_config,
+                        kv_cache_config,
+                        offload_config,
+                    )
+
+                initialized_config = offload_backend.initialize.call_args.args[0]
+                self.assertEqual(
+                    initialized_config.reserve_size,
+                    planned_pool_size,
+                )
+                self.assertEqual(
+                    initialized_config.alloc_size,
+                    expected_alloc_size,
+                )
+                self.assertEqual(initialized_config.world_size, 2)
+                self.assertEqual(initialized_config.rank_id, rank)
+                tp_group.barrier.assert_called_once_with()
+
+    def test_manager_rejects_pool_larger_than_dram_limit(self):
+        vllm_config, kv_cache_config, offload_config = (
+            self._make_manager_init_inputs()
+        )
+        offload_backend = SimpleNamespace(
+            OffloadConfig=MagicMock(),
+            Scene=SimpleNamespace(SHARED="shared"),
+            initialize=MagicMock(return_value=0),
+        )
+
+        with (
+            patch.object(
+                manager_module,
+                "get_tensor_model_parallel_rank",
+                return_value=0,
+            ),
+            patch.object(
+                manager_module,
+                "get_tensor_model_parallel_world_size",
+                return_value=1,
+            ),
+            patch.object(
+                manager_module,
+                "get_tp_group",
+                return_value=SimpleNamespace(),
+            ),
+            patch.object(
+                manager_module,
+                "get_sparse_kv_offload_cpu_pool_size_bytes",
+                return_value=(1 << 30) + 1,
+            ),
+            patch.object(manager_module, "offload", offload_backend, create=True),
+            patch.object(manager_module.torch, "zeros", return_value=MagicMock()),
+            patch.object(manager_module.torch, "empty", return_value=MagicMock()),
+            patch.object(SparseKVOffloadManager, "_build_cpp"),
+            self.assertRaisesRegex(ValueError, "exceeds DRAM limit"),
+        ):
+            SparseKVOffloadManager(
+                vllm_config,
+                kv_cache_config,
+                offload_config,
+            )
+
+        offload_backend.OffloadConfig.assert_not_called()
+        offload_backend.initialize.assert_not_called()
 
 
 class TestHostDeviceMemoryRatio(unittest.TestCase):

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -2,19 +2,13 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import torch
-from vllm.v1.kv_cache_interface import KVCacheSpec, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 
-from vllm_ascend.core.kv_cache_interface import (
-    AscendMLAAttentionSpec,
-    AscendSFAIndexerCacheSpec,
-)
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload import (
     sparse_kv_offload_manager as manager_module,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     SparseKVOffloadManager,
-    get_host_device_memory_usage_ratio,
     get_sparse_kv_offload_cpu_pool_size_bytes,
     plan_sparse_kv_offload_memory,
 )
@@ -96,6 +90,32 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         self.assertEqual(budget.dram_limit_blocks, 150)
         self.assertEqual(budget.final_num_blocks, 150)
         self.assertEqual(budget.limiting_factor, "dram")
+
+    def test_warning_when_dram_budget_caps_npu_utilization(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+
+        with self.assertLogs(manager_module.logger, level="WARNING") as logs:
+            plan_sparse_kv_offload_memory(
+                kv_cache_spec=specs,
+                vllm_config=vllm_config,
+                available_device_memory_bytes=1000 * 512,
+                dram_limit_bytes=alignment_reserve + 500 * 2048,
+                keep_device_kv_cache=False,
+            )
+        self.assertTrue(any("dram_size_per_dp_GB" in line for line in logs.output))
+
+    def test_no_warning_when_dram_budget_not_below_npu(self):
+        specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
+
+        with patch.object(manager_module.logger, "warning_once") as mock_warn:
+            plan_sparse_kv_offload_memory(
+                kv_cache_spec=specs,
+                vllm_config=vllm_config,
+                available_device_memory_bytes=1000 * 512,
+                dram_limit_bytes=alignment_reserve + 1000 * 2048,
+                keep_device_kv_cache=False,
+            )
+        mock_warn.assert_not_called()
 
     def test_keep_device_cache_counts_full_npu_page(self):
         specs, vllm_config, alignment_reserve = _make_memory_plan_inputs()
@@ -359,164 +379,6 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
 
         offload_backend.OffloadConfig.assert_not_called()
         offload_backend.initialize.assert_not_called()
-
-
-class TestHostDeviceMemoryRatio(unittest.TestCase):
-    def gen_kv_cache_specs(
-        self,
-        spec_type: type[KVCacheSpec],
-        num: int,
-        name_suffix: str,
-        **kwargs,
-    ):
-        kv_cache_specs = {}
-        for layer_id in range(num):
-            name = f"model.layers.{layer_id}.{name_suffix}"
-            spec = spec_type(**kwargs)
-            kv_cache_specs[name] = spec
-        return kv_cache_specs
-
-    def test_normal_case(self):
-        # same number of mla & indexer cache, no c8
-        # gold = kv_dim / idx_dim
-        #      = 576 / 128
-        #      = 4.5
-        hd_memory_ratio_gold = 4.5
-        mla_specs = self.gen_kv_cache_specs(
-            AscendMLAAttentionSpec,
-            4,
-            "self_attn.attn",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=576,
-            dtype=torch.bfloat16,
-            cache_dtype_str="bfloat16",
-            cache_sparse_sfa_c8=False,
-            store_on_host=True,
-        )
-        indexer_specs = self.gen_kv_cache_specs(
-            AscendSFAIndexerCacheSpec,
-            4,
-            "self_attn.indexer.k_cache",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=128,
-            dtype=torch.bfloat16,
-            cache_dtype_str="bfloat16",
-            scale_dim=0,
-            scale_dtype=torch.int8,
-            cache_sparse_li_c8=False,
-        )
-        all_specs = {}
-        all_specs.update(mla_specs)
-        all_specs.update(indexer_specs)
-        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
-
-    def test_indexer_share(self):
-        # multi layer share one indexer (GLM5.2), no c8
-        # gold = (kv_num * kv_dim) / (idx_num * idx_dim)
-        #      = (4 * 576) / (1 * 128)
-        #      = 18
-        hd_memory_ratio_gold = 18
-        mla_specs = self.gen_kv_cache_specs(
-            AscendMLAAttentionSpec,
-            4,
-            "self_attn.attn",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=576,
-            dtype=torch.bfloat16,
-            cache_dtype_str="bfloat16",
-            cache_sparse_sfa_c8=False,
-            store_on_host=True,
-        )
-        indexer_specs = self.gen_kv_cache_specs(
-            AscendSFAIndexerCacheSpec,
-            1,
-            "self_attn.indexer.k_cache",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=128,
-            dtype=torch.bfloat16,
-            cache_dtype_str="bfloat16",
-            scale_dim=0,
-            scale_dtype=torch.int8,
-            cache_sparse_li_c8=False,
-        )
-        all_specs = {}
-        all_specs.update(mla_specs)
-        all_specs.update(indexer_specs)
-        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
-
-    def test_li_c8(self):
-        # indxer c8 cache
-        # gold = (kv_num * kv_dim * bf16) / (idx_num * (idx_dim * int8 + scale_dim * fp16))
-        #      = (4 * 576 * 2) / (1 * (128 * 1 + 1 * 2))
-        #      = 35.44615384615385
-        hd_memory_ratio_gold = 35.44615384615385
-        mla_specs = self.gen_kv_cache_specs(
-            AscendMLAAttentionSpec,
-            4,
-            "self_attn.attn",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=576,
-            dtype=torch.bfloat16,
-            cache_dtype_str="bfloat16",
-            cache_sparse_sfa_c8=False,
-            store_on_host=True,
-        )
-        indexer_specs = self.gen_kv_cache_specs(
-            AscendSFAIndexerCacheSpec,
-            1,
-            "self_attn.indexer.k_cache",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=128,
-            dtype=torch.int8,
-            cache_dtype_str="bfloat16",
-            scale_dim=1,
-            scale_dtype=torch.float16,
-            cache_sparse_li_c8=True,
-        )
-        all_specs = {}
-        all_specs.update(mla_specs)
-        all_specs.update(indexer_specs)
-        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
-
-    def test_no_offload(self):
-        # no store_on_host specs
-        # gold = 0 (don't need host memory)
-        hd_memory_ratio_gold = 0
-        mla_specs = self.gen_kv_cache_specs(
-            AscendMLAAttentionSpec,
-            4,
-            "self_attn.attn",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=576,
-            dtype=torch.bfloat16,
-            cache_dtype_str="bfloat16",
-            cache_sparse_sfa_c8=False,
-            store_on_host=False,
-        )
-        indexer_specs = self.gen_kv_cache_specs(
-            AscendSFAIndexerCacheSpec,
-            1,
-            "self_attn.indexer.k_cache",
-            block_size=128,
-            num_kv_heads=1,
-            head_size=128,
-            dtype=torch.bfloat16,
-            cache_dtype_str="bfloat16",
-            scale_dim=0,
-            scale_dtype=torch.int8,
-            cache_sparse_li_c8=False,
-        )
-        all_specs = {}
-        all_specs.update(mla_specs)
-        all_specs.update(indexer_specs)
-        self.assertEqual(get_host_device_memory_usage_ratio(all_specs), hd_memory_ratio_gold)
 
 
 if __name__ == "__main__":

--- a/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
+++ b/tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py
@@ -56,12 +56,8 @@ def _make_memory_plan_inputs(max_num_seqs=2):
             store_on_host=False,
         ),
     }
-    vllm_config = SimpleNamespace(
-        scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs)
-    )
-    alignment_reserve = (
-        2 * manager_module._CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
-    )
+    vllm_config = SimpleNamespace(scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs))
+    alignment_reserve = 2 * manager_module._CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
     return specs, vllm_config, alignment_reserve
 
 
@@ -157,9 +153,7 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         )
 
         for invalid_specs, message in invalid_cases:
-            with self.subTest(message=message), self.assertRaisesRegex(
-                ValueError, message
-            ):
+            with self.subTest(message=message), self.assertRaisesRegex(ValueError, message):
                 plan_sparse_kv_offload_memory(
                     kv_cache_spec=invalid_specs,
                     vllm_config=vllm_config,
@@ -230,9 +224,7 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         )
         kv_cache_config = SimpleNamespace(
             num_blocks=200,
-            kv_cache_groups=[
-                SimpleNamespace(layer_names=["host.0"], kv_cache_spec=spec)
-            ],
+            kv_cache_groups=[SimpleNamespace(layer_names=["host.0"], kv_cache_spec=spec)],
         )
         vllm_config = SimpleNamespace(
             model_config=SimpleNamespace(
@@ -255,9 +247,7 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
         return vllm_config, kv_cache_config, offload_config
 
     def test_manager_initializes_offload_with_planned_pool_size(self):
-        vllm_config, kv_cache_config, offload_config = (
-            self._make_manager_init_inputs()
-        )
+        vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()
         planned_pool_size = 4096
         for rank, expected_alloc_size in ((0, planned_pool_size), (1, 0)):
             with self.subTest(rank=rank):
@@ -327,9 +317,7 @@ class TestSparseKVOffloadMemoryPlanning(unittest.TestCase):
                 tp_group.barrier.assert_called_once_with()
 
     def test_manager_rejects_pool_larger_than_dram_limit(self):
-        vllm_config, kv_cache_config, offload_config = (
-            self._make_manager_init_inputs()
-        )
+        vllm_config, kv_cache_config, offload_config = self._make_manager_init_inputs()
         offload_backend = SimpleNamespace(
             OffloadConfig=MagicMock(),
             Scene=SimpleNamespace(SHARED="shared"),

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -840,9 +840,7 @@ class TestNPUWorker(TestBase):
         worker.vllm_config = MagicMock()
         worker.get_kv_cache_spec = MagicMock(return_value={"layer": MagicMock()})
 
-        with patch(
-            "vllm_ascend.worker.worker.plan_sparse_kv_offload_memory"
-        ) as mock_plan_memory:
+        with patch("vllm_ascend.worker.worker.plan_sparse_kv_offload_memory") as mock_plan_memory:
             mock_plan_memory.return_value = SimpleNamespace(
                 npu_limit_blocks=1,
                 dram_limit_blocks=1,
@@ -869,17 +867,13 @@ class TestNPUWorker(TestBase):
         worker.cache_config = SimpleNamespace(kv_cache_memory_bytes=8192)
         worker.model_runner = MagicMock()
         worker.init_snapshot = SimpleNamespace(free_memory=16384)
-        worker._apply_kv_offload_decode_memory_constraints = MagicMock(
-            return_value=4096
-        )
+        worker._apply_kv_offload_decode_memory_constraints = MagicMock(return_value=4096)
 
         result = worker.determine_available_memory()
 
         self.assertEqual(result, 4096)
         worker.model_runner.profile_run.assert_called_once_with()
-        worker._apply_kv_offload_decode_memory_constraints.assert_called_once_with(
-            8192
-        )
+        worker._apply_kv_offload_decode_memory_constraints.assert_called_once_with(8192)
 
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")
@@ -950,9 +944,7 @@ class TestNPUWorker(TestBase):
             # result = requested_memory(8000) - non_kv_cache_memory(3500) = 4500
             expected_result = int(10000 * 0.8 - 3500)
             self.assertEqual(result, expected_result)
-            worker._apply_kv_offload_decode_memory_constraints.assert_called_once_with(
-                expected_result
-            )
+            worker._apply_kv_offload_decode_memory_constraints.assert_called_once_with(expected_result)
 
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -764,6 +764,123 @@ class TestNPUWorker(TestBase):
             # Verify call
             mock_model_runner._dummy_run.assert_called_once_with(mock_uniform_decode_query_len, uniform_decode=True)
 
+    @patch("vllm_ascend.worker.worker.plan_sparse_kv_offload_memory")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_sparse_kv_offload_memory_constraints_disabled(
+        self,
+        mock_get_ascend_config,
+        mock_plan_memory,
+    ):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        mock_get_ascend_config.return_value.sparse_kv_offload_config.enabled = False
+        worker = NPUWorker.__new__(NPUWorker)
+
+        self.assertEqual(
+            worker._apply_kv_offload_decode_memory_constraints(1234.9),
+            1234,
+        )
+        mock_plan_memory.assert_not_called()
+
+    @patch("vllm_ascend.worker.worker.plan_sparse_kv_offload_memory")
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_sparse_kv_offload_memory_constraints_use_planner_budget(
+        self,
+        mock_get_ascend_config,
+        mock_plan_memory,
+    ):
+        from vllm_ascend.worker.worker import GiB_bytes, NPUWorker
+
+        sparse_config = SimpleNamespace(
+            enabled=True,
+            dram_size_per_dp_GB=4,
+            keep_device_kv_cache=True,
+        )
+        mock_get_ascend_config.return_value.sparse_kv_offload_config = sparse_config
+        mock_plan_memory.return_value = SimpleNamespace(
+            npu_limit_blocks=10,
+            dram_limit_blocks=20,
+            workload_limit_blocks=30,
+            final_num_blocks=10,
+            final_planner_bytes=4096,
+            planned_host_bytes=2048,
+            planned_device_bytes=4096,
+            host_alignment_reserve_bytes=1024,
+            limiting_factor="npu",
+        )
+        cached_spec = {"layer": MagicMock()}
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.kv_cache_spec = cached_spec
+        worker.vllm_config = MagicMock()
+
+        result = worker._apply_kv_offload_decode_memory_constraints(8192)
+
+        self.assertEqual(result, 4096)
+        mock_plan_memory.assert_called_once_with(
+            kv_cache_spec=cached_spec,
+            vllm_config=worker.vllm_config,
+            available_device_memory_bytes=8192,
+            dram_limit_bytes=4 * GiB_bytes,
+            keep_device_kv_cache=True,
+        )
+
+    @patch("vllm_ascend.worker.worker.get_ascend_config")
+    def test_sparse_kv_offload_memory_constraints_fetch_kv_specs(
+        self,
+        mock_get_ascend_config,
+    ):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        mock_get_ascend_config.return_value.sparse_kv_offload_config = SimpleNamespace(
+            enabled=True,
+            dram_size_per_dp_GB=1,
+            keep_device_kv_cache=False,
+        )
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.vllm_config = MagicMock()
+        worker.get_kv_cache_spec = MagicMock(return_value={"layer": MagicMock()})
+
+        with patch(
+            "vllm_ascend.worker.worker.plan_sparse_kv_offload_memory"
+        ) as mock_plan_memory:
+            mock_plan_memory.return_value = SimpleNamespace(
+                npu_limit_blocks=1,
+                dram_limit_blocks=1,
+                workload_limit_blocks=1,
+                final_num_blocks=1,
+                final_planner_bytes=1024,
+                planned_host_bytes=512,
+                planned_device_bytes=512,
+                host_alignment_reserve_bytes=0,
+                limiting_factor="npu",
+            )
+
+            self.assertEqual(
+                worker._apply_kv_offload_decode_memory_constraints(1024),
+                1024,
+            )
+
+        worker.get_kv_cache_spec.assert_called_once_with()
+
+    def test_explicit_kv_cache_memory_applies_sparse_offload_constraints(self):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.cache_config = SimpleNamespace(kv_cache_memory_bytes=8192)
+        worker.model_runner = MagicMock()
+        worker.init_snapshot = SimpleNamespace(free_memory=16384)
+        worker._apply_kv_offload_decode_memory_constraints = MagicMock(
+            return_value=4096
+        )
+
+        result = worker.determine_available_memory()
+
+        self.assertEqual(result, 4096)
+        worker.model_runner.profile_run.assert_called_once_with()
+        worker._apply_kv_offload_decode_memory_constraints.assert_called_once_with(
+            8192
+        )
+
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")
     @patch("torch.npu.reset_peak_memory_stats")
@@ -817,6 +934,9 @@ class TestNPUWorker(TestBase):
             worker.cache_config.gpu_memory_utilization = 0.8
             worker.cache_config.kv_cache_memory_bytes = None
             worker.device = torch.device("npu:0")
+            worker._apply_kv_offload_decode_memory_constraints = MagicMock(
+                wraps=worker._apply_kv_offload_decode_memory_constraints
+            )
 
             # Mock torch.npu.memory_stats for profile_torch_peak
             # profile_torch_peak = memory_stats()["allocated_bytes.all.peak"] = 2000
@@ -830,6 +950,9 @@ class TestNPUWorker(TestBase):
             # result = requested_memory(8000) - non_kv_cache_memory(3500) = 4500
             expected_result = int(10000 * 0.8 - 3500)
             self.assertEqual(result, expected_result)
+            worker._apply_kv_offload_decode_memory_constraints.assert_called_once_with(
+                expected_result
+            )
 
     @patch("vllm_ascend.worker.worker.get_ascend_config")
     @patch("vllm_ascend.worker.worker.memory_profiling")

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -169,6 +169,8 @@ class SparseKVOffloadMemoryBudget:
 def _split_host_device_kv_specs(
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> tuple[list[KVCacheSpec], list[KVCacheSpec]]:
+    if not kv_cache_spec:
+        raise ValueError("Sparse KV offload requires a non-empty kv_cache_spec")
     host_specs: list[KVCacheSpec] = []
     device_specs: list[KVCacheSpec] = []
     for spec in kv_cache_spec.values():

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -1,7 +1,7 @@
 import contextlib
 import os
-from dataclasses import dataclass
 import typing
+from dataclasses import dataclass
 from zlib import adler32
 
 import numpy as np
@@ -184,10 +184,7 @@ def _split_host_device_kv_specs(
         raise ValueError("Sparse KV offload requires at least one device KV cache spec")
     block_sizes = {spec.block_size for spec in host_specs + device_specs}
     if len(block_sizes) != 1:
-        raise ValueError(
-            "Sparse KV offload memory planning requires one shared block size, "
-            f"got {sorted(block_sizes)}"
-        )
+        raise ValueError(f"Sparse KV offload memory planning requires one shared block size, got {sorted(block_sizes)}")
     return host_specs, device_specs
 
 
@@ -204,15 +201,11 @@ def plan_sparse_kv_offload_memory(
     device_page_size_bytes = sum(spec.page_size_bytes for spec in device_specs)
     total_page_size_bytes = host_page_size_bytes + device_page_size_bytes
 
-    host_alignment_reserve_bytes = (
-        len(host_specs) * _CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
-    )
+    host_alignment_reserve_bytes = len(host_specs) * _CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
     usable_dram_bytes = max(dram_limit_bytes - host_alignment_reserve_bytes, 0)
     dram_limit_blocks = usable_dram_bytes // host_page_size_bytes
 
-    npu_page_size_bytes = (
-        total_page_size_bytes if keep_device_kv_cache else device_page_size_bytes
-    )
+    npu_page_size_bytes = total_page_size_bytes if keep_device_kv_cache else device_page_size_bytes
     npu_limit_blocks = max(available_device_memory_bytes, 0) // npu_page_size_bytes
 
     max_blocks_per_request = max(
@@ -222,10 +215,7 @@ def plan_sparse_kv_offload_memory(
         )
         for spec in host_specs + device_specs
     )
-    workload_limit_blocks = (
-        max_blocks_per_request * vllm_config.scheduler_config.max_num_seqs
-        + _VLLM_NULL_BLOCK_COUNT
-    )
+    workload_limit_blocks = max_blocks_per_request * vllm_config.scheduler_config.max_num_seqs + _VLLM_NULL_BLOCK_COUNT
 
     limits = {
         "npu": npu_limit_blocks,
@@ -259,23 +249,12 @@ def get_sparse_kv_offload_cpu_pool_size_bytes(
         if isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs):
             layer_specs.update(group.kv_cache_spec.kv_cache_specs)
         else:
-            layer_specs.update(
-                (layer_name, group.kv_cache_spec)
-                for layer_name in group.layer_names
-            )
-    host_specs = [
-        spec
-        for spec in layer_specs.values()
-        if getattr(spec, "store_on_host", False)
-    ]
+            layer_specs.update((layer_name, group.kv_cache_spec) for layer_name in group.layer_names)
+    host_specs = [spec for spec in layer_specs.values() if getattr(spec, "store_on_host", False)]
     if not host_specs:
         raise ValueError("Sparse KV offload requires host-resident KV cache specs")
-    raw_host_bytes = kv_cache_config.num_blocks * sum(
-        spec.page_size_bytes for spec in host_specs
-    )
-    alignment_reserve_bytes = (
-        len(host_specs) * _CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
-    )
+    raw_host_bytes = kv_cache_config.num_blocks * sum(spec.page_size_bytes for spec in host_specs)
+    alignment_reserve_bytes = len(host_specs) * _CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
     return raw_host_bytes + alignment_reserve_bytes
 
 
@@ -484,12 +463,8 @@ class SparseKVOffloadManager:
 
         self._build_cpp()
 
-        dram_limit_bytes = int(
-            sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30)
-        )
-        planned_pool_size_bytes = get_sparse_kv_offload_cpu_pool_size_bytes(
-            kv_cache_config
-        )
+        dram_limit_bytes = int(sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30))
+        planned_pool_size_bytes = get_sparse_kv_offload_cpu_pool_size_bytes(kv_cache_config)
         if planned_pool_size_bytes > dram_limit_bytes:
             raise ValueError(
                 "Sparse KV offload planned CPU pool exceeds DRAM limit after "

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -222,7 +222,7 @@ def plan_sparse_kv_offload_memory(
         "dram": dram_limit_blocks,
         "workload": workload_limit_blocks,
     }
-    limiting_factor = min(limits, key=limits.get)
+    limiting_factor = min(limits, key=lambda name: limits[name])
     final_num_blocks = limits[limiting_factor]
     final_planner_bytes = final_num_blocks * total_page_size_bytes
     planned_host_bytes = final_num_blocks * host_page_size_bytes

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -120,6 +120,10 @@ def allocate_kv_offload_topk_profile_buffers(
 
 
 _CPU_CACHE_ALIGNMENT = 2 * 1024 * 1024
+# Worst-case 2 MiB-alignment waste per host layer (see empty_aligned_int8_cpu_tensors):
+# 1x for rounding the raw buffer base address up to the alignment boundary, plus 1x tail
+# padding for each of the two aligned tensors (k_cache_cpu, v_cache_cpu) whose sizes are
+# rounded up to whole alignment chunks.
 _CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER = 3 * _CPU_CACHE_ALIGNMENT
 _VLLM_NULL_BLOCK_COUNT = 1
 

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -50,20 +50,6 @@ def get_subscribed_compute_streams() -> set:
     return _SUBSCRIBED_COMPUTE_STREAMS
 
 
-def get_host_device_memory_usage_ratio(kv_cache_specs: dict[str, KVCacheSpec]) -> float:
-    page_size_bytes_host = 0
-    page_size_bytes_device = 0
-    for kv_cache_spec in kv_cache_specs.values():
-        assert isinstance(kv_cache_spec, KVCacheSpec)
-        if getattr(kv_cache_spec, "store_on_host", False):
-            page_size_bytes_host += kv_cache_spec.page_size_bytes
-        else:
-            page_size_bytes_device += kv_cache_spec.page_size_bytes
-
-    assert page_size_bytes_device > 0, "Case of no device kv cache is not considered."
-    return page_size_bytes_host / page_size_bytes_device
-
-
 def allocate_kv_offload_topk_buffer_pair(
     vllm_config: VllmConfig,
     sparse_kv_offload_config: SparseKVOffloadConfig,
@@ -226,6 +212,17 @@ def plan_sparse_kv_offload_memory(
         "dram": dram_limit_blocks,
         "workload": workload_limit_blocks,
     }
+    if dram_limit_blocks < npu_limit_blocks:
+        logger.warning_once(
+            "Sparse KV offload: host DRAM budget allows only %d KV blocks while NPU "
+            "memory could hold %d, so batch size / max_model_len capacity is limited "
+            "by host memory. Consider increasing sparse_kv_offload_config."
+            "dram_size_per_dp_GB (current budget %.2f GiB) to use more of the NPU "
+            "capacity.",
+            dram_limit_blocks,
+            npu_limit_blocks,
+            dram_limit_bytes / (1 << 30),
+        )
     limiting_factor = min(limits, key=lambda name: limits[name])
     final_num_blocks = limits[limiting_factor]
     final_planner_bytes = final_num_blocks * total_page_size_bytes

--- a/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
+++ b/vllm_ascend/distributed/kv_transfer/sparse_kv_offload/sparse_kv_offload_manager.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+from dataclasses import dataclass
 import typing
 from zlib import adler32
 
@@ -119,6 +120,8 @@ def allocate_kv_offload_topk_profile_buffers(
 
 
 _CPU_CACHE_ALIGNMENT = 2 * 1024 * 1024
+_CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER = 3 * _CPU_CACHE_ALIGNMENT
+_VLLM_NULL_BLOCK_COUNT = 1
 
 
 def empty_aligned_int8_cpu_tensors(
@@ -148,6 +151,130 @@ def empty_aligned_int8_cpu_tensors(
         allocate_tensors.append(raw_tensor[base_offset : base_offset + size])
         base_offset += chunk_num * alignment
     return allocate_tensors
+
+
+@dataclass(frozen=True)
+class SparseKVOffloadMemoryBudget:
+    npu_limit_blocks: int
+    dram_limit_blocks: int
+    workload_limit_blocks: int
+    final_num_blocks: int
+    final_planner_bytes: int
+    planned_host_bytes: int
+    planned_device_bytes: int
+    host_alignment_reserve_bytes: int
+    limiting_factor: str
+
+
+def _split_host_device_kv_specs(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> tuple[list[KVCacheSpec], list[KVCacheSpec]]:
+    host_specs: list[KVCacheSpec] = []
+    device_specs: list[KVCacheSpec] = []
+    for spec in kv_cache_spec.values():
+        if getattr(spec, "store_on_host", False):
+            host_specs.append(spec)
+        else:
+            device_specs.append(spec)
+    if not host_specs:
+        raise ValueError("Sparse KV offload requires at least one host KV cache spec")
+    if not device_specs:
+        raise ValueError("Sparse KV offload requires at least one device KV cache spec")
+    block_sizes = {spec.block_size for spec in host_specs + device_specs}
+    if len(block_sizes) != 1:
+        raise ValueError(
+            "Sparse KV offload memory planning requires one shared block size, "
+            f"got {sorted(block_sizes)}"
+        )
+    return host_specs, device_specs
+
+
+def plan_sparse_kv_offload_memory(
+    kv_cache_spec: dict[str, KVCacheSpec],
+    vllm_config: VllmConfig,
+    available_device_memory_bytes: int,
+    dram_limit_bytes: int,
+    keep_device_kv_cache: bool,
+) -> SparseKVOffloadMemoryBudget:
+    """Bound sparse KV offload blocks by NPU, DRAM, and active demand."""
+    host_specs, device_specs = _split_host_device_kv_specs(kv_cache_spec)
+    host_page_size_bytes = sum(spec.page_size_bytes for spec in host_specs)
+    device_page_size_bytes = sum(spec.page_size_bytes for spec in device_specs)
+    total_page_size_bytes = host_page_size_bytes + device_page_size_bytes
+
+    host_alignment_reserve_bytes = (
+        len(host_specs) * _CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
+    )
+    usable_dram_bytes = max(dram_limit_bytes - host_alignment_reserve_bytes, 0)
+    dram_limit_blocks = usable_dram_bytes // host_page_size_bytes
+
+    npu_page_size_bytes = (
+        total_page_size_bytes if keep_device_kv_cache else device_page_size_bytes
+    )
+    npu_limit_blocks = max(available_device_memory_bytes, 0) // npu_page_size_bytes
+
+    max_blocks_per_request = max(
+        cdiv(
+            spec.max_memory_usage_bytes(vllm_config),
+            spec.page_size_bytes,
+        )
+        for spec in host_specs + device_specs
+    )
+    workload_limit_blocks = (
+        max_blocks_per_request * vllm_config.scheduler_config.max_num_seqs
+        + _VLLM_NULL_BLOCK_COUNT
+    )
+
+    limits = {
+        "npu": npu_limit_blocks,
+        "dram": dram_limit_blocks,
+        "workload": workload_limit_blocks,
+    }
+    limiting_factor = min(limits, key=limits.get)
+    final_num_blocks = limits[limiting_factor]
+    final_planner_bytes = final_num_blocks * total_page_size_bytes
+    planned_host_bytes = final_num_blocks * host_page_size_bytes
+    planned_device_bytes = final_num_blocks * npu_page_size_bytes
+    return SparseKVOffloadMemoryBudget(
+        npu_limit_blocks=npu_limit_blocks,
+        dram_limit_blocks=dram_limit_blocks,
+        workload_limit_blocks=workload_limit_blocks,
+        final_num_blocks=final_num_blocks,
+        final_planner_bytes=final_planner_bytes,
+        planned_host_bytes=planned_host_bytes,
+        planned_device_bytes=planned_device_bytes,
+        host_alignment_reserve_bytes=host_alignment_reserve_bytes,
+        limiting_factor=limiting_factor,
+    )
+
+
+def get_sparse_kv_offload_cpu_pool_size_bytes(
+    kv_cache_config: KVCacheConfig,
+) -> int:
+    """Return a safe upper bound for aligned host KV allocations."""
+    layer_specs: dict[str, KVCacheSpec] = {}
+    for group in kv_cache_config.kv_cache_groups:
+        if isinstance(group.kv_cache_spec, UniformTypeKVCacheSpecs):
+            layer_specs.update(group.kv_cache_spec.kv_cache_specs)
+        else:
+            layer_specs.update(
+                (layer_name, group.kv_cache_spec)
+                for layer_name in group.layer_names
+            )
+    host_specs = [
+        spec
+        for spec in layer_specs.values()
+        if getattr(spec, "store_on_host", False)
+    ]
+    if not host_specs:
+        raise ValueError("Sparse KV offload requires host-resident KV cache specs")
+    raw_host_bytes = kv_cache_config.num_blocks * sum(
+        spec.page_size_bytes for spec in host_specs
+    )
+    alignment_reserve_bytes = (
+        len(host_specs) * _CPU_CACHE_MAX_ALIGNMENT_OVERHEAD_PER_LAYER
+    )
+    return raw_host_bytes + alignment_reserve_bytes
 
 
 def allocate_kv_cache_tensors_for_sparse_kv_offload(
@@ -355,15 +482,32 @@ class SparseKVOffloadManager:
 
         self._build_cpp()
 
+        dram_limit_bytes = int(
+            sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30)
+        )
+        planned_pool_size_bytes = get_sparse_kv_offload_cpu_pool_size_bytes(
+            kv_cache_config
+        )
+        if planned_pool_size_bytes > dram_limit_bytes:
+            raise ValueError(
+                "Sparse KV offload planned CPU pool exceeds DRAM limit after "
+                "alignment: "
+                f"planned={planned_pool_size_bytes / (1 << 30):.2f} GiB, "
+                f"limit={sparse_kv_offload_config.dram_size_per_dp_GB} GiB, "
+                f"num_blocks={kv_cache_config.num_blocks}"
+            )
+        actual_pool_size_bytes = min(planned_pool_size_bytes, dram_limit_bytes)
         logger.info(
-            "SparseKVOffloadManager start init CPU KV pool with %s "
-            "GB dram per dp group, it might be time consuming, please wait.",
+            "SparseKVOffloadManager starts CPU KV pool initialization: "
+            "planned=%.2f GiB, configured_limit=%s GiB, num_blocks=%s.",
+            actual_pool_size_bytes / (1 << 30),
             sparse_kv_offload_config.dram_size_per_dp_GB,
+            kv_cache_config.num_blocks,
         )
         config = offload.OffloadConfig()
         config.device_id = torch_npu.npu.current_device()
-        config.reserve_size = sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30)
-        config.alloc_size = sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30) if self.tp_rank == 0 else 0
+        config.reserve_size = actual_pool_size_bytes
+        config.alloc_size = actual_pool_size_bytes if self.tp_rank == 0 else 0
         config.world_size = self.tp_size
         config.rank_id = self.tp_rank
         config.scene = offload.Scene.SHARED

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -72,7 +72,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     get_layerwise_physical_layer_index,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
-    get_host_device_memory_usage_ratio,
+    plan_sparse_kv_offload_memory,
 )
 from vllm_ascend.distributed.parallel_state import init_ascend_model_parallel
 from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
@@ -483,6 +483,44 @@ class NPUWorker(WorkerBase):
             # If usage stat is enabled, collect relevant info.
             report_usage_stats(self.vllm_config)
 
+    def _apply_kv_offload_decode_memory_constraints(
+        self,
+        available_device_memory_bytes: int,
+    ) -> int:
+        GiB = lambda b: b / GiB_bytes
+        sparse_kv_offload_config = get_ascend_config().sparse_kv_offload_config
+        if not sparse_kv_offload_config.enabled:
+            return int(available_device_memory_bytes)
+
+        kv_cache_spec = getattr(self, "kv_cache_spec", None) or self.get_kv_cache_spec()
+        dram_limit_bytes = int(
+            sparse_kv_offload_config.dram_size_per_dp_GB * GiB_bytes
+        )
+        budget = plan_sparse_kv_offload_memory(
+            kv_cache_spec=kv_cache_spec,
+            vllm_config=self.vllm_config,
+            available_device_memory_bytes=available_device_memory_bytes,
+            dram_limit_bytes=dram_limit_bytes,
+            keep_device_kv_cache=sparse_kv_offload_config.keep_device_kv_cache,
+        )
+        logger.info_once(
+            "Sparse KV offload memory plan: npu_limit=%d blocks, "
+            "dram_limit=%d blocks, workload_limit=%d blocks, "
+            "final=%d blocks (%s limited), planner=%.2f GiB, "
+            "host=%.2f GiB, device=%.2f GiB, alignment_reserve=%.2f GiB.",
+            budget.npu_limit_blocks,
+            budget.dram_limit_blocks,
+            budget.workload_limit_blocks,
+            budget.final_num_blocks,
+            budget.limiting_factor,
+            GiB(budget.final_planner_bytes),
+            GiB(budget.planned_host_bytes),
+            GiB(budget.planned_device_bytes),
+            GiB(budget.host_alignment_reserve_bytes),
+            scope="local",
+        )
+        return int(budget.final_planner_bytes)
+
     @torch.inference_mode()
     def determine_available_memory(self) -> int:
         """Profiles the peak memory usage of the model to determine how much
@@ -510,8 +548,9 @@ class NPUWorker(WorkerBase):
                 GiB(self.init_snapshot.free_memory),
                 GiB(kv_cache_memory_bytes),
             )
-            kv_cache_memory_bytes = self.update_available_memory_for_sparse_kv_offload(kv_cache_memory_bytes)
-            return kv_cache_memory_bytes
+            return self._apply_kv_offload_decode_memory_constraints(
+                kv_cache_memory_bytes
+            )
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
@@ -574,45 +613,13 @@ class NPUWorker(WorkerBase):
         logger.info_once(
             "Available KV cache memory: %.2f GiB", GiB(self.available_kv_cache_memory_bytes), scope="local"
         )
-        self.available_kv_cache_memory_bytes = self.update_available_memory_for_sparse_kv_offload(
-            self.available_kv_cache_memory_bytes,
+        self.available_kv_cache_memory_bytes = (
+            self._apply_kv_offload_decode_memory_constraints(
+                self.available_kv_cache_memory_bytes
+            )
         )
 
         return int(self.available_kv_cache_memory_bytes)
-
-    def update_available_memory_for_sparse_kv_offload(self, available_memory):
-        """
-        A simple patch for Sparse KV offload: add additional available_memory according to the
-        ratio of host memory (kv) and dev memory (indexer), so we can allocate blocks for indexer cache
-        using all original available device memory without modify original kv_spec or vllm code.
-        For further optimization, consider to merge this logic to vllm kv_cache_utils.py,
-        or reuse hisparse's host pool logic after it's merged to vllm.
-        """
-        GiB = lambda b: b / GiB_bytes
-        sparse_kv_offload_config = get_ascend_config().sparse_kv_offload_config
-        if not sparse_kv_offload_config.enabled:
-            return available_memory
-        keep_device_kv_cache = sparse_kv_offload_config.keep_device_kv_cache
-        if keep_device_kv_cache:
-            needed_dram_size_bytes = available_memory
-        else:
-            kv_cache_spec = getattr(self, "kv_cache_spec", None) or self.get_kv_cache_spec()
-            host_device_memory_usage_ratio = get_host_device_memory_usage_ratio(kv_cache_spec)
-            needed_dram_size_bytes = host_device_memory_usage_ratio * available_memory
-        if needed_dram_size_bytes > sparse_kv_offload_config.dram_size_per_dp_GB * (1 << 30):
-            raise ValueError(
-                f"Needed dram size ({GiB(needed_dram_size_bytes)} GB) is larger than "
-                f"user specified dram size ({sparse_kv_offload_config.dram_size_per_dp_GB} GB). "
-                "Please increase sparse_kv_offload_config.dram_size_per_dp_GB if available on your device."
-            )
-        if not keep_device_kv_cache:
-            available_memory += needed_dram_size_bytes
-            logger.info_once(
-                "Sparse KV offload is enabled, enlarge total available memory to %.2f GiB",
-                GiB(available_memory),
-                scope="local",
-            )
-        return int(available_memory)
 
     def log_memory_stats(self) -> None:
         """Profiles the torch reserved memory, torch allocated memory in execute_model()."""

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -493,9 +493,7 @@ class NPUWorker(WorkerBase):
             return int(available_device_memory_bytes)
 
         kv_cache_spec = getattr(self, "kv_cache_spec", None) or self.get_kv_cache_spec()
-        dram_limit_bytes = int(
-            sparse_kv_offload_config.dram_size_per_dp_GB * GiB_bytes
-        )
+        dram_limit_bytes = int(sparse_kv_offload_config.dram_size_per_dp_GB * GiB_bytes)
         budget = plan_sparse_kv_offload_memory(
             kv_cache_spec=kv_cache_spec,
             vllm_config=self.vllm_config,
@@ -548,9 +546,7 @@ class NPUWorker(WorkerBase):
                 GiB(self.init_snapshot.free_memory),
                 GiB(kv_cache_memory_bytes),
             )
-            return self._apply_kv_offload_decode_memory_constraints(
-                kv_cache_memory_bytes
-            )
+            return self._apply_kv_offload_decode_memory_constraints(kv_cache_memory_bytes)
 
         # Execute a forward pass with dummy inputs to profile the memory usage
         # of the model.
@@ -613,10 +609,8 @@ class NPUWorker(WorkerBase):
         logger.info_once(
             "Available KV cache memory: %.2f GiB", GiB(self.available_kv_cache_memory_bytes), scope="local"
         )
-        self.available_kv_cache_memory_bytes = (
-            self._apply_kv_offload_decode_memory_constraints(
-                self.available_kv_cache_memory_bytes
-            )
+        self.available_kv_cache_memory_bytes = self._apply_kv_offload_decode_memory_constraints(
+            self.available_kv_cache_memory_bytes
         )
 
         return int(self.available_kv_cache_memory_bytes)


### PR DESCRIPTION
### What this PR does / why we need it?

Sparse KV offload (SFA with `enable_sparse_li_c8`) had two problems in memory planning:

1. `SparseKVOffloadManager` always sized the CPU KV pool at the **full configured `dram_size_per_dp_GB`**, regardless of how many KV blocks the engine actually planned to use. On large-DRAM configs (e.g. 180 GiB per DP group) this allocates far more DRAM than needed and makes pool initialization very slow (tens of minutes of hugepage-backed allocation), even when the active workload only needs a fraction of it.
2. The worker-side logic (`update_available_memory_for_sparse_kv_offload`) only enlarged total available memory by a host/device page-size ratio. The number of KV blocks was therefore never bounded by DRAM capacity or by active workload demand, and when the blocks implied by free NPU memory exceeded the configured DRAM, startup failed with a generic "please increase `sparse_kv_offload_config.dram_size_per_dp_GB`" error.

This PR replaces that logic with an explicit memory plan:

- New `plan_sparse_kv_offload_memory()` returns a `SparseKVOffloadMemoryBudget` that bounds the block count by the minimum of three limits and reports the limiting factor:
  - **NPU capacity** — free device memory (counting the full page size when `keep_device_kv_cache=True`, device portion only otherwise);
  - **DRAM limit** — `dram_size_per_dp_GB` minus a per-layer alignment reserve (each host layer may lose up to 3 × 2 MiB to 2 MiB-aligned allocations);
  - **Workload demand** — `max_blocks_per_request × max_num_seqs` plus the null block.
- `NPUWorker.determine_available_memory()` now applies the budget through `_apply_kv_offload_decode_memory_constraints()` and returns the planned bytes, with a one-shot log line showing every limit, the final block count, the limiting factor, and the host/device/alignment byte breakdown.
- `SparseKVOffloadManager` sizes the actual CPU pool from the planned block count (`num_blocks × host page sizes + alignment reserve`, via the new `get_sparse_kv_offload_cpu_pool_size_bytes()`) instead of the full configured DRAM, and raises an actionable error (planned vs. limit vs. `num_blocks`) if the planned pool still exceeds the DRAM limit.

As a result, the offload pool is allocated only as large as needed: DRAM footprint and CPU pool initialization time drop accordingly, and undersized `dram_size_per_dp_GB` configurations fail early with a clear message.

### Does this PR introduce _any_ user-facing change?

Yes. With sparse KV offload enabled:

- The CPU offload pool is no longer always allocated at the full `dram_size_per_dp_GB`; it is sized from the planned block count, so the number of KV cache blocks can be smaller than before when DRAM or workload demand is the limiting factor. The limiting factor and full plan are logged at startup.
- The previous error "Needed dram size ... Please increase `sparse_kv_offload_config.dram_size_per_dp_GB`" is replaced by a new "planned CPU pool exceeds DRAM limit after alignment" error carrying planned/limit/num_blocks values.
- Log messages around sparse KV offload memory planning have changed.

### How was this patch tested?

Unit tests added:

- `tests/ut/distributed/kv_transfer/sparse_kv_offload/test_sparse_kv_offload_manager.py` — memory plan limited by workload / DRAM / NPU (each asserting block counts, planned bytes and the limiting factor); non-positive NPU or DRAM capacity producing zero blocks; invalid spec layouts rejected (missing host or device specs, mixed block sizes); CPU pool size including the per-layer alignment reserve; `UniformTypeKVCacheSpecs` support; manager initializing the backend with the planned pool size (rank 0 allocates, other ranks 0) with a TP barrier; and rejection when the planned pool exceeds the DRAM limit.
- `tests/ut/worker/a2/test_worker_v1.py` — constraints disabled returns memory unchanged; planner budget returned by `_apply_kv_offload_decode_memory_constraints`; `kv_cache_spec` fetched when not cached; explicit `kv_cache_memory_bytes` path and the normal `determine_available_memory` path both apply the constraints.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
