### PR TITLE
[BugFix][KV Pool] Fix mixed layerwise indexer buffer allocation

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -48,7 +48,7 @@ if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     sys.modules["torch"] = _torch
     sys.modules["torch.distributed"] = _torch.distributed  # type: ignore[attr-defined]
 else:
-    import torch as _torch
+    _torch = importlib.import_module("torch")
 
 if not hasattr(_torch, "npu"):
     _npu = MagicMock()

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -45,13 +45,17 @@ if "torch" not in sys.modules and importlib.util.find_spec("torch") is None:
     _torch.sum = MagicMock(return_value=0)  # type: ignore[attr-defined]
     _torch.device = MagicMock()  # type: ignore[attr-defined]
     _torch.distributed = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["torch"] = _torch
+    sys.modules["torch.distributed"] = _torch.distributed  # type: ignore[attr-defined]
+else:
+    import torch as _torch
+
+if not hasattr(_torch, "npu"):
     _npu = MagicMock()
     _npu.Event = MagicMock
     _npu.current_device = MagicMock(return_value=0)
     _npu.set_device = MagicMock()
     _torch.npu = _npu  # type: ignore[attr-defined]
-    sys.modules["torch"] = _torch
-    sys.modules["torch.distributed"] = _torch.distributed  # type: ignore[attr-defined]
 
 if "torch_npu" not in sys.modules:
     sys.modules["torch_npu"] = MagicMock()
@@ -84,6 +88,7 @@ _vllm_mock_modules = [
     "vllm.utils.hashing",
     "vllm.utils.math_utils",
     "vllm.utils.network_utils",
+    "vllm.utils.torch_utils",
     "vllm.v1",
     "vllm.v1.attention",
     "vllm.v1.attention.backend",
@@ -107,6 +112,7 @@ if _MOCK_VLLM_DEPS:
 
 if _MOCK_VLLM_DEPS:
     sys.modules["vllm.utils.math_utils"].cdiv = lambda a, b: -(-a // b)  # type: ignore[attr-defined]
+    sys.modules["vllm.utils.torch_utils"].get_dtype_size = lambda dtype: dtype.itemsize  # type: ignore[attr-defined]
     sys.modules["vllm.logger"].logger = logging.getLogger("vllm")  # type: ignore[attr-defined]
 
 _base_mod: Any = (
@@ -184,6 +190,10 @@ class _FakeFullAttentionSpec(_FakeAttentionSpec):
     pass
 
 
+class _FakeMLAAttentionSpec(_FakeAttentionSpec):
+    pass
+
+
 class _FakeSlidingWindowSpec(_FakeKVCacheSpec):
     def __init__(self, block_size=16, sliding_window=32, **kwargs):
         super().__init__(block_size=block_size, sliding_window=sliding_window, **kwargs)
@@ -193,6 +203,10 @@ class _FakeMambaSpec(_FakeKVCacheSpec):
     def __init__(self, block_size=16, **kwargs):
         super().__init__(block_size=block_size, **kwargs)
         self.num_speculative_blocks = getattr(self, "num_speculative_blocks", 0)
+
+
+class _FakeSlidingWindowMLASpec(_FakeMLAAttentionSpec):
+    pass
 
 
 class _FakeUniformTypeKVCacheSpecs(_FakeKVCacheSpec):
@@ -328,7 +342,9 @@ _kv_interface_mod: Any = sys.modules["vllm.v1.kv_cache_interface"] if _MOCK_VLLM
 _kv_interface_mod.KVCacheSpec = _FakeKVCacheSpec  # type: ignore[attr-defined]
 _kv_interface_mod.AttentionSpec = _FakeAttentionSpec  # type: ignore[attr-defined]
 _kv_interface_mod.FullAttentionSpec = _FakeFullAttentionSpec  # type: ignore[attr-defined]
+_kv_interface_mod.MLAAttentionSpec = _FakeMLAAttentionSpec  # type: ignore[attr-defined]
 _kv_interface_mod.SlidingWindowSpec = _FakeSlidingWindowSpec  # type: ignore[attr-defined]
+_kv_interface_mod.SlidingWindowMLASpec = _FakeSlidingWindowMLASpec  # type: ignore[attr-defined]
 _kv_interface_mod.MambaSpec = _FakeMambaSpec  # type: ignore[attr-defined]
 _kv_interface_mod.UniformTypeKVCacheSpecs = _FakeUniformTypeKVCacheSpecs  # type: ignore[attr-defined]
 _kv_interface_mod.KVCacheGroupSpec = _FakeKVCacheGroupSpec  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
+++ b/tests/ut/distributed/ascend_store/test_layerwise_cache_layout.py
@@ -76,8 +76,40 @@ def test_no_reuse_skips_topology_validation():
         ],
     )
 
-    apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(2, 2))
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(2, 2)) is False
 
