### PR TITLE
[BugFix][ExampleProxy] Stop decode retries after streaming response starts

### DIFF
--- a/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
+++ b/examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py
@@ -872,12 +872,14 @@ async def stream_service_response(
     headers = auth_headers(request_id)
     max_attempts = max(1, max_retries)
     for attempt in range(1, max_attempts + 1):
-        first_chunk_sent = False
+        response_started = False
         try:
             async with client.stream("POST", endpoint, json=req_data, headers=headers) as response:
                 response.raise_for_status()
+                # The decoder may release the remote KV cache before the first
+                # response body chunk reaches the proxy.
+                response_started = True
                 async for chunk in response.aiter_bytes():
-                    first_chunk_sent = True
                     yield chunk
                 return
         except httpx.HTTPStatusError as exc:
@@ -885,14 +887,14 @@ async def stream_service_response(
                 raise
             logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
         except httpx.RequestError as exc:
-            if first_chunk_sent:
+            if response_started:
                 logger.error("Streaming to client interrupted after response started: %s", exc)
                 return
             if attempt == max_attempts:
                 raise
             logger.warning("Attempt %s failed for streaming %s: %s", attempt, endpoint, exc)
         except Exception as exc:
-            if first_chunk_sent:
+            if response_started:
                 logger.error("Streaming to client interrupted after response started: %s", exc)
                 return
             if attempt == max_attempts:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR prevents the disaggregated prefill proxy from retrying a decoder request after a successful streaming HTTP response has already been established.

The previous retry guard used `first_chunk_sent`. That leaves an unsafe window before the first response body chunk reaches the proxy:

1. The decoder completes its Mooncake KV pull.
2. The decoder sends `DONE_RECVING_MSG` to the prefiller from the receive thread cleanup path.
3. The prefiller reports the request as finished sending and releases its KV blocks.
4. The decoder produces the first output chunk.

If the proxy encounters a read failure between steps 2 and 4, `first_chunk_sent` is still false and the old code retries the decoder request even though the prefiller KV cache may already be gone.

The OpenAI streaming endpoint sends the successful HTTP response before iterating the output generator. This PR therefore uses successful response establishment as a conservative proxy-visible boundary: failures before a successful response may still use the existing retry policy, while failures after it terminate the stream without issuing another decoder request.

### Does this PR introduce any user-facing change?

No API change. A decoder stream that fails after its successful response has started is terminated instead of being retried with potentially released remote KV state.

### How was this patch tested?

- `.venv/bin/python -m py_compile examples/disaggregated_prefill_v1/load_balance_proxy_server_example.py`
- `git diff --check`
- Relevant pre-commit checks passed: ruff check/format, codespell, typos, package/import checks, and long-function checks.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
