### PR TITLE
[BugFix][310P] Adapting MRV2 for Qwen3-VL on the 310P

### DIFF
--- a/tests/e2e/pull_request/four_card/_310p/test_model_runner_v2_310p.py
+++ b/tests/e2e/pull_request/four_card/_310p/test_model_runner_v2_310p.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+import os
+from unittest.mock import patch
+
+from tests.e2e.conftest import VllmRunner
+
+
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+def test_qwen3_dense_mrv2_tp2_aclgraph_fp16():
+    with VllmRunner(
+        "Qwen/Qwen3-8B",
+        tensor_parallel_size=2,
+        enforce_eager=False,
+        dtype="float16",
+        max_model_len=16384,
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [1],
+        },
+    ) as vllm_model:
+        vllm_model.generate_greedy(["Hello, my name is"], max_tokens=5)
+
+
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+def test_qwen3_moe_mrv2_tp2_aclgraph_w8a8():
+    with VllmRunner(
+        "vllm-ascend/Qwen3-30B-A3B-W8A8",
+        tensor_parallel_size=2,
+        enforce_eager=False,
+        dtype="float16",
+        quantization="ascend",
+        max_model_len=16384,
+        max_num_batched_tokens=2048,
+        max_num_seqs=256,
+        compilation_config={
+            "cudagraph_mode": "FULL_DECODE_ONLY",
+            "cudagraph_capture_sizes": [1],
+        },
+    ) as vllm_model:
+        vllm_model.generate_greedy(["Hello, my name is"], max_tokens=5)

--- a/tests/ut/_310p/ops/test_qwen3vl_310.py
+++ b/tests/ut/_310p/ops/test_qwen3vl_310.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from types import SimpleNamespace
+
+import torch
+from vllm.model_executor.models.qwen3_vl import (
+    Qwen3_VisionTransformer,
+    pos_embed_interpolate_native,
+)
+
+from vllm_ascend._310p.ops.qwen3vl_310 import fast_pos_embed_interpolate_310
+from vllm_ascend.patch.worker.patch_idex_310 import Qwen3_VisionTransformer as PatchedVisionTransformer
+
+
+def test_310p_fast_pos_embed_uses_native_interpolate(monkeypatch):
+    captured = {}
+
+    def fake_native(embed_weight, t, h, w, num_grid_per_side, m_size, dtype):
+        captured["args"] = (t, h, w, num_grid_per_side, m_size, dtype)
+        return torch.ones(t * h * w, embed_weight.shape[1], dtype=dtype)
+
+    monkeypatch.setattr(
+        "vllm_ascend._310p.ops.qwen3vl_310.pos_embed_interpolate_native",
+        fake_native,
+    )
+    vision = SimpleNamespace(
+        pos_embed=SimpleNamespace(weight=torch.zeros(9, 4)),
+        num_grid_per_side=3,
+        spatial_merge_size=2,
+        dtype=torch.float16,
+    )
+
+    out = fast_pos_embed_interpolate_310(vision, [[1, 4, 4], [1, 2, 2]])
+
+    assert out.shape == (20, 4)
+    assert captured["args"] == (1, 2, 2, 3, 2, torch.float16)
+
+
+def test_310p_patches_qwen3_vision_pos_embed_interpolate():
+    assert PatchedVisionTransformer is Qwen3_VisionTransformer
+    assert Qwen3_VisionTransformer.fast_pos_embed_interpolate is fast_pos_embed_interpolate_310
+    assert Qwen3_VisionTransformer.fast_pos_embed_interpolate is not pos_embed_interpolate_native

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import torch
+from vllm.config.compilation import CUDAGraphMode
 from vllm.sampling_params import SamplingParams
 
 import vllm_ascend._310p.worker.v2.model_runner as model_runner_module
@@ -14,6 +15,7 @@ from vllm_ascend._310p.worker.v2.block_table import Ascend310PBlockTables
 from vllm_ascend._310p.worker.v2.model_runner import NPUModelRunner310V2
 from vllm_ascend._310p.worker.v2.model_state import Ascend310PModelState
 from vllm_ascend._310p.worker.v2.sampler import Ascend310PSampler
+from vllm_ascend.worker.v2.model_states.default import AscendModelState
 
 
 def _make_vllm_config(**overrides):
@@ -180,6 +182,45 @@ def test_model_state_uses_greedy_sampler() -> None:
     assert model_inputs == {}
     assert isinstance(sampler, Ascend310PSampler)
     assert speculator is None
+
+
+def test_model_state_refreshes_full_graph_seq_lens_buffers() -> None:
+    model_state = object.__new__(Ascend310PModelState)
+    model_state._capture_seq_lens_by_ptr = {}
+    shared_capture_buffer = torch.full((4,), -1, dtype=torch.int32)
+    second_capture_buffer = torch.full((3,), -1, dtype=torch.int32)
+
+    model_state._record_capture_seq_lens(shared_capture_buffer[:2])
+    model_state._record_capture_seq_lens(shared_capture_buffer)
+    model_state._record_capture_seq_lens(second_capture_buffer)
+    model_state._refresh_capture_seq_lens(torch.tensor([17, 9], dtype=torch.int32))
+
+    torch.testing.assert_close(shared_capture_buffer, torch.tensor([17, 9, 0, 0], dtype=torch.int32))
+    torch.testing.assert_close(second_capture_buffer, torch.tensor([17, 9, 0], dtype=torch.int32))
+
+
+def test_model_state_only_refreshes_seq_lens_for_full_runtime() -> None:
+    model_state = object.__new__(Ascend310PModelState)
+    capture_seq_lens = torch.full((2,), -1, dtype=torch.int32)
+    model_state._capture_seq_lens_by_ptr = {}
+    capture_batch = SimpleNamespace(seq_lens=capture_seq_lens)
+    input_batch = SimpleNamespace(seq_lens=torch.tensor([11, 12], dtype=torch.int32))
+
+    with patch.object(AscendModelState, "prepare_attn", return_value={}):
+        model_state.prepare_attn(
+            capture_batch,
+            CUDAGraphMode.NONE,
+            (),
+            object(),
+            [],
+            object(),
+            for_capture=True,
+        )
+        model_state.prepare_attn(input_batch, CUDAGraphMode.PIECEWISE, (), object(), [], object())
+        torch.testing.assert_close(capture_seq_lens, torch.full((2,), -1, dtype=torch.int32))
+
+        model_state.prepare_attn(input_batch, CUDAGraphMode.FULL, (), object(), [], object())
+        torch.testing.assert_close(capture_seq_lens, input_batch.seq_lens)
 
 
 def test_aclgraph_query_lens_ignore_padded_request_entries() -> None:

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -15,6 +15,7 @@ from vllm_ascend._310p.worker.v2.block_table import Ascend310PBlockTables
 from vllm_ascend._310p.worker.v2.model_runner import NPUModelRunner310V2
 from vllm_ascend._310p.worker.v2.model_state import Ascend310PModelState
 from vllm_ascend._310p.worker.v2.sampler import Ascend310PSampler
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.model_states.default import AscendModelState
 
 
@@ -45,6 +46,21 @@ def _make_vllm_config(**overrides):
 
 def test_config_accepts_tensor_parallelism() -> None:
     NPUModelRunner310V2._validate_config(_make_vllm_config())
+
+
+@pytest.mark.parametrize(("finished_req_ids", "sync_count"), [({"finished"}, 1), (set(), 0)])
+def test_finished_requests_synchronize_before_reusing_layout(finished_req_ids, sync_count) -> None:
+    runner = object.__new__(NPUModelRunner310V2)
+    scheduler_output = SimpleNamespace(finished_req_ids=finished_req_ids)
+
+    with (
+        patch.object(NPUModelRunner, "finish_requests") as finish_requests,
+        patch.object(model_runner_module.torch.npu, "current_stream") as current_stream,
+    ):
+        runner.finish_requests(scheduler_output)
+
+    finish_requests.assert_called_once_with(scheduler_output)
+    assert current_stream.return_value.synchronize.call_count == sync_count
 
 
 @pytest.mark.parametrize(

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -74,22 +74,11 @@ def test_config_rejects_out_of_scope_features(field, value, message) -> None:
         NPUModelRunner310V2._validate_config(_make_vllm_config(**{field: value}))
 
 
-def test_sampler_accepts_random_sampling_parameters() -> None:
+def test_sampler_rejects_random_sampling_parameters() -> None:
     sampler = Ascend310PSampler()
-    sampling_params = SamplingParams(
-        temperature=0.6,
-        top_p=0.95,
-        top_k=20,
-        min_p=0.01,
-        seed=7,
-    )
-    sampler.add_request(0, 4, sampling_params)
-
-    assert sampler.sampling_params[0] is sampling_params
-    assert sampler.generators[0].initial_seed() == 7
-
+    sampler.add_request(0, 4, SamplingParams(temperature=0))
     with pytest.raises(NotImplementedError, match="Unsupported sampling parameters"):
-        sampler.add_request(1, 4, SamplingParams(repetition_penalty=1.1))
+        sampler.add_request(1, 4, SamplingParams(temperature=1))
 
 
 def test_block_tables_use_cpu_metadata_for_gather_and_slot_mapping() -> None:

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -77,7 +77,7 @@ def test_config_rejects_out_of_scope_features(field, value, message) -> None:
 def test_greedy_sampler_rejects_triton_sampling_features() -> None:
     sampler = Ascend310PSampler()
     sampler.add_request(0, 4, SamplingParams(temperature=0))
-    with pytest.raises(NotImplementedError, match="greedy sampling only"):
+    with pytest.raises(NotImplementedError, match="Unsupported sampling parameters"):
         sampler.add_request(0, 4, SamplingParams(temperature=1))
 
 

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -48,6 +48,21 @@ def test_config_accepts_tensor_parallelism() -> None:
     NPUModelRunner310V2._validate_config(_make_vllm_config())
 
 
+def test_config_accepts_qwen3_vl_multimodal_mrope() -> None:
+    """Qwen3-VL is multimodal + MRoPE; first-release 310P MRv2 must allow it."""
+    config = _make_vllm_config()
+    config.model_config.is_multimodal_model = True
+    config.model_config.uses_mrope = True
+    NPUModelRunner310V2._validate_config(config)
+
+
+def test_config_rejects_hybrid_models() -> None:
+    config = _make_vllm_config()
+    config.model_config.is_hybrid = True
+    with pytest.raises(NotImplementedError, match="Hybrid models"):
+        NPUModelRunner310V2._validate_config(config)
+
+
 @pytest.mark.parametrize(("finished_req_ids", "sync_count"), [({"finished"}, 1), (set(), 0)])
 def test_finished_requests_synchronize_before_reusing_layout(finished_req_ids, sync_count) -> None:
     runner = object.__new__(NPUModelRunner310V2)

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+from vllm.sampling_params import SamplingParams
+
+import vllm_ascend._310p.worker.v2.model_runner as model_runner_module
+from vllm_ascend._310p.worker.v2.block_table import Ascend310PBlockTables
+from vllm_ascend._310p.worker.v2.model_runner import NPUModelRunner310V2
+from vllm_ascend._310p.worker.v2.model_state import Ascend310PModelState
+from vllm_ascend._310p.worker.v2.sampler import Ascend310PSampler
+
+
+def _make_vllm_config(**overrides):
+    config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            is_multimodal_model=False,
+            is_hybrid=False,
+            use_mla=False,
+        ),
+        parallel_config=SimpleNamespace(
+            tensor_parallel_size=2,
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+            decode_context_parallel_size=1,
+            prefill_context_parallel_size=1,
+            enable_expert_parallel=False,
+        ),
+        cache_config=SimpleNamespace(enable_prefix_caching=False),
+        speculative_config=None,
+        kv_transfer_config=None,
+        lora_config=None,
+    )
+    for name, value in overrides.items():
+        setattr(config, name, value)
+    return config
+
+
+def test_config_accepts_tensor_parallelism() -> None:
+    NPUModelRunner310V2._validate_config(_make_vllm_config())
+
+
+@pytest.mark.parametrize(
+    "setting",
+    [
+        "pipeline_parallel_size",
+        "data_parallel_size",
+        "decode_context_parallel_size",
+        "prefill_context_parallel_size",
+    ],
+)
+def test_config_rejects_non_tp_parallelism(setting: str) -> None:
+    config = _make_vllm_config()
+    setattr(config.parallel_config, setting, 2)
+    with pytest.raises(NotImplementedError, match="only supports tensor parallelism"):
+        NPUModelRunner310V2._validate_config(config)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("speculative_config", object(), "Speculative decoding"),
+        ("kv_transfer_config", object(), "KV cache transfer"),
+        ("lora_config", object(), "LoRA"),
+    ],
+)
+def test_config_rejects_out_of_scope_features(field, value, message) -> None:
+    with pytest.raises(NotImplementedError, match=message):
+        NPUModelRunner310V2._validate_config(_make_vllm_config(**{field: value}))
+
+
+def test_greedy_sampler_rejects_triton_sampling_features() -> None:
+    sampler = Ascend310PSampler()
+    sampler.add_request(0, 4, SamplingParams(temperature=0))
+    with pytest.raises(NotImplementedError, match="greedy sampling only"):
+        sampler.add_request(0, 4, SamplingParams(temperature=1))
+
+
+def test_block_tables_use_cpu_metadata_for_gather_and_slot_mapping() -> None:
+    block_tables = Ascend310PBlockTables(
+        block_sizes=[4],
+        max_num_reqs=3,
+        max_num_batched_tokens=8,
+        max_num_blocks_per_group=[4],
+        device=torch.device("cpu"),
+        kernel_block_sizes=[4],
+    )
+    block_tables.append_block_ids(0, ([10, 11],), overwrite=True)
+    block_tables.append_block_ids(1, ([20],), overwrite=True)
+
+    gathered = block_tables.gather_block_tables(np.array([1, 0], dtype=np.int32), num_reqs_padded=3)
+    torch.testing.assert_close(gathered[0][0, :2], torch.tensor([20, 0], dtype=torch.int32))
+    torch.testing.assert_close(gathered[0][1, :2], torch.tensor([10, 11], dtype=torch.int32))
+    torch.testing.assert_close(gathered[0][2], torch.zeros_like(gathered[0][2]))
+
+    slots = block_tables.compute_slot_mappings(
+        np.array([1, 0], dtype=np.int32),
+        np.array([0, 2, 4], dtype=np.int32),
+        np.array([0, 1, 4, 5, 0, 0, 0, 0], dtype=np.int64),
+        num_tokens_padded=8,
+    )
+    torch.testing.assert_close(
+        slots,
+        torch.tensor([[80, 81, 44, 45, -1, -1, -1, -1]], dtype=torch.int32),
+    )
+
+
+def test_block_table_expands_logical_blocks_to_310p_kernel_blocks() -> None:
+    block_tables = Ascend310PBlockTables(
+        block_sizes=[128],
+        max_num_reqs=1,
+        max_num_batched_tokens=2,
+        max_num_blocks_per_group=[1],
+        device=torch.device("cpu"),
+        kernel_block_sizes=[64],
+    )
+    block_tables.append_block_ids(0, ([7],), overwrite=True)
+    assert block_tables.block_tables_cpu[0][0, :2].tolist() == [14, 15]
+
+
+def test_kv_cache_allocation_uses_separate_nz_k_and_v() -> None:
+    class FakeAttentionSpec:
+        block_size = 128
+        storage_block_size = 128
+        page_size_bytes = 4096
+        num_kv_heads = 2
+        head_size = 128
+        head_size_v = 128
+        dtype = torch.float16
+
+    class FakeBackend:
+        @staticmethod
+        def get_kv_cache_shape(num_blocks, block_size, num_kv_heads, head_size, cache_type):
+            del cache_type
+            return (2, num_blocks, num_kv_heads * head_size // 16, block_size, 16)
+
+    spec = FakeAttentionSpec()
+    kv_cache_config = SimpleNamespace(
+        num_blocks=2,
+        kv_cache_groups=[SimpleNamespace(kv_cache_spec=spec, layer_names=["model.layers.0.self_attn"])],
+        kv_cache_tensors=[SimpleNamespace(size=8192, shared_by=["model.layers.0.self_attn"])],
+    )
+    runner = object.__new__(NPUModelRunner310V2)
+    runner.device = torch.device("cpu")
+    runner.cache_config = SimpleNamespace(cache_dtype="auto")
+    runner.kernel_block_sizes = [64]
+    runner.attn_groups = [[SimpleNamespace(backend=FakeBackend, layer_names=["model.layers.0.self_attn"])]]
+
+    allocations = []
+
+    def empty_with_format(*, size, dtype, device, acl_format):
+        allocations.append((size, dtype, device, acl_format))
+        return torch.zeros(size, dtype=dtype, device=device)
+
+    with (
+        patch.object(model_runner_module, "AttentionSpec", FakeAttentionSpec),
+        patch.object(model_runner_module, "AscendAttentionBackend310", FakeBackend),
+        patch.object(model_runner_module.torch_npu, "empty_with_format", empty_with_format),
+    ):
+        caches = runner._allocate_kv_cache_tensors(kv_cache_config, {})
+
+    k_cache, v_cache = caches["model.layers.0.self_attn"]
+    assert k_cache.data_ptr() != v_cache.data_ptr()
+    assert len(allocations) == 2
+    assert all(allocation[3] == model_runner_module.ACL_FORMAT_FRACTAL_NZ for allocation in allocations)
+
+
+def test_model_state_uses_greedy_sampler() -> None:
+    model_state = object.__new__(Ascend310PModelState)
+    model_state.rope_state = None
+
+    model_inputs = model_state.prepare_inputs(SimpleNamespace(), req_states=None)
+    sampler, speculator = model_state.custom_sampler(object())
+
+    assert model_inputs == {}
+    assert isinstance(sampler, Ascend310PSampler)
+    assert speculator is None
+
+
+def test_aclgraph_query_lens_ignore_padded_request_entries() -> None:
+    query_lens = NPUModelRunner310V2._get_valid_query_lens(
+        torch.tensor([3, 7, -1, -1], dtype=torch.int32),
+        torch.tensor([0, 2, 5], dtype=torch.int32),
+    )
+
+    torch.testing.assert_close(query_lens, torch.tensor([2, 3], dtype=torch.int32))
+
+
+def test_worker_selects_v2_runner_on_310p() -> None:
+    from vllm_ascend._310p.worker_310p import NPUWorker310
+
+    worker = object.__new__(NPUWorker310)
+    worker.vllm_config = SimpleNamespace()
+    worker.use_v2_model_runner = True
+    worker.device = torch.device("cpu")
+    with patch("vllm_ascend._310p.worker.v2.model_runner.NPUModelRunner310V2") as runner_cls:
+        worker.model_runner = worker._create_model_runner()
+    runner_cls.assert_called_once_with(worker.vllm_config, worker.device)

--- a/tests/ut/_310p/test_model_runner_v2_310p.py
+++ b/tests/ut/_310p/test_model_runner_v2_310p.py
@@ -74,11 +74,22 @@ def test_config_rejects_out_of_scope_features(field, value, message) -> None:
         NPUModelRunner310V2._validate_config(_make_vllm_config(**{field: value}))
 
 
-def test_greedy_sampler_rejects_triton_sampling_features() -> None:
+def test_sampler_accepts_random_sampling_parameters() -> None:
     sampler = Ascend310PSampler()
-    sampler.add_request(0, 4, SamplingParams(temperature=0))
+    sampling_params = SamplingParams(
+        temperature=0.6,
+        top_p=0.95,
+        top_k=20,
+        min_p=0.01,
+        seed=7,
+    )
+    sampler.add_request(0, 4, sampling_params)
+
+    assert sampler.sampling_params[0] is sampling_params
+    assert sampler.generators[0].initial_seed() == 7
+
     with pytest.raises(NotImplementedError, match="Unsupported sampling parameters"):
-        sampler.add_request(0, 4, SamplingParams(temperature=1))
+        sampler.add_request(1, 4, SamplingParams(repetition_penalty=1.1))
 
 
 def test_block_tables_use_cpu_metadata_for_gather_and_slot_mapping() -> None:

--- a/vllm_ascend/_310p/attention/metadata_builder.py
+++ b/vllm_ascend/_310p/attention/metadata_builder.py
@@ -120,6 +120,18 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
             AscendAttentionState.SpecDecoding,
             AscendAttentionState.ChunkedPrefill,
         )
