### PR TITLE
[Feature] Add Triton SFA DCP index remap

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_sfa_remap_sparse_indices.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_sfa_remap_sparse_indices.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPImpl
+from vllm_ascend.attention.context_parallel.sfa_remap import (
+    remap_sparse_indices_pytorch,
+)
+from vllm_ascend.ops.triton.sfa_remap_sparse_indices import (
+    remap_sparse_indices_triton,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+init_device_properties_triton()
+
+REMAP_BACKENDS = {
+    "triton": remap_sparse_indices_triton,
+    "pytorch": remap_sparse_indices_pytorch,
+}
+
+
+def _run_backend(
+    backend: str,
+    indices: torch.Tensor,
+    dcp_size: int,
+    rank: int,
+    interleave_size: int,
+) -> torch.Tensor:
+    output = torch.empty_like(indices)
+    return REMAP_BACKENDS[backend](
+        indices.contiguous(),
+        output,
+        dcp_size,
+        rank,
+        interleave_size,
+    )
+
+
+def _reference_remap(
+    indices: torch.Tensor,
+    dcp_size: int,
+    rank: int,
+    interleave_size: int,
+) -> torch.Tensor:
+    indices_cpu = indices.cpu()
+    blocks = torch.div(indices_cpu, interleave_size, rounding_mode="floor")
+    is_local = (indices_cpu >= 0) & (blocks.remainder(dcp_size) == rank)
+    remapped = (
+        torch.div(
+            indices_cpu,
+            dcp_size * interleave_size,
+            rounding_mode="floor",
+        )
+        * interleave_size
+        + indices_cpu.remainder(interleave_size)
+    )
+    result = torch.full_like(remapped, -1)
+    for source_row, local_row, result_row in zip(
+        remapped.view(-1, remapped.shape[-1]),
+        is_local.view(-1, is_local.shape[-1]),
+        result.view(-1, result.shape[-1]),
+        strict=True,
+    ):
+        values = source_row[local_row]
+        result_row[: values.numel()] = values
+    return result.to(indices.device)
+
+
+@pytest.mark.parametrize(
+    ("dcp_size", "rank", "interleave_size"),
+    [(2, 0, 1), (3, 1, 96), (8, 3, 64), (16, 7, 128)],
+)
+@pytest.mark.parametrize("num_rows", [5, 16, 64, 128])
+@pytest.mark.parametrize("backend", REMAP_BACKENDS)
+@torch.inference_mode()
+def test_sfa_remap_sparse_indices(
+    backend: str,
+    dcp_size: int,
+    rank: int,
+    interleave_size: int,
+    num_rows: int,
+) -> None:
+    torch.manual_seed(2026)
+    indices = torch.randint(
+        0,
+        20_000_000,
+        (num_rows, 1, 2048),
+        dtype=torch.int32,
+        device="npu",
+    )
+    indices[..., ::11] = -1
+
+    expected = _reference_remap(indices, dcp_size, rank, interleave_size)
+    actual = _run_backend(backend, indices, dcp_size, rank, interleave_size)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("top_k", [1, 7, 512, 2048, 8192])
+@pytest.mark.parametrize("backend", REMAP_BACKENDS)
+@torch.inference_mode()
+def test_sfa_remap_sparse_indices_supports_dynamic_top_k(backend: str, top_k: int) -> None:
+    indices = torch.arange(
+        5 * top_k,
+        dtype=torch.int32,
+        device="npu",
+    ).view(5, 1, top_k)
+    indices[..., ::11] = -1
+
+    expected = _reference_remap(indices, 16, 7, 128)
+    actual = _run_backend(backend, indices, 16, 7, 128)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("backend", REMAP_BACKENDS)
+@torch.inference_mode()
+def test_sfa_remap_sparse_indices_preserves_large_integer_precision(backend: str) -> None:
+    indices = torch.tensor(
+        [[16_777_216, 16_777_217, 16_777_344, -1]],
+        dtype=torch.int32,
+        device="npu",
+    )
+
+    expected = _reference_remap(indices, 2, 0, 128)
+    actual = _run_backend(backend, indices, 2, 0, 128)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)
+
+
+@pytest.mark.parametrize("backend", REMAP_BACKENDS)
+@torch.inference_mode()
+def test_sfa_cp_backend_remap(backend: str) -> None:
+    impl = AscendSFADCPImpl.__new__(AscendSFADCPImpl)
+    impl.dcp_size = 16
+    impl.dcp_rank = 7
+    impl._dcp_interleave_size = 128
+    impl._dcp_index_topk = 2048
+    impl._sfa_remap_backend = backend
+    impl._sfa_remap_impl = REMAP_BACKENDS[backend]
+    indices = torch.randint(
+        0,
+        20_000_000,
+        (16, 1, 2048),
+        dtype=torch.int32,
+        device="npu",
+    )
+    indices[..., ::11] = -1
+
+    expected = _reference_remap(indices, 16, 7, 128)
+    actual = impl._remap_sparse_indices(indices)
+
+    torch.testing.assert_close(actual, expected, atol=0, rtol=0)