+    assert kv_cache_config.kv_cache_tensors == original_tensors
+
+
+def test_no_reuse_skips_multi_component_layer_validation():
+    spec = MambaSpec(
+        block_size=2,
+        shapes=((1,),),
+        dtypes=(torch.int8,),
+    )
+    suffixes = (
+        "compressor.state_cache",
+        "indexer.k_cache",
+        "indexer.compressor.state_cache",
+        "swa_cache",
+        "attn",
+    )
+    layer_names = [f"model.layers.{layer}.self_attn.{suffix}" for layer in range(2) for suffix in suffixes]
+    original_tensors = [KVCacheTensor(size=16, shared_by=[layer_name]) for layer_name in layer_names]
+    kv_cache_config = SimpleNamespace(
+        kv_cache_tensors=original_tensors.copy(),
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=layer_names,
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(layer_names, spec),
+                ),
+            )
+        ],
+    )
+
+    assert apply_layerwise_kv_cache_plan(kv_cache_config, _make_vllm_config(2, 2)) is False
     assert kv_cache_config.kv_cache_tensors == original_tensors
 
 
@@ -461,6 +493,76 @@ def _make_sfa_indexer_spec() -> AscendSFAIndexerCacheSpec:
         scale_dtype=torch.float16,
         cache_sparse_li_c8=True,
     )
+
+
+def _make_unquantized_sfa_indexer_spec() -> AscendSFAIndexerCacheSpec:
+    return AscendSFAIndexerCacheSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.bfloat16,
+        cache_sparse_li_c8=False,
+    )
+
+
+def test_mixed_li_c8_indexers_share_one_buffer_per_main_slot():
+    main_spec = _make_sfa_main_spec()
+    c8_spec = _make_sfa_indexer_spec()
+    bf16_spec = _make_unquantized_sfa_indexer_spec()
+    main_by_layer = {layer: f"model.layers.{layer}.self_attn.attn" for layer in range(6)}
+    indexer_by_layer = {layer: f"model.layers.{layer}.self_attn.indexer.k_cache" for layer in range(6)}
+    indexer_specs = {indexer_by_layer[layer]: c8_spec if layer % 2 == 0 else bf16_spec for layer in range(6)}
+    num_blocks = 2
+    kv_cache_config = SimpleNamespace(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[
+            *(
+                KVCacheTensor(size=main_spec.page_size_bytes * num_blocks, shared_by=[name])
+                for name in main_by_layer.values()
+            ),
+            *(
+                KVCacheTensor(size=spec.page_size_bytes * num_blocks, shared_by=[name])
+                for name, spec in indexer_specs.items()
+            ),
+        ],
+        kv_cache_groups=[
+            SimpleNamespace(
+                layer_names=list(main_by_layer.values()),
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=dict.fromkeys(main_by_layer.values(), main_spec),
+                ),
+            ),
+            SimpleNamespace(
+                layer_names=list(indexer_by_layer.values()),
+                kv_cache_spec=UniformTypeKVCacheSpecs(
+                    block_size=2,
+                    kv_cache_specs=indexer_specs,
+                ),
+            ),
+        ],
+    )
+    vllm_config = _make_vllm_config(6, 3)
+    vllm_config.kv_transfer_config.kv_connector_extra_config["layerwise_independent_layers"] = []
+
+    apply_layerwise_kv_cache_plan(kv_cache_config, vllm_config)
+
+    main_tensors = [
+        tensor
+        for tensor in kv_cache_config.kv_cache_tensors
+        if not any(".indexer." in name for name in tensor.shared_by)
+    ]
+    indexer_tensors = [
+        tensor for tensor in kv_cache_config.kv_cache_tensors if any(".indexer." in name for name in tensor.shared_by)
+    ]
+    assert len(main_tensors) == 3
+    assert len(indexer_tensors) == 3
+    assert [tensor.shared_by for tensor in indexer_tensors] == [
+        [indexer_by_layer[0], indexer_by_layer[3]],
+        [indexer_by_layer[1], indexer_by_layer[4]],
+        [indexer_by_layer[2], indexer_by_layer[5]],
+    ]
+    assert all(tensor.size == bf16_spec.page_size_bytes * num_blocks for tensor in indexer_tensors)
 
 
 def test_component_sharing_merges_main_across_a_and_b_layers():

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -222,6 +222,45 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         self.assertEqual(len(worker.layer_load_tasks), 5)
         self.assertEqual(len(worker.layer_save_tasks), 5)
 
