### PR TITLE
fix(spec_decode): align QuaRot weights for Qwen3 DSpark

### DIFF
--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -39,6 +39,8 @@ class TestQwen3DSparkWeightLoading:
         model = model_cls.__new__(model_cls)
         rotation_path = "quarot.safetensors"
         object.__setattr__(model, "rotation_path", rotation_path)
+        object.__setattr__(model, "_quarot_fc_rotated", False)
+        object.__setattr__(model, "_quarot_fc_weights_rotated", 0)
 
         # Use a non-identity matrix so an unrotated FC weight fails the assertion.
         rotation_matrix = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
@@ -62,3 +64,78 @@ class TestQwen3DSparkWeightLoading:
         processed_weights = mock_parent_load_weights.call_args.args[0]
         torch.testing.assert_close(processed_weights[0][1], expected_fc_weight)
         torch.testing.assert_close(processed_weights[1][1], non_fc_weight)
+        assert model._quarot_fc_rotated is True
+        assert model._quarot_fc_weights_rotated == 1
+
+    def test_does_not_confirm_rotation_when_batch_has_no_fc_weights(self) -> None:
+        """Leave final fail-fast to the proposer after all weight batches load."""
+        model_cls = qwen3_dspark.AscendQwen3DSparkForCausalLM
+        model = model_cls.__new__(model_cls)
+        object.__setattr__(model, "rotation_path", "quarot.safetensors")
+        object.__setattr__(model, "_quarot_fc_rotated", False)
+        object.__setattr__(model, "_quarot_fc_weights_rotated", 0)
+        weights_to_load = [("model.embed_tokens.weight", torch.ones(1, 2))]
+
+        with (
+            patch.object(
+                qwen3_dspark,
+                "get_rotataion_matrix",
+                return_value=torch.eye(2),
+            ) as mock_get_rotation_matrix,
+            patch.object(qwen3_dspark.Qwen3DSparkForCausalLM, "load_weights") as mock_parent_load_weights,
+        ):
+            model.load_weights(weights_to_load)
+
+        mock_get_rotation_matrix.assert_not_called()
+        mock_parent_load_weights.assert_called_once()
+        assert model._quarot_fc_rotated is False
+        assert model._quarot_fc_weights_rotated == 0
+
+    def test_non_quarot_checkpoint_delegates_without_fc_requirement(self) -> None:
+        """A target without QuaRot must keep the existing loading behavior."""
+        model_cls = qwen3_dspark.AscendQwen3DSparkForCausalLM
+        model = model_cls.__new__(model_cls)
+        object.__setattr__(model, "rotation_path", None)
+        object.__setattr__(model, "_quarot_fc_rotated", False)
+        object.__setattr__(model, "_quarot_fc_weights_rotated", 0)
+        weights_to_load = [("model.embed_tokens.weight", torch.ones(1, 2))]
+        sentinel = object()
+
+        with patch.object(
+            qwen3_dspark.Qwen3DSparkForCausalLM,
+            "load_weights",
+            return_value=sentinel,
+        ) as mock_parent_load_weights:
+            result = model.load_weights(weights_to_load)
+
+        assert result is sentinel
+        mock_parent_load_weights.assert_called_once_with(weights_to_load)
+        assert model._quarot_fc_rotated is False
+        assert model._quarot_fc_weights_rotated == 0
+
+    def test_fc_rotation_state_survives_later_weight_batches(self) -> None:
+        """Incremental loaders may invoke load_weights more than once."""
+        model_cls = qwen3_dspark.AscendQwen3DSparkForCausalLM
+        model = model_cls.__new__(model_cls)
+        object.__setattr__(model, "rotation_path", "quarot.safetensors")
+        object.__setattr__(model, "_quarot_fc_rotated", False)
+        object.__setattr__(model, "_quarot_fc_weights_rotated", 0)
+        fc_weights = [("model.fc.weight", torch.eye(2))]
+        other_weights = [("model.embed_tokens.weight", torch.ones(1, 2))]
+
+        with (
+            patch.object(
+                qwen3_dspark,
+                "get_rotataion_matrix",
+                return_value=torch.eye(2),
+            ) as mock_get_rotation_matrix,
+            patch.object(qwen3_dspark.Qwen3DSparkForCausalLM, "load_weights") as mock_parent_load_weights,
+        ):
+            model.load_weights(other_weights)
+            model.load_weights(fc_weights)
+            model.load_weights(other_weights)
+
+        assert mock_parent_load_weights.call_count == 3
+        mock_get_rotation_matrix.assert_called_once_with("quarot.safetensors")
+        assert model._quarot_fc_rotated is True
+        assert model._quarot_fc_weights_rotated == 1

