### PR TITLE
[Performance][Attention] Reuse DSV4 compressor metadata across layers

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -897,6 +897,7 @@ estimated_times:
   tests/ut/attention/a2/test_attention_v1.py: 30
   tests/ut/attention/a2/test_attention_v1_precision.py: 540
   tests/ut/attention/a2/test_common_cp.py: 30
+  tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py: 30
   tests/ut/attention/a2/test_mla_cp.py: 30
   tests/ut/attention/a2/test_mla_cp_precision.py: 30
   tests/ut/attention/a2/test_mla_precision.py: 190

--- a/tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py
+++ b/tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from vllm.forward_context import ForwardContext, override_forward_context
+
+from vllm_ascend.attention.dsa_v1 import (
+    get_or_compute_compressor_metadata,
+    reset_compressor_metadata_cache,
+)
+from vllm_ascend.device.device_op import DeviceOperator
+
+
+def _make_forward_context() -> ForwardContext:
+    return ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+    )
+
+
+def test_reuses_by_cache_group_and_resets_between_substeps():
+    class PrefillMetadata(SimpleNamespace):
+        pass
+
+    class DecodeMetadata(SimpleNamespace):
+        pass
+
+    metadata = PrefillMetadata(
+        cache_group_key="model.layers.0.self_attn.attn",
+        full_compress_cos=torch.zeros((2, 1, 1, 4)),
+        full_compress_sin=torch.zeros((2, 1, 1, 4)),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        start_pos=torch.tensor([0], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        storage_block_size=32,
+        num_compressed_tokens=1,
+        num_actual_reqs=1,
+    )
+    same_group_metadata = PrefillMetadata(**vars(metadata))
+    same_group_decode_metadata = DecodeMetadata(**vars(metadata))
+    other_group_metadata = PrefillMetadata(
+        **{
+            **vars(metadata),
+            "cache_group_key": "model.layers.0.self_attn.indexer.k_cache",
+        }
+    )
+    unified_decode_query_start_loc = torch.tensor([0, 1], dtype=torch.int32)
+    unified_decode_start_pos = torch.tensor([4], dtype=torch.int32)
+    same_type_decode_metadata = PrefillMetadata(
+        **{
+            **vars(metadata),
+            "query_start_loc": unified_decode_query_start_loc,
+            "start_pos": unified_decode_start_pos,
+        }
+    )
+    outputs = [(torch.full((1,), value),) * 3 for value in range(6)]
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "get_dsa_compressor_slot_mapping_format",
+            return_value=0,
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "compressor_metadata",
+            create=True,
+            side_effect=outputs,
+        ) as metadata_op,
+    ):
+        with override_forward_context(_make_forward_context()):
+            first = get_or_compute_compressor_metadata(metadata, 4)
+            reused = get_or_compute_compressor_metadata(same_group_metadata, 4)
+            decode = get_or_compute_compressor_metadata(same_group_decode_metadata, 4)
+            isolated = get_or_compute_compressor_metadata(other_group_metadata, 4)
+            unified_decode = get_or_compute_compressor_metadata(same_type_decode_metadata, 4)
+            reset_compressor_metadata_cache()
+            next_substep = get_or_compute_compressor_metadata(metadata, 4)
+        with override_forward_context(_make_forward_context()):
+            next_forward = get_or_compute_compressor_metadata(metadata, 4)
+
+    assert first is reused
+    assert decode is not first
+    assert isolated is not first
+    assert unified_decode is not first
+    assert next_substep is not first
+    assert next_forward is not first
+    assert metadata_op.call_count == 6

--- a/tests/ut/attention/test_dsv4_block_geometry.py
+++ b/tests/ut/attention/test_dsv4_block_geometry.py
@@ -5,29 +5,25 @@ from types import SimpleNamespace
 
 import pytest
 import torch
+from vllm.forward_context import ForwardContext, override_forward_context
 
