### PR TITLE
[Feature][EPLB] Support EPLB for MiniMax-M3

### DIFF
--- a/tests/ut/models/minimax_m3/test_minimax_m3.py
+++ b/tests/ut/models/minimax_m3/test_minimax_m3.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import torch
 from torch import nn
@@ -126,11 +126,23 @@ class TestMiniMaxM3Modeling(unittest.TestCase):
         )
         gate = nn.Identity()
         gate.out_dtype = torch.float32
+        experts = nn.Identity()
+        experts.moe_config = Mock()
+        parallel_config = Mock()
+        parallel_config.enable_eplb = False
+        parallel_config.eplb_config.num_redundant_experts = 0
+        ep_group = Mock()
+        ep_group.device_group.size.return_value = 1
+        ep_group.rank_in_group = 0
 
         with (
             patch(
                 "vllm_ascend.models.minimax_m3.minimax_m3.get_tensor_model_parallel_world_size",
                 return_value=1,
+            ),
+            patch(
+                "vllm_ascend.models.minimax_m3.minimax_m3.get_ep_group",
+                return_value=ep_group,
             ),
             patch(
                 "vllm_ascend.models.minimax_m3.minimax_m3.MiniMaxM3MLP",
@@ -142,10 +154,14 @@ class TestMiniMaxM3Modeling(unittest.TestCase):
             ),
             patch(
                 "vllm_ascend.models.minimax_m3.minimax_m3.FusedMoEFactory",
-                return_value=nn.Identity(),
+                return_value=experts,
             ) as fused_moe,
         ):
-            MiniMaxM3MoE(config=config, prefix="model.layers.0.block_sparse_moe")
+            MiniMaxM3MoE(
+                config=config,
+                parallel_config=parallel_config,
+                prefix="model.layers.0.block_sparse_moe",
+            )
 
         kwargs = fused_moe.call_args.kwargs
         self.assertEqual(kwargs["activation"], "swigluoai_uninterleave")