+
+        # Paged and splitfuse attention consume device-side context lengths.
+        # Bind the persistent input buffers before graph capture so their
+        # forward paths do not trigger a pageable host-to-device copy.
+        device_metadata_states = (
+            AscendAttentionState.DecodeOnly,
+            *splitfuse_states,
+        )
+        if attn_metadata.attn_state in device_metadata_states:
+            attn_metadata.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
+            attn_metadata.query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
+
         if attn_metadata.attn_state not in splitfuse_states:
             return attn_metadata
 
@@ -129,10 +141,6 @@ class AscendAttentionMetadataBuilder310(AscendAttentionMetadataBuilder):
             attn_metadata,
             self._fill_query_lens_cpu(num_reqs, query_start_loc_cpu, is_drafting),
         )
-
-        # Bind device-side views for in-place graph replay updates.
-        attn_metadata.seq_lens = common_attn_metadata.seq_lens[:num_reqs]
-        attn_metadata.query_start_loc = common_attn_metadata.query_start_loc[: num_reqs + 1]
 
         if is_compressed_mask_supported():
             attn_metadata.attn_mask = AttentionMaskBuilder310.get_compressed_splitfuse_mask(self.device)

--- a/vllm_ascend/_310p/fused_moe/fused_moe.py
+++ b/vllm_ascend/_310p/fused_moe/fused_moe.py
@@ -129,6 +129,11 @@ class AscendMoERunner310(AscendMoERunner):
             routed_output_transform=routed_output_transform,
             routed_scaling_factor=routed_scaling_factor,
         )
+        if self.is_internal_router and self.gate is not None and not hasattr(self.gate, "weight_fp32"):
+            # Pre-cast the internal router weight during model loading. A
+            # forward-time Cast cannot be captured by ACLGraph on 310P.
+            # Ported from upstream #14863; keep _310p-local to ease main merge.
+            self.gate.precast_fp32_weight = True
 
         ascend_shared_experts = getattr(self, "ascend_shared_experts", None)
         if ascend_shared_experts is not None:

--- a/vllm_ascend/_310p/ops/qwen3vl_310.py
+++ b/vllm_ascend/_310p/ops/qwen3vl_310.py
@@ -16,6 +16,33 @@
 #
 
 import torch
+from vllm.model_executor.models.qwen3_vl import pos_embed_interpolate_native
+
+
+def fast_pos_embed_interpolate_310(self, grid_thw: list[list[int]]) -> torch.Tensor:
+    """Replace the upstream Triton bilinear pos-embed kernel on 310P.
+
+    ``Qwen3_VisionTransformer.fast_pos_embed_interpolate`` selects
+    ``triton_pos_embed_interpolate`` whenever ``HAS_TRITON`` is true. Triton
+    Ascend may be importable on 310P, but ``bishengir-compile`` does not accept
+    ``--target=Ascend310P3``, so encoder profile/image prefill crashes.
+    Keep the same native interpolate fallback that ``patch_qwen3vl`` uses on
+    910B; on 310P that patch is not loaded (see ``patch/worker/__init__.py``).
+    """
+    outputs = []
+    for t, h, w in grid_thw:
+        outputs.append(
+            pos_embed_interpolate_native(
+                self.pos_embed.weight,
+                t,
+                h,
+                w,
+                self.num_grid_per_side,
+                self.spatial_merge_size,
+                self.dtype,
+            )
+        )
+    return torch.cat(outputs, dim=0)
 
 
 # 310P RC: non_blocking H2D copy in rot_pos_emb can race with subsequent indexing.

--- a/vllm_ascend/_310p/worker/__init__.py
+++ b/vllm_ascend/_310p/worker/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+

--- a/vllm_ascend/_310p/worker/v2/__init__.py
+++ b/vllm_ascend/_310p/worker/v2/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+

--- a/vllm_ascend/_310p/worker/v2/block_table.py
+++ b/vllm_ascend/_310p/worker/v2/block_table.py
@@ -14,6 +14,9 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 class Ascend310PBlockTables(BlockTables):
     """CPU-owned MRV2 block tables matching the 310P MRV1 data path."""
 
+    # TODO: Refactor Triton-backed block-table operations through
+    # triton_dispatch after vLLM RFC #45133 lands.
+
     def __init__(
         self,
         block_sizes: list[int],

--- a/vllm_ascend/_310p/worker/v2/block_table.py
+++ b/vllm_ascend/_310p/worker/v2/block_table.py
@@ -14,8 +14,8 @@ from vllm.v1.worker.gpu.block_table import BlockTables
 class Ascend310PBlockTables(BlockTables):
     """CPU-owned MRV2 block tables matching the 310P MRV1 data path."""
 
-    # TODO: Refactor Triton-backed block-table operations through
-    # triton_dispatch after vLLM RFC #45133 lands.
+    # TODO: Refactor block-table operations to register 310P implementations
+    # through Triton Dispatcher after vLLM RFC #45133 lands.
 
     def __init__(
         self,

--- a/vllm_ascend/_310p/worker/v2/block_table.py
+++ b/vllm_ascend/_310p/worker/v2/block_table.py
@@ -1,0 +1,166 @@
+# Adapt from https://github.com/vllm-project/vllm/blob/main/vllm/v1/worker/gpu/block_table.py
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.worker.gpu.block_table import BlockTables
+
+
+class Ascend310PBlockTables(BlockTables):
+    """CPU-owned MRV2 block tables matching the 310P MRV1 data path."""
+
+    def __init__(
+        self,
+        block_sizes: list[int],
+        max_num_reqs: int,
+        max_num_batched_tokens: int,
+        max_num_blocks_per_group: list[int],
+        device: torch.device,
+        kernel_block_sizes: list[int] | None = None,
+        cp_size: int = 1,
+        cp_rank: int = 0,
+        cp_interleave: int = 1,
+    ) -> None:
+        if kernel_block_sizes is None:
+            kernel_block_sizes = block_sizes
+        if cp_size != 1:
+            raise NotImplementedError("310P model runner v2 only supports tensor parallelism.")
+        if len(max_num_blocks_per_group) != len(block_sizes):
+            raise ValueError("max_num_blocks_per_group must match the number of KV cache groups.")
+
+        self.block_sizes = block_sizes
+        self.kernel_block_sizes = kernel_block_sizes
+        self.max_num_reqs = max_num_reqs
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.device = device
+        self.cp_size = cp_size
+        self.cp_rank = cp_rank
+        self.cp_interleave = cp_interleave
+        self.num_kv_cache_groups = len(block_sizes)
+        self.blocks_per_kv_block = [
+            block_size // kernel_block_size for block_size, kernel_block_size in zip(block_sizes, kernel_block_sizes)
+        ]
+
+        table_shapes = [
+            (max_num_reqs, max_num_blocks * blocks_per_kv_block)
+            for max_num_blocks, blocks_per_kv_block in zip(max_num_blocks_per_group, self.blocks_per_kv_block)
+        ]
+        self.block_tables_cpu = [np.zeros(shape, dtype=np.int32) for shape in table_shapes]
+        self.input_block_tables_cpu = [np.zeros(shape, dtype=np.int32) for shape in table_shapes]
+        self.input_block_tables = [torch.zeros(shape, dtype=torch.int32, device=device) for shape in table_shapes]
+        self.num_blocks_np = np.zeros((self.num_kv_cache_groups, max_num_reqs), dtype=np.int32)
+        self.slot_mappings_cpu = np.full(
+            (self.num_kv_cache_groups, max_num_batched_tokens),
+            PAD_SLOT_ID,
+            dtype=np.int32,
+        )
+        # Persistent device buffers are reused by eager execution and ACLGraph.
+        self.slot_mappings = torch.full(
+            self.slot_mappings_cpu.shape,
+            PAD_SLOT_ID,
+            dtype=torch.int32,
+            device=device,
+        )
+
+    def init_block_table_layout_tensors(self) -> None:
+        """310P does not use Triton pointer tables."""
+
+    def append_block_ids(
+        self,
+        req_index: int,
+        new_block_ids: tuple[list[int], ...],
+        overwrite: bool,
+    ) -> None:
+        for group_id, block_ids in enumerate(new_block_ids):
+            start = 0 if overwrite else int(self.num_blocks_np[group_id, req_index])
+            blocks_per_kv_block = self.blocks_per_kv_block[group_id]
+            if blocks_per_kv_block > 1:
+                block_ids = [
+                    block_id * blocks_per_kv_block + offset
+                    for block_id in block_ids
+                    for offset in range(blocks_per_kv_block)
+                ]
+            end = start + len(block_ids)
+            if end > self.block_tables_cpu[group_id].shape[1]:
+                raise ValueError(f"Too many block IDs for request {req_index} in KV cache group {group_id}.")
+            self.block_tables_cpu[group_id][req_index, start:end] = block_ids
+            self.num_blocks_np[group_id, req_index] = end
+
+    def apply_staged_writes(self) -> None:
+        """Block IDs are written to their CPU owner immediately."""
+
+    @staticmethod
+    def _as_numpy(value: np.ndarray | torch.Tensor) -> np.ndarray:
+        if isinstance(value, np.ndarray):
+            return value.astype(np.int64, copy=False)
+        if value.device.type != "cpu":
+            raise TypeError("310P block-table metadata must come from the CPU request-state mirror.")
+        return value.detach().numpy().astype(np.int64, copy=False)
+
+    def gather_block_tables(
+        self,
+        idx_mapping: np.ndarray | torch.Tensor,
+        num_reqs_padded: int,
+    ) -> tuple[torch.Tensor, ...]:
+        idx_mapping_np = self._as_numpy(idx_mapping)
+        num_reqs = idx_mapping_np.shape[0]
+        if num_reqs_padded < num_reqs:
+            raise ValueError(f"num_reqs_padded ({num_reqs_padded}) is smaller than num_reqs ({num_reqs}).")
+
+        for group_id, (source, host_output, device_output) in enumerate(
+            zip(
+                self.block_tables_cpu,
+                self.input_block_tables_cpu,
+                self.input_block_tables,
+            )
+        ):
+            host_output[:num_reqs_padded].fill(0)
+            for batch_idx, req_idx in enumerate(idx_mapping_np):
+                num_blocks = int(self.num_blocks_np[group_id, req_idx])
+                host_output[batch_idx, :num_blocks] = source[req_idx, :num_blocks]
+            device_output[:num_reqs_padded].copy_(torch.from_numpy(host_output[:num_reqs_padded]), non_blocking=True)
+
+        return tuple(table[:num_reqs_padded] for table in self.input_block_tables)
+
+    def compute_slot_mappings(
+        self,
+        idx_mapping: np.ndarray | torch.Tensor,
+        query_start_loc: np.ndarray | torch.Tensor,
+        positions: np.ndarray | torch.Tensor,
+        num_tokens_padded: int,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        idx_mapping_np = self._as_numpy(idx_mapping)
+        query_start_loc_np = self._as_numpy(query_start_loc)
+        positions_np = self._as_numpy(positions)
+        if query_start_loc_np.shape[0] < idx_mapping_np.shape[0] + 1:
+            raise ValueError("query_start_loc does not contain all request boundaries.")
+
+        self.slot_mappings_cpu.fill(PAD_SLOT_ID)
+        for group_id, (block_table, block_size) in enumerate(zip(self.block_tables_cpu, self.kernel_block_sizes)):
+            for batch_idx, req_idx in enumerate(idx_mapping_np):
+                start = int(query_start_loc_np[batch_idx])
+                end = int(query_start_loc_np[batch_idx + 1])
+                token_positions = positions_np[start:end]
+                logical_block_indices = token_positions // block_size
+                block_numbers = block_table[req_idx, logical_block_indices]
+                block_offsets = token_positions % block_size
+                self.slot_mappings_cpu[group_id, start:end] = block_numbers * block_size + block_offsets
+
+        device_slots = self.slot_mappings if out is None else out
+        device_slots.copy_(torch.from_numpy(self.slot_mappings_cpu), non_blocking=True)
+        return device_slots[:, :num_tokens_padded]
+
+    def get_dummy_block_tables(self, num_reqs: int) -> tuple[torch.Tensor, ...]:
+        for block_table in self.input_block_tables:
+            block_table[:num_reqs].zero_()
+        return tuple(block_table[:num_reqs] for block_table in self.input_block_tables)
+
+    def get_dummy_slot_mappings(self, num_tokens: int) -> torch.Tensor:
+        self.slot_mappings.fill_(PAD_SLOT_ID)
+        return self.slot_mappings[:, :num_tokens]

--- a/vllm_ascend/_310p/worker/v2/model_runner.py
+++ b/vllm_ascend/_310p/worker/v2/model_runner.py
@@ -11,7 +11,7 @@ import torch
 import torch_npu
 from vllm.config import VllmConfig
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
     KVCacheConfig,
@@ -91,6 +91,14 @@ class NPUModelRunner310V2(NPUModelRunner):
         # TODO: Support LoRA in the next 310P MRV2 iteration.
         if vllm_config.lora_config is not None:
             raise NotImplementedError("LoRA is not supported by model runner v2 on 310P.")
+
+    def finish_requests(self, scheduler_output: SchedulerOutput) -> None:
+        super().finish_requests(scheduler_output)
+        if scheduler_output.finished_req_ids:
+            # A freed request slot can be reused and its CPU-owned block table
+            # rewritten in this step. Drain the previous ACLGraph replay before
+            # the new layout is gathered and copied to attention metadata.
+            torch.npu.current_stream().synchronize()
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         """Allocate the 310P attention cache as separate K/V NZ tensors."""

--- a/vllm_ascend/_310p/worker/v2/model_runner.py
+++ b/vllm_ascend/_310p/worker/v2/model_runner.py
@@ -41,6 +41,8 @@ _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
 class NPUModelRunner310V2(NPUModelRunner):
     """Model runner v2 for Ascend 310P."""
 
+    # TODO: Refactor Triton-dependent overrides through triton_dispatch after
+    # vLLM RFC #45133 lands.
     request_state_cls = Ascend310PRequestState
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
@@ -285,6 +287,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         idx_mapping_np: np.ndarray,
         query_start_loc_np: np.ndarray,
     ) -> None:
+        # TODO: Replace this CPU fallback through triton_dispatch after vLLM
+        # RFC #45133 lands.
         del idx_mapping, query_start_loc, all_token_ids, prefill_len, num_computed_tokens
         self.input_ids_cpu[: input_ids.shape[0]].zero_()
         self.next_prefill_tokens_cpu.zero_()
@@ -316,6 +320,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         query_start_loc_np: np.ndarray,
         num_scheduled_tokens: np.ndarray,
     ) -> None:
+        # TODO: Replace this CPU fallback through triton_dispatch after vLLM
+        # RFC #45133 lands.
         del idx_mapping, query_start_loc, num_computed_tokens
         self.input_buffers.seq_lens_cpu.zero_()
         self.positions_cpu[: positions.shape[0]].zero_()
@@ -346,6 +352,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         seq_lens_np: np.ndarray,
         prefill_len_np: np.ndarray,
     ) -> torch.Tensor:
