### PR TITLE
[BugFix][SpecDecode] Fix eagle-family aivec crash: blocking H2D for backup_next_token_ids

### DIFF
--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1780,7 +1780,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         self.backup_next_token_ids.np[:num_reqs] = np.array(
             [requests[gpu_input_batch.req_ids[i]].get_token_id(seq_lens_list[i]) for i in range(num_reqs)]
         )
-        self.backup_next_token_ids.copy_to_gpu(num_reqs)
+        # CpuGpuBuffer.copy_to_gpu uses non_blocking=True; on torch_npu the
+        # pinned H2D rides the SDMA engine, whose ordering w.r.t. subsequent
+        # compute kernels on the launch stream is not guaranteed. When the
+        # race is lost, the torch.where below consumes uninitialized memory
+        # (0xa5a5a5a5 marker) and the garbage ids reach the drafter's
+        # vocab-sized embedding gather, faulting the vector core (aivec MTE
+        # invalid GM address, EE9999, engine death). Payload is num_reqs
+        # int32 (<1KB) - a blocking copy is effectively free.
+        self.backup_next_token_ids.gpu[:num_reqs].copy_(
+            self.backup_next_token_ids.cpu[:num_reqs], non_blocking=False
+        )
 
         # Mask out the sampled tokens indices that should not be sampled.
         discard_sampled_tokens_req_indices = discard_request_indices[:num_discarded_requests]


### PR DESCRIPTION
### What this PR does / why we need it?
Eagle-family speculative decoding on Ascend dies with an engine-fatal hardware exception at longer prompts:

```
EE9999: vector core exception (aivec), MTE accesses an invalid GM address
fault kernel (plog): GatherV2_..._high_precision   # a vocab-sized embedding gather
args: vocab size 151936; index bytes carry 0xa5a5a5a5  # CANN's uninit-memory poison marker
```

100% reproducible at 16K prompts (Qwen3-8B + EAGLE3 head, K=5), intermittent at 4K, across multiple physical cards; all in-flight requests are truncated when the engine dies.

Root cause (bisected on 910B3 with timing-preserving probes): `prepare_next_token_ids_padded` ships the fallback `backup_next_token_ids` via `CpuGpuBuffer.copy_to_gpu` → `gpu.copy_(cpu, non_blocking=True)`. On torch_npu, pinned H2D copies ride the SDMA engine, whose ordering w.r.t. subsequent compute kernels on the launch stream is **not guaranteed**. When the race is lost, the `torch.where` consumer reads uninitialized memory and the garbage ids scatter into the drafter's `input_ids`; the vocab-sized embedding gather then indexes out of bounds and faults the vector core.

Why upstream GPU is safe: `cudaMemcpyAsync` enqueued on a stream is strictly ordered w.r.t. later kernels on that stream — the same `non_blocking=True` copy is safe on CUDA. The guarantee does not carry over to torch_npu's SDMA path; NPU ports cannot inherit CUDA stream-ordering intuitions.

Why eagle-family only: ngram/suffix drafters run after bookkeeping on CPU lists and never call this path (structurally immune). All other padded methods — dflash/dspark (via `use_eagle()`) and draft_model — DO share this racing copy and are narrower-window instances of the same bug, not immune; this fix covers them too. The frequency difference is trial counts, not immunity: we later measured (device-side counters, zero host sync) that the `torch.where` fallback-selection gate opens only ~7 rows per ~845 steps (request-boundary steps where the backup carries a real token), and the racing copy loses exactly once per run there — that single stale value is the engine-killing event; eagle's µs-dense launch cadence simply widens the launch-ahead window far more than the heavier draft_model/dflash steppers.

Fix: blocking copy for this <1KB payload (`num_reqs` int32). The microsecond cost buys a deterministic ordering. `CpuGpuBuffer.copy_to_gpu` is deliberately left untouched — larger buffers legitimately rely on non_blocking performance; this is a targeted fix at the racing consumer.
### Does this PR introduce _any_ user-facing change?
No config/API changes. Previously-crashing workloads (eagle/eagle3/mtp + longer prompts) now complete; numerics untouched (the racing copy only feeds fallback ids for requests whose sampled token was discarded).
### How was this patch tested?
Race conditions cannot be regression-tested on CPU; the evidence chain is the test:
- Repro: 16K single request, eagle3 + Qwen3-8B, K=5 — unpatched fails 4/4 configurations (clean empty streams / HTTP 500 → engine death); patched passes 4/4.
- Attribution probes (env-gated, research branch only): `ASCEND_LAUNCH_BLOCKING=1` rescues the crash (race confirmation); per-tensor clamp probes that preserve timing bisect the carrier — clamp only `next_token_ids` passes 16K, clamp only `target_token_ids` does not.
- Value-path verdict (on-device counters, zero host sync, read out via SIGUSR1 at end of a rescued run): across 843 steps the `torch.where` fallback gate opened 7 times (request-boundary rows, where the backup legitimately carries a real token via `get_token_id`), and exactly ONE out-of-vocab id escaped the `where` (c3=1). A value-capture probe pinned the escaped value at exactly **-1** (esc=[-1,-1]): the backup buffer's stale sentinel — upstream `get_token_id` returns -1 for not-yet-committed positions, so every normal step leaves -1 in the buffer, and the racing `where` on a gate-open step can observe the pre-landing (sentinel) state instead of the freshly written real token. A parallel counter excluding the sentinel read zero (c1x=0): no other garbage, no CANN poison marker ever entered the value path. That one -1 escape is precisely the unpatched engine's fatal event: the id scatters into the drafter's `input_ids` and the vocab-sized embedding gather indexes GM out of bounds. The run survived only because the clamp probe sanitized it after the counters. With the fix active the same 847-step run shows c3=0 (copy always lands before the `where`). All links of the value chain measured.
- Full matrix post-fix: 9/9 cells (4K/16K/32K × concurrency 1/4/16) all green, accept length 2.34–2.66 (counters and burst-gap estimates agree), where the unpatched engine never survived the 16K row.
- Hardware: Ascend 910B3, v0.23.0 docker, reproduced across 4 different physical cards.

> Note: developed with AI assistance (GLM-5.3); human-reviewed, human-validated on hardware.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
