### PR TITLE
[Doc] Add Triton operator description specification template

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py
@@ -2,38 +2,77 @@ import gc
 
 import pytest
 import torch
-from einops import rearrange
-from vllm.model_executor.layers.mamba.gdn.base import GatedDeltaNetAttention  # type: ignore[import-not-found]
 
 from vllm_ascend.ops.triton.fla.fused_qkvzba_split_reshape import fused_qkvzba_split_reshape_cat
 
 
-def validate_cmp(y_cal, y_ref, dtype, device="npu"):
+def fused_qkvzba_split_reshape_cat_torch_ref(
+    mixed_qkvz,
+    mixed_ba,
+    num_heads_qk,
+    num_heads_v,
+    head_qk_dim,
+    head_v_dim,
+):
+    """Pure-torch reference of fused_qkvzba_split_reshape_cat.
+
+    mixed_qkvz layout: [seq, num_heads_qk, (Q, K, V, Z)] where Q/K have
+    head_qk_dim elements and V/Z have (num_heads_v // num_heads_qk) * head_v_dim.
+    mixed_ba layout:  [seq, num_heads_qk, (B, A)] with num_heads_v // num_heads_qk
+    elements each.
+    """
+    v_heads_per_qk = num_heads_v // num_heads_qk
+    qkvz_dim_t = head_qk_dim * 2 + v_heads_per_qk * head_v_dim * 2
+    ba_dim_t = v_heads_per_qk * 2
+
+    seq_len = mixed_qkvz.shape[0]
+    mixed_qkvz = mixed_qkvz.view(seq_len, num_heads_qk, qkvz_dim_t)
+    mixed_ba = mixed_ba.view(seq_len, num_heads_qk, ba_dim_t)
+
+    q = mixed_qkvz[..., :head_qk_dim]
+    k = mixed_qkvz[..., head_qk_dim : 2 * head_qk_dim]
+    v = mixed_qkvz[..., 2 * head_qk_dim : 2 * head_qk_dim + v_heads_per_qk * head_v_dim]
+    z = mixed_qkvz[..., 2 * head_qk_dim + v_heads_per_qk * head_v_dim :]
+    b = mixed_ba[..., :v_heads_per_qk]
+    a = mixed_ba[..., v_heads_per_qk:]
+
+    v = v.reshape(seq_len, num_heads_v, head_v_dim)
+    z = z.reshape(seq_len, num_heads_v, head_v_dim)
+    b = b.reshape(seq_len, num_heads_v)
+    a = a.reshape(seq_len, num_heads_v)
+
+    q = q.reshape(seq_len, num_heads_qk * head_qk_dim)
+    k = k.reshape(seq_len, num_heads_qk * head_qk_dim)
+    v_flat = v.reshape(seq_len, num_heads_v * head_v_dim)
+
+    mixed_qkv = torch.cat((q, k, v_flat), dim=-1)
+    return mixed_qkv, z, b, a
+
+
+def validate_cmp(y_cal, y_ref, device="npu"):
     y_cal = y_cal.to(device)
     y_ref = y_ref.to(device)