-from vllm_ascend.attention.context_parallel.dsa_cp import AscendDSACPImpl
+from vllm_ascend.attention.dsa_v1 import get_or_compute_compressor_metadata
 from vllm_ascend.device.device_op import DeviceOperator
-from vllm_ascend.models.deepseek_v4.compressor import Compressor
 
 
 @pytest.mark.parametrize(
-    ("owner_cls", "method_name", "compress_ratio"),
-    [
-        (Compressor, "_compute_metadata", 4),
-        (AscendDSACPImpl, "_compute_compressor_metadata", 128),
-    ],
+    "compress_ratio",
+    [4, 128],
 )
 def test_compressor_metadata_uses_physical_storage_geometry(
     monkeypatch,
-    owner_cls,
-    method_name,
     compress_ratio,
 ):
     logical_block_table = torch.tensor([[7, 11]], dtype=torch.int32)
     query_start_loc = torch.tensor([0, 4], dtype=torch.int32)
     start_pos = torch.tensor([508], dtype=torch.int32)
     metadata = SimpleNamespace(
+        cache_group_key="model.layers.0.self_attn.attn",
         full_compress_cos=torch.zeros((8, 1, 1, 64), dtype=torch.bfloat16),
         full_compress_sin=torch.zeros((8, 1, 1, 64), dtype=torch.bfloat16),
         query_start_loc=query_start_loc,
@@ -59,10 +55,14 @@ def test_compressor_metadata_uses_physical_storage_geometry(
         fake_compressor_metadata,
         raising=False,
     )
-    owner = owner_cls.__new__(owner_cls)
-    owner.compress_ratio = compress_ratio
-
-    result = getattr(owner, method_name)(metadata)
+    forward_context = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+    )
+    with override_forward_context(forward_context):
+        result = get_or_compute_compressor_metadata(metadata, compress_ratio)
 
     assert result is expected
     args = captured["args"]

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -6,13 +6,27 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
+from vllm.forward_context import ForwardContext, override_forward_context
 
+from vllm_ascend.attention.dsa_v1 import (
+    get_or_compute_compressor_metadata,
+    reset_compressor_metadata_cache,
+)
 from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.models.deepseek_v4.compressor import (
     AscendCompressorMetadata,
     AscendCompressorStateCache,
     Compressor,
 )
+
+
+def _make_forward_context() -> ForwardContext:
+    return ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+    )
 
 
 class TestCompressorMetadata:
@@ -26,6 +40,7 @@ class TestCompressorMetadata:
         start_pos = torch.tensor([1, 3], dtype=torch.int32)
         block_table = torch.tensor([[0], [1]], dtype=torch.int32)
         metadata = SimpleNamespace(
+            cache_group_key="model.layers.0.self_attn.attn",
             full_compress_cos=full_cos,
             full_compress_sin=full_sin,
             query_start_loc=query_start_loc,
@@ -51,8 +66,9 @@ class TestCompressorMetadata:
                 create=True,
                 return_value=(result_cos, result_sin, slot_mapping),
             ) as metadata_op,
+            override_forward_context(_make_forward_context()),
         ):
-            actual = compressor._compute_metadata(metadata)
+            actual = get_or_compute_compressor_metadata(metadata, compressor.compress_ratio)
 
         assert actual[0] is result_cos
         assert actual[1] is result_sin
@@ -65,6 +81,55 @@ class TestCompressorMetadata:
         assert args[3] is start_pos
         assert args[4] is block_table
         assert args[5:] == (128, 7, 4, 3, 2)
