### PR TITLE
[BugFix][MRV2] Stabilize PCP full-decode graph padding

### DIFF
--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -17,7 +17,7 @@
 # This file is a part of the vllm-ascend project.
 #
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -297,6 +297,153 @@ def test_prepare_slot_mappings_pads_each_pcp_rank_for_full_decode_graph() -> Non
 
     expected = torch.tensor([[10, 11, 12, 13, -1, -1, -1, -1, 20, 21, 22, 23, -1, -1, -1, -1]])
     assert torch.equal(result, expected)
+
+
+def test_prepare_attn_uses_persistent_pad_filled_dummy_buffers() -> None:
+    manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager.pcp_world_size = 2
+    manager._local_block_tables = (
+        torch.full((4, 3), 7, dtype=torch.int32),
+    )
+    manager._gathered_kv_slot_mappings = torch.zeros(
+        (1, 16),
+        dtype=torch.int64,
+    )
+    input_batch = SimpleNamespace(
+        is_dummy=True,
+        num_reqs_after_padding=2,
+        num_tokens_after_padding=4,
+    )
+
+    block_tables, slot_mappings = manager.prepare_attn(input_batch)
+
+    persistent_block_table = manager._local_block_tables[0]
+    assert block_tables[0].data_ptr() == persistent_block_table.data_ptr()
+    assert torch.equal(block_tables[0], torch.zeros(2, 3, dtype=torch.int32))
+    assert torch.equal(
+        persistent_block_table[2:],
+        torch.full((2, 3), 7, dtype=torch.int32),
+    )
+    assert (
+        slot_mappings.data_ptr()
+        == manager._gathered_kv_slot_mappings.data_ptr()
+    )
+    assert slot_mappings.shape == (1, 8)
+    assert torch.all(slot_mappings == -1)
+
+
+def test_prepare_attn_delegates_runtime_batches() -> None:
+    manager = AscendPCPManager.__new__(AscendPCPManager)
+    input_batch = SimpleNamespace(is_dummy=False)
+    expected = ((torch.empty(0),), torch.empty(0))
+
+    with patch.object(
+        PCPManager,
+        "prepare_attn",
+        return_value=expected,
+    ) as prepare_attn:
+        actual = manager.prepare_attn(input_batch)
+
+    assert actual is expected
+    prepare_attn.assert_called_once_with(input_batch)
+
+
+def test_partition_batch_preserves_fia_dummy_layout() -> None:
+    global_batch = _make_global_pcp_batch()
+    global_batch.req_ids = ["decode-req"]
+    global_batch.num_scheduled_tokens = np.array([1], dtype=np.int32)
+    global_batch.num_tokens = 1
+    global_batch.num_reqs_after_padding = 2
+    global_batch.num_tokens_after_padding = 4
+    global_batch.query_start_loc_np = np.array([0, 1, 4], dtype=np.int32)
+    global_batch.query_start_loc = torch.tensor(
+        [0, 1, 4],
+        dtype=torch.int32,
+    )
+    global_batch.num_computed_tokens_np = np.array([10], dtype=np.int32)
+    global_batch.prefill_len_np = np.array([10], dtype=np.int32)
+    global_batch.num_computed_prefill_tokens_np = np.array(
+        [10],
+        dtype=np.int32,
+    )
+    global_batch.is_prefilling_np = np.array([False])
+    global_batch.seq_lens = torch.tensor([11, 999], dtype=torch.int32)
+    global_batch.seq_lens_cpu_upper_bound = torch.tensor(
+        [11],
+        dtype=torch.int32,
+    )
+    global_batch.input_ids[:4].copy_(
+        torch.tensor([101, 999, 999, 999], dtype=torch.int32)
+    )
+    global_batch.positions[:4].copy_(
+        torch.tensor([10, 999, 999, 999], dtype=torch.int64)
+    )
+    global_batch.is_padding[:4].fill_(False)
+
+    req_states = SimpleNamespace(
+        last_sampled_tokens=torch.zeros(2, dtype=torch.int64),
+        prefill_len=SimpleNamespace(
+            gpu=torch.zeros(2, dtype=torch.int32)
+        ),
+        draft_tokens=torch.empty((2, 0), dtype=torch.int64),
+    )
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=req_states,
+        max_num_reqs=2,
+        max_num_tokens=4,
+    )
+    input_buffers = manager._input_buffers
+    assert input_buffers is not None
+    input_buffers.positions[0] = 10
+    input_buffers.seq_lens[0] = 11
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.prepare_pos_seq_lens",
+            return_value=None,
+        ),
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.combine_sampled_and_draft_tokens",
+            return_value=torch.zeros(1, dtype=torch.int64),
+        ),
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
+    ):
+        local_batch = manager.partition_batch(global_batch)
+
+    assert local_batch.num_reqs == 1
+    assert local_batch.num_reqs_after_padding == 2
+    assert local_batch.num_tokens == 1
+    assert local_batch.num_tokens_after_padding == 4
+    expected_query_start_loc = np.array([0, 1, 4], dtype=np.int32)
+    np.testing.assert_array_equal(
+        local_batch.query_start_loc_np,
+        expected_query_start_loc,
+    )
+    torch.testing.assert_close(
+        local_batch.query_start_loc,
+        torch.from_numpy(expected_query_start_loc),
+    )
+    assert local_batch.input_ids.tolist() == [101, 0, 0, 0]
+    assert local_batch.positions.tolist() == [10, 0, 0, 0]
+    assert local_batch.seq_lens.tolist() == [11, 0]
+    np.testing.assert_array_equal(
+        local_batch.seq_lens_np,
+        np.array([11, 0], dtype=np.int32),
+    )
+    assert local_batch.seq_lens_cpu_upper_bound.tolist() == [11, 0]
+    assert local_batch.is_padding.tolist() == [False, True, True, True]
+    assert manager._hidden_restore_idx is not None
+    assert manager._hidden_restore_idx[1:4].tolist() == [0, 0, 0]
 
 
 def test_mrv2_runner_registers_ascend_pcp_manager() -> None:

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -19,8 +19,10 @@
 
 from dataclasses import dataclass, replace
 
