### PR TITLE
[Feature][MRV2] Support MTP and Eagle3 speculative decoding with PCP

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -178,6 +178,12 @@ a3:
       - name: mtpx-deepseek-r1-0528-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: MTPX-DeepSeek-R1-0528-W8A8.yaml
+      - name: mtpx-deepseek-r1-0528-w8a8-pcp
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: MTPX-DeepSeek-R1-0528-W8A8-PCP.yaml
+      - name: eagle3-qwen3-8b-bf16-pcp
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Eagle3-Qwen3-8B-BF16-PCP.yaml
       - name: deepseek-r1-0528-w8a8
         os: linux-aarch64-nightly-a3-16
         config_file_path: DeepSeek-R1-0528-W8A8.yaml
@@ -294,6 +300,12 @@ a3-560t:
       - name: mtpx-deepseek-r1-0528-w8a8
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: MTPX-DeepSeek-R1-0528-W8A8.yaml
+      - name: mtpx-deepseek-r1-0528-w8a8-pcp
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: MTPX-DeepSeek-R1-0528-W8A8-PCP.yaml
+      - name: eagle3-qwen3-8b-bf16-pcp
+        os: linux-aarch64-a3-16-cn12-001
+        config_file_path: Eagle3-Qwen3-8B-BF16-PCP.yaml
       - name: deepseek-r1-0528-w8a8
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: DeepSeek-R1-0528-W8A8.yaml

--- a/docs/source/user_guide/feature_guide/context_parallel.md
+++ b/docs/source/user_guide/feature_guide/context_parallel.md
@@ -19,8 +19,8 @@ PCP support is experimental and available only with ModelRunner V2. The followin
 
 | Attention Backend | Basic PCP | Prefix Caching + PCP | Chunked Prefill + PCP | MLAPO + PCP | Speculative Decoding + PCP | P/D Disaggregation + PCP | Sequence Parallelism (SP) + PCP |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| MLA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
