### PR TITLE
[v0.26.0rc][BugFix][Frontend] Select DeepSeek V4 effort mapping by checkpoint config

### DIFF
--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -5,9 +5,12 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionReque
 from vllm.parser.deepseek_v4 import DeepSeekV4Parser
 from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
 
+from vllm_ascend.patch.platform import patch_deepseek_v4_thinking
+
 
 class FakeTokenizer:
     vocab_size = 1
+    name_or_path = "deepseek-v4"
 
     def get_added_vocab(self):
         return {}
@@ -78,7 +81,7 @@ def test_reasoning_effort_enables_thinking_unless_user_overrides():
         ),
     ],
 )
-def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(
+def test_deepseek_v4_tokenizer_maps_post_preview_reasoning_effort_values(
     monkeypatch,
     kwargs,
     expected_mode,
@@ -90,6 +93,61 @@ def test_deepseek_v4_tokenizer_maps_latest_reasoning_effort_values(
         captured_kwargs.append(kwargs)
         return "prompt"
 
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"dspark_block_size": 5},
+    )
+    monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+
+    tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+    assert captured_kwargs[-1]["thinking_mode"] == expected_mode
+    assert captured_kwargs[-1]["reasoning_effort"] == expected_effort
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_mode", "expected_effort"),
+    [
+        ({}, "thinking", "low"),
+        ({"enable_thinking": True}, "thinking", "low"),
+        ({"enable_thinking": False}, "chat", None),
+        ({"reasoning_effort": "none"}, "chat", None),
+        ({"reasoning_effort": "minimal"}, "thinking", "low"),
+        ({"reasoning_effort": "low"}, "thinking", "low"),
+        ({"reasoning_effort": "medium"}, "thinking", "low"),
+        ({"reasoning_effort": "high"}, "thinking", "low"),
+        ({"reasoning_effort": "xhigh"}, "thinking", "high"),
+        ({"reasoning_effort": "max"}, "thinking", "high"),
+        ({"reasoning_effort": "unexpected"}, "thinking", "low"),
+        (
+            {"enable_thinking": False, "reasoning_effort": "max"},
+            "chat",
+            "high",
+        ),
+    ],
+)
+def test_deepseek_v4_tokenizer_maps_preview_reasoning_effort_values(
+    monkeypatch,
+    kwargs,
+    expected_mode,
+    expected_effort,
+):
+    captured_kwargs = []
+
+    def fake_encode_messages(messages, **kwargs):
+        captured_kwargs.append(kwargs)
+        return "prompt"
+
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"model_type": "deepseek_v4"},
+    )
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
 
@@ -123,6 +181,11 @@ def test_deepseek_v4_tokenizer_attaches_tools_to_existing_system(
         captured_kwargs.append(kwargs)
         return "prompt"
 
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"dspark_block_size": 5},
+    )
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     messages = [
@@ -165,7 +228,12 @@ def test_deepseek_v4_tokenizer_adds_system_for_tools_when_missing(monkeypatch):
     assert messages == original_messages
 
 
-def test_deepseek_v4_defaults_to_thinking_with_high_effort():
+def test_deepseek_v4_defaults_to_thinking_with_high_effort(monkeypatch):
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"dspark_block_size": 5},
+    )
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     prompt = tokenizer.apply_chat_template(
         [{"role": "user", "content": "hi"}],
@@ -173,6 +241,45 @@ def test_deepseek_v4_defaults_to_thinking_with_high_effort():
     )
 
     assert prompt.startswith("<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum")
+    assert prompt.endswith("<｜Assistant｜><think>")
+
+
+@pytest.mark.parametrize(
+    ("reasoning_effort", "expected_prefix"),
+    [
+        (None, "<｜begin▁of▁sentence｜><｜User｜>hi"),
+        ("high", "<｜begin▁of▁sentence｜><｜User｜>hi"),
+        (
+            "xhigh",
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.",
+        ),
+        (
+            "max",
+            "<｜begin▁of▁sentence｜>Reasoning Effort: Absolute maximum with no shortcuts permitted.",
+        ),
+    ],
+)
+def test_deepseek_v4_preview_checkpoint_uses_preview_prompts(
+    monkeypatch,
+    reasoning_effort,
+    expected_prefix,
+):
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"model_type": "deepseek_v4"},
+    )
+    tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
+    kwargs = {} if reasoning_effort is None else {"reasoning_effort": reasoning_effort}
+
+    prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": "hi"}],
+        tokenize=False,
+        **kwargs,
+    )
+
+    assert prompt.startswith(expected_prefix)
+    assert "Reasoning Effort: Beyond maximum" not in prompt
     assert prompt.endswith("<｜Assistant｜><think>")
 
 