+import numpy as np
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
@@ -88,9 +90,7 @@ class AscendPCPManager(PCPManager):
         # graph replays a fixed padded layout on every rank.
         graph_num_tokens = input_batch.num_tokens_after_padding
         is_decode_only = not bool(input_batch.is_prefilling_np.any())
-        # FULL_DECODE_ONLY graphs capture one token for every padded request.
-        # Keep the request-shaped metadata at that same fixed graph extent.
-        graph_num_reqs = graph_num_tokens if is_decode_only else input_batch.num_reqs_after_padding
+        graph_num_reqs = input_batch.num_reqs_after_padding
         if is_decode_only and graph_num_tokens > local_batch.num_tokens_after_padding:
             assert self._input_buffers is not None
             input_buffers = self._input_buffers
@@ -110,7 +110,24 @@ class AscendPCPManager(PCPManager):
             input_buffers.positions[actual_tokens:graph_num_tokens].zero_()
             input_buffers.is_padding[actual_tokens:graph_num_tokens].fill_(True)
             input_buffers.seq_lens[actual_reqs:graph_num_reqs].zero_()
-            input_buffers.query_start_loc[actual_reqs + 1 : graph_num_reqs + 1].fill_(actual_tokens)
+
+            # Decode requests are replicated on every PCP rank, so the global
+            # FULL-graph query layout is also the authoritative rank-local
+            # layout, including any FIA dummy request.
+            graph_query_start_loc_np = input_batch.query_start_loc_np[
+                : graph_num_reqs + 1
+            ]
+            async_copy_to_gpu(
+                graph_query_start_loc_np,
+                out=input_buffers.query_start_loc[: graph_num_reqs + 1],
+            )
+
+            # Graph padding has no RankSegment, so _build_batch_layout does
+            # not initialize the corresponding hidden restore indices.
+            assert self._hidden_restore_idx is not None
+            self._hidden_restore_idx[
+                input_batch.num_tokens : graph_num_tokens
+            ].zero_()
             seq_lens_cpu_upper_bound = torch.zeros(
                 graph_num_reqs,
                 dtype=local_batch.seq_lens_cpu_upper_bound.dtype,
@@ -121,6 +138,7 @@ class AscendPCPManager(PCPManager):
                 num_reqs_after_padding=graph_num_reqs,
                 num_tokens_after_padding=graph_num_tokens,
                 query_start_loc=input_buffers.query_start_loc[: graph_num_reqs + 1],
+                query_start_loc_np=graph_query_start_loc_np,
                 seq_lens=input_buffers.seq_lens[:graph_num_reqs],
                 seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
                 input_ids=input_buffers.input_ids[:graph_num_tokens],
@@ -128,7 +146,16 @@ class AscendPCPManager(PCPManager):
                 is_padding=input_buffers.is_padding[:graph_num_tokens],
             )
 