+        # TODO: Replace this CPU fallback through triton_dispatch after vLLM
+        # RFC #45133 lands.
         del idx_mapping, query_start_loc, seq_lens, prefill_len
         del draft_tokens, cu_num_logits, num_bonus_tokens
         if num_logits != len(idx_mapping_np):
@@ -363,6 +371,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         self,
         input_batch: AscendInputBatch,
     ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        # TODO: Route Triton-backed block-table preparation through
+        # triton_dispatch after vLLM RFC #45133 lands.
         block_tables = self.block_tables.gather_block_tables(
             input_batch.idx_mapping_np,
             num_reqs_padded=input_batch.num_reqs_after_padding,
@@ -392,6 +402,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         input_batch: AscendInputBatch,
         grammar_output: GrammarOutput | None,
     ):
+        # TODO: Route 310P sampling through triton_dispatch after vLLM RFC
+        # #45133 lands.
         if grammar_output is not None:
             # TODO: Restore MRV1 structured output support in the next 310P MRV2 iteration.
             raise NotImplementedError("Structured output is not supported by model runner v2 on 310P.")
@@ -412,6 +424,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         num_rejected: torch.Tensor,
         query_start_loc: torch.Tensor | None = None,
     ) -> None:
+        # TODO: Route the Triton-backed state update through triton_dispatch
+        # after vLLM RFC #45133 lands.
         del num_rejected
         num_entries = min(idx_mapping.shape[0], sampled_tokens.shape[0], num_sampled.shape[0])
         idx_mapping = idx_mapping[:num_entries]
@@ -455,6 +469,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         return query_lens.masked_select(idx_mapping[:num_query_lens] >= 0)
 
     def postprocess_num_computed_tokens(self, input_batch: AscendInputBatch) -> None:
+        # TODO: Route the Triton-backed state update through triton_dispatch
+        # after vLLM RFC #45133 lands.
         query_lens = input_batch.query_start_loc[1:] - input_batch.query_start_loc[:-1]
         self.req_states.num_computed_tokens.gpu.index_add_(
             0,

--- a/vllm_ascend/_310p/worker/v2/model_runner.py
+++ b/vllm_ascend/_310p/worker/v2/model_runner.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 
-"""Text-only model-runner-v2 implementation for Ascend 310P."""
-
 from __future__ import annotations
 
 from copy import deepcopy
@@ -41,7 +39,7 @@ _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
 
 
 class NPUModelRunner310V2(NPUModelRunner):
-    """MRV2 runner aligned with the text-only 310P MRV1 constraints."""
+    """Model runner v2 for Ascend 310P."""
 
     request_state_cls = Ascend310PRequestState
 
@@ -55,16 +53,20 @@ class NPUModelRunner310V2(NPUModelRunner):
     @staticmethod
     def _validate_config(vllm_config: VllmConfig) -> None:
         model_config = vllm_config.model_config
+        # TODO: Support multimodal and hybrid models in the next 310P MRV2 iteration.
         if model_config.is_multimodal_model or model_config.is_hybrid:
-            raise NotImplementedError("310P model runner v2 currently supports text-only, non-hybrid models.")
+            raise NotImplementedError("Multimodal and hybrid models are not supported by model runner v2 on 310P.")
         if model_config.use_mla:
             raise NotImplementedError("MLA is not supported by model runner v2 on 310P.")
+        # TODO: Support multi-dimensional RoPE in the next 310P MRV2 iteration.
         if getattr(model_config, "uses_mrope", False):
-            raise NotImplementedError("Multi-dimensional RoPE is outside the text-only 310P MRV2 scope.")
+            raise NotImplementedError("Multi-dimensional RoPE is not supported by model runner v2 on 310P.")
         if getattr(model_config, "enable_sleep_mode", False):
-            raise NotImplementedError("Sleep mode is outside the initial 310P MRV2 scope.")
+            raise NotImplementedError("Sleep mode is not supported by model runner v2 on 310P.")
 
         parallel_config = vllm_config.parallel_config
+        # TODO: Restore MRV1 data parallel support in the next 310P MRV2 iteration.
+        # Pipeline and context parallelism remain unsupported on 310P.
         unsupported_parallel = {
             "pipeline_parallel_size": getattr(parallel_config, "pipeline_parallel_size", 1),
             "data_parallel_size": getattr(parallel_config, "data_parallel_size", 1),
@@ -77,15 +79,18 @@ class NPUModelRunner310V2(NPUModelRunner):
                 f"310P model runner v2 only supports tensor parallelism; unsupported settings: {', '.join(enabled)}."
             )
         if getattr(parallel_config, "enable_expert_parallel", False):
-            raise NotImplementedError("Expert parallelism is outside the initial 310P MRV2 scope.")
+            raise NotImplementedError("Expert parallelism is not supported by model runner v2 on 310P.")
+        # TODO: Support speculative decoding in the next 310P MRV2 iteration.
         if vllm_config.speculative_config is not None:
             raise NotImplementedError("Speculative decoding is not supported by model runner v2 on 310P.")
         if vllm_config.kv_transfer_config is not None:
             raise NotImplementedError("KV cache transfer is not supported by model runner v2 on 310P.")
+        # TODO: Support prefix caching in the next 310P MRV2 iteration.
         if vllm_config.cache_config.enable_prefix_caching:
-            raise NotImplementedError("Prefix caching is outside the initial 310P MRV2 scope.")
+            raise NotImplementedError("Prefix caching is not supported by model runner v2 on 310P.")
+        # TODO: Support LoRA in the next 310P MRV2 iteration.
         if vllm_config.lora_config is not None:
-            raise NotImplementedError("LoRA is outside the initial 310P MRV2 scope.")
+            raise NotImplementedError("LoRA is not supported by model runner v2 on 310P.")
 
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         """Allocate the 310P attention cache as separate K/V NZ tensors."""
@@ -157,7 +162,8 @@ class NPUModelRunner310V2(NPUModelRunner):
                 specs = (group_spec,)
             attention_specs = [spec for spec in specs if isinstance(spec, AttentionSpec)]
             if len(attention_specs) != len(specs):
-                raise NotImplementedError("The initial 310P MRV2 implementation supports attention KV caches only.")
+                # TODO: Support non-attention KV cache specs in the next 310P MRV2 iteration.
+                raise NotImplementedError("Non-attention KV cache specs are not supported by model runner v2 on 310P.")
             max_head_size = max(spec.head_size for spec in attention_specs)
             if max_head_size > 256:
                 raise NotImplementedError(f"310P paged attention requires head_size <= 256, got {max_head_size}.")
@@ -335,6 +341,7 @@ class NPUModelRunner310V2(NPUModelRunner):
         del idx_mapping, query_start_loc, seq_lens, prefill_len
         del draft_tokens, cu_num_logits, num_bonus_tokens
         if num_logits != len(idx_mapping_np):
+            # TODO: Support draft tokens in the next 310P MRV2 iteration.
             raise NotImplementedError("310P MRV2 does not support draft tokens.")
         logits_indices_np = np.empty(num_logits, dtype=np.int64)
         for batch_idx, req_idx in enumerate(idx_mapping_np):
@@ -378,7 +385,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         grammar_output: GrammarOutput | None,
     ):
         if grammar_output is not None:
-            raise NotImplementedError("Structured output is outside the initial 310P MRV2 scope.")
+            # TODO: Restore MRV1 structured output support in the next 310P MRV2 iteration.
+            raise NotImplementedError("Structured output is not supported by model runner v2 on 310P.")
         logits = self.model.compute_logits(hidden_states[input_batch.logits_indices])
         sampler_output = self.sampler(logits, input_batch)
         can_sample_np = input_batch.seq_lens_np[: input_batch.num_reqs] >= input_batch.prefill_len_np

--- a/vllm_ascend/_310p/worker/v2/model_runner.py
+++ b/vllm_ascend/_310p/worker/v2/model_runner.py
@@ -41,8 +41,8 @@ _ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
 class NPUModelRunner310V2(NPUModelRunner):
     """Model runner v2 for Ascend 310P."""
 
-    # TODO: Refactor Triton-dependent overrides through triton_dispatch after
-    # vLLM RFC #45133 lands.
+    # TODO: Refactor Triton-dependent overrides to register 310P
+    # implementations through Triton Dispatcher after vLLM RFC #45133 lands.
     request_state_cls = Ascend310PRequestState
 
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
@@ -287,7 +287,7 @@ class NPUModelRunner310V2(NPUModelRunner):
         idx_mapping_np: np.ndarray,
         query_start_loc_np: np.ndarray,
     ) -> None:
-        # TODO: Replace this CPU fallback through triton_dispatch after vLLM
+        # TODO: Refactor this CPU fallback to use Triton Dispatcher after vLLM
         # RFC #45133 lands.
         del idx_mapping, query_start_loc, all_token_ids, prefill_len, num_computed_tokens
         self.input_ids_cpu[: input_ids.shape[0]].zero_()
@@ -320,7 +320,7 @@ class NPUModelRunner310V2(NPUModelRunner):
         query_start_loc_np: np.ndarray,
         num_scheduled_tokens: np.ndarray,
     ) -> None:
-        # TODO: Replace this CPU fallback through triton_dispatch after vLLM
+        # TODO: Refactor this CPU fallback to use Triton Dispatcher after vLLM
         # RFC #45133 lands.
         del idx_mapping, query_start_loc, num_computed_tokens
         self.input_buffers.seq_lens_cpu.zero_()
@@ -352,7 +352,7 @@ class NPUModelRunner310V2(NPUModelRunner):
         seq_lens_np: np.ndarray,
         prefill_len_np: np.ndarray,
     ) -> torch.Tensor:
-        # TODO: Replace this CPU fallback through triton_dispatch after vLLM
+        # TODO: Refactor this CPU fallback to use Triton Dispatcher after vLLM
         # RFC #45133 lands.
         del idx_mapping, query_start_loc, seq_lens, prefill_len
         del draft_tokens, cu_num_logits, num_bonus_tokens
@@ -371,8 +371,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         self,
         input_batch: AscendInputBatch,
     ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
-        # TODO: Route Triton-backed block-table preparation through
-        # triton_dispatch after vLLM RFC #45133 lands.
+        # TODO: Refactor block-table preparation to use Triton Dispatcher after
+        # vLLM RFC #45133 lands.
         block_tables = self.block_tables.gather_block_tables(
             input_batch.idx_mapping_np,
             num_reqs_padded=input_batch.num_reqs_after_padding,
@@ -402,7 +402,7 @@ class NPUModelRunner310V2(NPUModelRunner):
         input_batch: AscendInputBatch,
         grammar_output: GrammarOutput | None,
     ):
-        # TODO: Route 310P sampling through triton_dispatch after vLLM RFC
+        # TODO: Refactor 310P sampling to use Triton Dispatcher after vLLM RFC
         # #45133 lands.
         if grammar_output is not None:
             # TODO: Restore MRV1 structured output support in the next 310P MRV2 iteration.
@@ -424,8 +424,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         num_rejected: torch.Tensor,
         query_start_loc: torch.Tensor | None = None,
     ) -> None:
-        # TODO: Route the Triton-backed state update through triton_dispatch
-        # after vLLM RFC #45133 lands.
+        # TODO: Refactor this 310P state update to use Triton Dispatcher after
+        # vLLM RFC #45133 lands.
         del num_rejected
         num_entries = min(idx_mapping.shape[0], sampled_tokens.shape[0], num_sampled.shape[0])
         idx_mapping = idx_mapping[:num_entries]
@@ -469,8 +469,8 @@ class NPUModelRunner310V2(NPUModelRunner):
         return query_lens.masked_select(idx_mapping[:num_query_lens] >= 0)
 
     def postprocess_num_computed_tokens(self, input_batch: AscendInputBatch) -> None:
-        # TODO: Route the Triton-backed state update through triton_dispatch
-        # after vLLM RFC #45133 lands.
+        # TODO: Refactor this 310P state update to use Triton Dispatcher after
+        # vLLM RFC #45133 lands.
         query_lens = input_batch.query_start_loc[1:] - input_batch.query_start_loc[:-1]
         self.req_states.num_computed_tokens.gpu.index_add_(
             0,

--- a/vllm_ascend/_310p/worker/v2/model_runner.py
+++ b/vllm_ascend/_310p/worker/v2/model_runner.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+"""Text-only model-runner-v2 implementation for Ascend 310P."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+import numpy as np
+import torch
+import torch_npu
+from vllm.config import VllmConfig
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.sched.output import GrammarOutput
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
+from vllm.v1.worker.cp_utils import check_attention_cp_compatibility
+from vllm.v1.worker.gpu.attn_utils import (
+    get_shared_kv_cache_layers,
+    init_attn_backend,
+)
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
+from vllm.v1.worker.gpu.kv_connector import get_kv_connector
+from vllm.v1.worker.utils import bind_kv_cache
+
+from vllm_ascend._310p.attention.attention_v1 import AscendAttentionBackend310
+from vllm_ascend._310p.worker.v2.block_table import Ascend310PBlockTables
+from vllm_ascend._310p.worker.v2.states import Ascend310PRequestState
+from vllm_ascend.utils import ACL_FORMAT_FRACTAL_NZ
+from vllm_ascend.worker.v2.aclgraph_utils import ModelAclGraphManager
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch
+from vllm_ascend.worker.v2.model_runner import NPUModelRunner
+
+_ATTENTION_BLOCK_SIZE_LIMIT = 128 * 128
+
+
+class NPUModelRunner310V2(NPUModelRunner):
+    """MRV2 runner aligned with the text-only 310P MRV1 constraints."""
+
+    request_state_cls = Ascend310PRequestState
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        self._validate_config(vllm_config)
+        super().__init__(vllm_config, device)
+        self.input_ids_cpu = torch.zeros(self.max_num_tokens, dtype=torch.int32, device="cpu")
+        self.positions_cpu = torch.zeros(self.max_num_tokens, dtype=torch.int64, device="cpu")
+        self.next_prefill_tokens_cpu = torch.zeros(self.max_num_reqs, dtype=torch.int32, device="cpu")
+
+    @staticmethod
+    def _validate_config(vllm_config: VllmConfig) -> None:
+        model_config = vllm_config.model_config
+        if model_config.is_multimodal_model or model_config.is_hybrid:
+            raise NotImplementedError("310P model runner v2 currently supports text-only, non-hybrid models.")
+        if model_config.use_mla:
+            raise NotImplementedError("MLA is not supported by model runner v2 on 310P.")
+        if getattr(model_config, "uses_mrope", False):
+            raise NotImplementedError("Multi-dimensional RoPE is outside the text-only 310P MRV2 scope.")
+        if getattr(model_config, "enable_sleep_mode", False):
+            raise NotImplementedError("Sleep mode is outside the initial 310P MRV2 scope.")
+
+        parallel_config = vllm_config.parallel_config
+        unsupported_parallel = {
+            "pipeline_parallel_size": getattr(parallel_config, "pipeline_parallel_size", 1),
+            "data_parallel_size": getattr(parallel_config, "data_parallel_size", 1),
+            "decode_context_parallel_size": getattr(parallel_config, "decode_context_parallel_size", 1),
+            "prefill_context_parallel_size": getattr(parallel_config, "prefill_context_parallel_size", 1),
+        }
+        enabled = [name for name, size in unsupported_parallel.items() if size != 1]
+        if enabled:
+            raise NotImplementedError(
+                f"310P model runner v2 only supports tensor parallelism; unsupported settings: {', '.join(enabled)}."
+            )
+        if getattr(parallel_config, "enable_expert_parallel", False):
+            raise NotImplementedError("Expert parallelism is outside the initial 310P MRV2 scope.")
+        if vllm_config.speculative_config is not None:
+            raise NotImplementedError("Speculative decoding is not supported by model runner v2 on 310P.")
+        if vllm_config.kv_transfer_config is not None:
+            raise NotImplementedError("KV cache transfer is not supported by model runner v2 on 310P.")
+        if vllm_config.cache_config.enable_prefix_caching:
+            raise NotImplementedError("Prefix caching is outside the initial 310P MRV2 scope.")
+        if vllm_config.lora_config is not None:
+            raise NotImplementedError("LoRA is outside the initial 310P MRV2 scope.")
+
+    def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
+        """Allocate the 310P attention cache as separate K/V NZ tensors."""
+        kv_cache_config = deepcopy(kv_cache_config)
+        self.kv_cache_config = kv_cache_config
+
+        block_sizes = []
+        max_num_blocks_per_group = []
+        for kv_cache_group in kv_cache_config.kv_cache_groups:
+            spec = kv_cache_group.kv_cache_spec
+            block_sizes.append(spec.block_size)
+            max_num_blocks = cdiv(self.max_model_len, spec.block_size)
+            if spec.block_size <= 128:
+                alignment = 128 // spec.block_size
+                max_num_blocks = cdiv(max_num_blocks, alignment) * alignment
+            max_num_blocks_per_group.append(max_num_blocks)
+
+        self.attn_groups, attn_cg_support, self.kernel_block_sizes = init_attn_backend(
+            kv_cache_config, self.vllm_config, self.device
+        )
+        self._adjust_kernel_block_sizes(kv_cache_config)
+        self.block_tables = Ascend310PBlockTables(
+            block_sizes=block_sizes,
+            max_num_reqs=self.max_num_reqs,
+            max_num_batched_tokens=self.max_num_tokens,
+            max_num_blocks_per_group=max_num_blocks_per_group,
+            device=self.device,
+            kernel_block_sizes=self.kernel_block_sizes,
+            cp_size=self.dcp_size,
+            cp_rank=self.dcp_rank,
+            cp_interleave=self.cp_interleave,
+        )
+
+        cudagraph_mode = self.compilation_config.resolve_cudagraph_mode_and_sizes(
+            attn_cg_support.min_cg_support,
+            attn_cg_support.min_cg_attn_backend,
+            self.decode_query_len,
+            use_v2_model_runner=True,
+            tensor_parallel_size=self.parallel_config.tensor_parallel_size,
+            kv_cache_config=kv_cache_config,
+            max_num_reqs=self.max_num_reqs,
+        )
+        self.cudagraph_manager = ModelAclGraphManager(
+            self.vllm_config,
+            self.device,
+            cudagraph_mode,
+            self.decode_query_len,
+            self,
+            lora_capture_cases=self.lora_capture_cases,
+        )
+        check_attention_cp_compatibility(self.vllm_config)
+
+        shared_layers = get_shared_kv_cache_layers(self.vllm_config)
+        kv_caches_dict = self._allocate_kv_cache_tensors(kv_cache_config, shared_layers)
+        self.kv_caches: list[Any] = []
+        bind_kv_cache(
+            kv_caches_dict,
+            self.compilation_config.static_forward_context,
+            self.kv_caches,
+        )
+        self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
+
+    def _adjust_kernel_block_sizes(self, kv_cache_config: KVCacheConfig) -> None:
+        for group_id, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
+            group_spec = kv_cache_group.kv_cache_spec
+            if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                specs = tuple(group_spec.kv_cache_specs.values())
+            else:
+                specs = (group_spec,)
+            attention_specs = [spec for spec in specs if isinstance(spec, AttentionSpec)]
+            if len(attention_specs) != len(specs):
+                raise NotImplementedError("The initial 310P MRV2 implementation supports attention KV caches only.")
+            max_head_size = max(spec.head_size for spec in attention_specs)
+            if max_head_size > 256:
+                raise NotImplementedError(f"310P paged attention requires head_size <= 256, got {max_head_size}.")
+            backend = self.attn_groups[group_id][0].backend
+            supported_sizes = [
+                block_size
+                for block_size in backend.get_supported_kernel_block_sizes()
+                if block_size * max_head_size <= _ATTENTION_BLOCK_SIZE_LIMIT
+            ]
+            if not supported_sizes:
+                raise NotImplementedError(
+                    f"310P paged attention requires block_size * head_size <= {_ATTENTION_BLOCK_SIZE_LIMIT}."
+                )
+            self.kernel_block_sizes[group_id] = supported_sizes[0]
+
+    def _allocate_kv_cache_tensors(
+        self,
+        kv_cache_config: KVCacheConfig,
+        shared_layers: dict[str, str],
+    ) -> dict[str, Any]:
+        layer_specs: dict[str, KVCacheSpec] = {}
+        layer_group_ids: dict[str, int] = {}
+        for group_id, kv_cache_group in enumerate(kv_cache_config.kv_cache_groups):
+            group_spec = kv_cache_group.kv_cache_spec
+            for layer_name in kv_cache_group.layer_names:
+                if isinstance(group_spec, UniformTypeKVCacheSpecs):
+                    layer_specs[layer_name] = group_spec.kv_cache_specs[layer_name]
+                else:
+                    layer_specs[layer_name] = group_spec
+                layer_group_ids[layer_name] = group_id
+
+        layer_backends = {
+            layer_name: group.backend
+            for groups in self.attn_groups
+            for group in groups
+            for layer_name in group.layer_names
+        }
+        kv_caches: dict[str, Any] = {}
+        for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            layer_names = [name for name in kv_cache_tensor.shared_by if name not in shared_layers]
+            if not layer_names:
+                continue
+            cache_groups: dict[tuple[Any, ...], list[str]] = {}
+            for layer_name in layer_names:
+                spec = layer_specs[layer_name]
+                if not isinstance(spec, AttentionSpec):
+                    raise NotImplementedError(f"Unsupported 310P KV cache spec: {type(spec).__name__}.")
+                backend = layer_backends[layer_name]
+                group_id = layer_group_ids[layer_name]
+                storage_block_size = getattr(spec, "storage_block_size", spec.block_size)
+                kernel_block_size = (
+                    storage_block_size if storage_block_size != spec.block_size else self.kernel_block_sizes[group_id]
+                )
+                cache_groups.setdefault((spec, backend, kernel_block_size), []).append(layer_name)
+
+            for (spec, backend, kernel_block_size), cache_layer_names in cache_groups.items():
+                if not issubclass(backend, AscendAttentionBackend310):
+                    raise TypeError(f"310P selected unexpected attention backend {backend}.")
+                if kv_cache_tensor.size % spec.page_size_bytes != 0:
+                    raise ValueError("KV cache allocation is not page aligned.")
+                num_blocks = kv_cache_tensor.size // spec.page_size_bytes
+                if num_blocks < kv_cache_config.num_blocks:
+                    raise ValueError("KV cache allocation contains fewer blocks than requested.")
+                blocks_per_kv_block = spec.block_size // kernel_block_size
+                kv_cache_shape = backend.get_kv_cache_shape(
+                    num_blocks * blocks_per_kv_block,
+                    kernel_block_size,
+                    spec.num_kv_heads,
+                    spec.head_size,
+                    self.cache_config.cache_dtype,
+                )
+                if getattr(spec, "head_size_v", spec.head_size) != spec.head_size:
+                    raise NotImplementedError("310P MRV2 does not support asymmetric K/V head sizes.")
+                cache_shape = kv_cache_shape[1:]
+                k_cache = torch_npu.empty_with_format(
+                    size=cache_shape,
+                    dtype=spec.dtype,
+                    device=self.device,
+                    acl_format=ACL_FORMAT_FRACTAL_NZ,
+                )
+                v_cache = torch_npu.empty_with_format(
+                    size=cache_shape,
+                    dtype=spec.dtype,
+                    device=self.device,
+                    acl_format=ACL_FORMAT_FRACTAL_NZ,
+                )
+                for layer_name in cache_layer_names:
+                    kv_caches[layer_name] = (k_cache, v_cache)
+
+        for layer_name, target_layer_name in shared_layers.items():
+            kv_caches[layer_name] = kv_caches[target_layer_name]
+        expected_layers = {
+            layer_name
+            for kv_cache_group in kv_cache_config.kv_cache_groups
+            for layer_name in kv_cache_group.layer_names
+        }
+        if expected_layers != set(kv_caches):
+            raise RuntimeError("Some 310P KV cache layers were not initialized.")
+        return kv_caches
+
+    def _prepare_prefill_inputs(
+        self,
+        input_ids,
+        next_prefill_tokens,
+        idx_mapping,
+        query_start_loc,
+        all_token_ids,
+        prefill_len,
+        num_computed_tokens,
+        *,
+        idx_mapping_np,
+        query_start_loc_np,
+    ) -> None:
+        del idx_mapping, query_start_loc, all_token_ids, prefill_len, num_computed_tokens
+        self.input_ids_cpu[: input_ids.shape[0]].zero_()
+        self.next_prefill_tokens_cpu.zero_()
+        for batch_idx, req_idx in enumerate(idx_mapping_np):
+            num_computed = int(self.req_states.num_computed_tokens_np[req_idx])
+            req_prefill_len = int(self.req_states.prefill_len.np[req_idx])
+            if num_computed >= req_prefill_len:
+                continue
+            start = int(query_start_loc_np[batch_idx])
+            end = int(query_start_loc_np[batch_idx + 1])
+            self.input_ids_cpu[start:end] = self.req_states.all_token_ids.cpu[
+                req_idx, num_computed : num_computed + end - start
+            ]
+            next_position = num_computed + end - start
+            if next_position < req_prefill_len:
+                self.next_prefill_tokens_cpu[req_idx] = self.req_states.all_token_ids.cpu[req_idx, next_position]
+        input_ids.copy_(self.input_ids_cpu[: input_ids.shape[0]], non_blocking=True)
+        next_prefill_tokens.copy_(self.next_prefill_tokens_cpu, non_blocking=True)
+
+    def _prepare_pos_seq_lens(
+        self,
+        idx_mapping,
+        query_start_loc,
+        num_computed_tokens,
+        positions,
+        seq_lens,
+        *,
+        idx_mapping_np,
+        query_start_loc_np,
+        num_scheduled_tokens,
+    ) -> None:
+        del idx_mapping, query_start_loc, num_computed_tokens
+        self.input_buffers.seq_lens_cpu.zero_()
+        self.positions_cpu[: positions.shape[0]].zero_()
+        for batch_idx, (req_idx, num_tokens) in enumerate(zip(idx_mapping_np, num_scheduled_tokens)):
+            num_computed = int(self.req_states.num_computed_tokens_np[req_idx])
+            start = int(query_start_loc_np[batch_idx])
+            end = start + int(num_tokens)
+            self.positions_cpu[start:end] = torch.arange(num_computed, num_computed + num_tokens)
+            self.input_buffers.seq_lens_cpu[batch_idx] = num_computed + num_tokens
+        positions.copy_(self.positions_cpu[: positions.shape[0]], non_blocking=True)
+        seq_lens.copy_(self.input_buffers.seq_lens_cpu, non_blocking=True)
+
+    def _combine_sampled_and_draft_tokens(
+        self,
+        input_ids,
+        idx_mapping,
+        last_sampled_tokens,
+        query_start_loc,
+        seq_lens,
+        prefill_len,
+        draft_tokens,
+        cu_num_logits,
+        num_logits,
+        num_bonus_tokens,
+        *,
+        idx_mapping_np,
+        query_start_loc_np,
+        seq_lens_np,
+        prefill_len_np,
+    ):
+        del idx_mapping, query_start_loc, seq_lens, prefill_len
+        del draft_tokens, cu_num_logits, num_bonus_tokens
+        if num_logits != len(idx_mapping_np):
+            raise NotImplementedError("310P MRV2 does not support draft tokens.")
+        logits_indices_np = np.empty(num_logits, dtype=np.int64)
+        for batch_idx, req_idx in enumerate(idx_mapping_np):
+            query_end = int(query_start_loc_np[batch_idx + 1])
+            logits_indices_np[batch_idx] = query_end - 1
+            if seq_lens_np[batch_idx] > prefill_len_np[batch_idx]:
+                input_ids[query_end - 1 : query_end].copy_(last_sampled_tokens[req_idx])
+        return async_copy_to_gpu(logits_indices_np, device=self.device)
+
+    def prepare_attn(
+        self,
+        input_batch: AscendInputBatch,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        block_tables = self.block_tables.gather_block_tables(
+            input_batch.idx_mapping_np,
+            num_reqs_padded=input_batch.num_reqs_after_padding,
+        )
+        positions_np = np.zeros(input_batch.num_tokens_after_padding, dtype=np.int64)
+        for batch_idx, (start_position, num_scheduled_tokens) in enumerate(
+            zip(input_batch.num_computed_tokens_np, input_batch.num_scheduled_tokens)
+        ):
+            start = int(input_batch.query_start_loc_np[batch_idx])
+            end = start + int(num_scheduled_tokens)
+            positions_np[start:end] = np.arange(
+                start_position,
+                start_position + num_scheduled_tokens,
+                dtype=np.int64,
+            )
+        slot_mappings = self.block_tables.compute_slot_mappings(
+            input_batch.idx_mapping_np,
+            input_batch.query_start_loc_np,
+            positions_np,
+            num_tokens_padded=input_batch.num_tokens_after_padding,
+        )
+        return block_tables, slot_mappings
+
+    def sample(
+        self,
+        hidden_states: torch.Tensor,
+        input_batch: AscendInputBatch,
+        grammar_output: GrammarOutput | None,
+    ):
+        if grammar_output is not None:
+            raise NotImplementedError("Structured output is outside the initial 310P MRV2 scope.")
+        logits = self.model.compute_logits(hidden_states[input_batch.logits_indices])
+        sampler_output = self.sampler(logits, input_batch)
+        can_sample_np = input_batch.seq_lens_np[: input_batch.num_reqs] >= input_batch.prefill_len_np
+        num_sampled = async_copy_to_gpu(can_sample_np.astype(np.int32), device=self.device)
+        num_rejected = torch.zeros_like(num_sampled)
+        sampler_output.num_sampled = num_sampled
+        sampler_output.num_rejected = num_rejected
+        return sampler_output, num_sampled, num_rejected
+
+    def postprocess_sampled(
+        self,
+        idx_mapping: torch.Tensor,
+        sampled_tokens: torch.Tensor,
+        num_sampled: torch.Tensor,
+        num_rejected: torch.Tensor,
+        query_start_loc: torch.Tensor | None = None,
+    ) -> None:
+        del num_rejected
+        num_entries = min(idx_mapping.shape[0], sampled_tokens.shape[0], num_sampled.shape[0])
+        idx_mapping = idx_mapping[:num_entries]
+        sampled_tokens = sampled_tokens[:num_entries]
+        num_sampled = num_sampled[:num_entries]
+        valid_mask = idx_mapping >= 0
+        valid_indices = idx_mapping.masked_select(valid_mask)
+        sampled = sampled_tokens[:, 0].masked_select(valid_mask).to(self.req_states.last_sampled_tokens.dtype)
+        valid_num_sampled = num_sampled.masked_select(valid_mask)
+        has_sample = valid_num_sampled > 0
+
+        token_positions = self.req_states.total_len.gpu[valid_indices].to(torch.int64)
+        old_tokens = self.req_states.all_token_ids.gpu[valid_indices, token_positions]
+        stored_tokens = torch.where(has_sample, sampled.to(torch.int32), old_tokens)
+        self.req_states.all_token_ids.gpu.index_put_((valid_indices, token_positions), stored_tokens)
+        old_last = self.req_states.last_sampled_tokens[valid_indices, 0]
+        self.req_states.last_sampled_tokens.index_copy_(
+            0,
+            valid_indices,
+            torch.where(has_sample, sampled, old_last).unsqueeze(-1),
+        )
+        self.req_states.total_len.gpu.index_add_(0, valid_indices, valid_num_sampled)
+
+        if query_start_loc is not None:
+            query_lens = self._get_valid_query_lens(idx_mapping, query_start_loc)
+            self.req_states.num_computed_tokens.gpu.index_add_(
+                0,
+                valid_indices,
+                query_lens.to(self.req_states.num_computed_tokens.gpu.dtype),
+            )
+        self.model_state.postprocess_state(idx_mapping, num_sampled)
+
+    @staticmethod
+    def _get_valid_query_lens(
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+    ) -> torch.Tensor:
+        """Return real request query lengths without ACLGraph padding."""
+        num_query_lens = min(idx_mapping.shape[0], query_start_loc.shape[0] - 1)
+        query_lens = query_start_loc[1 : num_query_lens + 1] - query_start_loc[:num_query_lens]
+        return query_lens.masked_select(idx_mapping[:num_query_lens] >= 0)
+
+    def postprocess_num_computed_tokens(self, input_batch: AscendInputBatch) -> None:
+        query_lens = input_batch.query_start_loc[1:] - input_batch.query_start_loc[:-1]
+        self.req_states.num_computed_tokens.gpu.index_add_(
+            0,
+            input_batch.idx_mapping,
+            query_lens.to(self.req_states.num_computed_tokens.gpu.dtype),
+        )

--- a/vllm_ascend/_310p/worker/v2/model_runner.py
+++ b/vllm_ascend/_310p/worker/v2/model_runner.py
@@ -55,14 +55,12 @@ class NPUModelRunner310V2(NPUModelRunner):
     @staticmethod
     def _validate_config(vllm_config: VllmConfig) -> None:
         model_config = vllm_config.model_config
-        # TODO: Support multimodal and hybrid models in the next 310P MRV2 iteration.
-        if model_config.is_multimodal_model or model_config.is_hybrid:
-            raise NotImplementedError("Multimodal and hybrid models are not supported by model runner v2 on 310P.")
+        # Qwen3-VL (multimodal + MRoPE) is in scope for this 310P MRv2 iteration.
+        # Hybrid/GDN (Qwen3.5) remains deferred here; keep the hard reject.
+        if model_config.is_hybrid:
+            raise NotImplementedError("Hybrid models are not supported by model runner v2 on 310P.")
         if model_config.use_mla:
             raise NotImplementedError("MLA is not supported by model runner v2 on 310P.")
-        # TODO: Support multi-dimensional RoPE in the next 310P MRV2 iteration.
-        if getattr(model_config, "uses_mrope", False):
-            raise NotImplementedError("Multi-dimensional RoPE is not supported by model runner v2 on 310P.")
         if getattr(model_config, "enable_sleep_mode", False):
             raise NotImplementedError("Sleep mode is not supported by model runner v2 on 310P.")
 

--- a/vllm_ascend/_310p/worker/v2/model_runner.py
+++ b/vllm_ascend/_310p/worker/v2/model_runner.py
@@ -274,16 +274,16 @@ class NPUModelRunner310V2(NPUModelRunner):
 
     def _prepare_prefill_inputs(
         self,
-        input_ids,
-        next_prefill_tokens,
-        idx_mapping,
-        query_start_loc,
-        all_token_ids,
-        prefill_len,
-        num_computed_tokens,
+        input_ids: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        all_token_ids: torch.Tensor,
+        prefill_len: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
         *,
-        idx_mapping_np,
-        query_start_loc_np,
+        idx_mapping_np: np.ndarray,
+        query_start_loc_np: np.ndarray,
     ) -> None:
         del idx_mapping, query_start_loc, all_token_ids, prefill_len, num_computed_tokens
         self.input_ids_cpu[: input_ids.shape[0]].zero_()
@@ -306,15 +306,15 @@ class NPUModelRunner310V2(NPUModelRunner):
 
     def _prepare_pos_seq_lens(
         self,
-        idx_mapping,
-        query_start_loc,
-        num_computed_tokens,
-        positions,
-        seq_lens,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+        positions: torch.Tensor,
+        seq_lens: torch.Tensor,
         *,
-        idx_mapping_np,
-        query_start_loc_np,
-        num_scheduled_tokens,
+        idx_mapping_np: np.ndarray,
+        query_start_loc_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
     ) -> None:
         del idx_mapping, query_start_loc, num_computed_tokens
         self.input_buffers.seq_lens_cpu.zero_()
@@ -330,22 +330,22 @@ class NPUModelRunner310V2(NPUModelRunner):
 
     def _combine_sampled_and_draft_tokens(
         self,
-        input_ids,
-        idx_mapping,
-        last_sampled_tokens,
-        query_start_loc,
-        seq_lens,
-        prefill_len,
-        draft_tokens,
-        cu_num_logits,
-        num_logits,
-        num_bonus_tokens,
+        input_ids: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        last_sampled_tokens: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        seq_lens: torch.Tensor,
+        prefill_len: torch.Tensor,
+        draft_tokens: torch.Tensor,
+        cu_num_logits: torch.Tensor,
+        num_logits: int,
+        num_bonus_tokens: int,
         *,
-        idx_mapping_np,
-        query_start_loc_np,
-        seq_lens_np,
-        prefill_len_np,
-    ):
+        idx_mapping_np: np.ndarray,
+        query_start_loc_np: np.ndarray,
+        seq_lens_np: np.ndarray,
+        prefill_len_np: np.ndarray,
+    ) -> torch.Tensor:
         del idx_mapping, query_start_loc, seq_lens, prefill_len
         del draft_tokens, cu_num_logits, num_bonus_tokens
         if num_logits != len(idx_mapping_np):

--- a/vllm_ascend/_310p/worker/v2/model_state.py
+++ b/vllm_ascend/_310p/worker/v2/model_state.py
@@ -22,8 +22,8 @@ from .sampler import Ascend310PSampler
 class Ascend310PModelState(AscendModelState):
     """Model state with the Triton-free 310P sampler."""
 
-    # TODO: Remove the sampler override after its kernels use triton_dispatch
-    # following vLLM RFC #45133.
+    # TODO: Refactor the sampler override to use Triton Dispatcher after vLLM
+    # RFC #45133 lands.
 
     def __init__(
         self,

--- a/vllm_ascend/_310p/worker/v2/model_state.py
+++ b/vllm_ascend/_310p/worker/v2/model_state.py
@@ -13,6 +13,8 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.utils import AttentionGroup
 
+from vllm_ascend._310p.ops.rotary_embedding import prepare_mrope_cos_sin_slices_from_runner
+from vllm_ascend._310p.worker.v2.rope import Ascend310PRopeState, get_310p_rope_state
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 from vllm_ascend.worker.v2.model_states.default import AscendModelState
 
@@ -20,7 +22,7 @@ from .sampler import Ascend310PSampler
 
 
 class Ascend310PModelState(AscendModelState):
-    """Model state with the Triton-free 310P sampler."""
+    """Model state with Triton-free 310P sampler / MRoPE and encoder support."""
 
     # TODO: Refactor the sampler override to use Triton Dispatcher after vLLM
     # RFC #45133 lands.
@@ -32,15 +34,30 @@ class Ascend310PModelState(AscendModelState):
         encoder_cache: EncoderCache | None,
         device: torch.device,
     ) -> None:
-        if encoder_cache is not None:
-            # TODO: Support multimodal encoder state in the next 310P MRV2 iteration.
-            raise NotImplementedError("Multimodal encoder state is not supported by model runner v2 on 310P.")
-        # Plain-text Qwen3 uses ordinary 1D RoPE, for which upstream returns
-        # no RopeState and therefore does not launch its Triton position kernel.
-        super().__init__(vllm_config, model, encoder_cache, device)
+        # Initialize the full Ascend/DefaultModelState contract first so
+        # attributes such as ``prompt_embeds_state`` / ``encoder_runner`` exist,
+        # then swap RoPE to the Triton-free 310P implementation.
+        AscendModelState.__init__(self, vllm_config, model, encoder_cache, device)
         # ACLGraph replays the tensor addresses bound during capture. Keep every
         # captured seq_lens buffer so its contents can be refreshed before replay.
         self._capture_seq_lens_by_ptr: dict[int, torch.Tensor] = {}
+        self._replace_310p_rope_state(encoder_cache)
+
+    def _replace_310p_rope_state(self, encoder_cache: EncoderCache | None) -> None:
+        self.rope_state = get_310p_rope_state(
+            self.model_config,
+            self.model,
+            self.max_num_reqs,
+            self.max_num_tokens,
+            self.max_model_len,
+            self.device,
+        )
+        try:
+            from vllm.v1.worker.gpu.model_states.mm_pruning import maybe_create_mm_pruner
+        except ImportError:
+            self.mm_pruner = None
+        else:
+            self.mm_pruner = maybe_create_mm_pruner(self.model_config, self.model, self.rope_state, encoder_cache)
 
     def _record_capture_seq_lens(self, seq_lens: torch.Tensor) -> None:
         """Record the largest captured view for each physical buffer."""
@@ -83,6 +100,25 @@ class Ascend310PModelState(AscendModelState):
             kv_cache_config,
             for_capture=for_capture,
         )
+
+    def prepare_inputs(self, input_batch: AscendInputBatch, req_states):
+        if self.rope_state is None:
+            return super().prepare_inputs(input_batch, req_states)
+
+        assert isinstance(self.rope_state, Ascend310PRopeState)
+        # Upstream RopeState.prepare_positions uses Triton; 310P builds positions
+        # on CPU from staged prefill tables, then H2D copies.
+        self.rope_state.prepare_positions_cpu(
+            input_batch.idx_mapping_np,
+            input_batch.query_start_loc_np,
+            req_states.prefill_len.np,
+            req_states.num_computed_tokens_np,
+            input_batch.num_tokens_after_padding,
+        )
+        positions = self.rope_state.get_positions(input_batch.num_tokens_after_padding)
+        if self.model_config.uses_mrope:
+            prepare_mrope_cos_sin_slices_from_runner(self, positions)
+        return {"positions": positions}
 
     def custom_sampler(self, sampler):
         del sampler

--- a/vllm_ascend/_310p/worker/v2/model_state.py
+++ b/vllm_ascend/_310p/worker/v2/model_state.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
 
-"""Text-only MRV2 model state for Ascend 310P."""
+"""MRV2 model state for Ascend 310P."""
 
 import torch
 import torch.nn as nn
@@ -14,7 +14,7 @@ from .sampler import Ascend310PSampler
 
 
 class Ascend310PModelState(AscendModelState):
-    """Text-only model state with the Triton-free 310P sampler."""
+    """Model state with the Triton-free 310P sampler."""
 
     def __init__(
         self,
@@ -24,7 +24,8 @@ class Ascend310PModelState(AscendModelState):
         device: torch.device,
     ) -> None:
         if encoder_cache is not None:
-            raise NotImplementedError("Multimodal encoder state is outside the text-only 310P MRV2 scope.")
+            # TODO: Support multimodal encoder state in the next 310P MRV2 iteration.
+            raise NotImplementedError("Multimodal encoder state is not supported by model runner v2 on 310P.")
         # Plain-text Qwen3 uses ordinary 1D RoPE, for which upstream returns
         # no RopeState and therefore does not launch its Triton position kernel.
         super().__init__(vllm_config, model, encoder_cache, device)

--- a/vllm_ascend/_310p/worker/v2/model_state.py
+++ b/vllm_ascend/_310p/worker/v2/model_state.py
@@ -3,11 +3,17 @@
 
 """MRV2 model state for Ascend 310P."""
 
+from typing import Any
+
 import torch
 import torch.nn as nn
 from vllm.config import VllmConfig
+from vllm.config.compilation import CUDAGraphMode
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+from vllm.v1.worker.utils import AttentionGroup
 
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch
 from vllm_ascend.worker.v2.model_states.default import AscendModelState
 
 from .sampler import Ascend310PSampler
@@ -29,6 +35,51 @@ class Ascend310PModelState(AscendModelState):
         # Plain-text Qwen3 uses ordinary 1D RoPE, for which upstream returns
         # no RopeState and therefore does not launch its Triton position kernel.
         super().__init__(vllm_config, model, encoder_cache, device)
+        # ACLGraph replays the tensor addresses bound during capture. Keep every
+        # captured seq_lens buffer so its contents can be refreshed before replay.
+        self._capture_seq_lens_by_ptr: dict[int, torch.Tensor] = {}
+
+    def _record_capture_seq_lens(self, seq_lens: torch.Tensor) -> None:
+        """Record the largest captured view for each physical buffer."""
+        data_ptr = seq_lens.data_ptr()
+        recorded = self._capture_seq_lens_by_ptr.get(data_ptr)
+        if recorded is None or seq_lens.numel() > recorded.numel():
+            self._capture_seq_lens_by_ptr[data_ptr] = seq_lens
+
+    def _refresh_capture_seq_lens(self, runtime_seq_lens: torch.Tensor) -> None:
+        """Copy runtime lengths to buffers read by FULL graph replay."""
+        for capture_seq_lens in self._capture_seq_lens_by_ptr.values():
+            num_seq_lens = min(capture_seq_lens.numel(), runtime_seq_lens.numel())
+            capture_seq_lens[:num_seq_lens].copy_(runtime_seq_lens[:num_seq_lens], non_blocking=True)
+            if num_seq_lens < capture_seq_lens.numel():
+                capture_seq_lens[num_seq_lens:].zero_()
+
+    def prepare_attn(
+        self,
+        input_batch: AscendInputBatch,
+        cudagraph_mode: CUDAGraphMode,
+        block_tables: tuple[torch.Tensor, ...],
+        slot_mappings: torch.Tensor,
+        attn_groups: list[list[AttentionGroup]],
+        kv_cache_config: KVCacheConfig,
+        for_capture: bool = False,
+    ) -> dict[str, Any]:
+        if for_capture:
+            self._record_capture_seq_lens(input_batch.seq_lens)
+        elif cudagraph_mode == CUDAGraphMode.FULL:
+            # Updating only input_batch.seq_lens is insufficient when replay is
+            # bound to a different capture-time address.
+            self._refresh_capture_seq_lens(input_batch.seq_lens)
+
+        return super().prepare_attn(
+            input_batch,
+            cudagraph_mode,
+            block_tables,
+            slot_mappings,
+            attn_groups,
+            kv_cache_config,
+            for_capture=for_capture,
+        )
 
     def custom_sampler(self, sampler):
         del sampler

--- a/vllm_ascend/_310p/worker/v2/model_state.py
+++ b/vllm_ascend/_310p/worker/v2/model_state.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+"""Text-only MRV2 model state for Ascend 310P."""
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+
+from vllm_ascend.worker.v2.model_states.default import AscendModelState
+
+from .sampler import Ascend310PSampler
+
+
+class Ascend310PModelState(AscendModelState):
+    """Text-only model state with the Triton-free 310P sampler."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: nn.Module,
+        encoder_cache: EncoderCache | None,
+        device: torch.device,
+    ) -> None:
+        if encoder_cache is not None:
+            raise NotImplementedError("Multimodal encoder state is outside the text-only 310P MRV2 scope.")
+        # Plain-text Qwen3 uses ordinary 1D RoPE, for which upstream returns
+        # no RopeState and therefore does not launch its Triton position kernel.
+        super().__init__(vllm_config, model, encoder_cache, device)
+
+    def custom_sampler(self, sampler):
+        del sampler
+        return Ascend310PSampler(), None