+    def test_concrete_no_reuse_layout_is_not_reenabled_from_model_layer_count(self):
+        import torch
+        from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+        cls = self._make_worker_class()
+        worker = object.__new__(cls)
+        worker.num_layers = 4
+        worker.num_kv_cache_groups = 1
+        worker.hf_config = SimpleNamespace(num_hidden_layers=4)
+        worker.use_gva_layerwise = True
+        worker._extra_config = {
+            "layerwise_num_shared_buffers": 2,
+            "layerwise_independent_layers": [],
+        }
+        spec = FullAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.float16,
+        )
+        worker.kv_cache_config = SimpleNamespace(
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=[
+                        "model.layers.0.self_attn.attn",
+                        "model.layers.1.self_attn.attn",
+                    ],
+                    kv_cache_spec=spec,
+                )
+            ]
+        )
+
+        worker._init_layerwise_config()
+
+        self.assertIsNone(worker._layerwise_reuse_layout)
+        self.assertFalse(worker.layerwise_offload)
+        self.assertEqual(worker.prefetch_layer_map, {})
+        self.assertEqual(worker.independent_layers, [])
+
 
 class TestKVPoolWorkerInit(unittest.TestCase):
     """Test KVPoolWorker initialization with mocked dependencies."""

--- a/tests/ut/worker/a2/test_model_runner_v1.py
+++ b/tests/ut/worker/a2/test_model_runner_v1.py
@@ -415,6 +415,108 @@ class TestNPUModelRunnerKVCache(unittest.TestCase):
         self.assertEqual(indexer_spec.page_size_bytes, 2 * 16 * (128 + 2))
         self.assertFalse(hasattr(main_spec, "sfa_dcp_replicated_indexer_size"))
 
+    def test_mixed_li_c8_indexers_share_raw_buffer_only_with_layer_reuse(self):
+        runner = self._build_runner()
+        runner.vllm_config.kv_transfer_config = SimpleNamespace(
+            kv_connector="AscendStoreConnector",
+            kv_connector_extra_config={
+                "backend": "memcache",
+                "use_layerwise": True,
+            },
+        )
+        bf16_name = "model.layers.1.self_attn.indexer.k_cache"
+        c8_name = "model.layers.4.self_attn.indexer.k_cache"
+        bf16_spec = AscendSFAIndexerCacheSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.bfloat16,
+            cache_sparse_li_c8=False,
+        )
+        c8_spec = AscendSFAIndexerCacheSpec(
+            block_size=16,
+            num_kv_heads=1,
+            head_size=128,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_li_c8=True,
+        )
+        num_blocks = 2
+        group_spec = UniformTypeKVCacheSpecs(
+            block_size=16,
+            kv_cache_specs={bf16_name: bf16_spec, c8_name: c8_spec},
+        )
+        kv_cache_config = KVCacheConfig(
+            num_blocks=num_blocks,
+            kv_cache_tensors=[
+                KVCacheTensor(
+                    size=bf16_spec.page_size_bytes * num_blocks,
+                    shared_by=[c8_name, bf16_name],
+                )
+            ],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    layer_names=[c8_name, bf16_name],
+                    kv_cache_spec=group_spec,
+                )
+            ],
+        )
+        backend = MagicMock()
+        backend.get_kv_cache_shape.side_effect = lambda num_blocks, block_size, num_kv_heads, head_size: (
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_size,
+        )
+        runner._kv_cache_spec_attn_group_iterator = MagicMock(
+            return_value=[
+                SimpleNamespace(
+                    kv_cache_spec=bf16_spec,
+                    backend=backend,
+                    layer_names=[bf16_name],
+                ),
+                SimpleNamespace(
+                    kv_cache_spec=c8_spec,
+                    backend=backend,
+                    layer_names=[c8_name],
+                ),
+            ]
+        )
+
+        raw_caches_without_reuse = runner._allocate_kv_cache_tensors(kv_cache_config)
+        self.assertNotEqual(
+            raw_caches_without_reuse[bf16_name][0].untyped_storage().data_ptr(),
+            raw_caches_without_reuse[c8_name][0].untyped_storage().data_ptr(),
+        )
+        caches_without_reuse = runner._reshape_kv_cache_tensors(
+            kv_cache_config,
+            raw_caches_without_reuse,
+        )
+        self.assertEqual(len(caches_without_reuse[bf16_name]), 1)
+        self.assertEqual(caches_without_reuse[bf16_name][0].dtype, torch.bfloat16)
+        self.assertEqual(len(caches_without_reuse[c8_name]), 2)
+        self.assertEqual(caches_without_reuse[c8_name][0].dtype, torch.int8)
+        self.assertEqual(caches_without_reuse[c8_name][1].dtype, torch.float16)
+
+        runner.layerwise_kv_cache_reuse_applied = True
+        raw_caches = runner._allocate_kv_cache_tensors(kv_cache_config)
+        bf16_raw = raw_caches[bf16_name]
+        c8_raw = raw_caches[c8_name]
+        storage_ptr = bf16_raw[0].untyped_storage().data_ptr()
+        self.assertEqual(storage_ptr, c8_raw[0].untyped_storage().data_ptr())
+        self.assertEqual(storage_ptr, c8_raw[1].untyped_storage().data_ptr())
+
+        caches = runner._reshape_kv_cache_tensors(kv_cache_config, raw_caches)
+        self.assertEqual(len(caches[bf16_name]), 1)
+        self.assertEqual(caches[bf16_name][0].dtype, torch.bfloat16)
+        self.assertEqual(caches[bf16_name][0].shape, (2, 16, 1, 128))
+        self.assertEqual(len(caches[c8_name]), 2)
+        self.assertEqual(caches[c8_name][0].dtype, torch.int8)
+        self.assertEqual(caches[c8_name][0].shape, (2, 16, 1, 128))
+        self.assertEqual(caches[c8_name][1].dtype, torch.float16)
+        self.assertEqual(caches[c8_name][1].shape, (2, 16, 1, 1))
+
     def test_sparse_sfa_and_li_c8_allocate_and_reshape_independently(self):
         runner = self._build_runner()
         runner.use_sparse = True