--- a/tests/ut/patch/worker/test_patch_draft_quarot.py
+++ b/tests/ut/patch/worker/test_patch_draft_quarot.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm_ascend.patch.worker.patch_draft_quarot import get_rotation_path
+
+
+def _make_vllm_config(model_path, quant_description):
+    return SimpleNamespace(
+        model_config=SimpleNamespace(model=str(model_path)),
+        quant_config=SimpleNamespace(quant_description=quant_description),
+    )
+
+
+def test_get_rotation_path_uses_configured_relative_path(tmp_path):
+    rotation_path = tmp_path / "rotations" / "global.safetensors"
+    rotation_path.parent.mkdir()
+    rotation_path.touch()
+    config = _make_vllm_config(
+        tmp_path,
+        {
+            "optional": {
+                "quarot": {
+                    "rotation_map": {
+                        "global_rotation": "rotations/global.safetensors",
+                    }
+                }
+            }
+        },
+    )
+
+    assert get_rotation_path(config) == rotation_path
+
+
+def test_get_rotation_path_falls_back_to_default_file(tmp_path):
+    rotation_path = tmp_path / "optional" / "quarot.safetensors"
+    rotation_path.parent.mkdir()
+    rotation_path.touch()
+    config = _make_vllm_config(tmp_path, {})
+
+    assert get_rotation_path(config) == rotation_path
+
+
+def test_get_rotation_path_rejects_missing_configured_file(tmp_path):
+    config = _make_vllm_config(
+        tmp_path,
+        {
+            "optional": {
+                "quarot": {
+                    "rotation_map": {
+                        "global_rotation": "rotations/missing.safetensors",
+                    }
+                }
+            }
+        },
+    )
+
+    with pytest.raises(FileNotFoundError, match="Configured QuaRot rotation file does not exist"):
+        get_rotation_path(config)
+
+
+def test_get_rotation_path_returns_none_without_mapping_or_default(tmp_path):
+    config = _make_vllm_config(tmp_path, {})
+
+    assert get_rotation_path(config) is None
+
+
+def test_get_rotation_path_rejects_quarot_metadata_without_rotation_file(tmp_path):
+    config = _make_vllm_config(
+        tmp_path,
+        {"optional": {"quarot": {}}},
+    )
+
+    with pytest.raises(FileNotFoundError, match="QuaRot metadata is present"):
+        get_rotation_path(config)
+
+
+def test_get_rotation_path_treats_null_mapping_as_default(tmp_path):
+    rotation_path = tmp_path / "optional" / "quarot.safetensors"
+    rotation_path.parent.mkdir()
+    rotation_path.touch()
+    config = _make_vllm_config(
+        tmp_path,
+        {"optional": {"quarot": {"rotation_map": {"global_rotation": None}}}},
+    )
+
+    assert get_rotation_path(config) == rotation_path
+
+
+def test_get_rotation_path_ignores_default_file_without_quant_config(tmp_path):
+    rotation_path = tmp_path / "optional" / "quarot.safetensors"
+    rotation_path.parent.mkdir()
+    rotation_path.touch()
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(model=str(tmp_path)),
+        quant_config=None,
+    )
+
+    assert get_rotation_path(config) is None

--- a/tests/ut/spec_decode/test_llm_base_proposer.py
+++ b/tests/ut/spec_decode/test_llm_base_proposer.py
@@ -198,6 +198,85 @@ class TestQuaRotDraftBoundaries:
         torch.testing.assert_close(context_proj.weight, expected)
         torch.testing.assert_close(proposer._quarot_rotation, rotation)
 