--- a/tests/ut/models/minimax_m3/test_minimax_m3_eplb.py
+++ b/tests/ut/models/minimax_m3/test_minimax_m3_eplb.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+from torch import nn
+from transformers import PretrainedConfig
+from vllm.model_executor.models.interfaces import MixtureOfExperts
+
+from vllm_ascend.models.minimax_m3 import minimax_m3 as minimax_module
+from vllm_ascend.models.minimax_m3 import minimax_m3_vl as vl_module
+
+
+class _FakeGate(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.call_count = 0
+        self.out_dtype = torch.float32
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> tuple[torch.Tensor, None]:
+        self.call_count += 1
+        return hidden_states + 10, None
+
+
+class _FakeExperts(nn.Module):
+    def __init__(self, *, is_internal_router: bool = False) -> None:
+        super().__init__()
+        self.is_internal_router = is_internal_router
+        self.moe_config = SimpleNamespace(global_redundant_expert_num=0)
+        self.global_redundant_expert_num = 0
+        self.update_expert_map = Mock()
+        self.last_hidden_states: torch.Tensor | None = None
+        self.last_router_logits: torch.Tensor | None = None
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+    ) -> torch.Tensor:
+        self.last_hidden_states = hidden_states
+        self.last_router_logits = router_logits
+        return hidden_states * 2
+
+
+class _FakeDecoderLayer(nn.Module):
+    def __init__(self, moe: nn.Module | None = None) -> None:
+        super().__init__()
+        self.is_layer_sparse = moe is not None
+        if moe is not None:
+            self.block_sparse_moe = moe
+
+
+def _make_moe_metadata() -> minimax_module.MiniMaxM3MoE:
+    moe = minimax_module.MiniMaxM3MoE.__new__(minimax_module.MiniMaxM3MoE)
+    nn.Module.__init__(moe)
+    moe.experts = _FakeExperts()
+    moe.n_logical_experts = 8
+    moe.n_physical_experts = 10
+    moe.n_local_physical_experts = 5
+    moe.n_routed_experts = 8
+    moe.n_shared_experts = 1
+    moe.n_redundant_experts = 2
+    return moe
+
+
+class TestMiniMaxM3EPLB(unittest.TestCase):
+    def test_models_implement_mixture_of_experts_interface(self) -> None:
+        self.assertIn(
+            MixtureOfExperts,
+            minimax_module.MiniMaxM3SparseForCausalLM.__mro__,
+        )
+        self.assertIn(
+            MixtureOfExperts,
+            vl_module.MiniMaxM3SparseForConditionalGeneration.__mro__,
+        )
+
+    def test_moe_initializes_eplb_metadata_and_factory(self) -> None:
+        config = PretrainedConfig(
+            hidden_size=64,
+            intermediate_size=32,
+            num_local_experts=8,
+            num_experts_per_tok=2,
+            scoring_func="sigmoid",
+            n_shared_experts=1,
+            use_routing_bias=False,
+            routed_scaling_factor=1.0,
+            swiglu_limit=7.0,
+            swiglu_alpha=1.702,
+            swiglu_beta=1.0,
+        )
+        parallel_config = SimpleNamespace(
+            enable_eplb=True,
+            eplb_config=SimpleNamespace(num_redundant_experts=2),
+        )
+        ep_group = SimpleNamespace(
+            device_group=SimpleNamespace(size=lambda: 2),
+            rank_in_group=1,
+        )
+        gate = _FakeGate()
+        experts = _FakeExperts()
+
+        with (
+            patch.object(
+                minimax_module,
+                "get_tensor_model_parallel_world_size",
+                return_value=1,
+            ),
+            patch.object(
+                minimax_module,
+                "get_ep_group",
+                return_value=ep_group,
+            ),
+            patch.object(
+                minimax_module,
+                "MiniMaxM3MLP",
+                return_value=nn.Identity(),
+            ),
+            patch.object(
+                minimax_module,
+                "GateLinear",
+                return_value=gate,
+            ),
+            patch.object(
+                minimax_module,
+                "FusedMoEFactory",
+                return_value=experts,
+            ) as fused_moe,
+        ):
+            moe = minimax_module.MiniMaxM3MoE(
+                config=config,
+                parallel_config=parallel_config,
+                prefix="model.layers.0.block_sparse_moe",
+            )
+
+        self.assertEqual(moe.n_logical_experts, 8)
+        self.assertEqual(moe.n_physical_experts, 10)
+        self.assertEqual(moe.n_local_physical_experts, 5)
+        self.assertEqual(moe.physical_expert_start, 5)
+        self.assertEqual(moe.physical_expert_end, 10)
+        self.assertEqual(experts.global_redundant_expert_num, 2)
+        self.assertEqual(
+            experts.moe_config.global_redundant_expert_num,
+            2,
+        )
+        kwargs = fused_moe.call_args.kwargs
+        self.assertIs(kwargs["gate"], gate)
+        self.assertTrue(kwargs["enable_eplb"])
+        self.assertEqual(kwargs["num_redundant_experts"], 2)
+
+    def test_moe_forward_selects_router_input(self) -> None:
+        hidden_states = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+        for is_internal_router in (False, True):
+            with self.subTest(is_internal_router=is_internal_router):
+                moe = minimax_module.MiniMaxM3MoE.__new__(minimax_module.MiniMaxM3MoE)
+                nn.Module.__init__(moe)
+                gate = _FakeGate()
+                experts = _FakeExperts(is_internal_router=is_internal_router)
+                moe.gate = gate
+                moe.experts = experts
+
+                output = moe(hidden_states)
+
+                torch.testing.assert_close(output, hidden_states * 2)
+                torch.testing.assert_close(
+                    experts.last_hidden_states,
+                    hidden_states,
+                )
+                if is_internal_router:
+                    self.assertEqual(gate.call_count, 0)
+                    torch.testing.assert_close(
+                        experts.last_router_logits,
+                        hidden_states,
+                    )
+                else:
+                    self.assertEqual(gate.call_count, 1)
+                    torch.testing.assert_close(
+                        experts.last_router_logits,
+                        hidden_states + 10,
+                    )
+
+    def test_text_and_vl_models_update_expert_metadata(self) -> None:
+        moe = _make_moe_metadata()
+        sparse_layer = _FakeDecoderLayer(moe)
+        dense_layer = _FakeDecoderLayer()
+
+        language_model = minimax_module.MiniMaxM3SparseForCausalLM.__new__(minimax_module.MiniMaxM3SparseForCausalLM)
+        nn.Module.__init__(language_model)
+        language_model.model = nn.Module()
+        language_model.model.layers = nn.ModuleList([dense_layer, sparse_layer])
+
+        with patch.object(
+            minimax_module,
+            "MiniMaxM3DecoderLayer",
+            _FakeDecoderLayer,
+        ):
+            language_model._set_moe_parameters()
+
+        self.assertEqual(language_model.num_moe_layers, 1)
+        self.assertEqual(language_model.moe_layers, [moe.experts])
+        self.assertEqual(language_model.moe_mlp_layers, [moe])
+        self.assertEqual(language_model.num_logical_experts, 8)
+        self.assertEqual(language_model.num_redundant_experts, 2)
+
+        vl_model = vl_module.MiniMaxM3SparseForConditionalGeneration.__new__(
+            vl_module.MiniMaxM3SparseForConditionalGeneration
+        )
+        nn.Module.__init__(vl_model)
+        vl_model.language_model = language_model
+        vl_model._sync_moe_parameters()
+        vl_model.update_physical_experts_metadata(12, 5)
+
+        self.assertIs(vl_model.moe_layers, language_model.moe_layers)
+        self.assertEqual(vl_model.num_physical_experts, 12)
+        self.assertEqual(vl_model.num_redundant_experts, 4)
+        self.assertEqual(moe.n_physical_experts, 12)
+        self.assertEqual(moe.n_redundant_experts, 4)
+        moe.experts.update_expert_map.assert_called_once_with()
+        self.assertEqual(
+            moe.experts.global_redundant_expert_num,
+            4,
+        )
+        self.assertEqual(
+            moe.experts.moe_config.global_redundant_expert_num,
+            4,
+        )
+
+    def test_model_without_sparse_layers_has_zero_expert_metadata(
+        self,
+    ) -> None:
+        language_model = minimax_module.MiniMaxM3SparseForCausalLM.__new__(minimax_module.MiniMaxM3SparseForCausalLM)
+        nn.Module.__init__(language_model)
+        language_model.model = nn.Module()
+        language_model.model.layers = nn.ModuleList([_FakeDecoderLayer()])
+
+        with patch.object(
+            minimax_module,
+            "MiniMaxM3DecoderLayer",
+            _FakeDecoderLayer,
+        ):
+            language_model._set_moe_parameters()
+
+        self.assertEqual(language_model.num_moe_layers, 0)
+        self.assertEqual(language_model.num_logical_experts, 0)
+        self.assertEqual(language_model.num_physical_experts, 0)
+        self.assertEqual(language_model.num_redundant_experts, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/models/minimax_m3/test_minimax_m3_vit.py
+++ b/tests/ut/models/minimax_m3/test_minimax_m3_vit.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import torch
 import vllm
 from torch import nn
 from vllm.model_executor.models.utils import StageMissingLayer
@@ -44,6 +45,17 @@ class _DummyLanguageModel(nn.Module):
     def __init__(self, **kwargs) -> None:
         super().__init__()
         self.lm_head = nn.Identity()
+        self.expert_weights: list[list[torch.Tensor]] = []
+        self.num_expert_groups = 1
+        self.moe_layers: list[nn.Module] = []
+        self.moe_mlp_layers: list[nn.Module] = []
+        self.num_moe_layers = 0
+        self.num_logical_experts = 0
+        self.num_physical_experts = 0
+        self.num_local_physical_experts = 0
+        self.num_routed_experts = 0
+        self.num_shared_experts = 0
+        self.num_redundant_experts = 0
 
     def make_empty_intermediate_tensors(self, *args, **kwargs):
         return None

--- a/vllm_ascend/models/minimax_m3/minimax_m3.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3.py
@@ -32,8 +32,15 @@ import torch_npu
 from torch import nn
 from transformers import PretrainedConfig
 from vllm.compilation.decorators import support_torch_compile
-from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    ParallelConfig,
+    VllmConfig,
+    get_current_vllm_config,
+)
 from vllm.distributed import (
+    get_ep_group,
     get_pp_group,
     get_tensor_model_parallel_world_size,
 )
