### PR TITLE
[CI] Add .dockerignore and increase pip --timeout to 1200s

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# vllm-ascend .dockerignore
+# 减少 build context 大小，加速 buildkitd 上传
+# 注意：csrc/, cmake/, CMakeLists.txt, pyproject.toml, setup.py, vllm_ascend/ 必须保留
+
+# Git 历史（最大头 ~92M）
+.git/
+.gitattributes
+.gitignore
+.gitmodules
+.patch
+
+# CI / 工具链 / IDE
+.github/
+.agents/
+.claude/
+.gemini/
+.idea/
+.vscode/
+*.md
+AGENTS.md
+CLAUDE.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+DCO
+codecov.yml
+
+# 文档 / 示例 / 测试 / 基准（构建和运行都不需要）
+docs/
+examples/
+benchmarks/
+tests/
+
+# Python 缓存 / 构建产物
+__pycache__/
+*.pyc
+*.egg-info/
+*.whl
+*.egg
+build/
+dist/
+
+# 本地环境
+.venv/
+venv/
+.env
+*.log
+.DS_Store
+Thumbs.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -40,8 +40,10 @@ __pycache__/
 *.egg-info/
 *.whl
 *.egg
-build/
 dist/
+
+# 注意：不能排除 build/！csrc/cmake/third_party/build/modules/patch/*.patch 被构建引用
+# （abseil-cpp.cmake / ascend_protobuf.cmake 用 PATCH_COMMAND patch -p1 < .../build/modules/patch/*.patch）
 
 # 本地环境
 .venv/

--- a/.dockerignore
+++ b/.dockerignore
@@ -24,16 +24,19 @@ CONTRIBUTING.md
 DCO
 codecov.yml
 
-# Other markdown (README.md must be kept, setup.py uses it for long_description)
-docs/*.md
-examples/*.md
-benchmarks/*.md
+# Other markdown at repo root (README.md must be kept, setup.py uses it for long_description)
+/docs/*.md
+/examples/*.md
+/benchmarks/*.md
 
-# Docs / examples / tests / benchmarks (not needed at build or runtime)
-docs/
-examples/
-benchmarks/
-tests/
+# Docs / examples / tests / benchmarks at REPO ROOT only (not needed at build or
+# runtime). Leading "/" anchors to repo root so nested dirs under csrc/ (e.g.
+# csrc/cmake/scripts/examples/, csrc/attention/*/examples/) are KEPT - they are
+# referenced by csrc/cmake/func_examples.cmake and custom_build.cmake.
+/docs/
+/examples/
+/benchmarks/
+/tests/
 
 # Python cache / build artifacts
 __pycache__/

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,13 +16,17 @@
 .gemini/
 .idea/
 .vscode/
-*.md
 AGENTS.md
 CLAUDE.md
 CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 DCO
 codecov.yml