-| GQA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
+| MLA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | 🟠 Partial compatibility (MTP, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
+| GQA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | 🟠 Partial compatibility (Eagle3, eager and `FULL_DECODE_ONLY`) | ❌ No compatibility | ❌ No compatibility |
 | SFA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
 | DSA | ✅ Full compatibility | ✅ Full compatibility | ✅ Full compatibility | — Not applicable | ❌ No compatibility | ❌ No compatibility | ❌ No compatibility |
 
@@ -64,9 +64,55 @@ vllm serve <supported-model> \
 
 Unlike DCP, PCP adds extra ranks: `world_size_with_pcp = prefill_context_parallel_size * original_world_size`.
 
+#### Speculative Decoding
+
+MRV2 PCP supports MTP with MLA models and Eagle3 with GQA models. The target model runs with the configured PCP topology, while the draft model is replicated on every PCP rank and runs with a logical PCP size of `1`. Configure PCP only for the target model.
+
+For general speculative decoding configuration and model requirements, see [Speculative Decoding](speculative_decoding.md).
+
+##### MTP with MLA
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+
+vllm serve <mtp-capable-mla-model> \
+    --tensor-parallel-size 2 \
+    --prefill-context-parallel-size 2 \
+    --enable-chunked-prefill \
+    --enforce-eager \
+    --speculative-config '{"method": "mtp", "num_speculative_tokens": 3}'
+```
+
+##### Eagle3 with GQA
+
+```bash
+export VLLM_USE_V2_MODEL_RUNNER=1
+
+vllm serve <gqa-target-model> \
+    --tensor-parallel-size 2 \
+    --prefill-context-parallel-size 2 \
+    --enable-chunked-prefill \
+    --enforce-eager \
+    --speculative-config '{"method": "eagle3", "model": "<eagle3-draft-model>", "num_speculative_tokens": 3}'
+```
+
+For either method, remove `--enforce-eager` and add the following option to use the supported graph mode:
+
+```bash
+--compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+```
+
 #### Constraints
 
 - PCP is supported only with ModelRunner V2.
+- PCP speculative decoding supports only MTP with MLA models and Eagle3 with GQA models.
+- Draft sampling must use the greedy method.
+- Full graph execution with PCP is limited to `FULL_DECODE_ONLY`.
+- Pipeline parallelism, encoder-decoder models, multimodal inputs, and LoRA are not supported with MRV2 PCP.
+- DSA and SFA draft attention are not supported with PCP speculative decoding.
+- PCP and DCP cannot be enabled simultaneously.
+- Adaptive verification is not supported with PCP speculative decoding.
+- Dynamic draft lengths are outside the currently validated scope.
 - PCP and [DSA-CP](#dsa-cp) cannot be enabled simultaneously with the DSA backend.
 
 ### Decode Context Parallel

--- a/tests/e2e/nightly/single_node/models/configs/Eagle3-Qwen3-8B-BF16-PCP.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Eagle3-Qwen3-8B-BF16-PCP.yaml
@@ -1,0 +1,53 @@
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "Eagle3-Qwen3-8B-BF16-PCP"
+    model: "Qwen/Qwen3-8B"
+    envs:
+      VLLM_WORKER_MULTIPROC_METHOD: "spawn"
+      VLLM_USE_V2_MODEL_RUNNER: "1"
+      HCCL_BUFFSIZE: "1024"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      TASK_QUEUE_ENABLE: "1"
+      LCCL_DETERMINISTIC: "1"
+      SERVER_PORT: "DEFAULT_PORT"
+      VLLM_ENGINE_READY_TIMEOUT_S: "3000"
+    server_cmd:
+      - "--seed"
+      - "1024"
+      - "--no-enable-prefix-caching"
+      - "--enable-chunked-prefill"
+      - "--tensor-parallel-size"
+      - "2"
+      - "--prefill-context-parallel-size"
+      - "2"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-model-len"
+      - "15500"
+      - "--max-num-batched-tokens"
+      - "2048"
+      - "--max-num-seqs"
+      - "32"
+      - "--trust-remote-code"
+      - "--distributed-executor-backend"
+      - "mp"
+      - "--speculative-config"
+      - '{"method": "eagle3", "model": "RedHatAI/Qwen3-8B-speculator.eagle3", "num_speculative_tokens": 3}'
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--compilation-config"
+      - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+    benchmarks:
+      acc:
+        case_type: accuracy
+        dataset_path: vllm-ascend/gsm8k
+        request_conf: vllm_api_general_chat
+        dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+        max_out_len: 10240
+        batch_size: 32
+        temperature: 0
+        baseline: 93.3
+        threshold: 10

--- a/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8-PCP.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8-PCP.yaml
@@ -1,0 +1,54 @@
+# ==========================================
+# ACTUAL TEST CASES
+# ==========================================
+
+test_cases:
+  - name: "MTPX-DeepSeek-R1-0528-W8A8-mtp3-PCP"
+    model: "vllm-ascend/DeepSeek-R1-0528-W8A8"
+    envs:
+      OMP_NUM_THREADS: "100"
+      OMP_PROC_BIND: "false"
+      HCCL_BUFFSIZE: "1024"
+      HCCL_OP_EXPANSION_MODE: "AIV"
+      VLLM_RPC_TIMEOUT: "3600000"
+      VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "3600000"
+      VLLM_USE_V2_MODEL_RUNNER: "1"
+      SERVER_PORT: "DEFAULT_PORT"
+      VLLM_ENGINE_READY_TIMEOUT_S: "7200"
+    server_cmd:
+      - "--quantization"
+      - "ascend"
+      - "--seed"
+      - "1024"
+      - "--no-enable-prefix-caching"
+      - "--enable-chunked-prefill"
+      - "--tensor-parallel-size"
+      - "8"
+      - "--prefill-context-parallel-size"
+      - "2"
+      - "--enable-expert-parallel"
+      - "--port"
+      - "$SERVER_PORT"
+      - "--max-model-len"
+      - "40960"
+      - "--max-num-seqs"
+      - "14"
+      - "--max-num-batched-tokens"
+      - "2048"
+      - "--trust-remote-code"
+      - "--speculative-config"
+      - '{"num_speculative_tokens": 3, "method": "mtp"}'
+      - "--gpu-memory-utilization"
+      - "0.9"
+      - "--compilation-config"
+      - '{"cudagraph_capture_sizes": [56], "cudagraph_mode": "FULL_DECODE_ONLY"}'
+    benchmarks:
+      acc:
+        case_type: accuracy
+        dataset_path: vllm-ascend/aime2024
+        request_conf: vllm_api_general_chat
+        dataset_conf: aime2024/aime2024_gen_0_shot_chat_prompt
+        max_out_len: 32768
+        batch_size: 32
+        baseline: 86.67
+        threshold: 10

--- a/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
+++ b/tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Model Runner V2 context-parallel accuracy guards.
+"""Model Runner V2 context-parallel accuracy and feature guards.
 
 Run `pytest tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py`.
 """
@@ -26,6 +26,7 @@ from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
+from vllm import SamplingParams
 
 from tests.e2e.conftest import DPVllmRunner, VllmRunner, wait_until_npu_memory_free
 
@@ -33,6 +34,11 @@ MAX_NUM_SEQS = 4
 FULL_DECODE_GRAPH = {
     "cudagraph_mode": "FULL_DECODE_ONLY",
     "cudagraph_capture_sizes": [MAX_NUM_SEQS],
+}
+
+PCP_FULL_DECODE_GRAPH = {
+    "cudagraph_mode": "FULL_DECODE_ONLY",
+    "cudagraph_capture_sizes": [4, 8],
 }
 
 DSV3_2_MODEL = "vllm-ascend/DeepSeek-V3.2-W8A8-Pruning"
@@ -77,6 +83,17 @@ DSV4_PROMPTS = [
 DSV4_DSA_PCP_GOLDENS = [
     "Hello, my name is {name} and I",
     'What is the meaning of life?",\n    "What is',
+]
+
+
+MTP_PCP_MODEL = "wemaster/deepseek_mtp_main_random_bf16"
+EAGLE3_PCP_TARGET_MODEL = "Qwen/Qwen3-8B"
+EAGLE3_PCP_DRAFT_MODEL = "RedHatAI/Qwen3-8B-speculator.eagle3"
+
+LONG_CONTEXT = "This is a long context for PCP prefill validation. " * 64
+PCP_PROMPTS = [
+    LONG_CONTEXT + "Hello, my name is",
+    LONG_CONTEXT + "The president of the United States is",
 ]
 
 
@@ -267,3 +284,92 @@ def test_dsv3_2_sfa_pcp_model_runner_v2_graph_accuracy() -> None:
 def test_dsv4_dsa_pcp_model_runner_v2_graph_accuracy() -> None:
     """Guard MRV2 DSA PCP full-decode-only graph accuracy."""
     _run_accuracy_case(DSV4_DSA_PCP_CASE)
+
+
+def _run_pcp_spec_decode(
+    model: str,
+    speculative_config: dict[str, object],
+) -> None:
+    sampling_params = SamplingParams(max_tokens=16, temperature=0.0)
+    with VllmRunner(
+        model,
+        tensor_parallel_size=2,
+        prefill_context_parallel_size=2,
+        max_model_len=1024,
+        max_num_batched_tokens=64,
+        max_num_seqs=MAX_NUM_SEQS,
+        disable_log_stats=False,
+        distributed_executor_backend="mp",
+        enable_chunked_prefill=True,
+        compilation_config=PCP_FULL_DECODE_GRAPH,
+        speculative_config=speculative_config,
+    ) as runner:
+        outputs = runner.model.generate(PCP_PROMPTS, sampling_params)
+        metrics = runner.model.get_metrics()
+        num_drafts = sum(metric.value for metric in metrics if metric.name == "vllm:spec_decode_num_drafts")
+
+    token_ids = [output.outputs[0].token_ids for output in outputs]
+    assert len(token_ids) == len(PCP_PROMPTS)
+    assert all(token_ids)
+    assert num_drafts > 0
+
+
+@pytest.mark.e2e_model(MTP_PCP_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="moe",
+    feature="mtp,chunked_prefill",
+    parallel="TP,PCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "1024",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_mtp_mla_spec_decode_with_pcp() -> None:
+    """Guard MRV2 MTP MLA PCP full-decode-only graph execution."""
+    _run_pcp_spec_decode(
+        MTP_PCP_MODEL,
+        {
+            "method": "mtp",
+            "num_speculative_tokens": 3,
+        },
+    )
+
+
+@pytest.mark.e2e_model(EAGLE3_PCP_TARGET_MODEL, EAGLE3_PCP_DRAFT_MODEL)
+@pytest.mark.e2e_coverage(
+    arch="dense",
+    feature="eagle3,chunked_prefill",
+    parallel="TP,PCP",
+    deploy="pd_mix",
+    hardware="A3",
+    quantization="BF16",
+    graph_mode="full_decode_only",
+)
+@patch.dict(
+    os.environ,
+    {
+        "VLLM_USE_V2_MODEL_RUNNER": "1",
+        "VLLM_WORKER_MULTIPROC_METHOD": "spawn",
+        "HCCL_BUFFSIZE": "1024",
+    },
+)
+@wait_until_npu_memory_free(target_free_percentage=0.8)
+def test_eagle3_gqa_spec_decode_with_pcp() -> None:
+    """Guard MRV2 Eagle3 GQA PCP full-decode-only graph execution."""
+    _run_pcp_spec_decode(
+        EAGLE3_PCP_TARGET_MODEL,
+        {
+            "method": "eagle3",
+            "model": EAGLE3_PCP_DRAFT_MODEL,
+            "num_speculative_tokens": 3,
+        },
+    )

--- a/tests/ut/test_platform.py
+++ b/tests/ut/test_platform.py
@@ -662,6 +662,7 @@ class TestNPUPlatform(TestBase):
     def test_set_additional_forward_context_v2_includes_required_moe_fields(self):
         vllm_config = TestNPUPlatform.mock_vllm_config()
         vllm_config.use_v2_model_runner = True
+        vllm_config.parallel_config.prefill_context_parallel_size = 2
         dummy_comm_method = object()
 
         with (
@@ -683,6 +684,7 @@ class TestNPUPlatform(TestBase):
 
         self.assertFalse(kwargs["in_profile_run"])
         self.assertEqual(kwargs["padded_num_tokens"], 8)
+        self.assertEqual(kwargs["max_tokens_across_pcp"], 5)
         self.assertIs(kwargs["moe_comm_method"], dummy_comm_method)
         self.assertEqual(kwargs["dynamic_mx_quant_scale_alg"], 0)
 

--- a/tests/ut/worker/test_model_runner_v2.py
+++ b/tests/ut/worker/test_model_runner_v2.py
@@ -1,8 +1,9 @@
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import numpy as np
 import pytest
+import torch
 from vllm.config import CUDAGraphMode
 from vllm.v1.worker.gpu.model_runner import GPUModelRunner
 
@@ -97,3 +98,51 @@ def test_full_decode_only_keeps_graph_descriptor_request_count():
 
     assert num_reqs_padded == 4
     np.testing.assert_array_equal(actual[:5], np.array([0, 1, 2, 3, 4], dtype=np.int32))
+
+
+def test_sample_tokens_restores_replicated_draft_hidden_states():
+    runner = _make_runner(need_timing=False)
+    runner.is_last_pp_rank = True
+    runner.speculator = SimpleNamespace(replicated_pcp=True)
+    runner.use_spec_pp = False
+
+    aux_hidden_states = [
+        torch.arange(6, dtype=torch.float32).reshape(2, 3),
+        torch.arange(4, dtype=torch.float32).reshape(2, 2),
+    ]
+    state = Mock(aux_hidden_states=aux_hidden_states)
+    restored_state = object()
+    state._replace.return_value = restored_state
+    runner.execute_model_state = state
+
+    target_hidden_states = object()
+    restored_aux_hidden_states = torch.ones(4, 5)
+    runner.pcp_manager = SimpleNamespace(
+        restore_hidden_state_buffer=Mock(),
+        restore_hidden_states=Mock(
+            return_value=restored_aux_hidden_states,
+        ),
+    )
+    runner.model = SimpleNamespace(
+        get_mtp_target_hidden_states=lambda: target_hidden_states,
+    )
+    grammar_output = object()
+    expected_output = object()
+
+    with patch.object(
+        GPUModelRunner,
+        "sample_tokens",
+        return_value=expected_output,
+    ) as parent_sample_tokens:
+        actual = runner.sample_tokens(grammar_output)
+
+    assert actual is expected_output
+    parent_sample_tokens.assert_called_once_with(grammar_output)
+    runner.pcp_manager.restore_hidden_state_buffer.assert_called_once_with(target_hidden_states)
+    restored_input = runner.pcp_manager.restore_hidden_states.call_args.args[0]
+    torch.testing.assert_close(
+        restored_input,
+        torch.cat(aux_hidden_states, dim=-1),
+    )
+    state._replace.assert_called_once_with(aux_hidden_states=[restored_aux_hidden_states])
+    assert runner.execute_model_state is restored_state

--- a/tests/ut/worker/test_mtp_pcp_speculator_v2.py
+++ b/tests/ut/worker/test_mtp_pcp_speculator_v2.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+import torch
+from vllm.v1.worker.gpu.spec_decode.mtp.speculator import MTPSpeculator
+
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch
+from vllm_ascend.worker.v2.spec_decode.autoregressive import (
+    speculator as speculator_module,
+)
+from vllm_ascend.worker.v2.spec_decode.mtp.speculator import (
+    AscendMTPSpeculator,
+)
+from vllm_ascend.worker.v2.spec_decode.pcp_utils import (
+    disable_target_pcp_for_replicated_draft,
+)
+
+
+def _make_padded_input_batch() -> MagicMock:
+    input_batch = MagicMock(spec=AscendInputBatch)
+    input_batch.num_reqs = 2
+    input_batch.num_reqs_after_padding = 4
+    input_batch.num_tokens = 6
+    input_batch.num_tokens_after_padding = 8
+    input_batch.idx_mapping = torch.tensor([3, 7], dtype=torch.int32)
+    input_batch.query_start_loc = torch.tensor([0, 3, 6, 6, 6], dtype=torch.int32)
+    input_batch.query_start_loc_np = np.array([0, 3, 6, 6, 6], dtype=np.int32)
+    input_batch.seq_lens = torch.arange(4, dtype=torch.int32)
+    input_batch.seq_lens_cpu_upper_bound = torch.arange(4, dtype=torch.int32)
+    input_batch.input_ids = torch.arange(8, dtype=torch.int32)
+    input_batch.positions = torch.arange(8, dtype=torch.int64)
+    input_batch.is_padding = torch.zeros(8, dtype=torch.bool)
+    input_batch.seq_lens_np = np.arange(4, dtype=np.int32)
+    return input_batch
+
+
+@pytest.mark.parametrize(
+    ("target_pcp_size", "expected_execution_pcp_size"),
+    [(2, 1), (1, 1)],
+)
+def test_draft_runtime_config_preserves_target_worker_topology(
+    target_pcp_size: int,
+    expected_execution_pcp_size: int,
+) -> None:
+    draft_parallel_config = SimpleNamespace(
+        prefill_context_parallel_size=2,
+        enable_expert_parallel=False,
+        enable_eplb=False,
+        rank=0,
+    )
+    target_parallel_config = SimpleNamespace(
+        prefill_context_parallel_size=target_pcp_size,
+        enable_expert_parallel=True,
+        enable_eplb=True,
+        rank=7,
+        data_parallel_size=2,
+        data_parallel_rank=1,
+    )
+    target_config = SimpleNamespace(
+        parallel_config=target_parallel_config,
+        speculative_config=SimpleNamespace(
+            draft_parallel_config=draft_parallel_config,
+        ),
+        compilation_config=SimpleNamespace(
+            cudagraph_mode=SimpleNamespace(decode_mode=lambda: None),
+        ),
+    )
+    draft_model_config = object()
+    captured: dict[str, SimpleNamespace] = {}
+
+    def fake_replace(config, **changes):
+        values = vars(config).copy()
+        values.update(changes)
+        return SimpleNamespace(**values)
+
+    def fake_parent_init(speculator, execution_config, device):
+        captured["execution_config"] = execution_config
+        speculator.vllm_config = execution_config
+        speculator.speculative_config = execution_config.speculative_config
+        speculator.draft_model_config = draft_model_config
+        speculator.input_buffers = object()
+        speculator.max_num_reqs = 4
+        speculator.max_num_tokens = 8
+        speculator.num_speculative_steps = 3
+
+    with (
+        patch.object(
+            speculator_module,
+            "replace",
+            side_effect=fake_replace,
+        ),
+        patch.object(
+            speculator_module.AutoRegressiveSpeculator,
+            "__init__",
+            new=fake_parent_init,
+        ),
+        patch.object(
+            speculator_module,
+            "AscendInputBuffers",
+            return_value=object(),
+        ),
+    ):
+        speculator = AscendMTPSpeculator(target_config, torch.device("cpu"))
+
+    execution_config = captured["execution_config"]
+    execution_parallel_config = execution_config.parallel_config
+    assert execution_parallel_config.prefill_context_parallel_size == expected_execution_pcp_size
+    assert execution_parallel_config.enable_expert_parallel
+    assert execution_parallel_config.enable_eplb
+    assert execution_parallel_config.rank == target_parallel_config.rank
+    assert execution_parallel_config.data_parallel_size == 2
+    assert execution_parallel_config.data_parallel_rank == 1
+    assert target_parallel_config.prefill_context_parallel_size == target_pcp_size
+    assert target_parallel_config.enable_expert_parallel
+    assert target_parallel_config.enable_eplb
+
+    draft_config = speculator.draft_vllm_config
+    assert draft_parallel_config.prefill_context_parallel_size == 2
+    assert not draft_parallel_config.enable_expert_parallel
+    assert not draft_parallel_config.enable_eplb
+    assert draft_config.model_config is draft_model_config
+    assert draft_config.parallel_config.prefill_context_parallel_size == expected_execution_pcp_size
+    assert draft_config.parallel_config.pipeline_parallel_size == 1
+
+
+@pytest.mark.parametrize(("replicated_pcp", "manager_is_disabled"), [(True, True), (False, False)])
+def test_draft_pcp_context_restores_manager_after_error(
+    replicated_pcp: bool,
+    manager_is_disabled: bool,
+) -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.pcp_manager = MagicMock()
+    speculator.replicated_pcp = replicated_pcp
+    speculator.model_state = SimpleNamespace(pcp_manager=speculator.pcp_manager)
+
+    with (
+        pytest.raises(RuntimeError, match="proposal failed"),
+        disable_target_pcp_for_replicated_draft(speculator),
+    ):
+        assert (speculator.model_state.pcp_manager is None) is manager_is_disabled
+        raise RuntimeError("proposal failed")
+
+    assert speculator.model_state.pcp_manager is speculator.pcp_manager
+
+
+def test_draft_pcp_context_rejects_mismatched_manager() -> None:
+    current_pcp_manager = MagicMock()
+    speculator = SimpleNamespace(
+        replicated_pcp=True,
+        model_state=SimpleNamespace(pcp_manager=current_pcp_manager),
+        pcp_manager=MagicMock(),
+    )
+
+    with (
+        pytest.raises(
+            RuntimeError,
+            match="requires model_state to use the target PCP manager",
+        ),
+        disable_target_pcp_for_replicated_draft(speculator),
+    ):
+        pytest.fail("mismatched manager must fail before draft execution")
+
+    assert speculator.model_state.pcp_manager is current_pcp_manager
+
+
+@pytest.mark.parametrize(
+    ("replicated_pcp", "expected_source"),
+    [(True, "draft"), (False, "target")],
+)
+def test_draft_prefill_attn_groups_follow_draft_topology(
+    replicated_pcp: bool,
+    expected_source: str,
+) -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.replicated_pcp = replicated_pcp
+    speculator.attn_groups = [["draft"]]
+    speculator.target_attn_groups = [["target"]]
+
+    expected = speculator.attn_groups if expected_source == "draft" else speculator.target_attn_groups
+    assert speculator.draft_prefill_attn_groups is expected
+
+
+def test_prepare_replicated_prefill_attn_uses_global_batch() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.block_tables = MagicMock()
+    speculator.kv_cache_config = object()
+    speculator._build_draft_attn_metadata = MagicMock(return_value={"draft.layer": object()})
+    input_batch = _make_padded_input_batch()
+    input_batch.is_dummy = False
+    speculator.input_batch = input_batch
+    speculator.replicated_pcp = True
+    global_slot_mapping = torch.arange(input_batch.num_tokens_after_padding).unsqueeze(0)
+    slot_mappings = {"draft.layer": object()}
+    speculator.block_tables.compute_slot_mappings.return_value = global_slot_mapping
+    original_attn_metadata = {"local.layer": object()}
+    original_slot_mappings = MagicMock()
+
+    with patch.object(
+        speculator_module,
+        "build_slot_mappings_by_layer",
+        return_value=slot_mappings,
+    ) as build_slot_mappings:
+        attn_metadata, actual_slot_mappings = speculator._prepare_replicated_prefill_attn(
+            original_attn_metadata,
+            original_slot_mappings,
+            input_batch.num_reqs_after_padding,
+            input_batch.num_tokens_after_padding,
+        )
+
+    assert attn_metadata == speculator._build_draft_attn_metadata.return_value
+    assert actual_slot_mappings is slot_mappings
+    speculator.block_tables.gather_block_tables.assert_called_once_with(
+        input_batch.idx_mapping,
+        num_reqs_padded=input_batch.num_reqs_after_padding,
+    )
+    speculator.block_tables.compute_slot_mappings.assert_called_once_with(
+        input_batch.idx_mapping,
+        input_batch.query_start_loc,
+        input_batch.positions,
+        num_tokens_padded=input_batch.num_tokens_after_padding,
+    )
+    build_slot_mappings.assert_called_once_with(
+        global_slot_mapping,
+        speculator.kv_cache_config,
+    )
+    speculator._build_draft_attn_metadata.assert_called_once_with(
+        num_reqs=input_batch.num_reqs,
+        num_reqs_padded=input_batch.num_reqs_after_padding,
+        num_tokens_padded=input_batch.num_tokens_after_padding,
+        seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+        step=0,
+        query_start_loc_np=input_batch.query_start_loc_np,
+    )
+
+
+def test_prefill_rebuilds_replicated_pcp_metadata_before_filtering() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.replicated_pcp = True
+    speculator.input_batch = _make_padded_input_batch()
+    speculator.input_batch.is_dummy = False
+    speculator.draft_attn_layer_names = {"draft.layer"}
+
+    draft_metadata = object()
+    global_slot_mappings = MagicMock()
+    speculator._prepare_replicated_prefill_attn = MagicMock(
+        return_value=(
+            {
+                "draft.layer": draft_metadata,
+                "target.layer": object(),
+            },
+            global_slot_mappings,
+        )
+    )
+    local_attn_metadata = {"local.layer": object()}
+    local_slot_mappings = MagicMock()
+
+    with patch.object(
+        speculator_module.AutoRegressiveSpeculator,
+        "_prefill",
+    ) as parent_prefill:
+        speculator._prefill(
+            num_reqs=2,
+            num_tokens=8,
+            attn_metadata=local_attn_metadata,
+            slot_mappings=local_slot_mappings,
+            num_tokens_across_dp=None,
+        )
+
+    speculator._prepare_replicated_prefill_attn.assert_called_once_with(
+        local_attn_metadata,
+        local_slot_mappings,
+        2,
+        8,
+    )
+    parent_prefill.assert_called_once()
+    parent_args = parent_prefill.call_args.args
+    assert parent_args[:2] == (2, 8)
+    assert parent_args[2] == {"draft.layer": draft_metadata}
+    assert parent_args[3] is global_slot_mappings
+
+
+def test_graph_prefill_reuses_model_state_metadata() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.draft_attn_layer_names = {"draft.layer"}
+    draft_metadata = object()
+    speculator.model_state = SimpleNamespace(
+        attn_metadata={
+            "draft.layer": draft_metadata,
+            "target.layer": object(),
+        }
+    )
+
+    actual = speculator.build_draft_attn_metadatas(
+        num_reqs_padded=4,
+        is_draft_model_prefill=True,
+    )
+
+    assert actual == [{"draft.layer": draft_metadata}]
+
+
+def test_propose_disables_target_pcp_manager_for_replicated_draft() -> None:
+    speculator = object.__new__(AscendMTPSpeculator)
+    speculator.replicated_pcp = True
+    speculator.input_batch = None
+    speculator.pcp_manager = MagicMock()
+    speculator.model_state = SimpleNamespace(
+        pcp_manager=speculator.pcp_manager,
+    )
+    input_batch = _make_padded_input_batch()
+    expected = object()
+
+    def parent_propose(*args, **kwargs):
+        assert args[0] is input_batch
+        assert speculator.model_state.pcp_manager is None
+        return expected
+
+    with (
+        patch.object(
+            MTPSpeculator,
+            "propose",
+            side_effect=parent_propose,
+        ),
+        patch.object(
+            speculator_module,
+            "build_attn_metadata_wrapper",
+            return_value=nullcontext(),
+        ),
+        patch.object(
+            speculator_module,
+            "torch_gather_wrapper",
+            return_value=nullcontext(),
+        ),
+    ):
+        actual = speculator.propose(
+            input_batch,
+            *[MagicMock() for _ in range(10)],
+        )
+
+    assert actual is expected
+    assert speculator.input_batch is input_batch
+    assert speculator.model_state.pcp_manager is speculator.pcp_manager

--- a/tests/ut/worker/test_pcp_manager_v2.py
+++ b/tests/ut/worker/test_pcp_manager_v2.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 # This file is a part of the vllm-ascend project.
 #
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -25,7 +26,9 @@ import torch
 from vllm.config import CUDAGraphMode
 from vllm.v1.worker.gpu import model_runner as vllm_model_runner
 from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
+from vllm_ascend.worker.v2 import states as states_module
 from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
 from vllm_ascend.worker.v2.model_runner import NPUModelRunner
 from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
@@ -315,6 +318,298 @@ def test_prepare_slot_mappings_pads_each_pcp_rank_for_full_decode_graph() -> Non
     assert torch.equal(result, expected)
 
 
+def test_partition_batch_preserves_fia_dummy_layout() -> None:
+    global_batch = _make_global_pcp_batch()
+    global_batch.req_ids = ["decode-req"]
+    global_batch.num_scheduled_tokens = np.array([1], dtype=np.int32)
+    global_batch.num_tokens = 1
+    global_batch.num_reqs_after_padding = 2
+    global_batch.num_tokens_after_padding = 4
+    global_batch.query_start_loc_np = np.array([0, 1, 4], dtype=np.int32)
+    global_batch.query_start_loc = torch.tensor(
+        [0, 1, 4],
+        dtype=torch.int32,
+    )
+    global_batch.num_computed_tokens_np = np.array([10], dtype=np.int32)
+    global_batch.prefill_len_np = np.array([10], dtype=np.int32)
+    global_batch.num_computed_prefill_tokens_np = np.array(
+        [10],
+        dtype=np.int32,
+    )
+    global_batch.is_prefilling_np = np.array([False])
+    global_batch.seq_lens = torch.tensor([11, 999], dtype=torch.int32)
+    global_batch.seq_lens_cpu_upper_bound = torch.tensor(
+        [11],
+        dtype=torch.int32,
+    )
+    global_batch.input_ids[:4].copy_(torch.tensor([101, 999, 999, 999], dtype=torch.int32))
+    global_batch.positions[:4].copy_(torch.tensor([10, 999, 999, 999], dtype=torch.int64))
+    global_batch.is_padding[:4].fill_(False)
+
+    req_states = SimpleNamespace(
+        last_sampled_tokens=torch.zeros(2, dtype=torch.int64),
+        prefill_len=SimpleNamespace(gpu=torch.zeros(2, dtype=torch.int32)),
+        draft_tokens=torch.empty((2, 0), dtype=torch.int64),
+    )
+    manager = AscendPCPManager(
+        pcp_world_size=2,
+        pcp_rank=0,
+        device=torch.device("cpu"),
+        req_states=req_states,
+        max_num_reqs=2,
+        max_num_tokens=4,
+    )
+    manager.vllm_config = object()
+    input_buffers = manager._input_buffers
+    assert input_buffers is not None
+    input_buffers.positions[0] = 10
+    input_buffers.seq_lens[0] = 11
+
+    with (
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.prepare_pos_seq_lens",
+            return_value=None,
+        ),
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.combine_sampled_and_draft_tokens",
+            return_value=torch.zeros(1, dtype=torch.int64),
+        ),
+        patch(
+            "vllm.v1.worker.gpu.pcp_manager.async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.async_copy_to_gpu",
+            side_effect=_mock_async_copy_to_cpu,
+        ),
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.build_attn_state",
+            return_value=object(),
+        ),
+    ):
+        local_batch = manager.partition_batch(global_batch)
+
+    assert local_batch.num_reqs == 1
+    assert local_batch.num_reqs_after_padding == 2
+    assert local_batch.num_tokens == 1
+    assert local_batch.num_tokens_after_padding == 4
+    expected_query_start_loc = np.array([0, 1, 4], dtype=np.int32)
+    np.testing.assert_array_equal(
+        local_batch.query_start_loc_np,
+        expected_query_start_loc,
+    )
+    torch.testing.assert_close(
+        local_batch.query_start_loc,
+        torch.from_numpy(expected_query_start_loc),
+    )
+    assert local_batch.input_ids.tolist() == [101, 0, 0, 0]
+    assert local_batch.positions.tolist() == [10, 0, 0, 0]
+    assert local_batch.seq_lens.tolist() == [11, 0]
+    np.testing.assert_array_equal(
+        local_batch.seq_lens_np,
+        np.array([11, 0], dtype=np.int32),
+    )
+    assert local_batch.seq_lens_cpu_upper_bound.tolist() == [11, 0]
+    assert local_batch.is_padding.tolist() == [False, True, True, True]
+    assert manager._hidden_restore_idx is not None
+    assert manager._hidden_restore_idx[1:4].tolist() == [0, 0, 0]
+
+
+def test_partition_batch_restores_speculative_target_inputs() -> None:
+    global_batch = _make_global_pcp_batch()
+    global_batch.req_ids = ["spec-a", "spec-b"]
+    global_batch.num_reqs = 2
+    global_batch.num_reqs_after_padding = 2
+    global_batch.num_tokens = 5
+    global_batch.num_tokens_after_padding = 5
+    global_batch.input_ids = torch.tensor([101, 102, 201, 202, 203], dtype=torch.int32)
+    global_batch.positions = torch.tensor([10, 11, 20, 21, 22], dtype=torch.int64)
+    global_batch.is_padding = torch.zeros(5, dtype=torch.bool)
+    global_batch.num_scheduled_tokens = np.array([2, 3], dtype=np.int32)
+    global_batch.num_computed_tokens_np = np.array([10, 20], dtype=np.int32)
+    global_batch.is_prefilling_np = np.array([False, False])
+    global_batch.num_draft_tokens = 3
+    global_batch.num_draft_tokens_per_req = np.array([1, 2], dtype=np.int32)
+
+    local_batch = replace(
+        global_batch,
+        req_ids=["spec-b", "spec-a"],
+        input_ids=torch.zeros(5, dtype=torch.int32),
+        num_draft_tokens=0,
+        num_draft_tokens_per_req=None,
+        num_scheduled_tokens=np.array([3, 2], dtype=np.int32),
+        num_computed_tokens_np=np.array([20, 10], dtype=np.int32),
+        seq_lens_np=np.array([23, 12], dtype=np.int32),
+    )
+    manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager.pcp_rank = 1
+    manager.pcp_world_size = 2
+    manager._padded_gather_idx = torch.tensor([0, 1, 2, 3, 4, 2, 3, 4, 0, 1])
+    manager.vllm_config = object()
+    local_attn_state = object()
+
+    with (
+        patch.object(
+            PCPManager,
+            "partition_batch",
+            return_value=local_batch,
+        ) as parent_partition,
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.build_attn_state",
+            return_value=local_attn_state,
+        ),
+    ):
+        result = manager.partition_batch(global_batch)
+
+    parent_input = parent_partition.call_args.args[0]
+    assert parent_input is not global_batch
+    assert parent_input.num_draft_tokens == 0
+    assert parent_input.num_draft_tokens_per_req is None
+    assert manager._global_batch is global_batch
+    assert result.input_ids.tolist() == [201, 202, 203, 101, 102]
+    assert result.num_draft_tokens == 3
+    np.testing.assert_array_equal(
+        result.num_draft_tokens_per_req,
+        np.array([2, 1], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        result.seq_lens_np,
+        np.array([23, 12], dtype=np.int32),
+    )
+    assert result.attn_state is local_attn_state
+
+
+def test_request_state_cpu_and_numpy_tokens_share_storage() -> None:
+    def init_base_state(
+        state,
+        max_num_reqs,
+        max_model_len,
+        max_num_batched_tokens,
+        num_speculative_steps,
+        vocab_size,
+        device,
+    ) -> None:
+        state.max_num_reqs = max_num_reqs
+        state.num_computed_tokens_np = np.zeros(max_num_reqs, dtype=np.int32)
+
+    with patch.object(
+        states_module.RequestState,
+        "__init__",
+        init_base_state,
+    ):
+        state = states_module.AscendRequestState(
+            max_num_reqs=2,
+            max_model_len=16,
+            max_num_batched_tokens=16,
+            num_speculative_steps=1,
+            vocab_size=32,
+            device=torch.device("cpu"),
+        )
+
+    assert state.num_computed_tokens_cpu.data_ptr() == state.num_computed_tokens_np.ctypes.data
+    state.num_computed_tokens_np[0] = 17
+    assert state.num_computed_tokens_cpu[0].item() == 17
+    state.num_computed_tokens_cpu[1] = 23
+    assert state.num_computed_tokens_np[1] == 23
+
+
+def test_pcp_manager_restores_model_owned_hidden_buffer() -> None:
+    hidden_states = torch.tensor([[1.0, 2.0], [3.0, 4.0], [-1.0, -1.0], [-1.0, -1.0]])
+    restored = torch.tensor([[1.0, 2.0], [5.0, 6.0], [3.0, 4.0], [9.0, 9.0]])
+    manager = AscendPCPManager.__new__(AscendPCPManager)
+    manager.pcp_world_size = 2
+    manager._padded_gather_idx = torch.empty(6, dtype=torch.int64)
+    manager._global_batch = SimpleNamespace(
+        num_tokens=3,
+        num_tokens_after_padding=4,
+    )
+
+    captured_local_hidden_states = []
+
+    def parent_restore_hidden_states(value):
+        captured_local_hidden_states.append(value.clone())
+        return restored.clone()
+
+    with (
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.get_pp_group",
+            return_value=SimpleNamespace(is_last_rank=True),
+        ),
+        patch.object(
+            PCPManager,
+            "restore_hidden_states",
+            side_effect=parent_restore_hidden_states,
+        ) as restore_hidden_states_mock,
+    ):
+        manager.restore_hidden_state_buffer(hidden_states)
+
+    restore_hidden_states_mock.assert_called_once()
+    torch.testing.assert_close(
+        captured_local_hidden_states[0],
+        torch.tensor([[1.0, 2.0], [3.0, 4.0], [-1.0, -1.0]]),
+    )
+    torch.testing.assert_close(hidden_states[:3], restored[:3])
+    torch.testing.assert_close(hidden_states[3], torch.zeros(2))
+
+
+def test_pcp_manager_skips_hidden_restore_before_last_pp_rank() -> None:
+    manager = AscendPCPManager.__new__(AscendPCPManager)
+    hidden_states = torch.randn(2, 4)
+
+    with (
+        patch(
+            "vllm_ascend.worker.v2.pcp_manager.get_pp_group",
+            return_value=SimpleNamespace(is_last_rank=False),
+        ),
+        patch.object(PCPManager, "restore_hidden_states") as parent_restore,
+    ):
+        restored_hidden_states = manager.restore_hidden_states(hidden_states)
+        manager.restore_hidden_state_buffer(hidden_states)
+
+    assert restored_hidden_states is hidden_states
+    parent_restore.assert_not_called()
+
+
+@pytest.mark.parametrize("method", ["mtp", "eagle3"])
+def test_validate_config_allows_supported_speculators(method: str) -> None:
+    speculative_config = SimpleNamespace(
+        method=method,
+        draft_sample_method="greedy",
+    )
+    vllm_config = _make_pcp_config(
+        CUDAGraphMode.NONE,
+        sparse_mla=False,
+    )
+    vllm_config.speculative_config = speculative_config
+
+    AscendPCPManager.validate_config(
+        vllm_config,
+        supports_mm_inputs=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("method", "draft_sample_method", "error"),
+    [
+        ("draft_model", "greedy", "only with MTP and Eagle3"),
+        ("mtp", "random", "requires greedy draft sampling"),
+    ],
+)
+def test_validate_config_rejects_unsupported_speculator_options(
+    method: str,
+    draft_sample_method: str,
+    error: str,
+) -> None:
+    vllm_config = _make_pcp_config(CUDAGraphMode.NONE, sparse_mla=False)
+    vllm_config.speculative_config = SimpleNamespace(
+        method=method,
+        draft_sample_method=draft_sample_method,
+    )
+
+    with pytest.raises(NotImplementedError, match=error):
+        AscendPCPManager.validate_config(vllm_config, supports_mm_inputs=False)
+
+
 def test_mrv2_runner_registers_ascend_pcp_manager() -> None:
     runner = NPUModelRunner.__new__(NPUModelRunner)
     assert runner.pcp_manager_cls is AscendPCPManager
@@ -331,6 +626,7 @@ def test_sample_tokens_uses_global_batch_only_on_non_last_pp_rank(
     manager._global_batch = global_batch
     runner.pcp_manager = manager
     runner.is_last_pp_rank = is_last_pp_rank
+    runner.speculator = None
     runner.use_spec_pp = False
     runner.execute_model_state = vllm_model_runner.ExecuteModelState(
         input_batch=local_batch,

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -574,6 +574,8 @@ class NPUPlatform(Platform):
 
         if num_tokens is None and attn_metadata is not None:
             num_tokens = list(attn_metadata.values())[0].num_actual_tokens
+        pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
+        max_tokens_across_pcp = num_tokens if pcp_size > 1 else 0
         dp_world_size = get_dp_group().world_size
         if dp_world_size > 1 and dp_metadata is not None:
             max_tokens_across_dp = dp_metadata.num_tokens_across_dp_cpu.max().item()
@@ -608,6 +610,7 @@ class NPUPlatform(Platform):
             "num_tokens": num_tokens,
             "padded_length": padded_length,
             "max_tokens_across_dp": max_tokens_across_dp,
+            "max_tokens_across_pcp": max_tokens_across_pcp,
             "mc2_mask": mc2_mask,
             "is_draft_model": is_draft_model,
             "is_draft_model_prefill": is_draft_model_prefill,

--- a/vllm_ascend/worker/v2/model_runner.py
+++ b/vllm_ascend/worker/v2/model_runner.py
@@ -188,10 +188,8 @@ class NPUModelRunner(GPUModelRunner):
             device=self.device,
         )
 
-        # we need to copy num_computed_tokens back to cpu to help
-        # update actual seq_lens_cpu. gpu attention backend doesn't need these
-        # attributes, cause their attention backends doesn't use seq_lens_cpu.
-        # and seq_lens_cpu is deprecated in gpu_model_runner_v2.
+        # Pinned D2H staging for corrected device state after spec rejection.
+        # The authoritative host state is the shared NumPy/torch RequestState view.
         self.num_computed_tokens_event = torch.npu.Event()
         self.num_computed_tokens_stream = torch.npu.Stream()
         self.num_computed_tokens_cpu = torch.empty(
@@ -215,6 +213,33 @@ class NPUModelRunner(GPUModelRunner):
     def pcp_manager_cls(self) -> type[AscendPCPManager]:
         return AscendPCPManager
 
+    def _restore_replicated_draft_target_states(self) -> None:
+        """Restore target states consumed by a replicated PCP draft."""
+        state = self.execute_model_state
+        pcp_manager = self.pcp_manager
+        if (
+            state is None
+            or pcp_manager is None
+            or not self.is_last_pp_rank
+            or not getattr(self.speculator, "replicated_pcp", False)
+        ):
+            return
+
+        get_hidden_states = getattr(
+            self.model,
+            "get_mtp_target_hidden_states",
+            None,
+        )
+        if get_hidden_states is not None:
+            mtp_target_hidden_states = get_hidden_states()
+            if mtp_target_hidden_states is not None:
+                pcp_manager.restore_hidden_state_buffer(mtp_target_hidden_states)
+
+        aux_hidden_states = state.aux_hidden_states
+        if aux_hidden_states:
+            restored_aux_hidden_states = pcp_manager.restore_hidden_states(torch.cat(aux_hidden_states, dim=-1))
+            self.execute_model_state = state._replace(aux_hidden_states=[restored_aux_hidden_states])
+
     def sample_tokens(self, grammar_output):
         pcp_manager = self.pcp_manager
         if pcp_manager is not None and not self.is_last_pp_rank and self.execute_model_state is not None:
@@ -226,6 +251,8 @@ class NPUModelRunner(GPUModelRunner):
             self.execute_model_state = self.execute_model_state._replace(
                 input_batch=pcp_manager.global_batch,
             )
+
+        self._restore_replicated_draft_target_states()
         output = super().sample_tokens(grammar_output)
 
         if self.use_spec_pp and self.is_last_pp_rank:
@@ -241,6 +268,8 @@ class NPUModelRunner(GPUModelRunner):
                 assert isinstance(self.pcp_manager, AscendPCPManager)
                 self.pcp_manager.vllm_config = self.vllm_config
                 self.model_state.pcp_manager = self.pcp_manager
+                if self.speculator is not None:
+                    self.speculator.pcp_manager = self.pcp_manager
         if self.model_config.enable_return_routed_experts:
             self.init_routed_experts_capturer()
 
@@ -869,8 +898,7 @@ class NPUModelRunner(GPUModelRunner):
             query_start_loc,
         )
 
-        # Skip D2H copy without MTP: num_computed_tokens_cpu is synced
-        # from num_computed_tokens_np in _update_seq_lens_cpu instead.
+        # Without MTP, update_requests writes the shared NumPy/torch CPU state.
         if self.speculator is not None:
             self._copy_num_computed_tokens_to_cpu()
 
@@ -896,16 +924,13 @@ class NPUModelRunner(GPUModelRunner):
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
 
         # MTP needs D2H copy to get reverted num_computed_tokens after rejection.
-        # Without MTP, num_computed_tokens_np is already correct from update_requests.
+        # req_states.num_computed_tokens_cpu shares storage with its NumPy view,
+        # so this update also corrects the num_computed_tokens_np used by PCP.
         if self.speculator is not None:
             self.num_computed_tokens_event.synchronize()
             for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
                 req_index = self.req_states.req_id_to_index[req_id]
                 self.req_states.num_computed_tokens_cpu[req_index] = self.num_computed_tokens_cpu[req_index]
-        else:
-            for req_id in scheduler_output.scheduled_cached_reqs.req_ids:
-                req_index = self.req_states.req_id_to_index[req_id]
-                self.req_states.num_computed_tokens_cpu[req_index] = self.req_states.num_computed_tokens_np[req_index]
 
         # update seq_lens_cpu
         for i, req_id in enumerate(req_ids):  # type: ignore

--- a/vllm_ascend/worker/v2/pcp_manager.py
+++ b/vllm_ascend/worker/v2/pcp_manager.py
@@ -19,8 +19,11 @@
 
 from dataclasses import dataclass, replace
 
+import numpy as np
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.v1.worker.gpu.buffer_utils import async_copy_to_gpu
 from vllm.v1.worker.gpu.pcp_manager import PCPManager
 
 from vllm_ascend.worker.v2.attn_utils import build_attn_state
@@ -51,6 +54,11 @@ class AscendPCPManager(PCPManager):
             raise RuntimeError("PCP global batch is unavailable before partition_batch().")
         return global_batch
 
+    @property
+    def is_last_pp_rank(self) -> bool:
+        """Whether this PCP manager belongs to the last PP stage."""
+        return get_pp_group().is_last_rank
+
     @staticmethod
     def validate_config(
         vllm_config: VllmConfig,
@@ -69,9 +77,14 @@ class AscendPCPManager(PCPManager):
             raise NotImplementedError("MRV2 PCP does not support MM inputs yet.")
         if vllm_config.lora_config is not None:
             raise NotImplementedError("MRV2 PCP does not support LoRA yet.")
-        if vllm_config.speculative_config is not None:
-            raise NotImplementedError("MRV2 PCP does not support speculative decoding yet.")
-
+        speculative_config = vllm_config.speculative_config
+        if speculative_config is not None:
+            if speculative_config.method not in ("mtp", "eagle3"):
+                raise NotImplementedError("Ascend MRV2 PCP supports speculative decoding only with MTP and Eagle3.")
+            if speculative_config.draft_sample_method != "greedy":
+                raise NotImplementedError(
+                    "Ascend MRV2 PCP speculative decoding currently requires greedy draft sampling."
+                )
         is_sparse_mla = hasattr(model_config.hf_text_config, "index_topk")
         cudagraph_mode = vllm_config.compilation_config.cudagraph_mode
         if is_sparse_mla and cudagraph_mode not in {
@@ -82,18 +95,72 @@ class AscendPCPManager(PCPManager):
         if cudagraph_mode.has_full_cudagraphs() and cudagraph_mode != CUDAGraphMode.FULL_DECODE_ONLY:
             raise NotImplementedError("MRV2 PCP supports FULL_DECODE_ONLY CUDA graphs only.")
 
+    # TODO To bypass the upstream verification, a pseudo-batch method is used to perform reconstruction after bypassing,
+    # and the changes will be deleted after the upstream is merged.
+    def _partition_speculative_batch_compat(
+        self,
+        global_batch: AscendInputBatch,
+    ) -> AscendInputBatch:
+        """Adapt spec decode until upstream PCP supports it natively."""
+        global_draft_counts = global_batch.num_draft_tokens_per_req
+        if global_draft_counts is None:
+            raise RuntimeError("PCP speculative decoding requires per-request draft token counts.")
+        if np.any(global_draft_counts[global_batch.is_prefilling_np] != 0):
+            raise NotImplementedError("PCP speculative decoding does not support draft tokens on prefill requests.")
+
+        # Upstream currently rejects speculative batches before building the
+        # ordinary PCP rank-local layout. Temporarily clear only its spec
+        # indicators, then restore the authoritative speculative state below.
+        non_spec_batch = replace(  # type: ignore[call-arg]
+            global_batch,
+            num_draft_tokens=0,
+            num_draft_tokens_per_req=None,
+        )
+        try:
+            local_batch = super().partition_batch(non_spec_batch)
+        finally:
+            self._global_batch = global_batch
+        assert isinstance(local_batch, AscendInputBatch)
+
+        # Upstream rewrites the local decode tokens while constructing its
+        # non-spec logits layout. Restore the already prepared K+1 target
+        # inputs from the authoritative global batch.
+        assert self._padded_gather_idx is not None
+        local_num_tokens_padded = local_batch.num_tokens_after_padding
+        rank_token_start = self.pcp_rank * local_num_tokens_padded
+        local_gather_idx = self._padded_gather_idx[rank_token_start : rank_token_start + local_num_tokens_padded]
+        torch.index_select(
+            global_batch.input_ids,
+            0,
+            local_gather_idx,
+            out=local_batch.input_ids[:local_num_tokens_padded],
+        )
+        draft_count_by_req = dict(zip(global_batch.req_ids, global_draft_counts, strict=True))
+        local_draft_counts = np.fromiter(
+            (draft_count_by_req[req_id] for req_id in local_batch.req_ids),
+            dtype=np.int32,
+            count=local_batch.num_reqs,
+        )
+        return replace(  # type: ignore[call-arg]
+            local_batch,
+            num_draft_tokens=int(local_draft_counts.sum()),
+            num_draft_tokens_per_req=local_draft_counts,
+        )
+
     def partition_batch(self, input_batch: AscendInputBatch) -> AscendInputBatch:
         """Partition the batch and update Ascend-specific local metadata."""
-        local_batch = super().partition_batch(input_batch)
-        assert isinstance(local_batch, AscendInputBatch)
+        global_batch = input_batch
+        if global_batch.num_draft_tokens > 0:
+            local_batch = self._partition_speculative_batch_compat(global_batch)
+        else:
+            local_batch = super().partition_batch(global_batch)
+            assert isinstance(local_batch, AscendInputBatch)
 
         # PCP builds the local layout from actual tokens, but a FULL decode
         # graph replays a fixed padded layout on every rank.
-        graph_num_tokens = input_batch.num_tokens_after_padding
-        is_decode_only = not bool(input_batch.is_prefilling_np.any())
-        # FULL_DECODE_ONLY graphs capture one token for every padded request.
-        # Keep the request-shaped metadata at that same fixed graph extent.
-        graph_num_reqs = graph_num_tokens if is_decode_only else input_batch.num_reqs_after_padding
+        graph_num_tokens = global_batch.num_tokens_after_padding
+        graph_num_reqs = global_batch.num_reqs_after_padding
+        is_decode_only = not bool(global_batch.is_prefilling_np.any())
         if is_decode_only and graph_num_tokens > local_batch.num_tokens_after_padding:
             assert self._input_buffers is not None
             input_buffers = self._input_buffers
@@ -113,7 +180,20 @@ class AscendPCPManager(PCPManager):
             input_buffers.positions[actual_tokens:graph_num_tokens].zero_()
             input_buffers.is_padding[actual_tokens:graph_num_tokens].fill_(True)
             input_buffers.seq_lens[actual_reqs:graph_num_reqs].zero_()
-            input_buffers.query_start_loc[actual_reqs + 1 : graph_num_reqs + 1].fill_(actual_tokens)
+
+            # Decode requests are replicated on every PCP rank, so the global
+            # FULL-graph query layout is also the authoritative rank-local
+            # layout, including any FIA dummy request.
+            graph_query_start_loc_np = global_batch.query_start_loc_np[: graph_num_reqs + 1]
+            async_copy_to_gpu(
+                graph_query_start_loc_np,
+                out=input_buffers.query_start_loc[: graph_num_reqs + 1],
+            )
+
+            # Graph padding has no RankSegment, so _build_batch_layout does
+            # not initialize the corresponding hidden restore indices.
+            assert self._hidden_restore_idx is not None
+            self._hidden_restore_idx[global_batch.num_tokens : graph_num_tokens].zero_()
             seq_lens_cpu_upper_bound = torch.zeros(
                 graph_num_reqs,
                 dtype=local_batch.seq_lens_cpu_upper_bound.dtype,
@@ -124,6 +204,7 @@ class AscendPCPManager(PCPManager):
                 num_reqs_after_padding=graph_num_reqs,
                 num_tokens_after_padding=graph_num_tokens,
                 query_start_loc=input_buffers.query_start_loc[: graph_num_reqs + 1],
+                query_start_loc_np=graph_query_start_loc_np,
                 seq_lens=input_buffers.seq_lens[:graph_num_reqs],
                 seq_lens_cpu_upper_bound=seq_lens_cpu_upper_bound,
                 input_ids=input_buffers.input_ids[:graph_num_tokens],
@@ -131,7 +212,16 @@ class AscendPCPManager(PCPManager):
                 is_padding=input_buffers.is_padding[:graph_num_tokens],
             )
 
-        local_batch.seq_lens_np = local_batch.num_computed_tokens_np + local_batch.num_scheduled_tokens
+        local_seq_lens_np = local_batch.num_computed_tokens_np + local_batch.num_scheduled_tokens
+        if local_batch.num_reqs_after_padding > local_batch.num_reqs:
+            padded_seq_lens_np = np.zeros(
+                local_batch.num_reqs_after_padding,
+                dtype=local_seq_lens_np.dtype,
+            )
+            padded_seq_lens_np[: local_batch.num_reqs] = local_seq_lens_np
+            local_seq_lens_np = padded_seq_lens_np
+
+        local_batch.seq_lens_np = local_seq_lens_np
         num_valid_tokens = local_batch.num_scheduled_tokens
         if local_batch.num_draft_tokens_per_req is not None:
             num_valid_tokens = num_valid_tokens - local_batch.num_draft_tokens_per_req
@@ -143,6 +233,39 @@ class AscendPCPManager(PCPManager):
             num_valid_tokens,
         )
         return local_batch
+
+    def restore_hidden_states(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Restore active tokens and zero any fixed-graph padding rows."""
+        if not self.is_last_pp_rank:
+            return hidden_states
+
+        restored_hidden_states = super().restore_hidden_states(hidden_states)
+        if self._global_batch is None:
+            return restored_hidden_states
+
+        num_tokens = self._global_batch.num_tokens
+        num_tokens_after_padding = self._global_batch.num_tokens_after_padding
+        if num_tokens == num_tokens_after_padding:
+            return restored_hidden_states
+        if restored_hidden_states.shape[0] != num_tokens_after_padding:
+            raise RuntimeError(
+                "PCP restored hidden-state length does not match the global "
+                "graph layout: "
+                f"{restored_hidden_states.shape[0]} != {num_tokens_after_padding}."
+            )
+
+        restored_hidden_states[num_tokens:num_tokens_after_padding].zero_()
+        return restored_hidden_states
+
+    def restore_hidden_state_buffer(self, hidden_states: torch.Tensor) -> None:
+        """Restore a model-owned rank-local buffer to the global PCP layout."""
+        if not self.is_last_pp_rank:
+            return
+
+        assert self._padded_gather_idx is not None
+        local_num_tokens_padded = self._padded_gather_idx.shape[0] // self.pcp_world_size
+        restored_hidden_states = self.restore_hidden_states(hidden_states[:local_num_tokens_padded])
+        hidden_states[: restored_hidden_states.shape[0]].copy_(restored_hidden_states)
 
     def prepare_slot_mappings(self) -> torch.Tensor:
         """Pad PCP slot mappings to the fixed FULL-decode graph layout.

--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -19,13 +19,15 @@
 import logging
 from contextlib import contextmanager
 from copy import copy
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import numpy as np
 import torch
 from vllm.config import VllmConfig, replace
 from vllm.config.compilation import CUDAGraphMode
 from vllm.v1.attention.backend import AttentionBackend
 from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.worker.gpu.attn_utils import build_slot_mappings_by_layer
 from vllm.v1.worker.gpu.block_table import BlockTables
 from vllm.v1.worker.gpu.cudagraph_utils import BatchExecutionDescriptor
 from vllm.v1.worker.gpu.input_batch import InputBatch, InputBuffers
@@ -43,9 +45,31 @@ from vllm_ascend.worker.v2.attn_utils import (
     build_attn_metadata_wrapper,
     build_draft_attn_metadata_factory,
 )
-from vllm_ascend.worker.v2.input_batch import AscendInputBuffers
+from vllm_ascend.worker.v2.input_batch import AscendInputBatch, AscendInputBuffers
+from vllm_ascend.worker.v2.spec_decode.pcp_utils import disable_target_pcp_for_replicated_draft
+
+if TYPE_CHECKING:
+    from vllm_ascend.worker.v2.model_states.default import AscendModelState
+    from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
 
 logger = logging.getLogger(__name__)
+
+
+def _prepare_replicated_pcp_config(
+    vllm_config: VllmConfig,
+) -> tuple[VllmConfig, bool]:
+    """Return the draft execution config and whether target PCP is replicated."""
+    target_parallel_config = vllm_config.parallel_config
+    replicated_pcp = target_parallel_config.prefill_context_parallel_size > 1
+    if replicated_pcp:
+        vllm_config = replace(
+            vllm_config,
+            parallel_config=replace(
+                target_parallel_config,
+                prefill_context_parallel_size=1,
+            ),
+        )
+    return vllm_config, replicated_pcp
 
 
 class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
@@ -61,6 +85,8 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
     builders and skip the generic MLA/GQA init and update logic.
     """
 
+    model_state: "AscendModelState"
+
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
         """Override the upstream __init__ for Ascend NPUs.
 
@@ -68,6 +94,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         seq_lens_cpu from input_batch), so we replace input_buffers with
         AscendInputBuffers after super().__init__.
         """
+        vllm_config, self.replicated_pcp = _prepare_replicated_pcp_config(vllm_config)
         super().__init__(vllm_config, device)
 
         self.attn_architecture: str | None = None
@@ -94,6 +121,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         # when in decode phase of eagle speculator, we need some value in
         # draft model's input_batch. so we keep a reference here.
         self.input_batch: InputBatch | None = None
+        self.pcp_manager: AscendPCPManager | None = None
 
     def _create_draft_vllm_config(self) -> VllmConfig:
         """Build the runtime config used while executing the draft model."""
@@ -106,6 +134,55 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             model_config=self.draft_model_config,
             parallel_config=parallel_config,
         )
+
+    @property
+    def draft_prefill_attn_groups(self) -> list[list[AttentionGroup]]:
+        if self.replicated_pcp:
+            return self.attn_groups
+        return self.target_attn_groups
+
+    def _prepare_replicated_prefill_attn(
+        self,
+        attn_metadata: dict[str, Any] | None,
+        slot_mappings: dict[str, torch.Tensor] | None,
+        num_reqs_padded: int,
+        num_tokens_padded: int,
+    ) -> tuple[
+        dict[str, Any] | None,
+        dict[str, torch.Tensor] | None,
+    ]:
+        """Rebuild global draft prefill state for replicated PCP."""
+        input_batch = self.input_batch
+        if not self.replicated_pcp or attn_metadata is None or input_batch is None:
+            return attn_metadata, slot_mappings
+
+        assert isinstance(input_batch, AscendInputBatch)
+        if input_batch.is_dummy:
+            return attn_metadata, slot_mappings
+
+        self.block_tables.gather_block_tables(
+            input_batch.idx_mapping,
+            num_reqs_padded=num_reqs_padded,
+        )
+        slot_mappings_tensor = self.block_tables.compute_slot_mappings(
+            input_batch.idx_mapping,
+            input_batch.query_start_loc,
+            input_batch.positions,
+            num_tokens_padded=num_tokens_padded,
+        )
+        slot_mappings = build_slot_mappings_by_layer(
+            slot_mappings_tensor,
+            self.kv_cache_config,
+        )
+        attn_metadata = self._build_draft_attn_metadata(
+            num_reqs=input_batch.num_reqs,
+            num_reqs_padded=num_reqs_padded,
+            num_tokens_padded=num_tokens_padded,
+            seq_lens_cpu_upper_bound=input_batch.seq_lens_cpu_upper_bound,
+            step=0,
+            query_start_loc_np=input_batch.query_start_loc_np,
+        )
+        return attn_metadata, slot_mappings
 
     def init_cudagraph_manager(self, cudagraph_mode: CUDAGraphMode) -> None:
         super().init_cudagraph_manager(cudagraph_mode)
@@ -152,7 +229,11 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         self.input_batch = input_batch
         # wrap build_attn_metadata to use Ascend attention metadata building.
         # so we can call super().propose() directly.
-        with build_attn_metadata_wrapper(), torch_gather_wrapper():
+        with (
+            disable_target_pcp_for_replicated_draft(self),
+            build_attn_metadata_wrapper(),
+            torch_gather_wrapper(),
+        ):
             return super().propose(
                 input_batch,
                 attn_metadata,
@@ -216,22 +297,26 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         assert self.prefill_cudagraph_manager is not None
         if self.prefill_cudagraph_manager.use_breakable_cg:
             self.prefill_cudagraph_manager.init_breakable_cg_runner(self.model)
-        self.prefill_cudagraph_manager.capture(
-            self._prefill,
-            self.model_state,
-            self.target_input_buffers,
-            self.block_tables,
-            self.target_attn_groups,
-            self.kv_cache_config,
-            progress_bar_desc="Capturing prefill CUDA graphs",
-        )
+        with disable_target_pcp_for_replicated_draft(self):
+            self.prefill_cudagraph_manager.capture(
+                self._prefill,
+                self.model_state,
+                self.target_input_buffers,
+                self.block_tables,
+                self.draft_prefill_attn_groups,
+                self.kv_cache_config,
+                progress_bar_desc="Capturing prefill CUDA graphs",
+            )
 
         if self.num_speculative_steps == 1:
             return
 
         # Capture all decode draft generation steps as a single graph.
         assert self.decode_cudagraph_manager is not None
-        with build_attn_metadata_wrapper():
+        with (
+            disable_target_pcp_for_replicated_draft(self),
+            build_attn_metadata_wrapper(),
+        ):
             self.decode_cudagraph_manager.capture(
                 self._multi_step_decode,
                 self.model_state,
@@ -318,6 +403,12 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         cudagraph_runtime_mode: CUDAGraphMode = CUDAGraphMode.NONE,
         mm_inputs: tuple[list[torch.Tensor], torch.Tensor] | None = None,
     ) -> None:
+        attn_metadata, slot_mappings = self._prepare_replicated_prefill_attn(
+            attn_metadata,
+            slot_mappings,
+            num_reqs,
+            num_tokens,
+        )
         # Draft prefill reuses target metadata, but the target metadata may
         # also contain target-only attention layers (e.g. GDN layers).
         if attn_metadata is not None and self.draft_attn_layer_names is not None:
@@ -344,6 +435,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
         step: int,
         num_query_per_req: int = 1,
         causal: bool = True,
+        query_start_loc_np: np.ndarray | None = None,
     ) -> dict[str, Any] | None:
         assert self.input_batch is not None
         with build_draft_attn_metadata_factory(
@@ -359,6 +451,7 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
                 step,
                 num_query_per_req,
                 causal,
+                query_start_loc_np=query_start_loc_np,
             )
         if attn_metadata is not None:
             # Ascend-specific: force DecodeOnly attention state for the draft model.

--- a/vllm_ascend/worker/v2/spec_decode/pcp_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/pcp_utils.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Protocol
+
+from vllm_ascend.worker.v2.pcp_manager import AscendPCPManager
+
+if TYPE_CHECKING:
+    from vllm_ascend.worker.v2.model_states.default import AscendModelState
+
+
+class ReplicatedPCPDraftSpeculator(Protocol):
+    """State required to suspend target PCP for replicated draft execution."""
+
+    replicated_pcp: bool
+    model_state: "AscendModelState"
+    pcp_manager: AscendPCPManager | None
+
+
+@contextmanager
+def disable_target_pcp_for_replicated_draft(
+    speculator: ReplicatedPCPDraftSpeculator,
+) -> Iterator[None]:
+    """Keep replicated PCP=1 draft out of target PCP partitioning."""
+    target_pcp_manager = speculator.pcp_manager
+    if not speculator.replicated_pcp or target_pcp_manager is None:
+        yield
+        return
+
+    model_state = speculator.model_state
+    # Target and draft share model_state, so validate the target manager
+    # before temporarily detaching it for replicated PCP=1 execution.
+    if model_state.pcp_manager is not target_pcp_manager:
+        raise RuntimeError("Replicated draft execution requires model_state to use the target PCP manager.")
+
+    model_state.pcp_manager = None
+    try:
+        yield
+    finally:
+        model_state.pcp_manager = target_pcp_manager

--- a/vllm_ascend/worker/v2/states.py
+++ b/vllm_ascend/worker/v2/states.py
@@ -41,31 +41,6 @@ class AscendRequestState(RequestState):
             vocab_size,
             device,
         )
-        # vllm gpu_model_runner_v2 deprecate the seqs_lens_cpu attribute,
-        # because they think most attention backends do not need it.
-        # However, Ascend attention backend muse uses seqs_lens_cpu,
-        # so we keep num_computed_tokens_cpu here, seq_lens_cpu need to be
-        # calculated by num_computed_tokens_cpu + decode_token_per_req outside.
-        self.num_computed_tokens_cpu: torch.Tensor = torch.zeros(
-            self.max_num_reqs,
-            dtype=torch.int32,
-            device="cpu",
-        )
-
-    def add_request(
-        self,
-        req_id,
-        prompt_len,
-        all_token_ids,
-        num_computed_tokens,
-        max_tokens=None,
-    ):
-        super().add_request(
-            req_id,
-            prompt_len,
-            all_token_ids,
-            num_computed_tokens,
-            max_tokens=max_tokens,
-        )
-        req_idx = self.req_id_to_index[req_id]
-        self.num_computed_tokens_cpu[req_idx] = num_computed_tokens
+        # Ascend attention needs a torch CPU view of the upstream NumPy state.
+        # Sharing storage keeps both APIs coherent without duplicate writes.
+        self.num_computed_tokens_cpu: torch.Tensor = torch.from_numpy(self.num_computed_tokens_np)


### PR DESCRIPTION
### What this PR does / why we need it?

> [!IMPORTANT]
> This is a stacked Draft PR based on #14959. Until #14959 is merged, GitHub's `main`-based diff also contains its two-file PCP graph-padding prerequisite. Review the logical delta after #14959; this branch will be rebased onto `main` after the dependency merges.

This PR enables MTP and Eagle3 speculative decoding for MRV2 with prefill context parallelism (PCP), using the existing MRV2 execution and ACL graph paths.

- Keep target execution rank-local under its configured PCP topology.
- Restore the global input batch and target hidden states before sampling.
- Run the draft model as a replicated global batch on every PCP rank. A dedicated `replicated_pcp` semantic switch gives the draft execution config PCP=1 without changing the target topology.
- Build GQA/MLA draft attention from the draft `VllmConfig`; no global `enable_pcp()` cache mutation or parallel PCP backend hierarchy is required.
- Rebuild global draft block tables, slot mappings, and attention metadata after runtime padding for eager draft prefill. Supported `FULL_DECODE_ONLY` draft replay reuses the existing model-state metadata because PCP decode rows are replicated.
- Temporarily detach the shared target PCP manager only while the replicated PCP=1 draft executes or captures, and restore it on success and failure paths.
- Restore model-owned MTP target buffers and Eagle3 auxiliary hidden states at the ModelRunner sampling boundary.
- Propagate the draft/target PCP size through the current `VllmConfig` when constructing FusedMoE.
- Reuse the existing MRV2 draft graph dispatch instead of adding a separate PCP speculative graph implementation.

The supported scope is MRV2 + PCP with MTP or Eagle3 and GQA/MLA attention. DSA/SFA draft attention, DCP, adaptive verification, dynamic draft lengths, and non-greedy draft sampling remain outside this PR.

### Does this PR introduce _any_ user-facing change?

MRV2 users can enable MTP or Eagle3 speculative decoding together with PCP. There is no new CLI option. Unsupported PCP speculative combinations fail explicitly during validation.

### How was this patch tested?

Current extracted branch:

- `python -m py_compile` on all 8 production and 8 test files in the stacked speculative delta
- `ruff check` on all production, unit-test, and E2E files in the delta
- `git diff --check` for both the #14959 base and #14960 stacked delta
- Verified the extracted final files match the reviewed integration branch, except for one E2E import-order lint fix
- ACL graph source-contract regressions executed directly and passed

The branch adds focused UT coverage for:

- replicated draft PCP=1 versus target PCP topology
- target PCP-manager detachment and exception-safe restoration
- global draft metadata/slot-mapping reconstruction for eager prefill and model-state metadata reuse for full-graph replay
- draft attention-group selection
- speculative PCP batch compatibility and local attention-state rebuilding
- MTP model-owned and Eagle3 auxiliary hidden-state restoration
- GQA/MLA unified PCP metadata and backend capability selection
- FusedMoE draft/target PCP configuration propagation

It adds two independent four-card E2E cases in `tests/e2e/pull_request/four_card/context_parallel/test_accuracy_v2.py` for MTP/MLA and Eagle3/GQA with TP=2 and PCP=2, chunked prefill, and `FULL_DECODE_ONLY`.

The migrated four-card E2E file passes `python -m py_compile`, `ruff check`, `ruff format --check`, and `pytest --collect-only` (3 tests collected). Actual four-card NPU execution of the MTP and Eagle3 cases remains for CI.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
