### PR TITLE
[Performance][MoE] Reuse MC2 expert scales for combine

### DIFF
--- a/tests/ut/ops/a2/test_token_dispatcher.py
+++ b/tests/ut/ops/a2/test_token_dispatcher.py
@@ -263,6 +263,34 @@ class TestTokenDispatcherWithMC2(TestBase):
             self.assertEqual(output.group_list_type, 0)  # group_list_type == 0
             self.assertIsInstance(output.combine_metadata, MoEMC2CombineMetadata)
 
+    def test_token_dispatch_reuses_fp32_expert_scales_for_combine(self):
+        hidden_states = torch.randn(10, 128, dtype=torch.bfloat16)
+        topk_weights = torch.randn(10, 1, dtype=torch.bfloat16)
+        topk_ids = torch.randint(0, 8, (10, 1))
+        expert_map = torch.tensor([0, 1, 2, 3, 4, 5, 6, 7])
+        self.dispatcher.enable_dispatch_v2 = True
+        self.dispatcher.need_expert_scale = True
+
+        with patch(
+            "torch_npu.npu_moe_distribute_dispatch_v2",
+            return_value=(torch.randn(10, 128),) * 5 + (None, None),
+            create=True,
+        ) as mock_dispatch:
+            token_dispatch_input = build_token_dispatch_input_fixture(
+                hidden_states=hidden_states,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                expert_map=expert_map,
+            )
+            output = self.dispatcher.token_dispatch(token_dispatch_input=token_dispatch_input)
+
+        dispatch_expert_scales = mock_dispatch.call_args.kwargs["expert_scales"]
+        self.assertEqual(dispatch_expert_scales.dtype, torch.float32)
+        self.assertIs(output.combine_metadata.topk_weights, dispatch_expert_scales)
+
+        combine_kwargs = self.dispatcher.get_combine_mc_kwargs(hidden_states, output.combine_metadata)
+        self.assertIs(combine_kwargs["expert_scales"], dispatch_expert_scales)
+
     def test_w4a8_per_channel_dispatch_uses_count_group_list(self):
         hidden_states = torch.randn(10, 128)
         topk_weights = torch.randn(10, 1)

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -243,6 +243,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
         token_dispatch_input: MoETokenDispatchInput,
     ):
         kwargs_mc2 = self.get_dispatch_mc2_kwargs(token_dispatch_input)
+        combine_topk_weights = kwargs_mc2.get("expert_scales", token_dispatch_input.topk_weights)
         output = (
             torch_npu.npu_moe_distribute_dispatch_v2(**kwargs_mc2)
             if self.enable_dispatch_v2
@@ -267,7 +268,7 @@ class TokenDispatcherWithMC2(MoETokenDispatcher[MoEMC2CombineMetadata]):
             group_list_type=group_list_type,
             combine_metadata=MoEMC2CombineMetadata(
                 topk_ids=token_dispatch_input.topk_ids,
-                topk_weights=token_dispatch_input.topk_weights,
+                topk_weights=combine_topk_weights,
                 expert_map=token_dispatch_input.routing.expert_map,
                 ep_recv_counts=ep_recv_counts,
                 tp_recv_counts=tp_recv_counts,


### PR DESCRIPTION
### What this PR does / why we need it?

MC2 dispatch converts `topk_weights` to FP32 before passing it as `expert_scales`. The original lower-precision tensor was then stored in combine metadata, so MC2 combine converted the same `[num_tokens, top_k]` values to FP32 a second time.

This change stores the already-converted dispatch tensor in the combine metadata when it is available. Combine therefore reuses the same FP32 tensor and avoids the duplicate Cast kernel. Non-hierarchical paths retain the existing behavior.

A unit test verifies that dispatch and combine receive the same FP32 tensor object.

### Does this PR introduce _any_ user-facing change?

No. This is an internal MoE performance optimization with no API or output behavior change.

### How was this patch tested?

- `git diff --check`
- `python -m py_compile vllm_ascend/ops/fused_moe/token_dispatcher.py tests/ut/ops/a2/test_token_dispatcher.py`
- Added `test_token_dispatch_reuses_fp32_expert_scales_for_combine`

NPU runtime tests and profiling comparison were not run locally because they require an Ascend environment. The expected profiling change is removal of the second `Cast [num_tokens, top_k]` immediately before `MoeDistributeCombineV2` when dispatch already supplies FP32 `expert_scales`.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
