### PR TITLE
[BugFix][MRV2] Fix DeepSeek V4 MTP V2 graph projection shape

### DIFF
--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -39,7 +39,7 @@ MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
     deploy="pd_mix",
     hardware="A3",
     quantization="W4A8",
-    graph_mode="eager",
+    graph_mode="full_decode_only",
 )
 @patch.dict(
     os.environ,
@@ -50,7 +50,7 @@ MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
     },
 )
 @wait_until_npu_memory_free()
-def test_deepseek_v4_mtp_eager():
+def test_deepseek_v4_mtp_full_decode_only():
     """Verify DeepSeek V4 MTP acceptance with ModelRunner V2."""
     prompts = [
         "Hello, my name is",
@@ -75,7 +75,8 @@ def test_deepseek_v4_mtp_eager():
         quantization="ascend",
         tokenizer_mode="deepseek_v4",
         block_size=128,
-        enforce_eager=True,
+        enforce_eager=False,
+        compilation_config={"cudagraph_mode": "FULL_DECODE_ONLY"},
         disable_log_stats=False,
         async_scheduling=True,
         speculative_config={

--- a/vllm_ascend/models/deepseek_v4/mtp.py
+++ b/vllm_ascend/models/deepseek_v4/mtp.py
@@ -118,16 +118,7 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         previous_hidden_states = previous_hidden_states.view(-1, self.hc_mult, self.config.hidden_size)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        if self.use_v2_model_runner:
-            # The Ascend unquantized linear graph path currently models GEMM
-            # as a 2-D operation. Preserve the V1 path and only flatten the HC
-            # axis for the V2 model runner before restoring the original shape.
-            projected_hidden_states = self.h_proj(previous_hidden_states.flatten(0, 1)).view_as(
-                previous_hidden_states
-            )
-        else:
-            projected_hidden_states = self.h_proj(previous_hidden_states)
-        hidden_states = self.e_proj(inputs_embeds).unsqueeze(-2) + projected_hidden_states
+        hidden_states = self.e_proj(inputs_embeds).unsqueeze(-2) + self.h_proj(previous_hidden_states)
 
         hidden_states, residual = self.mtp_block(
             positions=positions,

--- a/vllm_ascend/models/deepseek_v4/mtp.py
+++ b/vllm_ascend/models/deepseek_v4/mtp.py
@@ -118,7 +118,16 @@ class DeepSeekMultiTokenPredictorLayer(nn.Module):
         previous_hidden_states = previous_hidden_states.view(-1, self.hc_mult, self.config.hidden_size)
         previous_hidden_states = self.hnorm(previous_hidden_states)
 
-        hidden_states = self.e_proj(inputs_embeds).unsqueeze(-2) + self.h_proj(previous_hidden_states)
+        if self.use_v2_model_runner:
+            # The Ascend unquantized linear graph path currently models GEMM
+            # as a 2-D operation. Preserve the V1 path and only flatten the HC
+            # axis for the V2 model runner before restoring the original shape.
+            projected_hidden_states = self.h_proj(previous_hidden_states.flatten(0, 1)).view_as(
+                previous_hidden_states
+            )
+        else:
+            projected_hidden_states = self.h_proj(previous_hidden_states)
+        hidden_states = self.e_proj(inputs_embeds).unsqueeze(-2) + projected_hidden_states
 
         hidden_states, residual = self.mtp_block(
             positions=positions,

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -61,8 +61,7 @@ def unquantized_gemm_fake(
     weight: torch.Tensor,
     bias: torch.Tensor | None = None,
 ) -> torch.Tensor:
-    output_shape = (x.shape[0], weight.shape[0])
-    return torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    return x.new_empty((*x.shape[:-1], weight.shape[0]))
 
 
 direct_register_custom_op(


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek V4 MTP passes `previous_hidden_states` to `h_proj` with shape `[num_tokens, hc_mult, hidden_size]`. The Ascend `unquantized_gemm_fake` implementation always returns a 2-D tensor based on `x.shape[0]`, so MRV2 graph tracing loses the `hc_mult` dimension and can fail with an invalid reshape.

This change aligns the fake implementation with the upstream linear output-shape semantics:

```python
return x.new_empty((*x.shape[:-1], weight.shape[0]))
```

The output now preserves all leading dimensions of the input and replaces only the last dimension with `weight.shape[0]`, matching `torch.nn.functional.linear` for N-D inputs. No DeepSeek V4 model-side workaround is needed.

### Does this PR introduce _any_ user-facing change?

N/A

### How was this patch tested?

MRV1
```
num_drafts=109381.0
num_accepted_tokens_per_pos=[99892.0, 70153.0, 30754.0]
acceptance_per_pos=[0.9132481875279984, 0.6413636737641821, 0.2811640047174555]
acceptance_len=2.8357758660096364
```

MRV2
```
num_drafts=107554.0
num_accepted_tokens_per_pos=[98184.0, 71885.0, 34282.0]
acceptance_per_pos=[0.9128809714190081, 0.6683619391189543, 0.31874221321382745]
acceptance_len=2.8999851237517897
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
