### PR TITLE
[BugFix][Config] Clean up stale weekly and nightly additional configs

### DIFF
--- a/tests/e2e/nightly/multi_node/external_dp/config/GLM-5.1-W8A8C8-128k-1k-90-50-PD.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/GLM-5.1-W8A8C8-128k-1k-90-50-PD.yaml
@@ -90,7 +90,7 @@ templates:
       - --max-model-len
       - "202752"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -153,7 +153,7 @@ templates:
       - --max-model-len
       - "202752"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -221,7 +221,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -287,7 +287,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/nightly/multi_node/external_dp/config/GLM-5.2-W8A8C8-128k-1k-90-50-PD.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/GLM-5.2-W8A8C8-128k-1k-90-50-PD.yaml
@@ -90,7 +90,7 @@ templates:
       - --max-model-len
       - "202752"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -154,7 +154,7 @@ templates:
       - --max-model-len
       - "202752"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true,"c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -223,7 +223,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -290,7 +290,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/nightly/multi_node/external_dp/config/Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
@@ -131,7 +131,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
 

--- a/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-EPLB.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/DeepSeek-R1-W8A8-EPLB.yaml
@@ -57,7 +57,7 @@ deployment:
               }
           }'
           --additional-config
-          '{"enable_prefill_optimizations":true,"enable_weight_nz_layout":true,"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}}'
+          '{"weight_nz_mode":1,"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}}'
 
   -
     envs:
@@ -95,10 +95,11 @@ deployment:
               }
           }'
           --additional-config
-          '{"enable_prefill_optimizations":true,"enable_weight_nz_layout":true,"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}}'
+          '{"weight_nz_mode":1,"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}}'
   -
     envs:
       <<: *env_common
+    # #5533 requires the EPLB keys in the command below to be nested.
     server_cmd: >
       vllm serve vllm-ascend/DeepSeek-R1-0528-W8A8
         --host 0.0.0.0
@@ -134,7 +135,7 @@ deployment:
             }
         }'
         --additional-config
-        '{"multistream_overlap_shared_expert":true,"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}'
+        '{"multistream_overlap_shared_expert":true,"eplb_config": {"dynamic_eplb":true,"expert_heat_collection_interval":2048,"algorithm_execution_interval":200}}'
   -
     envs:
       <<: *env_common

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_128k_90_50.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_128k_90_50.yaml
@@ -44,7 +44,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   - envs:
       <<: *env_common
@@ -75,7 +75,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_128k_warmup:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_198k_function.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_198k_function.yaml
@@ -45,7 +45,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}' 
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -77,7 +77,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'  
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_128k_90_50.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_128k_90_50.yaml
@@ -46,7 +46,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -78,7 +78,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_128k_warmup:

--- a/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_198k_function.yaml
+++ b/tests/e2e/nightly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_198k_function.yaml
@@ -45,7 +45,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}' 
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -77,7 +77,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'  
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf:

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-R1-0528-W8A8.yaml
@@ -34,7 +34,7 @@ _server_cmd: &server_cmd
   - "--speculative-config"
   - '{"num_speculative_tokens": 1, "method": "mtp"}'
   - "--additional-config"
-  - '{"enable_weight_nz_layout": true}'
+  - '{"weight_nz_mode": 1}'
 
 _benchmarks_acc: &benchmarks_acc
   acc:

--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A2.yaml
@@ -51,7 +51,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding": true, "enable_npugraph_ex": true, "enable_static_kernel": true}'
+      - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true}}'
     benchmarks:
       acc:
         case_type: accuracy

--- a/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
@@ -39,7 +39,7 @@ _server_cmd: &server_cmd
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--additional-config"
-  - '{"enable_cpu_binding": true, "enable_npugraph_ex": true, "enable_static_kernel": true,"enable_fused_mc2":true,"weight_nz_mode":true,"enable_flashcomm1":true}'
+  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
 
 _benchmarks_3500: &benchmarks_3500
   perf_50:

--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-DeepSeek-R1-0528-W8A8.yaml
@@ -34,7 +34,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.9"
       - "--additional-config"
-      - '{"enable_weight_nz_layout": true}'
+      - '{"weight_nz_mode": 1}'
       - "--speculative-config"
       - '{"num_speculative_tokens": 1, "method": "mtp"}'
     test_content:

--- a/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-Qwen3-32B-Int8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Prefix-Cache-Qwen3-32B-Int8.yaml
@@ -28,7 +28,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.9"
       - "--additional-config"
-      - '{"enable_weight_nz_layout": true}'
+      - '{"weight_nz_mode": 1}'
     test_content:
       - "benchmark_comparisons"
     benchmark_comparisons_args:

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-27B-w8a8-A2.yaml
@@ -33,7 +33,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.95"
       - "--additional-config"
-      - '{"enable_cpu_binding":true, "enable_weight_nz_layout":true}'
+      - '{"enable_cpu_binding": true, "weight_nz_mode": 1}'
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 3,"enforce_eager": true}'
       - "--compilation-config"

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3_32b_w8a8_ml_A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3_32b_w8a8_ml_A3.yaml
@@ -55,7 +55,7 @@ test_cases:
       - "5500"
       - "--enforce-eager"
       - "--additional-config"
-      - '{"ascend_scheduler_config":{"enabled":false},"enable_weight_nz_layout":true}'
+      - '{"weight_nz_mode": 1}'
   - name: "Qwen3_32B_w8a8_Performance_3500_1500_A3"
     model: "vllm-ascend/Qwen3-32B-W8A8"
     envs:

--- a/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
+++ b/tests/e2e/nightly/single_node/models/scripts/test_single_node.py
@@ -306,7 +306,7 @@ def _extract_features(server_cmd: list[str] | str, envs: dict[str, Any]) -> list
 
     # Features from --additional-config JSON
     additional = _parse_json_flag(cmd_list, "--additional-config")
-    if additional.get("enable_weight_nz_layout"):
+    if additional.get("weight_nz_mode", 0) != 0:
         features.append("weight_nz_layout")
     tc = additional.get("torchair_graph_config") or {}
     if isinstance(tc, dict) and tc.get("enabled"):

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.1-W8A8C8-3.5k-1.5k-0-20-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.1-W8A8C8-3.5k-1.5k-0-20-PD.yaml
@@ -89,7 +89,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -153,7 +153,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -222,7 +222,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -288,7 +288,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
       - --max-num-seqs
       - "32"
       - --gpu-memory-utilization

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.1-W8A8C8-3.5k-1.5k-0-50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.1-W8A8C8-3.5k-1.5k-0-50-PD.yaml
@@ -90,7 +90,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -154,7 +154,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -223,7 +223,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -289,7 +289,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.1-W8A8C8-64k-1k-90-50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.1-W8A8C8-64k-1k-90-50-PD.yaml
@@ -89,7 +89,7 @@ templates:
       - --max-model-len
       - "133120"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -152,7 +152,7 @@ templates:
       - --max-model-len
       - "133120"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -220,7 +220,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -285,7 +285,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-3.5k-1.5k-0-20-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-3.5k-1.5k-0-20-PD.yaml
@@ -89,7 +89,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -153,7 +153,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -222,7 +222,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -288,7 +288,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false}'
       - --max-num-seqs
       - "32"
       - --gpu-memory-utilization

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-3.5k-1.5k-0-50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-3.5k-1.5k-0-50-PD.yaml
@@ -90,7 +90,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -154,7 +154,7 @@ templates:
       - --max-model-len
       - "18432"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "c8_enable_reshape_optim":false}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -223,7 +223,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -289,7 +289,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-64k-1k-90-50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-64k-1k-90-50-PD.yaml
@@ -89,7 +89,7 @@ templates:
       - --max-model-len
       - "133120"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -153,7 +153,7 @@ templates:
       - --max-model-len
       - "133120"
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable" : false,"multistream_overlap_shared_expert": true, "enable_dsa_cp":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "c8_enable_reshape_optim":true}'
       - --max-num-batched-tokens
       - "8192"
       - --trust-remote-code
@@ -222,7 +222,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"
@@ -288,7 +288,7 @@ templates:
       - --speculative-config
       - '{"num_speculative_tokens": 3,  "method":"deepseek_mtp","enforce_eager":true}'
       - --additional-config
