### PR TITLE
[Feature][Ops] Add custom GatherPaKvCache operator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,16 +58,19 @@ set(VLLM_ASCEND_CUSTOM_OP
     ${KERNEL_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/batch_matmul_transpose/op_kernel/batch_matmul_transpose_kernel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_kernel.cpp
 )
 
 set(VLLM_ASCEND_CUSTOM_OP_EXCLUDE_ASCEND950
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/mla_preprocess/op_kernel/mla_preprocess_kernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/csrc/batch_matmul_transpose/op_kernel/batch_matmul_transpose_kernel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_kernel.cpp
 )
 
 if(SOC_VERSION MATCHES "ascend950")
     message(STATUS "A5 hardware detected: disabling MLAPO operators")
     message(STATUS "A5 hardware detected: excluding batch_matmul_transpose operators")
+    message(STATUS "A5 hardware detected: excluding gather_pa_kv_cache operators")
     list(REMOVE_ITEM VLLM_ASCEND_CUSTOM_OP ${VLLM_ASCEND_CUSTOM_OP_EXCLUDE_ASCEND950})
 endif()
 
@@ -99,6 +102,7 @@ include_directories(
   ${TORCH_NPU_PATH}/include
   ${ASCEND_HOME_PATH}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/csrc/batch_matmul_transpose/op_host
+  ${CMAKE_CURRENT_SOURCE_DIR}/csrc/gather_pa_kv_cache/op_host
 )
 
 set(

--- a/csrc/gather_pa_kv_cache/gather_pa_kv_cache_torch_adpt.h
+++ b/csrc/gather_pa_kv_cache/gather_pa_kv_cache_torch_adpt.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef VLLM_ASCEND_GATHER_PA_KV_CACHE_TORCH_ADPT_H
+#define VLLM_ASCEND_GATHER_PA_KV_CACHE_TORCH_ADPT_H
+
+#include "op_host/gather_pa_kv_cache.h"
+
+namespace vllm_ascend {
+
+void gather_pa_kv_cache(const at::Tensor &keyCache, const at::Tensor &valueCache,
+                        const at::Tensor &blockTables, const at::Tensor &seqLens,
+                        at::Tensor &key, at::Tensor &value,
+                        const c10::optional<at::Tensor> &seqOffset, c10::string_view cacheMode,
+                        bool isSeqLensCumsum)
+{
+    auto [tilingPtr, blockDim] = ::gather_pa_kv_cache::gather_pa_kv_cache_tiling(
+        keyCache, valueCache, blockTables, seqLens, key, value, seqOffset, cacheMode, isSeqLensCumsum);
+
+    void *keyCachePtr = keyCache.data_ptr();
+    void *valueCachePtr = valueCache.data_ptr();
+    void *blockTablesPtr = blockTables.data_ptr();
+    void *seqLensPtr = seqLens.data_ptr();
+    void *seqOffsetPtr = seqOffset.has_value() ? seqOffset.value().data_ptr() : seqLensPtr;
+    void *keyPtr = key.data_ptr();
+    void *valuePtr = value.data_ptr();
+
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    at_npu::native::OpCommand cmd;
+    cmd.Name("gather_pa_kv_cache");
+    cmd.SetCustomHandler([stream, keyCachePtr, valueCachePtr, blockTablesPtr, seqLensPtr, seqOffsetPtr, keyPtr,
+                          valuePtr, tilingPtr, blockDim]() -> int {
+        gather_pa_kv_cache_impl(stream, keyCachePtr, valueCachePtr, blockTablesPtr, seqLensPtr, seqOffsetPtr,
+                                keyPtr, valuePtr, tilingPtr, blockDim);
+        return 0;
+    });
+    cmd.Run();
+}
+
+}  // namespace vllm_ascend
+
+#endif  // VLLM_ASCEND_GATHER_PA_KV_CACHE_TORCH_ADPT_H

--- a/csrc/gather_pa_kv_cache/op_host/gather_pa_kv_cache.h
+++ b/csrc/gather_pa_kv_cache/op_host/gather_pa_kv_cache.h
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef VLLM_ASCEND_GATHER_PA_KV_CACHE_HOST_H
+#define VLLM_ASCEND_GATHER_PA_KV_CACHE_HOST_H
+
+#include <algorithm>
+#include <climits>
+#include <string>
+#include <tuple>
+
+#include "acl/acl.h"
+#include "tiling/platform/platform_ascendc.h"
+#include "gather_pa_kv_cache_tiling.h"
+
+namespace gather_pa_kv_cache {
+
+constexpr int32_t DATA_BLOCK_SIZE = 32;
+constexpr int32_t MAX_CAPTURE_BATCHES = 1024;
+constexpr int32_t NZ_TMP_BUF_SIZE = 148 * 1024;
+constexpr int32_t NZ_LOCATE_INFO_SIZE = 40 * 1024;
+constexpr int32_t NZ_LOCATE_INFO_PADDING = 2 * DATA_BLOCK_SIZE;
+constexpr int32_t NZ_MAX_BLOCK_TABLE_WIDTH =
+    (NZ_LOCATE_INFO_SIZE - NZ_LOCATE_INFO_PADDING) / static_cast<int32_t>(sizeof(int32_t)) - 1;
+constexpr int32_t NZ_MAX_BLOCK_SIZE = 65536;
+
+inline bool IsSupportedNdDtype(at::ScalarType dtype)
+{
+    return dtype == at::kHalf || dtype == at::kBFloat16 || dtype == at::kChar;
+}
+
+inline void CheckCacheLayout(const at::Tensor &cache, const char *name)
+{
+    TORCH_CHECK(cache.dim() == 4, name, " must be a 4D tensor");
+    TORCH_CHECK(cache.size(0) > 0 && cache.size(1) > 0 && cache.size(2) > 0 && cache.size(3) > 0,
+                name, " dimensions must be positive");
+    int64_t expectedStride = 1;
+    for (int64_t dim = cache.dim() - 1; dim >= 1; --dim) {
+        TORCH_CHECK(cache.stride(dim) == expectedStride,
+                    name, " must be contiguous in every dimension except the first");
+        expectedStride *= cache.size(dim);
+    }
+    TORCH_CHECK(cache.stride(0) >= expectedStride, name, " has an invalid first-dimension stride");
+}
+
+inline void CheckMetadataTensor(const at::Tensor &tensor, const char *name, int64_t dim)
+{
+    TORCH_CHECK(tensor.dim() == dim, name, " must be a ", dim, "D tensor");
+    TORCH_CHECK(tensor.scalar_type() == at::kInt, name, " must have dtype int32");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+inline void CheckSameDevice(const at::Tensor &reference, const at::Tensor &tensor, const char *name)
+{
+    TORCH_CHECK(tensor.device() == reference.device(), name, " must be on the same device as key_cache");
+}
+
+inline std::tuple<void *, uint32_t> gather_pa_kv_cache_tiling(
+    const at::Tensor &keyCache, const at::Tensor &valueCache, const at::Tensor &blockTables,
+    const at::Tensor &seqLens, at::Tensor &key, at::Tensor &value,
+    const c10::optional<at::Tensor> &seqOffset, c10::string_view cacheMode, bool isSeqLensCumsum)
+{
+    const std::string cacheModeString(cacheMode.data(), cacheMode.size());
+    const bool isNz = cacheModeString == "PA_NZ";
+    TORCH_CHECK(cacheModeString == "Norm" || isNz,
+                "cache_mode must be either \"Norm\" or \"PA_NZ\", but got ", cacheModeString);
+
+    CheckCacheLayout(keyCache, "key_cache");
+    CheckCacheLayout(valueCache, "value_cache");
+    CheckMetadataTensor(blockTables, "block_tables", 2);
+    CheckMetadataTensor(seqLens, "seq_lens", 1);
+    TORCH_CHECK(key.is_contiguous(), "key must be contiguous");
+    TORCH_CHECK(value.is_contiguous(), "value must be contiguous");
+
+    CheckSameDevice(keyCache, valueCache, "value_cache");
+    CheckSameDevice(keyCache, blockTables, "block_tables");
+    CheckSameDevice(keyCache, seqLens, "seq_lens");
+    CheckSameDevice(keyCache, key, "key");
+    CheckSameDevice(keyCache, value, "value");
+
+    TORCH_CHECK(keyCache.scalar_type() == valueCache.scalar_type(),
+                "key_cache and value_cache must have the same dtype");
+    TORCH_CHECK(keyCache.scalar_type() == key.scalar_type(), "key and key_cache must have the same dtype");
+    TORCH_CHECK(valueCache.scalar_type() == value.scalar_type(), "value and value_cache must have the same dtype");
+    TORCH_CHECK(keyCache.size(0) == valueCache.size(0), "key_cache and value_cache must have the same block count");
+    TORCH_CHECK(key.size(0) == value.size(0), "key and value must have the same token count");
+    TORCH_CHECK(key.size(0) <= INT_MAX, "key and value token count must not exceed INT_MAX");
+
+    int64_t blockSize;
+    int64_t tokenSizeK;
+    int64_t tokenSizeV;
+    const int64_t typeByte = keyCache.element_size();
+    if (isNz) {
+        TORCH_CHECK(keyCache.scalar_type() == at::kChar,
+                    "PA_NZ mode only supports int8 on non-Ascend-950 hardware");
+        TORCH_CHECK(key.dim() == 2, "key must be a 2D tensor in PA_NZ mode");
+        TORCH_CHECK(value.dim() == 2, "value must be a 2D tensor in PA_NZ mode");
+        TORCH_CHECK(keyCache.size(3) == DATA_BLOCK_SIZE && valueCache.size(3) == DATA_BLOCK_SIZE,
+                    "PA_NZ cache innermost dimension must contain 32 int8 elements");
+
+        blockSize = keyCache.size(2);
+        TORCH_CHECK(valueCache.size(2) == blockSize, "key_cache and value_cache must have the same block size");
+        TORCH_CHECK(keyCache.size(1) * keyCache.size(3) == key.size(1),
+                    "key shape must match the PA_NZ key_cache token size");
+        TORCH_CHECK(valueCache.size(1) * valueCache.size(3) == value.size(1),
+                    "value shape must match the PA_NZ value_cache token size");
+        tokenSizeK = key.size(1);
+        tokenSizeV = value.size(1);
+        TORCH_CHECK(tokenSizeK * typeByte <= NZ_TMP_BUF_SIZE && tokenSizeV * typeByte <= NZ_TMP_BUF_SIZE,
+                    "PA_NZ token size must not exceed ", NZ_TMP_BUF_SIZE, " bytes");
+        TORCH_CHECK(blockSize <= NZ_MAX_BLOCK_SIZE,
+                    "PA_NZ block size must not exceed ", NZ_MAX_BLOCK_SIZE);
+        TORCH_CHECK(blockTables.size(1) <= NZ_MAX_BLOCK_TABLE_WIDTH,
+                    "PA_NZ block_tables width must not exceed ", NZ_MAX_BLOCK_TABLE_WIDTH);
+    } else {
+        TORCH_CHECK(IsSupportedNdDtype(keyCache.scalar_type()),
+                    "Norm mode only supports float16, bfloat16, and int8 on non-Ascend-950 hardware");
+        TORCH_CHECK(key.dim() == 3, "key must be a 3D tensor in Norm mode");
+        TORCH_CHECK(value.dim() == 3, "value must be a 3D tensor in Norm mode");
+
+        blockSize = keyCache.size(1);
+        TORCH_CHECK(valueCache.size(1) == blockSize, "key_cache and value_cache must have the same block size");
+        TORCH_CHECK(keyCache.size(2) == key.size(1) && keyCache.size(3) == key.size(2),
+                    "key shape must match the trailing dimensions of key_cache");
+        TORCH_CHECK(valueCache.size(2) == value.size(1) && valueCache.size(3) == value.size(2),
+                    "value shape must match the trailing dimensions of value_cache");
+        tokenSizeK = key.size(1) * key.size(2);
+        tokenSizeV = value.size(1) * value.size(2);
+        TORCH_CHECK(blockSize * tokenSizeK * typeByte <= INT_MAX,
+                    "one key cache block must not exceed INT_MAX bytes");
+        TORCH_CHECK(blockSize * tokenSizeV * typeByte <= INT_MAX,
+                    "one value cache block must not exceed INT_MAX bytes");
+    }
+
+    const int64_t numBatches = blockTables.size(0);
+    TORCH_CHECK(numBatches > 0 && numBatches <= MAX_CAPTURE_BATCHES,
+                "block_tables batch size must be in [1, ", MAX_CAPTURE_BATCHES, "]");
+    TORCH_CHECK(blockTables.size(1) > 0 && blockTables.size(1) <= INT_MAX,
+                "block_tables width must be in [1, INT_MAX]");
+    const int64_t expectedSeqLens = numBatches + (isSeqLensCumsum ? 1 : 0);
+    TORCH_CHECK(seqLens.numel() == expectedSeqLens, "seq_lens must contain ", expectedSeqLens,
+                " elements for the selected is_seq_lens_cumsum mode");
+
+    if (seqOffset.has_value()) {
+        CheckMetadataTensor(seqOffset.value(), "seq_offset", 1);
+        CheckSameDevice(keyCache, seqOffset.value(), "seq_offset");
+        TORCH_CHECK(seqOffset.value().numel() == numBatches,
+                    "seq_offset must contain one element per block_tables row");
+    }
+
+    TORCH_CHECK(blockSize > 0 && blockSize <= INT_MAX, "cache block size must be in [1, INT_MAX]");
+    TORCH_CHECK(tokenSizeK > 0 && tokenSizeK <= INT_MAX, "key token size must be in [1, INT_MAX] elements");
+    TORCH_CHECK(tokenSizeV > 0 && tokenSizeV <= INT_MAX, "value token size must be in [1, INT_MAX] elements");
+    TORCH_CHECK(tokenSizeK * typeByte % DATA_BLOCK_SIZE == 0,
+                "key token size in bytes must be aligned to ", DATA_BLOCK_SIZE);
+    TORCH_CHECK(tokenSizeV * typeByte % DATA_BLOCK_SIZE == 0,
+                "value token size in bytes must be aligned to ", DATA_BLOCK_SIZE);
+
+    GatherPaKvCacheTilingData tilingData = {
+        .blockSize = static_cast<int32_t>(blockSize),
+        .numTokens = static_cast<int32_t>(numBatches),
+        .numblkTabCol = static_cast<int32_t>(blockTables.size(1)),
+        .tokenSizeK = static_cast<int32_t>(tokenSizeK),
+        .tokenSizeV = static_cast<int32_t>(tokenSizeV),
+        .typeByte = static_cast<int32_t>(typeByte),
+        .hasSeqStarts = seqOffset.has_value() ? 1 : 0,
+        .isSeqLensCumsum = isSeqLensCumsum ? 1 : 0,
+        .kCacheBlockStride = keyCache.stride(0),
+        .vCacheBlockStride = valueCache.stride(0),
+        .tilingKey = isNz ? TILING_KEY_NZ
+                          : (keyCache.scalar_type() == at::kChar ? TILING_KEY_ND_INT8 : TILING_KEY_ND_B16),
+    };
+
+    const int64_t tilingSize = sizeof(GatherPaKvCacheTilingData);
+    static auto globalTilingData = at::empty(
+        {tilingSize * MAX_CAPTURE_BATCHES}, at::TensorOptions().dtype(at::kByte).device(keyCache.device()));
+    const int64_t tilingOffset = (numBatches - 1) * tilingSize;
+    void *tilingPtr = globalTilingData.data_ptr<uint8_t>() + tilingOffset;
+    const aclError copyResult = aclrtMemcpy(tilingPtr, tilingSize, &tilingData, tilingSize,
+                                            ACL_MEMCPY_HOST_TO_DEVICE);
+    TORCH_CHECK(copyResult == ACL_SUCCESS, "failed to copy gather_pa_kv_cache tiling data, error code: ", copyResult);
+
+    auto *platform = platform_ascendc::PlatformAscendCManager::GetInstance();
+    TORCH_CHECK(platform != nullptr, "failed to get AscendC platform information");
+    uint32_t blockDim = platform->GetCoreNumAiv();
+    TORCH_CHECK(blockDim > 0, "gather_pa_kv_cache requires at least one vector core");
+    if (isNz && key.size(0) > 0) {
+        blockDim = std::min(blockDim, static_cast<uint32_t>(key.size(0)));
+    }
+    return std::make_tuple(tilingPtr, blockDim);
+}
+
+}  // namespace gather_pa_kv_cache
+
+#endif  // VLLM_ASCEND_GATHER_PA_KV_CACHE_HOST_H

--- a/csrc/gather_pa_kv_cache/op_host/gather_pa_kv_cache_tiling.h
+++ b/csrc/gather_pa_kv_cache/op_host/gather_pa_kv_cache_tiling.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef GATHER_PA_KV_CACHE_TILING_H
+#define GATHER_PA_KV_CACHE_TILING_H
+
+#include <cstdint>
+
+constexpr int32_t TILING_KEY_NZ = 577;
+constexpr int32_t TILING_KEY_ND_INT8 = 618;
+constexpr int32_t TILING_KEY_ND_B16 = 619;
+
+struct GatherPaKvCacheTilingData {
+    int32_t blockSize;
+    int32_t numTokens;
+    int32_t numblkTabCol;
+    int32_t tokenSizeK;
+    int32_t tokenSizeV;
+    int32_t typeByte;
+    int32_t hasSeqStarts;
+    int32_t isSeqLensCumsum;
+    int64_t kCacheBlockStride;
+    int64_t vCacheBlockStride;
+    // vllm-ascend direct kernels do not receive the GE tiling key, so carry
+    // the original 577/618/619 key in the tiling payload.
+    int32_t tilingKey;
+};
+
+#endif  // GATHER_PA_KV_CACHE_TILING_H

--- a/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_kernel.cpp
+++ b/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_kernel.cpp
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#include "../op_host/gather_pa_kv_cache_tiling.h"
+#include "gather_pa_kv_cache_nd.h"
+#include "gather_pa_kv_cache_nz.h"
+#include "kernel_operator.h"
+using namespace AscendC;
+
+extern "C" __global__ __aicore__ void gather_pa_kv_cache(GM_ADDR keyCache, GM_ADDR valueCache, GM_ADDR blockTables,
+                                                         GM_ADDR seqLens, GM_ADDR key, GM_ADDR value, GM_ADDR seqOffset,
+                                                         GM_ADDR keyOut, GM_ADDR valueOut, GM_ADDR workspace,
+                                                         GM_ADDR tiling)
+{
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_AIV_ONLY);
+    AscendC::TPipe pipe;
+    auto tilingDataGm = reinterpret_cast<__gm__ GatherPaKvCacheTilingData *>(tiling);
+    GatherPaKvCacheTilingData tilingData = {
+        .blockSize = tilingDataGm->blockSize,
+        .numTokens = tilingDataGm->numTokens,
+        .numblkTabCol = tilingDataGm->numblkTabCol,
+        .tokenSizeK = tilingDataGm->tokenSizeK,
+        .tokenSizeV = tilingDataGm->tokenSizeV,
+        .typeByte = tilingDataGm->typeByte,
+        .hasSeqStarts = tilingDataGm->hasSeqStarts,
+        .isSeqLensCumsum = tilingDataGm->isSeqLensCumsum,
+        .kCacheBlockStride = tilingDataGm->kCacheBlockStride,
+        .vCacheBlockStride = tilingDataGm->vCacheBlockStride,
+        .tilingKey = tilingDataGm->tilingKey,
+    };
+
+    // The direct-kernel launcher has no GE tiling-key channel, so dispatch on
+    // the original key carried in the tiling payload.
+    if (tilingData.tilingKey == TILING_KEY_ND_INT8) {
+        GatherPaKvCache::GatherPaKvCacheNd<int8_t> op(&pipe);
+        op.Init(keyCache, valueCache, blockTables, seqLens, seqOffset, keyOut, valueOut, &tilingData);
+        op.Process();
+    }
+    if (tilingData.tilingKey == TILING_KEY_ND_B16) {
+        GatherPaKvCache::GatherPaKvCacheNd<half> op(&pipe);
+        op.Init(keyCache, valueCache, blockTables, seqLens, seqOffset, keyOut, valueOut, &tilingData);
+        op.Process();
+    }
+    if (tilingData.tilingKey == TILING_KEY_NZ) {
+        GatherPaKvCache::GatherPaKvCacheNz<int8_t> op(&pipe);
+        op.Init(keyCache, valueCache, blockTables, seqLens, seqOffset, keyOut, valueOut, &tilingData);
+        op.Process();
+    }
+}
+
+namespace vllm_ascend {
+
+extern void gather_pa_kv_cache_impl(void *stream, void *keyCache, void *valueCache, void *blockTables, void *seqLens,
+                                    void *seqOffset, void *keyOut, void *valueOut, void *tiling,
+                                    const uint32_t blockDim)
+{
+    gather_pa_kv_cache<<<blockDim, nullptr, stream>>>(keyCache, valueCache, blockTables, seqLens, keyOut, valueOut,
+                                                      seqOffset, keyOut, valueOut, nullptr, tiling);
+}
+
+}  // namespace vllm_ascend

--- a/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_nd.h
+++ b/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_nd.h
@@ -1,0 +1,224 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file gather_pa_kv_cache_nd.h
+ * \brief
+ */
+
+#ifndef GATHER_PA_KV_CACHE_ND_H_
+#define GATHER_PA_KV_CACHE_ND_H_
+
+#include "kernel_operator.h"
+namespace GatherPaKvCache {
+
+constexpr int32_t TYPEBYPE_ID = 5;
+constexpr int32_t UB_BUF_SIZE = 192 * 1024;
+constexpr int32_t VEC_SUBDIM = 2;
+
+template <typename T>
+class GatherPaKvCacheNd {
+public:
+    __aicore__ inline GatherPaKvCacheNd(AscendC::TPipe *p) : pipe(p){};
+    __aicore__ inline void Init(GM_ADDR keyCacheInGm, GM_ADDR valueCacheInGm, GM_ADDR blockTablesInGm,
+                                GM_ADDR seqLensInGm, GM_ADDR seqOffsetInGm, GM_ADDR keyOutGm, GM_ADDR valueOutGm,
+                                const GatherPaKvCacheTilingData *__restrict tilingData);
+    __aicore__ inline void Process();
+
+private:
+    __aicore__ inline int64_t GetBlockCacheOffset(
+        int32_t blockID, int64_t blockDataSize, int64_t cacheBlockStride) const
+    {
+        if (cacheBlockStride > 0) {
+            return static_cast<int64_t>(blockID) * cacheBlockStride;
+        }
+        return static_cast<int64_t>(blockID) * blockDataSize;
+    }
+    AscendC::TPipe *pipe;
+
+    // input
+
+    AscendC::GlobalTensor<T> inKeyCacheGM;
+    AscendC::GlobalTensor<T> inValueCacheGM;
+    AscendC::GlobalTensor<int32_t> inBlockTableGM;
+    AscendC::GlobalTensor<int32_t> inContextLenGM;
+    AscendC::GlobalTensor<int32_t> inseqOffsetGM;
+
+    // output
+    AscendC::GlobalTensor<T> outKeyGM;
+    AscendC::GlobalTensor<T> outValueGM;
+
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBuf;
+    AscendC::LocalTensor<T> tmpTensor;
+
+    // tiling param
+    int32_t blockSize = 0;
+    int32_t numBatchs = 0;
+    int32_t numblkTabCol = 0;
+    int32_t tokenSizeK = 0;
+    int32_t tokenSizeV = 0;
+    int32_t typeByte = 0;
+    int32_t hasSeqStarts = 0;
+    int32_t isSeqLensCumsum = 0;
+    int64_t kCacheBlockStride = 0;
+    int64_t vCacheBlockStride = 0;
+
+    int32_t ubLoopPerBlkK = 0;
+    int32_t ubLoopPerBlkV = 0;
+    int32_t ubBaseK = 0;
+    int32_t ubBaseV = 0;
+    int32_t ubBaseKTail = 0;
+    int32_t ubBaseVTail = 0;
+    int32_t cachelineBlkKTail = 0;
+    int32_t cachelineBlkVTail = 0;
+};
+
+template <typename T>
+__aicore__ inline void GatherPaKvCacheNd<T>::Init(GM_ADDR keyCacheInGm, GM_ADDR valueCacheInGm,
+                                                  GM_ADDR blockTablesInGm, GM_ADDR seqLensInGm,
+                                                  GM_ADDR seqOffsetInGm, GM_ADDR keyOutGm, GM_ADDR valueOutGm,
+                                                  const GatherPaKvCacheTilingData *__restrict tilingData)
+{
+    blockSize = tilingData->blockSize;
+    numBatchs = tilingData->numTokens;
+    numblkTabCol = tilingData->numblkTabCol;
+    tokenSizeK = tilingData->tokenSizeK;
+    tokenSizeV = tilingData->tokenSizeV;
+    typeByte = tilingData->typeByte;
+    hasSeqStarts = tilingData->hasSeqStarts;
+    isSeqLensCumsum = tilingData->isSeqLensCumsum;
+    kCacheBlockStride = tilingData->kCacheBlockStride;
+    vCacheBlockStride = tilingData->vCacheBlockStride;
+    // input
+    inKeyCacheGM.SetGlobalBuffer((__gm__ T *)keyCacheInGm);
+    inValueCacheGM.SetGlobalBuffer((__gm__ T *)valueCacheInGm);
+    inBlockTableGM.SetGlobalBuffer((__gm__ int32_t *)blockTablesInGm);
+    inContextLenGM.SetGlobalBuffer((__gm__ int32_t *)seqLensInGm);
+    inseqOffsetGM.SetGlobalBuffer((__gm__ int32_t *)seqOffsetInGm);
+    // output
+    outKeyGM.SetGlobalBuffer((__gm__ T *)keyOutGm);
+    outValueGM.SetGlobalBuffer((__gm__ T *)valueOutGm);
+
+    pipe->InitBuffer(tmpBuf, UB_BUF_SIZE); // ensure the size of one token less than 148kb
+    tmpTensor = tmpBuf.Get<T>();
+
+    ubLoopPerBlkK = (blockSize * tokenSizeK * sizeof(T) + UB_BUF_SIZE - 1) / UB_BUF_SIZE;
+    ubLoopPerBlkV = (blockSize * tokenSizeV * sizeof(T) + UB_BUF_SIZE - 1) / UB_BUF_SIZE;
+    int32_t cachelineBlkK = (blockSize * tokenSizeK * sizeof(T) + 512 - 1) / 512;
+    cachelineBlkKTail = blockSize * tokenSizeK * sizeof(T) % 512;
+    cachelineBlkKTail = cachelineBlkKTail == 0 ? 512 : cachelineBlkKTail;
+    ubBaseK = cachelineBlkK / ubLoopPerBlkK;
+    ubBaseKTail = cachelineBlkK % ubLoopPerBlkK;
+    int32_t cachelineBlkV = (blockSize * tokenSizeV * sizeof(T) + 512 - 1) / 512;
+    cachelineBlkVTail = blockSize * tokenSizeV * sizeof(T) % 512;
+    cachelineBlkVTail = cachelineBlkVTail == 0 ? 512 : cachelineBlkVTail;
+    ubBaseV = cachelineBlkV / ubLoopPerBlkV;
+    ubBaseVTail = cachelineBlkV % ubLoopPerBlkV;
+}
+
+template <typename T>
+__aicore__ inline void GatherPaKvCacheNd<T>::Process()
+{
+    int32_t vecIdx = AscendC::GetBlockIdx();  // current vector core id
+    int32_t coreNum = AscendC::GetBlockNum(); // total vector core number
+    vecIdx = (vecIdx % VEC_SUBDIM) * (coreNum / VEC_SUBDIM) + (vecIdx / VEC_SUBDIM);
+    int32_t taskID = 0;
+    int32_t tokenStart = 0;
+    if (isSeqLensCumsum)
+        tokenStart = inContextLenGM.GetValue(0);
+    for (int32_t batchId = 0; batchId < numBatchs; batchId++) {
+        int32_t tokenEnd, numToken;
+        if (isSeqLensCumsum) {
+            tokenEnd = inContextLenGM.GetValue(batchId + 1);
+            numToken = tokenEnd - tokenStart;
+        } else {
+            numToken = inContextLenGM.GetValue(batchId);
+            tokenEnd = tokenStart + numToken;
+        }
+        int32_t numBlk = (numToken + blockSize - 1) / blockSize;
+        int32_t lastBlkToken = numToken % blockSize;
+        lastBlkToken = lastBlkToken == 0 ? blockSize : lastBlkToken;
+        int32_t tableOffset = 0;
+        if (hasSeqStarts) {
+            tableOffset = inseqOffsetGM.GetValue(batchId) / blockSize;
+        }
+        for (int tableID = 0; tableID < numBlk; tableID++) {
+            int32_t blockID = inBlockTableGM.GetValue(batchId * numblkTabCol + tableOffset + tableID);
+            int32_t ubLoopPerBlkK_ = ubLoopPerBlkK;
+            int32_t ubLoopPerBlkV_ = ubLoopPerBlkV;
+            int32_t cachelineBlkKTail_ = cachelineBlkKTail;
+            int32_t ubBaseK_ = ubBaseK;
+            int32_t ubBaseKTail_ = ubBaseKTail;
+            int32_t cachelineBlkVTail_ = cachelineBlkVTail;
+            int32_t ubBaseV_ = ubBaseV;
+            int32_t ubBaseVTail_ = ubBaseVTail;
+            if (tableID == (numBlk - 1)) {
+                ubLoopPerBlkK_ = (lastBlkToken * tokenSizeK * sizeof(T) + UB_BUF_SIZE - 1) / UB_BUF_SIZE;
+                ubLoopPerBlkV_ = (lastBlkToken * tokenSizeV * sizeof(T) + UB_BUF_SIZE - 1) / UB_BUF_SIZE;
+                int32_t cachelineBlkK = (lastBlkToken * tokenSizeK * sizeof(T) + 512 - 1) / 512;
+                cachelineBlkKTail_ = lastBlkToken * tokenSizeK * sizeof(T) % 512;
+                cachelineBlkKTail_ = cachelineBlkKTail_ == 0 ? 512 : cachelineBlkKTail_;
+                ubBaseK_ = cachelineBlkK / ubLoopPerBlkK_;
+                ubBaseKTail_ = cachelineBlkK % ubLoopPerBlkK_;
+                int32_t cachelineBlkV = (lastBlkToken * tokenSizeV * sizeof(T) + 512 - 1) / 512;
+                cachelineBlkVTail_ = lastBlkToken * tokenSizeV * sizeof(T) % 512;
+                cachelineBlkVTail_ = cachelineBlkVTail_ == 0 ? 512 : cachelineBlkVTail_;
+                ubBaseV_ = cachelineBlkV / ubLoopPerBlkV_;
+                ubBaseVTail_ = cachelineBlkV % ubLoopPerBlkV_;
+            }
+            int32_t blkKOffset = 0;
+            for (int loopID = 0; loopID < ubLoopPerBlkK_; loopID++) {
+                int32_t realUbBaseK_ = (ubBaseK_ + (loopID < ubBaseKTail_ ? 1 : 0)) * 512 / sizeof(T);
+                if (loopID == (ubLoopPerBlkK_ - 1)) {
+                    realUbBaseK_ += (cachelineBlkKTail_ - 512) / sizeof(T);
+                }
+                if (taskID++ % coreNum == vecIdx) {
+                    uint16_t copyLen = realUbBaseK_ * sizeof(T) / 32;
+                    AscendC::DataCopyParams copyParams = {1, copyLen, 0, 0};
+                    int64_t kBlockStart = GetBlockCacheOffset(
+                        blockID, static_cast<int64_t>(blockSize) * tokenSizeK, kCacheBlockStride);
+                    DataCopy(tmpTensor, inKeyCacheGM[kBlockStart + blkKOffset], copyParams);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+                    DataCopy(outKeyGM[(tokenStart + tableID * blockSize) * tokenSizeK + blkKOffset], tmpTensor,
+                             copyParams);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+                }
+                blkKOffset += realUbBaseK_;
+            }
+            int32_t blkVOffset = 0;
+            for (int loopID = 0; loopID < ubLoopPerBlkV_; loopID++) {
+                int32_t realUbBaseV_ = (ubBaseV_ + (loopID < ubBaseVTail_ ? 1 : 0)) * 512 / sizeof(T);
+                if (loopID == (ubLoopPerBlkV_ - 1)) {
+                    realUbBaseV_ += (cachelineBlkVTail_ - 512) / sizeof(T);
+                }
+                if (taskID++ % coreNum == vecIdx) {
+                    uint16_t copyLen = realUbBaseV_ * sizeof(T) / 32;
+                    AscendC::DataCopyParams copyParams = {1, copyLen, 0, 0};
+                    int64_t vBlockStart = GetBlockCacheOffset(
+                        blockID, static_cast<int64_t>(blockSize) * tokenSizeV, vCacheBlockStride);
+                    DataCopy(tmpTensor, inValueCacheGM[vBlockStart + blkVOffset], copyParams);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE2_MTE3>(EVENT_ID1);
+                    DataCopy(outValueGM[(tokenStart + tableID * blockSize) * tokenSizeV + blkVOffset], tmpTensor,
+                             copyParams);
+                    AscendC::SetFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+                    AscendC::WaitFlag<AscendC::HardEvent::MTE3_MTE2>(EVENT_ID1);
+                }
+                blkVOffset += realUbBaseV_;
+            }
+        }
+        tokenStart = tokenEnd;
+    }
+}
+} // namespace GatherPaKvCache
+
+#endif // GATHER_PA_KV_CACHE_ND_H_

--- a/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_nz.h
+++ b/csrc/gather_pa_kv_cache/op_kernel/gather_pa_kv_cache_nz.h
@@ -1,0 +1,254 @@
+/**
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file gather_pa_kv_cache_nz.h
+ * \brief
+ */
+
+#ifndef GATHER_PA_KV_CACHE_NZ_H_
+#define GATHER_PA_KV_CACHE_NZ_H_
+#include "kernel_operator.h"
+
+namespace GatherPaKvCache {
+
+constexpr int32_t BLOCK_SIZE = 32;
+constexpr int32_t UB_LOCATE_INFO_SIZE = 40 * 1024;
+constexpr int32_t BUF_NUM_LOCATE_INFO = 2;
+constexpr int32_t UB_TMP_BUF_SIZE = 148 * 1024;
+constexpr uint16_t DATA_COPY_MAX_BLKCNT = 4095;
+
+template <typename T>
+class GatherPaKvCacheNz {
+public:
+    __aicore__ inline GatherPaKvCacheNz(AscendC::TPipe *p) : pipe(p){};
+    __aicore__ inline void Init(GM_ADDR keyCacheInGm, GM_ADDR valueCacheInGm, GM_ADDR blockTablesInGm,
+                                GM_ADDR seqLensInGm, GM_ADDR seqOffsetInGm, GM_ADDR keyOutGm, GM_ADDR valueOutGm,
+                                const GatherPaKvCacheTilingData *__restrict tilingData);
+    __aicore__ inline void Process();
+    __aicore__ inline void CopyLocateInfoIn(int32_t tokenId);
+    __aicore__ inline void RestoreDataFromCache(int32_t blkTabValue, int32_t blockOffset, int32_t numRsltProc,
+                                                int32_t ctxtId, bool isKeyValue);
+
+private:
+    AscendC::TPipe *pipe;
+
+    // input
+
+    AscendC::GlobalTensor<T> inKeyCacheGM;
+    AscendC::GlobalTensor<T> inValueCacheGM;
+    AscendC::GlobalTensor<int32_t> inBlockTableGM;
+    AscendC::GlobalTensor<int32_t> inContextLenGM;
+    AscendC::GlobalTensor<int32_t> inseqOffsetGM;
+
+    // output
+    AscendC::GlobalTensor<T> outKeyGM;
+    AscendC::GlobalTensor<T> outValueGM;
+
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> locateInfoBuf;
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBuf;
+
+    AscendC::LocalTensor<int32_t> contextLenTensor;
+    AscendC::LocalTensor<int32_t> blockTableTensor;
+    AscendC::LocalTensor<T> tmpTensor;
+
+    // tiling param
+    int32_t blockSize = 0;
+    int32_t numTokens = 0;
+    int32_t numblkTabCol = 0;
+    int32_t tokenSizeK = 0;
+    int32_t tokenSizeV = 0;
+    int32_t typeByte = 0;
+    int32_t hasSeqStarts = 0;
+    int32_t isSeqLensCumsum = 0;
+    int64_t kCacheBlockStride = 0;
+    int64_t vCacheBlockStride = 0;
+
+    uint32_t maxNumTokens = 0;
+    uint32_t eleNumPerBlk = 0;
+};
+
+template <typename T>
+__aicore__ inline void GatherPaKvCacheNz<T>::Init(GM_ADDR keyCacheInGm, GM_ADDR valueCacheInGm,
+                                                  GM_ADDR blockTablesInGm, GM_ADDR seqLensInGm,
+                                                  GM_ADDR seqOffsetInGm, GM_ADDR keyOutGm, GM_ADDR valueOutGm,
+                                                  const GatherPaKvCacheTilingData *__restrict tilingData)
+{
+    this->blockSize = tilingData->blockSize;
+    this->numTokens = tilingData->numTokens;
+    this->numblkTabCol = tilingData->numblkTabCol;
+    this->tokenSizeK = tilingData->tokenSizeK;
+    this->tokenSizeV = tilingData->tokenSizeV;
+    this->typeByte = tilingData->typeByte;
+    this->hasSeqStarts = tilingData->hasSeqStarts;
+    this->isSeqLensCumsum = tilingData->isSeqLensCumsum;
+    this->kCacheBlockStride = tilingData->kCacheBlockStride;
+    this->vCacheBlockStride = tilingData->vCacheBlockStride;
+    // input
+    this->inKeyCacheGM.SetGlobalBuffer((__gm__ T *)keyCacheInGm);
+    this->inValueCacheGM.SetGlobalBuffer((__gm__ T *)valueCacheInGm);
+    this->inBlockTableGM.SetGlobalBuffer((__gm__ int32_t *)blockTablesInGm);
+    this->inContextLenGM.SetGlobalBuffer((__gm__ int32_t *)seqLensInGm);
+    this->inseqOffsetGM.SetGlobalBuffer((__gm__ int32_t *)seqOffsetInGm);
+    // output
+    this->outKeyGM.SetGlobalBuffer((__gm__ T *)keyOutGm);
+    this->outValueGM.SetGlobalBuffer((__gm__ T *)valueOutGm);
+
+    this->pipe->InitBuffer(this->locateInfoBuf, UB_LOCATE_INFO_SIZE); // 40kb, save context len and block table
+    this->pipe->InitBuffer(this->tmpBuf, UB_TMP_BUF_SIZE);            // ensure the size of one token less than 148kb
+
+    // max number of context len per copy
+    this->maxNumTokens =
+        (UB_LOCATE_INFO_SIZE - BUF_NUM_LOCATE_INFO * BLOCK_SIZE) / sizeof(int32_t) / (this->numblkTabCol + 1);
+
+    // Reserve the cumulative sequence-length endpoint before the block-table
+    // region. The upstream GE path relies on this extra value being available.
+    int32_t maxBlkNumTokensRnd = ((this->maxNumTokens + 1) * sizeof(int32_t) - 1) / BLOCK_SIZE + 1;
+    int32_t maxNumTokensRnd = maxBlkNumTokensRnd * BLOCK_SIZE / sizeof(int32_t);
+
+    AscendC::LocalTensor<int32_t> locateInfoTensor = locateInfoBuf.Get<int32_t>();
+    this->contextLenTensor = locateInfoTensor[0];
+    this->blockTableTensor = locateInfoTensor[maxNumTokensRnd];
+    this->tmpTensor = tmpBuf.Get<T>();
+    this->eleNumPerBlk = BLOCK_SIZE / this->typeByte; // fp16, bf16, int8
+}
+
+template <typename T>
+__aicore__ inline void GatherPaKvCacheNz<T>::CopyLocateInfoIn(int32_t tokenId)
+{
+    int64_t copyNum = this->numTokens - tokenId;
+    if (copyNum > this->maxNumTokens) {
+        copyNum = this->maxNumTokens;
+    }
+
+    // Cumulative sequence lengths contain one more element than batch rows.
+    int64_t ctxtLenCopyNum = copyNum + (this->isSeqLensCumsum ? 1 : 0);
+    uint16_t ctxtLenBlkNum =
+        (ctxtLenCopyNum * sizeof(int32_t) - 1) / BLOCK_SIZE + 1; // block number
+    uint16_t blkTabBlkNum =
+        (copyNum * this->numblkTabCol * sizeof(int32_t) - 1) / BLOCK_SIZE + 1; // block number
+
+    AscendC::DataCopyParams ctxtLenCopyParams = {1, ctxtLenBlkNum, 0, 0};
+    AscendC::DataCopyParams blkTabCopyParams = {1, blkTabBlkNum, 0, 0};
+
+    DataCopy(this->contextLenTensor, this->inContextLenGM[static_cast<uint64_t>(tokenId)], ctxtLenCopyParams);
+    DataCopy(this->blockTableTensor, this->inBlockTableGM[static_cast<uint64_t>(tokenId * this->numblkTabCol)],
+             blkTabCopyParams);
+    AscendC::PipeBarrier<PIPE_ALL>();
+}
+
+template <typename T>
+__aicore__ inline void GatherPaKvCacheNz<T>::RestoreDataFromCache(int32_t blkTabValue, int32_t blockOffset,
+                                                                  int32_t numRsltProc, int32_t ctxtId, bool isKeyValue)
+{
+    // default is key
+    AscendC::GlobalTensor<T> inCacheGM = this->inKeyCacheGM;
+    AscendC::GlobalTensor<T> outGM = this->outKeyGM;
+    uint64_t tokenSize = this->tokenSizeK; // improve precision to avoid out of gm addr limit
+    int64_t cacheBlockStride = this->kCacheBlockStride;
+    if (!isKeyValue) {
+        inCacheGM = this->inValueCacheGM;
+        outGM = this->outValueGM;
+        tokenSize = this->tokenSizeV;
+        cacheBlockStride = this->vCacheBlockStride;
+    }
+
+    uint64_t start = (numRsltProc + ctxtId) * tokenSize * this->typeByte / sizeof(int8_t); // use int8 as T commonly
+    uint64_t cacheBlockStart = cacheBlockStride > 0
+                                   ? static_cast<uint64_t>(blkTabValue) * cacheBlockStride
+                                   : static_cast<uint64_t>(blkTabValue) * this->blockSize * tokenSize;
+    uint64_t cacheStart =
+        (cacheBlockStart + blockOffset * this->eleNumPerBlk) * this->typeByte / sizeof(int8_t);
+
+    uint16_t inBlkCnt = tokenSize / this->eleNumPerBlk; // max number is 4095
+    uint16_t inBlkLen = 1;
+    uint16_t inSrcStride = this->blockSize - 1;
+    uint16_t inDstStride = 0;
+
+    AscendC::DataCopyParams copyInParams = {inBlkCnt, inBlkLen, inSrcStride, inDstStride};
+
+    if (inBlkCnt > DATA_COPY_MAX_BLKCNT) {
+        // use int8 as T commonly
+        uint32_t localOffset = DATA_COPY_MAX_BLKCNT * BLOCK_SIZE / sizeof(int8_t);
+        uint64_t globalOffset = DATA_COPY_MAX_BLKCNT * this->blockSize * BLOCK_SIZE / sizeof(int8_t);
+
+        DataCopy(this->tmpTensor, inCacheGM[cacheStart], {DATA_COPY_MAX_BLKCNT, inBlkLen, inSrcStride, inDstStride});
+
+        uint16_t leftBlkCnt = inBlkCnt - DATA_COPY_MAX_BLKCNT;
+        DataCopy(this->tmpTensor[localOffset], inCacheGM[cacheStart + globalOffset],
+                 {leftBlkCnt, inBlkLen, inSrcStride, inDstStride});
+    } else {
+        DataCopy(this->tmpTensor, inCacheGM[cacheStart], copyInParams);
+    }
+    AscendC::PipeBarrier<PIPE_ALL>();
+
+    uint16_t outBlkLen = tokenSize * this->typeByte / BLOCK_SIZE; // fp16, bf16, int8
+    AscendC::DataCopyParams copyOutParams = {1, outBlkLen, 0, 0};
+
+    DataCopy(outGM[start], this->tmpTensor, copyOutParams);
+    AscendC::PipeBarrier<PIPE_ALL>();
+}
+
+template <typename T>
+__aicore__ inline void GatherPaKvCacheNz<T>::Process()
+{
+    int32_t vecIdx = AscendC::GetBlockIdx();  // current vector core id
+    int32_t coreNum = AscendC::GetBlockNum(); // total vector core number
+
+    int32_t numRsltProc = 0;
+    // Valid cumulative sequence lengths start at zero. The first UB copy
+    // happens below, so do not read contextLenTensor before it is populated.
+    int32_t ctxtStart = 0;
+
+    for (int32_t tokenId = 0; tokenId < this->numTokens; tokenId++) {
+        int32_t localtokenId = tokenId % this->maxNumTokens;
+
+        // copy partial block table in ub when local data is used up
+        if (localtokenId == 0) {
+            CopyLocateInfoIn(tokenId);
+        }
+
+        // get the context len of current token
+        int32_t ctxtLenValue;
+        if (this->isSeqLensCumsum) {
+            int32_t ctxtEnd = this->contextLenTensor.GetValue(localtokenId + 1);
+            ctxtLenValue = ctxtEnd - ctxtStart;
+            ctxtStart = ctxtEnd;
+        } else {
+            ctxtLenValue = this->contextLenTensor.GetValue(localtokenId);
+        }
+
+        uint32_t localBlkTabId = 0;
+        int32_t blkTabValue = 0;
+        for (int32_t ctxtId = 0; ctxtId < ctxtLenValue; ctxtId++) {
+            // need to change block id when block offset is equal to zero
+            int32_t blkOffset = ctxtId % this->blockSize;
+            if (blkOffset == 0) {
+                localBlkTabId = localtokenId * this->numblkTabCol + ctxtId / this->blockSize;
+                if (this->hasSeqStarts)
+                    localBlkTabId += this->inseqOffsetGM.GetValue(tokenId) / this->blockSize;
+                blkTabValue = this->blockTableTensor.GetValue(localBlkTabId);
+            }
+
+            // process one matrix every time for each core
+            if (ctxtId % coreNum != vecIdx) {
+                continue;
+            }
+
+            // process key and value
+            RestoreDataFromCache(blkTabValue, blkOffset, numRsltProc, ctxtId, true);
+            RestoreDataFromCache(blkTabValue, blkOffset, numRsltProc, ctxtId, false);
+        }
+        numRsltProc += ctxtLenValue;
+    }
+}
+} // namespace GatherPaKvCache
+
+#endif // GATHER_PA_KV_CACHE_NZ_H_

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -131,4 +131,17 @@ namespace vllm_ascend {
         void* gm_tiling_data,
         const uint32_t block_dim
     );
+
+    extern void gather_pa_kv_cache_impl(
+        void* stream,
+        void* key_cache,
+        void* value_cache,
+        void* block_tables,
+        void* seq_lens,
+        void* seq_offset,
+        void* key,
+        void* value,
+        void* tiling,
+        const uint32_t block_dim
+    );
 }

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -32,6 +32,7 @@
 #include "moe/add_rms_norm_bias/add_rms_norm_bias_torch_adpt.h"
 #ifdef VLLM_ENABLE_ATB_AND_DIRECT_KERNELS
 #include "batch_matmul_transpose/batch_matmul_transpose_torch_adpt.h"
+#include "gather_pa_kv_cache/gather_pa_kv_cache_torch_adpt.h"
 #include "mla_preprocess/mla_preprocess_torch_adpt.h"
 #endif
 #include "mc2/dispatch_ffn_combine/dispatch_ffn_combine_torch_adpt.h"
@@ -2093,6 +2094,12 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
     ops.def(
             "batch_matmul_transpose(Tensor tensor_a, Tensor tensor_b, Tensor tensor_c, str? format_mode=None, str? quant_mode=None) -> ()");
     ops.impl("batch_matmul_transpose", torch::kPrivateUse1, &vllm_ascend::batch_matmul_transpose);
+
+    ops.def(
+        "gather_pa_kv_cache(Tensor key_cache, Tensor value_cache, Tensor block_tables, Tensor seq_lens, "
+        "                   Tensor(a!) key, Tensor(b!) value, *, Tensor? seq_offset=None, "
+        "                   str cache_mode=\"Norm\", bool is_seq_lens_cumsum=False) -> ()");
+    ops.impl("gather_pa_kv_cache", torch::kPrivateUse1, &vllm_ascend::gather_pa_kv_cache);
 
     ops.def("swap_blocks(Tensor! x, Tensor! y, Tensor z) -> ()");
     ops.impl("swap_blocks", torch::kPrivateUse1, &vllm_ascend::swap_blocks);

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -102,6 +102,15 @@ void batch_matmul_transpose(const at::Tensor &tensor_a, const at::Tensor &tensor
 {
     return;
 }
+
+void gather_pa_kv_cache(const at::Tensor &key_cache, const at::Tensor &value_cache,
+                        const at::Tensor &block_tables, const at::Tensor &seq_lens,
+                        at::Tensor &key, at::Tensor &value,
+                        const c10::optional<at::Tensor> &seq_offset, c10::string_view cache_mode,
+                        bool is_seq_lens_cumsum)
+{
+    return;
+}
 #endif
 
 void device_print_meta(c10::string_view msg)
@@ -1953,6 +1962,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("mla_preprocess", &vllm_ascend::meta::mla_preprocess);
     // batch_matmul_transpose
     ops.impl("batch_matmul_transpose", &vllm_ascend::meta::batch_matmul_transpose);
+    // gather_pa_kv_cache
+    ops.impl("gather_pa_kv_cache", &vllm_ascend::meta::gather_pa_kv_cache);
 #endif
     // grouped_matmul_swiglu_quant_weight_nz meta implementation
     ops.impl("grouped_matmul_swiglu_quant_weight_nz", &vllm_ascend::meta::grouped_matmul_swiglu_quant);

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gather_pa_kv_cache.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/test_gather_pa_kv_cache.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
+
+
+def _make_cache(shape: tuple[int, ...], dtype: torch.dtype) -> torch.Tensor:
+    if dtype == torch.int8:
+        return torch.randint(-128, 128, shape, dtype=dtype)
+    return torch.randn(shape, dtype=torch.float32).to(dtype)
+
+
+def _golden(
+    cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    seq_offset: torch.Tensor | None,
+    is_seq_lens_cumsum: bool,
+) -> torch.Tensor:
+    block_size = cache.size(1)
+    if is_seq_lens_cumsum:
+        lengths = seq_lens[1:] - seq_lens[:-1]
+    else:
+        lengths = seq_lens
+
+    gathered = []
+    for batch_id, length in enumerate(lengths.tolist()):
+        table_offset = 0 if seq_offset is None else int(seq_offset[batch_id]) // block_size
+        block_count = (length + block_size - 1) // block_size
+        block_ids = block_tables[batch_id, table_offset : table_offset + block_count].to(torch.int64)
+        gathered.append(cache.index_select(0, block_ids).flatten(0, 1)[:length])
+    return torch.cat(gathered)
+
+
+def _to_pa_nz(cache: torch.Tensor) -> torch.Tensor:
+    num_blocks, block_size, token_size = cache.shape
+    assert cache.dtype == torch.int8
+    assert token_size % 32 == 0
+    return cache.view(num_blocks, block_size, token_size // 32, 32).permute(0, 2, 1, 3).contiguous()
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.int8])
+@pytest.mark.parametrize("is_seq_lens_cumsum", [False, True])
+def test_gather_pa_kv_cache(dtype: torch.dtype, is_seq_lens_cumsum: bool):
+    num_blocks = 12
+    block_size = 4
+    num_heads = 2
+    key_head_size = 64
+    value_head_size = 32
+
+    # Keep only every second physical block to exercise stride-aware cache access.
+    key_storage = _make_cache((num_blocks * 2, block_size, num_heads, key_head_size), dtype)
+    value_storage = _make_cache((num_blocks * 2, block_size, num_heads, value_head_size), dtype)
+    key_cache = key_storage[::2]
+    value_cache = value_storage[::2]
+    key_cache_npu = key_storage.npu()[::2]
+    value_cache_npu = value_storage.npu()[::2]
+    assert not key_cache_npu.is_contiguous()
+    assert not value_cache_npu.is_contiguous()
+
+    if is_seq_lens_cumsum:
+        block_tables = torch.tensor([[9, 2, 7, 4], [1, 8, 3, 6]], dtype=torch.int32)
+        seq_lens = torch.tensor([0, 6, 15], dtype=torch.int32)
+        seq_offset = None
+    else:
+        block_tables = torch.tensor([[0, 9, 2, 7], [1, 8, 3, 6]], dtype=torch.int32)
+        seq_lens = torch.tensor([6, 9], dtype=torch.int32)
+        seq_offset = torch.tensor([block_size, 0], dtype=torch.int32)
+
+    expected_key = _golden(key_cache, block_tables, seq_lens, seq_offset, is_seq_lens_cumsum)
+    expected_value = _golden(value_cache, block_tables, seq_lens, seq_offset, is_seq_lens_cumsum)
+    key = torch.empty_like(expected_key, device="npu")
+    value = torch.empty_like(expected_value, device="npu")
+
+    torch.ops._C_ascend.gather_pa_kv_cache(
+        key_cache_npu,
+        value_cache_npu,
+        block_tables.npu(),
+        seq_lens.npu(),
+        key,
+        value,
+        seq_offset=None if seq_offset is None else seq_offset.npu(),
+        is_seq_lens_cumsum=is_seq_lens_cumsum,
+    )
+
+    torch.testing.assert_close(key.cpu(), expected_key, rtol=0, atol=0)
+    torch.testing.assert_close(value.cpu(), expected_value, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("is_seq_lens_cumsum", [False, True])
+def test_gather_pa_kv_cache_pa_nz(is_seq_lens_cumsum: bool):
+    num_blocks = 12
+    block_size = 4
+    key_token_size = 96
+    value_token_size = 160
+    key_cache = _make_cache((num_blocks, block_size, key_token_size), torch.int8)
+    value_cache = _make_cache((num_blocks, block_size, value_token_size), torch.int8)
+
+    # PA_NZ is [num_blocks, token_size // 32, block_size, 32].
+    key_nz = _to_pa_nz(key_cache).repeat_interleave(2, dim=0).npu()[::2]
+    value_nz = _to_pa_nz(value_cache).repeat_interleave(2, dim=0).npu()[::2]
+    assert not key_nz.is_contiguous()
+    assert not value_nz.is_contiguous()
+
+    if is_seq_lens_cumsum:
+        block_tables = torch.tensor([[9, 2, 7, 4], [1, 8, 3, 6]], dtype=torch.int32)
+        seq_lens = torch.tensor([0, 6, 15], dtype=torch.int32)
+        seq_offset = None
+    else:
+        block_tables = torch.tensor([[0, 9, 2, 7], [1, 8, 3, 6]], dtype=torch.int32)
+        seq_lens = torch.tensor([6, 9], dtype=torch.int32)
+        seq_offset = torch.tensor([block_size, 0], dtype=torch.int32)
+
+    expected_key = _golden(key_cache, block_tables, seq_lens, seq_offset, is_seq_lens_cumsum)
+    expected_value = _golden(value_cache, block_tables, seq_lens, seq_offset, is_seq_lens_cumsum)
+    key = torch.empty_like(expected_key, device="npu")
+    value = torch.empty_like(expected_value, device="npu")
+
+    torch.ops._C_ascend.gather_pa_kv_cache(
+        key_nz,
+        value_nz,
+        block_tables.npu(),
+        seq_lens.npu(),
+        key,
+        value,
+        seq_offset=None if seq_offset is None else seq_offset.npu(),
+        cache_mode="PA_NZ",
+        is_seq_lens_cumsum=is_seq_lens_cumsum,
+    )
+
+    torch.testing.assert_close(key.cpu(), expected_key, rtol=0, atol=0)
+    torch.testing.assert_close(value.cpu(), expected_value, rtol=0, atol=0)
+
+
+def test_gather_pa_kv_cache_pa_nz_large_token():
+    # More than 4095 data blocks exercises the PA_NZ two-part GM-to-UB copy.
+    num_blocks = 5
+    block_size = 2
+    key_token_size = 32 * 4100
+    value_token_size = 32 * 4097
+    key_cache = _make_cache((num_blocks, block_size, key_token_size), torch.int8)
+    value_cache = _make_cache((num_blocks, block_size, value_token_size), torch.int8)
+    block_tables = torch.tensor([[4, 1]], dtype=torch.int32)
+    seq_lens = torch.tensor([3], dtype=torch.int32)
+    expected_key = _golden(key_cache, block_tables, seq_lens, None, False)
+    expected_value = _golden(value_cache, block_tables, seq_lens, None, False)
+    key = torch.empty_like(expected_key, device="npu")
+    value = torch.empty_like(expected_value, device="npu")
+
+    torch.ops._C_ascend.gather_pa_kv_cache(
+        _to_pa_nz(key_cache).npu(),
+        _to_pa_nz(value_cache).npu(),
+        block_tables.npu(),
+        seq_lens.npu(),
+        key,
+        value,
+        cache_mode="PA_NZ",
+    )
+
+    torch.testing.assert_close(key.cpu(), expected_key, rtol=0, atol=0)
+    torch.testing.assert_close(value.cpu(), expected_value, rtol=0, atol=0)
+
+
+def test_gather_pa_kv_cache_rejects_unaligned_token_size():
+    key_cache = torch.zeros((2, 4, 1, 3), dtype=torch.float16, device="npu")
+    value_cache = torch.zeros_like(key_cache)
+    block_tables = torch.zeros((1, 1), dtype=torch.int32, device="npu")
+    seq_lens = torch.ones((1,), dtype=torch.int32, device="npu")
+    key = torch.empty((1, 1, 3), dtype=torch.float16, device="npu")
+    value = torch.empty_like(key)
+
+    with pytest.raises(RuntimeError, match="key token size in bytes must be aligned"):
+        torch.ops._C_ascend.gather_pa_kv_cache(
+            key_cache,
+            value_cache,
+            block_tables,
+            seq_lens,
+            key,
+            value,
+        )
+
+
+def test_gather_pa_kv_cache_pa_nz_rejects_non_int8():
+    key_cache = torch.zeros((2, 1, 4, 16), dtype=torch.float16, device="npu")
+    value_cache = torch.zeros_like(key_cache)
+    block_tables = torch.zeros((1, 1), dtype=torch.int32, device="npu")
+    seq_lens = torch.ones((1,), dtype=torch.int32, device="npu")
+    key = torch.empty((1, 16), dtype=torch.float16, device="npu")
+    value = torch.empty_like(key)
+
+    with pytest.raises(RuntimeError, match="PA_NZ mode only supports int8"):
+        torch.ops._C_ascend.gather_pa_kv_cache(
+            key_cache,
+            value_cache,
+            block_tables,
+            seq_lens,
+            key,
+            value,
+            cache_mode="PA_NZ",
+        )

--- a/tests/e2e/pull_request/one_card/test_mla_precision.py
+++ b/tests/e2e/pull_request/one_card/test_mla_precision.py
@@ -18,6 +18,9 @@ from tests.e2e.pull_request.one_card.attention_utils import (
     create_vllm_config,
 )
 from vllm_ascend.attention.utils import AscendCommonAttentionMetadata
+from vllm_ascend.utils import enable_custom_op
+
+enable_custom_op()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1935,7 +1935,6 @@ class TestAscendMLAImpl(TestBase):
         self.assertTrue(torch.equal(prefix_out, out))
         self.assertTrue(torch.equal(prefix_lse, lse))
 
-    @patch("vllm_ascend.device.device_op.enable_custom_op", new=lambda: True)
     @patch.object(torch.ops._C_ascend, "gather_pa_kv_cache", create=True)
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
@@ -1984,7 +1983,6 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(out.shape, prefix_out.shape)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    @patch("vllm_ascend.device.device_op.enable_custom_op", new=lambda: True)
     @patch.object(torch.ops._C_ascend, "gather_pa_kv_cache", create=True)
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")

--- a/tests/ut/attention/test_mla_v1.py
+++ b/tests/ut/attention/test_mla_v1.py
@@ -1935,7 +1935,8 @@ class TestAscendMLAImpl(TestBase):
         self.assertTrue(torch.equal(prefix_out, out))
         self.assertTrue(torch.equal(prefix_lse, lse))
 
-    @patch("torch_npu.npu_gather_pa_kv_cache")
+    @patch("vllm_ascend.device.device_op.enable_custom_op", new=lambda: True)
+    @patch.object(torch.ops._C_ascend, "gather_pa_kv_cache", create=True)
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_compute_prefill_context(self, mock_fia, mock_update, mock_load):
@@ -1983,7 +1984,8 @@ class TestAscendMLAImpl(TestBase):
         self.assertEqual(out.shape, prefix_out.shape)
 
     @patch("vllm_ascend.attention.mla_v1.get_current_vllm_config")
-    @patch("torch_npu.npu_gather_pa_kv_cache")
+    @patch("vllm_ascend.device.device_op.enable_custom_op", new=lambda: True)
+    @patch.object(torch.ops._C_ascend, "gather_pa_kv_cache", create=True)
     @patch("torch_npu.npu_attention_update")
     @patch("torch_npu.npu_fused_infer_attention_score")
     def test_compute_prefill_context_non_power_of_two_heads(

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -47,7 +47,10 @@ def test_kv_cache_load_makes_seq_lens_contiguous():
 
     assert not context_seq_len_npu.is_contiguous()
 
-    with mock.patch("vllm_ascend.device.device_op.torch_npu.npu_gather_pa_kv_cache") as mock_gather:
+    with (
+        mock.patch("vllm_ascend.device.device_op.enable_custom_op", return_value=True) as mock_enable,
+        mock.patch.object(torch.ops._C_ascend, "gather_pa_kv_cache", create=True) as mock_gather,
+    ):
         BaseDeviceAdaptor.kv_cache_load(
             cache_kv_c,
             cache_k_pe,
@@ -58,6 +61,7 @@ def test_kv_cache_load_makes_seq_lens_contiguous():
             value,
         )
 
+    mock_enable.assert_called_once_with()
     mock_gather.assert_called_once()
     call_args = mock_gather.call_args.args
     assert call_args[0] is cache_kv_c
@@ -66,9 +70,9 @@ def test_kv_cache_load_makes_seq_lens_contiguous():
     assert call_args[3] is not context_seq_len_npu
     assert call_args[3].is_contiguous()
     torch.testing.assert_close(call_args[3], context_seq_len_npu)
+    assert call_args[4] is key
+    assert call_args[5] is value
     assert mock_gather.call_args.kwargs["seq_offset"] is seq_starts
-    assert mock_gather.call_args.kwargs["key"] is key
-    assert mock_gather.call_args.kwargs["value"] is value
 
 
 def test_npu_flash_attention_uses_fusion_attention_for_fp32():

--- a/tests/ut/device/test_device_op.py
+++ b/tests/ut/device/test_device_op.py
@@ -47,10 +47,7 @@ def test_kv_cache_load_makes_seq_lens_contiguous():
 
     assert not context_seq_len_npu.is_contiguous()
 
-    with (
-        mock.patch("vllm_ascend.device.device_op.enable_custom_op", return_value=True) as mock_enable,
-        mock.patch.object(torch.ops._C_ascend, "gather_pa_kv_cache", create=True) as mock_gather,
-    ):
+    with mock.patch.object(torch.ops._C_ascend, "gather_pa_kv_cache", create=True) as mock_gather:
         BaseDeviceAdaptor.kv_cache_load(
             cache_kv_c,
             cache_k_pe,
@@ -61,7 +58,6 @@ def test_kv_cache_load_makes_seq_lens_contiguous():
             value,
         )
 
-    mock_enable.assert_called_once_with()
     mock_gather.assert_called_once()
     call_args = mock_gather.call_args.args
     assert call_args[0] is cache_kv_c

--- a/vllm_ascend/device/device_op.py
+++ b/vllm_ascend/device/device_op.py
@@ -289,14 +289,14 @@ class BaseDeviceAdaptor:
 
     @staticmethod
     def kv_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_starts, key, value):
-        torch_npu.npu_gather_pa_kv_cache(
+        torch.ops._C_ascend.gather_pa_kv_cache(
             cache_kv_c,
             cache_k_pe,
             block_table,
             context_seq_len_npu.contiguous(),
+            key,
+            value,
             seq_offset=seq_starts,
-            key=key,
-            value=value,
         )
 
     @staticmethod
@@ -1556,6 +1556,18 @@ class Ascend310PDeviceAdaptor(BaseDeviceAdaptor):
             key_cache=key_cache,
             value_cache=value_cache,
             slot_indices=slot_mapping,
+        )
+
+    @staticmethod
+    def kv_cache_load(cache_kv_c, cache_k_pe, block_table, context_seq_len_npu, seq_offset, key, value):
+        torch_npu.npu_gather_pa_kv_cache(
+            cache_kv_c,
+            cache_k_pe,
+            block_table,
+            context_seq_len_npu.contiguous(),
+            seq_offset=seq_offset,
+            key=key,
+            value=value,
         )
 
     @staticmethod

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_connector.py
@@ -58,6 +58,7 @@ from vllm.v1.request import RequestStatus
 
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
 from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec, AscendSlidingWindowMLASpec
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
     RegisterRegions,
@@ -1368,14 +1369,14 @@ class KVCacheRecvingThread(threading.Thread):
         # Process each layer in the KV cache
         for _, (k_cache_layer, v_cache_layer) in kv_caches.items():
             # Load cache data into buffers
-            torch_npu.npu_gather_pa_kv_cache(
+            DeviceOperator.kv_cache_load(
                 k_cache_layer,
                 v_cache_layer,
                 block_table,
                 block_len_tensor,
-                seq_offset=seq_start_tensor,
-                key=k_buffer,
-                value=v_buffer,
+                seq_start_tensor,
+                k_buffer,
+                v_buffer,
             )
             if need_cat_cache:
                 self._cat_kv_cache(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_hybrid_connector.py
@@ -52,6 +52,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.request import RequestStatus
 
 from vllm_ascend.ascend_config import get_ascend_config, init_ascend_config
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import get_transfer_timeout_value
 from vllm_ascend.utils import enable_custom_op, is_vl_model
@@ -933,14 +934,14 @@ class KVCacheRecvingThread(threading.Thread):
         # Process each layer in the KV cache
         for _, (k_cache_layer, v_cache_layer) in self.kv_caches.items():
             # Load cache data into buffers
-            torch_npu.npu_gather_pa_kv_cache(
+            DeviceOperator.kv_cache_load(
                 k_cache_layer,
                 v_cache_layer,
                 block_table,
                 block_len_tensor,
-                seq_offset=seq_start_tensor,
-                key=k_buffer,
-                value=v_buffer,
+                seq_start_tensor,
+                k_buffer,
+                v_buffer,
             )
             if need_cat_cache:
                 self._cat_kv_cache(

--- a/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_p2p/mooncake_layerwise_connector.py
@@ -21,7 +21,6 @@ import msgspec
 import numpy as np
 import numpy.typing as npt
 import torch
-import torch_npu
 import zmq
 from mooncake.engine import TransferEngine  # type: ignore
 from vllm.config import VllmConfig
@@ -54,6 +53,7 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.worker.utils import extract_layer_index
 
 from vllm_ascend.ascend_config import get_ascend_config
+from vllm_ascend.device.device_op import DeviceOperator
 from vllm_ascend.distributed.kv_transfer.kv_p2p.mooncake_connector import GET_META_MSG
 from vllm_ascend.distributed.kv_transfer.utils.mooncake_transfer_engine import global_te
 from vllm_ascend.distributed.kv_transfer.utils.utils import (
@@ -1904,14 +1904,14 @@ class MooncakeLayerwiseConnectorWorker:
                     )
 
                     # Load cache data into buffers
-                    torch_npu.npu_gather_pa_kv_cache(
+                    DeviceOperator.kv_cache_load(
                         kv_layer[0],
                         kv_layer[1],
                         send_task.group_block_table[layer_group_idx],
                         send_task.group_block_len_tensor[layer_group_idx],
-                        seq_offset=send_task.group_seq_start_tensor[layer_group_idx],
-                        key=keys,
-                        value=values,
+                        send_task.group_seq_start_tensor[layer_group_idx],
+                        keys,
+                        values,
                     )
                     if self.pd_head_ratio != 1:
                         # sort kv caches for each block


### PR DESCRIPTION
### What this PR does / why we need it?

- Ports every non-Ascend-950 GatherPaKvCache path from [ops-transformer at c157c4b](https://github.com/hicann/ops-transformer/tree/c157c4b561c4e5c92551038800ec5aeb124862ee/attention/gather_pa_kv_cache):
  - tiling key 619: Norm FP16/BF16
  - tiling key 618: Norm INT8
  - tiling key 577: PA_NZ INT8
- Registers `_C_ascend::gather_pa_kv_cache` as a direct AscendC custom operator, following the `batch_matmul_transpose` launch path without invoking ACLNN.
- Routes the A2/A3 device adaptor and Mooncake cache-loading call sites through the custom operator.
- Explicitly excludes Ascend 950. Ascend 310P remains on the existing fallback because the upstream kernel does not support that platform.

### Upstream code preservation

The non-950 kernel code is intentionally kept as close to upstream as the direct vLLM launch path permits:

- `gather_pa_kv_cache_nd.h` is source-equivalent to upstream apart from whitespace and line wrapping. Its class layout, initialization, UB tiling, core split, block-table lookup, ND data movement, cumulative-length handling, sequence-offset handling, dtype template, and first-axis cache-stride support are preserved.
- `gather_pa_kv_cache_nz.h` preserves the upstream class/process structure, UB layout, per-core loop, block-table lookup, PA_NZ copy layout, and the 4095-block split-copy path.
- The original 11-argument device-kernel ABI is preserved. The unused upstream `key`, `value`, and `workspace` slots are populated by the direct launcher without changing the non-950 kernel inputs/outputs.
- The ten upstream tiling fields retain their original names, types, order, and element-based units: `blockSize`, `numTokens`, `numblkTabCol`, `tokenSizeK`, `tokenSizeV`, `typeByte`, `hasSeqStarts`, `isSeqLensCumsum`, `kCacheBlockStride`, and `vCacheBlockStride`.
- The upstream dtype/path mapping is preserved: ND INT8 -> 618, ND FP16/BF16 -> 619, PA_NZ INT8 -> 577. `cache_mode` only selects between the original Norm and PA_NZ paths.

The NZ header is deliberately not described as byte-for-byte identical. It has four scoped adaptations required by the supported vLLM inputs:

- use the upstream tiling stride fields for first-dimension-strided PA_NZ cache views;
- reserve and copy the extra cumulative-sequence-length endpoint;
- initialize the first cumulative start before the first UB copy;
- index `seq_offset` by the global sequence and convert the token offset to a block-table offset.

The GE/gert host tiler and compile-time `GET_TILING_DATA` / `TILING_KEY_IS` / `ORIG_DTYPE_KEY_CACHE` channel cannot be used by a monolithic direct custom operator. They are replaced with an ATen host adapter plus one extra `tilingKey` field for runtime dispatch. The operator schema/meta registration, direct launcher, device-adaptor routing, CMake integration, and UT are vllm-ascend-specific integration code.

### Does this PR introduce _any_ user-facing change?

Yes. Supported non-Ascend-950 platforms now use the vLLM Ascend custom GatherPaKvCache operator. The operator exposes `cache_mode` and `is_seq_lens_cumsum` keyword arguments.

### How was this patch tested?

- Built `vllm_ascend_kernels` and `vllm_ascend_C` successfully on Ascend 910B1 with CANN 9.0 after the upstream-preservation revision.
- Added `tests/e2e/nightly/single_node/ops/singlecard_ops/test_gather_pa_kv_cache.py`.
- Ran the final standalone NPU suite: 11 passed.
- Coverage includes ND FP16/BF16/INT8, PA_NZ INT8, normal/cumulative sequence lengths, optional sequence offsets, first-dimension-strided caches, the PA_NZ >4095-block copy split, and validation errors.
- Verified codespell, typos, Python repository checks, Python byte compilation, and `git diff --check`. The remote pre-commit job also passed.

`bash format.sh ci` could not complete in this container because the markdownlint npm environment selected an incompatible Node runtime. The local gitleaks download also selected an incompatible binary, and shellcheck is not installed; the remaining configured checks passed.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