+
+    def test_reuses_by_cache_group_and_resets_between_substeps(self):
+        metadata = SimpleNamespace(
+            cache_group_key="model.layers.0.self_attn.attn",
+            full_compress_cos=torch.zeros((2, 1, 1, 4)),
+            full_compress_sin=torch.zeros((2, 1, 1, 4)),
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            start_pos=torch.tensor([0], dtype=torch.int32),
+            block_table=torch.tensor([[0]], dtype=torch.int32),
+            storage_block_size=32,
+            num_compressed_tokens=1,
+            num_actual_reqs=1,
+        )
+        same_group_metadata = SimpleNamespace(**vars(metadata))
+        other_group_metadata = SimpleNamespace(
+            **{
+                **vars(metadata),
+                "cache_group_key": "model.layers.0.self_attn.indexer.k_cache",
+            }
+        )
+        outputs = [(torch.full((1,), value), torch.full((1,), value), torch.full((1,), value)) for value in range(4)]
+
+        with (
+            patch.object(
+                DeviceOperator,
+                "get_dsa_compressor_slot_mapping_format",
+                return_value=0,
+            ),
+            patch.object(
+                torch.ops._C_ascend,
+                "compressor_metadata",
+                create=True,
+                side_effect=outputs,
+            ) as metadata_op,
+        ):
+            with override_forward_context(_make_forward_context()):
+                first = get_or_compute_compressor_metadata(metadata, 4)
+                reused = get_or_compute_compressor_metadata(same_group_metadata, 4)
+                isolated = get_or_compute_compressor_metadata(other_group_metadata, 4)
+                reset_compressor_metadata_cache()
+                next_substep = get_or_compute_compressor_metadata(metadata, 4)
+            with override_forward_context(_make_forward_context()):
+                next_forward = get_or_compute_compressor_metadata(metadata, 4)
+
+        assert first is reused
+        assert isolated is not first
+        assert next_substep is not first
+        assert next_forward is not first
+        assert metadata_op.call_count == 4
 
 
 class TestCompressorForward:
@@ -105,7 +170,6 @@ class TestCompressorForward:
         compressed_kv = torch.ones((1, 1, 4))
         compute_metadata = MagicMock(return_value=(compress_cos, compress_sin, slot_mapping))
         compressor._compute_metadata = compute_metadata
