### PR TITLE
[Feature]Virtual Pipeline Parallel

### DIFF
--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -579,6 +579,32 @@ class AscendConfig:
                 "MegaMoe is not supported for this model config; additional_config.enable_fused_mc2 will be set to 0."
             )
 
+        # Virtual Pipeline Parallelism (VPP)
+        self.virtual_pipeline_parallel_size: int = additional_config.get(
+            "virtual_pipeline_parallel_size", 1)
+        vp_size = self.virtual_pipeline_parallel_size
+        pp_size = vllm_config.parallel_config.pipeline_parallel_size
+        self.vpp_layer_ranges: list[list[tuple[int, int]]] | None = None
+        if vp_size > 1:
+            if pp_size < vp_size:
+                raise ValueError(
+                    "virtual_pipeline_parallel_size > 1 requires "
+                    "pipeline_parallel_size >= vp_size.")
+            if vp_size != 2:
+                raise ValueError(
+                    "currently virtual_pipeline_parallel requires vp_size == 2"
+                )
+            num_layers = vllm_config.model_config.hf_text_config.num_hidden_layers
+            raw_ranges = additional_config.get("vpp_layer_ranges", None)
+            if raw_ranges is not None:
+                from vllm_ascend.distributed.vpp_utils import validate_vpp_layer_ranges
+                self.vpp_layer_ranges = validate_vpp_layer_ranges(
+                    raw_ranges, num_layers, pp_size, vp_size)
+                logger.info(
+                    "VPP enabled with manual layer ranges: vp_size=%d, "
+                    "pp_size=%d, num_layers=%d, ranges=%s",
+                    vp_size, pp_size, num_layers, self.vpp_layer_ranges)
+
         # mlapo_keep_prefill_weights preconditions: the prefill weights are only
         # freed by MLAPO in the MLA attention path, so the keep switch is only
         # meaningful under those same conditions. Fail fast on a no-op / mistaken

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -17,6 +17,7 @@ from vllm_ascend.device.hardware_profile import (
     MoECommPolicy,
     get_current_hardware_profile,
 )