+    def test_qwen3_dspark_keeps_rotated_fc_and_loads_shared_rotation(self, monkeypatch):
+        proposer = self._make_proposer()
+        rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]], dtype=torch.float32)
+        fc = nn.Linear(10, 2, bias=False)
+        initial_weight = torch.arange(1.0, 21.0).reshape(2, 10)
+        fc.weight.data.copy_(initial_weight)
+
+        class FakeQwen3DSpark:
+            pass
+
+        fake_model = FakeQwen3DSpark()
+        fake_model.model = SimpleNamespace(fc=fc)
+        fake_model._quarot_fc_rotated = True
+        fake_model._quarot_fc_weights_rotated = 1
+        proposer.model = fake_model
+        monkeypatch.setattr(proposer, "_load_quarot_rotation", lambda _: rotation)
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.llm_base_proposer.Qwen3DSparkForCausalLM",
+            FakeQwen3DSpark,
+        )
+
+        proposer._maybe_anti_rotate_fc()
+
+        torch.testing.assert_close(fc.weight, initial_weight)
+        torch.testing.assert_close(proposer._quarot_rotation, rotation)
+
+    def test_qwen3_dspark_rejects_unconfirmed_fc_rotation(self, monkeypatch):
+        proposer = self._make_proposer()
+        rotation = torch.eye(2)
+
+        class FakeQwen3DSpark:
+            pass
+
+        fake_model = FakeQwen3DSpark()
+        fake_model._quarot_fc_rotated = False
+        fake_model._quarot_fc_weights_rotated = 0
+        proposer.model = fake_model
+        monkeypatch.setattr(proposer, "_load_quarot_rotation", lambda _: rotation)
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.llm_base_proposer.Qwen3DSparkForCausalLM",
+            FakeQwen3DSpark,
+        )
+
+        with pytest.raises(RuntimeError, match=r"no fc\.\* weight was confirmed"):
+            proposer._maybe_anti_rotate_fc()
+
+    def test_qwen3_dspark_without_quarot_does_not_require_fc_flag(self, monkeypatch):
+        proposer = self._make_proposer()
+
+        class FakeQwen3DSpark:
+            pass
+
+        proposer.model = FakeQwen3DSpark()
+        monkeypatch.setattr(proposer, "_load_quarot_rotation", lambda _: None)
+        monkeypatch.setattr(
+            "vllm_ascend.spec_decode.llm_base_proposer.Qwen3DSparkForCausalLM",
+            FakeQwen3DSpark,
+        )
+
+        proposer._maybe_anti_rotate_fc()
+
+    def test_quarot_rotation_load_failure_is_not_silently_ignored(self, monkeypatch):
+        config = SimpleNamespace(model_config=SimpleNamespace(model="target"))
+        monkeypatch.setattr(
+            "vllm_ascend.patch.worker.patch_draft_quarot.get_rotation_path",
+            lambda _: "quarot.safetensors",
+        )
+
+        def fail_to_load_rotation(_):
+            raise RuntimeError("invalid rotation")
+
+        monkeypatch.setattr(
+            "vllm_ascend.patch.worker.patch_draft_quarot.get_rotataion_matrix",
+            fail_to_load_rotation,
+        )
+
+        with pytest.raises(RuntimeError, match="invalid rotation"):
+            AscendSpecDecodeBaseProposer._load_quarot_rotation(config)
+
     def test_copies_unrotated_shared_weight_without_mutating_target(self):
         proposer = self._make_proposer()
         proposer._quarot_rotation = torch.tensor([[0.0, 1.0], [-1.0, 0.0]])

--- a/vllm_ascend/models/qwen3_dspark.py
+++ b/vllm_ascend/models/qwen3_dspark.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 
 import torch
 from vllm.config import VllmConfig
+from vllm.logger import logger
 from vllm.model_executor.models.qwen3_dspark import Qwen3DSparkForCausalLM
 
 from vllm_ascend.patch.worker.patch_draft_quarot import get_rotataion_matrix, get_rotation_path
@@ -29,16 +30,30 @@ def process_weight(linear_weight: torch.Tensor, rotation_weight: torch.Tensor):
 class AscendQwen3DSparkForCausalLM(Qwen3DSparkForCausalLM):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__(vllm_config=vllm_config, prefix=prefix)
-        self.rotation_path = get_rotation_path(vllm_config) if vllm_config.quant_config is not None else None
+        self.rotation_path = get_rotation_path(vllm_config)
+        self._quarot_fc_rotated = False
+        self._quarot_fc_weights_rotated = 0
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         if self.rotation_path is not None:
             processed_weights: list[tuple[str, torch.Tensor]] = []
-            rotation_weight = get_rotataion_matrix(self.rotation_path)
+            rotation_weight: torch.Tensor | None = None
+            fc_weights_rotated = 0
             for name, loaded_weight in weights:
                 if "fc." in name:
+                    if rotation_weight is None:
+                        rotation_weight = get_rotataion_matrix(self.rotation_path)
                     loaded_weight = process_weight(loaded_weight, rotation_weight)
