### PR TITLE
[CI][Model] Stabilize MiniMax-M3 nightly validation

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-BF16-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-BF16-A3.yaml
@@ -38,7 +38,9 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode":"FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding":true,"ascend_compilation_config":{"enable_static_kernel":true,"fuse_norm_quant":false},"multistream_overlap_shared_expert":true,"weight_nz_mode":2,"enable_reduce_sample": true}'
+      - '{"enable_cpu_binding":true,"ascend_compilation_config":{"enable_static_kernel":false,"fuse_norm_quant":false},"multistream_overlap_shared_expert":true,"weight_nz_mode":2,"enable_reduce_sample":false}'
+    test_content:
+      - chat_completion
     benchmarks:
       acc:
         case_type: accuracy
@@ -48,9 +50,10 @@ test_cases:
         max_out_len: 9000
         batch_size: 8
         baseline: 95
-        threshold: 5
+        threshold: 2
         num_prompts: 400
         temperature: 1.0
+        top_p: 0.95
         ignore_eos: false
       acc_textvqa:
         case_type: accuracy
@@ -62,7 +65,8 @@ test_cases:
         batch_size: 8
         baseline: 72
         temperature: 1.0
-        threshold: 5
+        top_p: 0.95
+        threshold: 2
       perf:
         case_type: performance
         dataset_path: vllm-ascend/GSM8K-in256-bs1-Minimax


### PR DESCRIPTION
### What this PR does / why we need it?

This PR stabilizes the MiniMax-M3 BF16 A3 nightly configuration:

- explicitly uses `test_content: [chat_completion]` so the smoke request exercises the model's chat endpoint instead of the default completions endpoint;
- disables `enable_static_kernel`;
- disables `enable_reduce_sample`;
- pins `top_p: 0.95` for both GSM8K and TextVQA accuracy cases;
- tightens both accuracy thresholds from `5` to `2`.

These settings match the real-weight A3 validation path used for MiniMax-M3. This PR only changes the nightly test case and does **not** revert #13838.

### Does this PR introduce _any_ user-facing change?

No. This only changes nightly CI configuration and acceptance thresholds.

### How was this patch tested?

Configuration checks:

- YAML parsing and an explicit assertion that `test_content` resolves to `chat_completion`;
- explicit assertions for both accuracy cases, the performance threshold, and the two additional-config flags;
- `git diff --check`.

Real-weight validation on 16 Ascend A3 logical devices with DP=2, TP=8, EP enabled, and `FULL_DECODE_ONLY` ACLGraph:

| Case | Result | Target |
| --- | ---: | ---: |
| Service startup and chat smoke | HTTP 200, non-empty output | Pass |
| GSM8K accuracy | 96.875% (32 available samples) | 95 +/- 2: Pass |
| TextVQA accuracy | 71.2109375% (512 available samples) | 72 +/- 2: Pass |
| Output token throughput | 17.5082 token/s | >= 20.2051 token/s: Fail |

The performance threshold is unchanged by this PR. The validation container used a temporary uncommitted revert of #13838 while investigating a separate configuration regression; per request, that revert is not included here.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