+from vllm_ascend.distributed.parallel_state import get_virtual_pipeline_parallel_rank
 from vllm_ascend.utils import (
     has_layer_idx,
     is_moe_model,
@@ -83,6 +84,42 @@ def override_mrv2_in_profile_run(enabled: bool):
 def get_mrv2_in_profile_run() -> bool:
     return _MRV2_IN_PROFILE_RUN.get()
 
+def _maybe_set_vpp_moe_layers(forward_context, model_instance: torch.nn.Module | None) -> None:
+    """Restrict fast MoE cold-start lookup to the current VPP stage.
+
+    Upstream fast_moe_cold_start stores a rank-local list of all MoE layer
+    names and then resolves custom-op calls by incrementing
+    ``forward_context.moe_layer_index``. Under VPP we enter a fresh forward
+    context for each virtual stage, so the counter resets to 0 every stage.
+    Without narrowing ``all_moe_layers`` to the current stage, vp1 will reuse
+    vp0's MoE layers on the same PP rank.
+    """
+
+    if forward_context.all_moe_layers is None or model_instance is None:
+        return
+
+    model = getattr(model_instance, "model", None)
+    model_layers = getattr(model, "layers", None)
+    vpp_layer_ranges = getattr(model_layers, "vpp_layer_ranges", None)
+    if vpp_layer_ranges is None or model_layers is None:
+        return
+
+    vp_stage = get_virtual_pipeline_parallel_rank()
+    if vp_stage >= len(vpp_layer_ranges):
+        return
+
+    start, end = vpp_layer_ranges[vp_stage]
+    stage_moe_layers: list[str] = []
+    for layer_idx in range(start, end):
+        layer = model_layers[layer_idx]
+        experts = getattr(getattr(layer, "mlp", None), "experts", None)
+        layer_name = getattr(experts, "layer_name", None)
+        if layer_name is not None:
+            stage_moe_layers.append(layer_name)
+
+    forward_context.all_moe_layers = stage_moe_layers
+    forward_context.moe_layer_index = 0
+
 
 def use_cann_megamoe(vllm_config: VllmConfig) -> bool:
     # TODO: drop the EP-size guard when MegaMoe supports larger EP sizes.
@@ -140,6 +177,9 @@ def set_ascend_forward_context(
         forward_context = get_forward_context()
         forward_context.draft_attn_metadatas = draft_attn_metadatas
         forward_context.device_metadata_executor = device_metadata_executor
+        _maybe_set_vpp_moe_layers(forward_context, model_instance)
+
+        forward_context.input_ids = input_ids
 
         from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method
 

--- a/vllm_ascend/distributed/parallel_state.py
+++ b/vllm_ascend/distributed/parallel_state.py
@@ -17,6 +17,45 @@ _P_TP: GroupCoordinator | None = None
 
 _DYNAMIC_EPLB: GroupCoordinator | None = None
 
+# Virtual Pipeline Parallelism (VPP) state
+_VIRTUAL_PIPELINE_PARALLEL_SIZE: int = 1
+_VIRTUAL_PIPELINE_PARALLEL_RANK: int = 0
+# Construction-vs-runtime latch. Stays False from process start until the
+# first ``set_virtual_pipeline_parallel_rank`` call (i.e. until the VPP
+# schedule loop begins). While False, ``is_first_rank`` / ``is_last_rank``
+# return the *static* fold-back topology answer so that model ``__init__``
+# can place ``embed_tokens`` / ``norm`` / ``lm_head`` on the physical rank
+# that owns the first / last virtual stage. Flips True at the start of
+# execution and is reset only on teardown / re-init. See
+# ``patch_distributed.GroupCoordinatorPatch``.
+_VPP_RUNTIME_ACTIVE: bool = False
+
+
+def get_virtual_pipeline_parallel_size() -> int:
+    return _VIRTUAL_PIPELINE_PARALLEL_SIZE
+
+
+def get_virtual_pipeline_parallel_rank() -> int:
+    return _VIRTUAL_PIPELINE_PARALLEL_RANK
+
+
+def set_virtual_pipeline_parallel_rank(rank: int) -> None:
+    global _VIRTUAL_PIPELINE_PARALLEL_RANK, _VPP_RUNTIME_ACTIVE
+    _VIRTUAL_PIPELINE_PARALLEL_RANK = rank
+    # First call marks the end of model construction; from here on
+    # is_first_rank / is_last_rank must honor the live virtual stage.
+    _VPP_RUNTIME_ACTIVE = True
+
+
+def get_vpp_runtime_active() -> bool:
+    """Whether the VPP schedule loop has started.
+
+    Returns False during model construction (the latch has not been
+    flipped yet) and True once the first ``set_virtual_pipeline_parallel_rank``
+    call has been made by the execution loop.
+    """
+    return _VPP_RUNTIME_ACTIVE
+
 
 def init_ascend_model_parallel(
     parallel_config: ParallelConfig,
@@ -85,6 +124,14 @@ def init_ascend_model_parallel(
 
     global _MC2
     _MC2 = init_model_parallel_group(group_ranks, get_world_group().local_rank, backend, group_name="mc2")
+
+    # Cache the configured virtual pipeline parallel size so ``vpp_utils``
+    # can answer ``is_vpp_last_stage`` without re-reading the ascend config.
+    global _VIRTUAL_PIPELINE_PARALLEL_SIZE, _VPP_RUNTIME_ACTIVE
+    _VIRTUAL_PIPELINE_PARALLEL_SIZE = get_ascend_config().virtual_pipeline_parallel_size
+    # Begin each engine lifecycle in the construction phase so model
+    # __init__ sees the static fold-back topology through is_first/last_rank.
+    _VPP_RUNTIME_ACTIVE = False
 
     if get_ascend_config().eplb_config.dynamic_eplb:
         global _DYNAMIC_EPLB
@@ -208,6 +255,12 @@ def destroy_ascend_model_parallel():
     if _DYNAMIC_EPLB:
         _DYNAMIC_EPLB.destroy()
     _DYNAMIC_EPLB = None
+
+    global _VIRTUAL_PIPELINE_PARALLEL_SIZE, _VIRTUAL_PIPELINE_PARALLEL_RANK
+    global _VPP_RUNTIME_ACTIVE
+    _VIRTUAL_PIPELINE_PARALLEL_SIZE = 1
+    _VIRTUAL_PIPELINE_PARALLEL_RANK = 0
+    _VPP_RUNTIME_ACTIVE = False
 
 
 def get_global_rank(parallel_config: ParallelConfig | None = None) -> int:

--- a/vllm_ascend/distributed/vpp_utils.py
+++ b/vllm_ascend/distributed/vpp_utils.py
@@ -1,0 +1,360 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Virtual Pipeline Parallelism (VPP) utilities.
+
+Implements a V-shaped fold-back layer assignment topology:
+- Even virtual stages flow forward  (rank 0 -> rank N-1)
+- Odd  virtual stages flow backward (rank N-1 -> rank 0)
+
+Example with pp_size=2, vp_size=2, 8 layers (2 per chunk):
+  Rank 0: chunks [0, 3] -> layers [0,1] + [6,7]  (first + last)
+  Rank 1: chunks [1, 2] -> layers [2,3] + [4,5]  (middle, fold point)
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+    from torch import nn
+
+
+def get_vpp_indices(
+    num_hidden_layers: int,
+    pp_rank: int,
+    pp_size: int,
+    vp_size: int,
+) -> list[tuple[int, int]]:
+    """Return layer ranges for each virtual stage on a given PP rank.
+
+    Uses V-shaped fold-back assignment:
+      even vp: chunk_idx = vp * pp_size + pp_rank        (forward)
+      odd  vp: chunk_idx = (vp+1) * pp_size - 1 - pp_rank (backward)
+
+    Supports uneven distribution: when ``num_hidden_layers`` is not
+    divisible by ``pp_size * vp_size``, the first *remainder* chunks
+    each receive one extra layer.
+
+    Returns:
+        List of (start_layer, end_layer) tuples, one per virtual stage.
+        Layer indices are 0-based, end is exclusive.
+
+    Examples:
+        >>> get_vpp_indices(8, 0, 2, 2)
+        [(0, 2), (6, 8)]
+        >>> get_vpp_indices(8, 1, 2, 2)
+        [(2, 4), (4, 6)]
+        >>> get_vpp_indices(61, 0, 4, 2)
+        [(0, 8), (54, 61)]
+        >>> get_vpp_indices(61, 3, 4, 2)
+        [(24, 32), (32, 39)]
+    """
+    total_chunks = pp_size * vp_size
+    base = num_hidden_layers // total_chunks
+    remainder = num_hidden_layers % total_chunks
+
+    def _chunk_range(chunk_idx: int) -> tuple[int, int]:
+        if chunk_idx < remainder:
+            start = chunk_idx * (base + 1)
+            end = start + base + 1
+        else:
+            start = remainder * (base + 1) + (chunk_idx - remainder) * base
+            end = start + base
+        return (start, end)
+
+    ranges: list[tuple[int, int]] = []
+    for vp in range(vp_size):
+        if vp % 2 == 0:
+            chunk_idx = vp * pp_size + pp_rank
+        else:
+            chunk_idx = (vp + 1) * pp_size - 1 - pp_rank
+        ranges.append(_chunk_range(chunk_idx))
+    return ranges
+
+
+def validate_vpp_layer_ranges(
+    layer_ranges: list[list[list[int]]],
+    num_hidden_layers: int,
+    pp_size: int,
+    vp_size: int,
+) -> list[list[tuple[int, int]]]:
+    """Validate and normalize user-provided ``vpp_layer_ranges``.
+
+    Args:
+        layer_ranges: ``pp_size`` entries, each containing ``vp_size``
+            ``[start, end)`` pairs.  Example for pp=4, vp=2, 61 layers::
+
+                [
+                    [[0, 8],  [53, 61]],   # rank 0
+                    [[8, 16], [45, 53]],    # rank 1
+                    [[16, 24],[37, 45]],    # rank 2
+                    [[24, 37]],             # rank 3 (fold-point, may merge)
+                ]
+
+        num_hidden_layers: total layers in the model.
+        pp_size: pipeline parallel size.
+        vp_size: virtual pipeline parallel size.
+
+    Returns:
+        Normalized list of ``list[tuple[int, int]]`` per rank.
+
+    Raises:
+        ValueError on any validation failure.
+    """
+    if len(layer_ranges) != pp_size:
+        raise ValueError(
+            f"vpp_layer_ranges must have {pp_size} entries (one per PP rank), "
+            f"got {len(layer_ranges)}.")
+
+    normalized: list[list[tuple[int, int]]] = []
+    all_indices: set[int] = set()
+
+    for rank, rank_ranges in enumerate(layer_ranges):
+        if len(rank_ranges) != vp_size:
+            raise ValueError(
+                f"Rank {rank}: expected {vp_size} layer ranges "
+                f"(one per virtual stage), got {len(rank_ranges)}.")
+        rank_tuples: list[tuple[int, int]] = []
+        for stage_idx, pair in enumerate(rank_ranges):
+            if len(pair) != 2:
+                raise ValueError(
+                    f"Rank {rank}, stage {stage_idx}: expected [start, end], "
+                    f"got {pair}.")
+            start, end = int(pair[0]), int(pair[1])
+            if start < 0 or end > num_hidden_layers or start >= end:
+                raise ValueError(
+                    f"Rank {rank}, stage {stage_idx}: invalid range "
+                    f"[{start}, {end}) for {num_hidden_layers} layers.")
+            for i in range(start, end):
+                if i in all_indices:
+                    raise ValueError(
+                        f"Layer {i} is assigned to multiple ranks/stages.")
+                all_indices.add(i)
+            rank_tuples.append((start, end))
+        normalized.append(rank_tuples)
+
+    if all_indices != set(range(num_hidden_layers)):
+        missing = set(range(num_hidden_layers)) - all_indices
+        raise ValueError(
+            f"Not all layers are covered.  Missing layers: "
+            f"{sorted(missing)}")
+
+    return normalized
+
+
+def is_vpp_first_stage(pp_rank: int, vp_stage: int) -> bool:
+    """Whether this is the very first stage in the VPP pipeline."""
+    return vp_stage == 0 and pp_rank == 0
+
+
+def is_vpp_last_stage(
+    pp_rank: int,
+    pp_size: int,
+    vp_stage: int,
+    vp_size: int,
+) -> bool:
+    """Whether this is the very last stage in the VPP pipeline.
+
+    For even vp_size the last sweep is backward, ending at rank 0.
+    For odd  vp_size the last sweep is forward,  ending at rank pp_size-1.
+    """
+    if vp_stage != vp_size - 1:
+        return False
+    if vp_size % 2 == 0:
+        return pp_rank == 0
+    else:
+        return pp_rank == pp_size - 1
+
+
+def is_vpp_fold_point(
+    pp_rank: int,
+    pp_size: int,
+    vp_stage: int,
+    vp_size: int,
+) -> bool:
+    """Whether this rank is a fold point after the given virtual stage.
+
+    At a fold point the same GPU continues to the next virtual stage
+    without any inter-rank communication.
+    """
+    if vp_stage >= vp_size - 1:
+        return False
+    is_forward = (vp_stage % 2 == 0)
+    if is_forward:
+        return pp_rank == pp_size - 1
+    else:
+        return pp_rank == 0
+
+
+@dataclass
+class VPPCommInfo:
+    need_recv: bool
+    recv_src: int
+    need_send: bool
+    send_dst: int
+
+
+def get_vpp_comm_info(
+    pp_rank: int,
+    pp_size: int,
+    vp_stage: int,
+    vp_size: int,
+) -> VPPCommInfo:
+    """Compute send/recv info for a given rank and virtual stage.
+
+    Returns a VPPCommInfo with:
+      - need_recv / recv_src: whether to recv and from which PP rank
+      - need_send / send_dst: whether to send and to which PP rank
+    """
+    is_forward = (vp_stage % 2 == 0)
+
+    # --- Recv logic ---
+    is_first = is_vpp_first_stage(pp_rank, vp_stage)
+    is_fold_from_prev = False
+    if vp_stage > 0:
+        prev_forward = ((vp_stage - 1) % 2 == 0)
+        if prev_forward and pp_rank == pp_size - 1:
+            is_fold_from_prev = True
+        elif not prev_forward and pp_rank == 0:
+            is_fold_from_prev = True
+
+    need_recv = not is_first and not is_fold_from_prev
+    recv_src = (pp_rank - 1) if is_forward else (pp_rank + 1)
+
+    # --- Send logic ---
+    is_last = is_vpp_last_stage(pp_rank, pp_size, vp_stage, vp_size)
+    is_fold_to_next = is_vpp_fold_point(pp_rank, pp_size, vp_stage, vp_size)
+    need_send = not is_last and not is_fold_to_next
+    send_dst = (pp_rank + 1) if is_forward else (pp_rank - 1)
+
+    return VPPCommInfo(
+        need_recv=need_recv,
+        recv_src=recv_src,
+        need_send=need_send,
+        send_dst=send_dst,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model-level VPP utilities
+# ---------------------------------------------------------------------------
+
+LayerFn = Callable[..., "nn.Module"]
+
+
+def make_vpp_layers(
+    num_hidden_layers: int,
+    layer_fn: LayerFn,
+    prefix: str,
+    vp_size: int,
+    custom_layer_ranges: list[tuple[int, int]] | None = None,
+) -> tuple[list[tuple[int, int]], "nn.ModuleList"]:
+    """Build a ModuleList with VPP layer assignment.
+
+    Layers not owned by this rank are replaced with ``PPMissingLayer``.
+
+    Args:
+        custom_layer_ranges: If provided, used directly instead of
+            auto-computing via ``get_vpp_indices``.  Must contain
+            ``vp_size`` entries of ``(start, end)`` for this rank.
+
+    Returns:
+        (layer_ranges, modules) where *layer_ranges* is a list of
+        ``(start, end)`` for each virtual stage on this rank.
+    """
+    import torch
+    from vllm.distributed.parallel_state import get_pp_group
+    from vllm.model_executor.models.utils import PPMissingLayer
+    from vllm.model_executor.offloader import get_offloader
+
+    if custom_layer_ranges is not None:
+        layer_ranges = custom_layer_ranges
+    else:
+        pp_rank = get_pp_group().rank_in_group
+        pp_size = get_pp_group().world_size
+        layer_ranges = get_vpp_indices(
+            num_hidden_layers, pp_rank, pp_size, vp_size
+        )
+
+    local_indices: set[int] = set()
+    for start, end in layer_ranges:
+        local_indices.update(range(start, end))
+
+    modules = torch.nn.ModuleList(
+        get_offloader().wrap_modules(
+            layer_fn(prefix=f"{prefix}.{i}") if i in local_indices
+            else PPMissingLayer()
+            for i in range(num_hidden_layers)
+        )
+    )
+    return layer_ranges, modules
+
+
+def get_vp_size() -> int:
+    """Return the configured virtual pipeline parallel size (1 if unset)."""
+    from vllm_ascend.ascend_config import get_ascend_config
+    try:
+        return get_ascend_config().virtual_pipeline_parallel_size
+    except RuntimeError:
+        return 1
+
+
+def get_custom_layer_ranges_for_rank() -> list[tuple[int, int]] | None:
+    """Return manually specified VPP layer ranges for the current PP rank, or None."""
+    from vllm_ascend.ascend_config import get_ascend_config
+    try:
+        all_ranges = get_ascend_config().vpp_layer_ranges
+    except RuntimeError:
+        return None
+    if all_ranges is None:
+        return None
+    from vllm.distributed import get_pp_group
+    return all_ranges[get_pp_group().rank_in_group]
+
+
+def setup_vpp_layers(
+    self,
+    num_hidden_layers: int,
+    layer_fn: "LayerFn",
+    prefix: str,
+) -> None:
+    """Attach VPP-aware layer attributes to ``self`` (model instance).
+
+    Sets:
+        * ``self.vpp_layer_ranges`` — list of ``(start, end)`` per vp_stage
+        * ``self.layers``           — ``nn.ModuleList`` for this pp_rank
+        * ``self.start_layer`` / ``self.end_layer`` — boundaries of the
+          first/last stage on this rank (for compatibility with non-VPP
+          code paths that read these attributes).
+
+    Reads the VPP size and custom layer ranges from ``get_ascend_config()``.
+    No-op (besides reading config) when ``vp_size <= 1`` is not possible
+    here — callers must check ``vp_size`` themselves if they want to
+    fall back to the upstream ``make_layers`` path.
+    """
+    custom_ranges = get_custom_layer_ranges_for_rank()
+    self.vpp_layer_ranges, self.layers = make_vpp_layers(
+        num_hidden_layers,
+        layer_fn,
+        prefix,
+        get_vp_size(),
+        custom_layer_ranges=custom_ranges,
+    )
+    self.start_layer = self.vpp_layer_ranges[0][0]
+    self.end_layer = self.vpp_layer_ranges[-1][1]

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -68,6 +68,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     "VLLM_VERSION": lambda: os.getenv("VLLM_VERSION", None),
     # Whether to anbale dynamic EPLB
     "DYNAMIC_EPLB": lambda: os.getenv("DYNAMIC_EPLB", "false").lower(),
+    # Whether to enable Virtual Pipeline Parallelism (VPP) support on the
+    # multiproc executor. Default: false (opt-in).
+    "ENABLE_VPP": lambda: os.getenv("ENABLE_VPP", "false").lower() in ("true", "1"),
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -35,8 +35,13 @@ import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa
 import vllm_ascend.patch.platform.patch_mamba_manager  # noqa
 
-if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true":
+if os.getenv("DYNAMIC_EPLB", "false").lower() in ("true", "1") or os.getenv("EXPERT_MAP_RECORD", "false") == "true" \
+    or os.getenv("ENABLE_VPP", "false").lower() in ("true", "1"):
     import vllm_ascend.patch.platform.patch_multiproc_executor  # noqa
+
+import vllm_ascend.patch.platform.patch_scheduler  # noqa
+import vllm_ascend.patch.platform.patch_outputs  # noqa
+import vllm_ascend.patch.platform.patch_vpp_core  # noqa
 
 import vllm_ascend.patch.platform.patch_balance_schedule  # noqa
 import vllm_ascend.patch.platform.patch_dyntra_lb_core  # noqa

--- a/vllm_ascend/patch/platform/patch_multiproc_executor.py
+++ b/vllm_ascend/patch/platform/patch_multiproc_executor.py
@@ -150,6 +150,19 @@ class AscendMultiprocExecutor(MultiprocExecutor):
         pp_size = self.parallel_config.pipeline_parallel_size
         pcp_size = self.parallel_config.prefill_context_parallel_size
         return tp_size, pp_size, pcp_size
+    
+    def _get_output_rank(self) -> int:
+        additional_config = self.vllm_config.additional_config or {}
+        vp_size = additional_config.get("virtual_pipeline_parallel_size", 0)
+        # With an even vp_size the V-shaped fold-back assignment places the
+        # last virtual stage (norm / lm_head) back on PP rank 0, so the
+        # ModelRunnerOutput is produced by global rank 0.
+        if vp_size > 1 and vp_size % 2 == 0:
+            return 0
+        # No VPP or an odd vp_size: the last stage is the first TP worker of
+        # the last PP stage. Compute the original upstream formula directly
+        # (the core MultiprocExecutor._get_output_rank is hard-coded to 0).
+        return super()._get_output_rank()
 
     def _post_init_executor(self) -> None:
         pass

--- a/vllm_ascend/patch/platform/patch_outputs.py
+++ b/vllm_ascend/patch/platform/patch_outputs.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Inject ``VppContinuationOutput`` into ``vllm.v1.outputs``.
+
+vLLM 0.22.1 upstream does NOT define ``VppContinuationOutput`` — it is part
+of the VPP feature. vllm-ascend installs the class here as a monkey-patch
+on ``vllm.v1.outputs`` so that:
+
+  * the worker (``vllm_ascend.worker.model_runner_v1``) and the engine core
+    (``vllm.v1.engine.core``) reference the **same class object**;
+  * ``pickle`` round-trips between worker and engine core resolve to a
+    class the engine core can ``isinstance``-check.
+
+The injection runs at import time. Any later
+``from vllm.v1.outputs import VppContinuationOutput`` (in either process)
+gets this exact class.
+"""
+
+from dataclasses import dataclass
+
+import vllm.v1.outputs as _vllm_outputs
+from vllm.v1.outputs import KVConnectorOutput
+
+
+@dataclass
+class VppContinuationOutput:
+    """Indicates VPP execution yielded and should be resumed."""
+
+    next_vp_stage: int = 0
+    kv_connector_output: KVConnectorOutput | None = None
+
+
+# Install on the vllm module so all callers (worker & engine core) see the
+# same class object. Idempotent — if a future vLLM upstream adds this class
+# already, we just keep theirs.
+if not hasattr(_vllm_outputs, "VppContinuationOutput"):
+    _vllm_outputs.VppContinuationOutput = VppContinuationOutput
+else:
+    # Upstream already provides it; keep their definition but rebind our
+    # local symbol so direct imports still work.
+    VppContinuationOutput = _vllm_outputs.VppContinuationOutput
+
+
+# Make ``pickle`` locate the class under ``vllm.v1.outputs`` (matching the
+# symlink above) rather than ``vllm_ascend.patch.platform.patch_outputs``.
+# Both worker and engine-core processes execute this module at startup,
+# so the symbol is always present in the receiving process.
+VppContinuationOutput.__module__ = "vllm.v1.outputs"
+
+
+__all__ = ["VppContinuationOutput"]

--- a/vllm_ascend/patch/platform/patch_scheduler.py
+++ b/vllm_ascend/patch/platform/patch_scheduler.py
@@ -1,0 +1,113 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import vllm.v1.core.sched.scheduler as _sched_mod  # noqa: F401  (force load)
+from vllm.v1.core.sched import output as _output_mod
+from vllm.v1.core.sched.output import (
+    SchedulerOutput as _UpstreamSchedulerOutput,
+)
+from vllm.v1.core.sched.scheduler import Scheduler
+
+"""Replace ``vllm.v1.core.sched.output.SchedulerOutput`` with a VPP-aware
+subclass.
+
+Because every reference is resolved via Python attribute lookup on the
+module (``from vllm.v1.core.sched.output import SchedulerOutput``), both
+the engine-core and worker processes see this subclass as long as this
+patch is loaded in both.
+
+Field-ordering note: dataclass inheritance appends ``batch_id`` at the
+end (after ``new_block_ids_to_zero``).  This is safe because:
+"""
+
+@dataclass
+class SchedulerOutput(_UpstreamSchedulerOutput):
+    """Upstream ``SchedulerOutput`` + the ``batch_id`` VPP field.
+
+    Inherits the entire upstream field set and ``make_empty()`` so the
+    schema tracks upstream automatically; only ``batch_id`` is declared
+    here.  ``make_empty()`` is inherited unchanged from upstream and
+    leaves ``batch_id`` at its default (``0``).
+    """
+
+    # Per-scheduler monotonically increasing id; under VPP scheme2 NPU
+    # workers key their continuation-context dict on this value.
+    batch_id: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Install the replacement on the vLLM module.
+# ---------------------------------------------------------------------------
+_output_mod.SchedulerOutput = SchedulerOutput
+_sched_mod.SchedulerOutput = SchedulerOutput
+
+# Make ``pickle`` locate the class under ``vllm.v1.core.sched.output``
+# (matching the symlink above) rather than ``vllm_ascend.patch.platform
+# .patch_scheduler_output``.  Both worker and engine-core processes
+# execute this module at startup so the symbol is always present in the
+# receiving process.
+SchedulerOutput.__module__ = "vllm.v1.core.sched.output"
+
+
+__all__ = ["SchedulerOutput"]
+
+"""Patch ``vllm.v1.core.sched.scheduler.Scheduler`` for VPP.
+"""
+# ---------------------------------------------------------------------------
+# VPP: per-batch id stamping
+# ---------------------------------------------------------------------------
+_original_scheduler_init = Scheduler.__init__
+
+
+def _ascend_vpp_scheduler_init(self, *args, **kwargs) -> None:
+    """Wrap ``Scheduler.__init__`` to seed the per-instance batch counter.
+
+    The counter is *not* read by upstream vLLM; vllm-ascend only.  Keeping
+    it as a plain instance attribute avoids touching the vllm dataclass
+    schema and survives garbage collection naturally with ``self``.
+    """
+    _original_scheduler_init(self, *args, **kwargs)
+    self._vpp_next_batch_id: int = 0
+
+
+Scheduler.__init__ = _ascend_vpp_scheduler_init
+
+
+_original_scheduler_schedule = Scheduler.schedule
+
+
+def _ascend_vpp_scheduler_schedule(self):
+    scheduler_output = _original_scheduler_schedule(self)
+    if scheduler_output is None:
+        return scheduler_output
+
+    # Per-instance counter; never reset across steps so workers see a
+    # unique id for every batch even after empty scheduling steps.
+    if not hasattr(self, "_vpp_next_batch_id"):
+        # Defensive: a Scheduler constructed before the wrapper was
+        # installed (e.g. during tests) will not have the counter.
+        self._vpp_next_batch_id = 0
+    scheduler_output.batch_id = self._vpp_next_batch_id
+    self._vpp_next_batch_id += 1
+
+    return scheduler_output
+
+
+Scheduler.schedule = _ascend_vpp_scheduler_schedule

--- a/vllm_ascend/patch/platform/patch_vpp_core.py
+++ b/vllm_ascend/patch/platform/patch_vpp_core.py
@@ -1,0 +1,277 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Patches ``vllm.v1.engine.core.EngineCore`` to support Virtual Pipeline
+Parallelism (VPP) scheme2.
+
+The vLLM tree does NOT ship VPP: ``VppContinuationOutput`` is injected by
+``patch_outputs`` and the per-batch ``batch_id`` stamping by
+``patch_scheduler``.  This patch closes the engine-core gap by:
+
+  * ``EngineCore.__init__`` — detect VPP from
+    ``vllm_config.additional_config["virtual_pipeline_parallel_size"]``,
+    record ``self.vpp_enabled``, bump ``self.batch_queue_size`` by one
+    so the fold-back scheme can over-schedule, and allocate
+    ``self.allow_over_batch_queue`` / ``self._deferred_scheduler_output``.
+  * ``EngineCore.step_with_batch_queue`` — respect
+    ``allow_over_batch_queue``, dispatch on ``VppContinuationOutput``
+    (re-issue ``execute_model`` and re-enqueue), handle the ``None``-output
+    case for VPP-disabled batches coming back from ``sample_tokens``, and
+    replay ``_deferred_scheduler_output`` on the next visit.  When VPP is
+    not enabled it delegates to the original upstream method unchanged.
+  * ``DPEngineCoreProc.execute_dummy_batch`` — when a batch queue is
+    active, dispatch a non-blocking collective RPC instead of
+    blocking; otherwise fall back to the inherited behaviour. A blocking
+    drain would destroy pipeline overlap.
+
+This patch is intentionally engine-only; the model/executor sides are
+patched separately via ``patch_vpp_make_layers`` / ``patch_multiproc_executor``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from concurrent.futures import Future
+from typing import cast
+
+from vllm.v1.engine.core import DPEngineCoreProc, EngineCore
+from vllm.v1.outputs import ModelRunnerOutput, VppContinuationOutput
+from vllm.logger import logger
+
+# Extra headroom above ``batch_queue_size`` for the deque capacity.
+# VPP over-schedules by +1 for the fold-back continuation cycle, and
+# transient bursts (e.g. async pre-fetching) risk silent drops if
+# ``maxlen`` is too tight.  Value 10 is empirically sufficient; scale
+# proportionally with ``max_num_seqs`` if needed.
+_VPP_BATCH_QUEUE_HEADROOM = 10
+
+# ---------------------------------------------------------------------------
+# EngineCore.__init__ — VPP-aware setup
+# ---------------------------------------------------------------------------
+_original_engine_core_init = EngineCore.__init__
+
+
+def _ascend_vpp_post_init(self: EngineCore) -> None:
+    """Apply VPP-specific state adjustments AFTER the original __init__.
+
+    The original ``__init__`` already builds the ``batch_queue`` according
+    to ``max_concurrent_batches``; we simply resize when VPP is enabled
+    and stash the auxiliary attributes.
+    """
+    additional_config = getattr(self.vllm_config, "additional_config", None)
+    vp_size = additional_config.get("virtual_pipeline_parallel_size", 1) if isinstance(additional_config, dict) else 1
+    self.vpp_enabled = isinstance(vp_size, int) and vp_size > 1
+    self.vp_size = int(vp_size) if self.vpp_enabled else 1
+
+    self.allow_over_batch_queue = False
+    self._deferred_scheduler_output = None
+
+    if self.vpp_enabled and self.batch_queue is not None:
+        # VPP scheme2 needs one extra batch in flight so the fold-back
+        # schedule can over-subscribe; the headroom keeps the deque from
+        # dropping entries during the over-scheduled continuation cycle.
+        self.batch_queue_size += 1
+        self.batch_queue = deque(maxlen=self.batch_queue_size + _VPP_BATCH_QUEUE_HEADROOM)
+
+
+def _ascend_vpp_engine_core_init(self: EngineCore, *args, **kwargs) -> None:
+    _original_engine_core_init(self, *args, **kwargs)
+    _ascend_vpp_post_init(self)
+
+
+EngineCore.__init__ = _ascend_vpp_engine_core_init
+
+
+# ---------------------------------------------------------------------------
+# EngineCore.step_with_batch_queue — VPP-aware scheduling
+# ---------------------------------------------------------------------------
+# Captured before reassignment so the non-VPP path can delegate to the
+# original upstream method unchanged (byte-identical behaviour for users
+# who have not enabled VPP).  Only ``vpp_enabled`` engines run the
+# VPP-aware loop below.
+_original_step_with_batch_queue = EngineCore.step_with_batch_queue
+
+
+def _ascend_vpp_step_with_batch_queue(
+    self: EngineCore,
+) -> tuple[dict, bool]:
+    """Drop-in replacement for ``EngineCore.step_with_batch_queue``.
+
+    When VPP is disabled, delegates to the original upstream method so that
+    non-VPP users are unaffected by the VPP-aware rewrite.  When VPP is
+    enabled, respects ``allow_over_batch_queue``, recognizes
+    ``VppContinuationOutput``, and replays ``_deferred_scheduler_output``
+    across calls.
+    """
+    if not getattr(self, "vpp_enabled", False):
+        return _original_step_with_batch_queue(self)
+
+    batch_queue = self.batch_queue
+    assert batch_queue is not None
+
+    # Try to schedule a new batch if the batch queue is not full, but
+    # the scheduler may return an empty batch if all requests are scheduled.
+    # Note that this is not blocking.
+    can_schedule = len(batch_queue) < self.batch_queue_size or self.allow_over_batch_queue
+    logger.info("batch queue size:%s, self.batch_queue_size:%s", len(batch_queue), self.batch_queue_size)
+
+    if self.allow_over_batch_queue:
+        self.allow_over_batch_queue = False
+
+    model_executed = False
+    deferred_scheduler_output = None
+    if can_schedule and self.scheduler.has_requests():
+        scheduler_output = self.scheduler.schedule()
+        with self.log_error_detail(scheduler_output):
+            exec_future = self.model_executor.execute_model(scheduler_output, non_block=True)
+        if self.is_ec_consumer:
+            model_executed = scheduler_output.total_num_scheduled_tokens > 0
+
+        if self.is_pooling_model or not model_executed or self.vpp_enabled:
+            # No sampling required (no requests scheduled).
+            future = cast(
+                Future[ModelRunnerOutput | VppContinuationOutput | None],
+                exec_future,
+            )
+        else:
+            if not scheduler_output.pending_structured_output_tokens:
+                # We aren't waiting for any tokens, get any grammar output
+                # and sample immediately.
+                grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+                future = self.model_executor.sample_tokens(grammar_output, non_block=True)
+            else:
+                # We need to defer sampling until we have processed
+                # the model output from the prior step.
+                deferred_scheduler_output = scheduler_output
+
+        if not deferred_scheduler_output:
+            # Add this step's future to the queue.
+            batch_queue.appendleft((future, scheduler_output, exec_future))
+            if model_executed and len(batch_queue) < self.batch_queue_size and not batch_queue[-1][0].done():
+                # Don't block on next worker response unless the queue
+                # is full or there are no more requests to schedule.
+                return None, True
+
+    elif not batch_queue:
+        # Queue is empty. We should not reach here since this method
+        # should only be called when the scheduler contains requests
+        # or the queue is non-empty.
+        return None, False
+
+    # Block until the next result is available.
+    future, scheduler_output, exec_model_fut = batch_queue.pop()
+    with (
+        self.log_error_detail(scheduler_output),
+        self.log_iteration_details(scheduler_output),
+    ):
+        model_output = future.result()
+        if isinstance(model_output, VppContinuationOutput):
+            self.allow_over_batch_queue = True
+            if model_output.kv_connector_output:
+                self.scheduler._update_from_kv_xfer_finished(model_output.kv_connector_output)
+            exec_future = self.model_executor.execute_model(scheduler_output, non_block=True)
+            if model_output.next_vp_stage == self.vp_size - 1:
+                # We aren't waiting for any tokens, get any grammar
+                # output and sample immediately.
+                grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+                future = self.model_executor.sample_tokens(grammar_output, non_block=True)
+            else:
+                future = cast(
+                    Future[ModelRunnerOutput | VppContinuationOutput | None],
+                    exec_future,
+                )
+            batch_queue.appendleft((future, scheduler_output, exec_future))
+            return None, True
+
+        if model_output is None:
+            if not self.vpp_enabled:
+                # None from sample_tokens() implies that the original
+                # execute_model() call failed - raise that exception.
+                exec_model_fut.result()
+                raise RuntimeError("unexpected error")
+            if scheduler_output.pending_structured_output_tokens:
+                self._deferred_scheduler_output = scheduler_output
+                return None, True
+            grammar_output = self.scheduler.get_grammar_bitmask(scheduler_output)
+            future = self.model_executor.sample_tokens(grammar_output, non_block=True)
+            batch_queue.appendleft((future, scheduler_output, exec_model_fut))
+            if len(batch_queue) < self.batch_queue_size and not batch_queue[-1][0].done():
+                return None, True
+            return None, True
+
+    # Before processing the model output, process any aborts that
+    # happened during the model execution.
+    self._process_aborts_queue()
+    engine_core_outputs = self.scheduler.update_from_output(scheduler_output, model_output)
+
+    if deferred_scheduler_output is None and self._deferred_scheduler_output is not None:
+        deferred_scheduler_output = self._deferred_scheduler_output
+        self._deferred_scheduler_output = None
+
+    # NOTE(nick): We can either handle the deferred tasks here or save
+    # in a field and do it immediately once step_with_batch_queue is
+    # re-called. The latter slightly favors TTFT over TPOT/throughput.
+    if deferred_scheduler_output:
+        # If we are doing speculative decoding with structured output,
+        # we need to get the draft token ids from the prior step before
+        # we can compute the grammar bitmask for the deferred request.
+        if self.use_spec_decode:
+            draft_token_ids = self.model_executor.take_draft_token_ids()
+            assert draft_token_ids is not None
+            # Update the draft token ids in the scheduler output to
+            # filter out the invalid spec tokens, which will be padded
+            # with -1 and skipped by the grammar bitmask computation.
+            self.scheduler.update_draft_token_ids_in_output(draft_token_ids, deferred_scheduler_output)
+        # We now have the tokens needed to compute the bitmask for
+        # the deferred request. Get the bitmask and call sample tokens.
+        grammar_output = self.scheduler.get_grammar_bitmask(deferred_scheduler_output)
+        future = self.model_executor.sample_tokens(grammar_output, non_block=True)
+        batch_queue.appendleft((future, deferred_scheduler_output, exec_future))
+
+    return engine_core_outputs, model_executed
+
+
+EngineCore.step_with_batch_queue = _ascend_vpp_step_with_batch_queue
+
+
+# ---------------------------------------------------------------------------
+# DPEngineCoreProc.execute_dummy_batch — non-blocking under batch queue
+# ---------------------------------------------------------------------------
+_original_dp_execute_dummy_batch = DPEngineCoreProc.execute_dummy_batch
+
+
+def _ascend_vpp_dp_execute_dummy_batch(self: DPEngineCoreProc) -> None:
+    """Run a dummy batch, non-blocking if a batch queue is active.
+
+    A blocking ``execute_dummy_batch`` would drain every in-flight
+    future in the worker ``futures_queue`` and destroy pipeline overlap.
+    When VPP keeps a ``batch_queue`` populated we instead issue a
+    non-blocking collective RPC; the dummy future is consumed the next
+    time ``step_with_batch_queue`` drains the queue, and worker-side
+    ordering keeps the DP all2all calls paired up correctly.
+    """
+    if getattr(self, "batch_queue", None) is not None:
+        self.model_executor.collective_rpc(
+            "execute_dummy_batch",
+            unique_reply_rank=self.model_executor.output_rank,
+            non_block=True,
+        )
+        return
+    _original_dp_execute_dummy_batch(self)
+
+
+DPEngineCoreProc.execute_dummy_batch = _ascend_vpp_dp_execute_dummy_batch

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -63,3 +63,4 @@ import vllm_ascend.patch.worker.patch_v2.patch_dspark  # noqa
 
 # only patch routed experts capture in main2main.
 import vllm_ascend.patch.worker.patch_routed_experts_capture  # noqa
+import vllm_ascend.patch.worker.patch_vpp_make_layers  # noqa

--- a/vllm_ascend/patch/worker/patch_distributed.py
+++ b/vllm_ascend/patch/worker/patch_distributed.py
@@ -15,21 +15,34 @@
 
 from __future__ import annotations
 
-import logging
+from collections import deque
+import pickle
 from functools import wraps
 from typing import Any, cast
 
 import torch
 import vllm
-from torch.distributed import Backend
-from vllm.distributed.parallel_state import GroupCoordinator, _get_unique_name, _register_group
+from torch import Tensor
+from torch.distributed import Backend, ProcessGroup, Work
+from vllm.distributed.parallel_state import (
+    GroupCoordinator,
+    _get_unique_name,
+    _register_group,
+    _split_tensor_dict,
+)
+from vllm.logger import logger
 
 from vllm_ascend.distributed.device_communicators.npu_communicator import NPUCommunicator
 from vllm_ascend.patch.worker._hccl_pg_registry import HcclPgKey, HcclPgRegistry, make_hccl_pg_key
 from vllm_ascend.utils import create_hccl_pg_options
+from vllm_ascend.distributed.parallel_state import (
+    get_virtual_pipeline_parallel_rank,
+    get_virtual_pipeline_parallel_size,
+    get_vpp_runtime_active,
+)
+from vllm_ascend.distributed.vpp_utils import is_vpp_last_stage as _is_vpp_last_stage
 
 _HCCL_PG_REGISTRY = HcclPgRegistry()
-logger = logging.getLogger(__name__)
 
 
 def _normalize_backend(backend: str | Backend) -> str:
@@ -110,10 +123,17 @@ class GroupCoordinatorPatch(GroupCoordinator):
     ):
         self.use_all2all = use_all2all
 
+        # One entry per async send_tensor_dict call: (isend handles, retained
+        # source tensors). The tensor refs keep the source memory alive while
+        # the non-blocking sends are in flight, so it is neither freed nor
+        # overwritten before completion (cf. async-send data-corruption fix).
+        self._async_send_buff: deque[tuple[list[Work], list[Tensor]]] = deque()
+
         group_name = group_name or "anonymous"
         self.unique_name = _get_unique_name(group_name)
         _register_group(self)
 
+        self.group_ranks = group_ranks
         self.rank = torch.distributed.get_rank()
         self.local_rank = local_rank
         self.backend = _normalize_backend(torch_distributed_backend)
@@ -127,6 +147,12 @@ class GroupCoordinatorPatch(GroupCoordinator):
         self.device_group = None
         self.device = None
         self.use_custom_op_call = True
+
+        self.vpp_size = get_virtual_pipeline_parallel_size()
+        self.vpp_stage = get_virtual_pipeline_parallel_rank()
+
+        self.torch_distributed_backend = torch_distributed_backend
+        self.use_message_queue_broadcaster = use_message_queue_broadcaster
         self.use_cpu_custom_send_recv = False
         self.group_name = group_name
         self.group_ranks = group_ranks
@@ -249,6 +275,250 @@ class GroupCoordinatorPatch(GroupCoordinator):
         self._init_device_communicator()
         return True
 
+    def all_to_all(
+        self,
+        input_: torch.Tensor,
+        scatter_dim: int = 0,
+        gather_dim: int = -1,
+        scatter_sizes: list[int] | None = None,
+        gather_sizes: list[int] | None = None,
+    ) -> torch.Tensor:
+        if self.world_size == 1:
+            return input_
+        assert -input_.dim() <= scatter_dim < input_.dim(), (
+            f"Invalid scatter dim ({scatter_dim}) for input tensor with shape {input_.size()}"
+        )
+        assert -input_.dim() <= gather_dim < input_.dim(), (
+            f"Invalid gather dim ({gather_dim}) for input tensor with shape {input_.size()}"
+        )
+        assert self.device_communicator is not None, "device_communicator should be initialized when world_size > 1"
+        return self.device_communicator.all_to_all(input_, scatter_dim, gather_dim, scatter_sizes, gather_sizes)
+
+    @property
+    def is_first_rank(self):
+        """Return whether the caller is the first process in the group.
+
+        Under VPP this is *phase-dependent*:
+
+        * Construction (``get_vpp_runtime_active()`` is False, i.e. before
+          the VPP schedule loop starts): return the **static** topology
+          answer -- the first virtual stage always starts at pp_rank 0 --
+          so model ``__init__`` places ``embed_tokens`` on the rank that
+          owns the first stage.
+        * Runtime (after the loop starts): return the **dynamic** answer
+          for the current virtual stage, used by ``forward`` to decide
+          whether to embed the input ids.
+        """
+        if get_virtual_pipeline_parallel_size() <= 1:
+            return self.rank == self.first_rank
+        if not get_vpp_runtime_active():
+            return self.rank_in_group == 0
+        return self.rank_in_group == 0 and get_virtual_pipeline_parallel_rank() == 0
+
+    @property
+    def is_last_rank(self):
+        """Return whether the caller is the last process in the group.
+
+        Under VPP this is *phase-dependent*:
+
+        * Construction (``get_vpp_runtime_active()`` is False, i.e. before
+          the VPP schedule loop starts): return the **static** fold-back
+          topology answer -- which physical rank owns the very last
+          virtual stage -- so model ``__init__`` places ``norm`` /
+          ``lm_head`` on the correct rank. This is ``is_vpp_last_stage``
+          evaluated at ``vp_stage = vp_size - 1`` and does **not** depend
+          on the (still-zero) live virtual rank.
+        * Runtime (after the loop starts): return the **dynamic** answer
+          for the current virtual stage, used by ``forward`` to decide
+          whether to apply norm / emit logits.
+        """
+        vp_size = get_virtual_pipeline_parallel_size()
+        if vp_size <= 1:
+            return self.rank == self.last_rank
+        pp_rank = self.rank_in_group
+        pp_size = self.world_size
+        if not get_vpp_runtime_active():
+            return self.is_vpp_last_stage(
+                pp_rank=pp_rank, pp_size=pp_size,
+                vp_stage=vp_size - 1, vp_size=vp_size)
+        vp_stage = get_virtual_pipeline_parallel_rank()
+        return self.is_vpp_last_stage(
+            pp_rank=pp_rank, pp_size=pp_size,
+            vp_stage=vp_stage, vp_size=vp_size)
+
+    def is_vpp_last_stage(
+        self,
+        pp_rank: int,
+        pp_size: int,
+        vp_stage: int,
+        vp_size: int,
+    ) -> bool:
+        """Delegate to the shared implementation in ``vpp_utils`` so the
+        fold-back semantics are defined exactly once.
+        """
+        return _is_vpp_last_stage(pp_rank, pp_size, vp_stage, vp_size)
+
+    def _release_completed_send_buff(self) -> None:
+        """Lazily drop async-send batches whose hccl sends have completed.
+
+        gloo ``Work.is_completed()`` is unreliable on this backend, so we gate
+        on the hccl handles only (``handles[2:]``, reliable) and ``wait()`` the
+        gloo metadata handles (``handles[:2]``) as a backstop before dropping.
+        The waited entry is old (its hccl already completed) so the wait is
+        ~instant and does NOT reintroduce the fold-point deadlock (that
+        deadlock comes from blocking on a *current* send; here we block on an
+        already-completed old one).
+
+        Metadata-only entries (``handles[2:]`` empty, e.g. empty
+        ``IntermediateTensors``) have no hccl gate and used to leak forever
+        because ``not hccl_handles`` short-circuited the loop. Drop them
+        best-effort: pop without blocking ``wait()`` on the gloo metadata
+        (which would reintroduce the fold-point deadlock risk). The retained
+        ``size_tensor`` / ``object_tensor`` go out of scope on pop, releasing
+        the only large memory; the small gloo ``Work`` handles may dangle but
+        are bounded.
+        """
+        while self._async_send_buff:
+            handles = self._async_send_buff[0][0]
+            # handles[:2] = gloo metadata；handles[2:] = hccl tensor（is_completed 可靠）
+            hccl_handles = handles[2:]
+            if not hccl_handles:
+                # Metadata-only send: no reliable completion signal, just drop.
+                self._async_send_buff.popleft()
+                continue
+            if not all(h.is_completed() for h in hccl_handles):
+                break   # 队首 hccl 尚未完成 → FIFO 后续更未完成，停止
+            popped = self._async_send_buff.popleft()
+            for h in popped[0][:2]:   # gloo metadata wait 兜底，确保已发出
+                h.wait()
+
+    def _wait_send_buff(self) -> None:
+        """Block until every in-flight async send has completed."""
+        while self._async_send_buff:
+            handles, _ = self._async_send_buff.popleft()
+            for handle in handles:
+                handle.wait()
+
+    def send_tensor_dict(
+        self,
+        tensor_dict: dict[str, Any],
+        dst: int | None = None,
+        all_gather_group: "GroupCoordinator | None" = None,
+        all_gather_tensors: dict[str, bool] | None = None,
+        is_async: bool = False,
+    ) -> dict[str, Any] | None:
+        """Send a tensor dict, optionally fully non-blocking (``is_async=True``).
+
+        ``isend_tensor_dict`` is overridden so the metadata is also posted with
+        ``isend`` (upstream sends it via a blocking ``send_object``). The VPP
+        stage schedule needs every point-to-point op non-blocking, otherwise a
+        fold-point send whose matching recv lives in a later iteration deadlocks
+        both ranks inside the metadata send.
+        """
+        if not is_async:
+            return super().send_tensor_dict(
+                tensor_dict,
+                dst=dst,
+                all_gather_group=all_gather_group,
+                all_gather_tensors=all_gather_tensors,
+            )
+        if not torch.distributed.is_initialized() or self.world_size == 1:
+            return tensor_dict
+        self.isend_tensor_dict(
+            tensor_dict,
+            dst=dst,
+            all_gather_group=all_gather_group,
+            all_gather_tensors=all_gather_tensors,
+        )
+        return None
+
+    def isend_tensor_dict(
+        self,
+        tensor_dict: dict[str, Any],
+        dst: int | None = None,
+        all_gather_group: "GroupCoordinator | None" = None,
+        all_gather_tensors: dict[str, bool] | None = None,
+    ) -> list:
+        """Non-blocking tensor-dict send: metadata and tensors both use isend.
+
+        Retains references to every source/metadata tensor in
+        ``_async_send_buff`` until the sends complete, so the memory is neither
+        freed nor overwritten while in flight.
+        """
+        if self.world_size <= 1:
+            return []
+        # Non-VPP (vp_size <= 1): fall back to upstream blocking isend so it
+        # pairs with the upstream irecv_tensor_dict on the peer rank. The async
+        # path below (non-blocking metadata isend + FIFO release) is only
+        # correct under the VPP stage schedule; under regular PP it deadlocks
+        # against the sync recv on the peer.
+        if get_virtual_pipeline_parallel_size() <= 1:
+            return super().isend_tensor_dict(
+                tensor_dict,
+                dst=dst,
+                all_gather_group=all_gather_group,
+                all_gather_tensors=all_gather_tensors,
+            )
+        if dst is None:
+            dst = (self.rank_in_group + 1) % self.world_size
+        assert dst < self.world_size, f"Invalid dst rank ({dst})"
+
+        self._release_completed_send_buff()
+        all_gather_size = 1 if all_gather_group is None else all_gather_group.world_size
+        all_gather_rank = (
+            0 if all_gather_group is None else all_gather_group.rank_in_group
+        )
+        group = self.device_group
+        metadata_group = self.cpu_group
+
+        metadata_list, tensor_list = _split_tensor_dict(tensor_dict)
+        # Non-blocking metadata send (the deadlock fix: upstream blocks here on
+        # send_object while the matching recv is posted in a later iteration).
+        handles, retained = self._isend_object(metadata_list, dst=dst)
+
+        tensor_keys = [k for k, v in tensor_dict.items() if isinstance(v, torch.Tensor)]
+        assert len(tensor_keys) == len(tensor_list)
+        for key, tensor in zip(tensor_keys, tensor_list):
+            if tensor.numel() == 0:
+                continue
+            if self._should_use_all_gather(
+                key, tensor.numel(), all_gather_group, all_gather_tensors
+            ):
+                tensor = tensor.reshape(all_gather_size, -1)[all_gather_rank]
+            comm_group = metadata_group if tensor.is_cpu else group
+            handle = torch.distributed.isend(
+                tensor, dst=self.ranks[dst], group=comm_group
+            )
+            if handle is not None:
+                handles.append(handle)
+            retained.append(tensor)
+
+        if handles:
+            self._async_send_buff.append((handles, retained))
+        return handles
+
+    def _isend_object(
+        self, obj: Any, dst: int
+    ) -> tuple[list, list[Tensor]]:
+        """Non-blocking send_object: isend the size + pickled object, retain refs."""
+        assert dst < self.world_size, f"Invalid dst rank ({dst})"
+        assert dst != self.rank_in_group, (
+            "Invalid destination rank. Destination rank is the same "
+            "as the current rank."
+        )
+        object_tensor = torch.frombuffer(pickle.dumps(obj), dtype=torch.uint8)
+        size_tensor = torch.tensor(
+            [object_tensor.numel()], dtype=torch.long, device="cpu"
+        )
+        retained = [size_tensor, object_tensor]
+        handles: list = []
+        for tensor in retained:
+            handle = torch.distributed.isend(
+                tensor, dst=self.ranks[dst], group=self.cpu_group
+            )
+            if handle is not None:
+                handles.append(handle)
+        return handles, retained
 
 vllm.distributed.parallel_state.GroupCoordinator = GroupCoordinatorPatch
 _patch_destroy_distributed_environment()

--- a/vllm_ascend/patch/worker/patch_vpp_make_layers.py
+++ b/vllm_ascend/patch/worker/patch_vpp_make_layers.py
@@ -1,0 +1,121 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+# This file is a part of the vllm-ascend project.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+VPP patch for the shared pipeline-parallel layer allocator ``make_layers``.
+
+Previously every VPP-enabled model needed its own ``__init__`` patch that
+reimplemented the *whole* constructor just to swap
+``make_layers`` -> ``setup_vpp_layers`` (see the now-removed
+``patch_vpp_deepseek``).  ``make_layers`` is the single entry point
+*every* model uses to build its decoder stack under pipeline parallelism,
+so patching it here makes V-shaped fold-back layer assignment available
+to all of them automatically — no per-model shim required.
+
+When ``vp_size > 1`` this drops in ``make_vpp_layers`` and attaches the
+per-virtual-stage ranges to the returned ``ModuleList`` as
+``modules.vpp_layer_ranges``, so a model's forward pass can pick the right
+slice for the current virtual stage::
+
+    vpp_ranges = getattr(self.layers, "vpp_layer_ranges", None)
+    if vpp_ranges is None:                 # vanilla PP
+        start, end = self.start_layer, self.end_layer
+    else:                                  # VPP
+        start, end = vpp_ranges[get_virtual_pipeline_parallel_rank()]
+
+Scope
+-----
+This covers layer *construction* only.  The two remaining VPP concerns are
+handled centrally:
+
+* ``norm`` / ``lm_head`` placement -- upstream gates this on
+  ``is_last_rank``, which under VPP is phase-latched in
+  ``patch_distributed``: at construction time it returns the static
+  fold-back topology, so the upstream ``__init__`` already places these
+  layers on the correct rank without a per-model patch.
+* Forward-pass range selection -- under ``ENABLE_VPP`` the model runner
+  sets ``start_layer`` / ``end_layer`` from ``vpp_layer_ranges`` per
+  virtual stage, so the standard upstream forward
+  (``islice(self.layers, self.start_layer, self.end_layer)``) needs no
+  change.
+"""
+from __future__ import annotations
+
+import sys
+
+from vllm.model_executor.models import utils as _model_utils
+
+from vllm_ascend.distributed.vpp_utils import (
+    get_custom_layer_ranges_for_rank,
+    get_vp_size,
+    make_vpp_layers,
+)
+
+
+_original_make_layers = _model_utils.make_layers
+
+
+def _vpp_make_layers(
+    num_hidden_layers: int,
+    layer_fn,
+    prefix: str,
+):
+    """Drop-in replacement for ``make_layers`` that is VPP-aware."""
+    vp_size = get_vp_size()
+    if vp_size <= 1:
+        return _original_make_layers(num_hidden_layers, layer_fn, prefix)
+
+    custom_ranges = get_custom_layer_ranges_for_rank()
+    layer_ranges, modules = make_vpp_layers(
+        num_hidden_layers,
+        layer_fn,
+        prefix,
+        vp_size,
+        custom_layer_ranges=custom_ranges,
+    )
+    # Expose the per-virtual-stage ranges so a model's forward can select
+    # the right slice for the current vp_stage.
+    modules.vpp_layer_ranges = layer_ranges
+
+    # start_layer / end_layer span every virtual stage owned by this rank
+    # (min start .. max end), mirroring what setup_vpp_layers sets.
+    start_layer = layer_ranges[0][0]
+    end_layer = layer_ranges[-1][1]
+    return start_layer, end_layer, modules
+
+
+# Replace the function in its defining module ...
+_model_utils.make_layers = _vpp_make_layers
+
+# ... and rebind every consumer that did ``from .utils import make_layers``.
+# That import form binds ``make_layers`` into the importing module's own
+# namespace, so patching ``utils.make_layers`` alone would leave already-
+# imported model modules pointing at the original function.  Modules that
+# are imported lazily *after* this patch pick up the new version
+# automatically (they read ``utils.make_layers`` at import time); this loop
+# fixes the modules that were imported eagerly, before the patch ran.
+#
+# Scoped to ``vllm.*`` modules: ``make_layers`` is only re-exported by vLLM
+# model modules, and limiting the scan avoids touching unrelated modules
+# (e.g. transformers ships its own unrelated ``make_layers`` and emits a
+# deprecation warning merely on attribute access).  The identity check
+# (``is _original_make_layers``) guarantees we never overwrite a different
+# function that merely shares the name.
+for _name, _mod in list(sys.modules.items()):
+    if _mod is None or not _name.startswith("vllm"):
+        continue
+    if getattr(_mod, "make_layers", None) is _original_make_layers:
+        _mod.make_layers = _vpp_make_layers

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -88,12 +88,14 @@ from vllm.v1.outputs import (
     AsyncModelRunnerOutput,
     DraftTokenIds,
     ECConnectorOutput,
+    KVConnectorOutput,
     LogprobsLists,
     LogprobsTensors,
     ModelRunnerOutput,
     RoutedExpertsLists,
     RoutedExpertsTensors,
     SamplerOutput,
+    VppContinuationOutput,
     make_empty_encoder_model_runner_output,
 )
 from vllm.v1.sample.logits_processor import build_logitsprocs
@@ -215,6 +217,11 @@ from vllm_ascend.ascend_forward_context import (  # isort: skip
 
 from vllm.model_executor.models.interfaces import supports_multimodal_pruning
 
+from vllm_ascend.distributed.parallel_state import (
+    get_virtual_pipeline_parallel_rank,
+    get_virtual_pipeline_parallel_size,
+    set_virtual_pipeline_parallel_rank,
+)
 from vllm_ascend.sample.rejection_sampler import AscendRejectionSampler
 
 if TYPE_CHECKING:
@@ -223,7 +230,7 @@ if TYPE_CHECKING:
 else:
     xgr = LazyLoader("xgr", globals(), "xgrammar")
 
-
+from vllm.distributed.parallel_state import GroupCoordinator
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 
 from vllm_ascend.core.kv_cache_interface import (
@@ -241,6 +248,16 @@ PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
 
 SEQ_LEN_WITH_MAX_PA_WORKSPACE = 6144
 
+
+def init_model_parallel_group(pp_group: GroupCoordinator, usage: str) -> GroupCoordinator:
+    return GroupCoordinator(
+        group_ranks=pp_group.group_ranks,
+        local_rank=pp_group.local_rank,
+        torch_distributed_backend=pp_group.torch_distributed_backend,
+        use_device_communicator=pp_group.use_device_communicator,
+        use_message_queue_broadcaster=pp_group.use_message_queue_broadcaster,
+        group_name=pp_group.unique_name + "_" + usage,
+    )
 
 @dataclass
 class GraphCaptureContext:
@@ -298,6 +315,53 @@ class ExecuteModelState(NamedTuple):
     ec_connector_output: "ECConnectorOutput | None"
     cudagraph_stats: CUDAGraphStat | None
     batch_desc: BatchDescriptor
+
+
+@dataclass
+class VppBatchContext:
+    batch_id: int
+    scheduler_output: "SchedulerOutput"
+    num_scheduled_tokens: int
+    num_scheduled_tokens_np: np.ndarray
+    max_num_scheduled_tokens: int
+    num_tokens_unpadded: int
+    num_tokens_padded: int
+    num_reqs: int
+    num_reqs_padded: int
+    logits_indices: torch.Tensor
+    spec_decode_metadata: SpecDecodeMetadata | None
+    spec_decode_common_attn_metadata: AscendCommonAttentionMetadata | None
+    attn_metadata: "PerLayerAttnMetadata"
+    batch_desc: BatchDescriptor
+    cudagraph_mode: CUDAGraphMode
+    num_tokens_across_dp: torch.Tensor | None
+    input_ids: torch.Tensor | None
+    inputs_embeds: torch.Tensor | None
+    positions: torch.Tensor
+    model_kwargs: dict[str, Any]
+    ec_connector_output: "ECConnectorOutput | None"
+    cudagraph_stats: CUDAGraphStat | None
+    has_encoder_input: bool
+    vp_size: int
+    input_batch_snapshot: NPUInputBatch
+    num_prompt_logprobs_snapshot: dict[str, int]
+    query_start_loc_cpu_snapshot: torch.Tensor
+    discard_request_indices_cpu_snapshot: torch.Tensor
+    num_discarded_requests_snapshot: int
+    next_vp_stage: int = 0
+    carry_intermediate_tensors: IntermediateTensors | None = None
+    pending_noop_cleanup: bool = False
+
+
+@dataclass
+class VppPendingSampleState:
+    execute_model_state: ExecuteModelState
+    kv_connector_output: "KVConnectorOutput | None"
+    input_batch: NPUInputBatch
+    num_prompt_logprobs: dict[str, int]
+    query_start_loc_cpu: torch.Tensor
+    discard_request_indices_cpu: torch.Tensor
+    num_discarded_requests: int
 
 
 class NPUModelRunner(GPUModelRunner):
@@ -610,6 +674,17 @@ class NPUModelRunner(GPUModelRunner):
             self._offload_req_ids_tensor = self._make_buffer(self.max_num_reqs, dtype=torch.int64)
             self._offload_token_to_req = self._make_buffer(self.max_num_tokens, dtype=torch.int32)
 
+        # defined for virtual pipeline parallism(vpp) algorithm
+        self._vpp_contexts: dict[int, VppBatchContext] | None = None
+        self._vpp_pp_group_prev: GroupCoordinator | None = None
+        self._vpp_pp_group_next: GroupCoordinator | None = None
+        self._pending_vpp_sample_states: deque[VppPendingSampleState] | None = None
+        if self._get_vpp_size() > 1:
+            self._vpp_contexts = {}
+            self._vpp_pp_group_prev = get_pp_group()
+            self._vpp_pp_group_next = init_model_parallel_group(get_pp_group(), "next_pp_group")
+            self._pending_vpp_sample_states = deque()
+
     @property
     def use_dcp(self) -> bool:
         return self.dcp_size > 1
@@ -635,6 +710,38 @@ class NPUModelRunner(GPUModelRunner):
         self.cached.clear()
         self._pending_encoder_cache_copies.clear()
 
+    def _is_vpp_last_or_pp_last(self) -> bool:
+        """Return True if this rank hosts the final output layer.
+
+        Under VPP the "last rank" depends on the fold-back topology, not
+        simply on ``get_pp_group().is_last_rank``.
+        """
+        if not hasattr(self, "_vpp_last_cached"):
+            try:
+                from vllm_ascend.ascend_config import get_ascend_config
+                vp_size = get_ascend_config().virtual_pipeline_parallel_size
+            except RuntimeError:
+                vp_size = 1
+            if vp_size <= 1:
+                self._vpp_last_cached = get_pp_group().is_last_rank
+            else:
+                from vllm_ascend.distributed.vpp_utils import is_vpp_last_stage
+                pp_rank = get_pp_group().rank_in_group
+                pp_size = get_pp_group().world_size
+                last_vp = vp_size - 1
+                self._vpp_last_cached = is_vpp_last_stage(pp_rank, pp_size, last_vp, vp_size)
+        return self._vpp_last_cached
+
+    def _get_vpp_size(self) -> int:
+        if not hasattr(self, "_vpp_size_cached"):
+            try:
+                from vllm_ascend.ascend_config import get_ascend_config
+                self._vpp_size_cached = (
+                    get_ascend_config().virtual_pipeline_parallel_size)
+            except RuntimeError:
+                self._vpp_size_cached = 1
+        return self._vpp_size_cached
+
     def _set_up_drafter(self):
         # Set up speculative decoding.
         self.drafter: (
@@ -656,7 +763,7 @@ class NPUModelRunner(GPUModelRunner):
             spec_token_num = self.speculative_config.num_speculative_tokens
             assert spec_token_num > 0
             self.decode_token_per_req = 1 + spec_token_num
-            if get_pp_group().is_last_rank:
+            if self._is_vpp_last_or_pp_last():
                 self.drafter = self._get_drafter()
                 if self.speculative_config.method == "eagle3":
                     assert isinstance(self.drafter, AscendEagleProposer)
@@ -1350,7 +1457,6 @@ class NPUModelRunner(GPUModelRunner):
         self.num_discarded_requests = len(discard_request_indices)
         self.discard_request_indices.np[: self.num_discarded_requests] = discard_request_indices
         self.discard_request_indices.copy_to_gpu(self.num_discarded_requests)
-
         self.discard_request_mask.np[:num_reqs] = discard_requests_mask
         self.discard_request_mask.copy_to_gpu(num_reqs)
 
@@ -1555,6 +1661,149 @@ class NPUModelRunner(GPUModelRunner):
             spec_decode_metadata,
             total_num_scheduled_tokens,
         )
+
+    def _rebuild_input_ids_with_corrected_positions(
+        self,
+        scheduler_output,
+        num_reqs,
+        total_num_scheduled_tokens,
+        req_indices,
+        position_offsets,
+        positions_np,
+        cu_num_tokens,
+        base_num_computed_tokens_np,
+    ) -> None:
+        # base_num_computed_tokens_np contains per-request starts:
+        # decode requests use async-corrected lengths, prefill requests use CPU lengths.
+        base = base_num_computed_tokens_np
+        np.add(
+            base[req_indices],
+            position_offsets[:total_num_scheduled_tokens],
+            out=positions_np,
+        )
+
+        token_indices = (
+            positions_np[:total_num_scheduled_tokens]
+            + req_indices * self.input_batch.token_ids_cpu.shape[1]
+        )
+        torch.index_select(
+            self.input_batch.token_ids_cpu_tensor.flatten(),
+            0,
+            torch.from_numpy(token_indices),
+            out=self.input_ids.cpu[:total_num_scheduled_tokens],
+        )
+
+        self.input_ids.copy_to_gpu(total_num_scheduled_tokens)
+        self._prepare_input_ids(
+            scheduler_output,
+            num_reqs,
+            total_num_scheduled_tokens,
+            cu_num_tokens,
+        )
+
+    def _preprocess(
+        self,
+        scheduler_output: "SchedulerOutput",
+        num_input_tokens: int,
+        intermediate_tensors: IntermediateTensors | None = None,
+    ) -> tuple[
+        torch.Tensor | None,
+        torch.Tensor | None,
+        torch.Tensor,
+        IntermediateTensors | None,
+        dict[str, Any],
+        ECConnectorOutput | None,
+    ]:
+        restore_state = None
+
+        # For PCP, local worker token count can differ from scheduler global count.
+        # Multimodal preprocessing must use local scheduled token count.
+        if (
+            self.pcp_size > 1
+            and self.supports_mm_inputs
+            and get_pp_group().is_first_rank
+            and not self.model_config.is_encoder_decoder
+        ):
+            positions_np = (
+                self.positions.np
+                if hasattr(self.positions, "np")
+                else self._positions_np_buf
+            )
+            local_num_sched, local_total = self.pcp_manager.get_local_schedule_layout()
+            restore_state = self.pcp_manager.maybe_localize_scheduler_output_for_mm_preprocess(
+                scheduler_output=scheduler_output,
+                req_ids=self.input_batch.req_ids,
+                requests=self.requests,
+                positions_np=positions_np,
+                local_num_scheduled_tokens=local_num_sched,
+                local_total_num_scheduled_tokens=local_total,
+                encoder_cache=self.encoder_cache,
+            )
+
+        try:
+            if self._get_vpp_size() > 1:
+                intermediate_tensors = IntermediateTensors({})
+
+            return super()._preprocess(
+                scheduler_output, num_input_tokens, intermediate_tensors
+            )
+        finally:
+            if (
+                self.pcp_size > 1
+                and self.supports_mm_inputs
+                and get_pp_group().is_first_rank
+                and not self.model_config.is_encoder_decoder
+            ):
+                self.pcp_manager.restore_scheduler_output_after_mm_preprocess(
+                    scheduler_output, restore_state
+                )
+
+    def _gather_mm_embeddings(
+        self,
+        scheduler_output: "SchedulerOutput",
+        shift_computed_tokens: int = 0,
+    ) -> tuple[list[torch.Tensor], torch.Tensor]:
+        if self.pcp_size <= 1:
+            return super()._gather_mm_embeddings(scheduler_output, shift_computed_tokens)
+
+        local_num_scheduled_tokens, _ = self.pcp_manager.get_local_schedule_layout()
+        if local_num_scheduled_tokens is None:
+            return super()._gather_mm_embeddings(scheduler_output, shift_computed_tokens)
+
+        total_num_scheduled_tokens = int(np.sum(local_num_scheduled_tokens))
+        positions_np = self.positions.np if hasattr(self.positions, "np") else self._positions_np_buf
+        mm_embeds = list[torch.Tensor]()
+        is_mm_embed = torch.zeros(
+            total_num_scheduled_tokens, dtype=torch.bool, device="cpu"
+        )
+
+        (
+            mm_embeds,
+            should_sync_mrope_positions,
+            should_sync_xdrope_positions,
+        ) = self.pcp_manager.gather_mm_embeddings_for_pcp(
+            req_ids=self.input_batch.req_ids,
+            requests=self.requests,
+            positions_np=positions_np,
+            local_num_scheduled_tokens=local_num_scheduled_tokens,
+            shift_computed_tokens=shift_computed_tokens,
+            encoder_cache=self.encoder_cache,
+            is_mm_embed=is_mm_embed,
+            model=self.model,
+            is_multimodal_pruning_enabled=self.is_multimodal_pruning_enabled,
+            uses_mrope=self.uses_mrope,
+            warning_once=logger.warning_once,
+        )
+
+        if should_sync_mrope_positions:
+            self._calc_mrope_positions(scheduler_output)
+            self.mrope_positions.copy_to_gpu(total_num_scheduled_tokens)
+
+        if should_sync_xdrope_positions:
+            self._calc_xdrope_positions(scheduler_output)
+            self.xdrope_positions.copy_to_gpu(total_num_scheduled_tokens)
+
+        return mm_embeds, is_mm_embed
 
     def _build_attn_state(self, num_reqs, num_scheduled_tokens, num_valid_tokens):
         if np.all(self.input_batch.num_computed_tokens_cpu[:num_reqs] == 0):
@@ -2137,6 +2386,10 @@ class NPUModelRunner(GPUModelRunner):
             # allocated blocks that may reuse the same physical KV cache IDs.
             get_kv_transfer_group().handle_preemptions(kv_connector_metadata)
 
+        if self._get_vpp_size() > 1:
+            return self._execute_model_vpp_yield(
+                scheduler_output, intermediate_tensors
+            )
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with record_function_or_nullcontext("prepare input"):
             with self.synchronize_input_prep():
@@ -2461,6 +2714,15 @@ class NPUModelRunner(GPUModelRunner):
             aux_hidden_states = None
             if self.use_aux_hidden_state_outputs:
                 hidden_states, aux_hidden_states = hidden_states
+                if self.pcp_size > 1 and not isinstance(hidden_states, IntermediateTensors):
+                    # NOTE we must `slice` hidden_states because pcp_allgather_restore_idx
+                    # ignores the padding from CUDA Graph.
+                    hidden_states = self.pcp_manager.get_restore_hidden_states(hidden_states)
+                    if aux_hidden_states is not None:
+                        aux_hidden_states = [
+                            self.pcp_manager.get_restore_hidden_states(aux_hidden_states_pcp)
+                            for aux_hidden_states_pcp in aux_hidden_states
+                        ]
             if not self.broadcast_pp_output:
                 # Common case.
                 if not get_pp_group().is_last_rank:
@@ -2527,17 +2789,641 @@ class NPUModelRunner(GPUModelRunner):
             deferred_state_corrections_fn()
         return None
 
+    def _execute_model_vpp_yield(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors: IntermediateTensors | None = None,
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors | VppContinuationOutput | None:
+        batch_id = getattr(scheduler_output, "batch_id", None)
+        if batch_id is None:
+            raise RuntimeError("VPP requires SchedulerOutput.batch_id")
+
+        ctx = self._vpp_contexts.get(batch_id)
+        if ctx is None:
+            prepared = self._prepare_vpp_context(
+                scheduler_output, intermediate_tensors
+            )
+            if not isinstance(prepared, tuple):
+                return prepared
+            ctx, stage_intermediate_tensors = prepared
+            self._vpp_contexts[batch_id] = ctx
+        else:
+            if ctx.pending_noop_cleanup:
+                # Fold-point ranks in vp_size=2 may finish both local stages in
+                # the prior call and only need to participate in one final noop.
+                self._vpp_contexts.pop(batch_id, None)
+                return self._make_vpp_empty_output()
+            stage_intermediate_tensors = None
+
+        return self._run_vpp_stage(ctx, stage_intermediate_tensors)
+
+    def _make_vpp_empty_output(
+        self,
+        kv_connector_output: "KVConnectorOutput | None" = None,
+    ) -> ModelRunnerOutput:
+        output = copy(EMPTY_MODEL_RUNNER_OUTPUT)
+        output.kv_connector_output = kv_connector_output
+        return output
+
+    def _merge_vpp_kv_connector_output(
+        self,
+        accumulated: "KVConnectorOutput | None",
+        current: "KVConnectorOutput | None",
+    ) -> "KVConnectorOutput | None":
+        if current is None:
+            return accumulated
+        if accumulated is None:
+            return KVConnectorOutput(
+                finished_sending=set(current.finished_sending or ()) or None,
+                finished_recving=set(current.finished_recving or ()) or None,
+                kv_connector_stats=current.kv_connector_stats,
+                kv_cache_events=current.kv_cache_events,
+                invalid_block_ids=set(current.invalid_block_ids),
+                expected_finished_count=current.expected_finished_count,
+            )
+
+        if current.finished_sending:
+            accumulated.finished_sending = set(accumulated.finished_sending or ())
+            accumulated.finished_sending.update(current.finished_sending)
+        if current.finished_recving:
+            accumulated.finished_recving = set(accumulated.finished_recving or ())
+            accumulated.finished_recving.update(current.finished_recving)
+
+        if accumulated.kv_connector_stats is None:
+            accumulated.kv_connector_stats = current.kv_connector_stats
+        elif current.kv_connector_stats is not None:
+            accumulated.kv_connector_stats = (
+                accumulated.kv_connector_stats.aggregate(
+                    current.kv_connector_stats
+                )
+            )
+
+        if accumulated.kv_cache_events is None:
+            accumulated.kv_cache_events = current.kv_cache_events
+        elif current.kv_cache_events is not None:
+            accumulated.kv_cache_events.add_events(
+                current.kv_cache_events.get_all_events()
+            )
+            accumulated.kv_cache_events.increment_workers(1)
+
+        accumulated.invalid_block_ids.update(current.invalid_block_ids)
+        if current.expected_finished_count > 0:
+            accumulated.expected_finished_count = current.expected_finished_count
+        return accumulated
+
+    def _prepare_vpp_context(
+        self,
+        scheduler_output: "SchedulerOutput",
+        intermediate_tensors: IntermediateTensors | None,
+    ) -> tuple[VppBatchContext, IntermediateTensors | None] | ModelRunnerOutput | AsyncModelRunnerOutput | None:
+        if self._get_vpp_size() > 1:
+            set_virtual_pipeline_parallel_rank(0)
+        num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
+        with record_function_or_nullcontext("prepare input"):
+            with self.synchronize_input_prep():
+                # Update persistent batch states.
+                self._update_states(scheduler_output)
+
+                if has_ec_transfer() and get_ec_transfer().is_producer:
+                    with self.maybe_get_ec_connector_output(
+                        scheduler_output,
+                        encoder_cache=self.encoder_cache,
+                    ) as ec_connector_output:
+                        self._execute_mm_encoder(scheduler_output)
+                        return make_empty_encoder_model_runner_output(
+                            scheduler_output)
+
+                if not num_scheduled_tokens:
+                    if (
+                        self.parallel_config.distributed_executor_backend
+                        == "external_launcher"
+                        and self.parallel_config.data_parallel_size > 1
+                    ):
+                        self._dummy_run(1)
+                    if not has_kv_transfer_group():
+                        return EMPTY_MODEL_RUNNER_OUTPUT
+                    return self.kv_connector_no_forward(
+                        scheduler_output, self.vllm_config
+                    )
+                if self.cache_config.kv_sharing_fast_prefill:
+                    assert not self.num_prompt_logprobs, (
+                        "--kv-sharing-fast-prefill produces incorrect "
+                        "logprobs for prompt tokens, tokens, please disable "
+                        "it when the requests need prompt logprobs"
+                    )
+
+                num_reqs = self.input_batch.num_reqs
+                req_ids = self.input_batch.req_ids
+                tokens = [
+                    scheduler_output.num_scheduled_tokens[i]
+                    for i in req_ids
+                ]
+                num_scheduled_tokens_np = np.array(tokens, dtype=np.int32)
+                max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
+
+                (
+                    logits_indices,
+                    spec_decode_metadata,
+                    total_num_scheduled_tokens,
+                ) = self._prepare_inputs(
+                    scheduler_output,
+                    num_scheduled_tokens_np,
+                )
+
+                num_tokens_unpadded = (
+                    scheduler_output.total_num_scheduled_tokens
+                )
+                if self.pcp_size > 1:
+                    num_tokens_unpadded = (
+                        self.pcp_manager.total_num_sampled_tokens_pcp)
+                cascade_attn_prefix_lens = None
+                if (self.cascade_attn_enabled
+                        and not self.parallel_config.enable_dbo):
+                    cascade_attn_prefix_lens = (
+                        self._compute_cascade_attn_prefix_lens(
+                            num_scheduled_tokens_np,
+                            self.input_batch.num_computed_tokens_cpu[:num_reqs],
+                            scheduler_output.num_common_prefix_blocks,
+                        )
+                    )
+
+                (
+                    cudagraph_mode,
+                    batch_desc,
+                    should_ubatch,
+                    num_tokens_across_dp,
+                    cudagraph_stats,
+                ) = self._determine_batch_execution_and_padding(
+                    num_tokens=num_tokens_unpadded,
+                    num_reqs=num_reqs,
+                    num_scheduled_tokens_np=num_scheduled_tokens_np,
+                    max_num_scheduled_tokens=max_num_scheduled_tokens,
+                    use_cascade_attn=cascade_attn_prefix_lens is not None,
+                    num_encoder_reqs=len(
+                        scheduler_output.scheduled_encoder_inputs),
+                )
+
+                logger.debug(
+                    "Running batch with cudagraph_mode: %s, batch_descriptor: %s, "
+                    "should_ubatch: %s, num_tokens_across_dp: %s",
+                    cudagraph_mode,
+                    batch_desc,
+                    should_ubatch,
+                    num_tokens_across_dp,
+                )
+
+                num_tokens_padded = batch_desc.num_tokens
+                num_reqs_padded = (
+                    batch_desc.num_reqs
+                    if batch_desc.num_reqs is not None
+                    else num_reqs
+                )
+                ubatch_slices, ubatch_slices_padded = maybe_create_ubatch_slices(
+                    should_ubatch,
+                    num_scheduled_tokens_np,
+                    num_tokens_padded,
+                    num_reqs_padded,
+                    self.parallel_config.num_ubatches,
+                )
+
+                pad_attn = cudagraph_mode == CUDAGraphMode.FULL
+
+                use_spec_decode = (
+                    len(scheduler_output.scheduled_spec_decode_tokens) > 0
+                )
+                ubatch_slices_attn = (
+                    ubatch_slices_padded if pad_attn else ubatch_slices
+                )
+
+                if (
+                    cudagraph_mode == CUDAGraphMode.FULL
+                    or (enable_sp() and not self.model_config.use_mla)
+                    and self.pcp_size == 1
+                ):
+                    old_num_reqs_padded = num_reqs_padded
+                    num_reqs_padded = self._pad_query_start_loc_for_fia(
+                        self.query_start_loc,
+                        num_tokens_padded, num_reqs_padded, num_reqs)
+                    if enable_sp() and num_tokens_padded == num_tokens_unpadded:
+                        if num_reqs_padded > old_num_reqs_padded:
+                            num_reqs_padded = old_num_reqs_padded
+                            self.query_start_loc.np[num_reqs_padded + 1] = 0
+
+                (attn_metadata, spec_decode_common_attn_metadata) = (
+                    self._build_attention_metadata(
+                        num_tokens=num_tokens_unpadded
+                        if not (self.use_cp and
+                                self.pcp_manager.pcp_use_hybrid_attn)
+                        else total_num_scheduled_tokens,
+                        num_tokens_padded=num_tokens_padded,
+                        num_reqs=num_reqs,
+                        num_reqs_padded=num_reqs_padded,
+                        max_query_len=max_num_scheduled_tokens,
+                        ubatch_slices=ubatch_slices_attn,
+                        logits_indices=logits_indices,
+                        use_spec_decode=use_spec_decode,
+                        num_scheduled_tokens=scheduler_output.num_scheduled_tokens,
+                        num_scheduled_tokens_np=num_scheduled_tokens_np,
+                        cascade_attn_prefix_lens=cascade_attn_prefix_lens,
+                    )
+                )
+
+            (
+                input_ids,
+                inputs_embeds,
+                positions,
+                intermediate_tensors,
+                model_kwargs,
+                ec_connector_output,
+            ) = self._preprocess(
+                scheduler_output,
+                num_tokens_padded
+                if not (self.use_cp and self.pcp_manager.pcp_use_hybrid_attn)
+                else total_num_scheduled_tokens,
+                intermediate_tensors,
+            )
+
+            update_cos_sin(positions)
+
+        if self.dynamic_eplb:
+            with record_function_or_nullcontext("EPLB weight D2D"):
+                self.eplb_updator.forward_before()
+
+        if self.calculate_kv_scales:  # type: ignore[has-type]
+            cudagraph_mode = CUDAGraphMode.NONE
+            self.calculate_kv_scales = False  # type: ignore[has-type]
+        if self.debugger is not None:
+            dbg_cfg = getattr(self.debugger, "config", None)
+            dump_level = str(
+                getattr(dbg_cfg, "level", "L1")).upper() if dbg_cfg is not None else "L1"
+            if dump_level in ("L0", "MIX"):
+                self.debugger.start(model=self.model)
+            else:
+                self.debugger.start()
+        if self.ascend_config.enable_async_exponential:
+            self.sampler.do_async_exponential(
+                b_s=logits_indices.shape[0],
+                head_dim=self.model_config.get_vocab_size(),
+                generators=self.input_batch.sampling_metadata.generators,
+            )
+
+        num_encoder_reqs = len(scheduler_output.scheduled_encoder_inputs)
+        has_encoder_input = (
+            self.model_config.is_encoder_decoder and num_encoder_reqs > 0
+        )
+
+        # VPP: clone attn_metadata tensor views so each batch's ctx is
+        # independent. Under VPP, batches stay in-flight across yields; a later
+        # batch's _build_attention_metadata overwrites the worker's persistent
+        # buffers (slot_mapping / block_table / query_start_loc / seq_lens)
+        # that these metadata tensors view into. Without cloning, a batch
+        # resumed after a yield reads another batch's metadata and the NPU
+        # attention op (npu_fused_infer_attention_score*) faults with an aicore
+        # exception. Only tensors are cloned; NPU Events / non-tensors are left
+        # as-is (shared by reference is fine for them).
+        _seen = set()
+        def _clone(md):
+            if id(md) in _seen:
+                return
+            _seen.add(id(md))
+            fds = getattr(md, '__dataclass_fields__', None)
+            if fds is not None:
+                for fn in fds:
+                    v = getattr(md, fn, None)
+                    if isinstance(v, torch.Tensor):
+                        setattr(md, fn, v.clone())
+                    else:
+                        _clone(v)
+            elif isinstance(md, dict):
+                for v in md.values():
+                    _clone(v)
+            elif isinstance(md, list):
+                for v in md:
+                    _clone(v)
+        _clone(attn_metadata)
+
+        ctx = VppBatchContext(
+            batch_id=scheduler_output.batch_id,
+            scheduler_output=scheduler_output,
+            num_scheduled_tokens=num_scheduled_tokens,
+            num_scheduled_tokens_np=num_scheduled_tokens_np,
+            max_num_scheduled_tokens=max_num_scheduled_tokens,
+            num_tokens_unpadded=num_tokens_unpadded,
+            num_tokens_padded=num_tokens_padded,
+            num_reqs=num_reqs,
+            num_reqs_padded=num_reqs_padded,
+            logits_indices=logits_indices,
+            spec_decode_metadata=spec_decode_metadata,
+            spec_decode_common_attn_metadata=spec_decode_common_attn_metadata,
+            attn_metadata=attn_metadata,
+            batch_desc=batch_desc,
+            cudagraph_mode=cudagraph_mode,
+            num_tokens_across_dp=num_tokens_across_dp,
+            input_ids=input_ids,
+            inputs_embeds=inputs_embeds,
+            positions=positions,
+            model_kwargs=model_kwargs,
+            ec_connector_output=ec_connector_output,
+            cudagraph_stats=cudagraph_stats,
+            has_encoder_input=has_encoder_input,
+            vp_size=self._get_vpp_size(),
+            input_batch_snapshot=self.input_batch.clone_for_vpp_sampling(),
+            num_prompt_logprobs_snapshot=self.num_prompt_logprobs.copy(),
+            query_start_loc_cpu_snapshot=self.query_start_loc.cpu[: num_reqs_padded + 1].clone(),
+            discard_request_indices_cpu_snapshot=self.discard_request_indices.cpu[
+                : self.num_discarded_requests
+            ].clone(),
+            num_discarded_requests_snapshot=self.num_discarded_requests,
+        )
+        return ctx, intermediate_tensors
+
+    def _run_vpp_stage(
+        self,
+        ctx: VppBatchContext,
+        intermediate_tensors: IntermediateTensors | None,
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors | VppContinuationOutput | None:
+        from vllm_ascend.distributed.vpp_utils import (
+            get_vpp_comm_info,
+            is_vpp_fold_point,
+            is_vpp_last_stage,
+        )
+
+        pp_rank = get_pp_group().rank_in_group
+        pp_size = get_pp_group().world_size
+        all_gather_group = get_tp_group() if not enable_sp() else None
+        aggregated_kv_connector_output = None
+        continued_across_fold_point = False
+
+        while ctx.next_vp_stage < ctx.vp_size:
+            vp_stage = ctx.next_vp_stage
+            set_virtual_pipeline_parallel_rank(vp_stage)
+
+            comm = get_vpp_comm_info(pp_rank, pp_size, vp_stage, ctx.vp_size)
+
+            if comm.need_recv:
+                # Check if the sender is a fold-point rank that sent via
+                # CPU Gloo (to avoid HCCL stream deadlock).
+                fold_recv = (
+                    vp_stage > 0
+                    and is_vpp_fold_point(
+                        comm.recv_src, pp_size, vp_stage - 1, ctx.vp_size
+                    )
+                )
+                if fold_recv:
+                    intermediate_tensors = IntermediateTensors(
+                        self._vpp_pp_group_next.recv_tensor_dict(
+                            src=comm.recv_src,
+                            all_gather_group=all_gather_group,
+                        )
+                    )
+                else:
+                    intermediate_tensors = IntermediateTensors(
+                        self._vpp_pp_group_prev.recv_tensor_dict(
+                            src=comm.recv_src,
+                            all_gather_group=all_gather_group,
+                        )
+                    )
+                intermediate_tensors = self.sync_and_slice_intermediate_tensors(
+                    ctx.num_tokens_padded, intermediate_tensors, True
+                )
+            elif vp_stage > 0:
+                intermediate_tensors = ctx.carry_intermediate_tensors
+
+            with (
+                record_function_or_nullcontext("forward"),
+                set_ascend_forward_context(
+                    ctx.attn_metadata,
+                    self.vllm_config,
+                    num_tokens=ctx.num_tokens_padded,
+                    num_tokens_across_dp=ctx.num_tokens_across_dp,
+                    aclgraph_runtime_mode=ctx.cudagraph_mode,
+                    batch_descriptor=ctx.batch_desc,
+                    num_actual_tokens=ctx.scheduler_output.total_num_scheduled_tokens,
+                    model_instance=self.model,
+                    max_tokens_across_pcp=0
+                    if self.pcp_size == 1
+                    else self.pcp_manager.max_num_tokens_across_pcp,
+                    skip_compiled=ctx.has_encoder_input,
+                ),
+                self.maybe_get_kv_connector_output(
+                    ctx.scheduler_output
+                ) as kv_connector_output,
+            ):
+                hidden_states = self._model_forward(
+                    ctx.num_tokens_padded,
+                    ctx.input_ids,
+                    ctx.positions,
+                    intermediate_tensors,
+                    ctx.inputs_embeds,
+                    **ctx.model_kwargs,
+                )
+
+            aggregated_kv_connector_output = self._merge_vpp_kv_connector_output(
+                aggregated_kv_connector_output,
+                kv_connector_output,
+            )
+            is_last = is_vpp_last_stage(
+                pp_rank, pp_size, vp_stage, ctx.vp_size
+            )
+            ctx.next_vp_stage += 1
+
+            if is_last:
+                self._vpp_contexts.pop(ctx.batch_id, None)
+                return self._postprocess_after_forward(
+                    ctx, hidden_states, aggregated_kv_connector_output
+                )
+
+            assert isinstance(hidden_states, IntermediateTensors)
+            if comm.need_send:
+                if continued_across_fold_point:
+                    # Fold-point send: route through CPU Gloo backend to
+                    # avoid HCCL stream deadlock.  HCCL serialises ops
+                    # within a process-group, so a fold-point isend whose
+                    # matching recv is in a later RPC call blocks all
+                    # subsequent HCCL recv ops for other batches.  Gloo
+                    # uses TCP buffering and does not have this issue.
+                    self._vpp_pp_group_next.send_tensor_dict(
+                        hidden_states.tensors,
+                        dst=comm.send_dst,
+                        all_gather_group=all_gather_group,
+                        is_async=True,
+                    )
+                else:
+                    self._vpp_pp_group_prev.send_tensor_dict(
+                        hidden_states.tensors,
+                        dst=comm.send_dst,
+                        all_gather_group=all_gather_group,
+                        is_async=True,
+                    )
+                ctx.carry_intermediate_tensors = None
+            else:
+                ctx.carry_intermediate_tensors = hidden_states
+
+            if (
+                ctx.vp_size % 2 == 0
+                and is_vpp_fold_point(pp_rank, pp_size, vp_stage, ctx.vp_size)
+            ):
+                # Keep fold-point stages back-to-back on the same rank so core
+                # only yields at real cross-rank boundaries.
+                continued_across_fold_point = True
+                intermediate_tensors = ctx.carry_intermediate_tensors
+                continue
+
+            if ctx.vp_size % 2 == 0 and ctx.next_vp_stage >= ctx.vp_size:
+                if continued_across_fold_point:
+                    ctx.pending_noop_cleanup = True
+                else:
+                    self._vpp_contexts.pop(ctx.batch_id, None)
+                return self._make_vpp_empty_output(
+                    aggregated_kv_connector_output
+                )
+
+            return VppContinuationOutput(
+                next_vp_stage=ctx.next_vp_stage,
+                kv_connector_output=aggregated_kv_connector_output,
+            )
+
+        self._vpp_contexts.pop(ctx.batch_id, None)
+        return self._make_vpp_empty_output(aggregated_kv_connector_output)
+
+    def _postprocess_after_forward(
+        self,
+        ctx: VppBatchContext,
+        hidden_states: torch.Tensor,
+        kv_connector_output: "KVConnectorOutput | None",
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
+        aux_hidden_states = None
+        if self.use_aux_hidden_state_outputs:
+            hidden_states, aux_hidden_states = hidden_states
+        if self.pcp_size > 1:
+            hidden_states = self.pcp_manager.get_restore_hidden_states(
+                hidden_states)
+            if aux_hidden_states is not None:
+                aux_hidden_states = [
+                    self.pcp_manager.get_restore_hidden_states(
+                        aux_hidden_states_pcp)
+                    for aux_hidden_states_pcp in aux_hidden_states
+                ]
+        if not self.broadcast_pp_output:
+            # `hidden_states` here is always a regular `torch.Tensor`:
+            # this function is only called from `_run_vpp_stage` when
+            # `is_vpp_last_stage(...)` is True, and the last stage's
+            # `_model_forward` returns a tensor. `IntermediateTensors` /
+            # `VppContinuationOutput` are handled earlier in `_run_vpp_stage`
+            # before we ever reach this point.
+            if self.is_pooling_model:
+                output = self._pool(
+                    hidden_states,
+                    ctx.num_scheduled_tokens,
+                    ctx.num_scheduled_tokens_np,
+                    kv_connector_output,
+                )
+                output.kv_connector_output = kv_connector_output
+                if self.debugger is not None:
+                    self.debugger.stop()
+                    self.debugger.step()
+                return output
+            sample_hidden_states = hidden_states[ctx.logits_indices]
+            logits = self.model.compute_logits(sample_hidden_states)
+        else:
+            assert not self.is_pooling_model
+            # `hidden_states` is always a regular `torch.Tensor` here
+            # (see comment in the non-broadcast branch above). The legacy
+            # IntermediateTensors send path was dead under vllm-ascend's
+            # in-runner P2P implementation.
+            sample_hidden_states = hidden_states[ctx.logits_indices]
+            logits = self.model.compute_logits(sample_hidden_states)
+
+            model_output_broadcast_data: dict[str, Any] = {}
+            if logits is not None:
+                model_output_broadcast_data["logits"] = logits.contiguous()
+            broadcasted = get_pp_group().broadcast_tensor_dict(
+                model_output_broadcast_data,
+                # VPP fold-back moves the last virtual stage off the
+                # canonical last PP rank.
+                src=(0 if self._get_vpp_size() > 1
+                     and self._get_vpp_size() % 2 == 0
+                     else len(get_pp_group().ranks) - 1),
+            )
+            assert broadcasted is not None
+            logits = broadcasted["logits"]
+        self._pending_vpp_sample_states.append(
+            VppPendingSampleState(
+                execute_model_state=ExecuteModelState(
+                    ctx.scheduler_output,
+                    logits,
+                    ctx.spec_decode_metadata,
+                    ctx.spec_decode_common_attn_metadata,
+                    hidden_states,
+                    sample_hidden_states,
+                    aux_hidden_states,
+                    ctx.attn_metadata,
+                    ctx.positions,
+                    ctx.ec_connector_output,
+                    ctx.cudagraph_stats,
+                    ctx.batch_desc,
+                ),
+                kv_connector_output=kv_connector_output,
+                input_batch=ctx.input_batch_snapshot,
+                num_prompt_logprobs=ctx.num_prompt_logprobs_snapshot,
+                query_start_loc_cpu=ctx.query_start_loc_cpu_snapshot,
+                discard_request_indices_cpu=ctx.discard_request_indices_cpu_snapshot,
+                num_discarded_requests=ctx.num_discarded_requests_snapshot,
+            )
+        )
+        return None
+
+    @contextmanager
+    def _use_vpp_pending_sample_state(self, pending_state: VppPendingSampleState):
+        prev_input_batch = self.input_batch
+        prev_num_prompt_logprobs = self.num_prompt_logprobs
+        prev_num_discarded_requests = self.num_discarded_requests
+        prev_query_start_loc = self.query_start_loc.cpu[: pending_state.query_start_loc_cpu.shape[0]].clone()
+        prev_discard_request_indices = self.discard_request_indices.cpu[: prev_num_discarded_requests].clone()
+
+        self.input_batch = pending_state.input_batch
+        self.num_prompt_logprobs = pending_state.num_prompt_logprobs.copy()
+        self.query_start_loc.cpu[: pending_state.query_start_loc_cpu.shape[0]].copy_(pending_state.query_start_loc_cpu)
+        self.query_start_loc.copy_to_gpu(pending_state.query_start_loc_cpu.shape[0])
+        self.num_discarded_requests = pending_state.num_discarded_requests
+        if pending_state.num_discarded_requests > 0:
+            self.discard_request_indices.cpu[: pending_state.num_discarded_requests].copy_(
+                pending_state.discard_request_indices_cpu
+            )
+            self.discard_request_indices.copy_to_gpu(pending_state.num_discarded_requests)
+        try:
+            yield
+        finally:
+            self.input_batch = prev_input_batch
+            self.num_prompt_logprobs = prev_num_prompt_logprobs
+            self.query_start_loc.cpu[: prev_query_start_loc.shape[0]].copy_(prev_query_start_loc)
+            self.query_start_loc.copy_to_gpu(prev_query_start_loc.shape[0])
+            self.num_discarded_requests = prev_num_discarded_requests
+            if prev_num_discarded_requests > 0:
+                self.discard_request_indices.cpu[: prev_num_discarded_requests].copy_(prev_discard_request_indices)
+                self.discard_request_indices.copy_to_gpu(prev_num_discarded_requests)
+            # Release the snapshot back to the pool for reuse.
+            pending_state.input_batch.release_to_pool()
+
     @torch.inference_mode()
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         profiling_chunk_config = self.ascend_config.scheduler_config.profiling_chunk_config
-        kv_connector_output = self.kv_connector_output
-        self.kv_connector_output = None
-        pp = get_pp_group()
-        use_pp_spec_decode = self.speculative_config is not None and pp.world_size > 1
+        pending_vpp_state = None
+        execute_model_state = self.execute_model_state
+        use_pp_spec_decode = False
+        if self._pending_vpp_sample_states:
+            pending_vpp_state = self._pending_vpp_sample_states.popleft()
+            kv_connector_output = pending_vpp_state.kv_connector_output
+            execute_model_state = pending_vpp_state.execute_model_state
+        else:
+            kv_connector_output = self.kv_connector_output
+            self.kv_connector_output = None
+            pp = get_pp_group()
+            use_pp_spec_decode = self.speculative_config is not None and pp.world_size > 1
 
-        if self.execute_model_state is None:
+        if execute_model_state is None:
             # Nothing to do (PP non-final rank case), output isn't used.
             if not kv_connector_output:
                 return None  # noqa
@@ -2550,61 +3436,84 @@ class NPUModelRunner(GPUModelRunner):
             output.kv_connector_output = kv_connector_output
             return output
 
-        # Unpack ephemeral state.
-        (
-            scheduler_output,
-            logits,
-            spec_decode_metadata,
-            spec_decode_common_attn_metadata,
-            hidden_states,
-            sample_hidden_states,
-            aux_hidden_states,
-            attn_metadata,
-            positions,
-            ec_connector_output,
-            cudagraph_stats,
-            batch_desc,
-        ) = self.execute_model_state
-        # Clear ephemeral state.
-        self.execute_model_state = None
-
-        # Apply structured output bitmasks if present.
-        if grammar_output is not None:
-            # here we are different from gpu_model_runner,
-            # the apply_grammar_bitmask uses torch.compile to optimize this,ascend does not support it now
-            logits_dtype = logits.dtype
-            logits = logits.to("cpu").float()
-            apply_grammar_bitmask(scheduler_output, grammar_output, self.input_batch, logits)
-            logits = logits.to(self.device).to(logits_dtype)
-
-        with record_function_or_nullcontext("sample_token"):
-            sampler_output = self._sample(logits, spec_decode_metadata)
-
-        if self.need_accepted_tokens:
-            if self.sampling_done_event is None:
-                self.sampling_done_event = torch.npu.Event()
-
-            assert self.sampling_done_event is not None
-            self.sampling_done_event.record()
-
-        self.valid_sampled_token_count_gpu = None
-
-        def propose_draft_token_ids(sampled_token_ids):
-            assert spec_decode_common_attn_metadata is not None
-            self._draft_token_ids = self.propose_draft_token_ids(
-                sampled_token_ids,
-                self.input_batch.sampling_metadata,
+        sample_context = (
+            self._use_vpp_pending_sample_state(pending_vpp_state)
+            if pending_vpp_state is not None
+            else nullcontext()
+        )
+        with sample_context:
+            # Unpack ephemeral state.
+            (
                 scheduler_output,
+                logits,
                 spec_decode_metadata,
                 spec_decode_common_attn_metadata,
-                positions,
-                scheduler_output.total_num_scheduled_tokens,
                 hidden_states,
-                aux_hidden_states,
                 sample_hidden_states,
+                aux_hidden_states,
+                attn_metadata,
+                positions,
+                ec_connector_output,
+                cudagraph_stats,
                 batch_desc,
+            ) = execute_model_state
+            # Clear ephemeral state.
+            if pending_vpp_state is None:
+                self.execute_model_state = None
+
+            # Apply structured output bitmasks if present.
+            if grammar_output is not None:
+                # here we are different from gpu_model_runner,
+                # the apply_grammar_bitmask uses torch.compile to optimize this,ascend does not support it now
+                logits_dtype = logits.dtype
+                logits = logits.to("cpu").float()
+                apply_grammar_bitmask(scheduler_output, grammar_output, self.input_batch, logits)
+                logits = logits.to(self.device).to(logits_dtype)
+
+            with record_function_or_nullcontext("sample_token"):
+                sampler_output = self._sample(logits, spec_decode_metadata)
+
+            if self.need_accepted_tokens:
+                if self.sampling_done_event is None:
+                    self.sampling_done_event = torch.npu.Event()
+
+                assert self.sampling_done_event is not None
+                self.sampling_done_event.record()
+
+            self.valid_sampled_token_count_gpu: torch.Tensor | None = None # type: ignore[no-redef]
+
+            def propose_draft_token_ids(sampled_token_ids):
+                assert spec_decode_common_attn_metadata is not None
+                self._draft_token_ids = self.propose_draft_token_ids(
+                    sampled_token_ids,
+                    self.input_batch.sampling_metadata,
+                    scheduler_output,
+                    spec_decode_metadata,
+                    spec_decode_common_attn_metadata,
+                    positions,
+                    scheduler_output.total_num_scheduled_tokens,
+                    hidden_states,
+                    aux_hidden_states,
+                    sample_hidden_states,
+                    batch_desc,
+                )
+                self._copy_draft_token_ids_to_cpu(scheduler_output)
+
+            (
+                logprobs_lists,
+                valid_sampled_token_ids,
+                prompt_logprobs_dict,
+                req_ids_output_copy,
+                req_id_to_index_output_copy,
+                invalid_req_indices,
+            ) = self._bookkeeping_sync(
+                scheduler_output,
+                sampler_output,
+                logits,
+                hidden_states,
+                scheduler_output.total_num_scheduled_tokens,
+                spec_decode_metadata,
             )
-            self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         output_spec_token_ids = None
         use_padded_batch = False
@@ -2627,22 +3536,6 @@ class NPUModelRunner(GPUModelRunner):
                 with record_function_or_nullcontext("draft_token"):
                     propose_draft_token_ids(sampler_output.sampled_token_ids)
 
-        (
-            logprobs_lists,
-            valid_sampled_token_ids,
-            prompt_logprobs_dict,
-            req_ids_output_copy,
-            req_id_to_index_output_copy,
-            invalid_req_indices,
-        ) = self._bookkeeping_sync(
-            scheduler_output,
-            sampler_output,
-            logits,
-            hidden_states,
-            scheduler_output.total_num_scheduled_tokens,
-            spec_decode_metadata,
-        )
-
         with record_function_or_nullcontext("draft_token"):
             if self.speculative_config:
                 if not early_pp_padded_drafter:
@@ -2657,11 +3550,11 @@ class NPUModelRunner(GPUModelRunner):
                     # tokens on the CPU, so they are run after bookkeeping.
                     propose_draft_token_ids(valid_sampled_token_ids)
 
-            # vLLM v0.18 defers KV connector finalization during target-model
-            # forward when speculative decoding is enabled. Finalize here after
-            # draft model runs so KV pool save/put can complete.
-            if self.speculative_config is not None:
-                self.finalize_kv_connector()
+                # vLLM v0.18 defers KV connector finalization during target-model
+                # forward when speculative decoding is enabled. Finalize here after
+                # draft model runs so KV pool save/put can complete.
+                if self.speculative_config is not None:
+                    self.finalize_kv_connector()
 
             draft_token_ids = self._draft_token_ids if use_pp_spec_decode else None
             if draft_token_ids is not None:
@@ -2703,16 +3596,16 @@ class NPUModelRunner(GPUModelRunner):
         if self.dynamic_eplb:
             self.eplb_updator.forward_end(self.eplb_heat_collection_status)
 
-        self._finalize_dump_data()
+            self._finalize_dump_data()
 
-        if self.need_accepted_tokens:
-            assert self.sampling_done_event is not None
-            with (
-                record_function_or_nullcontext("async_state_update"),
-                torch.npu.stream(global_stream()),
-            ):
-                global_stream().wait_event(self.sampling_done_event)
-                self._update_states_after_model_execute(sampler_output.sampled_token_ids, scheduler_output)
+            if self.need_accepted_tokens:
+                assert self.sampling_done_event is not None
+                with (
+                    record_function_or_nullcontext("async_state_update"),
+                    torch.npu.stream(global_stream()),
+                ):
+                    global_stream().wait_event(self.sampling_done_event)
+                    self._update_states_after_model_execute(sampler_output.sampled_token_ids, scheduler_output)
 
         if not self.use_async_scheduling:
             if self.routed_experts_initialized:
@@ -2975,6 +3868,15 @@ class NPUModelRunner(GPUModelRunner):
             "inputs_embeds": inputs_embeds,
             **model_kwargs,
         }
+
+        # Virtual Pipeline Parallism: fix the start_layer and end_layer for 
+        # inner_model to the current virtual stage's slice.
+        if self._get_vpp_size() > 1:
+            inner_model = self.model.model
+            vpp_ranges = getattr(inner_model.layers, "vpp_layer_ranges", None)
+            if vpp_ranges is not None:
+                inner_model.start_layer, inner_model.end_layer = vpp_ranges[get_virtual_pipeline_parallel_rank()]
+
         run_model = partial(self.model, **model_inputs)
 
         if self.enable_enpu:
@@ -3045,7 +3947,11 @@ class NPUModelRunner(GPUModelRunner):
         intermediate_tensors: IntermediateTensors | None,
         sync_self: bool,
     ) -> IntermediateTensors:
-        # vLLM renamed sync_and_slice to sync_and_gather.
+        if self._get_vpp_size() > 1:
+            return None
+        # vllm renamed sync_and_slice to sync_and_gather.
+        # The Ascend override logic is identical: skip the upstream all_gather
+        # (flashcomm1 does not scatter residual before PP send).
         return self.sync_and_slice_intermediate_tensors(
             num_tokens, intermediate_tensors, sync_self
         )
@@ -3574,6 +4480,11 @@ class NPUModelRunner(GPUModelRunner):
         profile_cpp: bool = False,
         skip_gdn_state_update: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        if self._get_vpp_size() > 1:
+            # Dummy runs execute a single synthetic forward and must start from
+            # the first virtual stage instead of reusing the previous request's
+            # VPP stage.
+            set_virtual_pipeline_parallel_rank(0)
         # only support eager mode and piecewise graph now
         assert cudagraph_runtime_mode is None or cudagraph_runtime_mode.valid_runtime_modes()
         # If cudagraph_mode.decode_mode() == FULL and
@@ -3797,6 +4708,22 @@ class NPUModelRunner(GPUModelRunner):
 
             if get_pp_group().is_first_rank:
                 intermediate_tensors = None
+                # In VPP mode, rank 0 also processes non-first virtual stages
+                # that require intermediate_tensors during actual inference.
+                # Pre-allocate the buffer here so it is ready when needed.
+                if self.intermediate_tensors is None:
+                    if get_virtual_pipeline_parallel_size() > 1:
+                        max_actual_tokens = self.max_num_tokens
+                        if enable_sp():
+                            tp_size = get_tensor_model_parallel_world_size()
+                            max_actual_tokens = (self.max_num_tokens + tp_size - 1) // tp_size
+                        self.intermediate_tensors = (
+                            self.model.make_empty_intermediate_tensors(
+                                batch_size=max_actual_tokens,
+                                dtype=self.dtype,
+                                device=self.device,
+                            )
+                        )
             else:
                 # When PP and sequence parallelism are enabled, during dummy_run the estimated space should divide
                 # num_tokens by
@@ -3894,6 +4821,8 @@ class NPUModelRunner(GPUModelRunner):
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
+        if isinstance(hidden_states, IntermediateTensors):
+            return None
         output = None
 
         # For profile, have maximum num_reqs and that collectively have

--- a/vllm_ascend/worker/npu_input_batch.py
+++ b/vllm_ascend/worker/npu_input_batch.py
@@ -17,6 +17,7 @@
 # Adapted from vllm-project/vllm/vllm/worker/gpu_input_batch.py
 #
 
+from collections import deque
 
 import numpy as np
 import torch
@@ -33,7 +34,6 @@ from vllm.v1.sample.thinking_budget_state import (
 from vllm.v1.worker.gpu_input_batch import InputBatch
 
 from vllm_ascend.worker.block_table import MultiGroupBlockTable
-
 
 class NPUInputBatch(InputBatch):
     # main2main compat: `use_replayssm` and `slot_mapping_modes` were
@@ -82,6 +82,10 @@ class NPUInputBatch(InputBatch):
         self.device = device
         self.pin_memory = pin_memory
         self.vocab_size = vocab_size
+        self._block_sizes = block_sizes.copy()
+        self._kernel_block_sizes = [sizes.copy() for sizes in kernel_block_sizes]
+        self._num_speculative_tokens = num_speculative_tokens
+        self._cp_kv_cache_interleave_size = cp_kv_cache_interleave_size
 
         self._req_ids: list[str | None] = []
         self.req_id_to_index: dict[str, int] = {}
@@ -256,3 +260,158 @@ class NPUInputBatch(InputBatch):
         # (e.g. penalties).
         self.sampled_token_ids_cpu: torch.Tensor | None = None
         self.async_copy_ready_event: torch.Event | None = None
+
+    # ------------------------------------------------------------------
+    # Object pool for VPP clone reuse -- avoids repeated torch.zeros alloc
+    # ------------------------------------------------------------------
+    _vpp_clone_pool: deque["NPUInputBatch"] = deque(maxlen=32)
+
+    @classmethod
+    def _acquire_for_clone(cls, **kwargs) -> "NPUInputBatch":
+        """Get an NPUInputBatch from the pool, or create a new one."""
+        if cls._vpp_clone_pool and len(cls._vpp_clone_pool) > 0:
+            inst = cls._vpp_clone_pool.popleft()
+            inst._reset_for_clone()
+            return inst
+        return cls(**kwargs)
+
+    def _reset_for_clone(self):
+        """Reset mutable state while keeping large tensor allocations alive."""
+        self._req_ids.clear()
+        self.req_id_to_index.clear()
+
+        self.num_tokens.fill(0)
+        self.num_tokens_no_spec.fill(0)
+        self.num_prompt_tokens.fill(0)
+        self.num_computed_tokens_cpu_tensor.zero_()
+        self.num_computed_tokens_cpu.fill(0)
+
+        self.temperature.zero_()
+        self.temperature_cpu_tensor.zero_()
+        self.greedy_reqs.clear()
+        self.random_reqs.clear()
+
+        self.top_p.zero_()
+        self.top_p_cpu_tensor.zero_()
+        self.top_p_reqs.clear()
+
+        self.top_k.zero_()
+        self.top_k_cpu_tensor.zero_()
+        self.top_k_reqs.clear()
+
+        self.spec_decode_unsupported_reqs.clear()
+
+        self.frequency_penalties.zero_()
+        self.frequency_penalties_cpu_tensor.zero_()
+        self.frequency_penalties_reqs.clear()
+
+        self.presence_penalties.zero_()
+        self.presence_penalties_cpu_tensor.zero_()
+        self.presence_penalties_reqs.clear()
+
+        self.repetition_penalties.zero_()
+        self.repetition_penalties_cpu_tensor.zero_()
+        self.repetition_penalties_reqs.clear()
+
+        self.num_accepted_tokens_cpu_tensor.fill_(1)
+
+        self.generators.clear()
+        self.num_logprobs.clear()
+
+        self.has_allowed_token_ids.clear()
+        self.allowed_token_ids_mask = None
+        self.allowed_token_ids_mask_cpu_tensor = None
+
+        self.bad_words_token_ids.clear()
+        self.logits_processing_needs_token_ids.fill(False)
+        self.req_output_token_ids = []
+        self.spec_token_ids = [[] for _ in range(self.max_num_reqs)]
+
+        self.prev_sampled_token_ids = None
+        self.prev_req_id_to_index = None
+        self.sampled_token_ids_cpu = None
+        self.async_copy_ready_event = None
+        self.sampling_metadata = self._make_sampling_metadata()
+
+    def release_to_pool(self):
+        """Return this instance to the pool for later reuse."""
+        NPUInputBatch._vpp_clone_pool.append(self)
+
+    def clone_for_vpp_sampling(self) -> "NPUInputBatch":
+        """Clone the sampling-visible batch state for a yielded VPP batch."""
+        clone = NPUInputBatch._acquire_for_clone(
+            max_num_reqs=self.max_num_reqs,
+            max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.max_num_batched_tokens,
+            device=self.device,
+            pin_memory=self.pin_memory,
+            vocab_size=self.vocab_size,
+            block_sizes=self._block_sizes,
+            kernel_block_sizes=self._kernel_block_sizes,
+            logitsprocs=self.logitsprocs,
+            logitsprocs_need_output_token_ids=self.logitsprocs_need_output_token_ids,
+            is_spec_decode=self.is_spec_decode,
+            is_pooling_model=self.is_pooling_model,
+            num_speculative_tokens=self._num_speculative_tokens,
+            cp_kv_cache_interleave_size=self._cp_kv_cache_interleave_size,
+        )
+
+        clone._req_ids = self._req_ids.copy()
+        clone.req_id_to_index = self.req_id_to_index.copy()
+        clone.token_ids_cpu_tensor = self.token_ids_cpu_tensor
+        clone.token_ids_cpu = self.token_ids_cpu
+        clone.is_token_ids_tensor = self.is_token_ids_tensor
+        clone.is_token_ids = self.is_token_ids
+        clone.num_tokens = self.num_tokens.copy()
+        clone.num_tokens_no_spec = self.num_tokens_no_spec.copy()
+        clone.num_prompt_tokens = self.num_prompt_tokens.copy()
+        clone.num_computed_tokens_cpu_tensor.copy_(self.num_computed_tokens_cpu_tensor)
+
+        clone.temperature_cpu_tensor.copy_(self.temperature_cpu_tensor)
+        clone.greedy_reqs = self.greedy_reqs.copy()
+        clone.random_reqs = self.random_reqs.copy()
+
+        clone.top_p_cpu_tensor.copy_(self.top_p_cpu_tensor)
+        clone.top_p_reqs = self.top_p_reqs.copy()
+
+        clone.top_k_cpu_tensor.copy_(self.top_k_cpu_tensor)
+        clone.top_k_reqs = self.top_k_reqs.copy()
+
+        clone.spec_decode_unsupported_reqs = self.spec_decode_unsupported_reqs.copy()
+
+        clone.frequency_penalties_cpu_tensor.copy_(self.frequency_penalties_cpu_tensor)
+        clone.frequency_penalties_reqs = self.frequency_penalties_reqs.copy()
+
+        clone.presence_penalties_cpu_tensor.copy_(self.presence_penalties_cpu_tensor)
+        clone.presence_penalties_reqs = self.presence_penalties_reqs.copy()
+
+        clone.repetition_penalties_cpu_tensor.copy_(self.repetition_penalties_cpu_tensor)
+        clone.repetition_penalties_reqs = self.repetition_penalties_reqs.copy()
+
+        clone.num_accepted_tokens_cpu_tensor.copy_(self.num_accepted_tokens_cpu_tensor)
+
+        clone.generators = self.generators.copy()
+        clone.num_logprobs = self.num_logprobs.copy()
+
+        clone.has_allowed_token_ids = self.has_allowed_token_ids.copy()
+        if self.allowed_token_ids_mask_cpu_tensor is not None:
+            clone.allowed_token_ids_mask_cpu_tensor = self.allowed_token_ids_mask_cpu_tensor
+        if self.allowed_token_ids_mask is not None:
+            clone.allowed_token_ids_mask = self.allowed_token_ids_mask
+
+        clone.bad_words_token_ids = {
+            req_idx: [token_ids.copy() for token_ids in bad_words]
+            for req_idx, bad_words in self.bad_words_token_ids.items()
+        }
+        clone.logits_processing_needs_token_ids = self.logits_processing_needs_token_ids.copy()
+        clone.req_output_token_ids = self.req_output_token_ids.copy()
+        clone.spec_token_ids = [token_ids.copy() for token_ids in self.spec_token_ids]
+
+        clone.prev_sampled_token_ids = self.prev_sampled_token_ids
+        clone.prev_req_id_to_index = (
+            None if self.prev_req_id_to_index is None else self.prev_req_id_to_index.copy()
+        )
+        clone.sampled_token_ids_cpu = self.sampled_token_ids_cpu
+        clone.async_copy_ready_event = self.async_copy_ready_event
+        clone.sampling_metadata = clone._make_sampling_metadata()
+        return clone

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -50,7 +50,7 @@ from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.torch_utils import STR_DTYPE_TO_TORCH_DTYPE
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
-from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
+from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput, VppContinuationOutput
 from vllm.v1.utils import report_usage_stats
 from vllm.v1.worker.gpu_worker import AsyncIntermediateTensors
 from vllm.v1.worker.startup_plan import (
@@ -649,7 +649,7 @@ class NPUWorker(WorkerBase):
     def execute_model(
         self,
         scheduler_output: "SchedulerOutput",
-    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
+) -> ModelRunnerOutput | AsyncModelRunnerOutput | VppContinuationOutput | None:
         self.log_memory_stats()
         # enable msMonitor to monitor the performance of vllm-ascend
         if get_ascend_config().msmonitor_use_daemon:
@@ -660,6 +660,24 @@ class NPUWorker(WorkerBase):
                 handle.wait()
             self._pp_send_work = []
 
+        vp_size = self._get_vpp_size()
+        if vp_size > 1:
+            return self._execute_model_vpp(scheduler_output, vp_size)
+        return self._execute_model_regular(scheduler_output)
+    
+    def _get_vpp_size(self) -> int:
+        if not hasattr(self, "_vpp_size_cached"):
+            try:
+                from vllm_ascend.ascend_config import get_ascend_config
+                self._vpp_size_cached = get_ascend_config().virtual_pipeline_parallel_size
+            except RuntimeError:
+                self._vpp_size_cached = 1
+        return self._vpp_size_cached
+
+    def _execute_model_regular(
+        self,
+        scheduler_output: "SchedulerOutput",
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
         intermediate_tensors = None
         forward_pass = scheduler_output.total_num_scheduled_tokens > 0
         if forward_pass and not get_pp_group().is_first_rank:
@@ -713,6 +731,35 @@ class NPUWorker(WorkerBase):
         output = copy.copy(EMPTY_MODEL_RUNNER_OUTPUT)
         output.kv_connector_output = kv_connector_output
         return output
+
+    def _execute_model_vpp(
+        self,
+        scheduler_output: "SchedulerOutput",
+        vp_size: int,
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | VppContinuationOutput | None:
+        """Execute model with VPP.
+
+        All per-stage VPP execution and P2P communication happen inside
+        model_runner.execute_model.
+        """
+        batch_id = getattr(scheduler_output, "batch_id", None)
+        if batch_id is None:
+            raise RuntimeError("VPP requires SchedulerOutput.batch_id")
+        output = self.model_runner.execute_model(
+            scheduler_output, None)
+        if isinstance(output, VppContinuationOutput):
+            return output
+        if isinstance(output, (ModelRunnerOutput, AsyncModelRunnerOutput, NoneType)):
+            return output
+
+        # Unreachable under vllm-ascend's VPP impl: P2P sends and
+        # kv-connector aggregation happen inside the model runner, so
+        # `execute_model` only ever returns one of the three types
+        # handled above. The legacy `IntermediateTensors` pass-through
+        # was dead; if a future refactor surfaces a new type here it
+        # should be added to the isinstance tuple above, not silently
+        # passed through.
+        return None
 
     @torch.inference_mode()
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput | AsyncModelRunnerOutput:


### PR DESCRIPTION
What this PR does / why we need it?
This PR adds Virtual Pipeline Parallelism (VPP) support to vllm-ascend on
top of vLLM v0.22.1, implemented as pure-Python monkey-patches with zero
modification to the upstream vLLM core. It is opt-in and fully backward
compatible (default vp_size=1 leaves all code paths unchanged).

VPP splits one logical forward into vp_size virtual stages distributed across
PP ranks using a V-shaped fold-back topology (even virtual stages sweep
forward rank 0 → N-1, odd stages sweep backward rank N-1 → 0). At the fold
point the same physical rank continues to the next virtual stage with no
inter-rank communication. This overlaps communication with computation across
virtual stages and shrinks the pipeline bubble versus plain PP — measured to
outperform Context-Parallel-Pipeline (CPP) on DeepSeek-V3.1
(see How was this patch tested?).

User-facing config (all opt-in):

--additional-config '{"virtual_pipeline_parallel_size": 2,
                      "vpp_layer_ranges": [[..], [..]]}'   // optional manual override
ENABLE_VPP=true                                         // env: VPP-aware output-rank routing
Key implementation pieces:

┌──────────────┬──────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Area │ File(s) │ What it does │
├──────────────┼──────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Topology │ distributed/vpp_utils.py (new) │ V-fold layer assignment (get_vpp_indices), per-stage comm plan (get_vpp_comm_info), fold-point / │
│ math │ │ last-stage predicates │
├────────────────┼────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Global state │ distributed/parallel_state.py │ vp_rank/vp_size globals + the _VPP_RUNTIME_ACTIVE construction-vs-runtime latch │
├────────────────┼────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Config │ ascend_config.py, envs.py │ virtual_pipeline_parallel_size + vpp_layer_ranges validation; ENABLE_VPP env switch │
├────────────────┼─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ EngineCore │ patch/platform/patch_vpp_core.py │ Replaces step_with_batch_queue with a fold-back dispatch loop that re-issues execute_model on │
│ │ │ VppContinuationOutput │
├────────────────┼─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Scheduler │ patch/platform/patch_scheduler.py, │ Stamps monotonic batch_id on SchedulerOutput; injects pickle-safe VppContinuationOutput │
│ │ patch_outputs.py │ │
├────────────────┼─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Executor │ patch/platform/patch_multiproc_executor.py │ Routes ModelRunnerOutput to the correct global rank per V-fold topology │
├────────────────┼─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Worker │ worker/worker.py, worker/model_runner_v1.py │ execute_model dispatch; the resumable _run_vpp_stage loop driving one virtual stage per RPC, │
│ │ │ keyed by batch_id via _vpp_contexts │
├────────────────┼─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Distributed │ patch/worker/patch_distributed.py │ Phase-latched is_first_rank/is_last_rank (so upstream init places embed/norm/lm_head on │
│ │ │ the correct physical rank) + fully-async send_tensor_dict │
├────────────────┼─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Layer build │ patch/worker/patch_vpp_make_layers.py │ One centralized patch on the shared make_layers → all models get V-fold layer materialization │
│ │ │ for free │
├────────────────┼─────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Per-stage │ ascend_forward_context.py, │ Scope the MoE layer list per virtual stage; snapshot sampling state (embed stage and sampling │
│ support │ worker/npu_input_batch.py │ stage land in different RPCs) │
└────────────────┴─────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────┘

Design highlights worth noting for review:

Resumable execution across RPCs. A single logical forward spans multiple
execute_model calls. The worker yields VppContinuationOutput between
virtual stages; EngineCore.step_with_batch_queue re-issues the same
SchedulerOutput (matched by batch_id) until the last stage produces real
logits. Per-batch progress lives in _vpp_contexts: dict[batch_id, ctx].
Construction-vs-runtime latch. Upstream model init places
norm/lm_head on is_last_rank, which at construction time (vp_rank=0)
would be wrong for every rank. _VPP_RUNTIME_ACTIVE makes
is_first_rank/is_last_rank return the static fold-back topology during
init and the dynamic current-virtual-stage answer during forward.
This sinks topology correctness into the rank predicates themselves, so no
per-model init patch is needed — every model that builds its decoder
via the shared make_layers is VPP-correct.
Fold-point deadlock avoidance. The matching recv of a fold-point
send lands in a later RPC iteration, which would deadlock on a single
serialized HCCL stream. Mitigated by (a) two PP comm groups for the
forward/backward sweeps, (b) fully async isend-based send_tensor_dict
with a FIFO send buffer holding source tensors until HCCL completion
Does this PR introduce any user-facing change?

Yes — additive and opt-in only; no change when vp_size == 1:

New additional_config keys: virtual_pipeline_parallel_size (int, default
1; >1 requires pipeline_parallel_size > 1) and optional
vpp_layer_ranges (manual per-rank, per-stage [start, end) override,
validated for full, non-overlapping coverage).
New environment variable ENABLE_VPP (default false), documented in
vllm_ascend/envs.py. Required to be true (or DYNAMIC_EPLB=true) whenever
virtual_pipeline_parallel_size > 1, so the multiproc executor routes outputs
to the correct PP rank.
No public API/type removal or rename; no change to default behavior.
How was this patch tested?

Functional bring-up on a 16-card Ascend NPU node, DeepSeek-V3.1-Terminus
-w8a8-QuaRot-lfs, TP=8 × PP=2 × vp_size=2:

export ENABLE_VPP=true
vllm serve <DeepSeek-V3.1-Terminus-w8a8-QuaRot-lfs>
--tensor-parallel-size 8 --pipeline-parallel-size 2
--enable-expert-parallel --max-num-seqs 16
--max-model-len 527360 --max-num-batched-tokens 16384
--gpu-memory-utilization 0.88 --enable-chunked-prefill
--enforce-eager
--additional-config '{"virtual_pipeline_parallel_size": 2}'

Verified from the server log:

Correct uneven layer split: VPP enabled (uneven): vp_size=2, pp_size=2, num_layers=61, 1 chunks get 16 layers, 3 chunks get 15 layers.
Construction-phase latch fires correctly on all 16 ranks (is_first_rank
True on PP0 ranks, False on PP1 ranks) → embed/norm/lm_head land on the
right physical ranks, no PPMissingLayer unpack errors.
Application startup complete; the engine serves requests end-to-end across
the multi-RPC virtual-stage loop.
Performance vs CPP: VPP (TP8 × PP2 × vp2) outperforms Context-Parallel-
Pipeline (TP8 × CPP2) on the same model under our offline throughput
workload. [TODO: insert your measured numbers — e.g. prefill/decode tokens/s
for VPP vs CPP, same concurrency/input length.]

Test gaps / plan. End-to-end VPP correctness is inherently multi-process
and NPU-dependent, which makes a pure UT hard. As a follow-up I plan to add UTs
for the pure topology functions that are hardware-independent:
get_vpp_indices (even/uneven coverage), get_vpp_comm_info
(fold-point recv/send direction), and is_vpp_last_stage/is_vpp_fold_point
for both even and odd vp_size. Happy to include them in this PR if reviewers
prefer.

New additional_config keys: virtual_pipeline_parallel_size (int, default
1; >1 requires pipeline_parallel_size > 1) and optional
vpp_layer_ranges (manual per-rank, per-stage [start, end) override,
validated for full, non-overlapping coverage).
New environment variable ENABLE_VPP (default false), documented in
vllm_ascend/envs.py. Required to be true (or DYNAMIC_EPLB=true) whenever
virtual_pipeline_parallel_size > 1, so the multiproc executor routes outputs
to the correct PP rank.
No public API/type removal or rename; no change to default behavior.
How was this patch tested?

Functional bring-up on a 16-card Ascend NPU node, DeepSeek-V3.1-Terminus
-w8a8-QuaRot-lfs, TP=8 × PP=2 × vp_size=2:

export ENABLE_VPP=true
vllm serve <DeepSeek-V3.1-Terminus-w8a8-QuaRot-lfs>
--tensor-parallel-size 8 --pipeline-parallel-size 2
--enable-expert-parallel --max-num-seqs 16
--max-model-len 527360 --max-num-batched-tokens 16384
--gpu-memory-utilization 0.88 --enable-chunked-prefill
--enforce-eager
--additional-config '{"virtual_pipeline_parallel_size": 2}'

Verified from the server log:

Correct uneven layer split: VPP enabled (uneven): vp_size=2, pp_size=2, num_layers=61, 1 chunks get 16 layers, 3 chunks get 15 layers.
Construction-phase latch fires correctly on all 16 ranks (is_first_rank
True on PP0 ranks, False on PP1 ranks) → embed/norm/lm_head land on the
right physical ranks, no PPMissingLayer unpack errors.
Application startup complete; the engine serves requests end-to-end across
the multi-RPC virtual-stage loop.
Performance vs CPP: VPP (TP8 × PP2 × vp2) outperforms Context-Parallel-
Pipeline (TP8 × CPP2) on the same model under our offline throughput
workload. [TODO: insert your measured numbers — e.g. prefill/decode tokens/s
for VPP vs CPP, same concurrency/input length.]

Test gaps / plan. End-to-end VPP correctness is inherently multi-process
and NPU-dependent, which makes a pure UT hard. As a follow-up I plan to add UTs
for the pure topology functions that are hardware-independent:
get_vpp_indices (even/uneven coverage), get_vpp_comm_info
(fold-point recv/send direction), and is_vpp_last_stage/is_vpp_fold_point
for both even and odd vp_size. Happy to include them in this PR if reviewers
prefer.

CoAuthor:
[wangxiaochao6@hisilicon.com](mailto:wangxiaochao6@hisilicon.com)
[gaojingchun1@huawei.com](mailto:gaojingchun1@huawei.com)
[luojintao5@huawei.com](mailto:luojintao5@huawei.com)
[lixushi@huawei.com](mailto:lixushi@huawei.com)
[liufeng248@huawei.com](mailto:liufeng248@huawei.com)
[shiyan67@huawei.com](mailto:shiyan67@huawei.com)

vLLM version: v0.24.0
vLLM main: https://github.com/vllm-project/vllm/commit/85c09e9885e346ea1612da30ebff5a75f67d2350

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
