### PR TITLE
[Test][Triton] Add single-kernel KDA coverage

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_aux_kernels.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_aux_kernels.py
@@ -1,0 +1,306 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Direct NPU precision tests for the auxiliary KDA Triton kernels.
+
+Kernel-to-test mapping:
+
+* ``chunk_local_cumsum_scalar_kernel`` ->
+  ``test_chunk_local_cumsum_scalar_kernel``
+* ``chunk_local_cumsum_vector_kernel`` ->
+  ``test_chunk_local_cumsum_vector_kernel``
+* ``l2norm_fwd_persistent_kernel`` -> ``test_l2norm_fwd_persistent_kernel``
+* ``l2norm_fwd_tiled_kernel`` -> ``test_l2norm_fwd_tiled_kernel``
+* ``solve_tril_16x16_kernel_kda`` -> ``test_solve_tril_16x16_kernel_kda``
+* ``merge_16x16_to_32x32_inverse_kernel_kda`` ->
+  ``test_merge_16x16_to_32x32_inverse_kernel_kda``
+* ``merge_16x16_to_64x64_inverse_kernel_kda`` ->
+  ``test_merge_16x16_to_64x64_inverse_kernel_kda``
+
+Every test directly launches only the kernel named in the test. References are
+computed independently with PyTorch in float32 on CPU.
+"""
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+from vllm.triton_utils import triton
+
+from vllm_ascend.ops.triton.kda.cumsum import (
+    chunk_local_cumsum_scalar_kernel,
+    chunk_local_cumsum_vector_kernel,
+)
+from vllm_ascend.ops.triton.kda.l2norm import (
+    l2norm_fwd_persistent_kernel,
+    l2norm_fwd_tiled_kernel,
+)
+from vllm_ascend.ops.triton.kda.solve_tril import (
+    merge_16x16_to_32x32_inverse_kernel_kda,
+    merge_16x16_to_64x64_inverse_kernel_kda,
+    solve_tril_16x16_kernel_kda,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+DEVICE = "npu"
+SEED = 42
+L2NORM_EPS = 1e-6
+L2NORM_RTOL = 3e-4
+L2NORM_ATOL = 1e-3
+SOLVE_RTOL = 5e-4
+SOLVE_ATOL = 5e-4
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _initialize_triton_device() -> None:
+    init_device_properties_triton()
+
+
+def _chunk_cumsum_reference(
+    x: torch.Tensor,
+    chunk_size: int,
+    *,
+    reverse: bool,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    """Compute independent per-chunk cumsums on CPU in float32."""
+    x_fp32 = x.to(dtype=torch.float32, device="cpu")
+    result = torch.empty_like(x_fp32)
+    for start in range(0, x.shape[1], chunk_size):
+        chunk = x_fp32[:, start : start + chunk_size]
+        if reverse:
+            chunk = torch.flip(torch.cumsum(torch.flip(chunk, dims=(1,)), dim=1), dims=(1,))
+        else:
+            chunk = torch.cumsum(chunk, dim=1)
+        result[:, start : start + chunk_size] = chunk * scale
+    return result
+
+
+def _l2norm_reference(x: torch.Tensor, eps: float) -> torch.Tensor:
+    """Normalize the final dimension on CPU with float32 accumulation."""
+    x_fp32 = x.to(dtype=torch.float32, device="cpu")
+    return x_fp32 * torch.rsqrt(x_fp32.square().sum(dim=-1, keepdim=True) + eps)
+
+
+def _make_block_strictly_lower_input(B: int, T: int, H: int, BT: int) -> torch.Tensor:
+    """Build ``[B, T, H, BT]`` block-local strictly-lower matrices."""
+    generator = torch.Generator(device="cpu").manual_seed(SEED + BT)
+    A = torch.zeros((B, T, H, BT), dtype=torch.float32)
+    for i_b in range(B):
+        for start in range(0, T, BT):
+            block_size = min(BT, T - start)
+            for i_h in range(H):
+                block = torch.randn((block_size, block_size), generator=generator, dtype=torch.float32)
+                A[i_b, start : start + block_size, i_h, :block_size] = torch.tril(block * 0.02, diagonal=-1)
+    return A
+
+
+def _block_inverse_reference(A: torch.Tensor) -> torch.Tensor:
+    """Invert each block-local ``I + A`` matrix independently on CPU."""
+    B, T, H, BT = A.shape
+    result = torch.zeros_like(A, dtype=torch.float32, device="cpu")
+    A_fp32 = A.to(dtype=torch.float32, device="cpu")
+    for i_b in range(B):
+        for start in range(0, T, BT):
+            block_size = min(BT, T - start)
+            identity = torch.eye(block_size, dtype=torch.float32)
+            for i_h in range(H):
+                block = A_fp32[i_b, start : start + block_size, i_h, :block_size]
+                result[i_b, start : start + block_size, i_h, :block_size] = torch.linalg.solve(
+                    identity + block, identity
+                )
+    return result
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, *, rtol: float, atol: float) -> None:
+    actual_cpu = actual.detach().to(dtype=torch.float32, device="cpu")
+    assert torch.isfinite(actual_cpu).all(), "Triton output contains NaN or Inf"
+    torch.testing.assert_close(actual_cpu, expected, rtol=rtol, atol=atol)
+
+
+@torch.inference_mode()
+def test_chunk_local_cumsum_scalar_kernel() -> None:
+    B, T, H = 2, 147, 4
+    chunk_size = 16
+    block_t = 128
+    scale = 0.125
+    generator = torch.Generator(device="cpu").manual_seed(SEED)
+    x_cpu = torch.randn((B, T, H), generator=generator, dtype=torch.float32)
+    expected = _chunk_cumsum_reference(x_cpu, chunk_size, reverse=False, scale=scale)
+    x = x_cpu.to(DEVICE)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(T, block_t), B)
+
+    chunk_local_cumsum_scalar_kernel[grid](
+        s=x,
+        o=output,
+        scale=scale,
+        cu_seqlens=None,
+        chunk_indices=None,
+        T=T,
+        H=H,
+        BLOCK_T=block_t,
+        REVERSE=False,
+        HEAD_FIRST=False,
+        CHUNK_SIZE=chunk_size,
+        num_warps=8,
+        num_stages=3,
+    )
+    torch.npu.synchronize()
+
+    _assert_close(output, expected, rtol=1e-5, atol=1e-5)
+
+
+@torch.inference_mode()
+def test_chunk_local_cumsum_vector_kernel() -> None:
+    B, T, H, S = 1, 67, 2, 33
+    chunk_size = 16
+    block_s = 32
+    generator = torch.Generator(device="cpu").manual_seed(SEED + 1)
+    x_cpu = torch.randn((B, T, H, S), generator=generator, dtype=torch.float32)
+    expected = _chunk_cumsum_reference(x_cpu, chunk_size, reverse=True)
+    x = x_cpu.to(DEVICE)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(S, block_s), triton.cdiv(T, chunk_size), B * H)
+
+    chunk_local_cumsum_vector_kernel[grid](
+        s=x,
+        o=output,
+        cu_seqlens=None,
+        chunk_indices=None,
+        T=T,
+        B=B,
+        H=H,
+        S=S,
+        BT=chunk_size,
+        REVERSE=True,
+        HEAD_FIRST=False,
+    )
+    torch.npu.synchronize()
+
+    _assert_close(output, expected, rtol=1e-5, atol=1e-5)
+
+
+@torch.inference_mode()
+def test_l2norm_fwd_persistent_kernel() -> None:
+    M, N = 143, 128
+    mblock = 69
+    num_chunks = 2
+    rows_per_program = mblock * num_chunks
+    generator = torch.Generator(device="cpu").manual_seed(SEED + 2)
+    x_cpu = torch.randn((M, N), generator=generator, dtype=torch.float32)
+    x_cpu[0].zero_()
+    expected = _l2norm_reference(x_cpu, L2NORM_EPS)
+    x = x_cpu.to(DEVICE)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(M, rows_per_program),)
+
+    l2norm_fwd_persistent_kernel[grid](
+        X=x,
+        Y=output,
+        eps=L2NORM_EPS,
+        M=M,
+        N=N,
+        MBLOCK=mblock,
+        NUM_CHUNKS=num_chunks,
+    )
+    torch.npu.synchronize()
+
+    _assert_close(output, expected, rtol=L2NORM_RTOL, atol=L2NORM_ATOL)
+
+
+@torch.inference_mode()
+def test_l2norm_fwd_tiled_kernel() -> None:
+    M, N = 35, 96
+    block_d = 128
+    mblock = 32
+    generator = torch.Generator(device="cpu").manual_seed(SEED + 3)
+    x_cpu = torch.randn((M, N), generator=generator, dtype=torch.float32)
+    x_cpu[-1].zero_()
+    expected = _l2norm_reference(x_cpu, L2NORM_EPS)
+    x = x_cpu.to(DEVICE)
+    output = torch.empty_like(x)
+    grid = (triton.cdiv(M, mblock),)
+
+    l2norm_fwd_tiled_kernel[grid](
+        X=x,
+        Y=output,
+        eps=L2NORM_EPS,
+        M=M,
+        N=N,
+        BD=block_d,
+        MBLOCK=mblock,
+    )
+    torch.npu.synchronize()
+
+    _assert_close(output, expected, rtol=L2NORM_RTOL, atol=L2NORM_ATOL)
+
+
+@torch.inference_mode()
+def test_solve_tril_16x16_kernel_kda() -> None:
+    B, T, H, BT = 1, 23, 2, 16
+    A_cpu = _make_block_strictly_lower_input(B, T, H, BT)
+    expected = _block_inverse_reference(A_cpu)
+    A = A_cpu.to(DEVICE)
+    output = torch.zeros_like(A)
+    grid = (triton.cdiv(T, BT), B * H)
+
+    solve_tril_16x16_kernel_kda[grid](
+        A=A,
+        Ai=output,
+        cu_seqlens=None,
+        chunk_indices=None,
+        T=T,
+        H=H,
+        BT=BT,
+        DOT_PRECISION="ieee",
+    )
+    torch.npu.synchronize()
+
+    _assert_close(output, expected, rtol=SOLVE_RTOL, atol=SOLVE_ATOL)
+
+
+@torch.inference_mode()
+def test_merge_16x16_to_32x32_inverse_kernel_kda() -> None:
+    B, T, H, BT = 1, 51, 2, 32
+    A_cpu = _make_block_strictly_lower_input(B, T, H, BT)
+    expected = _block_inverse_reference(A_cpu)
+    A = A_cpu.to(DEVICE)
+    output = torch.zeros_like(A)
+    grid = (triton.cdiv(T, BT), B * H)
+
+    merge_16x16_to_32x32_inverse_kernel_kda[grid](
+        A=A,
+        Ai=output,
+        cu_seqlens=None,
+        chunk_indices=None,
+        T=T,
+        H=H,
+        BT=BT,
+        DOT_PRECISION="ieee",
+    )
+    torch.npu.synchronize()
+
+    _assert_close(output, expected, rtol=SOLVE_RTOL, atol=SOLVE_ATOL)
+
+
+@torch.inference_mode()
+def test_merge_16x16_to_64x64_inverse_kernel_kda() -> None:
+    B, T, H, BT = 1, 123, 1, 64
+    A_cpu = _make_block_strictly_lower_input(B, T, H, BT)
+    expected = _block_inverse_reference(A_cpu)
+    A = A_cpu.to(DEVICE)
+    output = torch.zeros_like(A)
+    grid = (triton.cdiv(T, BT), B * H)
+
+    merge_16x16_to_64x64_inverse_kernel_kda[grid](
+        A=A,
+        Ai=output,
+        cu_seqlens=None,
+        chunk_indices=None,
+        T=T,
+        H=H,
+        BT=BT,
+        DOT_PRECISION="ieee",
+    )
+    torch.npu.synchronize()
+
+    _assert_close(output, expected, rtol=SOLVE_RTOL, atol=SOLVE_ATOL)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_core_kernels.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_core_kernels.py
@@ -1,0 +1,855 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Single-kernel precision tests for the core KDA Triton kernels.
+
+Kernel-to-test mapping (each test directly launches exactly one production
+kernel and never calls a production wrapper):
+
+* ``layer_norm_gated_fwd_kernel`` ->
+  ``test_layer_norm_gated_fwd_kernel``
+* ``layer_norm_gated_fwd_kernel1`` ->
+  ``test_layer_norm_gated_fwd_kernel1``
+* ``chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter`` ->
+  ``test_chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter``
+* ``chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra`` ->
+  ``test_chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra``
+* ``recompute_w_u_fwd_kernel`` -> ``test_recompute_w_u_fwd_kernel``
+* ``chunk_gla_fwd_kernel_o`` -> ``test_chunk_gla_fwd_kernel_o``
+* ``kda_gate_fwd_kernel`` -> ``test_kda_gate_fwd_kernel``
+
+All references use independent PyTorch operations with FP32 accumulation.
+"""
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+import torch
+import torch.nn.functional as F
+import torch_npu  # noqa: F401
+
+from vllm_ascend.ops.triton.kda.kda import (
+    chunk_gla_fwd_kernel_o,
+    chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter,
+    chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra,
+    kda_gate_fwd_kernel,
+    layer_norm_gated_fwd_kernel,
+    layer_norm_gated_fwd_kernel1,
+    recompute_w_u_fwd_kernel,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+DEVICE = "npu"
+CHUNK_SIZE = 64
+SUB_CHUNK_SIZE = 16
+EPS = 1e-5
+
+
+@dataclass(frozen=True)
+class SequenceLayout:
+    batch_size: int
+    sequence_width: int
+    segments: tuple[tuple[int, int, int], ...]
+    grid_chunks: int
+    total_chunks: int
+    cu_seqlens: torch.Tensor | None
+    chunk_indices: torch.Tensor | None
+
+    @property
+    def is_varlen(self) -> bool:
+        return self.cu_seqlens is not None
+
+
+@pytest.fixture(scope="module", autouse=True)
+def init_triton_device_properties():
+    init_device_properties_triton()
+
+
+def _ceil_div(lhs: int, rhs: int) -> int:
+    return (lhs + rhs - 1) // rhs
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def _randn(
+    shape: tuple[int, ...],
+    dtype: torch.dtype,
+    *,
+    scale: float = 1.0,
+) -> torch.Tensor:
+    return (torch.randn(shape, dtype=torch.float32) * scale).to(dtype).contiguous()
+
+
+def _make_layout(is_varlen: bool) -> SequenceLayout:
+    if not is_varlen:
+        batch_size, sequence_width = 2, 75
+        grid_chunks = _ceil_div(sequence_width, CHUNK_SIZE)
+        return SequenceLayout(
+            batch_size=batch_size,
+            sequence_width=sequence_width,
+            segments=tuple((batch, 0, sequence_width) for batch in range(batch_size)),
+            grid_chunks=grid_chunks,
+            total_chunks=batch_size * grid_chunks,
+            cu_seqlens=None,
+            chunk_indices=None,
+        )
+
+    lengths = (37, 70)
+    cumulative = [0]
+    for length in lengths:
+        cumulative.append(cumulative[-1] + length)
+    indices = [
+        (sequence, chunk) for sequence, length in enumerate(lengths) for chunk in range(_ceil_div(length, CHUNK_SIZE))
+    ]
+    return SequenceLayout(
+        batch_size=1,
+        sequence_width=cumulative[-1],
+        segments=tuple((0, cumulative[index], length) for index, length in enumerate(lengths)),
+        grid_chunks=len(indices),
+        total_chunks=len(indices),
+        cu_seqlens=torch.tensor(cumulative, dtype=torch.int64),
+        chunk_indices=torch.tensor(indices, dtype=torch.int64),
+    )
+
+
+def _iter_chunks(layout: SequenceLayout) -> Iterator[tuple[int, int, int, int]]:
+    global_chunk = 0
+    for batch, sequence_start, sequence_length in layout.segments:
+        for chunk in range(_ceil_div(sequence_length, CHUNK_SIZE)):
+            token_start = sequence_start + chunk * CHUNK_SIZE
+            chunk_length = min(CHUNK_SIZE, sequence_length - chunk * CHUNK_SIZE)
+            state_chunk = global_chunk if layout.is_varlen else batch * layout.grid_chunks + chunk
+            yield batch, token_start, chunk_length, state_chunk
+            global_chunk += 1
+
+
+def _npu_metadata(layout: SequenceLayout) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+    cu_seqlens = None if layout.cu_seqlens is None else layout.cu_seqlens.to(DEVICE)
+    chunk_indices = None if layout.chunk_indices is None else layout.chunk_indices.to(DEVICE)
+    return cu_seqlens, chunk_indices
+
+
+def _tolerances(dtype: torch.dtype) -> tuple[float, float]:
+    if dtype == torch.bfloat16:
+        return 4e-2, 4e-2
+    if dtype == torch.float16:
+        return 1.5e-2, 1.5e-2
+    return 5e-4, 5e-4
+
+
+def _assert_close(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    dtype: torch.dtype,
+    *,
+    rtol: float | None = None,
+    atol: float | None = None,
+) -> None:
+    default_rtol, default_atol = _tolerances(dtype)
+    torch.testing.assert_close(
+        actual.detach().cpu().float(),
+        expected.detach().cpu().float(),
+        rtol=default_rtol if rtol is None else rtol,
+        atol=default_atol if atol is None else atol,
+    )
+
+
+def _layer_norm_gated_reference(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor | None,
+    bias: torch.Tensor | None,
+    residual: torch.Tensor | None,
+    activation: str,
+    is_rms_norm: bool,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
+    residual_out = x.float()
+    if residual is not None:
+        residual_out = residual_out + residual.float()
+
+    mean = None if is_rms_norm else residual_out.mean(dim=-1)
+    centered = residual_out if mean is None else residual_out - mean[:, None]
+    variance = centered.square().mean(dim=-1)
+    rstd = torch.rsqrt(variance + EPS)
+    normalized = residual_out * rstd[:, None] if is_rms_norm else centered * rstd[:, None]
+    if weight is not None:
+        normalized = normalized * weight.float()[None, :]
+    if bias is not None:
+        normalized = normalized + bias.float()[None, :]
+
+    gate_fp32 = gate.float()
+    if activation in ("silu", "swish"):
+        normalized = normalized * F.silu(gate_fp32)
+    elif activation == "sigmoid":
+        normalized = normalized * torch.sigmoid(gate_fp32)
+    return normalized.to(x.dtype), mean, rstd, residual_out.to(x.dtype)
+
+
+def _scaled_dot_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    layout: SequenceLayout,
+    scale: float,
+    *,
+    inter_sub_chunk: bool,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    _, _, heads, _ = q.shape
+    a_ref = torch.zeros(
+        layout.batch_size,
+        layout.sequence_width,
+        heads,
+        CHUNK_SIZE,
+        dtype=torch.float32,
+    )
+    aqk_ref = torch.zeros_like(a_ref)
+
+    for batch, token_start, chunk_length, _ in _iter_chunks(layout):
+        for head in range(heads):
+            q_chunk = q[batch, token_start : token_start + chunk_length, head].float()
+            k_chunk = k[batch, token_start : token_start + chunk_length, head].float()
+            gate_chunk = gate[batch, token_start : token_start + chunk_length, head].float()
+            gated_k = k_chunk * torch.exp2(gate_chunk)
+            inverse_gated_k = k_chunk * torch.exp2(-gate_chunk)
+            kkt = gated_k @ inverse_gated_k.transpose(0, 1)
+            qkt = (q_chunk * torch.exp2(gate_chunk)) @ inverse_gated_k.transpose(0, 1)
+
+            for row in range(chunk_length):
+                sub_chunk = row // SUB_CHUNK_SIZE
+                if inter_sub_chunk:
+                    column_start = 0
+                    a_column_end = sub_chunk * SUB_CHUNK_SIZE
+                    aqk_column_end = a_column_end
+                else:
+                    column_start = sub_chunk * SUB_CHUNK_SIZE
+                    a_column_end = row
+                    aqk_column_end = row + 1
+
+                output_row = token_start + row
+                if a_column_end > column_start:
+                    a_ref[batch, output_row, head, column_start:a_column_end] = (
+                        kkt[row, column_start:a_column_end] * beta[batch, output_row, head].float()
+                    )
+                if aqk_column_end > column_start:
+                    aqk_ref[batch, output_row, head, column_start:aqk_column_end] = (
+                        qkt[row, column_start:aqk_column_end] * scale
+                    )
+    return a_ref, aqk_ref
+
+
+def _recompute_reference(
+    q: torch.Tensor | None,
+    k: torch.Tensor,
+    value: torch.Tensor,
+    beta: torch.Tensor,
+    coefficients: torch.Tensor,
+    gate: torch.Tensor,
+    layout: SequenceLayout,
+    *,
+    store_qg: bool,
+    store_kg: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    dtype = k.dtype
+    _, _, heads, _ = k.shape
+    w_ref = torch.zeros_like(k)
+    u_ref = torch.zeros_like(value)
+    qg_ref = torch.zeros_like(q) if store_qg and q is not None else None
+    kg_ref = torch.zeros_like(k) if store_kg else None
+
+    for batch, token_start, chunk_length, _ in _iter_chunks(layout):
+        for head in range(heads):
+            token_slice = slice(token_start, token_start + chunk_length)
+            a_chunk = coefficients[batch, token_slice, head, :chunk_length].float()
+            beta_chunk = beta[batch, token_slice, head].float()
+            gate_chunk = gate[batch, token_slice, head].float()
+
+            weighted_value = (value[batch, token_slice, head].float() * beta_chunk[:, None]).to(dtype).float()
+            weighted_key = (k[batch, token_slice, head].float() * beta_chunk[:, None]).to(dtype).float()
+            weighted_key = (weighted_key * torch.exp2(gate_chunk)).to(dtype).float()
+            u_ref[batch, token_slice, head] = (a_chunk @ weighted_value).to(dtype)
+            w_ref[batch, token_slice, head] = (a_chunk @ weighted_key).to(dtype)
+
+            if qg_ref is not None and q is not None:
+                qg_ref[batch, token_slice, head] = (q[batch, token_slice, head].float() * torch.exp2(gate_chunk)).to(
+                    dtype
+                )
+            if kg_ref is not None:
+                last_gate = gate_chunk[-1]
+                kg_ref[batch, token_slice, head] = (
+                    k[batch, token_slice, head].float() * torch.exp2(last_gate[None, :] - gate_chunk)
+                ).to(dtype)
+    return w_ref, u_ref, qg_ref, kg_ref
+
+
+def _chunk_gla_reference(
+    q: torch.Tensor,
+    value: torch.Tensor,
+    gate: torch.Tensor,
+    state: torch.Tensor,
+    coefficients: torch.Tensor,
+    layout: SequenceLayout,
+    scale: float,
+) -> torch.Tensor:
+    dtype = q.dtype
+    _, _, heads, _ = q.shape
+    out = torch.zeros_like(value)
+    for batch, token_start, chunk_length, state_chunk in _iter_chunks(layout):
+        for head in range(heads):
+            token_slice = slice(token_start, token_start + chunk_length)
+            scaled_q = (q[batch, token_slice, head].float() * scale).to(dtype).float()
+            gated_q = (scaled_q * torch.exp2(gate[batch, token_slice, head].float())).to(dtype).float()
+            state_output = gated_q @ state[state_chunk, head].float().transpose(0, 1)
+
+            a_chunk = coefficients[batch, token_slice, head, :chunk_length].float()
+            a_chunk = torch.tril(a_chunk).to(dtype).float()
+            value_output = a_chunk @ value[batch, token_slice, head].float()
+            out[batch, token_slice, head] = (state_output + value_output).to(dtype)
+    return out
+
+
+@pytest.mark.parametrize(
+    ("dtype", "tokens", "hidden", "activation", "is_rms_norm", "with_residual", "with_affine"),
+    [
+        pytest.param(
+            torch.float16,
+            37,
+            60,
+            "silu",
+            False,
+            True,
+            True,
+            id="fp16-layernorm-residual-affine-silu-tail",
+        ),
+        pytest.param(
+            torch.bfloat16,
+            33,
+            96,
+            "sigmoid",
+            True,
+            False,
+            False,
+            id="bf16-rms-no-residual-no-affine-sigmoid-tail",
+        ),
+    ],
+)
+@torch.inference_mode()
+def test_layer_norm_gated_fwd_kernel(
+    dtype: torch.dtype,
+    tokens: int,
+    hidden: int,
+    activation: str,
+    is_rms_norm: bool,
+    with_residual: bool,
+    with_affine: bool,
+) -> None:
+    torch.manual_seed(11)
+    x_cpu = _randn((tokens, hidden), dtype, scale=0.4)
+    gate_cpu = _randn((tokens, hidden), dtype, scale=0.7)
+    residual_cpu = _randn((tokens, hidden), dtype, scale=0.2) if with_residual else None
+    weight_cpu = (1 + _randn((hidden,), dtype, scale=0.1)) if with_affine else None
+    bias_cpu = _randn((hidden,), dtype, scale=0.1) if with_affine else None
+    y_ref, mean_ref, rstd_ref, residual_ref = _layer_norm_gated_reference(
+        x_cpu,
+        gate_cpu,
+        weight_cpu,
+        bias_cpu,
+        residual_cpu,
+        activation,
+        is_rms_norm,
+    )
+
+    x = x_cpu.to(DEVICE)
+    gate = gate_cpu.to(DEVICE)
+    residual = None if residual_cpu is None else residual_cpu.to(DEVICE)
+    weight = None if weight_cpu is None else weight_cpu.to(DEVICE)
+    bias = None if bias_cpu is None else bias_cpu.to(DEVICE)
+    y = torch.empty_like(x)
+    mean = None if is_rms_norm else torch.empty(tokens, dtype=torch.float32, device=DEVICE)
+    rstd = torch.empty(tokens, dtype=torch.float32, device=DEVICE)
+    residual_out = torch.empty_like(x) if with_residual else None
+    block_tokens = 32
+
+    layer_norm_gated_fwd_kernel[(_ceil_div(tokens, block_tokens),)](
+        x=x,
+        g=gate,
+        y=y,
+        w=weight,
+        b=bias,
+        residual=residual,
+        residual_out=residual_out,
+        mean=mean,
+        rstd=rstd,
+        eps=EPS,
+        T=tokens,
+        D=hidden,
+        BT=block_tokens,
+        BD=_next_power_of_2(hidden),
+        ACTIVATION=activation,
+        IS_RMS_NORM=is_rms_norm,
+        num_warps=4,
+    )
+
+    _assert_close(y, y_ref, dtype)
+    _assert_close(rstd, rstd_ref, torch.float32, rtol=8e-4, atol=8e-4)
+    if mean is not None and mean_ref is not None:
+        _assert_close(mean, mean_ref, torch.float32, rtol=8e-4, atol=8e-4)
+    if residual_out is not None:
+        _assert_close(residual_out, residual_ref, dtype)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "tokens", "hidden", "activation", "is_rms_norm", "with_residual", "with_affine"),
+    [
+        pytest.param(
+            torch.float16,
+            5,
+            768,
+            "sigmoid",
+            True,
+            True,
+            True,
+            id="fp16-rms-residual-affine-sigmoid-non-power-of-two",
+        ),
+        pytest.param(
+            torch.bfloat16,
+            3,
+            1000,
+            "silu",
+            False,
+            False,
+            False,
+            id="bf16-layernorm-no-residual-no-affine-silu-tail",
+        ),
+    ],
+)
+@torch.inference_mode()
+def test_layer_norm_gated_fwd_kernel1(
+    dtype: torch.dtype,
+    tokens: int,
+    hidden: int,
+    activation: str,
+    is_rms_norm: bool,
+    with_residual: bool,
+    with_affine: bool,
+) -> None:
+    torch.manual_seed(12)
+    x_cpu = _randn((tokens, hidden), dtype, scale=0.4)
+    gate_cpu = _randn((tokens, hidden), dtype, scale=0.7)
+    residual_cpu = _randn((tokens, hidden), dtype, scale=0.2) if with_residual else None
+    weight_cpu = (1 + _randn((hidden,), dtype, scale=0.1)) if with_affine else None
+    bias_cpu = _randn((hidden,), dtype, scale=0.1) if with_affine else None
+    y_ref, mean_ref, rstd_ref, residual_ref = _layer_norm_gated_reference(
+        x_cpu,
+        gate_cpu,
+        weight_cpu,
+        bias_cpu,
+        residual_cpu,
+        activation,
+        is_rms_norm,
+    )
+
+    x = x_cpu.to(DEVICE)
+    gate = gate_cpu.to(DEVICE)
+    residual = None if residual_cpu is None else residual_cpu.to(DEVICE)
+    weight = None if weight_cpu is None else weight_cpu.to(DEVICE)
+    bias = None if bias_cpu is None else bias_cpu.to(DEVICE)
+    y = torch.empty_like(x)
+    mean = None if is_rms_norm else torch.empty(tokens, dtype=torch.float32, device=DEVICE)
+    rstd = torch.empty(tokens, dtype=torch.float32, device=DEVICE)
+    residual_out = torch.empty_like(x) if with_residual else None
+
+    layer_norm_gated_fwd_kernel1[(tokens,)](
+        x=x,
+        g=gate,
+        y=y,
+        w=weight,
+        b=bias,
+        residual=residual,
+        residual_out=residual_out,
+        mean=mean,
+        rstd=rstd,
+        eps=EPS,
+        D=hidden,
+        BD=_next_power_of_2(hidden),
+        ACTIVATION=activation,
+        IS_RMS_NORM=is_rms_norm,
+        num_warps=4,
+    )
+
+    _assert_close(y, y_ref, dtype)
+    _assert_close(rstd, rstd_ref, torch.float32, rtol=8e-4, atol=8e-4)
+    if mean is not None and mean_ref is not None:
+        _assert_close(mean, mean_ref, torch.float32, rtol=8e-4, atol=8e-4)
+    if residual_out is not None:
+        _assert_close(residual_out, residual_ref, dtype)
+
+
+@pytest.mark.parametrize(
+    ("is_varlen", "dtype", "key_dim"),
+    [
+        pytest.param(False, torch.float16, 128, id="fixed-fp16-k128-two-chunks"),
+        pytest.param(True, torch.bfloat16, 48, id="varlen-bf16-k48-tail-chunks"),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter(
+    is_varlen: bool,
+    dtype: torch.dtype,
+    key_dim: int,
+) -> None:
+    torch.manual_seed(21)
+    layout = _make_layout(is_varlen)
+    heads = 2
+    shape = (layout.batch_size, layout.sequence_width, heads, key_dim)
+    q_cpu = _randn(shape, dtype, scale=0.25)
+    k_cpu = _randn(shape, dtype, scale=0.25)
+    # The production KDA path feeds this kernel the FP32 cumulative gate
+    # emitted by chunk_local_cumsum.
+    gate_cpu = _randn(shape, torch.float32, scale=0.12)
+    beta_cpu = torch.rand(shape[:-1], dtype=torch.float32).mul(0.5).add(0.25).to(dtype)
+    scale = key_dim**-0.5
+    a_ref, aqk_ref = _scaled_dot_reference(
+        q_cpu,
+        k_cpu,
+        gate_cpu,
+        beta_cpu,
+        layout,
+        scale,
+        inter_sub_chunk=True,
+    )
+
+    q, k, gate, beta = (tensor.to(DEVICE) for tensor in (q_cpu, k_cpu, gate_cpu, beta_cpu))
+    a = torch.zeros(
+        layout.batch_size,
+        layout.sequence_width,
+        heads,
+        CHUNK_SIZE,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    aqk = torch.zeros_like(a)
+    cu_seqlens, chunk_indices = _npu_metadata(layout)
+
+    chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter[(layout.grid_chunks, layout.batch_size * heads)](
+        q=q,
+        k=k,
+        g=gate,
+        beta=beta,
+        A=a,
+        Aqk=aqk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=layout.sequence_width,
+        H=heads,
+        K=key_dim,
+        BT=CHUNK_SIZE,
+        BC=SUB_CHUNK_SIZE,
+        NC=CHUNK_SIZE // SUB_CHUNK_SIZE,
+    )
+
+    _assert_close(a, a_ref, dtype, rtol=5e-2, atol=2e-2)
+    _assert_close(aqk, aqk_ref, dtype, rtol=5e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize(
+    ("is_varlen", "dtype", "key_dim"),
+    [
+        pytest.param(False, torch.float16, 128, id="fixed-fp16-k128-two-chunks"),
+        pytest.param(True, torch.bfloat16, 24, id="varlen-bf16-k24-tail-chunks"),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra(
+    is_varlen: bool,
+    dtype: torch.dtype,
+    key_dim: int,
+) -> None:
+    torch.manual_seed(22)
+    layout = _make_layout(is_varlen)
+    heads = 2
+    shape = (layout.batch_size, layout.sequence_width, heads, key_dim)
+    q_cpu = _randn(shape, dtype, scale=0.25)
+    k_cpu = _randn(shape, dtype, scale=0.25)
+    gate_cpu = _randn(shape, dtype, scale=0.12)
+    beta_cpu = torch.rand(shape[:-1], dtype=torch.float32).mul(0.5).add(0.25).to(dtype)
+    scale = key_dim**-0.5
+    a_ref, aqk_ref = _scaled_dot_reference(
+        q_cpu,
+        k_cpu,
+        gate_cpu,
+        beta_cpu,
+        layout,
+        scale,
+        inter_sub_chunk=False,
+    )
+
+    q, k, gate, beta = (tensor.to(DEVICE) for tensor in (q_cpu, k_cpu, gate_cpu, beta_cpu))
+    a = torch.zeros(
+        layout.batch_size,
+        layout.sequence_width,
+        heads,
+        CHUNK_SIZE,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    aqk = torch.zeros_like(a)
+    cu_seqlens, chunk_indices = _npu_metadata(layout)
+
+    chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra[
+        (
+            layout.grid_chunks,
+            CHUNK_SIZE // SUB_CHUNK_SIZE,
+            layout.batch_size * heads,
+        )
+    ](
+        q=q,
+        k=k,
+        g=gate,
+        beta=beta,
+        A=a,
+        Aqk=aqk,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=layout.sequence_width,
+        H=heads,
+        K=key_dim,
+        BT=CHUNK_SIZE,
+        BC=SUB_CHUNK_SIZE,
+        BK=max(_next_power_of_2(key_dim), SUB_CHUNK_SIZE),
+    )
+
+    _assert_close(a, a_ref, dtype, rtol=5e-2, atol=2e-2)
+    _assert_close(aqk, aqk_ref, dtype, rtol=5e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize(
+    ("is_varlen", "dtype", "key_dim", "value_dim", "store_qg", "store_kg"),
+    [
+        pytest.param(False, torch.float16, 128, 128, True, False, id="fixed-fp16-k128-v128-store-qg"),
+        pytest.param(True, torch.bfloat16, 48, 80, False, True, id="varlen-bf16-k48-v80-store-kg"),
+    ],
+)
+@torch.inference_mode()
+def test_recompute_w_u_fwd_kernel(
+    is_varlen: bool,
+    dtype: torch.dtype,
+    key_dim: int,
+    value_dim: int,
+    store_qg: bool,
+    store_kg: bool,
+) -> None:
+    torch.manual_seed(31)
+    layout = _make_layout(is_varlen)
+    heads = 2
+    q_cpu = _randn(
+        (layout.batch_size, layout.sequence_width, heads, key_dim),
+        dtype,
+        scale=0.25,
+    )
+    k_cpu = _randn(q_cpu.shape, dtype, scale=0.25)
+    value_cpu = _randn(
+        (layout.batch_size, layout.sequence_width, heads, value_dim),
+        dtype,
+        scale=0.25,
+    )
+    beta_cpu = (
+        torch.rand(layout.batch_size, layout.sequence_width, heads, dtype=torch.float32).mul(0.5).add(0.25).to(dtype)
+    )
+    coefficients_cpu = _randn(
+        (layout.batch_size, layout.sequence_width, heads, CHUNK_SIZE),
+        dtype,
+        scale=0.03,
+    )
+    gate_cpu = _randn(q_cpu.shape, dtype, scale=0.12)
+    w_ref, u_ref, qg_ref, kg_ref = _recompute_reference(
+        q_cpu if store_qg else None,
+        k_cpu,
+        value_cpu,
+        beta_cpu,
+        coefficients_cpu,
+        gate_cpu,
+        layout,
+        store_qg=store_qg,
+        store_kg=store_kg,
+    )
+
+    q = q_cpu.to(DEVICE) if store_qg else None
+    k = k_cpu.to(DEVICE)
+    value = value_cpu.to(DEVICE)
+    beta = beta_cpu.to(DEVICE)
+    coefficients = coefficients_cpu.to(DEVICE)
+    gate = gate_cpu.to(DEVICE)
+    w = torch.zeros_like(k)
+    u = torch.zeros_like(value)
+    qg = torch.zeros_like(q) if q is not None else None
+    kg = torch.zeros_like(k) if store_kg else None
+    cu_seqlens, chunk_indices = _npu_metadata(layout)
+
+    recompute_w_u_fwd_kernel[(layout.grid_chunks, layout.batch_size * heads)](
+        q=q,
+        k=k,
+        qg=qg,
+        kg=kg,
+        v=value,
+        beta=beta,
+        w=w,
+        u=u,
+        A=coefficients,
+        gk=gate,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=layout.sequence_width,
+        H=heads,
+        K=key_dim,
+        V=value_dim,
+        BT=CHUNK_SIZE,
+        BK=64,
+        BV=64,
+        DOT_PRECISION="ieee",
+    )
+
+    _assert_close(w, w_ref, dtype, rtol=6e-2, atol=2e-2)
+    _assert_close(u, u_ref, dtype, rtol=6e-2, atol=2e-2)
+    if qg is not None and qg_ref is not None:
+        _assert_close(qg, qg_ref, dtype)
+    if kg is not None and kg_ref is not None:
+        _assert_close(kg, kg_ref, dtype)
+
+
+@pytest.mark.parametrize(
+    ("is_varlen", "dtype", "key_dim", "value_dim"),
+    [
+        pytest.param(False, torch.float16, 128, 144, id="fixed-fp16-k128-v144-two-chunks"),
+        pytest.param(True, torch.bfloat16, 48, 80, id="varlen-bf16-k48-v80-tail-chunks"),
+    ],
+)
+@torch.inference_mode()
+def test_chunk_gla_fwd_kernel_o(
+    is_varlen: bool,
+    dtype: torch.dtype,
+    key_dim: int,
+    value_dim: int,
+) -> None:
+    torch.manual_seed(41)
+    layout = _make_layout(is_varlen)
+    heads = 2
+    q_cpu = _randn(
+        (layout.batch_size, layout.sequence_width, heads, key_dim),
+        dtype,
+        scale=0.2,
+    )
+    value_cpu = _randn(
+        (layout.batch_size, layout.sequence_width, heads, value_dim),
+        dtype,
+        scale=0.2,
+    )
+    gate_cpu = _randn(q_cpu.shape, dtype, scale=0.12)
+    state_cpu = _randn(
+        (layout.total_chunks, heads, value_dim, key_dim),
+        dtype,
+        scale=0.05,
+    )
+    coefficients_cpu = _randn(
+        (layout.batch_size, layout.sequence_width, heads, CHUNK_SIZE),
+        torch.float32,
+        scale=0.02,
+    )
+    scale = key_dim**-0.5
+    out_ref = _chunk_gla_reference(
+        q_cpu,
+        value_cpu,
+        gate_cpu,
+        state_cpu,
+        coefficients_cpu,
+        layout,
+        scale,
+    )
+
+    q, value, gate, state, coefficients = (
+        tensor.to(DEVICE) for tensor in (q_cpu, value_cpu, gate_cpu, state_cpu, coefficients_cpu)
+    )
+    out = torch.zeros_like(value)
+    cu_seqlens, chunk_indices = _npu_metadata(layout)
+
+    chunk_gla_fwd_kernel_o[
+        (
+            _ceil_div(value_dim, 128),
+            layout.grid_chunks,
+            layout.batch_size * heads,
+        )
+    ](
+        q=q,
+        v=value,
+        g=gate,
+        h=state,
+        o=out,
+        A=coefficients,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=layout.sequence_width,
+        H=heads,
+        K=key_dim,
+        V=value_dim,
+        BT=CHUNK_SIZE,
+    )
+
+    _assert_close(out, out_ref, dtype, rtol=6e-2, atol=3e-2)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "tokens", "with_bias", "beta", "threshold"),
+    [
+        pytest.param(torch.float16, 65, True, 1.5, 5.0, id="fp16-bias-linear-threshold-tail"),
+        pytest.param(torch.bfloat16, 17, False, 1.5, 5.0, id="bf16-no-bias-tail"),
+    ],
+)
+@torch.inference_mode()
+def test_kda_gate_fwd_kernel(
+    dtype: torch.dtype,
+    tokens: int,
+    with_bias: bool,
+    beta: float,
+    threshold: float,
+) -> None:
+    torch.manual_seed(51)
+    heads, head_dim = 3, 40
+    gate_cpu = _randn((tokens, heads, head_dim), dtype, scale=0.8)
+    gate_cpu[0, :, 0] = torch.tensor(threshold / beta + 2, dtype=dtype)
+    a_cpu = _randn((heads,), torch.float32, scale=0.2) - 0.7
+    bias_cpu = _randn((heads, head_dim), dtype, scale=0.2) if with_bias else None
+
+    biased_gate = gate_cpu.float()
+    if bias_cpu is not None:
+        biased_gate = biased_gate + bias_cpu.float()[None, :, :]
+    out_ref = -torch.exp(a_cpu.float())[None, :, None] * F.softplus(
+        biased_gate,
+        beta=beta,
+        threshold=threshold,
+    )
+
+    gate = gate_cpu.to(DEVICE)
+    a = a_cpu.to(DEVICE)
+    bias = None if bias_cpu is None else bias_cpu.to(DEVICE)
+    out = torch.empty((tokens, heads, head_dim), dtype=torch.float32, device=DEVICE)
+
+    kda_gate_fwd_kernel[lambda meta: (_ceil_div(tokens, meta["BT"]), heads)](
+        g=gate,
+        A=a,
+        y=out,
+        g_bias=bias,
+        beta=beta,
+        threshold=threshold,
+        T=tokens,
+        H=heads,
+        D=head_dim,
+        BD=_next_power_of_2(head_dim),
+        HAS_BIAS=with_bias,
+    )
+
+    _assert_close(out, out_ref, dtype, rtol=2e-3, atol=2e-3)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_state_kernels.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_state_kernels.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# mypy: ignore-errors
+"""Single-kernel NPU precision tests for the KDA state kernels.
+
+Kernel-to-test mapping (each parameterized case launches only the named raw
+Triton kernel and never calls a production wrapper):
+
+* ``chunk_gated_delta_rule_fwd_kernel_h_blockdim64_kda``
+  -> ``test_chunk_gated_delta_rule_fwd_kernel_h_blockdim64_kda``
+* ``fused_recurrent_gated_delta_rule_fwd_kernel``
+  -> ``test_fused_recurrent_gated_delta_rule_fwd_kernel_kda``
+
+All expected values are computed by independent CPU float32 recurrences from
+the quantized kernel inputs.
+"""
+
+import math
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.ops.triton.kda.chunk_delta_h import (
+    chunk_gated_delta_rule_fwd_kernel_h_blockdim64_kda,
+)
+from vllm_ascend.ops.triton.kda.fused_recurrent_kda import (
+    fused_recurrent_gated_delta_rule_fwd_kernel,
+)
+from vllm_ascend.ops.triton.triton_utils import init_device_properties_triton
+
+DEVICE = "npu"
+CHUNK_SIZE = 64
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _initialize_triton_device() -> None:
+    init_device_properties_triton()
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def _tolerances(dtype: torch.dtype) -> tuple[float, float]:
+    if dtype == torch.bfloat16:
+        return 3e-2, 3e-2
+    return 1e-2, 1e-2
+
+
+def _assert_close(name: str, actual: torch.Tensor, expected: torch.Tensor, dtype: torch.dtype) -> None:
+    actual = actual.detach().to(torch.float32).cpu()
+    expected = expected.detach().to(torch.float32).cpu()
+    assert torch.isfinite(actual).all(), f"{name}: the kernel produced a non-finite value"
+    rtol, atol = _tolerances(dtype)
+    torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol, msg=lambda msg: f"{name}: {msg}")
+
+
+def _chunk_state_reference(
+    k: torch.Tensor,
+    u: torch.Tensor,
+    w: torch.Tensor,
+    gk: torch.Tensor,
+    initial_state: torch.Tensor,
+    sequence_ranges: list[tuple[int, int]],
+    chunk_offsets: list[int],
+    output_shape: tuple[int, ...],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """CPU FP32 reference for the chunk-state kernel's KDA path."""
+    dtype = k.dtype
+    _, _, num_k_heads, key_dim = k.shape
+    num_heads = u.shape[2]
+    value_dim = u.shape[-1]
+
+    flat_k = k.reshape(-1, num_k_heads, key_dim)
+    flat_u = u.reshape(-1, num_heads, value_dim)
+    flat_w = w.reshape(-1, num_heads, key_dim)
+    flat_gk = gk.reshape(-1, num_heads, key_dim)
+
+    total_chunks = chunk_offsets[-1]
+    states_at_chunk_start = torch.empty(total_chunks, num_heads, value_dim, key_dim, dtype=dtype)
+    new_value = torch.empty_like(flat_u)
+    final_state = torch.empty_like(initial_state, dtype=torch.float32)
+    heads_per_k_head = num_heads // num_k_heads
+
+    for sequence_index, (bos, eos) in enumerate(sequence_ranges):
+        for head in range(num_heads):
+            state = initial_state[sequence_index, head].to(torch.float32).clone()
+            key_head = head // heads_per_k_head
+            for local_chunk, chunk_bos in enumerate(range(bos, eos, CHUNK_SIZE)):
+                chunk_eos = min(chunk_bos + CHUNK_SIZE, eos)
+                global_chunk = chunk_offsets[sequence_index] + local_chunk
+                states_at_chunk_start[global_chunk, head] = state.to(dtype)
+
+                key = flat_k[chunk_bos:chunk_eos, key_head].to(torch.float32)
+                value = flat_u[chunk_bos:chunk_eos, head].to(torch.float32)
+                weight = flat_w[chunk_bos:chunk_eos, head].to(torch.float32)
+                residual = value - torch.matmul(weight, state.transpose(0, 1))
+                new_value[chunk_bos:chunk_eos, head] = residual.to(dtype)
+
+                # KDA supplies a base-2 cumulative vector gate. The kernel
+                # applies the final gate of each chunk before its state update.
+                gate = torch.exp2(flat_gk[chunk_eos - 1, head].to(torch.float32))
+                state = state * gate.unsqueeze(0)
+                quantized_residual = residual.to(dtype).to(torch.float32)
+                state = state + torch.matmul(quantized_residual.transpose(0, 1), key)
+            final_state[sequence_index, head] = state
+
+    return states_at_chunk_start.reshape(output_shape), new_value.reshape_as(u), final_state
+
+
+def _fused_recurrent_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    initial_states: list[torch.Tensor],
+    sequence_ranges: list[tuple[int, int]],
+    scale: float,
+    use_qk_l2norm: bool,
+) -> tuple[torch.Tensor, torch.Tensor, list[torch.Tensor]]:
+    """CPU FP32 KDA recurrence with per-token state snapshots."""
+    dtype = q.dtype
+    _, total_tokens, num_qk_heads, _ = q.shape
+    num_value_heads = v.shape[2]
+    value_dim = v.shape[-1]
+    value_heads_per_qk_head = num_value_heads // num_qk_heads
+    output = torch.empty(1, total_tokens, num_value_heads, value_dim, dtype=dtype)
+    token_states = torch.empty(
+        total_tokens,
+        num_value_heads,
+        value_dim,
+        k.shape[-1],
+        dtype=torch.float32,
+    )
+    final_states: list[torch.Tensor] = []
+
+    for sequence_index, (bos, eos) in enumerate(sequence_ranges):
+        state = initial_states[sequence_index].to(torch.float32).clone()
+        for token in range(bos, eos):
+            for value_head in range(num_value_heads):
+                qk_head = value_head // value_heads_per_qk_head
+                query = q[0, token, qk_head].to(torch.float32)
+                key = k[0, token, qk_head].to(torch.float32)
+                if use_qk_l2norm:
+                    query = query / torch.sqrt(torch.sum(query * query) + 1e-6)
+                    key = key / torch.sqrt(torch.sum(key * key) + 1e-6)
+
+                state_head = state[value_head]
+                gate = torch.exp(g[0, token, value_head].to(torch.float32))
+                state_head = state_head * gate.unsqueeze(0)
+                residual = v[0, token, value_head].to(torch.float32) - torch.mv(state_head, key)
+                residual = residual * beta[0, token, value_head].to(torch.float32)
+                state_head = state_head + residual.unsqueeze(1) * key.unsqueeze(0)
+                state[value_head] = state_head
+                output[0, token, value_head] = torch.mv(state_head, query * scale).to(dtype)
+            token_states[token] = state
+        final_states.append(state.clone())
+
+    return output, token_states, final_states
+
+
+@pytest.mark.parametrize(
+    ("dtype", "sequence_lengths"),
+    [
+        pytest.param(torch.float16, None, id="fixed-batch-fp16"),
+        pytest.param(torch.bfloat16, [5, 70], id="varlen-bf16"),
+    ],
+)
+@pytest.mark.skip_global_cleanup
+@torch.inference_mode()
+def test_chunk_gated_delta_rule_fwd_kernel_h_blockdim64_kda(
+    dtype: torch.dtype,
+    sequence_lengths: list[int] | None,
+) -> None:
+    """Directly test fixed-batch and variable-length KDA state layouts."""
+    generator = torch.Generator().manual_seed(20260825)
+    num_heads, num_k_heads = 2, 1
+    key_dim, value_dim = 96, 80
+
+    if sequence_lengths is None:
+        batch_size, sequence_length = 2, 70
+        num_sequences = batch_size
+        sequence_ranges = [(batch * sequence_length, (batch + 1) * sequence_length) for batch in range(batch_size)]
+        chunk_offsets = [batch * math.ceil(sequence_length / CHUNK_SIZE) for batch in range(batch_size + 1)]
+        cu_seqlens_cpu = None
+        chunk_offsets_cpu = None
+        output_shape = (
+            batch_size,
+            math.ceil(sequence_length / CHUNK_SIZE),
+            num_heads,
+            value_dim,
+            key_dim,
+        )
+    else:
+        batch_size, sequence_length = 1, sum(sequence_lengths)
+        num_sequences = len(sequence_lengths)
+        cumulative = [0]
+        chunk_offsets = [0]
+        for length in sequence_lengths:
+            cumulative.append(cumulative[-1] + length)
+            chunk_offsets.append(chunk_offsets[-1] + math.ceil(length / CHUNK_SIZE))
+        sequence_ranges = list(zip(cumulative[:-1], cumulative[1:]))
+        cu_seqlens_cpu = torch.tensor(cumulative, dtype=torch.int64)
+        chunk_offsets_cpu = torch.tensor(chunk_offsets, dtype=torch.int64)
+        output_shape = (batch_size, chunk_offsets[-1], num_heads, value_dim, key_dim)
+
+    k_cpu = (torch.randn(batch_size, sequence_length, num_k_heads, key_dim, generator=generator) * 0.15).to(dtype)
+    u_cpu = (torch.randn(batch_size, sequence_length, num_heads, value_dim, generator=generator) * 0.15).to(dtype)
+    w_cpu = (torch.randn(batch_size, sequence_length, num_heads, key_dim, generator=generator) * 0.03).to(dtype)
+    gk_cpu = (-torch.rand(batch_size, sequence_length, num_heads, key_dim, generator=generator) * 0.02).to(dtype)
+    h0_cpu = torch.randn(num_sequences, num_heads, value_dim, key_dim, generator=generator) * 0.03
+
+    expected_h, expected_v_new, expected_ht = _chunk_state_reference(
+        k_cpu,
+        u_cpu,
+        w_cpu,
+        gk_cpu,
+        h0_cpu,
+        sequence_ranges,
+        chunk_offsets,
+        output_shape,
+    )
+
+    k = k_cpu.to(DEVICE)
+    u = u_cpu.to(DEVICE)
+    w = w_cpu.to(DEVICE)
+    gk = gk_cpu.to(DEVICE)
+    h0 = h0_cpu.to(DEVICE)
+    h = torch.empty(output_shape, dtype=dtype, device=DEVICE)
+    v_new = torch.empty_like(u)
+    ht = torch.empty_like(h0, dtype=torch.float32)
+    cu_seqlens = None if cu_seqlens_cpu is None else cu_seqlens_cpu.to(DEVICE)
+    chunk_offsets_tensor = None if chunk_offsets_cpu is None else chunk_offsets_cpu.to(DEVICE)
+
+    grid = (math.ceil(value_dim / 64), num_sequences * num_heads)
+    chunk_gated_delta_rule_fwd_kernel_h_blockdim64_kda[grid](
+        k=k,
+        v=u,
+        w=w,
+        v_new=v_new,
+        g=None,
+        gk=gk,
+        h=h,
+        h0=h0,
+        ht=ht,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets_tensor,
+        T=sequence_length,
+        H=num_heads,
+        Hg=num_k_heads,
+        K=key_dim,
+        V=value_dim,
+        BT=CHUNK_SIZE,
+    )
+
+    assert h.shape == expected_h.shape
+    assert v_new.shape == expected_v_new.shape
+    assert ht.shape == expected_ht.shape
+    _assert_close("chunk-start states", h, expected_h, dtype)
+    _assert_close("new values", v_new, expected_v_new, dtype)
+    _assert_close("final states", ht, expected_ht, dtype)
+
+
+@pytest.mark.parametrize(
+    ("dtype", "continuous_batching"),
+    [
+        pytest.param(torch.float16, False, id="varlen-noninplace-scalar-beta-l2norm-fp16"),
+        pytest.param(torch.bfloat16, True, id="continuous-inplace-vector-beta-bf16"),
+    ],
+)
+@pytest.mark.skip_global_cleanup
+@torch.inference_mode()
+def test_fused_recurrent_gated_delta_rule_fwd_kernel_kda(
+    dtype: torch.dtype,
+    continuous_batching: bool,
+) -> None:
+    """Directly test KDA recurrence, state snapshots, and continuous slots."""
+    generator = torch.Generator().manual_seed(20260826)
+    sequence_lengths = [2, 3]
+    cumulative = [0]
+    for length in sequence_lengths:
+        cumulative.append(cumulative[-1] + length)
+    sequence_ranges = list(zip(cumulative[:-1], cumulative[1:]))
+
+    batch_size, total_tokens = 1, cumulative[-1]
+    num_sequences = len(sequence_lengths)
+    num_qk_heads, num_value_heads = 2, 4
+    # The production kernel loads the KDA gate in full BK vectors without a
+    # tail mask, so use the smallest supported aligned key dimension.
+    key_dim, value_dim = 64, 20
+    scale = key_dim**-0.5
+    use_qk_l2norm = not continuous_batching
+
+    q_cpu = (torch.randn(batch_size, total_tokens, num_qk_heads, key_dim, generator=generator) * 0.2).to(dtype)
+    k_cpu = (torch.randn(batch_size, total_tokens, num_qk_heads, key_dim, generator=generator) * 0.2).to(dtype)
+    v_cpu = (torch.randn(batch_size, total_tokens, num_value_heads, value_dim, generator=generator) * 0.2).to(dtype)
+    g_cpu = (-torch.rand(batch_size, total_tokens, num_value_heads, key_dim, generator=generator) * 0.03).to(dtype)
+    if continuous_batching:
+        beta_cpu = (
+            0.2
+            + 0.6
+            * torch.rand(
+                batch_size,
+                total_tokens,
+                num_value_heads,
+                value_dim,
+                generator=generator,
+            )
+        ).to(dtype)
+        state_cpu = torch.randn(num_sequences + 1, num_value_heads, value_dim, key_dim, generator=generator) * 0.03
+        state_cpu[0].zero_()
+        state_indices_cpu = torch.tensor([[1, 1, 0], [2, 2, 2]], dtype=torch.int64)
+        initial_states = [state_cpu[1], state_cpu[2]]
+    else:
+        beta_cpu = (
+            0.2
+            + 0.6
+            * torch.rand(
+                batch_size,
+                total_tokens,
+                num_value_heads,
+                generator=generator,
+            )
+        ).to(dtype)
+        state_cpu = torch.randn(total_tokens, num_value_heads, value_dim, key_dim, generator=generator) * 0.03
+        state_indices_cpu = None
+        initial_states = [state_cpu[bos] for bos, _ in sequence_ranges]
+
+    expected_o, expected_token_states, expected_final_states = _fused_recurrent_reference(
+        q_cpu,
+        k_cpu,
+        v_cpu,
+        g_cpu,
+        beta_cpu,
+        initial_states,
+        sequence_ranges,
+        scale,
+        use_qk_l2norm,
+    )
+
+    q = q_cpu.to(DEVICE)
+    k = k_cpu.to(DEVICE)
+    v = v_cpu.to(DEVICE)
+    g = g_cpu.to(DEVICE)
+    beta = beta_cpu.to(DEVICE)
+    state = state_cpu.to(DEVICE)
+    o = torch.empty(batch_size, total_tokens, num_value_heads, value_dim, dtype=dtype, device=DEVICE)
+    cu_seqlens = torch.tensor(cumulative, dtype=torch.int64, device=DEVICE)
+    state_indices = None if state_indices_cpu is None else state_indices_cpu.to(DEVICE)
+    if continuous_batching:
+        final_state = state
+        stride_indices_seq, stride_indices_tok = state_indices.stride()
+    else:
+        final_state = torch.empty(total_tokens, num_value_heads, value_dim, key_dim, dtype=torch.float32, device=DEVICE)
+        stride_indices_seq, stride_indices_tok = 1, 1
+
+    block_k = _next_power_of_2(key_dim)
+    block_v = min(_next_power_of_2(value_dim), 8)
+    grid = (math.ceil(key_dim / block_k), math.ceil(value_dim / block_v), num_sequences * num_value_heads)
+    fused_recurrent_gated_delta_rule_fwd_kernel[grid](
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        o=o,
+        h0=state,
+        ht=final_state,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=state_indices,
+        num_accepted_tokens=None,
+        scale=scale,
+        N=num_sequences,
+        T=total_tokens,
+        B=batch_size,
+        H=num_qk_heads,
+        HV=num_value_heads,
+        K=key_dim,
+        V=value_dim,
+        BK=block_k,
+        BV=block_v,
+        stride_init_state_token=state.stride(0),
+        stride_final_state_token=final_state.stride(0),
+        stride_indices_seq=stride_indices_seq,
+        stride_indices_tok=stride_indices_tok,
+        INPLACE_FINAL_STATE=continuous_batching,
+        IS_BETA_HEADWISE=beta.ndim == v.ndim,
+        USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm,
+        IS_KDA=True,
+        num_warps=1,
+        num_stages=3,
+    )
+
+    assert o.shape == expected_o.shape
+    _assert_close("recurrent output", o, expected_o, dtype)
+    if continuous_batching:
+        expected_state = state_cpu.clone()
+        expected_state[1] = expected_final_states[0]
+        expected_state[2] = expected_final_states[1]
+        _assert_close("in-place final states", final_state, expected_state, dtype)
+        torch.testing.assert_close(final_state[0].cpu(), torch.zeros_like(final_state[0].cpu()), rtol=0, atol=0)
+    else:
+        _assert_close("per-token states", final_state, expected_token_states, dtype)

--- a/vllm_ascend/ops/triton/docs/kda.md
+++ b/vllm_ascend/ops/triton/docs/kda.md
@@ -1,0 +1,131 @@
+# KDA (Kimi Delta Attention)
+
+## Description
+
+- **Function**: Provides the Ascend Triton forward implementation of KDA. `chunk_kda` decomposes prefill into 64-token chunks, while `fused_recurrent_kda` evaluates the recurrent update used by decode. The module also contains the KDA decay-gate and gated normalization helpers.
+- **Formula**: Let the mathematical recurrent state be $S_t \in \mathbb{R}^{K \times V}$ and the key-dimension decay gate be $g_t \in \mathbb{R}^{K}$. After optional Q/K normalization, KDA computes
+
+  $$
+  \widetilde{S}_t = \operatorname{Diag}(\exp(g_t)) S_{t-1},
+  $$
+
+  $$
+  \delta_t = \beta_t \odot \left(v_t - \widetilde{S}_t^{\mathsf T} k_t\right),
+  $$
+
+  $$
+  S_t = \widetilde{S}_t + k_t \delta_t^{\mathsf T}, \qquad
+  o_t = \text{scale} \cdot S_t^{\mathsf T} q_t.
+  $$
+
+  Kernels physically store the transposed state as $S_t^{\mathsf T} \in \mathbb{R}^{V \times K}$, with the key dimension K contiguous. In the chunk path, $G_i = \sum_{r=0}^{i} g_r$ and token interactions use $E_{ij}=\exp(G_i-G_j)$. The KKT kernels construct a strictly lower-triangular correction $L$ and causal query-key matrix $P$, after which the solve kernels compute $M=(I+L)^{-1}$.
+- **Algorithm flow**:
+  1. When requested, normalize chunk Q/K with the standalone tiled L2Norm kernel. Recurrent mode performs Q/K normalization inside its fused kernel. The persistent L2Norm kernel is also available as a shared helper.
+  2. Compute the chunk cumulative vector gate with `chunk_local_cumsum_vector_kernel`, then convert it to base-2 exponent space. `chunk_local_cumsum_scalar_kernel` is the scalar-gate variant of the shared cumulative-sum utility and is not called by `chunk_kda`.
+  3. Build the inter-subchunk and intra-subchunk KKT blocks with `chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_inter` and `chunk_kda_scaled_dot_kkt_fwd_kernel_intra_sub_intra`.
+  4. Invert each lower-triangular block with `solve_tril_16x16_kernel_kda`, then assemble 32x32 and 64x64 inverses with `merge_16x16_to_32x32_inverse_kernel_kda` and `merge_16x16_to_64x64_inverse_kernel_kda`.
+  5. Recompute W/U with `recompute_w_u_fwd_kernel`. `chunk_gated_delta_rule_fwd_kernel_h_blockdim64_kda` propagates the state using FP32 accumulation and FP32 final states; stored per-chunk state snapshots use the key dtype.
+  6. Produce the chunk output with `chunk_gla_fwd_kernel_o`.
+  7. For recurrent execution, `fused_recurrent_gated_delta_rule_fwd_kernel` combines vector decay, optional Q/K normalization, beta application, output generation, and state update. It supports flattened variable-length inputs and slot-indexed in-place state updates.
+  8. `kda_gate_fwd_kernel` implements the standalone negative-softplus decay gate. `layer_norm_gated_fwd_kernel` and `layer_norm_gated_fwd_kernel1` implement the gated LayerNorm/RMSNorm helper for feature dimensions up to and above 512, respectively.
+- **Supported modes**: Fixed-length and flattened variable-length chunk inputs, recurrent execution, and slot-indexed in-place recurrent states. The raw kernels in this PR were validated with FP32, FP16, and BF16 inputs on Atlas A3. Other Ascend platforms are not claimed by this test result.
+
+## Parameters
+
+### `chunk_kda`
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `q` | Input | Query tensor `[B, T, H, K]` | fp32 / fp16 / bf16 | ND |
+| `k` | Input | Key tensor `[B, T, H, K]` | same as `q` | ND |
+| `v` | Input/Output | Value work buffer `[B, T, H, V]`; the chunk output is written to this buffer | same as `q` | ND |
+| `g` | Input | Key-dimension decay gate `[B, T, H, K]`, consumed through `exp(g)` | fp32 / fp16 / bf16 | ND |
+| `beta` | Input | Scalar update factor per token and head, `[B, T, H]` | fp32 / fp16 / bf16 | ND |
+| `initial_state` | Input | Required initial state `[N, H, V, K]` in physical `[V, K]` layout | fp32 | ND |
+| `scale` | Attribute | Query scale; defaults to `K ** -0.5` | fp32 | scalar |
+| `cu_seqlens` | Input | Cumulative offsets `[N + 1]` for a flattened variable-length batch | int32 / int64 | ND |
+| `output_final_state` | Attribute | Controls whether the FP32 state after the last chunk is returned | bool | scalar |
+| `use_qk_l2norm_in_kernel` | Attribute | Applies the standalone tiled L2Norm kernel to Q/K before chunk execution | bool | scalar |
+| `prebuilt_meta` | Attribute | Optional cached metadata containing 64-token `chunk_indices_chunk64` and `chunk_offsets_chunk64` | Python object | N/A |
+| `o` | Output | Attention output `[B, T, H, V]`, backed by the contiguous value work buffer | fp32 / fp16 / bf16 | ND |
+| `final_state` | Output | Optional final state `[N, H, V, K]` in physical `[V, K]` layout | fp32 | ND |
+
+### `fused_recurrent_kda`
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `q` | Input | Query tensor `[B, T, H, K]` | fp32 / fp16 / bf16 | ND |
+| `k` | Input | Key tensor `[B, T, H, K]` | same as `q` | ND |
+| `v` | Input | Value tensor `[B, T, HV, V]` | fp32 / fp16 / bf16 | ND |
+| `g` | Input | Vector decay gate `[B, T, HV, K]` | fp32 / fp16 / bf16 | ND |
+| `beta` | Input | Required scalar beta `[B, T, HV]` or value-vector beta `[B, T, HV, V]` | fp32 / fp16 / bf16 | ND |
+| `initial_state` | Input/Input-Output | Required slot- or token-indexed state whose per-state layout is `[HV, V, K]`; aliases `final_state` in in-place mode | fp32 | ND |
+| `scale` | Attribute | Query scale; defaults to `K ** -0.5` | fp32 | scalar |
+| `cu_seqlens` | Input | Cumulative offsets `[N + 1]` for flattened variable-length input | int32 / int64 | ND |
+| `inplace_final_state` | Attribute | Updates slot-indexed `initial_state` in place when enabled | bool | scalar |
+| `use_qk_l2norm_in_kernel` | Attribute | Fuses Q/K L2 normalization into the recurrent kernel | bool | scalar |
+| `ssm_state_indices` | Input | State-slot mapping; one-dimensional for one-token sequences or two-dimensional for multi-token sequences | int32 / int64 | ND |
+| `o` | Output | Output storage is allocated like `k`; the current public KDA integration therefore requires `H = HV` and `K = V` | fp32 / fp16 / bf16 | ND |
+| `final_state` | Output | In-place state alias, or token-indexed states `[T, HV, V, K]` in non-in-place flattened mode | fp32 | ND |
+
+### Standalone KDA helpers
+
+| Parameter | Input/Output/Attribute | Description | Data type | Data format |
+| --- | --- | --- | --- | --- |
+| `g` | Input | Raw gate `[..., H * K]` for `fused_kda_gate`, or activation gate `[..., D]` for `rms_norm_gated` | fp32 / fp16 / bf16 | ND |
+| `A` | Input | Per-head log-decay coefficient for `fused_kda_gate`, shaped `[H]` or `[1, 1, H, 1]` | fp32 / fp16 / bf16 | ND |
+| `head_k_dim` | Attribute | Key dimension K used to reshape the fused gate output to `[..., H, K]` | int32 | scalar |
+| `g_bias` | Input | Optional contiguous gate bias `[H, K]` or equivalent flattened `[H * K]` | fp32 / fp16 / bf16 | ND |
+| `beta` | Attribute | Softplus beta used by `fused_kda_gate`; defaults to `1.0` | fp32 | scalar |
+| `threshold` | Attribute | Softplus linear-approximation threshold; defaults to `20.0` | fp32 | scalar |
+| `x` | Input/Input-Output | Input `[..., D]` to `rms_norm_gated`; its contiguous work buffer may be reused for the output | fp32 / fp16 / bf16 | ND |
+| `weight` | Input | RMSNorm weight `[D]`; the value may be `None` | fp32 / fp16 / bf16 | ND |
+| `bias` | Input | RMSNorm bias `[D]`; the value may be `None` | fp32 / fp16 / bf16 | ND |
+| `residual` | Input | Optional residual with the same shape as `x` | fp32 / fp16 / bf16 | ND |
+| `activation` | Attribute | Gate activation: `swish`/`silu` or `sigmoid` | string | scalar |
+| `prenorm` | Attribute | Returns both the gated output and residual output when enabled | bool | scalar |
+| `residual_in_fp32` | Attribute | Uses FP32 for a newly allocated residual path when no residual tensor is supplied | bool | scalar |
+| `eps` | Attribute | RMSNorm epsilon; defaults to `1e-6` | fp32 | scalar |
+| `gate_output` | Output | Negative-softplus gate `[..., H, K]` from `fused_kda_gate` | fp32 | ND |
+| `norm_output` | Output | Gated RMSNorm output with the same shape and dtype as `x` | fp32 / fp16 / bf16 | ND |
+
+## Constraints
+
+- Tensor inputs to one operation must reside on the same NPU and agree on their batch, token, head, and feature dimensions as described above.
+- `initial_state` and `beta` are required by the current chunk and recurrent wrappers even though some Python annotations provide `None` defaults.
+- Chunk mode uses a fixed chunk size of 64 and 16-token inverse sub-blocks, and supports `K <= 256`. Its state layout is `[N, H, V, K]`; the state is not updated in place.
+- With `cu_seqlens`, inputs must be flattened to `B = 1`; offsets must start at 0, end at T, and be nondecreasing.
+- Without chunk Q/K normalization, Q and K must already have the dense layout expected by the raw kernels. The wrappers make V, G, beta, and state contiguous; normalization helpers make their own inputs contiguous.
+- The current recurrent output allocation requires the public integration shape `H = HV` and `K = V`. The more general H/HV and K/V raw-kernel contract must not be used through this wrapper without matching output storage.
+- In recurrent in-place mode, `ssm_state_indices` is required. A one-dimensional mapping is valid only when every sequence contains one token; multi-token sequences require a row-major two-dimensional mapping with a contiguous token dimension.
+- Recurrent state slots use `[HV, V, K]` with contiguous K. Slot indices less than or equal to zero are null entries: the kernel returns without producing a valid output for that sequence, so callers must ignore those positions.
+- Recurrent non-in-place final-state storage is supported for flattened `B = 1` input. The public wrapper does not expose the low-level speculative-decoding `num_accepted_tokens` path.
+- L2Norm and gated LayerNorm/RMSNorm require `D <= 65536 / element_size` for each row.
+- For `fused_kda_gate`, `A.numel() * head_k_dim` must equal `g.shape[-1]`; `g_bias`, when present, must contain one K-element bias vector per head.
+- Only inference forward paths are implemented; backward/autograd kernels are not provided.
+
+## Origin and Differences
+
+- **Origin**: The KDA algorithm and GPU Triton decomposition are based on the `flash-linear-attention` KDA implementation used by vLLM. The copied source retains its MIT license notice; vLLM Ascend ports the implementation to its Ascend Triton backend.
+- **Differences**:
+    - Uses Ascend-oriented grids, tiling, block pointers, vector-core L2Norm, and specialized triangular-solve and state-update kernels.
+    - Converts cumulative gates with `log2(e)` for `exp2` evaluation and keeps selected KKT values, accumulators, and final recurrent states in FP32.
+    - Accepts prebuilt chunk metadata and supports slot-indexed in-place recurrent states for inference integration.
+    - Provides forward-only inference kernels and does not include the upstream backward/autograd or newer training-oriented options.
+
+## Test Cases
+
+The tests contain one test function per production kernel and one direct raw `kernel[grid](...)` launch in each function. Parameterization produces 25 collected cases for 16 kernels; every collected case therefore executes one target-kernel launch and compares it with an independent PyTorch CPU FP32 reference. The suite covers FP32, FP16, BF16, fixed and variable-length layouts, partial chunks, non-power-of-two dimensions, optional inputs, and in-place/non-in-place state paths. On Atlas A3, the complete suite result is `25 passed, 0 failed`.
+
+| Test file | Kernels | Cases | Precision tolerance |
+| --- | ---: | ---: | --- |
+| `test_kda_aux_kernels.py` | 7 | 7 | cumsum `1e-5/1e-5`; L2Norm `3e-4/1e-3`; solve/merge `5e-4/5e-4` (`rtol/atol`) |
+| `test_kda_core_kernels.py` | 7 | 14 | low-precision primary outputs `2e-3` to `6e-2`; normalization mean/rstd `8e-4` |
+| `test_kda_state_kernels.py` | 2 | 4 | FP16 `1e-2/1e-2`; BF16 `3e-2/3e-2` (`rtol/atol`) |
+
+```bash
+pytest -sv \
+  tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_aux_kernels.py \
+  tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_core_kernels.py \
+  tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kda_state_kernels.py
+```


### PR DESCRIPTION
## What this PR does / why we need it

This is a follow-up to #9035, which introduced the KDA Triton operators for Ascend NPU with operator-level end-to-end coverage.

This PR adds direct NPU precision tests for all 16 production KDA Triton kernels and a KDA operator description following the Triton documentation specification. Each test function:

- directly raw-launches exactly one target `kernel[grid](...)`;
- compares its outputs with an independent PyTorch CPU FP32 reference;
- avoids calling production wrappers or chaining multiple production kernels.

Only tests and operator documentation are changed. There is no production-code or user-facing behavior change.

## Coverage

- Auxiliary kernels: scalar/vector chunk cumsum, persistent/tiled L2Norm, 16x16 triangular solve, and 32x32/64x64 inverse merge.
- Core kernels: two gated LayerNorm variants, two scaled KKT variants, W/U recomputation, chunk output, and KDA gate.
- State kernels: chunk-state propagation and fused recurrent KDA.

The 25 collected cases cover FP32/FP16/BF16, fixed and variable-length layouts, partial tail chunks, non-power-of-two dimensions, optional inputs, and in-place/non-in-place state paths.

## Documentation

- Added `vllm_ascend/ops/triton/docs/kda.md` using the structure defined by `triton_description_specification.md`.
- Documented the KDA recurrence, the 16-kernel chunk/recurrent execution flow, public parameters and tensor layouts, constraints, upstream origin and Ascend-specific differences, and the single-kernel validation results.
- Renamed the three new test files to remove the `_npu` suffix; no test logic changed during the rename.

## Single-kernel test methodology

The tests deliberately validate the raw Triton kernels instead of the composed KDA operators:

1. Each test function targets one imported production `@triton.jit` kernel and manually prepares its input/output tensors, launch grid, constexpr metadata, and variable-length metadata (`cu_seqlens`, `chunk_indices`, or `chunk_offsets`) when required.
2. The function directly calls the target `kernel[grid](...)` exactly once and synchronizes the NPU. It does not call a production wrapper and does not launch another production kernel to prepare inputs or post-process outputs.
3. Expected outputs are calculated independently on CPU in FP32 from the actual quantized kernel inputs. The references use PyTorch tensor operations or explicit recurrent/block-matrix equations and do not reuse KDA production helpers.
4. Non-finite outputs are rejected and numerical results are compared with `torch.testing.assert_close`. Tolerances are selected by the numerical behavior of each kernel family:
   - cumsum: `rtol=1e-5`, `atol=1e-5`;
   - L2Norm: `rtol=3e-4`, `atol=1e-3`;
   - triangular solve/inverse merge: `rtol=5e-4`, `atol=5e-4`;
   - gated LayerNorm statistics: `rtol=8e-4`, `atol=8e-4`;
   - low-precision matrix/recurrent kernels: FP16/BF16 tolerances from `1e-2` up to `6e-2`, depending on the accumulated path.
5. An AST audit checks that all 16 test functions contain exactly one raw production-kernel launch, preserving a one-test-to-one-kernel mapping even for parameterized cases.

The inputs exercise fixed and flattened variable-length batches, aligned and partial chunks, head mapping, non-power-of-two dimensions, optional residual/weight/bias paths, both activation variants, scalar/vector beta, and in-place/non-in-place state updates.

## How was this patch tested?

- Ascend A3 full single-kernel suite:

  | Test file | Kernels | Collected cases | Result |
  | --- | ---: | ---: | ---: |
  | `test_kda_aux_kernels.py` | 7 | 7 | 7 passed |
  | `test_kda_core_kernels.py` | 7 | 14 | 14 passed |
  | `test_kda_state_kernels.py` | 2 | 4 | 4 passed |
  | **Total** | **16** | **25** | **25 passed, 0 failed** |

  The final complete run finished in 23.24 seconds with the Triton compilation cache warm.

- `python3 -m py_compile` on all three new test files
- `ruff check` on all three new test files
- `ruff format --check` on all three new test files
- `markdownlint` on `vllm_ascend/ops/triton/docs/kda.md`
- AST audit confirming one raw production-kernel launch per test function

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