--- a/tests/ut/attention/a2/test_sfa_cp_precision.py
+++ b/tests/ut/attention/a2/test_sfa_cp_precision.py
@@ -3,6 +3,7 @@
 import torch
 
 from vllm_ascend.attention.context_parallel.sfa_cp import AscendSFADCPImpl
+from vllm_ascend.attention.context_parallel.sfa_remap import remap_sparse_indices_pytorch
 
 
 def _make_impl(rank: int, interleave_size: int = 2) -> AscendSFADCPImpl:
@@ -11,8 +12,8 @@ def _make_impl(rank: int, interleave_size: int = 2) -> AscendSFADCPImpl:
     impl.dcp_rank = rank
     impl._dcp_interleave_size = interleave_size
     impl._dcp_index_topk = 8
-    impl._remap_order = torch.arange(8, dtype=torch.float32)
-    impl._remap_invalid_index = torch.tensor(-1.0)
+    impl._sfa_remap_backend = "pytorch"
+    impl._sfa_remap_impl = remap_sparse_indices_pytorch
     return impl
 
 

--- a/vllm_ascend/attention/context_parallel/sfa_cp.py
+++ b/vllm_ascend/attention/context_parallel/sfa_cp.py
@@ -11,6 +11,7 @@ from vllm.distributed import get_tp_group
 from vllm.utils.math_utils import cdiv
 from vllm.v1.kv_cache_interface import AttentionSpec
 
+from vllm_ascend import envs as ascend_envs
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.context_parallel.common_cp import (
     DCPImplMixin,
@@ -35,6 +36,18 @@ from vllm_ascend.utils import (
 )
 
 M = TypeVar("M", bound=AscendSFAMetadata)
+
+SFA_REMAP_BACKEND_ENV = "VLLM_ASCEND_SFA_REMAP_BACKEND"
+SFA_REMAP_BACKENDS = ("triton", "pytorch")
+
+
+def _resolve_sfa_remap_backend() -> str:
+    backend = ascend_envs.VLLM_ASCEND_SFA_REMAP_BACKEND.lower()
+    if backend not in SFA_REMAP_BACKENDS:
+        raise RuntimeError(
+            f"Invalid {SFA_REMAP_BACKEND_ENV}={backend!r}; expected one of {SFA_REMAP_BACKENDS}."
+        )
+    return backend
 
 
 @dataclass
@@ -844,9 +857,19 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
                 break
         if self._dcp_index_topk <= 0:
             raise RuntimeError("index_topk must be set in the model config for DCP SFA.")
-        device = self.q_proj.weight.device
-        self._remap_order = torch.arange(self._dcp_index_topk, dtype=torch.float32, device=device)
-        self._remap_invalid_index = torch.tensor(-1.0, dtype=torch.float32, device=device)
+        self._sfa_remap_backend = _resolve_sfa_remap_backend()
+        if self._sfa_remap_backend == "triton":
+            from vllm_ascend.ops.triton.sfa_remap_sparse_indices import (
+                remap_sparse_indices_triton,
+            )
+
+            self._sfa_remap_impl = remap_sparse_indices_triton
+        else:
+            from vllm_ascend.attention.context_parallel.sfa_remap import (
+                remap_sparse_indices_pytorch,
+            )
+
+            self._sfa_remap_impl = remap_sparse_indices_pytorch
 
     @staticmethod
     def _has_prefill(attn_metadata: M) -> bool:
@@ -942,31 +965,15 @@ class AscendSFADCPImpl(DCPImplMixin, AscendSFAImpl):
                 f"topk_indices last dimension ({topk_count}) exceeds configured index_topk ({self._dcp_index_topk})."
             )
 