--- a/tests/ut/worker/a2/test_worker_v1.py
+++ b/tests/ut/worker/a2/test_worker_v1.py
@@ -148,6 +148,61 @@ class TestNPUWorker(TestBase):
         self.assertEqual((num_layers, num_slots), (7, 3))
         self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
 
+    def test_layer_reuse_memory_factor_uses_largest_mixed_indexer(self):
+        from vllm_ascend.core.kv_cache_interface import (
+            AscendMLAAttentionSpec,
+            AscendSFAIndexerCacheSpec,
+        )
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 2
+        main_spec = AscendMLAAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=8,
+            dtype=torch.bfloat16,
+        )
+        bf16_indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.bfloat16,
+            cache_sparse_li_c8=False,
+        )
+        c8_indexer_spec = AscendSFAIndexerCacheSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=4,
+            dtype=torch.int8,
+            scale_dim=1,
+            scale_dtype=torch.float16,
+            cache_sparse_li_c8=True,
+        )
+        specs = {
+            "model.layers.0.self_attn.attn": main_spec,
+            "model.layers.1.self_attn.attn": main_spec,
+            "model.layers.0.self_attn.indexer.k_cache": bf16_indexer_spec,
+            "model.layers.1.self_attn.indexer.k_cache": c8_indexer_spec,
+        }
+
+        num_layers, num_slots, factor = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {
+                "layerwise_num_shared_buffers": 1,
+                "layerwise_independent_layers": [],
+            },
+        )
+
+        expected_logical_bytes = (
+            2 * main_spec.page_size_bytes + bf16_indexer_spec.page_size_bytes + c8_indexer_spec.page_size_bytes
+        )
+        expected_physical_bytes = main_spec.page_size_bytes + bf16_indexer_spec.page_size_bytes
+        self.assertEqual((num_layers, num_slots), (2, 1))
+        self.assertEqual(factor, expected_logical_bytes / expected_physical_bytes)
+
     def test_incomplete_layer_layout_does_not_scale_memory_budget(self):
         from vllm_ascend.worker.worker import NPUWorker
 
@@ -196,6 +251,29 @@ class TestNPUWorker(TestBase):
         )
 
         self.assertEqual(memory_info, (3, 3, 1.0))