-
         with patch.object(
             torch.ops._C_ascend,
             "compressor",

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -2176,6 +2176,7 @@ class TestRunMergedDraft(TestBase):
         self.vllm_config.cache_config = MagicMock(spec=CacheConfig)
         self.vllm_config.scheduler_config = MagicMock()
         self.vllm_config.model_config = MagicMock()
+        self.vllm_config.model_config.hf_config = MagicMock(spec=[])
         self.vllm_config.model_config.hf_text_config = MagicMock(spec=[])
         self.vllm_config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
         self.vllm_config.compilation_config = MagicMock()

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -17,6 +17,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import (
     build_dspark_swa_indices,
     get_dspark_sparse_sas_window,
+    get_or_compute_compressor_metadata,
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -104,6 +105,7 @@ class AscendDSAReqMetadata:
     storage_block_size: int
     query_start_loc: torch.Tensor
     cp_metadata: DSACPMetadata
+    cache_group_key: str = ""
     num_compressed_tokens: int | None = None
     sin: torch.Tensor = None
     cos: torch.Tensor = None
@@ -203,6 +205,11 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.seq_lens: torch.Tensor = None
         self.seq_lens_cpu: torch.Tensor = None
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
+        if not layer_names:
+            raise ValueError("DSA-CP metadata builder requires at least one layer name")
+        # vLLM assigns one builder result to every layer name in the attention
+        # group. Keep one canonical prefix as the semantic group identity.
+        self.cache_group_key = layer_names[0]
         hf_config = self.model_config.hf_config
 
         self.hadamard = None
@@ -583,6 +590,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens[:num_reqs],
             query_start_loc=query_start_loc,
             cp_metadata=cp_metadata,
+            cache_group_key=self.cache_group_key,
             sin=sin,
             cos=cos,
             start_pos=start_pos,
@@ -799,6 +807,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens[:num_reqs],
             query_start_loc=query_start_loc,
             cp_metadata=cp_metadata,
+            cache_group_key=self.cache_group_key,
             sin=sin,
             cos=cos,
             full_compress_sin=full_compress_sin,
@@ -1173,36 +1182,6 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             compressor_state=compressor_state_metadata,
             indexer_cache=indexer_cache_metadata,
             indexer_state=indexer_state_metadata,
-        )
-
-    def _compute_compressor_metadata(
-        self,
-        metadata: AscendDSAReqMetadata,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        assert metadata.full_compress_cos is not None
-        assert metadata.full_compress_sin is not None
-        assert metadata.num_compressed_tokens is not None
-        assert metadata.start_pos is not None
-        assert metadata.num_actual_reqs is not None
-        full_compress_cos = metadata.full_compress_cos.view(
-            metadata.full_compress_cos.shape[0],
-            metadata.full_compress_cos.shape[-1],
-        )
-        full_compress_sin = metadata.full_compress_sin.view(
-            metadata.full_compress_sin.shape[0],
-            metadata.full_compress_sin.shape[-1],
-        )
-        return torch.ops._C_ascend.compressor_metadata(
-            full_compress_cos,
-            full_compress_sin,
-            metadata.query_start_loc,
-            metadata.start_pos,
-            metadata.block_table,
-            metadata.storage_block_size,
-            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
-            self.compress_ratio,
-            metadata.num_compressed_tokens,
-            metadata.num_actual_reqs,
         )
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
@@ -1650,8 +1629,9 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
                 )
 
             coff = 2 if self.compressor_overlap else 1
-            compress_cos, compress_sin, compress_slot_mapping = self._compute_compressor_metadata(
+            compress_cos, compress_sin, compress_slot_mapping = get_or_compute_compressor_metadata(
                 compressor_attn_metadata.req_metadata,
+                self.compress_ratio,
             )
             compressed_kv = torch.ops._C_ascend.compressor(
                 hidden_states_cache,
@@ -1801,8 +1781,9 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         assert indexer_kv_scale_metadata.req_metadata is not None
         assert indexer_kv_state_metadata.req_metadata is not None
         assert self.indexer is not None
-        compressed_cos, compressed_sin, indexer_slot_mapping = self._compute_compressor_metadata(
+        compressed_cos, compressed_sin, indexer_slot_mapping = get_or_compute_compressor_metadata(
             indexer_kv_scale_metadata.req_metadata,
+            self.compress_ratio,
         )
         kv = torch.ops._C_ascend.compressor(
             x,

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -7,6 +7,7 @@ import torch.distributed as dist
 import torch_npu
 from vllm.config import VllmConfig
 from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
 from vllm.triton_utils import HAS_TRITON
 from vllm.v1.attention.backend import (
     AttentionBackend,
@@ -61,6 +62,79 @@ else:
 
 # The SAS and QLI metadata operators use a fixed 1024-element int32 layout.
 DSA_METADATA_BUFFER_SIZE = 1024
+
+CompressorMetadataOutput = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+_COMPRESSOR_METADATA_CACHE_KEY = "dsv4_compressor_metadata_cache"
+
+
+def reset_compressor_metadata_cache() -> None:
+    """Release metadata outputs before a composite forward changes substeps."""
+    get_forward_context().additional_kwargs.pop(_COMPRESSOR_METADATA_CACHE_KEY, None)
+
+
+def get_or_compute_compressor_metadata(
+    metadata: Any,
+    compress_ratio: int,
+) -> CompressorMetadataOutput:
+    """Build compressor metadata once per cache group in the current substep.
+
+    Attention metadata builders provide a semantic cache-group key, and all
+    layers in that group consume the same result. Composite speculative
+    forwards reset this cache when switching substeps, so only the current
+    substep's outputs stay live. The metadata op remains in model forward for
+    graph capture.
+
+    Prefill and decode must stay isolated. On v0.26 they used separate
+    dataclasses, so the cache key includes ``type(metadata)``. Main unifies
+    both into ``AscendDSAReqMetadata``, so the key also includes the input
+    tensor identities that distinguish those phases.
+    """
+    forward_context = get_forward_context()
+    cache: dict[tuple, CompressorMetadataOutput] = forward_context.additional_kwargs.setdefault(
+        _COMPRESSOR_METADATA_CACHE_KEY,
+        {},
+    )
+    cache_group_key = metadata.cache_group_key
+    if not cache_group_key:
+        raise ValueError("DSV4 compressor metadata requires a cache-group key")
+    cache_key = (
+        cache_group_key,
+        type(metadata),
+        id(metadata.query_start_loc),
+        id(metadata.start_pos),
+    )
+    cached_metadata = cache.get(cache_key)
+    if cached_metadata is not None:
+        return cached_metadata
+
+    assert metadata.full_compress_cos is not None
+    assert metadata.full_compress_sin is not None
+    assert metadata.num_compressed_tokens is not None
+    assert metadata.start_pos is not None
+    assert metadata.num_actual_reqs is not None
+    full_compress_cos = metadata.full_compress_cos.view(
+        metadata.full_compress_cos.shape[0],
+        metadata.full_compress_cos.shape[-1],
+    )
+    full_compress_sin = metadata.full_compress_sin.view(
+        metadata.full_compress_sin.shape[0],
+        metadata.full_compress_sin.shape[-1],
+    )
+    computed_metadata = torch.ops._C_ascend.compressor_metadata(
+        full_compress_cos,
+        full_compress_sin,
+        metadata.query_start_loc,
+        metadata.start_pos,
+        metadata.block_table,
+        metadata.storage_block_size,
+        DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+        compress_ratio,
+        metadata.num_compressed_tokens,
+        metadata.num_actual_reqs,
+    )
+    cache[cache_key] = computed_metadata
+    return computed_metadata
+
 
 _DSV4_DSA_OVERLAP_STREAM = None
 
@@ -208,6 +282,7 @@ class AscendDSAReqMetadata:
     slot_mapping: torch.Tensor | None
     storage_block_size: int
     query_start_loc: torch.Tensor
+    cache_group_key: str = ""
 
     num_compressed_tokens: int | None = None
     sin: torch.Tensor = None
@@ -391,6 +466,11 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.seq_lens: torch.Tensor = None
 
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
+        if not layer_names:
+            raise ValueError("DSA metadata builder requires at least one layer name")
+        # vLLM assigns one builder result to every layer name in the attention
+        # group. Keep one canonical prefix as the semantic group identity.
+        self.cache_group_key = layer_names[0]
         self.hadamard = None
         self._init_hadamard(layer_names)
         self.start_pos_prefill: torch.Tensor = torch.zeros(
@@ -775,6 +855,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             slot_mapping=slot_mapping,
             storage_block_size=self.storage_block_size,
             query_start_loc=query_start_loc,
+            cache_group_key=self.cache_group_key,
             num_compressed_tokens=num_compressed_tokens,
             sin=sin,
             cos=cos,
@@ -935,6 +1016,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             slot_mapping=slot_mapping,
             storage_block_size=self.storage_block_size,
             query_start_loc=query_start_loc,
+            cache_group_key=self.cache_group_key,
             num_compressed_tokens=self.num_actual_tokens,
             sin=sin,
             cos=cos,

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -23,7 +23,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import typing
 from dataclasses import dataclass
 
 import torch
@@ -166,37 +165,10 @@ class Compressor(nn.Module):
                 f"Only support compress_ratio in [4, 128]. Got unsupported compress_ratio: {compress_ratio}"
             )
 
-    def _compute_metadata(
-        self,
-        metadata: typing.Any,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        from vllm_ascend.device.device_op import DeviceOperator
+    def _compute_metadata(self, metadata):
+        from vllm_ascend.attention.dsa_v1 import get_or_compute_compressor_metadata
 
-        assert metadata.full_compress_cos is not None
-        assert metadata.full_compress_sin is not None
-        assert metadata.num_compressed_tokens is not None
-        assert metadata.start_pos is not None
-        assert metadata.num_actual_reqs is not None
-        full_compress_cos = metadata.full_compress_cos.view(
-            metadata.full_compress_cos.shape[0],
-            metadata.full_compress_cos.shape[-1],
-        )
-        full_compress_sin = metadata.full_compress_sin.view(
-            metadata.full_compress_sin.shape[0],
-            metadata.full_compress_sin.shape[-1],
-        )
-        return torch.ops._C_ascend.compressor_metadata(
-            full_compress_cos,
-            full_compress_sin,
-            metadata.query_start_loc,
-            metadata.start_pos,
-            metadata.block_table,
-            metadata.storage_block_size,
-            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
-            self.compress_ratio,
-            metadata.num_compressed_tokens,
-            metadata.num_actual_reqs,
-        )
+        return get_or_compute_compressor_metadata(metadata, self.compress_ratio)
 
     def forward(
         self,

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -24,6 +24,7 @@
 # limitations under the License.
 #
 from dataclasses import dataclass
+from typing import Any
 
 import torch
 from torch import nn
@@ -88,8 +89,8 @@ class AscendCompressorStateCache(CompressorStateCache):
 class AscendCompressorMetadata:
     """Request metadata for the compressed KV and compressor state caches."""
 
-    cache: typing.Any
-    state: typing.Any
+    cache: Any
+    state: Any
 
 
 class Compressor(nn.Module):
@@ -165,7 +166,7 @@ class Compressor(nn.Module):
                 f"Only support compress_ratio in [4, 128]. Got unsupported compress_ratio: {compress_ratio}"
             )
 
-    def _compute_metadata(self, metadata):
+    def _compute_metadata(self, metadata: Any):
         from vllm_ascend.attention.dsa_v1 import get_or_compute_compressor_metadata
 
         return get_or_compute_compressor_metadata(metadata, self.compress_ratio)

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1401,6 +1401,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             forward_context.attn_metadata = (
                 multi_steps_attn_metadata[draft_index + 1] if multi_steps_attn_metadata else None
             )
+            if self.use_compress:
+                # A merged speculative forward reuses one ForwardContext while
+                # each substep has different compressor inputs. Drop the prior
+                # substep's outputs before entering the next model invocation.
+                from vllm_ascend.attention.dsa_v1 import reset_compressor_metadata_cache
+
+                reset_compressor_metadata_cache()
 
             model_kwargs = {
                 "input_ids": model_input_ids,


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek V4 currently launches `compressor_metadata` before every compressor invocation, even though layers in the same cache group use identical compressor inputs within one speculative substep.

This PR syncs main with the `releases/v0.26.0rc` #14994 implementation:

- lazily computes compressor metadata at the first real compressor consumer and reuses it across layers in that cache group;
- keeps the helper in `dsa_v1` so regular DSA, DSA-CP, and `Compressor.forward` share one cache;
- keys the cache by cache-group, metadata type, and input tensor identity so prefill/decode stay isolated (v0.26 used separate dataclasses; main unifies them into `AscendDSAReqMetadata`);
- explicitly resets the cache when a merged MTP/DSpark forward changes speculative substeps;
- keeps the metadata op inside model forward so ACLGraph captures each substep's real operator invocation.

Compressor kernel + FP32 RMSNorm at init is #15002.

### Does this PR introduce _any_ user-facing change?

No. This is an internal DSV4 performance optimization with unchanged cache geometry and model outputs.

### How was this patch tested?

- Unit regression covering same-phase reuse, prefill/decode isolation (including unified-type isolation), group isolation, substep reset, and forward-context lifetime.
- C4/C128 physical storage block geometry coverage on the shared helper.
- `bash format.sh ci` expected from PR CI.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