-        # Remap the topk indices from the replicated view to the DCP-local KV cache view.
-        # We use float32 for better performance on Ascend.
-        topk_indices_fp32 = topk_indices.to(torch.float32)
-        interleave_size = self._dcp_interleave_size
-        local_block_indices = torch.floor(topk_indices_fp32 / interleave_size)
-        local_owner_base = torch.floor(local_block_indices / self.dcp_size) * self.dcp_size
-        local_owner = local_block_indices - local_owner_base
-        local_owner_mask = (topk_indices_fp32 >= 0) & (local_owner == self.dcp_rank)
-        if interleave_size == 1:
-            remapped_indices_fp32 = torch.floor(topk_indices_fp32 / self.dcp_size)
-        else:
-            local_offsets = topk_indices_fp32 - local_block_indices * interleave_size
-            remapped_indices_fp32 = torch.floor(topk_indices_fp32 / (self.dcp_size * interleave_size))
-            remapped_indices_fp32 = remapped_indices_fp32 * interleave_size + local_offsets
-        remapped_indices = torch.where(
-            local_owner_mask,
-            remapped_indices_fp32,
-            self._remap_invalid_index,
-        ).to(topk_indices.dtype)
-
-        # Compact local indices to the front without changing their top-k order.
-        original_order = self._remap_order[:topk_count].expand_as(topk_indices)
-        pack_keys = original_order + (~local_owner_mask).to(torch.float32) * topk_count
-        _, pack_order = torch.sort(pack_keys, dim=-1)
-        return torch.gather(remapped_indices, dim=-1, index=pack_order.to(torch.int32))
+        contiguous_indices = topk_indices.contiguous()
+        remapped_indices = torch.empty_like(contiguous_indices)
+        return self._sfa_remap_impl(
+            contiguous_indices,
+            remapped_indices,
+            self.dcp_size,
+            self.dcp_rank,
+            self._dcp_interleave_size,
+        )
 
     def _all_to_all_dcp_tensor(
         self,

--- a/vllm_ascend/attention/context_parallel/sfa_remap.py
+++ b/vllm_ascend/attention/context_parallel/sfa_remap.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import torch
+
+
+def remap_sparse_indices_pytorch(
+    indices: torch.Tensor,
+    output: torch.Tensor,
+    dcp_size: int,
+    dcp_rank: int,
+    interleave_size: int,
+) -> torch.Tensor:
+    """PyTorch fallback for SFA DCP index remap."""
+    if indices.dtype != torch.int32:
+        raise TypeError(f"indices must have dtype int32, got {indices.dtype}")
+    if not indices.is_contiguous():
+        raise ValueError("indices must be contiguous")
+    if output.shape != indices.shape or output.dtype != indices.dtype:
+        raise ValueError("output must match indices shape and dtype")
+    if not output.is_contiguous():
+        raise ValueError("output must be contiguous")
+
+    top_k = indices.shape[-1]
+    blocks = torch.div(indices, interleave_size, rounding_mode="floor")
+    is_local = (indices >= 0) & (blocks.remainder(dcp_size) == dcp_rank)
+    remapped = (
+        torch.div(
+            indices,
+            dcp_size * interleave_size,
+            rounding_mode="floor",
+        )
+        * interleave_size
+        + indices.remainder(interleave_size)
+    )
+
+    compact_positions = torch.cumsum(is_local.to(torch.int64), dim=-1) - 1
+    tail_positions = torch.arange(
+        top_k,
+        dtype=torch.int64,
+        device=indices.device,
+    ).view((1,) * (indices.ndim - 1) + (top_k,)).expand_as(indices)
+    scatter_positions = torch.where(is_local, compact_positions, tail_positions + top_k)
+    scatter_values = torch.where(is_local, remapped, torch.full_like(remapped, -1))
+
+    scratch = torch.full(
+        (*indices.shape[:-1], top_k * 2),
+        -1,
+        dtype=indices.dtype,
+        device=indices.device,
+    )
+    scratch.scatter_(-1, scatter_positions, scatter_values)
+    output.copy_(scratch[..., :top_k])
+    return output

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -100,6 +100,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # SFA DCP sparse index remap backend. "triton" is the default; "pytorch"
+    # keeps the tensor-op implementation available as a fallback.
+    "VLLM_ASCEND_SFA_REMAP_BACKEND": lambda: os.getenv("VLLM_ASCEND_SFA_REMAP_BACKEND", "triton"),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/ops/triton/sfa_remap_sparse_indices.py
+++ b/vllm_ascend/ops/triton/sfa_remap_sparse_indices.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import torch
+from vllm.triton_utils import tl, triton
+
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
+
+triton_sum = tl.sum
+
+
+@triton.jit
+def _sfa_remap_sparse_indices_stage1_kernel(
+    input_ptr,
+    intermediate_ptr,
+    counts_ptr,
+    rows,
+    top_k: tl.constexpr,
+    num_cores: tl.constexpr,
+    segment_size: tl.constexpr,
+    dcp_size: tl.constexpr,
+    dcp_rank: tl.constexpr,
+    interleave_size: tl.constexpr,
+    interleave_shift: tl.constexpr,
+    dcp_interleave_shift: tl.constexpr,
+    use_power_of_two: tl.constexpr,
+):
+    """Stable-compact one input segment per vector core."""
+    core = tl.program_id(0)
+    segment_start = core * segment_size
+    lanes = tl.arange(0, segment_size)
+    offsets = segment_start + lanes
+    valid_offset = offsets < top_k
+
+    for row in tl.range(0, rows):
+        values = tl.load(
+            input_ptr + row * top_k + offsets,
+            mask=valid_offset,
+            other=-1,
+        ).to(tl.int32)
+        valid_value = valid_offset & (values >= 0)
+        if use_power_of_two:
+            has_local_owner = (values & ((dcp_size - 1) << interleave_shift)) == (
+                dcp_rank << interleave_shift
+            )
+            remapped = (
+                ((values >> dcp_interleave_shift) << interleave_shift)
+                | (values & (interleave_size - 1))
+            )
+        else:
+            block = values // interleave_size
+            owner = block % dcp_size
+            has_local_owner = owner == dcp_rank
+            remapped = (block // dcp_size) * interleave_size + values % interleave_size
+
+        is_local = valid_value & has_local_owner
+        local_position = tl.cumsum(is_local.to(tl.int32), axis=0) - 1
+        local_count = triton_sum(is_local.to(tl.int32), axis=0)
+        tl.store(
+            intermediate_ptr + row * top_k + segment_start + local_position,
+            remapped,
+            mask=is_local,
+        )
+        tl.store(counts_ptr + row * num_cores + core, local_count)
+
+
+@triton.jit
+def _sfa_remap_sparse_indices_prefix_offsets_kernel(
+    counts_ptr,
+    offsets_ptr,
+    num_segments: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    """Exclusive prefix sum of per-segment counts for one row."""
+    row = tl.program_id(0)
+    lanes = tl.arange(0, block_size)
+    mask = lanes < num_segments
+    counts = tl.load(counts_ptr + row * num_segments + lanes, mask=mask, other=0)
+    offsets = tl.cumsum(counts, axis=0) - counts
+    tl.store(offsets_ptr + row * num_segments + lanes, offsets, mask=mask)
+
+
+@triton.jit
+def _sfa_remap_sparse_indices_stage2_kernel(
+    intermediate_ptr,
+    output_ptr,
+    counts_ptr,
+    offsets_ptr,
+    top_k: tl.constexpr,
+    num_segments: tl.constexpr,
+    segment_size: tl.constexpr,
+):
+    """Copy compacted segment prefixes to their final row positions."""
+    program = tl.program_id(0)
+    row = program // num_segments
+    segment = program % num_segments
+    count = tl.load(counts_ptr + program)
+    output_base = tl.load(offsets_ptr + program)
+
+    lanes = tl.arange(0, segment_size)
+    valid_value = lanes < count
+    values = tl.load(
+        intermediate_ptr + row * top_k + segment * segment_size + lanes,
+        mask=valid_value,
+        other=0,
+    )
+    tl.store(
+        output_ptr + row * top_k + output_base + lanes,
+        values,
+        mask=valid_value,
+    )
+
+    if segment == num_segments - 1:
+        tail_start = output_base + count
+        for tile in tl.range(0, (top_k + segment_size - 1) // segment_size):
+            tail_offsets = tail_start + tile * segment_size + lanes
+            tl.store(
+                output_ptr + row * top_k + tail_offsets,
+                -1,
+                mask=tail_offsets < top_k,
+            )
+
+
+@triton.jit
+def _sfa_remap_sparse_indices_stage2_copy_kernel(
+    intermediate_ptr,
+    output_ptr,
+    counts_ptr,
+    offsets_ptr,
+    top_k: tl.constexpr,
+    num_segments: tl.constexpr,
+    segment_size: tl.constexpr,
+):
+    """Copy compacted segment prefixes without tail fill."""
+    program = tl.program_id(0)
+    row = program // num_segments
+    segment = program % num_segments
+    count = tl.load(counts_ptr + program)
+    output_base = tl.load(offsets_ptr + program)
+
+    lanes = tl.arange(0, segment_size)
+    valid_value = lanes < count
+    values = tl.load(
+        intermediate_ptr + row * top_k + segment * segment_size + lanes,
+        mask=valid_value,
+        other=0,
+    )
+    tl.store(
+        output_ptr + row * top_k + output_base + lanes,
+        values,
+        mask=valid_value,
+    )
+
+
+@triton.jit
+def _sfa_remap_sparse_indices_tail_fill_kernel(
+    output_ptr,
+    counts_ptr,
+    offsets_ptr,
+    top_k: tl.constexpr,
+    num_segments: tl.constexpr,
+    segment_size: tl.constexpr,
+):
+    """Fill output tails in parallel after segment copies finish."""
+    row = tl.program_id(0)
+    tile = tl.program_id(1)
+    last_segment = row * num_segments + (num_segments - 1)
+    local_count = tl.load(offsets_ptr + last_segment) + tl.load(counts_ptr + last_segment)
+
+    lanes = tl.arange(0, segment_size)
+    offsets = tile * segment_size + lanes
+    tl.store(
+        output_ptr + row * top_k + offsets,
+        -1,
+        mask=(offsets >= local_count) & (offsets < top_k),
+    )
+
+
+def remap_sparse_indices_triton(
+    indices: torch.Tensor,
+    output: torch.Tensor,
+    dcp_size: int,
+    dcp_rank: int,
+    interleave_size: int,
+) -> torch.Tensor:
+    """Remap and stable-compact SFA indices with the staged Triton path."""
+    if indices.dtype != torch.int32:
+        raise TypeError(f"indices must have dtype int32, got {indices.dtype}")
+    if not indices.is_contiguous():
+        raise ValueError("indices must be contiguous")
+    if indices.ndim == 0 or indices.shape[-1] <= 0:
+        raise ValueError("indices must have a non-empty top-k dimension")
+    if dcp_size <= 0 or not 0 <= dcp_rank < dcp_size:
+        raise ValueError(f"invalid dcp_size/dcp_rank: {dcp_size}/{dcp_rank}")
+    if interleave_size <= 0:
+        raise ValueError(f"interleave_size must be positive, got {interleave_size}")
+    if output.shape != indices.shape or output.dtype != indices.dtype:
+        raise ValueError("output must match indices shape and dtype")
+    if not output.is_contiguous():
+        raise ValueError("output must be contiguous")
+
+    top_k = indices.shape[-1]
+    rows = indices.numel() // top_k
+    num_cores = get_vectorcore_num()
+    segment_size = triton.next_power_of_2(triton.cdiv(top_k, num_cores))
+    use_power_of_two = (dcp_size & (dcp_size - 1) == 0) and (
+        interleave_size & (interleave_size - 1) == 0
+    )
+    interleave_shift = interleave_size.bit_length() - 1 if use_power_of_two else 0
+    dcp_interleave_shift = (dcp_size * interleave_size).bit_length() - 1 if use_power_of_two else 0
+
+    intermediate = torch.empty_like(indices)
+    counts = torch.empty((rows, num_cores), dtype=torch.int32, device=indices.device)
+    _sfa_remap_sparse_indices_stage1_kernel[(num_cores,)](
+        indices,
+        intermediate,
+        counts,
+        rows,
+        top_k=top_k,
+        num_cores=num_cores,
+        segment_size=segment_size,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
+        interleave_size=interleave_size,
+        interleave_shift=interleave_shift,
+        dcp_interleave_shift=dcp_interleave_shift,
+        use_power_of_two=use_power_of_two,
+        multibuffer=False,
+    )
+
+    offsets = torch.empty_like(counts)
+    _sfa_remap_sparse_indices_prefix_offsets_kernel[(rows,)](
+        counts,
+        offsets,
+        num_segments=num_cores,
+        block_size=triton.next_power_of_2(num_cores),
+        multibuffer=False,
+    )
+    if top_k == 2048 and rows >= 32:
+        _sfa_remap_sparse_indices_stage2_copy_kernel[(rows * num_cores,)](
+            intermediate,
+            output,
+            counts,
+            offsets,
+            top_k=top_k,
+            num_segments=num_cores,
+            segment_size=segment_size,
+            multibuffer=False,
+        )
+        _sfa_remap_sparse_indices_tail_fill_kernel[(rows, triton.cdiv(top_k, segment_size))](
+            output,
+            counts,
+            offsets,
+            top_k=top_k,
+            num_segments=num_cores,
+            segment_size=segment_size,
+            multibuffer=False,
+        )
+    else:
+        _sfa_remap_sparse_indices_stage2_kernel[(rows * num_cores,)](
+            intermediate,
+            output,
+            counts,
+            offsets,
+            top_k=top_k,
+            num_segments=num_cores,
+            segment_size=segment_size,
+            multibuffer=False,
+        )
+    return output


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds a standalone Triton backend for SFA DCP sparse index remapping and wires SFA DCP to use it by default.

The previous PyTorch tensor implementation is kept as a fallback backend via `VLLM_ASCEND_SFA_REMAP_BACKEND=pytorch`. The default remains `VLLM_ASCEND_SFA_REMAP_BACKEND=triton`.

Implementation notes:
- Remap and compact `int32` top-k indices without an Ascend C custom operator dependency.
- Preserve the PyTorch backend as a fallback path.
- Keep `top_k=2048` optimized for larger row counts by splitting stage2 copy from tail fill when `rows >= 32`.
- Keep the `counts` exclusive prefix sum in Triton instead of using `torch.cumsum`, avoiding an AICPU cumsum and extra ACLNN cast/sub kernels on Ascend.
- For power-of-two DCP/interleave cases, test ownership by masking the owner bits directly instead of shifting then masking.

Measured on 192.168.13.161, `top_k=2048`, `dcp_size=8`, `dcp_rank=3`, `interleave_size=128`, preallocated output:

| rows | Triton median | PyTorch fallback median | Speedup vs PyTorch |
|---:|---:|---:|---:|
| 32 | 0.271363 ms | 0.648803 ms | 2.39x |
| 64 | 0.262941 ms | 0.738422 ms | 2.81x |
| 128 | 0.453400 ms | 1.151662 ms | 2.54x |

For the primary `128 x 2048` case, single-operator profiling shows the Triton path has 4 device events per call: stage1, prefix-offsets, stage2 copy, and tail fill. The previous `aclnnCumsum_CumsumAiCpu_Cumsum` event is no longer present. After the owner-bit optimization, stage1 dropped from about `445 us/call` to about `373 us/call` in the same profiling setup.

### Does this PR introduce _any_ user-facing change?

Yes. SFA DCP sparse index remap now defaults to the Triton backend. Users can force the fallback path with:

```bash
VLLM_ASCEND_SFA_REMAP_BACKEND=pytorch
```

### How was this patch tested?

Static checks:

```bash
python3 -m py_compile vllm_ascend/ops/triton/sfa_remap_sparse_indices.py
```

NPU smoke on 192.168.13.161 with this branch content:

```bash
ASCEND_RT_VISIBLE_DEVICES=0 python - <<'PY'
# Verified Triton and PyTorch fallback exact output for:
# rows/top_k = 32/2048, 64/2048, 128/2048
# dcp_size/interleave_size = 4/128, 8/128, 16/128
PY
```

Full pytest note: `pytest -q tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_sfa_remap_sparse_indices.py` was attempted on the same container, but the container's checked-out vLLM did not match this vllm-ascend main baseline and failed before collecting this test with `ModuleNotFoundError: No module named 'vllm.v1.attention.ops.pcp'`.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