+
+    def test_no_reuse_does_not_validate_multi_component_layers(self):
+        from vllm_ascend.worker.worker import NPUWorker
+
+        worker = NPUWorker.__new__(NPUWorker)
+        worker.model_config = MagicMock()
+        worker.parallel_config = MagicMock()
+        worker.model_config.get_num_layers.return_value = 2
+        suffixes = (
+            "compressor.state_cache",
+            "indexer.k_cache",
+            "indexer.compressor.state_cache",
+            "swa_cache",
+            "attn",
+        )
+        specs = {f"model.layers.{layer}.self_attn.{suffix}": MagicMock() for layer in range(2) for suffix in suffixes}
+
+        memory_info = worker._get_layerwise_kv_cache_memory_info(
+            specs,
+            {"layerwise_num_shared_buffers": 2},
+        )
+
+        self.assertEqual(memory_info, (2, 2, 1.0))
 
     @patch("vllm_ascend.utils.adapt_patch")
     @patch("vllm_ascend.ops")

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/layerwise_cache_layout.py
@@ -14,6 +14,8 @@ from vllm.v1.kv_cache_interface import (
     UniformTypeKVCacheSpecs,
 )
 
+from vllm_ascend.core.kv_cache_interface import AscendSFAIndexerCacheSpec
+
 _NUM_SHARED_BUFFERS = "layerwise_num_shared_buffers"
 _PREFETCH_LAYERS = "layerwise_prefetch_layers"
 _INDEPENDENT_LAYERS = "layerwise_independent_layers"
@@ -65,6 +67,32 @@ class LayerwiseReuseLayout:
     independent_layers: list[int]
     num_prefetch_layers: int
     has_layer_reuse: bool
+
+
+def is_compatible_mixed_li_c8_indexer_specs(specs: list[KVCacheSpec]) -> bool:
+    """Return whether indexer specs differ only by their LI C8 layout."""
+    if len(specs) < 2 or not all(isinstance(spec, AscendSFAIndexerCacheSpec) for spec in specs):
+        return False
+    if {spec.cache_sparse_li_c8 for spec in specs} != {False, True}:
+        return False
+
+    reference = specs[0]
+    reference_shape = (
+        reference.block_size,
+        reference.num_kv_heads,
+        reference.head_size,
+        reference.sfa_dcp_replicated_indexer_size,
+    )
+    return all(
+        (
+            spec.block_size,
+            spec.num_kv_heads,
+            spec.head_size,
+            spec.sfa_dcp_replicated_indexer_size,
+        )
+        == reference_shape
+        for spec in specs[1:]
+    )
 
 
 def get_gva_layerwise_config(kv_transfer_config: Any) -> dict[str, Any] | None:
@@ -193,6 +221,18 @@ def get_layerwise_kv_cache_specs(
     return layer_specs
 
 
+def is_layerwise_reuse_requested(
+    layer_specs: dict[str, KVCacheSpec],
+    base_layers: int,
+    extra_config: dict[str, Any],
+) -> bool:
+    """Return whether the configuration maps any logical layers onto shared buffers."""
+    physical_layers = {get_layerwise_physical_layer_index(layer_name, base_layers) for layer_name in layer_specs}
+    if not physical_layers:
+        return False
+    return build_layerwise_cache_layout(len(physical_layers), extra_config).has_layer_reuse
+
+
 def build_layerwise_reuse_layout(
     layer_specs: dict[str, KVCacheSpec],
     base_layers: int,
@@ -279,18 +319,20 @@ def build_layerwise_reuse_layout(
 def apply_layerwise_kv_cache_plan(
     kv_cache_config: KVCacheConfig,
     vllm_config: VllmConfig,
-) -> None:
-    """Rewrite logical layer tensors to use shared physical KV buffers."""
+) -> bool:
+    """Rewrite logical tensors and report whether buffer reuse was applied."""
     extra_config = get_gva_layerwise_config(vllm_config.kv_transfer_config)
     if extra_config is None:
-        return
+        return False
 
     old_tensors = kv_cache_config.kv_cache_tensors
     if len(old_tensors) <= 1:
-        return
+        return False
 
     base_layers = vllm_config.model_config.get_num_layers(vllm_config.parallel_config)
     layer_specs = get_layerwise_kv_cache_specs(kv_cache_config)
+    if not is_layerwise_reuse_requested(layer_specs, base_layers, extra_config):
+        return False
     reuse_layout = build_layerwise_reuse_layout(
         layer_specs,
         base_layers,
@@ -298,7 +340,7 @@ def apply_layerwise_kv_cache_plan(
     )
     actual_layers = len(reuse_layout.layer_cache_specs)
     if not reuse_layout.has_layer_reuse:
-        return
+        return False
     if any(len(tensor.shared_by) != 1 or tensor.offset != 0 or tensor.block_stride != 0 for tensor in old_tensors):
         raise NotImplementedError(
             "Layerwise KV cache reuse does not support pre-shared or packed KV cache tensor descriptors."
@@ -310,7 +352,7 @@ def apply_layerwise_kv_cache_plan(
             base_layers,
             actual_layers,
         )
-        return
+        return False
     if actual_layers > base_layers:
         logger.info(
             "Layer reuse includes %d base and %d MTP/spec-decode layer(s).",
@@ -338,6 +380,31 @@ def apply_layerwise_kv_cache_plan(
             )
         )
 
+    def _merge_mixed_li_c8_indexer_specs(named_specs: list[NamedKVCacheSpec]) -> None:
+        specs = [named_spec.spec for named_spec in named_specs]
+        if not is_compatible_mixed_li_c8_indexer_specs(specs):
+            raise ValueError(
+                "Layers sharing one layerwise indexer buffer must have identical "
+                "cache specs or compatible LI C8 and unquantized indexer layouts."
+            )
+
+        shared_by = [named_spec.layer_name for named_spec in named_specs]
+        cache_tensors = [tensors_by_name[layer_name] for layer_name in shared_by]
+        for named_spec, cache_tensor in zip(named_specs, cache_tensors, strict=True):
+            expected_size = named_spec.spec.page_size_bytes * kv_cache_config.num_blocks
+            if cache_tensor.size != expected_size:
+                raise ValueError(
+                    f"Layerwise indexer tensor size mismatch for {named_spec.layer_name}: "
+                    f"expected {expected_size}, got {cache_tensor.size}."
+                )
+
+        new_tensors.append(
+            KVCacheTensor(
+                shared_by=shared_by,
+                size=max(tensor.size for tensor in cache_tensors),
+            )
+        )
+
     new_tensors: list[KVCacheTensor] = []
     for slot in reuse_layout.buffer_slots:
         _merge_specs([reuse_layout.layer_cache_specs[layer].main for layer in slot])
@@ -347,7 +414,11 @@ def apply_layerwise_kv_cache_plan(
             if indexer is not None:
                 indexer_specs.append(indexer)
         if indexer_specs:
-            _merge_specs(indexer_specs)
+            reference_spec = indexer_specs[0].spec
+            if all(indexer.spec == reference_spec for indexer in indexer_specs[1:]):
+                _merge_specs(indexer_specs)
+            else:
+                _merge_mixed_li_c8_indexer_specs(indexer_specs)
     kv_cache_config.kv_cache_tensors = new_tensors
     logger.info(
         "Layerwise KV cache reuse merged %d descriptors into %d descriptors using %d buffer assignments.",
@@ -355,3 +426,4 @@ def apply_layerwise_kv_cache_plan(
         len(new_tensors),
         len(reuse_layout.buffer_slots),
     )
+    return True

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -48,6 +48,8 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
     get_layerwise_kv_cache_specs,
+    get_layerwise_physical_layer_index,
+    is_layerwise_reuse_requested,
 )
 
 
@@ -199,17 +201,20 @@ class KVPoolScheduler:
         if self.use_gva_layerwise:
             extra_config = get_gva_layerwise_config(vllm_config.kv_transfer_config)
             if kv_cache_config is not None and extra_config is not None:
-                reuse_layout = build_layerwise_reuse_layout(
-                    get_layerwise_kv_cache_specs(kv_cache_config),
-                    self.num_layers,
-                    extra_config,
-                )
-                if reuse_layout.layer_cache_specs:
-                    self.num_layers = max(
-                        self.num_layers,
-                        max(reuse_layout.layer_cache_specs) + 1,
+                layer_specs = get_layerwise_kv_cache_specs(kv_cache_config)
+                base_layers = self.num_layers
+                physical_layers = {
+                    get_layerwise_physical_layer_index(layer_name, base_layers) for layer_name in layer_specs
+                }
+                if physical_layers:
+                    self.num_layers = max(self.num_layers, max(physical_layers) + 1)
+                if is_layerwise_reuse_requested(layer_specs, base_layers, extra_config):
+                    reuse_layout = build_layerwise_reuse_layout(
+                        layer_specs,
+                        base_layers,
+                        extra_config,
                     )
-                self.layerwise_offload = reuse_layout.has_layer_reuse
+                    self.layerwise_offload = reuse_layout.has_layer_reuse
             else:
                 self.layerwise_offload = build_layerwise_cache_layout(
                     self.num_layers,

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -69,6 +69,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_reuse_layout,
     get_layerwise_kv_cache_specs,
     get_layerwise_physical_layer_index,
+    is_layerwise_reuse_requested,
 )
 from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
@@ -369,11 +370,13 @@ class KVPoolWorker:
                     )
                     self.num_layers = effective_num_layers
             if self.use_gva_layerwise:
-                self._layerwise_reuse_layout = build_layerwise_reuse_layout(
-                    get_layerwise_kv_cache_specs(self.kv_cache_config),
-                    base_layers,
-                    self._extra_config,
-                )
+                layer_specs = get_layerwise_kv_cache_specs(self.kv_cache_config)
+                if is_layerwise_reuse_requested(layer_specs, base_layers, self._extra_config):
+                    self._layerwise_reuse_layout = build_layerwise_reuse_layout(
+                        layer_specs,
+                        base_layers,
+                        self._extra_config,
+                    )
 
         if self.kv_cache_config is not None and self.num_kv_cache_groups > 1:
             for group_id, group_spec in enumerate(self.kv_cache_config.kv_cache_groups):
@@ -416,10 +419,11 @@ class KVPoolWorker:
                     self.num_layers,
                     self._extra_config,
                 )
-                self.layerwise_offload = cache_layout.has_layer_reuse
-                self.independent_layers = cache_layout.independent_layers
-                self.prefetch_layer_map = cache_layout.prefetch_layer_map
                 self.num_prefetch_layers = cache_layout.num_prefetch_layers
+                if self.kv_cache_config is None:
+                    self.layerwise_offload = cache_layout.has_layer_reuse
+                    self.independent_layers = cache_layout.independent_layers
+                    self.prefetch_layer_map = cache_layout.prefetch_layer_map
             else:
                 self.layerwise_offload = self._layerwise_reuse_layout.has_layer_reuse
                 self.independent_layers = self._layerwise_reuse_layout.independent_layers

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -80,6 +80,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVCacheTensor,
     MambaSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -133,6 +134,7 @@ from vllm_ascend.compilation.acl_graph import (
 )
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_layout import (
     apply_layerwise_kv_cache_plan,
+    is_compatible_mixed_li_c8_indexer_specs,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     allocate_kv_cache_tensors_for_sparse_kv_offload,
@@ -3747,7 +3749,10 @@ class NPUModelRunner(GPUModelRunner):
         self._mamba_bufs = None
         self._mamba_copy_bufs = None
         self.may_add_encoder_only_layers_to_kv_cache_config()
-        apply_layerwise_kv_cache_plan(kv_cache_config, self.vllm_config)
+        self.layerwise_kv_cache_reuse_applied = apply_layerwise_kv_cache_plan(
+            kv_cache_config,
+            self.vllm_config,
+        )
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)
         # NOTE(cmq): initialize_attn_backend must before using self.attn_groups
         self.initialize_attn_backend(kv_cache_config)
@@ -3992,6 +3997,69 @@ class NPUModelRunner(GPUModelRunner):
 
         return dsa_k_tensor, dsa_k_scale_tensor
 
+    def _allocate_mixed_li_c8_indexer_tensors(
+        self,
+        kv_cache_tensor: KVCacheTensor,
+        specs: list[KVCacheSpec],
+        num_blocks: int,
+        alignment: int,
+        share_raw_buffer: bool,
+    ) -> dict[str, tuple[torch.Tensor, ...]]:
+        """Allocate compatible mixed indexers with optional layerwise sharing."""
+        raw_buffer = None
+        if share_raw_buffer:
+            expected_size = max(spec.page_size_bytes for spec in specs) * num_blocks
+            if kv_cache_tensor.size != expected_size:
+                raise ValueError(
+                    "Mixed layerwise indexer buffer has an unexpected size: "
+                    f"expected {expected_size}, got {kv_cache_tensor.size}."
+                )
+            raw_buffer = self._allocate_int8_cache_tensor(kv_cache_tensor.size, alignment)
+
+        raw_caches: dict[str, tuple[torch.Tensor, ...]] = {}
+        for layer_name, spec in zip(kv_cache_tensor.shared_by, specs, strict=True):
+            assert isinstance(spec, AscendSFAIndexerCacheSpec)
+            k_tensor_size = (
+                num_blocks
+                * spec.sfa_dcp_replicated_indexer_size
+                * spec.block_size
+                * spec.num_kv_heads
+                * spec.head_size
+                * get_dtype_size(spec.dtype)
+            )
+            scale_offset = None
+            required_size = k_tensor_size
+            if spec.scale_dim:
+                scale_tensor_size = (
+                    num_blocks
+                    * spec.sfa_dcp_replicated_indexer_size
+                    * spec.block_size
+                    * spec.num_kv_heads
+                    * spec.scale_dim
+                    * get_dtype_size(spec.scale_dtype)
+                )
+                scale_offset = self._align_up(k_tensor_size, get_dtype_size(spec.scale_dtype))
+                required_size = scale_offset + scale_tensor_size
+
+            layer_raw_buffer = (
+                raw_buffer
+                if raw_buffer is not None
+                else self._allocate_int8_cache_tensor(required_size, alignment)
+            )
+            if required_size > layer_raw_buffer.numel():
+                raise ValueError(
+                    f"Mixed layerwise indexer views for {layer_name} need "
+                    f"{required_size} bytes, but the shared buffer has {layer_raw_buffer.numel()} bytes."
+                )
+            if scale_offset is None:
+                raw_caches[layer_name] = (layer_raw_buffer[:k_tensor_size],)
+                continue
+            raw_caches[layer_name] = (
+                layer_raw_buffer[:k_tensor_size],
+                layer_raw_buffer[scale_offset:required_size],
+            )
+        return raw_caches
+
     def _allocate_kv_cache_tensors(self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
         """
         Initializes the KV cache buffer with the correct size. The buffer needs
@@ -4025,6 +4093,18 @@ class NPUModelRunner(GPUModelRunner):
                 if isinstance(layer_kv_cache_spec[layer_name], AttentionSpec):
                     use_attn = True
             self.hybrid_with_attn_and_mamba = self.hybrid_with_attn_and_mamba or (use_mamba and use_attn)
+            shared_specs = [layer_kv_cache_spec[layer_name] for layer_name in kv_cache_tensor.shared_by]
+            if is_compatible_mixed_li_c8_indexer_specs(shared_specs):
+                kv_cache_raw_tensors.update(
+                    self._allocate_mixed_li_c8_indexer_tensors(
+                        kv_cache_tensor,
+                        shared_specs,
+                        kv_cache_config.num_blocks,
+                        alignment,
+                        share_raw_buffer=getattr(self, "layerwise_kv_cache_reuse_applied", False),
+                    )
+                )
+                continue
             for idx in range(len(kv_cache_tensor.shared_by)):
                 layer_name = kv_cache_tensor.shared_by[idx]
                 # Single tensor path for: mamba, hybrid attn-mamba, or cache_only_layers

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -66,6 +66,7 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     build_layerwise_reuse_layout,
     get_gva_layerwise_config,
     get_layerwise_physical_layer_index,
+    is_layerwise_reuse_requested,
 )
 from vllm_ascend.distributed.kv_transfer.sparse_kv_offload.sparse_kv_offload_manager import (
     get_host_device_memory_usage_ratio,
@@ -949,6 +950,8 @@ class NPUWorker(WorkerBase):
         num_layers = len(physical_layers)
         if num_layers < base_layers:
             return num_layers, num_layers, 1.0
+        if not is_layerwise_reuse_requested(kv_cache_spec, base_layers, extra_config):
+            return num_layers, num_layers, 1.0
         reuse_layout = build_layerwise_reuse_layout(
             kv_cache_spec,
             base_layers,
@@ -962,11 +965,13 @@ class NPUWorker(WorkerBase):
         physical_page_bytes = 0
         for slot in reuse_layout.buffer_slots:
             physical_page_bytes += reuse_layout.layer_cache_specs[slot[0]].main.spec.page_size_bytes
-            for layer in slot:
-                indexer = reuse_layout.layer_cache_specs[layer].indexer
-                if indexer is not None:
-                    physical_page_bytes += indexer.spec.page_size_bytes
-                    break
+            indexer_page_sizes = [
+                indexer.spec.page_size_bytes
+                for layer in slot
+                if (indexer := reuse_layout.layer_cache_specs[layer].indexer) is not None
+            ]
+            if indexer_page_sizes:
+                physical_page_bytes += max(indexer_page_sizes)
         return num_layers, num_buffer_assignments, logical_page_bytes / physical_page_bytes
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes mixed LI C8 and unquantized SFA indexer cache allocation for GVA layerwise reuse.

- Share one raw indexer buffer per layerwise slot only when layer reuse is actually applied.
- Preserve independent per-layer allocation when the concrete KV cache plan does not reuse layers.
- Keep scheduler/worker reuse state and KV memory accounting consistent with the concrete cache layout.
- Add regression coverage for reuse and non-reuse paths.

### Does this PR introduce _any_ user-facing change?

Yes. It fixes incorrect KV cache allocation for mixed LI C8/unquantized SFA models using layerwise KV offload. There is no API or configuration change.

### How was this patch tested?

- `pytest -q --confcutdir=tests/ut/distributed/ascend_store tests/ut/distributed/ascend_store/test_pool_worker.py` (103 passed)
- Ruff lint and format checks on all changed files
- Python compile checks on the changed runtime files
- NPU-specific runtime validation is left to CI.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
