### PR TITLE
[Platform][BugFix] Backport bounded SHM reader waits for vLLM 0.26.0

### DIFF
--- a/tests/ut/patch/platform/test_patch_shm_broadcast.py
+++ b/tests/ut/patch/platform/test_patch_shm_broadcast.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import threading
+from unittest import mock
+
+import pytest
+from vllm.distributed.device_communicators.shm_broadcast import MessageQueue
+
+import vllm_ascend.patch.platform.patch_shm_broadcast as patch
+
+
+@pytest.mark.parametrize("should_warn", [False, True])
+def test_reader_timeout_caps_indefinite_waits(monkeypatch, should_warn):
+    monkeypatch.setattr(patch, "SHM_READER_RECHECK_INTERVAL_MS", 7)
+    timeout = MessageQueue.ReadTimeoutWithWarnings(timeout=None, should_warn=should_warn)
+    assert timeout.timeout_ms() == 7
+
+
+def test_reader_rechecks_shm_after_lost_notify(monkeypatch):
+    monkeypatch.setattr(patch, "SHM_READER_RECHECK_INTERVAL_MS", 50)
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024 * 1024,
+        max_chunks=1,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+    poll_started = threading.Event()
+    allow_timeout = threading.Event()
+    result = {}
+
+    def acquire_read():
+        try:
+            with reader.acquire_read(indefinite=True) as buf:
+                result["value"] = buf[0]
+        except Exception as exc:
+            result["exception"] = exc
+
+    def poll_timeout(*, timeout: int | None = None):
+        poll_started.set()
+        assert allow_timeout.wait(timeout=5)
+        return []
+
+    try:
+        writer.wait_until_ready()
+        reader.wait_until_ready()
+        reader._spin_condition.last_read = 0
+        reader._spin_condition.busy_loop_s = 0
+
+        with mock.patch.object(
+            reader._spin_condition.poller,
+            "poll",
+            side_effect=poll_timeout,
+        ) as poll:
+            read_thread = threading.Thread(target=acquire_read, daemon=True)
+            read_thread.start()
+            assert poll_started.wait(timeout=5)
+            with writer.acquire_write(timeout=0.1) as buf:
+                buf[0] = 123
+            allow_timeout.set()
+            read_thread.join(timeout=5)
+
+            assert not read_thread.is_alive()
+            poll.assert_called_once_with(timeout=50)
+
+        if exception := result.get("exception"):
+            raise exception
+        assert result["value"] == 123
+    finally:
+        writer.shutdown()
+        reader.shutdown()
+        for socket in (
+            writer.local_socket,
+            writer._spin_condition.local_notify_socket,
+            reader.local_socket,
+            reader._spin_condition.local_notify_socket,
+            reader._spin_condition.read_cancel_socket,
+            reader._spin_condition.write_cancel_socket,
+        ):
+            socket.close(linger=0)
+
+
+def test_acquire_read_releases_slot_when_reader_raises():
+    writer = MessageQueue(
+        n_reader=1,
+        n_local_reader=1,
+        max_chunk_bytes=1024 * 1024,
+        max_chunks=1,
+    )
+    reader = MessageQueue.create_from_handle(writer.export_handle(), rank=0)
+    try:
+        writer.wait_until_ready()
+        reader.wait_until_ready()
+        writer.enqueue({"payload": "first"})
+
+        with (
+            pytest.raises(RuntimeError, match="reader failed"),
+            reader.acquire_read(timeout=0.1),
+        ):
+            raise RuntimeError("reader failed")
+
+        with writer.buffer.get_metadata(0) as metadata_buffer:
+            assert metadata_buffer[0] == 1
+            assert metadata_buffer[1] == 1
+
+        with writer.acquire_write(timeout=0.1) as buf:
+            buf[0] = 0
+    finally:
+        writer.shutdown()
+        reader.shutdown()
+        for socket in (
+            writer.local_socket,
+            writer._spin_condition.local_notify_socket,
+            reader.local_socket,
+            reader._spin_condition.local_notify_socket,
+            reader._spin_condition.read_cancel_socket,
+            reader._spin_condition.write_cancel_socket,
+        ):
+            socket.close(linger=0)

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -602,6 +602,23 @@
 #       profiling startup and per-step timing callbacks without monkey-patching
 #       `EngineCore` and the multiprocess entry point.
 #
