### PR TITLE
[Test][Mamba] add e2e tests for Mamba/hybrid models

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -855,6 +855,7 @@ estimated_times:
   tests/e2e/pull_request/two_card/rlhf/consistency/test_moe_routing_replay.py: 560
   tests/e2e/pull_request/two_card/test_prefix_caching.py: 420
   tests/e2e/pull_request/two_card/test_qwen3_30b_a3b.py: 260
+  tests/e2e/pull_request/two_card/model_runner_v2/test_mamba_hybrid.py: 220
   tests/e2e/pull_request/two_card/test_qwen3_5_35b_a3b_w8a8.py: 370
   tests/e2e/pull_request/two_card/test_qwen3_6_27b_fia.py: 570
   tests/e2e/pull_request/two_card/test_qwen3_moe_eplb.py: 470

--- a/tests/e2e/pull_request/two_card/model_runner_v2/test_mamba_hybrid.py
+++ b/tests/e2e/pull_request/two_card/model_runner_v2/test_mamba_hybrid.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+# Copyright 2023 The vLLM team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Inference with Model Runner V2 for Mamba/hybrid model.
+
+Run `pytest -sv tests/e2e/pull_request/two_card/model_runner_v2/test_mamba_hybrid.py`.
+"""
+
+import os
+from unittest.mock import patch
+
+from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
+
+QWEN35_DENSE_MODEL = os.environ.get("QWEN35_DENSE_MODEL", "Qwen/Qwen3.5-27B")
+
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+@wait_until_npu_memory_free()
+def test_qwen35_27b_eager_mode():
+    example_prompts = [
+        "Hello, my name is",
+    ]
+    max_tokens = 5
+    with VllmRunner(
+        QWEN35_DENSE_MODEL,
+        data_parallel_size=1,
+        tensor_parallel_size=2,
+        enable_expert_parallel=False,
+        max_model_len=4096,
+        enforce_eager=True,
+        gpu_memory_utilization=0.9,
+        distributed_executor_backend="mp",
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(example_prompts, max_tokens)
+        assert outputs[0][1]
+        del vllm_model
+
+@patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
+@wait_until_npu_memory_free()
+def test_qwen35_27b_acl_graph():
+    example_prompts = [
+        "Hello, my name is",
+    ]
+    max_tokens = 5
+    with VllmRunner(
+        QWEN35_DENSE_MODEL,
+        data_parallel_size=1,
+        tensor_parallel_size=2,
+        enable_expert_parallel=False,
+        max_model_len=4096,
+        gpu_memory_utilization=0.9,
+        distributed_executor_backend="mp",
+        cudagraph_capture_sizes=[1, 2, 4, 8],
+    ) as vllm_model:
+        outputs = vllm_model.generate_greedy(example_prompts, max_tokens)
+        assert outputs[0][1]
+        del vllm_model

--- a/tests/e2e/pull_request/two_card/model_runner_v2/test_mamba_hybrid.py
+++ b/tests/e2e/pull_request/two_card/model_runner_v2/test_mamba_hybrid.py
@@ -27,6 +27,7 @@ from tests.e2e.conftest import VllmRunner, wait_until_npu_memory_free
 
 QWEN35_DENSE_MODEL = os.environ.get("QWEN35_DENSE_MODEL", "Qwen/Qwen3.5-27B")
 
+
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 @wait_until_npu_memory_free()
 def test_qwen35_27b_eager_mode():
@@ -47,6 +48,7 @@ def test_qwen35_27b_eager_mode():
         outputs = vllm_model.generate_greedy(example_prompts, max_tokens)
         assert outputs[0][1]
         del vllm_model
+
 
 @patch.dict(os.environ, {"VLLM_USE_V2_MODEL_RUNNER": "1"})
 @wait_until_npu_memory_free()


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds end-to-end tests for Mamba and hybrid-architecture models. This test case runs inference for Qwen3.5‑27B under both `enforce_eager` and CUDAGraph modes.

### How was this patch tested?

The newly added end-to-end tests passed locally.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