-      - '{"fuse_muls_add":true,"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
+      - '{"ascend_compilation_config": {"fuse_muls_add": true},"recompute_scheduler_enable":true,"multistream_overlap_shared_expert":true,"enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true}'
       - --trust-remote-code
       - --max-num-seqs
       - "32"

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.6-W4A8-128k-1k-TPOT50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.6-W4A8-128k-1k-TPOT50-PD.yaml
@@ -130,7 +130,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.6-W4A8-254k-1k-TPOT20-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.6-W4A8-254k-1k-TPOT20-PD.yaml
@@ -131,7 +131,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 1,"tp_size": 16},"decode": {"dp_size": 1,"tp_size": 16}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.6-W4A8-3.5k-1.5k-TPOT50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.6-W4A8-3.5k-1.5k-TPOT50-PD.yaml
@@ -133,7 +133,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-128k-1k-TPOT50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-128k-1k-TPOT50-PD.yaml
@@ -130,7 +130,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-254k-1k-TPOT20-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-254k-1k-TPOT20-PD.yaml
@@ -131,7 +131,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 1,"tp_size": 16},"decode": {"dp_size": 1,"tp_size": 16}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-3.5k-1.5k-TPOT50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-3.5k-1.5k-TPOT50-PD.yaml
@@ -133,7 +133,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-64k-1k-TPOT50-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/Kimi-K2.7-W4A8-64k-1k-TPOT50-PD.yaml
@@ -131,7 +131,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "lmhead_tensor_parallel_size":16}'
+      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/QWEN3_235B_PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/QWEN3_235B_PD.yaml
@@ -106,8 +106,8 @@ templates:
       - --quantization
       - "ascend"
       - --no-enable-prefix-caching
-      - --additional-config
-      - '{"ascend_scheduler_config":{"enabled":true,"enable_chunked_prefill":true}}'
+      # #4623 removed Ascend Scheduler; use the vLLM scheduler CLI instead.
+      - --enable-chunked-prefill
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30000", "engine_id": "0", "kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 1, "tp_size": 16}, "decode": {"dp_size": 32, "tp_size": 1}}}'
 
@@ -148,7 +148,8 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[6,12,18]}'
       - --additional-config
-      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"dynamic_eplb":true,"num_iterations_eplb_update":4000,"num_wait_worker_iterations":200,"init_redundancy_expert":0,"gate_eplb":false}'
+      # #5533 renamed and nested the legacy EPLB keys below.
+      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":4000,"algorithm_execution_interval":200,"num_redundant_experts":0}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "1", "kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 1, "tp_size": 16}, "decode": {"dp_size": 32, "tp_size": 1}}}'
 
@@ -189,7 +190,8 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[6,12,18]}'
       - --additional-config
-      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"dynamic_eplb":true,"num_iterations_eplb_update":4000,"num_wait_worker_iterations":200,"init_redundancy_expert":0,"gate_eplb":false}'
+      # #5533 renamed and nested the legacy EPLB keys below.
+      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":4000,"algorithm_execution_interval":200,"num_redundant_experts":0}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "1", "kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 1, "tp_size": 16}, "decode": {"dp_size": 32, "tp_size": 1}}}'
 

--- a/tests/e2e/weekly/multi_node/external_dp/config/QWEN3_235B_PD_3_5K_1_5k.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/QWEN3_235B_PD_3_5K_1_5k.yaml
@@ -106,8 +106,8 @@ templates:
       - --quantization
       - "ascend"
       - --no-enable-prefix-caching
-      - --additional-config
-      - '{"ascend_scheduler_config": {"enabled": true,"enable_chunked_prefill":true}}'
+      # #4623 removed Ascend Scheduler; use the vLLM scheduler CLI instead.
+      - --enable-chunked-prefill
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_producer", "kv_port": "30000", "engine_id": "0", "kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
 
@@ -147,7 +147,8 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[5,10,15]}'
       - --additional-config
-      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"dynamic_eplb":true,"num_iterations_eplb_update":4000,"num_wait_worker_iterations":200,"init_redundancy_expert":0,"gate_eplb":false}'
+      # #5533 renamed and nested the legacy EPLB keys below.
+      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":4000,"algorithm_execution_interval":200,"num_redundant_experts":0}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "2", "kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
 
@@ -187,7 +188,8 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY","cudagraph_capture_sizes":[5,10,15]}'
       - --additional-config