+                    fc_weights_rotated += 1
                 processed_weights.append((name, loaded_weight))
-            super().load_weights(processed_weights)
-        else:
-            super().load_weights(weights)
+            result = super().load_weights(processed_weights)
+            if fc_weights_rotated > 0:
+                self._quarot_fc_rotated = True
+                self._quarot_fc_weights_rotated += fc_weights_rotated
+                logger.info(
+                    "[spec_decode/quarot] Rotated %d Qwen3 DSpark FC weight(s) using %s.",
+                    fc_weights_rotated,
+                    self.rotation_path,
+                )
+            return result
+        return super().load_weights(weights)

--- a/vllm_ascend/patch/worker/patch_draft_quarot.py
+++ b/vllm_ascend/patch/worker/patch_draft_quarot.py
@@ -13,6 +13,8 @@ from vllm.model_executor.models.utils import (
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_QUAROT_ROTATION_PATH = Path("optional/quarot.safetensors")
+
 
 def get_embedding_tensor(directory_path):
     """
@@ -43,14 +45,57 @@ def get_rotation_path(target_vllm_config):
     """
     Gets the path of the rotation matrix, returns None if the target model is not a quarot model.
     """
-    target_model_path = target_vllm_config.model_config.model
-    try:
-        quant_description = target_vllm_config.quant_config.quant_description
-        rotation_relative_path = quant_description["optional"]["quarot"]["rotation_map"]["global_rotation"]
-    except KeyError:
+    target_model_path = Path(target_vllm_config.model_config.model)
+    quant_config = getattr(target_vllm_config, "quant_config", None)
+    quant_description = getattr(quant_config, "quant_description", None)
+    if not isinstance(quant_description, dict):
         return None
 
-    return Path(target_model_path) / rotation_relative_path
+    optional = quant_description.get("optional", {})
+    if optional is None:
+        optional = {}
+    if not isinstance(optional, dict):
+        raise ValueError("QuaRot metadata field 'optional' must be a dictionary.")
+    has_quarot_metadata = "quarot" in optional
+    quarot = optional.get("quarot", {})
+    if quarot is None:
+        quarot = {}
+    if not isinstance(quarot, dict):
+        raise ValueError("QuaRot metadata field 'optional.quarot' must be a dictionary.")
+    rotation_map = quarot.get("rotation_map", {})
+    if rotation_map is None:
+        rotation_map = {}
+    if not isinstance(rotation_map, dict):
+        raise ValueError("QuaRot metadata field 'optional.quarot.rotation_map' must be a dictionary.")
+    rotation_relative_path = rotation_map.get("global_rotation")
+
+    if rotation_relative_path is None or rotation_relative_path == "":
+        # Older ModelSlim descriptions may omit the optional QuaRot mapping
+        # even though the rotation is packaged at the conventional location.
+        # Use the same fallback for every DSpark/QuaRot loading path so FC and
+        # shared embed/lm_head weights cannot end up in different bases.
+        rotation_path = target_model_path / DEFAULT_QUAROT_ROTATION_PATH
+        if rotation_path.is_file():
+            logger.info(
+                "QuaRot rotation mapping is missing; using the default file at %s.",
+                rotation_path,
+            )
+            return rotation_path
+        if has_quarot_metadata:
+            raise FileNotFoundError(
+                "QuaRot metadata is present, but no global rotation file was configured "
+                f"and the default file does not exist: {rotation_path}"
+            )
+        return None
+
+    if not isinstance(rotation_relative_path, (str, os.PathLike)):
+        raise ValueError("QuaRot global_rotation must be a filesystem path.")
+    rotation_path = Path(rotation_relative_path)
+    if not rotation_path.is_absolute():
+        rotation_path = target_model_path / rotation_path
+    if not rotation_path.is_file():
+        raise FileNotFoundError(f"Configured QuaRot rotation file does not exist: {rotation_path}")
+    return rotation_path
 
 
 def get_rotataion_matrix(rotation_path):
@@ -64,7 +109,7 @@ def get_rotataion_matrix(rotation_path):
         return Q
     except Exception as e:
         logger.error(
-            "Failed to load rotation weight from '%s'. If you want to use quarot model with eagle3, take a check.",
+            "Failed to load QuaRot rotation weight from '%s'. Check the target and draft model configuration.",
             rotation_path,
         )
         raise e

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -267,12 +267,7 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         """Align the draft hidden-state projection with a QuaRot target."""
         if self.method not in ("dflash", "dspark"):
             return
-        # Qwen3 DSpark aligns fc.* in its model-specific weight loader and owns
-        # separate embedding/lm_head weights, so no generic alignment is needed.
-        if isinstance(self.model, Qwen3DSparkForCausalLM):
-            return
-        target_model_path = self.vllm_config.model_config.model
-        rotation = self._load_quarot_rotation(target_model_path)
+        rotation = self._load_quarot_rotation(self.vllm_config)
         if rotation is None:
             return
 
@@ -281,6 +276,17 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         # modules must not directly consume rotated target tensors.
         rotation = rotation.to(self.device, dtype=torch.float32)
         self._quarot_rotation = rotation
+        # Qwen3 / GQA DSpark anti-rotates fc.* in its model-specific weight
+        # loader. Verify that work completed before using the same rotation to
+        # align the shared embedding and lm_head boundaries below.
+        if isinstance(self.model, Qwen3DSparkForCausalLM):
+            fc_weights_rotated = getattr(self.model, "_quarot_fc_weights_rotated", 0)
+            if not getattr(self.model, "_quarot_fc_rotated", False) or fc_weights_rotated <= 0:
+                raise RuntimeError(
+                    "QuaRot rotation was loaded for Qwen3 DSpark shared weights, but no fc.* weight "
+                    "was confirmed as rotated."
+                )
+            return
         draft_model = getattr(self.model, "model", None)
         projection_name = "fc"
         projection = getattr(draft_model, projection_name, None) if draft_model is not None else None
@@ -383,54 +389,24 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         return draft_layer
 
     @staticmethod
-    def _load_quarot_rotation(target_model_path: str) -> torch.Tensor | None:
+    def _load_quarot_rotation(target_vllm_config: VllmConfig) -> torch.Tensor | None:
         """Load the global rotation when the target has a QuaRot descriptor."""
-        import json
-        from pathlib import Path
+        # Import lazily to avoid a worker-patch/spec-decode import cycle on 310P.
+        from vllm_ascend.patch.worker.patch_draft_quarot import get_rotataion_matrix, get_rotation_path
 
-        from safetensors.torch import load_file
-
-        descriptor_path = Path(target_model_path) / "quant_model_description.json"
-        if not descriptor_path.exists():
+        target_model_path = target_vllm_config.model_config.model
+        rotation_path = get_rotation_path(target_vllm_config)
+        if rotation_path is None:
             logger.info(
-                "[spec_decode/quarot] No descriptor found at %s; treating the target as non-QuaRot.",
-                descriptor_path,
-            )
-            return None
-        try:
-            with open(descriptor_path) as descriptor_file:
-                descriptor = json.load(descriptor_file)
-            relative_path = (
-                descriptor.get("optional", {})
-                .get("quarot", {})
-                .get("rotation_map", {})
-                .get("global_rotation", "optional/quarot.safetensors")
-            )
-        except (ValueError, OSError) as error:
-            logger.warning(
-                "[spec_decode/quarot] Failed to read %s (%s); skipping draft alignment.",
-                descriptor_path,
-                error,
-            )
-            return None
-
-        rotation_path = Path(target_model_path) / relative_path
-        if not rotation_path.exists():
-            logger.warning(
-                "[spec_decode/quarot] Rotation file %s is missing; skipping draft alignment.",
-                rotation_path,
+                "[spec_decode/quarot] No rotation found for %s; treating the target as non-QuaRot.",
+                target_model_path,
             )
             return None
         logger.info("[spec_decode/quarot] Loading global rotation from %s.", rotation_path)
-        try:
-            return load_file(rotation_path)["global_rotation"]
-        except Exception as error:
-            logger.warning(
-                "[spec_decode/quarot] Failed to load rotation %s: %s",
-                rotation_path,
-                error,
-            )
-            return None
+        # Once a QuaRot path is resolved, loading it is mandatory. Silently
+        # falling back here could leave FC rotated while shared boundaries are
+        # not, producing valid-looking startup with unusable draft logits.
+        return get_rotataion_matrix(rotation_path)
 
     def _get_model(self) -> nn.Module:
         """


### PR DESCRIPTION
Unify rotation path resolution for the Qwen3 DSpark FC and shared draft boundaries. Verify FC anti-rotation before aligning the shared embedding and LM head, and fail fast on incomplete QuaRot metadata or weights.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