+# ** 19a. File: platform/patch_shm_broadcast.py**
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#   1. `vllm.distributed.device_communicators.shm_broadcast.MessageQueue`
+#    Why:
+#       vLLM 0.26.0 local readers can wait indefinitely after a best-effort ZMQ
+#       notification is lost. A caller exception can also leave a read slot
+#       unreleased and block the writer.
+#    How:
+#       Replace `timeout_ms` and `acquire_read` with the implementations from the
+#       upstream fix. Idle waits are capped at five seconds, and read-slot cleanup
+#       runs in a `finally` block.
+#    Related PR:
+#       https://github.com/vllm-project/vllm/pull/45224
+#       https://github.com/vllm-project/vllm-ascend/pull/14181
+#    Future Plan:
+#       Remove this patch when the supported vLLM release includes PR #45224.
+#
 # ** 20. File: platform/patch_speculative_config.py**
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #   1. `vllm.config.speculative.SpeculativeConfig.hf_config_override`

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -28,7 +28,7 @@ import vllm_ascend.patch.platform.patch_media_connector  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
-from vllm_ascend.utils import is_310p
+from vllm_ascend.utils import is_310p, vllm_version_is
 
 if not is_310p():
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa
@@ -36,6 +36,9 @@ else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_recompute_chat  # noqa
+
+if vllm_version_is("0.26.0"):
+    import vllm_ascend.patch.platform.patch_shm_broadcast  # noqa
 import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -28,7 +28,7 @@ import vllm_ascend.patch.platform.patch_media_connector  # noqa
 import vllm_ascend.patch.platform.patch_mla_prefill_backend  # noqa
 import vllm_ascend.patch.platform.patch_pp_mtp  # noqa
 import vllm_ascend.patch.platform.patch_use_v2_model_runner  # noqa
-from vllm_ascend.utils import is_310p, vllm_version_is
+from vllm_ascend.utils import is_310p
 
 if not is_310p():
     import vllm_ascend.patch.platform.patch_mamba_config  # noqa
@@ -36,9 +36,7 @@ else:
     import vllm_ascend.patch.platform.patch_mamba_config_310  # noqa
 import vllm_ascend.patch.platform.patch_minimax_m2_config  # noqa
 import vllm_ascend.patch.platform.patch_recompute_chat  # noqa
-
-if vllm_version_is("0.26.0"):
-    import vllm_ascend.patch.platform.patch_shm_broadcast  # noqa
+import vllm_ascend.patch.platform.patch_shm_broadcast  # noqa
 import vllm_ascend.patch.platform.patch_structured_output  # noqa
 import vllm_ascend.patch.platform.patch_weight_transfer_engine  # noqa
 import vllm_ascend.patch.platform.patch_torch_accelerator  # noqa

--- a/vllm_ascend/patch/platform/patch_shm_broadcast.py
+++ b/vllm_ascend/patch/platform/patch_shm_broadcast.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import time
+from contextlib import contextmanager
+
+from vllm.distributed.device_communicators import shm_broadcast
+
+MessageQueue = shm_broadcast.MessageQueue
+
+# Cap how long an idle reader parks before re-reading the authoritative SHM
+# written flag. This bounds lost-notify recovery latency while keeping the
+# periodic wakeup negligible (one flag check per reader every five seconds).
+SHM_READER_RECHECK_INTERVAL_MS = 5000
+
+
+def timeout_ms(self) -> int:
+    """Return a timeout capped at the SHM recheck interval."""
+    wait_ms = SHM_READER_RECHECK_INTERVAL_MS
+    if self.warning_wait_time_ms is not None:
+        wait_ms = min(wait_ms, self.warning_wait_time_ms)
+    if self.timeout is None:
+        return wait_ms
+    time_left_ms = int((self.deadline - time.monotonic()) * 1000)
+    if time_left_ms <= 0:
+        raise TimeoutError
+    return min(wait_ms, time_left_ms)
+
+
+@contextmanager
+def acquire_read(
+    self,
+    timeout: float | None = None,
+    indefinite: bool = False,
+):
+    assert self._is_local_reader, "Only readers can acquire read"
+    read_timeout = self.ReadTimeoutWithWarnings(timeout=timeout, should_warn=not indefinite)
+    with self.buffer.get_metadata(self.current_idx) as metadata_buffer:
+        while True:
+
+            def check():
+                shm_broadcast.memory_fence()
+                read_flag = metadata_buffer[self.local_reader_rank + 1]
+                written_flag = metadata_buffer[0]
+                return not (not written_flag or read_flag)
+
+            if shm_broadcast.SPINLOOP_EXT_ENABLED and not check():
+                shm_broadcast.spinloop(
+                    metadata_buffer[0 : self.local_reader_rank + 1],
+                    check,
+                    timeout=shm_broadcast.SPINLOOP_TIMEOUT_SECONDS,
+                )
+
+            if not check():
+                # This block is either not written or already read by this reader.
+                self._spin_condition.wait(timeout_ms=read_timeout.timeout_ms())
+
+                if self.shutting_down:
+                    raise RuntimeError("cancelled")
+
+                if read_timeout.should_warn():
+                    shm_broadcast.logger.info(
+                        shm_broadcast.LONG_WAIT_TIME_LOG_MSG,
+                        shm_broadcast.VLLM_RINGBUFFER_WARNING_INTERVAL,
+                    )
+                continue
+
+            with self.buffer.get_data(self.current_idx) as buf:
+                try:
+                    yield buf
+                finally:
+                    metadata_buffer[self.local_reader_rank + 1] = 1
+                    # Ensure the writer sees read completion before the reader
+                    # advances to the next ring-buffer slot.
+                    shm_broadcast.memory_fence()
+                    next_idx = self.current_idx + 1
+                    self.current_idx = next_idx % self.buffer.max_chunks
+                    self._spin_condition.record_read()
+            break
+
+
+MessageQueue.ReadTimeoutWithWarnings.timeout_ms = timeout_ms
+MessageQueue.acquire_read = acquire_read