-      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"dynamic_eplb":true,"num_iterations_eplb_update":4000,"num_wait_worker_iterations":200,"init_redundancy_expert":0,"gate_eplb":false}'
+      # #5533 renamed and nested the legacy EPLB keys below.
+      - '{"finegrained_tp_config": {"lmhead_tensor_parallel_size":8},"eplb_config":{"dynamic_eplb":true,"expert_heat_collection_interval":4000,"algorithm_execution_interval":200,"num_redundant_experts":0}}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1", "kv_role": "kv_consumer", "kv_port": "30200", "engine_id": "2", "kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2, "tp_size": 8}, "decode": {"dp_size": 32, "tp_size": 1}}}'
 

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_3.5k_1.5k_0_20.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_3.5k_1.5k_0_20.yaml
@@ -49,7 +49,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": false}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": false}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -81,7 +81,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": false}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": false}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_TPOT20:

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_3.5k_1.5k_0_50.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_3.5k_1.5k_0_50.yaml
@@ -46,7 +46,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -78,7 +78,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_TPOT50:

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_64k_90_50.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.1-W8A8C8-A3_64k_90_50.yaml
@@ -46,7 +46,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   - envs:
       <<: *env_common
@@ -77,7 +77,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_64k_warmup:

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_3.5k_1.5k_0_20.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_3.5k_1.5k_0_20.yaml
@@ -49,7 +49,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": false}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": false}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -81,7 +81,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": false}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": false, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": false}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_TPOT20:

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_3.5k_1.5k_0_50.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_3.5k_1.5k_0_50.yaml
@@ -46,7 +46,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -78,7 +78,7 @@ deployment:
       --no-enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_TPOT50:

--- a/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_64k_90_50.yaml
+++ b/tests/e2e/weekly/multi_node/internal_dp/config/GLM-5.2-W8A8C8-A3_64k_90_50.yaml
@@ -46,7 +46,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
   -
     envs:
@@ -78,7 +78,7 @@ deployment:
       --enable-prefix-caching
       --async-scheduling
       --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
-      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "fuse_muls_add": true, "multistream_overlap_shared_expert": true}'
+      --additional-config '{"enable_dsa_cp": true, "enable_sparse_sfa_c8": false, "enable_sparse_li_c8": true, "enable_balance_scheduling": true, "ascend_compilation_config": {"fuse_muls_add": true}, "multistream_overlap_shared_expert": true}'
       --speculative-config '{"num_speculative_tokens": 3, "method": "deepseek_mtp","enforce_eager":true}'
 benchmarks:
   perf_64k_warmup:

--- a/tests/e2e/weekly/single_node/configs/Deepseek_R1_W8A8_Reasoning_output_A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Deepseek_R1_W8A8_Reasoning_output_A3.yaml
@@ -41,8 +41,6 @@ _server_cmd: &server_cmd
   - "--no-enable-prefix-caching"
   - "--reasoning-parser"
   - "deepseek_r1"
-  - "--additional-config"
-  - '{"ascend_scheduler_config":{"enabled":false},"torchair_graph_config":{"enabled":false,"enable_multistream_shared_expert":false}}'
 
 _benchmarks: &benchmarks
   acc:

--- a/tests/e2e/weekly/single_node/configs/Minimax_M2.7_w8a8_A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Minimax_M2.7_w8a8_A3.yaml
@@ -39,7 +39,7 @@ _server_cmd: &server_cmd
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--additional-config"
-  - '{"enable_cpu_binding": true, "enable_npugraph_ex": true, "enable_static_kernel": true,"enable_fused_mc2":true,"weight_nz_mode":true,"enable_flashcomm1":true}'
+  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
 
 
 _benchmarks_acc: &benchmarks_acc

--- a/tests/e2e/weekly/single_node/configs/Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3.yaml
@@ -72,7 +72,7 @@ test_cases:
       - "--hf-overrides"
       - '{"rope_parameters": {"rope_type":"yarn","rope_theta": 1000000.0,"factor":4.3,"original_max_position_embeddings":32768}}'
       - "--additional-config"
-      - '{"ascend_scheduler_config":{"enabled":false},"pa_shape_list": [4,8,16,32,48,64,96,128,160,192]}'
+      - '{"pa_shape_list": [4,8,16,32,48,64,96,128,160,192]}'
     benchmarks:
       <<: *benchmarks
 