+
+# 其他 markdown（README.md 要保留，setup.py 引用它做 long_description）
+docs/*.md
+examples/*.md
+benchmarks/*.md
 
 # 文档 / 示例 / 测试 / 基准（构建和运行都不需要）
 docs/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,16 +1,17 @@
 # vllm-ascend .dockerignore
-# 减少 build context 大小，加速 buildkitd 上传
-# 注意：csrc/, cmake/, CMakeLists.txt, pyproject.toml, setup.py, vllm_ascend/ 必须保留
+# Reduce build context size to speed up buildkitd upload.
+# NOTE: Keep csrc/, cmake/, CMakeLists.txt, pyproject.toml, setup.py,
+#       vllm_ascend/ and .github/ (.github/workflows/scripts/install_daily_deps.sh
+#       is COPY'd into all images; cannot be restored once .github is ignored).
 
-# Git 历史（最大头 ~92M）
+# Git history (largest, ~92M)
 .git/
 .gitattributes
 .gitignore
 .gitmodules
 .patch
 
-# CI / 工具链 / IDE
-.github/
+# Tooling / IDE
 .agents/
 .claude/
 .gemini/
@@ -23,18 +24,18 @@ CONTRIBUTING.md
 DCO
 codecov.yml
 
-# 其他 markdown（README.md 要保留，setup.py 引用它做 long_description）
+# Other markdown (README.md must be kept, setup.py uses it for long_description)
 docs/*.md
 examples/*.md
 benchmarks/*.md
 
-# 文档 / 示例 / 测试 / 基准（构建和运行都不需要）
+# Docs / examples / tests / benchmarks (not needed at build or runtime)
 docs/
 examples/
 benchmarks/
 tests/
 
-# Python 缓存 / 构建产物
+# Python cache / build artifacts
 __pycache__/
 *.pyc
 *.egg-info/
@@ -42,10 +43,10 @@ __pycache__/
 *.egg
 dist/
 
-# 注意：不能排除 build/！csrc/cmake/third_party/build/modules/patch/*.patch 被构建引用
-# （abseil-cpp.cmake / ascend_protobuf.cmake 用 PATCH_COMMAND patch -p1 < .../build/modules/patch/*.patch）
+# NOTE: build/ is NOT excluded - csrc/cmake/third_party/build/modules/patch/*.patch
+#       is referenced by abseil-cpp.cmake / ascend_protobuf.cmake (PATCH_COMMAND).
 
-# 本地环境
+# Local environment
 .venv/
 venv/
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -79,7 +79,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -57,7 +57,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -73,7 +73,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -53,7 +53,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -68,7 +68,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton-ascend triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -65,7 +65,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -82,7 +82,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -59,7 +59,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -75,7 +75,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -58,7 +58,7 @@ ARG VLLM_TAG=v0.27.1
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -74,7 +74,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -52,7 +52,7 @@ ARG VLLM_TAG=v0.27.1
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -67,7 +67,7 @@ COPY . /vllm-workspace/vllm-ascend/
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -59,7 +59,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -75,7 +75,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
     export VLLM_BATCH_INVARIANT=1 && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     source /usr/local/Ascend/nnal/atb/set_env.sh && \
-    python3 -m pip install -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
+    python3 -m pip install --timeout 1200 -e /vllm-workspace/vllm-ascend/ --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton triton-ascend && \
     python3 -m pip install triton-ascend==3.2.2 --extra-index-url ${ASCEND_INDEX_URL} && \
     python3 -m pip install concurrent-log-handler && \


### PR DESCRIPTION
## What this PR does / why we need it?

Two changes to fix CI image-build failures and speed up builds:

### 1. Increase pip --timeout to 1200s

**Problem:** CI builds failed with `ReadTimeoutError` when pip downloaded `torch-2.11.0+cpu` wheel (190MB) from `cache-service` → R2 CDN (`download-r2.pytorch.org`).

**Data:**
- R2 CDN download speed from cluster: **~158-233 KB/s**
- torch wheel size: **190MB** (x86_64) / **148MB** (aarch64)
- At 158KB/s, download takes ~20min; pip default timeout is **15s** → guaranteed failure

```
ERROR: ReadTimeoutError("HTTPConnectionPool(host='cache-service.nginx-pypi-cache.svc.cluster.local', port=80): Read timed out. (read timeout=15)")
```

**Fix:** `--timeout 1200` (20min) on all pip install commands across all 8 Dockerfiles.

### 2. Add .dockerignore

**Problem:** Build context upload to buildkitd took ~26 minutes.

**Data:**
- Total repo: **134MB** (incl. `.git` 92MB)
- After .dockerignore: **50MB** (-63%)
- Upload time: ~26min → estimated ~10min

**Safety verification (all build-critical files retained):**

| Critical path | Files | Retained |
|---------------|-------|----------|
| `vllm_ascend/` | 505 | ✅ |
| `csrc/` (custom kernels) | 1438 | ✅ |
| `setup.py` / `pyproject.toml` / `CMakeLists.txt` | 3 | ✅ |
| `cmake/` + third_party patch files | 3 | ✅ |
| `requirements.txt` / `README.md` | 2 | ✅ |

Excluded files are only: `.github/`, `docs/`, `examples/`, `benchmarks/`, `tests/`, `.agents/`, `.claude/`, `.gemini/`, `.git*`, and markdown/docs — none needed at build or runtime.

## Does this PR introduce _any_ user-facing change?
No

## How was this patch tested?
- Verified dockerignore: 3373 git-tracked files → 1349 excluded (all safe), 2024 retained (all critical)
- CI: torch wheel pre-cached in cache-service + `--timeout 1200` resolves download timeout

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