@@ -255,10 +362,16 @@ def test_deepseek_v4_explicit_disable_overrides_reasoning_effort(kwargs):
         ),
     ],
 )
-def test_deepseek_v4_renders_0731_reasoning_effort_prompts(
+def test_deepseek_v4_renders_post_preview_reasoning_effort_prompts(
+    monkeypatch,
     reasoning_effort,
     expected_prefix,
 ):
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"dspark_block_size": 5},
+    )
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     prompt = tokenizer.apply_chat_template(
         [{"role": "user", "content": "hi"}],

--- a/tests/ut/patch/platform/test_deepseek_v4_thinking.py
+++ b/tests/ut/patch/platform/test_deepseek_v4_thinking.py
@@ -213,6 +213,11 @@ def test_deepseek_v4_tokenizer_adds_system_for_tools_when_missing(monkeypatch):
         captured_messages.append(messages)
         return "prompt"
 
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"dspark_block_size": 5},
+    )
     monkeypatch.setattr(deepseek_v4, "encode_messages", fake_encode_messages)
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     messages = [{"role": "user", "content": "hi"}]
@@ -336,7 +341,12 @@ def test_parser_splits_implicit_start_reasoning(request_kwargs):
         {"enable_thinking": False, "reasoning_effort": "max"},
     ],
 )