@@ -87,7 +87,7 @@ test_cases:
       - "--hf-overrides"
       - '{"rope_parameters": {"rope_type":"yarn","rope_theta": 1000000.0,"factor":4.3,"original_max_position_embeddings":32768}}'
       - "--additional-config"
-      - '{"ascend_scheduler_config":{"enabled":false},"pa_shape_list": [4,8,16,32,48,64,96,128,160,192]}'
+      - '{"pa_shape_list": [4,8,16,32,48,64,96,128,160,192]}'
     benchmarks:
       <<: *benchmarks
   - name: "Qwen3_235B_Accuracy_EPLB_gsm8k_lite"

--- a/tests/e2e/weekly/single_node/configs/Qwen3-32B.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3-32B.yaml
@@ -30,7 +30,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.9"
       - "--additional-config"
-      - '{"enable_weight_nz_layout":true}'
+      - '{"weight_nz_mode": 1}'
     benchmarks:
       acc:
         case_type: accuracy

--- a/tests/e2e/weekly/single_node/configs/Qwen3_32b_W8A8_wl_A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwen3_32b_W8A8_wl_A3.yaml
@@ -100,7 +100,7 @@ test_cases:
       - "--quantization"
       - "ascend"
       - "--additional-config"
-      - '{"enable_weight_nz_layout":true}'
+      - '{"weight_nz_mode": 1}'
     benchmarks:
       <<: *benchmarks_aime
   - name: "Qwen3_32B_w8a8_Performance_A3"
@@ -119,7 +119,7 @@ test_cases:
       - "--quantization"
       - "ascend"
       - "--additional-config"
-      - '{"enable_weight_nz_layout":true}'
+      - '{"weight_nz_mode": 1}'
     benchmarks:
       <<: *benchmarks_perf1
   - name: "single_Qwen3_32B_w8a8_server_A3"
@@ -138,5 +138,5 @@ test_cases:
       - "--quantization"
       - "ascend"
       - "--additional-config"
-      - '{"enable_weight_nz_layout":true}'
+      - '{"weight_nz_mode": 1}'
       - "--enforce-eager"

--- a/tests/e2e/weekly/single_node/configs/Qwq_32b_A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Qwq_32b_A3.yaml
@@ -64,8 +64,6 @@ test_cases:
       - "--max-num-batched-tokens"
       - "32768"
       - "--enforce-eager"
-      - "--additional-config"
-      - '{"ascend_scheduler_config":{"enabled":false}}'
   - name: "Qwq_32B_gsm8k_Accuracy_A3"
     model: "Qwen/QwQ-32B"
     envs:


### PR DESCRIPTION
### What this PR does / why we need it?

The strict `AscendConfig(extra=forbid)` validation introduced by #13838 exposes stale keys in weekly and nightly smoke-test YAML files.

This PR:

- moves compilation options such as `enable_npugraph_ex`, `enable_static_kernel`, and `fuse_muls_add` under `ascend_compilation_config`;
- moves `lmhead_tensor_parallel_size` under `finegrained_tp_config`;
- replaces the removed `enable_weight_nz_layout` switch with `weight_nz_mode: 1`;
- migrates legacy EPLB names into the current nested `eplb_config` schema, following #5533;
- replaces the removed Ascend Scheduler wrapper with the vLLM `--enable-chunked-prefill` option, following #4623;
- removes disabled or obsolete configuration entries with no current runtime consumer;
- updates single-node feature extraction to detect NZ layout through `weight_nz_mode != 0`.

### Does this PR introduce _any_ user-facing change?

No. This only updates test configurations and their feature-reporting metadata to match the current validated configuration schema.

### How was this patch tested?

- `git diff --check`
- Parsed all 157 YAML files under `tests/e2e/weekly` and `tests/e2e/nightly` and all 309 remaining embedded `--additional-config` JSON values.
- Checked top-level and nested keys against the current `AscendConfig` schemas with no unknown keys found.
- Verified that the migrated legacy keys no longer occur in weekly/nightly YAML files.
- `codespell`, `typos`, and `tools/check_symbolic_meta.py` passed locally.
- Constructed Pydantic `AscendConfig` instances for the original 13 single-node migrations and verified `weight_nz_mode` feature extraction for values 0, 1, and 2.

Full NPU smoke testing is left to CI because the local WSL CPU environment does not provide `torch_npu`.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
