### PR TITLE
[Doc] Remove transformers 5.2.0 upgrade note from GLM-5 doc

### DIFF
--- a/docs/source/tutorials/models/GLM5.md
+++ b/docs/source/tutorials/models/GLM5.md
@@ -6,7 +6,7 @@ This document applies to both `GLM-5` and `GLM-5.1`. Unless otherwise specified,
 
 [GLM-5](https://huggingface.co/zai-org/GLM-5) uses a Mixture-of-Experts (MoE) architecture and targets complex systems engineering and long-horizon agentic tasks.
 
-The `GLM-5` model is first supported in `vllm-ascend:v0.17.0rc1`, and all **v0.17.0rc1 and later versions** can run stably. To use the latest features (e.g., PD separation, MTP), it is recommended to use the latest release candidate or official version. The version of transformers need to be upgraded to 5.2.0 or later versions.
+The `GLM-5` model is first supported in `vllm-ascend:v0.17.0rc1`, and all **v0.17.0rc1 and later versions** can run stably. To use the latest features (e.g., PD separation, MTP), it is recommended to use the latest release candidate or official version.
 
 This document will show the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
 


### PR DESCRIPTION
  ### What this PR does / why we need it?
  - Removes the sentence "The version of transformers need to be upgraded to 5.2.0 or later versions." from the intro of  the GLM-5/GLM-5.1 doc.
  - The statement is outdated and redundant: the actual transformers version is pinned by the release's
  `requirements.txt` (`transformers==5.14.1` on `releases/v0.26.0rc`), while the doc claims a 5.2.0 minimum that does
  not reflect the real dependency and is not part of the model's version-support statement.                                                                                                                                                       Note: other places in the same doc still reference `transformers 5.2.0` (installation comments at lines 143–144 and
  the FAQ at line ~1366); they are left unchanged in this PR and can be cleaned up in a follow-up if the 5.2.0 note is
  confirmed fully obsolete.                                                                                             
  ### Does this PR introduce _any_ user-facing change?
  No. Documentation-only update, which is not considered a user-facing change.

### How was this patch tested?
  No functional code changes; the patch only edits documentation text. Verified by viewing the rendered markdown;
  existing CI doc checks cover the rest.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