--- a/vllm_ascend/patch/platform/patch_shm_broadcast.py
+++ b/vllm_ascend/patch/platform/patch_shm_broadcast.py
@@ -8,14 +8,19 @@ from vllm.distributed.device_communicators import shm_broadcast
 
 MessageQueue = shm_broadcast.MessageQueue
 
-# Cap how long an idle reader parks before re-reading the authoritative SHM
-# written flag. This bounds lost-notify recovery latency while keeping the
-# periodic wakeup negligible (one flag check per reader every five seconds).
+# Cap on how long an idle reader parks before re-reading the authoritative SHM
+# written-flag. Bounds lost-notify recovery latency to ~5s while the periodic
+# wakeup stays negligible (one flag check per reader every 5s).
 SHM_READER_RECHECK_INTERVAL_MS = 5000
 
 
 def timeout_ms(self) -> int:
-    """Return a timeout capped at the SHM recheck interval."""
+    """Returns a timeout, capped at the recheck interval, that is:
+    - min(time to deadline, time to next warning) if we're logging warnings
+    - time to deadline, if we're not logging warnings
+    - recheck interval if the timeout is None and we're not logging warnings
+    - raise TimeoutError if we are past the deadline
+    """
     wait_ms = SHM_READER_RECHECK_INTERVAL_MS
     if self.warning_wait_time_ms is not None:
         wait_ms = min(wait_ms, self.warning_wait_time_ms)
@@ -52,26 +57,38 @@ def acquire_read(
                 )
 
             if not check():
-                # This block is either not written or already read by this reader.
+                # this block is either
+                # (1) not written
+                # (2) already read by this reader
+
+                # for readers, `self.current_idx` is the next block to read
+                # if this block is not ready,
+                # we need to wait until it is written
                 self._spin_condition.wait(timeout_ms=read_timeout.timeout_ms())
 
                 if self.shutting_down:
                     raise RuntimeError("cancelled")
 
+                # if we wait for a long time, log a message
                 if read_timeout.should_warn():
                     shm_broadcast.logger.info(
                         shm_broadcast.LONG_WAIT_TIME_LOG_MSG,
                         shm_broadcast.VLLM_RINGBUFFER_WARNING_INTERVAL,
                     )
+
                 continue
 
+            # found a block that is not read by this reader
+            # let caller read from the buffer
             with self.buffer.get_data(self.current_idx) as buf:
                 try:
                     yield buf
                 finally:
+                    # caller has read from the buffer; set the read flag.
                     metadata_buffer[self.local_reader_rank + 1] = 1
-                    # Ensure the writer sees read completion before the reader
-                    # advances to the next ring-buffer slot.
+                    # Memory fence ensures the read flag is visible to the writer.
+                    # Without this, writer may not see our read completion and
+                    # could wait indefinitely for all readers to finish.
                     shm_broadcast.memory_fence()
                     next_idx = self.current_idx + 1
                     self.current_idx = next_idx % self.buffer.max_chunks


### PR DESCRIPTION
### What this PR does / why we need it?

Backports vLLM PR #45224 to the v0.26.0 release branch, following vllm-ascend PR #14181.

vLLM v0.26.0 branched before the upstream fix and is vulnerable to two local shared-memory broadcast failure modes:

1. An idle reader can wait indefinitely when a best-effort ZMQ notification is lost.
2. A caller exception inside `acquire_read()` can leave the ring-buffer read slot unreleased and block the writer.

This patch caps idle waits at five seconds so readers periodically recheck the authoritative SHM written flag, and moves read-slot cleanup into a `finally` block. The patch implementation is kept identical to vllm-ascend PR #14181 and is loaded unconditionally on this release branch.

Related:
- vllm-project/vllm#45224
- vllm-project/vllm-ascend#14181

### Does this PR introduce _any_ user-facing change?

No API or configuration changes. The internal SHM broadcast path now recovers from lost notifications and releases read slots when consumer code raises.

### How was this patch tested?

Added `tests/ut/patch/platform/test_patch_shm_broadcast.py`, covering:

- capped indefinite reader waits;
- SHM rechecking after a lost ZMQ notification;
- read-slot cleanup when the reader raises.

Executed:

`TORCH_DEVICE_BACKEND_AUTOLOAD=0 VLLM_PLUGINS="" VLLM_VERSION=0.26.0 pytest -q tests/ut/patch/platform/test_patch_shm_broadcast.py`

Result: 4 passed.

Also executed `bash format.sh ci`; all pre-commit hooks passed.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