--- a/vllm_ascend/_310p/worker/v2/model_state.py
+++ b/vllm_ascend/_310p/worker/v2/model_state.py
@@ -22,6 +22,9 @@ from .sampler import Ascend310PSampler
 class Ascend310PModelState(AscendModelState):
     """Model state with the Triton-free 310P sampler."""
 
+    # TODO: Remove the sampler override after its kernels use triton_dispatch
+    # following vLLM RFC #45133.
+
     def __init__(
         self,
         vllm_config: VllmConfig,

--- a/vllm_ascend/_310p/worker/v2/rope.py
+++ b/vllm_ascend/_310p/worker/v2/rope.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from typing import cast
+
+import numpy as np
+import torch
+import torch.nn as nn
+from vllm.config import ModelConfig
+from vllm.model_executor.models.interfaces import SupportsMRoPE, SupportsXDRoPE
+from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor
+
+from vllm_ascend._310p.worker.v2.states import Ascend310PStagedWriteTensor
+
+
+class Ascend310PRopeState:
+    """Triton-free multi-dimensional RoPE state for 310P."""
+
+    def __init__(
+        self,
+        num_dims: int,
+        has_delta: bool,
+        max_num_reqs: int,
+        max_num_tokens: int,
+        max_model_len: int,
+        device: torch.device,
+    ) -> None:
+        self.num_dims = num_dims
+        self.has_delta = has_delta
+        self.max_model_len = max_model_len
+        self.device = device
+        self.prefill_positions = Ascend310PStagedWriteTensor(
+            (max_num_reqs * num_dims, max_model_len),
+            dtype=torch.int32,
+            device=device,
+            uva_instead_of_gpu=True,
+        )
+        self.prefill_delta = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
+        self.positions_cpu = torch.zeros((num_dims, max_num_tokens + 1), dtype=torch.int64, device="cpu")
+        self.positions = torch.zeros((num_dims, max_num_tokens + 1), dtype=torch.int64, device=device)
+
+    def init_prefill_positions(
+        self,
+        req_idx: int,
+        model: nn.Module,
+        prefill_token_ids: list[int],
+        mm_features: list,
+    ) -> None:
+        if self.has_delta:
+            mrope_model = cast(SupportsMRoPE, model)
+            prefill_positions, delta = mrope_model.get_mrope_input_positions(prefill_token_ids, mm_features)
+            self.prefill_delta.np[req_idx] = delta
+        else:
+            xdrope_model = cast(SupportsXDRoPE, model)
+            prefill_positions = xdrope_model.get_xdrope_input_positions(prefill_token_ids, mm_features)
+
+        for dim in range(self.num_dims):
+            self.prefill_positions.stage_write(
+                self.num_dims * req_idx + dim,
+                0,
+                prefill_positions[dim].tolist(),
+            )
+
+    def apply_staged_writes(self) -> None:
+        self.prefill_positions.apply_write()
+        if self.has_delta:
+            self.prefill_delta.copy_to_uva()
+
+    def prepare_positions_cpu(
+        self,
+        idx_mapping_np: np.ndarray,
+        query_start_loc_np: np.ndarray,
+        prefill_lens_np: np.ndarray,
+        num_computed_tokens_np: np.ndarray,
+        num_tokens_after_padding: int,
+    ) -> None:
+        self.positions_cpu[:, :num_tokens_after_padding].zero_()
+        for batch_idx, req_idx in enumerate(idx_mapping_np):
+            query_start = int(query_start_loc_np[batch_idx])
+            query_end = int(query_start_loc_np[batch_idx + 1])
+            num_computed = int(num_computed_tokens_np[req_idx])
+            query_len = query_end - query_start
+            if num_computed < int(prefill_lens_np[req_idx]):
+                row_start = self.num_dims * int(req_idx)
+                positions = self.prefill_positions.cpu[
+                    row_start : row_start + self.num_dims,
+                    num_computed : num_computed + query_len,
+                ]
+                self.positions_cpu[:, query_start:query_end].copy_(positions)
+            else:
+                delta = int(self.prefill_delta.np[req_idx]) if self.has_delta else 0
+                decode_positions = torch.arange(
+                    num_computed + delta,
+                    num_computed + delta + query_len,
+                    dtype=torch.int64,
+                )
+                self.positions_cpu[:, query_start:query_end] = decode_positions
+
+        self.positions[:, :num_tokens_after_padding].copy_(
+            self.positions_cpu[:, :num_tokens_after_padding], non_blocking=True
+        )
+
+    def get_positions(self, num_tokens: int) -> torch.Tensor:
+        return self.positions[:, :num_tokens]
+
+
+def get_310p_rope_state(
+    model_config: ModelConfig,
+    model: nn.Module,
+    max_num_reqs: int,
+    max_num_tokens: int,
+    max_model_len: int,
+    device: torch.device,
+) -> Ascend310PRopeState | None:
+    if model_config.uses_mrope:
+        assert isinstance(model, SupportsMRoPE)
+        return Ascend310PRopeState(3, True, max_num_reqs, max_num_tokens, max_model_len, device)
+    if model_config.uses_xdrope_dim > 0:
+        assert isinstance(model, SupportsXDRoPE)
+        return Ascend310PRopeState(
+            model_config.uses_xdrope_dim,
+            False,
+            max_num_reqs,
+            max_num_tokens,
+            max_model_len,
+            device,
+        )
+    return None

--- a/vllm_ascend/_310p/worker/v2/sampler.py
+++ b/vllm_ascend/_310p/worker/v2/sampler.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from types import SimpleNamespace
+
+import torch
+from vllm.sampling_params import SamplingParams
+from vllm.v1.worker.gpu.sample.output import SamplerOutput
+
+
+class Ascend310PSampler:
+    """Triton-free sampler for 310P MRV2; currently supports greedy sampling."""
+
+    def __init__(self) -> None:
+        self.penalties_state = SimpleNamespace(output_bin_counts=None)
+
+    def add_request(
+        self,
+        req_idx: int,
+        prompt_len: int,
+        sampling_params: SamplingParams,
+    ) -> None:
+        del req_idx, prompt_len
+        unsupported = []
+        if sampling_params.temperature != 0:
+            unsupported.append("temperature")
+        if sampling_params.top_p != 1.0:
+            unsupported.append("top_p")
+        if sampling_params.top_k not in (-1, 0):
+            unsupported.append("top_k")
+        if sampling_params.min_p != 0.0:
+            unsupported.append("min_p")
+        if sampling_params.repetition_penalty != 1.0:
+            unsupported.append("repetition_penalty")
+        if sampling_params.presence_penalty != 0.0 or sampling_params.frequency_penalty != 0.0:
+            unsupported.append("presence/frequency penalty")
+        if sampling_params.logprobs is not None or sampling_params.prompt_logprobs is not None:
+            unsupported.append("logprobs")
+        if (
+            getattr(sampling_params, "bad_words", None)
+            or getattr(sampling_params, "logit_bias", None)
+            or getattr(sampling_params, "allowed_token_ids", None)
+        ):
+            unsupported.append("logits processors")
+        if unsupported:
+            raise NotImplementedError(
+                "310P model runner v2 currently supports greedy sampling only; "
+                f"unsupported parameters: {', '.join(unsupported)}."
+            )
+
+    def apply_staged_writes(self) -> None:
+        pass
+
+    def __call__(self, logits: torch.Tensor, input_batch) -> SamplerOutput:
+        sampled = logits.argmax(dim=-1).to(torch.int32)
+        num_sampled = input_batch.seq_lens.new_ones(input_batch.num_reqs)
+        return SamplerOutput(
+            sampled_token_ids=sampled.view(-1, 1),
+            logprobs_tensors=None,
+            num_nans=None,
+            num_sampled=num_sampled,
+            num_rejected=torch.zeros_like(num_sampled),
+        )

--- a/vllm_ascend/_310p/worker/v2/sampler.py
+++ b/vllm_ascend/_310p/worker/v2/sampler.py
@@ -11,6 +11,9 @@ from vllm.v1.worker.gpu.sample.output import SamplerOutput
 class Ascend310PSampler:
     """Triton-free sampler for 310P MRV2."""
 
+    # TODO: Refactor this sampler to register 310P implementations through
+    # Triton Dispatcher after vLLM RFC #45133 lands.
+
     def __init__(self) -> None:
         self.penalties_state = SimpleNamespace(output_bin_counts=None)
 

--- a/vllm_ascend/_310p/worker/v2/sampler.py
+++ b/vllm_ascend/_310p/worker/v2/sampler.py
@@ -9,7 +9,7 @@ from vllm.v1.worker.gpu.sample.output import SamplerOutput
 
 
 class Ascend310PSampler:
-    """Triton-free sampler for 310P MRV2; currently supports greedy sampling."""
+    """Triton-free sampler for 310P MRV2."""
 
     def __init__(self) -> None:
         self.penalties_state = SimpleNamespace(output_bin_counts=None)
@@ -43,9 +43,9 @@ class Ascend310PSampler:
         ):
             unsupported.append("logits processors")
         if unsupported:
+            # TODO: Support additional sampling features in the next 310P MRV2 iteration.
             raise NotImplementedError(
-                "310P model runner v2 currently supports greedy sampling only; "
-                f"unsupported parameters: {', '.join(unsupported)}."
+                f"Unsupported sampling parameters on model runner v2 for 310P: {', '.join(unsupported)}."
             )
 
     def apply_staged_writes(self) -> None:

--- a/vllm_ascend/_310p/worker/v2/sampler.py
+++ b/vllm_ascend/_310p/worker/v2/sampler.py
@@ -7,17 +7,12 @@ import torch
 from vllm.sampling_params import SamplingParams
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 
-from vllm_ascend._310p.sample.sampler import AscendSampler310, _random_sample_310p
-from vllm_ascend.sample.sampler import apply_top_k_top_p
-
 
 class Ascend310PSampler:
     """Triton-free sampler for 310P MRV2."""
 
     def __init__(self) -> None:
         self.penalties_state = SimpleNamespace(output_bin_counts=None)
-        self.sampling_params: dict[int, SamplingParams] = {}
-        self.generators: dict[int, torch.Generator] = {}
 
     def add_request(
         self,
@@ -25,8 +20,16 @@ class Ascend310PSampler:
         prompt_len: int,
         sampling_params: SamplingParams,
     ) -> None:
-        del prompt_len
+        del req_idx, prompt_len
         unsupported = []
+        if sampling_params.temperature != 0:
+            unsupported.append("temperature")
+        if sampling_params.top_p != 1.0:
+            unsupported.append("top_p")
+        if sampling_params.top_k not in (-1, 0):
+            unsupported.append("top_k")
+        if sampling_params.min_p != 0.0:
+            unsupported.append("min_p")
         if sampling_params.repetition_penalty != 1.0:
             unsupported.append("repetition_penalty")
         if sampling_params.presence_penalty != 0.0 or sampling_params.frequency_penalty != 0.0:
@@ -44,79 +47,12 @@ class Ascend310PSampler:
             raise NotImplementedError(
                 f"Unsupported sampling parameters on model runner v2 for 310P: {', '.join(unsupported)}."
             )
-        self.sampling_params[req_idx] = sampling_params
-        if sampling_params.seed is None:
-            self.generators.pop(req_idx, None)
-        else:
-            generator = torch.Generator(device="cpu")
-            generator.manual_seed(sampling_params.seed)
-            self.generators[req_idx] = generator
 
     def apply_staged_writes(self) -> None:
         pass
 
     def __call__(self, logits: torch.Tensor, input_batch) -> SamplerOutput:
-        idx_mapping_np = input_batch.idx_mapping_np[: input_batch.num_reqs]
-        params = [self.sampling_params[int(req_idx)] for req_idx in idx_mapping_np]
-
-        temperatures = torch.tensor(
-            [param.temperature for param in params],
-            dtype=torch.float32,
-            device=logits.device,
-        )
-        greedy_mask = temperatures == 0
-        if all(param.temperature == 0 for param in params):
-            sampled = AscendSampler310.greedy_sample(logits[: input_batch.num_reqs]).to(torch.int32)
-            return self._build_output(sampled, input_batch)
-
-        safe_temperatures = torch.where(greedy_mask, torch.ones_like(temperatures), temperatures)
-        processed_logits = logits[: input_batch.num_reqs].to(torch.float32).clone()
-        processed_logits = processed_logits / safe_temperatures.unsqueeze(-1)
-
-        min_p = torch.tensor(
-            [param.min_p for param in params],
-            dtype=torch.float32,
-            device=logits.device,
-        )
-        if any(param.min_p != 0.0 for param in params):
-            probs = processed_logits.softmax(dim=-1)
-            min_p_thresholds = probs.max(dim=-1, keepdim=True).values * min_p.unsqueeze(-1)
-            processed_logits.masked_fill_(probs < min_p_thresholds, -float("inf"))
-
-        vocab_size = processed_logits.shape[-1]
-        top_k = torch.tensor(
-            [param.top_k if 0 < param.top_k < vocab_size else vocab_size for param in params],
-            dtype=torch.int32,
-            device=logits.device,
-        )
-        top_p = torch.tensor(
-            [param.top_p for param in params],
-            dtype=torch.float32,
-            device=logits.device,
-        )
-        k = top_k if any(param.top_k not in (-1, 0) and param.top_k < vocab_size for param in params) else None
-        p = top_p if any(param.top_p != 1.0 for param in params) else None
-        filtered = apply_top_k_top_p(processed_logits, k, p)
-        candidate_ids = None
-        if isinstance(filtered, tuple):
-            processed_logits, candidate_ids = filtered
-        else:
-            processed_logits = filtered
-
-        generators = {
-            batch_idx: self.generators[int(req_idx)]
-            for batch_idx, req_idx in enumerate(idx_mapping_np)
-            if int(req_idx) in self.generators
-        }
-        sampled = _random_sample_310p(processed_logits.softmax(dim=-1), generators)
-        sampled = torch.where(greedy_mask, processed_logits.argmax(dim=-1), sampled)
-        if candidate_ids is not None:
-            sampled = candidate_ids.gather(dim=-1, index=sampled.unsqueeze(-1)).squeeze(-1)
-        sampled = sampled.to(torch.int32)
-        return self._build_output(sampled, input_batch)
-
-    @staticmethod
-    def _build_output(sampled: torch.Tensor, input_batch) -> SamplerOutput:
+        sampled = logits.argmax(dim=-1).to(torch.int32)
         num_sampled = input_batch.seq_lens.new_ones(input_batch.num_reqs)
         return SamplerOutput(
             sampled_token_ids=sampled.view(-1, 1),

--- a/vllm_ascend/_310p/worker/v2/sampler.py
+++ b/vllm_ascend/_310p/worker/v2/sampler.py
@@ -7,12 +7,17 @@ import torch
 from vllm.sampling_params import SamplingParams
 from vllm.v1.worker.gpu.sample.output import SamplerOutput
 
+from vllm_ascend._310p.sample.sampler import AscendSampler310, _random_sample_310p
+from vllm_ascend.sample.sampler import apply_top_k_top_p
+
 
 class Ascend310PSampler:
     """Triton-free sampler for 310P MRV2."""
 
     def __init__(self) -> None:
         self.penalties_state = SimpleNamespace(output_bin_counts=None)
+        self.sampling_params: dict[int, SamplingParams] = {}
+        self.generators: dict[int, torch.Generator] = {}
 
     def add_request(
         self,
@@ -20,16 +25,8 @@ class Ascend310PSampler:
         prompt_len: int,
         sampling_params: SamplingParams,
     ) -> None:
-        del req_idx, prompt_len
+        del prompt_len
         unsupported = []
-        if sampling_params.temperature != 0:
-            unsupported.append("temperature")
-        if sampling_params.top_p != 1.0:
-            unsupported.append("top_p")
-        if sampling_params.top_k not in (-1, 0):
-            unsupported.append("top_k")
-        if sampling_params.min_p != 0.0:
-            unsupported.append("min_p")
         if sampling_params.repetition_penalty != 1.0:
             unsupported.append("repetition_penalty")
         if sampling_params.presence_penalty != 0.0 or sampling_params.frequency_penalty != 0.0:
@@ -47,12 +44,79 @@ class Ascend310PSampler:
             raise NotImplementedError(
                 f"Unsupported sampling parameters on model runner v2 for 310P: {', '.join(unsupported)}."
             )
+        self.sampling_params[req_idx] = sampling_params
+        if sampling_params.seed is None:
+            self.generators.pop(req_idx, None)
+        else:
+            generator = torch.Generator(device="cpu")
+            generator.manual_seed(sampling_params.seed)
+            self.generators[req_idx] = generator
 
     def apply_staged_writes(self) -> None:
         pass
 
     def __call__(self, logits: torch.Tensor, input_batch) -> SamplerOutput:
-        sampled = logits.argmax(dim=-1).to(torch.int32)
+        idx_mapping_np = input_batch.idx_mapping_np[: input_batch.num_reqs]
+        params = [self.sampling_params[int(req_idx)] for req_idx in idx_mapping_np]
+
+        temperatures = torch.tensor(
+            [param.temperature for param in params],
+            dtype=torch.float32,
+            device=logits.device,
+        )
+        greedy_mask = temperatures == 0
+        if all(param.temperature == 0 for param in params):
+            sampled = AscendSampler310.greedy_sample(logits[: input_batch.num_reqs]).to(torch.int32)
+            return self._build_output(sampled, input_batch)
+
+        safe_temperatures = torch.where(greedy_mask, torch.ones_like(temperatures), temperatures)
+        processed_logits = logits[: input_batch.num_reqs].to(torch.float32).clone()
+        processed_logits = processed_logits / safe_temperatures.unsqueeze(-1)
+
+        min_p = torch.tensor(
+            [param.min_p for param in params],
+            dtype=torch.float32,
+            device=logits.device,
+        )
+        if any(param.min_p != 0.0 for param in params):
+            probs = processed_logits.softmax(dim=-1)
+            min_p_thresholds = probs.max(dim=-1, keepdim=True).values * min_p.unsqueeze(-1)
+            processed_logits.masked_fill_(probs < min_p_thresholds, -float("inf"))
+
+        vocab_size = processed_logits.shape[-1]
+        top_k = torch.tensor(
+            [param.top_k if 0 < param.top_k < vocab_size else vocab_size for param in params],
+            dtype=torch.int32,
+            device=logits.device,
+        )
+        top_p = torch.tensor(
+            [param.top_p for param in params],
+            dtype=torch.float32,
+            device=logits.device,
+        )
+        k = top_k if any(param.top_k not in (-1, 0) and param.top_k < vocab_size for param in params) else None
+        p = top_p if any(param.top_p != 1.0 for param in params) else None
+        filtered = apply_top_k_top_p(processed_logits, k, p)
+        candidate_ids = None
+        if isinstance(filtered, tuple):
+            processed_logits, candidate_ids = filtered
+        else:
+            processed_logits = filtered
+
+        generators = {
+            batch_idx: self.generators[int(req_idx)]
+            for batch_idx, req_idx in enumerate(idx_mapping_np)
+            if int(req_idx) in self.generators
+        }
+        sampled = _random_sample_310p(processed_logits.softmax(dim=-1), generators)
+        sampled = torch.where(greedy_mask, processed_logits.argmax(dim=-1), sampled)
+        if candidate_ids is not None:
+            sampled = candidate_ids.gather(dim=-1, index=sampled.unsqueeze(-1)).squeeze(-1)
+        sampled = sampled.to(torch.int32)
+        return self._build_output(sampled, input_batch)
+
+    @staticmethod
+    def _build_output(sampled: torch.Tensor, input_batch) -> SamplerOutput:
         num_sampled = input_batch.seq_lens.new_ones(input_batch.num_reqs)
         return SamplerOutput(
             sampled_token_ids=sampled.view(-1, 1),

--- a/vllm_ascend/_310p/worker/v2/states.py
+++ b/vllm_ascend/_310p/worker/v2/states.py
@@ -13,7 +13,7 @@ from vllm_ascend.worker.v2.states import AscendRequestState
 class Ascend310PStagedWriteTensor:
     """CPU-owned replacement for vLLM's Triton-backed staged writes."""
 
-    # TODO: Refactor this Triton replacement through triton_dispatch after
+    # TODO: Refactor this 310P implementation to use Triton Dispatcher after
     # vLLM RFC #45133 lands.
 
     def __init__(
@@ -71,8 +71,8 @@ class Ascend310PStagedWriteTensor:
 class Ascend310PRequestState(AscendRequestState):
     """MRV2 request state using the same CPU-owner model as MRV1 310P."""
 
-    # TODO: Use the upstream dispatched staged-write state after vLLM RFC
-    # #45133 lands.
+    # TODO: Refactor staged writes to use Triton Dispatcher after vLLM RFC
+    # #45133 lands while retaining the 310P implementation.
 
     def __init__(
         self,

--- a/vllm_ascend/_310p/worker/v2/states.py
+++ b/vllm_ascend/_310p/worker/v2/states.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from collections.abc import Iterable, Sequence
+
+import numpy as np
+import torch
+from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor, UvaBuffer
+
+from vllm_ascend.worker.v2.states import AscendRequestState
+
+
+class Ascend310PStagedWriteTensor:
+    """CPU-owned replacement for vLLM's Triton-backed staged writes."""
+
+    def __init__(
+        self,
+        size: int | Sequence[int],
+        dtype: torch.dtype,
+        device: torch.device,
+        max_concurrency: int | None = None,
+        uva_instead_of_gpu: bool = False,
+    ) -> None:
+        del max_concurrency
+        self.dtype = dtype
+        self.device = device
+        self.uva_instead_of_gpu = uva_instead_of_gpu
+        self._dirty_indices: set[int] = set()
+        if uva_instead_of_gpu:
+            self._uva_buffer = UvaBuffer(size, dtype)
+            self.cpu = self._uva_buffer.cpu
+            self.np = self._uva_buffer.np
+            self.gpu = self._uva_buffer.uva
+        else:
+            self.cpu = torch.zeros(size, dtype=dtype, device="cpu")
+            self.np = self.cpu.numpy()
+            self.gpu = torch.zeros(size, dtype=dtype, device=device)
+
+    def stage_write(
+        self,
+        index: int,
+        start: int,
+        values: Iterable[int] | Iterable[float],
+    ) -> None:
+        values = list(values)
+        if values:
+            self.np[index, start : start + len(values)] = values
+            self._dirty_indices.add(index)
+
+    def stage_write_elem(self, index: int, value: int | float) -> None:
+        self.np[index] = value
+        self._dirty_indices.add(index)
+
+    def apply_write(self) -> None:
+        if not self._dirty_indices:
+            return
+        if self.uva_instead_of_gpu:
+            self.gpu = self._uva_buffer.uva
+            self._dirty_indices.clear()
+            return
+        indices = sorted(self._dirty_indices)
+        indices_device = torch.tensor(indices, dtype=torch.int64, device=self.device)
+        values = self.cpu[indices].to(self.device, non_blocking=True)
+        self.gpu.index_copy_(0, indices_device, values)
+        self._dirty_indices.clear()
+
+
+class Ascend310PRequestState(AscendRequestState):
+    """MRV2 request state using the same CPU-owner model as MRV1 310P."""
+
+    def __init__(
+        self,
+        max_num_reqs: int,
+        max_model_len: int,
+        max_num_batched_tokens: int,
+        num_speculative_steps: int,
+        vocab_size: int,
+        device: torch.device,
+    ) -> None:
+        self.max_num_reqs = max_num_reqs
+        self.max_model_len = max_model_len
+        self.max_num_batched_tokens = max_num_batched_tokens
+        self.num_speculative_steps = num_speculative_steps
+        self.vocab_size = vocab_size
+        self.device = device
+
+        self.req_id_to_index: dict[str, int] = {}
+        self.index_to_req_id: dict[int, str] = {}
+        self.free_indices = list(range(max_num_reqs))
+        self.all_token_ids = Ascend310PStagedWriteTensor(
+            (max_num_reqs, max_model_len),
+            dtype=torch.int32,
+            device=device,
+            uva_instead_of_gpu=True,
+        )
+        self.prompt_len = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
+        self.prefill_len = UvaBackedTensor(max_num_reqs, dtype=torch.int32)
+        self.total_len = Ascend310PStagedWriteTensor(max_num_reqs, dtype=torch.int32, device=device)
+        self.num_computed_prefill_tokens = np.zeros(max_num_reqs, dtype=np.int32)
+        self.num_computed_tokens = Ascend310PStagedWriteTensor(max_num_reqs, dtype=torch.int32, device=device)
+        self.num_computed_tokens_np = np.zeros(max_num_reqs, dtype=np.int32)
+        self.num_computed_tokens_cpu = torch.zeros(max_num_reqs, dtype=torch.int32, device="cpu")
+        self.last_sampled_tokens = torch.zeros(max_num_reqs, 1, dtype=torch.int64, device=device)
+        self.max_seq_len = np.zeros(max_num_reqs, dtype=np.int32)
+        self.draft_tokens = torch.zeros(
+            max_num_reqs,
+            num_speculative_steps,
+            dtype=torch.int64,
+            device=device,
+        )
+        self.next_prefill_tokens = torch.zeros(max_num_reqs, dtype=torch.int32, device=device)
+
+    def add_request(
+        self,
+        req_id: str,
+        prompt_len: int,
+        all_token_ids: list[int],
+        num_computed_tokens: int,
+        max_tokens: int | None = None,
+    ) -> None:
+        super().add_request(
+            req_id,
+            prompt_len,
+            all_token_ids,
+            num_computed_tokens,
+            max_tokens=max_tokens,
+        )
+        req_idx = self.req_id_to_index[req_id]
+        self.num_computed_tokens_cpu[req_idx] = num_computed_tokens
+        if num_computed_tokens > 0:
+            self.last_sampled_tokens[req_idx, 0] = all_token_ids[num_computed_tokens - 1]

--- a/vllm_ascend/_310p/worker/v2/states.py
+++ b/vllm_ascend/_310p/worker/v2/states.py
@@ -13,6 +13,9 @@ from vllm_ascend.worker.v2.states import AscendRequestState
 class Ascend310PStagedWriteTensor:
     """CPU-owned replacement for vLLM's Triton-backed staged writes."""
 
+    # TODO: Refactor this Triton replacement through triton_dispatch after
+    # vLLM RFC #45133 lands.
+
     def __init__(
         self,
         size: int | Sequence[int],
@@ -67,6 +70,9 @@ class Ascend310PStagedWriteTensor:
 
 class Ascend310PRequestState(AscendRequestState):
     """MRV2 request state using the same CPU-owner model as MRV1 310P."""
+
+    # TODO: Use the upstream dispatched staged-write state after vLLM RFC
+    # #45133 lands.
 
     def __init__(
         self,

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -30,14 +30,24 @@ from vllm_ascend.worker.worker import NPUWorker, init_workspace_manager
 
 
 class NPUWorker310(NPUWorker):
+    def _create_model_runner(self):
+        if self.use_v2_model_runner:
+            from vllm_ascend._310p.worker.v2.model_runner import NPUModelRunner310V2
+
+            model_runner = NPUModelRunner310V2(self.vllm_config, self.device)
+            logger.info_once("Using NPUWorker310 and NPUModelRunner310V2.")
+            return model_runner
+
+        model_runner = NPUModelRunner310(self.vllm_config, self.device)
+        logger.info_once("Using NPUWorker310 and NPUModelRunner310.")
+        return model_runner
+
     def init_device(self):
         self.device = self._init_device()
         torch_npu.npu.set_compile_mode(jit_compile=False)
 
         init_workspace_manager(self.device, num_ubatches=1)
-
-        self.model_runner = NPUModelRunner310(self.vllm_config, self.device)
-        logger.info_once("Using NPUWorker310 and NPUModelRunner310.")
+        self.model_runner = self._create_model_runner()
 
     def save_sharded_state(
         self,

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -24,6 +24,7 @@ from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
 from vllm.utils.torch_utils import set_random_seed  # noqa: E402
 
+from vllm_ascend._310p.model_runner_310p import NPUModelRunner310
 from vllm_ascend.utils import is_rc_device
 from vllm_ascend.worker.worker import NPUWorker, init_workspace_manager
 
@@ -36,8 +37,6 @@ class NPUWorker310(NPUWorker):
             model_runner = NPUModelRunner310V2(self.vllm_config, self.device)
             logger.info_once("Using NPUWorker310 and NPUModelRunner310V2.")
             return model_runner
-
-        from vllm_ascend._310p.model_runner_310p import NPUModelRunner310
 
         model_runner = NPUModelRunner310(self.vllm_config, self.device)
         logger.info_once("Using NPUWorker310 and NPUModelRunner310.")

--- a/vllm_ascend/_310p/worker_310p.py
+++ b/vllm_ascend/_310p/worker_310p.py
@@ -24,7 +24,6 @@ from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, memory_profiling
 from vllm.utils.torch_utils import set_random_seed  # noqa: E402
 
-from vllm_ascend._310p.model_runner_310p import NPUModelRunner310
 from vllm_ascend.utils import is_rc_device
 from vllm_ascend.worker.worker import NPUWorker, init_workspace_manager
 
@@ -37,6 +36,8 @@ class NPUWorker310(NPUWorker):
             model_runner = NPUModelRunner310V2(self.vllm_config, self.device)
             logger.info_once("Using NPUWorker310 and NPUModelRunner310V2.")
             return model_runner
+
+        from vllm_ascend._310p.model_runner_310p import NPUModelRunner310
 
         model_runner = NPUModelRunner310(self.vllm_config, self.device)
         logger.info_once("Using NPUWorker310 and NPUModelRunner310.")

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -683,11 +683,24 @@
 #       Patch Qwen GDN methods to use Ascend GDN implementations and the 310P
 #       GDN attention backend. RC devices also route upstream GDNAttentionBackend
 #       to the 310P metadata builder.
+#
+#   4. `vllm.model_executor.models.qwen3_vl.Qwen3_VisionTransformer.fast_pos_embed_interpolate`
+#      (+ `rot_pos_emb` on RC)
+#    Why:
+#       On 310P, `patch_qwen3vl` is not imported. Upstream may pick the Triton
+#       bilinear pos-embed path when HAS_TRITON is true, but bishengir has no
+#       Ascend310P3 target, so Qwen3-VL encoder profile/image prefill fails.
+#       RC also needs blocking H2D in `rot_pos_emb` to avoid indexing races.
+#    How:
+#       Always bind `fast_pos_embed_interpolate_310` (native interpolate). On RC
+#       also bind `rot_pos_emb_310`. Implementations live under
+#       `vllm_ascend/_310p/ops/qwen3vl_310.py`.
 #    Related PR (if no, explain why):
 #       No, 310P custom operator and backend behavior are vllm-ascend specific.
 #    Future Plan:
 #       Remove this patch when upstream exposes stable hooks for 310P GDN
-#       chunk metadata, spec-decode input layout, and backend selection.
+#       chunk metadata, spec-decode input layout, backend selection, and
+#       vision pos-embed dispatch that does not require Triton on 310P.
 #
 # ** 8. File: worker/patch_kimi_k25.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/vllm_ascend/patch/platform/patch_use_v2_model_runner.py
+++ b/vllm_ascend/patch/platform/patch_use_v2_model_runner.py
@@ -1,6 +1,10 @@
 import vllm.envs as envs
 from vllm.config.vllm import VllmConfig
 
+from vllm_ascend.utils import is_310p
+
+_original_validate_v2_model_runner = VllmConfig._validate_v2_model_runner
+
 
 def _patched_use_v2_model_runner(self) -> bool:
     """Return VLLM_USE_V2_MODEL_RUNNER env directly.
@@ -18,3 +22,12 @@ def _patched_use_v2_model_runner(self) -> bool:
 
 
 VllmConfig.use_v2_model_runner = property(_patched_use_v2_model_runner)
+
+
+def _patched_validate_v2_model_runner(self) -> None:
+    if is_310p():
+        return
+    _original_validate_v2_model_runner(self)
+
+
+VllmConfig._validate_v2_model_runner = _patched_validate_v2_model_runner

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -19,7 +19,7 @@ from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.utils import is_310p
 
-if HAS_TRITON:
+if HAS_TRITON and not is_310p():
     import vllm_ascend.patch.worker.patch_triton
     import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -19,7 +19,7 @@ from vllm.triton_utils import HAS_TRITON
 
 from vllm_ascend.utils import is_310p
 
-if HAS_TRITON and not is_310p():
+if HAS_TRITON:
     import vllm_ascend.patch.worker.patch_triton
     import vllm_ascend.patch.worker.patch_v2.patch_triton  # noqa
 

--- a/vllm_ascend/patch/worker/patch_idex_310.py
+++ b/vllm_ascend/patch/worker/patch_idex_310.py
@@ -1,4 +1,5 @@
 from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import QwenGatedDeltaNetAttention
+from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
 from vllm.third_party.flash_linear_attention.ops import index as fla_index
 
 from vllm_ascend._310p.ops.fla.gdn_310 import AscendGatedDeltaNetAttention310
@@ -6,6 +7,7 @@ from vllm_ascend._310p.ops.fla.idex import (
     prepare_chunk_indices_310,
     prepare_chunk_offsets_310,
 )
+from vllm_ascend._310p.ops.qwen3vl_310 import fast_pos_embed_interpolate_310
 from vllm_ascend._310p.spec_decode.llm_base_proposer_310 import AscendSpecDecodeBaseProposer310
 from vllm_ascend.ops.gdn import AscendGatedDeltaNetAttention
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
@@ -37,8 +39,14 @@ QwenGatedDeltaNetAttention.get_state_dtype = AscendGatedDeltaNetAttention310.get
 # MTP ACL graph padding replay fixes provided by gdn_attn_builder_310.py.
 QwenGatedDeltaNetAttention.get_attn_backend = AscendGatedDeltaNetAttention310.get_attn_backend
 
+# 310P: ``patch_qwen3vl`` is not loaded (see ``patch/worker/__init__.py``).
+# Force native bilinear pos-embed so Qwen3-VL encoder profiling does not depend
+# on Triton Ascend / bishengir Ascend310P3 support.
+Qwen3_VisionTransformer.fast_pos_embed_interpolate = (  # type: ignore[method-assign]
+    fast_pos_embed_interpolate_310
+)
+
 if is_rc_device():
-    from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer
     from vllm.v1.attention.backends.gdn_attn import GDNAttentionBackend
 
     from vllm_ascend._310p.ops.gdn_attn_builder_310 import GDNAttentionMetadataBuilder310

--- a/vllm_ascend/patch/worker/patch_v2/patch_block_table.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_block_table.py
@@ -18,7 +18,12 @@
 #
 from vllm.v1.worker.gpu import model_runner
 
-from vllm_ascend.worker.v2.block_table import AscendBlockTables
+from vllm_ascend.utils import is_310p
+
+if is_310p():
+    from vllm_ascend._310p.worker.v2.block_table import Ascend310PBlockTables as AscendBlockTables
+else:
+    from vllm_ascend.worker.v2.block_table import AscendBlockTables
 
 # vllm-ascend need to initialize slot mapping as torch.int32 dtype,
 # but vllm default is torch.int64 dtype.

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -126,7 +126,8 @@ class NPUModelRunner(GPUModelRunner):
 
         # AscendRequestState has extra `num_computed_tokens_cpu` attribute.
         # so reinitialize req_states here.
-        self.req_states: AscendRequestState = AscendRequestState(
+        request_state_cls = getattr(self, "request_state_cls", AscendRequestState)
+        self.req_states: AscendRequestState = request_state_cls(
             max_num_reqs=self.max_num_reqs,
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
@@ -235,6 +236,24 @@ class NPUModelRunner(GPUModelRunner):
             ):
                 self._dummy_run(mc2_tokens_capacity, skip_attn=True, skip_eplb=True, is_profile=True)
             super().profile_run()
+
+    def _prepare_prefill_inputs(self, *args, **kwargs) -> None:
+        kwargs.pop("idx_mapping_np")
+        kwargs.pop("query_start_loc_np")
+        prepare_prefill_inputs(*args, **kwargs)
+
+    def _prepare_pos_seq_lens(self, *args, **kwargs) -> None:
+        kwargs.pop("idx_mapping_np")
+        kwargs.pop("query_start_loc_np")
+        kwargs.pop("num_scheduled_tokens")
+        prepare_pos_seq_lens(*args, **kwargs)
+
+    def _combine_sampled_and_draft_tokens(self, *args, **kwargs):
+        kwargs.pop("idx_mapping_np")
+        kwargs.pop("query_start_loc_np")
+        kwargs.pop("seq_lens_np")
+        kwargs.pop("prefill_len_np")
+        return combine_sampled_and_draft_tokens(*args, **kwargs)
 
     if vllm_version_is("0.27.1"):
 
@@ -345,7 +364,7 @@ class NPUModelRunner(GPUModelRunner):
 
             # Get prefill tokens if any.
             if batch_has_prefill:
-                prepare_prefill_inputs(
+                self._prepare_prefill_inputs(
                     self.input_buffers.input_ids,
                     self.req_states.next_prefill_tokens,
                     idx_mapping,
@@ -353,15 +372,20 @@ class NPUModelRunner(GPUModelRunner):
                     self.req_states.all_token_ids.gpu,
                     self.req_states.prefill_len.gpu,
                     self.req_states.num_computed_tokens.gpu,
+                    idx_mapping_np=idx_mapping_np,
+                    query_start_loc_np=query_start_loc_np,
                 )
 
             # Prepare positions and seq_lens.
-            prepare_pos_seq_lens(
+            self._prepare_pos_seq_lens(
                 idx_mapping,
                 query_start_loc,
                 self.req_states.num_computed_tokens.gpu,
                 self.input_buffers.positions,
                 self.input_buffers.seq_lens,
+                idx_mapping_np=idx_mapping_np,
+                query_start_loc_np=query_start_loc_np,
+                num_scheduled_tokens=num_scheduled_tokens,
             )
             seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
 
@@ -370,7 +394,7 @@ class NPUModelRunner(GPUModelRunner):
 
             # Some input token ids are directly read from the last sampled tokens
             # and draft tokens. Also, get the logits indices to sample tokens from.
-            logits_indices = combine_sampled_and_draft_tokens(
+            logits_indices = self._combine_sampled_and_draft_tokens(
                 self.input_buffers.input_ids,
                 idx_mapping,
                 self.req_states.last_sampled_tokens,
@@ -381,6 +405,10 @@ class NPUModelRunner(GPUModelRunner):
                 cu_num_logits,
                 total_num_logits,
                 self.model_state.num_new_sampled_tokens_per_step,
+                idx_mapping_np=idx_mapping_np,
+                query_start_loc_np=query_start_loc_np,
+                seq_lens_np=self.input_buffers.seq_lens_np[:num_reqs],
+                prefill_len_np=prefill_len_np,
             )
 
             # CPU upper bound on seq_lens (num_computed_tokens + num_scheduled_tokens).
@@ -562,7 +590,7 @@ class NPUModelRunner(GPUModelRunner):
 
             # Get prefill tokens if any.
             if batch_has_prefill:
-                prepare_prefill_inputs(
+                self._prepare_prefill_inputs(
                     self.input_buffers.input_ids,
                     self.req_states.next_prefill_tokens,
                     idx_mapping,
@@ -570,15 +598,20 @@ class NPUModelRunner(GPUModelRunner):
                     self.req_states.all_token_ids.gpu,
                     self.req_states.prefill_len.gpu,
                     self.req_states.num_computed_tokens.gpu,
+                    idx_mapping_np=idx_mapping_np,
+                    query_start_loc_np=query_start_loc_np,
                 )
 
             # Prepare positions and seq_lens.
-            prepare_pos_seq_lens(
+            self._prepare_pos_seq_lens(
                 idx_mapping,
                 query_start_loc,
                 self.req_states.num_computed_tokens.gpu,
                 self.input_buffers.positions,
                 self.input_buffers.seq_lens,
+                idx_mapping_np=idx_mapping_np,
+                query_start_loc_np=query_start_loc_np,
+                num_scheduled_tokens=num_scheduled_tokens,
             )
             seq_lens = self.input_buffers.seq_lens[:num_reqs_padded]
 
@@ -587,7 +620,7 @@ class NPUModelRunner(GPUModelRunner):
 
             # Some input token ids are directly read from the last sampled tokens
             # and draft tokens. Also, get the logits indices to sample tokens from.
-            logits_indices = combine_sampled_and_draft_tokens(
+            logits_indices = self._combine_sampled_and_draft_tokens(
                 self.input_buffers.input_ids,
                 idx_mapping,
                 self.req_states.last_sampled_tokens,
@@ -598,6 +631,10 @@ class NPUModelRunner(GPUModelRunner):
                 cu_num_logits,
                 total_num_logits,
                 self.model_state.num_new_sampled_tokens_per_step,
+                idx_mapping_np=idx_mapping_np,
+                query_start_loc_np=query_start_loc_np,
+                seq_lens_np=self.input_buffers.seq_lens_np[:num_reqs],
+                prefill_len_np=prefill_len_np,
             )
 
             # CPU upper bound on seq_lens (num_computed_tokens + num_scheduled_tokens).

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -126,8 +126,8 @@ class NPUModelRunner(GPUModelRunner):
 
         # AscendRequestState has extra `num_computed_tokens_cpu` attribute.
         # so reinitialize req_states here.
-        # TODO: Replace the 310P Triton fallback hook with triton_dispatch after
-        # vLLM RFC #45133 lands.
+        # TODO: Refactor the 310P fallback to use Triton Dispatcher after vLLM
+        # RFC #45133 lands.
         request_state_cls = getattr(self, "request_state_cls", AscendRequestState)
         self.req_states: AscendRequestState = request_state_cls(
             max_num_reqs=self.max_num_reqs,
@@ -252,8 +252,8 @@ class NPUModelRunner(GPUModelRunner):
         idx_mapping_np: np.ndarray,
         query_start_loc_np: np.ndarray,
     ) -> None:
-        # TODO: Route platform overrides through triton_dispatch after vLLM
-        # RFC #45133 lands.
+        # TODO: Refactor platform overrides to use Triton Dispatcher after
+        # vLLM RFC #45133 lands.
         del idx_mapping_np, query_start_loc_np
         prepare_prefill_inputs(
             input_ids,
@@ -277,8 +277,8 @@ class NPUModelRunner(GPUModelRunner):
         query_start_loc_np: np.ndarray,
         num_scheduled_tokens: np.ndarray,
     ) -> None:
-        # TODO: Route platform overrides through triton_dispatch after vLLM
-        # RFC #45133 lands.
+        # TODO: Refactor platform overrides to use Triton Dispatcher after
+        # vLLM RFC #45133 lands.
         del idx_mapping_np, query_start_loc_np, num_scheduled_tokens
         prepare_pos_seq_lens(
             idx_mapping,
@@ -306,8 +306,8 @@ class NPUModelRunner(GPUModelRunner):
         seq_lens_np: np.ndarray,
         prefill_len_np: np.ndarray,
     ) -> torch.Tensor:
-        # TODO: Route platform overrides through triton_dispatch after vLLM
-        # RFC #45133 lands.
+        # TODO: Refactor platform overrides to use Triton Dispatcher after
+        # vLLM RFC #45133 lands.
         del idx_mapping_np, query_start_loc_np, seq_lens_np, prefill_len_np
         return combine_sampled_and_draft_tokens(
             input_ids,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -126,6 +126,8 @@ class NPUModelRunner(GPUModelRunner):
 
         # AscendRequestState has extra `num_computed_tokens_cpu` attribute.
         # so reinitialize req_states here.
+        # TODO: Replace the 310P Triton fallback hook with triton_dispatch after
+        # vLLM RFC #45133 lands.
         request_state_cls = getattr(self, "request_state_cls", AscendRequestState)
         self.req_states: AscendRequestState = request_state_cls(
             max_num_reqs=self.max_num_reqs,
@@ -250,6 +252,8 @@ class NPUModelRunner(GPUModelRunner):
         idx_mapping_np: np.ndarray,
         query_start_loc_np: np.ndarray,
     ) -> None:
+        # TODO: Route platform overrides through triton_dispatch after vLLM
+        # RFC #45133 lands.
         del idx_mapping_np, query_start_loc_np
         prepare_prefill_inputs(
             input_ids,
@@ -273,6 +277,8 @@ class NPUModelRunner(GPUModelRunner):
         query_start_loc_np: np.ndarray,
         num_scheduled_tokens: np.ndarray,
     ) -> None:
+        # TODO: Route platform overrides through triton_dispatch after vLLM
+        # RFC #45133 lands.
         del idx_mapping_np, query_start_loc_np, num_scheduled_tokens
         prepare_pos_seq_lens(
             idx_mapping,
@@ -300,6 +306,8 @@ class NPUModelRunner(GPUModelRunner):
         seq_lens_np: np.ndarray,
         prefill_len_np: np.ndarray,
     ) -> torch.Tensor:
+        # TODO: Route platform overrides through triton_dispatch after vLLM
+        # RFC #45133 lands.
         del idx_mapping_np, query_start_loc_np, seq_lens_np, prefill_len_np
         return combine_sampled_and_draft_tokens(
             input_ids,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -237,23 +237,82 @@ class NPUModelRunner(GPUModelRunner):
                 self._dummy_run(mc2_tokens_capacity, skip_attn=True, skip_eplb=True, is_profile=True)
             super().profile_run()
 
-    def _prepare_prefill_inputs(self, *args, **kwargs) -> None:
-        kwargs.pop("idx_mapping_np")
-        kwargs.pop("query_start_loc_np")
-        prepare_prefill_inputs(*args, **kwargs)
+    def _prepare_prefill_inputs(
+        self,
+        input_ids: torch.Tensor,
+        next_prefill_tokens: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        all_token_ids: torch.Tensor,
+        prefill_len: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+        *,
+        idx_mapping_np: np.ndarray,
+        query_start_loc_np: np.ndarray,
+    ) -> None:
+        del idx_mapping_np, query_start_loc_np
+        prepare_prefill_inputs(
+            input_ids,
+            next_prefill_tokens,
+            idx_mapping,
+            query_start_loc,
+            all_token_ids,
+            prefill_len,
+            num_computed_tokens,
+        )
 
-    def _prepare_pos_seq_lens(self, *args, **kwargs) -> None:
-        kwargs.pop("idx_mapping_np")
-        kwargs.pop("query_start_loc_np")
-        kwargs.pop("num_scheduled_tokens")
-        prepare_pos_seq_lens(*args, **kwargs)
+    def _prepare_pos_seq_lens(
+        self,
+        idx_mapping: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        num_computed_tokens: torch.Tensor,
+        positions: torch.Tensor,
+        seq_lens: torch.Tensor,
+        *,
+        idx_mapping_np: np.ndarray,
+        query_start_loc_np: np.ndarray,
+        num_scheduled_tokens: np.ndarray,
+    ) -> None:
+        del idx_mapping_np, query_start_loc_np, num_scheduled_tokens
+        prepare_pos_seq_lens(
+            idx_mapping,
+            query_start_loc,
+            num_computed_tokens,
+            positions,
+            seq_lens,
+        )
 
-    def _combine_sampled_and_draft_tokens(self, *args, **kwargs):
-        kwargs.pop("idx_mapping_np")
-        kwargs.pop("query_start_loc_np")
-        kwargs.pop("seq_lens_np")
-        kwargs.pop("prefill_len_np")
-        return combine_sampled_and_draft_tokens(*args, **kwargs)
+    def _combine_sampled_and_draft_tokens(
+        self,
+        input_ids: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        last_sampled_tokens: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        seq_lens: torch.Tensor,
+        prefill_len: torch.Tensor,
+        draft_tokens: torch.Tensor,
+        cu_num_logits: torch.Tensor,
+        num_logits: int,
+        num_bonus_tokens: int,
+        *,
+        idx_mapping_np: np.ndarray,
+        query_start_loc_np: np.ndarray,
+        seq_lens_np: np.ndarray,
+        prefill_len_np: np.ndarray,
+    ) -> torch.Tensor:
+        del idx_mapping_np, query_start_loc_np, seq_lens_np, prefill_len_np
+        return combine_sampled_and_draft_tokens(
+            input_ids,
+            idx_mapping,
+            last_sampled_tokens,
+            query_start_loc,
+            seq_lens,
+            prefill_len,
+            draft_tokens,
+            cu_num_logits,
+            num_logits,
+            num_bonus_tokens,
+        )
 
     if vllm_version_is("0.27.1"):
 

--- a/vllm_ascend/worker/v2/model_states/__init__.py
+++ b/vllm_ascend/worker/v2/model_states/__init__.py
@@ -22,6 +22,8 @@ import torch.nn as nn
 from vllm.config import VllmConfig
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 
+from vllm_ascend.device.device_config import is_310p
+
 
 def init_asecnd_model_state(
     vllm_config: VllmConfig,
@@ -40,6 +42,18 @@ def init_asecnd_model_state(
         )
 
         return AscendMambaHybridModelState(
+            vllm_config,
+            model,
+            encoder_cache,
+            device,
+        )
+
+    if is_310p():
+        from vllm_ascend._310p.worker.v2.model_state import (
+            Ascend310PModelState,
+        )
+
+        return Ascend310PModelState(
             vllm_config,
             model,
             encoder_cache,


### PR DESCRIPTION

### What this PR does / why we need it?

This PR adds Model Runner V2 support for Qwen3-VL on Ascend 310P , including these features:
* Tensor Parallelism
* Eager and ACLGraph execution
* NZ-format KV cache
* Triton-free request states, sampling, block-table handling, and input preparation

### Does this PR introduce _any_ user-facing change?

Yes. Ascend 310P users can enable Model Runner V2 for supported Qwen3-VL models.

### How was this patch tested?

vLLM version: v0.27.1
vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