-        local_batch.seq_lens_np = local_batch.num_computed_tokens_np + local_batch.num_scheduled_tokens
+        local_seq_lens_np = local_batch.num_computed_tokens_np + local_batch.num_scheduled_tokens
+        if local_batch.num_reqs_after_padding > local_batch.num_reqs:
+            padded_seq_lens_np = np.zeros(
+                local_batch.num_reqs_after_padding,
+                dtype=local_seq_lens_np.dtype,
+            )
+            padded_seq_lens_np[: local_batch.num_reqs] = local_seq_lens_np
+            local_seq_lens_np = padded_seq_lens_np
+
+        local_batch.seq_lens_np = local_seq_lens_np
         num_valid_tokens = local_batch.num_scheduled_tokens
         if local_batch.num_draft_tokens_per_req is not None:
             num_valid_tokens = num_valid_tokens - local_batch.num_draft_tokens_per_req
@@ -140,6 +167,28 @@ class AscendPCPManager(PCPManager):
             num_valid_tokens,
         )
         return local_batch
+
+    def prepare_attn(
+        self,
+        input_batch: AscendInputBatch,
+    ) -> tuple[tuple[torch.Tensor, ...], torch.Tensor]:
+        """Use capture-safe dummy metadata without changing runtime prep."""
+        if not input_batch.is_dummy:
+            return super().prepare_attn(input_batch)
+
+        assert self._local_block_tables is not None
+        num_reqs = input_batch.num_reqs_after_padding
+        for block_table in self._local_block_tables:
+            block_table[:num_reqs].zero_()
+        return (
+            tuple(
+                block_table[:num_reqs]
+                for block_table in self._local_block_tables
+            ),
+            self.get_dummy_slot_mappings(
+                input_batch.num_tokens_after_padding
+            ),
+        )
 
     def prepare_slot_mappings(self) -> torch.Tensor:
         """Pad PCP slot mappings to the fixed FULL-decode graph layout.


### PR DESCRIPTION
### What this PR does / why we need it?

This Draft PR is a focused follow-up to the MRV2 PCP graph support already merged into `main`. It fixes tail batches under `FULL_DECODE_ONLY`, where graph padding and the PCP-partitioned batch can disagree about FIA dummy requests.

- Preserve the authoritative global/FIA dummy-query layout while partitioning a PCP batch.
- Pad sequence lengths and hidden-state restore indices to the graph-padded request count.
- Keep graph-capture input buffers persistent and initialize unused entries with `PAD_SLOT_ID`.
- Add focused regression coverage for tail-batch metadata, dummy requests, hidden-state restoration, and capture-buffer reuse.

The change is intentionally independent of speculative decoding and can be reviewed as a general PCP graph correctness fix.

### Does this PR introduce _any_ user-facing change?

No API or CLI change. It prevents invalid metadata and shape mismatches for MRV2 PCP tail batches in `FULL_DECODE_ONLY` graph mode.

### How was this patch tested?

Current extracted branch:

- `python -m py_compile vllm_ascend/worker/v2/pcp_manager.py tests/ut/worker/test_pcp_manager_v2.py`
- `ruff check` on the changed production and test files
- `git diff --check upstream/main...HEAD`

Earlier validation of the same graph-padding patch:

- `pytest -q tests/ut/worker/test_pcp_manager_v2.py` — 7 passed, 1 skipped
- MiniMax GPQA service validation completed 198/198 requests after the tail-batch fix

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