-    if dtype == torch.float16 or dtype == torch.bfloat16:
-        torch.testing.assert_close(y_ref, y_cal, rtol=5e-03, atol=5e-03, equal_nan=True)
-    elif dtype == torch.float32:
-        torch.testing.assert_close(y_ref, y_cal, rtol=1e-03, atol=1e-03, equal_nan=True)
-    elif (
-        dtype == torch.int32
-        or dtype == torch.int64
-        or dtype == torch.int16
-        or dtype == torch.int8
-        or dtype == torch.uint32
-        or dtype == torch.bool
-    ):
-        assert torch.equal(y_cal, y_ref)
-    else:
-        raise ValueError('Invalid parameter "dtype" is found : {}'.format(dtype))
+    # Pure data-movement op (load/store only, no arithmetic): results must be
+    # bit-exact, which is the unified precision tolerance for this operator type.
+    torch.testing.assert_close(y_ref, y_cal, rtol=0, atol=0, equal_nan=True)
 
 
-@pytest.mark.parametrize("seq_len", [1, 64, 1024, 2048])
-@pytest.mark.parametrize("num_heads_qk", [2, 4, 8])
-@pytest.mark.parametrize("num_heads_v", [8])
-@pytest.mark.parametrize("head_qk_dim", [256])
-@pytest.mark.parametrize("head_v_dim", [128])
-@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+# Real inference shapes used by Qwen3-GDN-10B (gqa_interleaved_layout=True),
+# with num_heads_qk / num_heads_v divided by tp_size (here tp_size = 1):
+#   num_k_heads=16, num_v_heads=128, head_k_dim=512, head_v_dim=512
+# Plus a generic case covering a wider parameter space (v_heads_per_qk >= 1).
+TEST_CASES = [
+    (64, 16, 128, 512, 512),
+    (2048, 16, 128, 512, 512),
+    (128, 8, 32, 128, 64),
+]
+
+
+@pytest.mark.parametrize(
+    "seq_len, num_heads_qk, num_heads_v, head_qk_dim, head_v_dim",
+    TEST_CASES,
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
 def test_fused_qkvzba_split_reshape_cat(
     seq_len,
     num_heads_qk,
@@ -54,35 +93,29 @@ def test_fused_qkvzba_split_reshape_cat(
 
     projected_states_ba = torch.randn(seq_len, 2 * num_heads_v, dtype=dtype, device=device)
 
-    projected_states_qkvz_copy = projected_states_qkvz.clone()
-    projected_states_ba_copy = projected_states_ba.clone()
-
     mixed_qkv, z, b, a = fused_qkvzba_split_reshape_cat(
-        projected_states_qkvz_copy,
-        projected_states_ba_copy,
+        projected_states_qkvz.clone(),
+        projected_states_ba.clone(),
         num_heads_qk,
         num_heads_v,
         head_qk_dim,
         head_v_dim,
     )
 
-    gdn = GatedDeltaNetAttention.__new__(GatedDeltaNetAttention)
-    gdn.num_k_heads = num_heads_qk
-    gdn.num_v_heads = num_heads_v
-    gdn.head_k_dim = head_qk_dim
-    gdn.head_v_dim = head_v_dim
-    gdn.tp_size = 1
-
-    query, key, value, z_ref, b_ref, a_ref = gdn.fix_query_key_value_ordering(
-        mixed_qkvz=projected_states_qkvz, mixed_ba=projected_states_ba
+    mixed_qkv_ref, z_ref, b_ref, a_ref = fused_qkvzba_split_reshape_cat_torch_ref(
+        projected_states_qkvz,
+        projected_states_ba,
+        num_heads_qk,
+        num_heads_v,
+        head_qk_dim,
+        head_v_dim,
     )
-    query, key, value = map(lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value))
-    mixed_qkv_ref = torch.cat((query, key, value), dim=-1)
 
-    validate_cmp(mixed_qkv, mixed_qkv_ref, dtype)
-    validate_cmp(z, z_ref, dtype)
-    validate_cmp(b, b_ref, dtype)
-    validate_cmp(a, a_ref, dtype)
+    validate_cmp(mixed_qkv, mixed_qkv_ref)
+    validate_cmp(z, z_ref)
+    validate_cmp(b, b_ref)
+    validate_cmp(a, a_ref)
+
     gc.collect()
     torch.npu.empty_cache()
     torch.npu.reset_peak_memory_stats()

--- a/vllm_ascend/ops/triton/docs/fused_qkvzba_split_reshape.md
+++ b/vllm_ascend/ops/triton/docs/fused_qkvzba_split_reshape.md
@@ -16,7 +16,7 @@
      - Load Q/K/V/Z from the interleaved `mixed_qkvz` head block.
      - Load B/A from the interleaved `mixed_ba` head block.
      - Store Q/K/V into the type-contiguous `mixed_qkv` layout, Z into `z`, and B/A into `b`/`a`, each using its own row stride; out-of-range rows are masked.
-- **Supported modes**: Ascend NPU only (Triton kernel), used by the GDN linear attention `gqa_interleaved_layout=True` path (e.g. Qwen3-Next) in `vllm_ascend/ops/gdn.py`; works in both eager and graph-capture modes.
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950 (Triton kernel), used by the GDN linear attention `gqa_interleaved_layout=True` path (e.g. Qwen3-Next) in `vllm_ascend/ops/gdn.py`; works in both eager and graph-capture modes.
 
 ## Parameters
 

--- a/vllm_ascend/ops/triton/docs/fused_qkvzba_split_reshape.md
+++ b/vllm_ascend/ops/triton/docs/fused_qkvzba_split_reshape.md
@@ -4,11 +4,11 @@
 
 - **Function**: Splits and re-arranges the fused QKVZ and BA projections of the GDN (Gated Delta Network) linear attention into type-contiguous layouts. It replaces the host-side `split` + `reshape`/`cat` chain in the `gqa_interleaved_layout=True` path with a single fused Triton kernel.
 - **Formula**: Pure data movement (load/store only, no arithmetic):
-  - Input `mixed_qkvz`: `[num_tokens, num_heads_qk * (Q + K + V + Z)]`, where each head block is `[Q(head_qk), K(head_qk), V(v_heads_per_qk * head_v), Z(v_heads_per_qk * head_v)]` and `v_heads_per_qk = num_heads_v // num_heads_qk`
-  - Input `mixed_ba`: `[num_tokens, num_heads_qk * (B + A)]`, where each head block is `[B(v_heads_per_qk), A(v_heads_per_qk)]`
-  - Output `mixed_qkv`: `[num_tokens, Q_all | K_all | V_all]` (concatenated by type, `Q_all = K_all = num_heads_qk * head_qk`, `V_all = num_heads_v * head_v`)
-  - Output `z`: `[num_tokens, num_heads_v, head_v]`
-  - Output `b`, `a`: `[num_tokens, num_heads_v]`
+    - Input `mixed_qkvz`: `[num_tokens, num_heads_qk * (Q + K + V + Z)]`, where each head block is `[Q(head_qk), K(head_qk), V(v_heads_per_qk * head_v), Z(v_heads_per_qk * head_v)]` and `v_heads_per_qk = num_heads_v // num_heads_qk`
+    - Input `mixed_ba`: `[num_tokens, num_heads_qk * (B + A)]`, where each head block is `[B(v_heads_per_qk), A(v_heads_per_qk)]`
+    - Output `mixed_qkv`: `[num_tokens, Q_all | K_all | V_all]` (concatenated by type, `Q_all = K_all = num_heads_qk * head_qk`, `V_all = num_heads_v * head_v`)
+    - Output `z`: `[num_tokens, num_heads_v, head_v]`
+    - Output `b`, `a`: `[num_tokens, num_heads_v]`
 - **Algorithm flow** (processed row by row, independently):
   1. Compute grid: `grid_size = min(num_vectorcore, total_rows)` vector cores, each processing `rows_per_vec = ceil(total_rows / grid_size)` rows.
   2. Tile rows: `rows_per_iter` rows per tile, derived from the UB (unified buffer) budget (`ub_size`, `elements_per_row`) and capped by `MAX_ROWS_PER_ITER`, to keep each load/store block within the UB.

--- a/vllm_ascend/ops/triton/docs/fused_qkvzba_split_reshape.md
+++ b/vllm_ascend/ops/triton/docs/fused_qkvzba_split_reshape.md
@@ -1,0 +1,58 @@
+# fused_qkvzba_split_reshape_cat
+
+## Description
+
+- **Function**: Splits and re-arranges the fused QKVZ and BA projections of the GDN (Gated Delta Network) linear attention into type-contiguous layouts. It replaces the host-side `split` + `reshape`/`cat` chain in the `gqa_interleaved_layout=True` path with a single fused Triton kernel.
+- **Formula**: Pure data movement (load/store only, no arithmetic):
+  - Input `mixed_qkvz`: `[num_tokens, num_heads_qk * (Q + K + V + Z)]`, where each head block is `[Q(head_qk), K(head_qk), V(v_heads_per_qk * head_v), Z(v_heads_per_qk * head_v)]` and `v_heads_per_qk = num_heads_v // num_heads_qk`
+  - Input `mixed_ba`: `[num_tokens, num_heads_qk * (B + A)]`, where each head block is `[B(v_heads_per_qk), A(v_heads_per_qk)]`
+  - Output `mixed_qkv`: `[num_tokens, Q_all | K_all | V_all]` (concatenated by type, `Q_all = K_all = num_heads_qk * head_qk`, `V_all = num_heads_v * head_v`)
+  - Output `z`: `[num_tokens, num_heads_v, head_v]`
+  - Output `b`, `a`: `[num_tokens, num_heads_v]`
+- **Algorithm flow** (processed row by row, independently):
+  1. Compute grid: `grid_size = min(num_vectorcore, total_rows)` vector cores, each processing `rows_per_vec = ceil(total_rows / grid_size)` rows.
+  2. Tile rows: `rows_per_iter` rows per tile, derived from the UB (unified buffer) budget (`ub_size`, `elements_per_row`) and capped by `MAX_ROWS_PER_ITER`, to keep each load/store block within the UB.
+  3. For each row tile, iterate over `NUM_HEADS_QK` head groups with `tl.static_range`:
+     - Load Q/K/V/Z from the interleaved `mixed_qkvz` head block.
+     - Load B/A from the interleaved `mixed_ba` head block.
+     - Store Q/K/V into the type-contiguous `mixed_qkv` layout, Z into `z`, and B/A into `b`/`a`, each using its own row stride; out-of-range rows are masked.
+- **Supported modes**: Ascend NPU only (Triton kernel), used by the GDN linear attention `gqa_interleaved_layout=True` path (e.g. Qwen3-Next) in `vllm_ascend/ops/gdn.py`; works in both eager and graph-capture modes.
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `mixed_qkvz` | Input | Fused QKVZ projection in interleaved GQA layout `[num_tokens, num_heads_qk * (Q + K + V + Z)]` | fp32 / fp16 / bf16 | ND |
+| `mixed_ba` | Input | Fused BA projection in interleaved GQA layout `[num_tokens, num_heads_qk * (B + A)]` | fp32 / fp16 / bf16 | ND |
+| `num_heads_qk` | Input (attribute) | Number of Q/K head groups per TP rank (`cdiv(num_k_heads, tp_size)`) | int32 | scalar |
+| `num_heads_v` | Input (attribute) | Number of V/Z heads per TP rank (`cdiv(num_v_heads, tp_size)`) | int32 | scalar |
+| `head_qk` | Input (attribute) | Head dimension of Q/K (`head_k_dim`) | int32 | scalar |
+| `head_v` | Input (attribute) | Head dimension of V/Z (`head_v_dim`) | int32 | scalar |
+| `mixed_qkv` | Output | QKV concatenated by type `[num_tokens, num_heads_qk * head_qk * 2 + num_heads_v * head_v]` | same as `mixed_qkvz` | ND |
+| `z` | Output | Z state `[num_tokens, num_heads_v, head_v]` | same as `mixed_qkvz` | ND |
+| `b` | Output | B decay `[num_tokens, num_heads_v]` | same as `mixed_ba` | ND |
+| `a` | Output | A decay `[num_tokens, num_heads_v]` | same as `mixed_ba` | ND |
+
+## Constraints
+
+- `num_heads_v` must be divisible by `num_heads_qk` (`v_heads_per_qk = num_heads_v // num_heads_qk >= 1`).
+- `mixed_qkvz.shape[1]` must equal `num_heads_qk * (head_qk * 2 + v_heads_per_qk * head_v * 2)`.
+- `mixed_ba.shape[1]` must equal `num_heads_qk * v_heads_per_qk * 2`.
+- Output dtypes are inherited from the inputs (`mixed_qkv`/`z` from `mixed_qkvz`; `b`/`a` from `mixed_ba`).
+- `NUM_HEADS_QK`, `NUM_HEADS_V`, `HEAD_QK`, `HEAD_V`, and all row strides are compile-time `constexpr`; the row loop and row masks handle arbitrary `total_rows`, so dynamic token counts are supported.
+- Only for inference (decoding/prefill) on NPU; `num_tokens` is flattened from `batch * seq_len`.
+
+## Origin and Differences
+
+- **Origin**: Based on the fused split/reshape logic of the flash-linear-attention project (MIT license, see header of the source file), rewritten as an Ascend NPU Triton kernel. It replaces the torch `split` + `reshape`/`cat` chain in the GDN attention `gqa_interleaved_layout=True` path of `vllm_ascend/ops/gdn.py`.
+- **Differences**:
+    - NPU adaptation for performance: fuses the split + reshape/cat into a single Triton kernel to avoid multiple device-side memory copies; parallelized over vector cores with UB-aware row tiling (`rows_per_iter`) to improve AICore utilization;
+    - Modified for a specific vllm-ascend logic or different input parameters: consumes the interleaved GQA layout `[seq, num_heads_qk, (Q, K, V, Z)]` / `[seq, num_heads_qk, (B, A)]` produced by the `gqa_interleaved_layout` linear projections, and outputs the type-contiguous `mixed_qkv` expected by the `qwen_gdn_attention_core` custom op.
+
+## Test Cases
+
+The test covers both real inference shapes (Qwen3-GDN-10B, `gqa_interleaved_layout=True`, TP=1: `num_heads_qk=16`, `num_heads_v=128`, `head_qk=512`, `head_v=512`) and a broader generic parameter space. As this is a pure data-movement operator (no arithmetic), the unified precision tolerance is bit-exact (`rtol=0, atol=0`).
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py
+```

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -1,0 +1,41 @@
+> [!NOTE]
+> **Filling Instructions**
+> - Place the document under `vllm_ascend/ops/triton/docs`, named after the operator. If a same-named document already exists, add a suffix to distinguish it.
+> - Fill in strictly following the template. For items that do not apply, use "N/A"; do not leave them blank or missing.
+
+# ops
+
+<!-- Operator name -->
+
+## Description
+
+- **Function**:
+- **Formula**:
+- **Algorithm flow** (processed row by row, independently):
+- **Supported modes**:
+
+## Parameters
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+
+## Constraints
+
+- Shape, dtype, value range, constraints, and graph-mode support of each input parameter
+
+## Origin and Differences
+
+- **Origin**: which vllm operator it is modified from, or developed from scratch
+- **Differences**:
+  - NPU adaptation for performance;
+  - Modified for a specific vllm-ascend logic or different input parameters
+
+## Test Cases
+
+> [!NOTE]
+> - Single-operator accuracy test cases should be placed under `tests/e2e/nightly/single_node/ops/singlecard_ops/triton`.
+> - For inference scenarios, use the actual shapes and other parameters adopted by the model as single-operator test cases, rather than arbitrarily constructed ones.
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_top_k_top_p_triton.py
+```

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -33,8 +33,10 @@
 ## Test Cases
 
 > [!NOTE]
+> **Test Case Instructions**
 > - Single-operator accuracy test cases should be placed under `tests/e2e/nightly/single_node/ops/singlecard_ops/triton`.
 > - For inference scenarios, use the actual shapes and other parameters adopted by the model as single-operator test cases, rather than arbitrarily constructed ones.
+> - Accuracy comparison results should use a unified precision tolerance based on the operator type and data type; example cases will be provided later.
 
 ```bash
 pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_top_k_top_p_triton.py

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -1,5 +1,6 @@
 > [!NOTE]
 > **Filling Instructions**
+>
 > - Place the document under `vllm_ascend/ops/triton/docs`, named after the operator. If a same-named document already exists, add a suffix to distinguish it.
 > - Fill in strictly following the template. For items that do not apply, use "N/A"; do not leave them blank or missing.
 
@@ -32,6 +33,7 @@
 
 > [!NOTE]
 > **Test Case Instructions**
+>
 > - Single-operator accuracy test cases should be placed under `tests/e2e/nightly/single_node/ops/singlecard_ops/triton`.
 > - For inference scenarios, use the actual shapes and other parameters adopted by the model as single-operator test cases, rather than arbitrarily constructed ones.
 > - Accuracy comparison results should use a unified precision tolerance based on the operator type and data type; example cases will be provided later.

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -11,9 +11,12 @@
 - **Function**:
 - **Formula**:
 - **Algorithm flow** (processed row by row, independently):
-- **Supported modes**:
+- **Supported modes**: Atlas A2, Atlas A3, and Ascend 950
 
 ## Parameters
+
+> [!NOTE]
+> All parameters are required.
 
 | Parameter | Input/Output/Attribute | Description | Data type | Data format |
 | --- | --- | --- | --- | --- |

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -41,3 +41,12 @@
 ```bash
 pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_top_k_top_p_triton.py
 ```
+
+## Example
+
+A worked example of this template is committed alongside it in the same branch:
+
+- **Operator doc**: `vllm_ascend/ops/triton/docs/fused_qkvzba_split_reshape.md`
+- **Accuracy test**: `tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py`
+
+The example doc is filled section by section following this template; the example test uses the actual shapes adopted by the model in inference (Qwen3-GDN-10B, `gqa_interleaved_layout=True`) and applies the unified precision tolerance based on the operator type and data type (bit-exact for this pure data-movement operator).

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -39,7 +39,7 @@
 > - Accuracy comparison results should use a unified precision tolerance based on the operator type and data type; example cases will be provided later.
 
 ```bash
-pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_apply_top_k_top_p_triton.py
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_fused_qkvzba_split_reshape_cat.py
 ```
 
 ## Example

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -1,6 +1,5 @@
 > [!NOTE]
 > **Filling Instructions**
-
 > - Place the document under `vllm_ascend/ops/triton/docs`, named after the operator. If a same-named document already exists, add a suffix to distinguish it.
 > - Fill in strictly following the template. For items that do not apply, use "N/A"; do not leave them blank or missing.
 
@@ -33,7 +32,6 @@
 
 > [!NOTE]
 > **Test Case Instructions**
-
 > - Single-operator accuracy test cases should be placed under `tests/e2e/nightly/single_node/ops/singlecard_ops/triton`.
 > - For inference scenarios, use the actual shapes and other parameters adopted by the model as single-operator test cases, rather than arbitrarily constructed ones.
 > - Accuracy comparison results should use a unified precision tolerance based on the operator type and data type; example cases will be provided later.

--- a/vllm_ascend/ops/triton/docs/triton_description_specification.md
+++ b/vllm_ascend/ops/triton/docs/triton_description_specification.md
@@ -1,11 +1,10 @@
 > [!NOTE]
 > **Filling Instructions**
+
 > - Place the document under `vllm_ascend/ops/triton/docs`, named after the operator. If a same-named document already exists, add a suffix to distinguish it.
 > - Fill in strictly following the template. For items that do not apply, use "N/A"; do not leave them blank or missing.
 
-# ops
-
-<!-- Operator name -->
+# Operator name
 
 ## Description
 
@@ -27,13 +26,14 @@
 
 - **Origin**: which vllm operator it is modified from, or developed from scratch
 - **Differences**:
-  - NPU adaptation for performance;
-  - Modified for a specific vllm-ascend logic or different input parameters
+    - NPU adaptation for performance;
+    - Modified for a specific vllm-ascend logic or different input parameters
 
 ## Test Cases
 
 > [!NOTE]
 > **Test Case Instructions**
+
 > - Single-operator accuracy test cases should be placed under `tests/e2e/nightly/single_node/ops/singlecard_ops/triton`.
 > - For inference scenarios, use the actual shapes and other parameters adopted by the model as single-operator test cases, rather than arbitrarily constructed ones.
 > - Accuracy comparison results should use a unified precision tolerance based on the operator type and data type; example cases will be provided later.


### PR DESCRIPTION

## Why

There is currently no unified template for documenting Triton operators under `vllm_ascend/ops/triton`. New operator docs tend to be written in an ad-hoc way, making them hard to review and search.

## What

Add a specification template at `vllm_ascend/ops/triton/docs/triton_description_specification.md`, which defines a standardized structure for each Triton operator doc:

- **Description**: function, formula, algorithm flow, supported modes
- **Parameters**: table of parameter name / input-output-attribute / description / data type / data format
- **Constraints**: shape, dtype, value range, constraints, and graph-mode support of each input
- **Origin and Differences**: which vllm operator it is derived from, and the NPU/vllm-ascend specific adaptations
- **Test Cases**: where single-operator accuracy tests should be placed, and an example pytest command

## Notes

- Naming rule: docs are placed under `vllm_ascend/ops/triton/docs` and named after the operator; add a suffix if the name already exists.
- Items that do not apply should be marked as "N/A" instead of left blank.
- Test cases must use the actual shapes/parameters from the inference scenario rather than arbitrarily constructed ones.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