@@ -65,6 +72,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.models.interfaces import (
     EagleModelMixin,
+    MixtureOfExperts,
     SupportsEagle3,
     SupportsLoRA,
     SupportsPP,
@@ -573,12 +581,31 @@ class MiniMaxM3MoE(nn.Module):
     def __init__(
         self,
         config: PretrainedConfig,
+        parallel_config: ParallelConfig,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
     ):
         super().__init__()
         self.tp_size = get_tensor_model_parallel_world_size()
-        self.n_shared_experts = getattr(config, "n_shared_experts", None)
+        self.n_shared_experts = getattr(config, "n_shared_experts", 0) or 0
+
+        self.ep_group = get_ep_group().device_group
+        self.ep_rank = get_ep_group().rank_in_group
+        self.ep_size = self.ep_group.size()
+        self.n_routed_experts = config.num_local_experts
+
+        eplb_config = parallel_config.eplb_config
+        self.enable_eplb = parallel_config.enable_eplb
+        self.n_logical_experts = self.n_routed_experts
+        self.n_redundant_experts = eplb_config.num_redundant_experts
+        self.n_physical_experts = (
+            self.n_logical_experts + self.n_redundant_experts
+        )
+        self.n_local_physical_experts = self.n_physical_experts // self.ep_size
+        self.physical_expert_start = self.ep_rank * self.n_local_physical_experts
+        self.physical_expert_end = (
+            self.physical_expert_start + self.n_local_physical_experts
+        )
 
         if self.tp_size > config.num_local_experts:
             raise ValueError(
@@ -617,6 +644,7 @@ class MiniMaxM3MoE(nn.Module):
         self.experts = FusedMoEFactory(
             shared_experts=self.shared_experts,
             num_experts=config.num_local_experts,
+            gate=self.gate,
             top_k=config.num_experts_per_tok,
             scoring_func=config.scoring_func,
             e_score_correction_bias=self.e_score_correction_bias,
@@ -632,7 +660,14 @@ class MiniMaxM3MoE(nn.Module):
             router_logits_dtype=self.gate.out_dtype,
             routed_scaling_factor=self.routed_scaling_factor,
             apply_routed_scale_to_output=True,
+            enable_eplb=self.enable_eplb,
+            num_redundant_experts=self.n_redundant_experts,
         )
+
+        # Ascend dispatch uses this metadata to size the global physical
+        # expert space. The upstream V2 EPLB factory only updates moe_config.
+        self.experts.global_redundant_expert_num = self.n_redundant_experts
+        self.experts.moe_config.global_redundant_expert_num = self.n_redundant_experts
 
     @staticmethod
     def ebias_weight_loader(param: nn.Parameter, loaded_weight: torch.Tensor) -> None:
@@ -643,9 +678,18 @@ class MiniMaxM3MoE(nn.Module):
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
 
-        # router_logits: (num_tokens, n_experts)
-        router_logits, _ = self.gate(hidden_states)
-        final_hidden_states = self.experts(hidden_states=hidden_states, router_logits=router_logits)
+        if self.experts.is_internal_router:
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=hidden_states,
+            )
+        else:
+            # router_logits: (num_tokens, n_experts)
+            router_logits, _ = self.gate(hidden_states)
+            final_hidden_states = self.experts(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+            )
 
         return final_hidden_states.view(num_tokens, hidden_dim)
 
@@ -762,6 +806,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
         config: PretrainedConfig,
         prefix: str,
         model_config: ModelConfig,
+        parallel_config: ParallelConfig,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
     ) -> None:
@@ -819,6 +864,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
             self.block_sparse_moe = MiniMaxM3MoE(
                 config=config,
                 quant_config=quant_config,
+                parallel_config=parallel_config,
                 prefix=f"{prefix}.block_sparse_moe",
             )
         else:
@@ -895,6 +941,7 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
                 config,
                 prefix,
                 model_config=model_config,
+                parallel_config=vllm_config.parallel_config,
                 cache_config=cache_config,
                 quant_config=quant_config,
             ),
@@ -1139,7 +1186,13 @@ class MiniMaxM3Model(nn.Module, EagleModelMixin):
         return loaded_params
 
 
-class MiniMaxM3SparseForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEagle3):
+class MiniMaxM3SparseForCausalLM(
+    nn.Module,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsEagle3,
+    MixtureOfExperts,
+):
     packed_modules_mapping = {
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "indexer_proj": ["index_q_proj", "index_k_proj"],
@@ -1175,6 +1228,7 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEa
             self.lm_head = PPMissingLayer()
 
         self.make_empty_intermediate_tensors = self.model.make_empty_intermediate_tensors
+        self._set_moe_parameters()
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.embed_input_ids(input_ids)
@@ -1196,6 +1250,56 @@ class MiniMaxM3SparseForCausalLM(nn.Module, SupportsLoRA, SupportsPP, SupportsEa
     ) -> torch.Tensor | IntermediateTensors:
         hidden_states = self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
         return hidden_states
+
+    def _set_moe_parameters(self) -> None:
+        self.expert_weights = []
+        self.num_expert_groups = 1
+        self.moe_layers = []
+        self.moe_mlp_layers: list[MiniMaxM3MoE] = []
+
+        example_moe = None
+        for layer in self.model.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            assert isinstance(layer, MiniMaxM3DecoderLayer)
+            if layer.is_layer_sparse:
+                example_moe = layer.block_sparse_moe
+                self.moe_mlp_layers.append(example_moe)
+                self.moe_layers.append(example_moe.experts)
+
+        self.num_moe_layers = len(self.moe_layers)
+        if example_moe is None:
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_shared_experts = 0
+            self.num_redundant_experts = 0
+            return
+
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_local_physical_experts = num_local_physical_experts
+            moe.n_physical_experts = num_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()
+            moe.experts.global_redundant_expert_num = self.num_redundant_experts
+            moe.experts.moe_config.global_redundant_expert_num = self.num_redundant_experts
 
     def compute_logits(
         self,

--- a/vllm_ascend/models/minimax_m3/minimax_m3.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3.py
@@ -23,7 +23,7 @@
 # limitations under the License.
 """Inference-only MiniMaxM3 model."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, MutableSequence, Sequence
 from itertools import islice
 from typing import Any
 
@@ -598,14 +598,10 @@ class MiniMaxM3MoE(nn.Module):
         self.enable_eplb = parallel_config.enable_eplb
         self.n_logical_experts = self.n_routed_experts
         self.n_redundant_experts = eplb_config.num_redundant_experts
-        self.n_physical_experts = (
-            self.n_logical_experts + self.n_redundant_experts
-        )
+        self.n_physical_experts = self.n_logical_experts + self.n_redundant_experts
         self.n_local_physical_experts = self.n_physical_experts // self.ep_size
         self.physical_expert_start = self.ep_rank * self.n_local_physical_experts
-        self.physical_expert_end = (
-            self.physical_expert_start + self.n_local_physical_experts
-        )
+        self.physical_expert_end = self.physical_expert_start + self.n_local_physical_experts
 
         if self.tp_size > config.num_local_experts:
             raise ValueError(
@@ -1252,7 +1248,7 @@ class MiniMaxM3SparseForCausalLM(
         return hidden_states
 
     def _set_moe_parameters(self) -> None:
-        self.expert_weights = []
+        self.expert_weights: MutableSequence[Sequence[torch.Tensor]] = []
         self.num_expert_groups = 1
         self.moe_layers = []
         self.moe_mlp_layers: list[MiniMaxM3MoE] = []

--- a/vllm_ascend/models/minimax_m3/minimax_m3_vl.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3_vl.py
@@ -31,6 +31,7 @@ from vllm.distributed import (
 from vllm.logger import logger
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.models.interfaces import (
+    MixtureOfExperts,
     MultiModalEmbeddings,
     SupportsEagle3,
     SupportsLoRA,
@@ -165,7 +166,14 @@ class MiniMaxM3VLModel(nn.Module):
     info=MiniMaxM3VLProcessingInfo,
     dummy_inputs=MiniMaxM3VLDummyInputsBuilder,
 )
-class MiniMaxM3SparseForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsLoRA, SupportsPP, SupportsEagle3):
+class MiniMaxM3SparseForConditionalGeneration(
+    nn.Module,
+    SupportsMultiModal,
+    SupportsLoRA,
+    SupportsPP,
+    SupportsEagle3,
+    MixtureOfExperts,
+):
     supports_encoder_tp_data = True
 
     packed_modules_mapping = {
@@ -228,6 +236,34 @@ class MiniMaxM3SparseForConditionalGeneration(nn.Module, SupportsMultiModal, Sup
         self.vision_tower = self.model.vision_tower
         self.language_model = self.model.language_model
         self.make_empty_intermediate_tensors = self.language_model.make_empty_intermediate_tensors
+        self._sync_moe_parameters()
+
+    def _sync_moe_parameters(self) -> None:
+        language_model = self.language_model
+        self.expert_weights = language_model.expert_weights
+        self.num_expert_groups = language_model.num_expert_groups
+        self.moe_layers = language_model.moe_layers
+        self.moe_mlp_layers = language_model.moe_mlp_layers
+        self.num_moe_layers = language_model.num_moe_layers
+        self.num_logical_experts = language_model.num_logical_experts
+        self.num_physical_experts = language_model.num_physical_experts
+        self.num_local_physical_experts = (
+            language_model.num_local_physical_experts
+        )
+        self.num_routed_experts = language_model.num_routed_experts
+        self.num_shared_experts = language_model.num_shared_experts
+        self.num_redundant_experts = language_model.num_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        self.language_model.update_physical_experts_metadata(
+            num_physical_experts,
+            num_local_physical_experts,
+        )
+        self._sync_moe_parameters()
 
     @property
     def lm_head(self) -> nn.Module:

--- a/vllm_ascend/models/minimax_m3/minimax_m3_vl.py
+++ b/vllm_ascend/models/minimax_m3/minimax_m3_vl.py
@@ -247,9 +247,7 @@ class MiniMaxM3SparseForConditionalGeneration(
         self.num_moe_layers = language_model.num_moe_layers
         self.num_logical_experts = language_model.num_logical_experts
         self.num_physical_experts = language_model.num_physical_experts
-        self.num_local_physical_experts = (
-            language_model.num_local_physical_experts
-        )
+        self.num_local_physical_experts = language_model.num_local_physical_experts
         self.num_routed_experts = language_model.num_routed_experts
         self.num_shared_experts = language_model.num_shared_experts
         self.num_redundant_experts = language_model.num_redundant_experts


### PR DESCRIPTION
### What this PR does / why we need it?

This PR introduces support for Expert Parallel Load Balancing (EPLB) for the MiniMax-M3 model on Ascend. It implements the necessary MoE parameters initialization, physical experts metadata updates, and integrates with the Ascend EPLB state extensions to enable efficient load balancing across expert parallel ranks.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Tested with existing and new unit tests for MiniMax-M3 on Ascend.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