-def test_deepseek_v4_explicit_disable_overrides_reasoning_effort(kwargs):
+def test_deepseek_v4_explicit_disable_overrides_reasoning_effort(monkeypatch, kwargs):
+    monkeypatch.setattr(
+        patch_deepseek_v4_thinking,
+        "get_hf_file_to_dict",
+        lambda *args, **kwargs: {"dspark_block_size": 5},
+    )
     tokenizer = deepseek_v4.get_deepseek_v4_tokenizer(FakeTokenizer())
     prompt = tokenizer.apply_chat_template(
         [{"role": "user", "content": "hi"}],

--- a/vllm_ascend/patch/__init__.py
+++ b/vllm_ascend/patch/__init__.py
@@ -109,15 +109,16 @@
 #    Why:
 #       DeepSeek-V4-Flash-0731 defines three reasoning effort levels: low has
 #       no prompt prefix, high uses the original "Absolute maximum" prefix,
-#       and max uses the new "Beyond maximum" prefix. The supported vLLM
-#       Python tokenizer predates this 0731 prompt mapping.
+#       and max uses the new "Beyond maximum" prefix. The earlier Flash
+#       checkpoint uses a different mapping where only max/xhigh selects the
+#       "Absolute maximum" prefix. The supported vLLM Python tokenizer
+#       predates the 0731 prompt mapping.
 #    How:
-#       Monkey-patch tokenizer normalization so omitted options select
-#       thinking with high effort and compatibility aliases map to canonical
-#       low, high, or max. Wrap render_message to prepend the official 0731
-#       prompt before the first message in thinking mode. Align the parser's
-#       default state with the tokenizer so implicit thinking is extracted as
-#       reasoning instead of content.
+#       Select the 0731 mapping when the model config contains a dspark_*
+#       field; otherwise preserve the earlier Flash mapping. Wrap
+#       render_message to prepend the selected prompt before the first message
+#       in thinking mode. Align the parser's default state with the tokenizer
+#       so implicit thinking is extracted as reasoning instead of content.
 #    Related PR (if no, explain why):
 #       https://github.com/vllm-project/vllm/pull/50580
 #       https://github.com/vllm-project/vllm/pull/51296

--- a/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
+++ b/vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
@@ -20,6 +20,7 @@ from typing import Any
 from vllm.entrypoints.chat_utils import ChatCompletionMessageParam
 from vllm.parser.deepseek_v4 import DeepSeekV4Parser
 from vllm.tokenizers import deepseek_v4, deepseek_v4_encoding
+from vllm.transformers_utils.repo_utils import get_hf_file_to_dict
 
 REASONING_EFFORT_PROMPTS = {
     "low": "",
@@ -52,6 +53,15 @@ _original_get_deepseek_v4_tokenizer = deepseek_v4.get_deepseek_v4_tokenizer
 _original_deepseek_v4_parser_init = DeepSeekV4Parser.__init__
 
 
+def _uses_preview_reasoning_effort_mapping(tokenizer: deepseek_v4.HfTokenizer) -> bool:
+    model_name_or_path = getattr(tokenizer, "name_or_path", None)
+    if not model_name_or_path:
+        return True
+
+    config = get_hf_file_to_dict("config.json", model_name_or_path)
+    return not (config and any(key.startswith("dspark_") for key in config))
+
+
 def _patched_render_message(
     index: int,
     messages: list[dict[str, Any]],
@@ -78,6 +88,7 @@ def _patched_render_message(
 
 
 def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
+    uses_preview_mapping = _uses_preview_reasoning_effort_mapping(tokenizer)
     dsv4_tokenizer = _original_get_deepseek_v4_tokenizer(tokenizer)
     tokenizer_cls = type(dsv4_tokenizer)
 
@@ -110,16 +121,24 @@ def _patched_get_deepseek_v4_tokenizer(tokenizer: deepseek_v4.HfTokenizer):
 
         reasoning_effort = kwargs.get("reasoning_effort")
         if not isinstance(reasoning_effort, str):
-            reasoning_effort = "high" if thinking_enabled else None
+            if thinking_enabled:
+                reasoning_effort = "low" if uses_preview_mapping else "high"
+            else:
+                reasoning_effort = None
         elif reasoning_effort == "none":
             thinking_mode = "chat"
             reasoning_effort = None
-        elif reasoning_effort == "max":
-            reasoning_effort = "max"
-        elif reasoning_effort in ("low", "minimal", "medium"):
-            reasoning_effort = "low"
-        else:
+        elif not uses_preview_mapping:
+            if reasoning_effort == "max":
+                reasoning_effort = "max"
+            elif reasoning_effort in ("low", "minimal", "medium"):
+                reasoning_effort = "low"
+            else:
+                reasoning_effort = "high"
+        elif reasoning_effort in ("max", "xhigh"):
             reasoning_effort = "high"
+        else:
+            reasoning_effort = "low"
 
         prompt_str = deepseek_v4.encode_messages(
             messages,


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes #14951.

#13993 added the post-Preview DeepSeek V4 reasoning-effort mapping to the v0.26 release stack, but applied it to every DeepSeek V4 checkpoint. The official V4 Preview encoders use different semantics: default/high has no effort prefix, while max/xhigh uses the original `Absolute maximum` prefix. Applying the post-Preview mapping makes a Preview model interpret the API default `high` as its maximum effort, causing many GPQA responses to exhaust `max_tokens=131072` and be truncated.

This PR reads the checkpoint `config.json` when wrapping the tokenizer. Checkpoints containing a `dspark_*` field, including DeepSeek-V4-Flash-0731 and DeepSeek-V4-Pro-0813, use the post-Preview `low/high/max` mapping. Checkpoints without those fields use the V4 Preview compatibility mapping. Explicit thinking disablement continues to override the requested effort.

The system/tools placement problem in https://github.com/vllm-project/vllm/issues/51829 is separate and remains covered by #14624.

### Does this PR introduce _any_ user-facing change?

Yes. On the v0.26 release stack, DeepSeek V4 Preview checkpoints no longer receive post-Preview high/max prompts. DeepSeek-V4-Flash-0731 and DeepSeek-V4-Pro-0813 behavior remains unchanged.

### How was this patch tested?

```bash
PYTHONPATH=/path/to/vllm-v0.26.0 python -m pytest -q \
  tests/ut/patch/platform/test_deepseek_v4_thinking.py \
  tests/ut/patch/platform/test_deepseek_v4_tool_streaming.py
# 61 passed

ruff check \
  tests/ut/patch/platform/test_deepseek_v4_thinking.py \
  vllm_ascend/patch/__init__.py \
  vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
# All checks passed!

ruff format --check \
  tests/ut/patch/platform/test_deepseek_v4_thinking.py \
  vllm_ascend/patch/__init__.py \
  vllm_ascend/patch/platform/patch_deepseek_v4_thinking.py
# 3 files already formatted
```

A tokenizer-only probe using local checkpoint directories produced:

```text
DeepSeek-V4-Flash (Preview)
  default: no effort prefix
  high: no effort prefix
  max: Absolute maximum
DeepSeek-V4-Flash-0731
  default: Absolute maximum
  high: Absolute maximum
  max: Beyond maximum
DeepSeek-V4-Pro-0813
  default: Absolute maximum
  high: Absolute maximum
  max: Beyond maximum
```

The Flash-0731 and Pro-0813 `config.json` files both contain `dspark_*` fields, while the Flash and Pro Preview configs do not. `python -m py_compile` on all changed Python files and `git diff --check` also passed. No NPU service was required because the regression is fully determined during prompt rendering.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
