### PR TITLE
[CI][Misc] Configure environment variables for non-interactive entrypoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,9 +86,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-
 # Make jemalloc and libascend_hal available to non-interactive entrypoints.
 # glibc expands $PLATFORM to the runtime architecture at process startup.
 ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,11 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 
+# Make jemalloc and libascend_hal available to non-interactive entrypoints.
+# glibc expands $PLATFORM to the runtime architecture at process startup.
+ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"
+
 # ===== Conditional installation based on BUILD_TYPE =====
 # All ARG definitions are in the same stage for better maintainability
 ARG BUILD_TYPE="release"

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -78,10 +78,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-RUN echo 'export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/lib64:/root/aicpu_kernels/0/aicpu_kernels_device/sand_box:$LD_LIBRARY_PATH' >> /root/.bashrc
-
 # Make runtime libraries available to non-interactive entrypoints.
 # glibc expands $PLATFORM to the runtime architecture at process startup.
 ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -82,6 +82,11 @@ RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 RUN echo 'export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/lib64:/root/aicpu_kernels/0/aicpu_kernels_device/sand_box:$LD_LIBRARY_PATH' >> /root/.bashrc
 
+# Make runtime libraries available to non-interactive entrypoints.
+# glibc expands $PLATFORM to the runtime architecture at process startup.
+ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64:/usr/lib64:/root/aicpu_kernels/0/aicpu_kernels_device/sand_box${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/lib"
+
 # Initialize driver directories, users and file groups
 RUN mkdir -m 750 /var/driver -m 750 /var/dmp -m 750 /usr/slog && \
     mkdir -m 755 /home/drv && \

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -72,10 +72,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 
-RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-RUN echo 'export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/lib64:/root/aicpu_kernels/0/aicpu_kernels_device/sand_box:$LD_LIBRARY_PATH' >> /root/.bashrc
-
 # Make runtime libraries available to non-interactive entrypoints.
 ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
     LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64:/usr/lib64:/root/aicpu_kernels/0/aicpu_kernels_device/sand_box${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/lib"

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -76,6 +76,10 @@ RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashr
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 RUN echo 'export LD_LIBRARY_PATH=/usr/local/Ascend/driver/lib64:/usr/lib64:/root/aicpu_kernels/0/aicpu_kernels_device/sand_box:$LD_LIBRARY_PATH' >> /root/.bashrc
 
+# Make runtime libraries available to non-interactive entrypoints.
+ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="/usr/local/Ascend/driver/lib64:/usr/lib64:/root/aicpu_kernels/0/aicpu_kernels_device/sand_box${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}:/usr/local/lib"
+
 # Initialize driver directories, users and file groups
 RUN mkdir -m 750 /var/driver -m 750 /var/dmp -m 750 /usr/slog && \
     mkdir -m 755 /home/drv && \

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -92,6 +92,11 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 
+# Make jemalloc and libascend_hal available to non-interactive entrypoints.
+# glibc expands $PLATFORM to the runtime architecture at process startup.
+ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"
+
 # ===== Conditional installation based on BUILD_TYPE =====
 # All ARG definitions are in the same stage for better maintainability
 ARG BUILD_TYPE="release"

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -89,9 +89,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-
 # Make jemalloc and libascend_hal available to non-interactive entrypoints.
 # glibc expands $PLATFORM to the runtime architecture at process startup.
 ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -81,9 +81,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
-RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-
 # Make jemalloc and libascend_hal available to non-interactive entrypoints.
 ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -84,6 +84,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 
+# Make jemalloc and libascend_hal available to non-interactive entrypoints.
+ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"
+
 # ===== Conditional installation based on BUILD_TYPE =====
 # All ARG definitions are in the same stage for better maintainability
 ARG BUILD_TYPE="release"

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -81,9 +81,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip cache purge
 
 # Append `libascend_hal.so` path (devlib) to LD_LIBRARY_PATH
-RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-
 # Make jemalloc and libascend_hal available to non-interactive entrypoints.
 # glibc expands $PLATFORM to the runtime architecture at process startup.
 ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -84,6 +84,11 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN echo "export LD_PRELOAD=/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 
+# Make jemalloc and libascend_hal available to non-interactive entrypoints.
+# glibc expands $PLATFORM to the runtime architecture at process startup.
+ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"
+
 # ===== Conditional installation based on BUILD_TYPE =====
 # All ARG definitions are in the same stage for better maintainability
 ARG BUILD_TYPE="release"

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -73,9 +73,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
-RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-
 # Make jemalloc and libascend_hal available to non-interactive entrypoints.
 ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -76,6 +76,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 
+# Make jemalloc and libascend_hal available to non-interactive entrypoints.
+ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"
+
 # ===== Conditional installation based on BUILD_TYPE =====
 # All ARG definitions are in the same stage for better maintainability
 ARG BUILD_TYPE="release"

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -81,9 +81,6 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     python3 -m pip install concurrent-log-handler && \
     python3 -m pip cache purge
 
-RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
-RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
-
 # Make jemalloc and libascend_hal available to non-interactive entrypoints.
 ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -84,6 +84,10 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 RUN echo "export LD_PRELOAD=/usr/lib64/libjemalloc.so.2:$LD_PRELOAD" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib" >> ~/.bashrc
 
+# Make jemalloc and libascend_hal available to non-interactive entrypoints.
+ENV LD_PRELOAD="/usr/lib64/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"
+
 # ===== Conditional installation based on BUILD_TYPE =====
 # All ARG definitions are in the same stage for better maintainability
 ARG BUILD_TYPE="release"


### PR DESCRIPTION
### What this PR does / why we need it?

We first encountered this issue while deploying a TTS workload using a
`vllm-omni:v0.26`-based image on an Ascend 910B host.

The environment was configured correctly when entering the container through
an interactive Bash shell, but processes launched directly through the
container entrypoint did not inherit `LD_PRELOAD` or the additional
`LD_LIBRARY_PATH` entries.

Issue #12059 describes the same root cause: the Dockerfiles configured these
variables through `~/.bashrc`, which is not sourced by direct Docker
entrypoints, Kubernetes workloads, CI steps, or commands such as
`python -m ...`.

Fixes #12059.

This PR defines `LD_PRELOAD` and `LD_LIBRARY_PATH` with image-level `ENV`
instructions so the required runtime libraries are available to both
interactive and non-interactive processes.

The redundant commands that wrote the same values to `~/.bashrc` have been
removed. Interactive Bash processes already inherit image-level `ENV`
variables, so retaining both configurations would append the same paths
twice and could make the environment difficult to inspect and debug.

For Ubuntu images, `LD_PRELOAD` uses glibc's `$PLATFORM` dynamic string token:

```dockerfile
ENV LD_PRELOAD="/usr/lib/\$PLATFORM-linux-gnu/libjemalloc.so.2${LD_PRELOAD:+:${LD_PRELOAD}}" \
    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:}/usr/local/lib"
```

glibc expands `$PLATFORM` at process startup. For example, on an Ascend 910B
ARM64 host it resolves to:

```text
/usr/lib/aarch64-linux-gnu/libjemalloc.so.2
```

This avoids hardcoding the architecture in the final runtime path and avoids
using the build host's `uname -m` during cross-platform image builds.

For openEuler images, the existing architecture-independent jemalloc path is
used:

```text
/usr/lib64/libjemalloc.so.2
```

The conditional variable expansion preserves an existing value without
introducing a leading or trailing separator:

```dockerfile
${LD_PRELOAD:+:${LD_PRELOAD}}
${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
```

The additional Ascend driver, `libascend_hal`, and AICPU sandbox paths required
by the 310P variants are also preserved in their image-level
`LD_LIBRARY_PATH`.

### Does this PR introduce _any_ user-facing change?

Yes.

Processes launched directly through Docker `ENTRYPOINT`/`CMD`, Kubernetes,
CI systems, or explicit non-interactive entrypoints now inherit
`LD_PRELOAD` and `LD_LIBRARY_PATH` without sourcing `~/.bashrc`.

Interactive Bash sessions inherit the same image-level environment and no
longer append duplicate jemalloc or library-path entries.

### How was this patch tested?

The complete repository lint suite was run on an ARM64 Ascend 910B machine
for the image-level `ENV` implementation:

```bash
bash format.sh ci
```

All hooks passed, including Ruff, codespell, typos, clang-format,
markdownlint, actionlint, Gitleaks, ShellCheck, and the repository-local
checks.

The default Ubuntu 910B image was successfully built with:

```bash
DOCKER_BUILDKIT=1 docker build \
  --progress=plain \
  --build-arg COMPILE_CUSTOM_KERNELS=0 \
  -f Dockerfile \
  -t vllm-ascend:platform-env-pr .
```

Non-interactive environment propagation and glibc `$PLATFORM` expansion were
verified with:

```bash
docker run --rm \
  --entrypoint python3 \
  vllm-ascend:platform-env-pr \
  -c 'import os; maps = open("/proc/self/maps").read(); preload = os.environ["LD_PRELOAD"]; assert "$PLATFORM" in preload; assert "/usr/local/lib" in os.environ["LD_LIBRARY_PATH"].split(":"); mapped = next(line for line in maps.splitlines() if "libjemalloc.so.2" in line); assert "/usr/lib/aarch64-linux-gnu/libjemalloc.so.2" in mapped; print(preload); print(mapped)'
```

Interactive Bash compatibility was verified with:

```bash
docker run --rm -it \
  --entrypoint /bin/bash \
  vllm-ascend:platform-env-pr \
  -ic 'test "${LD_PRELOAD%%:*}" = "/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2"; [[ ":${LD_LIBRARY_PATH}:" == *":/usr/local/lib:"* ]]; grep -q libjemalloc.so /proc/$$/maps; echo "interactive environment passed"'
```

The `vllm` and `vllm_ascend` imports were verified with the Ascend 910B host
driver environment mounted:

```bash
docker run --rm \
  --device=/dev/davinci_manager \
  --device=/dev/hisi_hdc \
  --device=/dev/devmm_svm \
  -v /usr/local/dcmi:/usr/local/dcmi \
  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
  -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
  -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
 