### PR TITLE
[Doc][Misc] Remove obsolete Sphinx toctree from feature guide index

### DIFF
--- a/docs/source/user_guide/feature_guide/index.md
+++ b/docs/source/user_guide/feature_guide/index.md
@@ -1,38 +1,3 @@
 # Feature Guide
 
 This section provides a detailed usage guide of vLLM Ascend features.
-
-:::{toctree}
-:caption: Feature Guide
-:maxdepth: 1
-graph_mode
-cpu_binding
-Ai_QoS_introduction_en
-quantization
-sleep_mode
-structured_output
-lora
-expert_parallelism_load_balancer
-netloader
-rfork
-dynamic_batch
-epd_disaggregation
-kv_pool
-layerwise_kv_pool
-layerwise_and_sparse_kv_cache_offloading
-kv_cache_cpu_offload
-dyntra_lb
-large_scale_ep
-ucm_deployment
-Fine_grained_TP
-layer_sharding
-speculative_decoding
-context_parallel
-weight_prefetch
-sequence_parallelism
-batch_invariance
-lmcache_ascend_deployment
-dynamic_chunk_pipeline_parallel
-flash_attention
-rl
-:::


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes the Sphinx-specific `toctree` directive from `docs/source/user_guide/feature_guide/index.md`. Since the project uses MkDocs (configured in `mkdocs.yml`) for documentation and navigation, the Sphinx `toctree` directive is obsolete and redundant.

### Does this PR introduce _any_ user-facing change?

No. Documentation-only updates are not considered user-facing changes.

### How was this patch tested?

Tested by verifying that the documentation builds correctly under MkDocs and the navigation structure defined in `mkdocs.yml` is unaffected.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
