### PR TITLE
[Feature] Add KV pool load metrics with layerwise not-overlapped time

### DIFF
--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -57,6 +57,18 @@ if "torch_npu" not in sys.modules:
     sys.modules["torch_npu"] = MagicMock()
     sys.modules["torch_npu._inductor"] = MagicMock()
 
+if "numpy" not in sys.modules and importlib.util.find_spec("numpy") is None:
+    _numpy = types.ModuleType("numpy")
+    _numpy.ndarray = MagicMock  # type: ignore[attr-defined]
+    _numpy.zeros = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+    _numpy.frombuffer = MagicMock(return_value=MagicMock())  # type: ignore[attr-defined]
+    _numpy.dtype = MagicMock()  # type: ignore[attr-defined]
+    sys.modules["numpy"] = _numpy
+
+for _mod in ("regex", "zmq", "msgpack"):
+    if _mod not in sys.modules and importlib.util.find_spec(_mod) is None:
+        sys.modules[_mod] = MagicMock()
+
 # ---------------------------------------------------------------------------
 # Mock vllm modules
 # ---------------------------------------------------------------------------
@@ -71,6 +83,7 @@ _vllm_mock_modules = [
     "vllm.distributed.kv_transfer.kv_connector.factory",
     "vllm.distributed.kv_transfer.kv_connector.v1",
     "vllm.distributed.kv_transfer.kv_connector.v1.base",
+    "vllm.distributed.kv_transfer.kv_connector.v1.metrics",
     "vllm.distributed.parallel_state",
     "vllm.envs",
     "vllm.forward_context",
@@ -96,6 +109,8 @@ _vllm_mock_modules = [
     "vllm.v1.core.single_type_kv_cache_manager",
     "vllm.v1.kv_cache_interface",
     "vllm.v1.kv_cache_spec_registry",
+    "vllm.v1.metrics",
+    "vllm.v1.metrics.utils",
     "vllm.v1.outputs",
     "vllm.v1.request",
     "vllm.v1.serial_utils",
@@ -119,6 +134,68 @@ _base_mod.KVConnectorRole = MagicMock()  # type: ignore[attr-defined]
 _base_mod.KVConnectorRole.SCHEDULER = "SCHEDULER"
 _base_mod.KVConnectorRole.WORKER = "WORKER"
 _base_mod.SupportsHMA = type("SupportsHMA", (), {})  # type: ignore[attr-defined]
+
+# ---------------------------------------------------------------------------
+# Mock vllm.distributed.kv_transfer.kv_connector.v1.metrics with real classes
+# so that ascend_store.metrics can subclass them under the mock environment.
+# ---------------------------------------------------------------------------
+from dataclasses import dataclass, field  # noqa: E402
+from typing import TypeVar  # noqa: E402
+
+
+@dataclass
+class _MockKVConnectorStats:
+    data: dict = field(default_factory=dict)
+
+
+class _MockKVConnectorPromMetrics:
+    def __init__(
+        self,
+        vllm_config,
+        metric_types,
+        labelnames,
+        per_engine_labelvalues,
+    ):
+        self._kv_transfer_config = getattr(
+            vllm_config, "kv_transfer_config", None
+        )
+        self._labelnames = labelnames
+        self.per_engine_labelvalues = per_engine_labelvalues
+        # The real framework builds metric_types as
+        # {Gauge: g, Counter: c, Histogram: h} (insertion order), so the
+        # positional lookup below matches the real keyed lookup.
+        values = list(metric_types.values()) if isinstance(metric_types, dict) else [
+            metric_types,
+            metric_types,
+            metric_types,
+        ]
+        self._gauge_cls = values[0]
+        self._counter_cls = values[1]
+        self._histogram_cls = values[2]
+
+
+_MockPromMetric = type("PromMetric", (), {})
+_MockPromMetricT = TypeVar("PromMetricT")
+
+_metrics_mod: Any = (
+    sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.metrics"]
+    if _MOCK_VLLM_DEPS
+    else types.SimpleNamespace()
+)
+_metrics_mod.KVConnectorStats = _MockKVConnectorStats
+_metrics_mod.KVConnectorPromMetrics = _MockKVConnectorPromMetrics
+_metrics_mod.PromMetric = _MockPromMetric
+_metrics_mod.PromMetricT = _MockPromMetricT
+
+_metrics_utils_mod: Any = (
+    sys.modules["vllm.v1.metrics.utils"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
+)
+_metrics_utils_mod.create_metric_per_engine = (
+    lambda metric, per_engine_labelvalues: {
+        idx: metric.labels(*labelvalues)
+        for idx, labelvalues in per_engine_labelvalues.items()
+    }
+)
 
 _events_mod: Any = sys.modules["vllm.distributed.kv_events"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
 _events_mod.KVCacheEvent = type("KVCacheEvent", (), {})  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -177,7 +177,7 @@ class _MockKVConnectorPromMetrics:
 
 
 _MockPromMetric = type("PromMetric", (), {})
-_MockPromMetricT = TypeVar("PromMetricT")
+_MockPromMetricT = TypeVar("_MockPromMetricT")
 
 _metrics_mod: Any = (
     sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.metrics"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()

--- a/tests/ut/distributed/ascend_store/_mock_deps.py
+++ b/tests/ut/distributed/ascend_store/_mock_deps.py
@@ -156,19 +156,21 @@ class _MockKVConnectorPromMetrics:
         labelnames,
         per_engine_labelvalues,
     ):
-        self._kv_transfer_config = getattr(
-            vllm_config, "kv_transfer_config", None
-        )
+        self._kv_transfer_config = getattr(vllm_config, "kv_transfer_config", None)
         self._labelnames = labelnames
         self.per_engine_labelvalues = per_engine_labelvalues
         # The real framework builds metric_types as
         # {Gauge: g, Counter: c, Histogram: h} (insertion order), so the
         # positional lookup below matches the real keyed lookup.
-        values = list(metric_types.values()) if isinstance(metric_types, dict) else [
-            metric_types,
-            metric_types,
-            metric_types,
-        ]
+        values = (
+            list(metric_types.values())
+            if isinstance(metric_types, dict)
+            else [
+                metric_types,
+                metric_types,
+                metric_types,
+            ]
+        )
         self._gauge_cls = values[0]
         self._counter_cls = values[1]
         self._histogram_cls = values[2]
@@ -178,24 +180,17 @@ _MockPromMetric = type("PromMetric", (), {})
 _MockPromMetricT = TypeVar("PromMetricT")
 
 _metrics_mod: Any = (
-    sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.metrics"]
-    if _MOCK_VLLM_DEPS
-    else types.SimpleNamespace()
+    sys.modules["vllm.distributed.kv_transfer.kv_connector.v1.metrics"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
 )
 _metrics_mod.KVConnectorStats = _MockKVConnectorStats
 _metrics_mod.KVConnectorPromMetrics = _MockKVConnectorPromMetrics
 _metrics_mod.PromMetric = _MockPromMetric
 _metrics_mod.PromMetricT = _MockPromMetricT
 
-_metrics_utils_mod: Any = (
-    sys.modules["vllm.v1.metrics.utils"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
-)
-_metrics_utils_mod.create_metric_per_engine = (
-    lambda metric, per_engine_labelvalues: {
-        idx: metric.labels(*labelvalues)
-        for idx, labelvalues in per_engine_labelvalues.items()
-    }
-)
+_metrics_utils_mod: Any = sys.modules["vllm.v1.metrics.utils"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
+_metrics_utils_mod.create_metric_per_engine = lambda metric, per_engine_labelvalues: {
+    idx: metric.labels(*labelvalues) for idx, labelvalues in per_engine_labelvalues.items()
+}
 
 _events_mod: Any = sys.modules["vllm.distributed.kv_events"] if _MOCK_VLLM_DEPS else types.SimpleNamespace()
 _events_mod.KVCacheEvent = type("KVCacheEvent", (), {})  # type: ignore[attr-defined]

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -334,6 +334,48 @@ class TestAscendStoreConnector(unittest.TestCase):
             mock_worker_cls.return_value.get_kv_events.return_value = events
             self.assertIsInstance(connector.get_kv_connector_kv_cache_events(), expected_type)
 
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.LookupKeyServer")
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolWorker")
+    def test_get_kv_connector_stats_worker_role_does_not_crash(self, mock_worker_cls, mock_lookup_cls):
+        """Regression test: worker-role instances must not raise AttributeError.
+
+        The upstream metrics framework calls get_kv_connector_stats() on
+        worker-role instances (kv_connector_model_runner_mixin), so the
+        scheduler-side attribute must exist (None) rather than be absent.
+        """
+        config = self._make_vllm_config()
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+        connector = AscendStoreConnector(
+            vllm_config=config,
+            role=KVConnectorRole.WORKER,
+            kv_cache_config=None,
+        )
+        self.assertIsNone(connector.connector_scheduler)
+
+        # Worker side: delegate to the worker's get_stats.
+        result = connector.get_kv_connector_stats()
+        mock_worker_cls.return_value.get_stats.assert_called_once()
+        self.assertIs(result, mock_worker_cls.return_value.get_stats.return_value)
+
+    @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolScheduler")
+    def test_get_kv_connector_stats_scheduler_role_prefers_scheduler(
+        self, mock_scheduler_cls
+    ):
+        config = self._make_vllm_config()
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+        connector = AscendStoreConnector(
+            vllm_config=config,
+            role=KVConnectorRole.SCHEDULER,
+            kv_cache_config=MagicMock(),
+        )
+        self.assertIsNone(connector.connector_worker)
+
+        result = connector.get_kv_connector_stats()
+        mock_scheduler_cls.return_value.get_stats.assert_called_once()
+        self.assertIs(result, mock_scheduler_cls.return_value.get_stats.return_value)
+
 
 class TestAscendStoreConnectorLayerwise(unittest.TestCase):
     """Test connector methods that are specific to layerwise mode."""

--- a/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
+++ b/tests/ut/distributed/ascend_store/test_ascend_store_connector.py
@@ -359,9 +359,7 @@ class TestAscendStoreConnector(unittest.TestCase):
         self.assertIs(result, mock_worker_cls.return_value.get_stats.return_value)
 
     @patch("vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.ascend_store_connector.KVPoolScheduler")
-    def test_get_kv_connector_stats_scheduler_role_prefers_scheduler(
-        self, mock_scheduler_cls
-    ):
+    def test_get_kv_connector_stats_scheduler_role_prefers_scheduler(self, mock_scheduler_cls):
         config = self._make_vllm_config()
         from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 

--- a/tests/ut/distributed/ascend_store/test_kv_transfer.py
+++ b/tests/ut/distributed/ascend_store/test_kv_transfer.py
@@ -804,6 +804,7 @@ class TestKVTransferTpMismatchDispatch(unittest.TestCase):
     def test_recving_dispatches_to_worker_when_tp_mismatch(self):
         worker = MagicMock()
         worker.tp_mismatch = True
+        worker._load_kv_tp_mismatch.return_value = (1, 0)
         t, _ = self._make_recving(worker=worker)
         req = ReqMeta(
             req_id="r1", token_len_chunk=16, block_ids_by_group=[[0]], block_hashes=[b"h0"], current_event=None

--- a/tests/ut/distributed/ascend_store/test_metrics.py
+++ b/tests/ut/distributed/ascend_store/test_metrics.py
@@ -1,0 +1,403 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
+    AscendStoreKVConnectorStats,
+    AscendStorePromMetrics,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal fake prometheus_client metric primitives (duck-typed).
+# ---------------------------------------------------------------------------
+class _FakeMetricChild:
+    def __init__(self):
+        self.observations = []
+        self.value = 0
+
+    def observe(self, value):
+        self.observations.append(value)
+
+    def inc(self, amount=1):
+        self.value += amount
+
+    def set(self, value):
+        self.value = value
+
+
+class _FakeMetric:
+    def __init__(self, name, documentation, labelnames=None, buckets=None, **kwargs):
+        self.name = name
+        self.documentation = documentation
+        self.labelnames = list(labelnames or [])
+        self.buckets = buckets
+        self.children = {}
+
+    def labels(self, *labelvalues):
+        key = tuple(labelvalues)
+        if key not in self.children:
+            self.children[key] = _FakeMetricChild()
+        return self.children[key]
+
+
+class _FakeGauge(_FakeMetric):
+    pass
+
+
+class _FakeCounter(_FakeMetric):
+    pass
+
+
+class _FakeHistogram(_FakeMetric):
+    pass
+
+
+def _make_metric_types():
+    """Build the metric_types dict for both mock and real vllm envs.
+
+    The mock KVConnectorPromMetrics resolves classes by dict insertion
+    order; the real one resolves them by the prometheus_client types as
+    keys. Build both key styles so the dict works either way.
+    """
+    try:
+        from prometheus_client import Counter, Gauge, Histogram
+
+        return {
+            Gauge: _FakeGauge,
+            Counter: _FakeCounter,
+            Histogram: _FakeHistogram,
+        }
+    except ImportError:
+        return {
+            "gauge": _FakeGauge,
+            "counter": _FakeCounter,
+            "histogram": _FakeHistogram,
+        }
+
+
+def _make_prom_metrics():
+    vllm_config = MagicMock()
+    return AscendStorePromMetrics(
+        vllm_config,
+        _make_metric_types(),
+        ["model_name"],
+        {0: ["test-model"]},
+    )
+
+
+class TestAscendStoreKVConnectorStats(unittest.TestCase):
+    def test_starts_empty_and_resets(self):
+        stats = AscendStoreKVConnectorStats()
+        self.assertTrue(stats.is_empty())
+        stats.record_load(0.1, 4)
+        self.assertFalse(stats.is_empty())
+        stats.reset()
+        self.assertTrue(stats.is_empty())
+
+    def test_record_load_appends_records(self):
+        stats = AscendStoreKVConnectorStats()
+        stats.record_load(0.5, 10, num_failed_keys=2, path="async")
+        stats.record_load(0.25, 5, path="sync")
+        records = stats.data["load"]
+        self.assertEqual(len(records), 2)
+        self.assertEqual(records[0]["path"], "async")
+        self.assertEqual(records[0]["num_failed_keys"], 2)
+        self.assertEqual(records[1]["num_keys"], 5)
+
+    def test_record_delayed_release_overwrites(self):
+        stats = AscendStoreKVConnectorStats()
+        stats.record_delayed_release(3)
+        stats.record_delayed_release(7)
+        self.assertEqual(stats.data["delayed_release"]["num_requests"], 7)
+
+    def test_aggregate_merges_lists_and_keeps_latest_gauge(self):
+        first = AscendStoreKVConnectorStats()
+        first.record_load(0.1, 2)
+        first.record_delayed_release(1)
+        second = AscendStoreKVConnectorStats()
+        second.record_load(0.2, 3)
+        second.record_delayed_release(5)
+
+        first.aggregate(second)
+        self.assertEqual(len(first.data["load"]), 2)
+        self.assertEqual(first.data["delayed_release"]["num_requests"], 5)
+
+    def test_aggregate_with_empty_other_is_noop(self):
+        stats = AscendStoreKVConnectorStats()
+        stats.record_load(0.1, 2)
+        stats.aggregate(AscendStoreKVConnectorStats())
+        self.assertEqual(len(stats.data["load"]), 1)
+
+    def test_reduce_load_metrics(self):
+        stats = AscendStoreKVConnectorStats()
+        for duration in [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]:
+            stats.record_load(duration, 2, num_failed_keys=1)
+        reduced = stats.reduce()
+        self.assertEqual(reduced["load_count"], 10)
+        self.assertAlmostEqual(reduced["load_avg_ms"], 550.0)
+        # Nearest-rank p90 of 10 samples: index int(0.9*10-eps)=8 -> 0.9s
+        self.assertAlmostEqual(reduced["load_p90_ms"], 900.0)
+        self.assertEqual(reduced["load_keys"], 20)
+        self.assertEqual(reduced["load_failed_keys"], 10)
+
+    def test_reduce_delayed_release_only(self):
+        stats = AscendStoreKVConnectorStats()
+        stats.record_delayed_release(4)
+        reduced = stats.reduce()
+        self.assertEqual(reduced["delayed_release_requests"], 4)
+        self.assertNotIn("load_count", reduced)
+
+    def test_reduce_empty(self):
+        self.assertEqual(AscendStoreKVConnectorStats().reduce(), {})
+
+    def test_rebuild_from_plain_data(self):
+        stats = AscendStoreKVConnectorStats()
+        stats.record_load(0.1, 2)
+        stats.record_delayed_release(3)
+        # Simulate the msgpack round-trip: only plain dicts/lists/numbers.
+        rebuilt = AscendStoreKVConnectorStats(data=stats.data)
+        self.assertEqual(rebuilt.reduce()["load_count"], 1)
+        self.assertEqual(rebuilt.reduce()["delayed_release_requests"], 3)
+
+
+class TestAscendStorePromMetrics(unittest.TestCase):
+    def test_observe_records_load_metrics_with_path_label(self):
+        prom = _make_prom_metrics()
+        prom.observe(
+            {
+                "load": [
+                    {
+                        "duration_seconds": 0.05,
+                        "num_keys": 8,
+                        "num_failed_keys": 1,
+                        "path": "sync",
+                    }
+                ]
+            }
+        )
+        duration_child = prom._histogram_load_duration.children[("test-model", "sync")]
+        self.assertEqual(duration_child.observations, [0.05])
+        keys_child = prom._counter_load_keys.children[("test-model", "sync")]
+        self.assertEqual(keys_child.value, 8)
+        failed_child = prom._counter_load_failed_keys.children[("test-model", "sync")]
+        self.assertEqual(failed_child.value, 1)
+
+    def test_observe_separates_paths(self):
+        prom = _make_prom_metrics()
+        prom.observe(
+            {
+                "load": [
+                    {"duration_seconds": 0.1, "num_keys": 1, "num_failed_keys": 0, "path": "sync"},
+                    {"duration_seconds": 0.2, "num_keys": 2, "num_failed_keys": 0, "path": "layerwise"},
+                ]
+            }
+        )
+        self.assertEqual(len(prom._histogram_load_duration.children), 2)
+        self.assertIn(("test-model", "sync"), prom._histogram_load_duration.children)
+        self.assertIn(("test-model", "layerwise"), prom._histogram_load_duration.children)
+
+    def test_observe_sets_delayed_release_gauge(self):
+        prom = _make_prom_metrics()
+        prom.observe({"delayed_release": {"num_requests": 6}})
+        gauge_child = prom._gauge_delayed_release.children[("test-model",)]
+        self.assertEqual(gauge_child.value, 6)
+
+    def test_observe_empty_data_is_noop(self):
+        prom = _make_prom_metrics()
+        prom.observe(None)
+        prom.observe({})
+        self.assertEqual(prom._histogram_load_duration.children, {})
+
+    def test_metric_registration_names(self):
+        prom = _make_prom_metrics()
+        self.assertEqual(prom._histogram_load_duration.name, "vllm:kv_pool_load_duration_seconds")
+        self.assertEqual(prom._counter_load_keys.name, "vllm:kv_pool_load_keys_total")
+        self.assertEqual(
+            prom._counter_load_failed_keys.name, "vllm:kv_pool_load_failed_keys_total"
+        )
+        self.assertEqual(
+            prom._gauge_delayed_release.name, "vllm:kv_pool_delayed_release_requests"
+        )
+
+
+class TestKVPoolWorkerLoadTiming(unittest.TestCase):
+    """Verify the load-timing instrumentation on KVPoolWorker."""
+
+    def _make_worker(self):
+        import importlib
+
+        module = "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker"
+        # Patching requires the module (and thus its attributes) to exist.
+        importlib.import_module(module)
+        with (
+            patch(f"{module}.get_tensor_model_parallel_rank", return_value=0),
+            patch(f"{module}.get_tensor_model_parallel_world_size", return_value=1),
+            patch(f"{module}.get_pcp_group") as pcp_group,
+            patch(f"{module}.get_decode_context_model_parallel_world_size", return_value=1),
+            patch(f"{module}.get_decode_context_model_parallel_rank", return_value=0),
+            patch(f"{module}.importlib") as mock_importlib,
+        ):
+            pcp_group.return_value.world_size = 1
+            mock_importlib.import_module.return_value = MagicMock()
+
+            config = MagicMock()
+            config.model_config.model = "org/llama-7b"
+            config.model_config.use_mla = False
+            config.model_config.hf_text_config = MagicMock(spec=[])
+            config.model_config.get_num_layers.return_value = 2
+            config.model_config.get_total_num_kv_heads.return_value = 1
+            config.parallel_config.data_parallel_rank = 0
+            config.parallel_config.rank = 0
+            config.parallel_config.pipeline_parallel_size = 1
+            config.kv_transfer_config.kv_role = "kv_producer"
+            config.kv_transfer_config.kv_connector_extra_config = {"backend": "mooncake"}
+            config.cache_config.block_size = 16
+            config.kv_events_config = None
+
+            from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+                KVPoolWorker,
+            )
+
+            return KVPoolWorker(config, use_layerwise=False)
+
+    def test_sync_load_timing_recorded(self):
+        worker = self._make_worker()
+        worker._record_load_started("req-1")
+        time.sleep(0.01)
+        worker._record_load_finished("req-1", 4, num_failed_keys=1, path="sync")
+
+        stats = worker.get_stats()
+        self.assertIsNotNone(stats)
+        records = stats.data["load"]
+        self.assertEqual(len(records), 1)
+        self.assertGreaterEqual(records[0]["duration_seconds"], 0.01)
+        self.assertEqual(records[0]["num_keys"], 4)
+        self.assertEqual(records[0]["num_failed_keys"], 1)
+        self.assertEqual(records[0]["path"], "sync")
+
+    def test_get_stats_resets_between_calls(self):
+        worker = self._make_worker()
+        worker._record_load_started("req-1")
+        worker._record_load_finished("req-1", 2)
+        self.assertIsNotNone(worker.get_stats())
+        self.assertIsNone(worker.get_stats())
+
+    def test_unstarted_request_is_ignored(self):
+        worker = self._make_worker()
+        worker._record_load_finished("ghost", 3)
+        self.assertIsNone(worker.get_stats())
+
+    def test_zero_keys_request_is_ignored(self):
+        worker = self._make_worker()
+        worker._record_load_started("req-0")
+        worker._record_load_finished("req-0", 0)
+        self.assertIsNone(worker.get_stats())
+        # Start time must not leak.
+        self.assertNotIn("req-0", worker._load_start_times)
+
+    def test_layerwise_timing_recorded(self):
+        worker = self._make_worker()
+
+        block_range = MagicMock()
+        block_range.request.req_id = "req-lw"
+        block_range.start_block = 0
+        block_range.end_block = 3
+        task = MagicMock()
+        task.block_ranges = [block_range]
+        worker.layer_load_tasks = [[task]]
+
+        worker._record_layerwise_load_started()
+        time.sleep(0.01)
+        worker._record_layerwise_load_finished()
+
+        stats = worker.get_stats()
+        self.assertIsNotNone(stats)
+        records = stats.data["load"]
+        self.assertEqual(len(records), 1)
+        self.assertGreaterEqual(records[0]["duration_seconds"], 0.01)
+        self.assertEqual(records[0]["num_keys"], 3)
+        self.assertEqual(records[0]["path"], "layerwise")
+        # Both bookkeeping dicts are drained.
+        self.assertEqual(worker._load_start_times, {})
+        self.assertEqual(worker._layerwise_load_keys, {})
+
+
+class TestKVPoolSchedulerDelayedRelease(unittest.TestCase):
+    """Verify the delayed-release gauge snapshot on KVPoolScheduler."""
+
+    def _make_scheduler(self):
+        import importlib
+
+        module = "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler"
+        # Patching requires the module (and thus its attributes) to exist.
+        importlib.import_module(module)
+        with (
+            patch(f"{module}.LookupKeyClient"),
+            patch(f"{module}.importlib") as mock_importlib,
+        ):
+            mock_importlib.import_module.return_value = MagicMock()
+
+            config = MagicMock()
+            config.kv_transfer_config.kv_role = "kv_producer"
+            config.kv_transfer_config.kv_connector_extra_config = {}
+            config.kv_transfer_config.get_from_extra_config.return_value = True
+            config.parallel_config.data_parallel_rank = 0
+            config.parallel_config.prefill_context_parallel_size = 1
+            config.parallel_config.decode_context_parallel_size = 1
+            config.parallel_config.tensor_parallel_size = 1
+            config.parallel_config.pipeline_parallel_size = 1
+            config.parallel_config.rank = 0
+            config.parallel_config.world_size = 1
+            config.cache_config.block_size = 16
+            config.cache_config.hash_block_size = 16
+            config.model_config.model = "org/llama-7b"
+            config.model_config.use_mla = False
+            config.model_config.hf_text_config = MagicMock(spec=[])
+            config.model_config.get_total_num_kv_heads.return_value = 1
+            config.model_config.get_num_layers.return_value = 2
+
+            from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler import (
+                KVPoolScheduler,
+            )
+
+            return KVPoolScheduler(config, use_layerwise=False)
+
+    def test_snapshot_records_delayed_free_window(self):
+        scheduler = self._make_scheduler()
+        scheduler._delayed_free_req_ids.update({"r1", "r2"})
+        scheduler._kv_stats.record_delayed_release(len(scheduler._delayed_free_req_ids))
+
+        stats = scheduler.get_stats()
+        self.assertEqual(stats.data["delayed_release"]["num_requests"], 2)
+
+    def test_get_stats_resets_between_calls(self):
+        scheduler = self._make_scheduler()
+        scheduler._kv_stats.record_delayed_release(1)
+        first = scheduler.get_stats()
+        self.assertEqual(first.data["delayed_release"]["num_requests"], 1)
+        # After the reset a fresh snapshot is empty until recorded again.
+        self.assertTrue(scheduler.get_stats().is_empty())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ut/distributed/ascend_store/test_metrics.py
+++ b/tests/ut/distributed/ascend_store/test_metrics.py
@@ -20,7 +20,6 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
-
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
     AscendStoreKVConnectorStats,
     AscendStorePromMetrics,
@@ -232,12 +231,8 @@ class TestAscendStorePromMetrics(unittest.TestCase):
         prom = _make_prom_metrics()
         self.assertEqual(prom._histogram_load_duration.name, "vllm:kv_pool_load_duration_seconds")
         self.assertEqual(prom._counter_load_keys.name, "vllm:kv_pool_load_keys_total")
-        self.assertEqual(
-            prom._counter_load_failed_keys.name, "vllm:kv_pool_load_failed_keys_total"
-        )
-        self.assertEqual(
-            prom._gauge_delayed_release.name, "vllm:kv_pool_delayed_release_requests"
-        )
+        self.assertEqual(prom._counter_load_failed_keys.name, "vllm:kv_pool_load_failed_keys_total")
+        self.assertEqual(prom._gauge_delayed_release.name, "vllm:kv_pool_delayed_release_requests")
 
 
 class TestKVPoolWorkerLoadTiming(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_metrics.py
+++ b/tests/ut/distributed/ascend_store/test_metrics.py
@@ -123,6 +123,14 @@ class TestAscendStoreKVConnectorStats(unittest.TestCase):
         self.assertEqual(records[0]["num_failed_keys"], 2)
         self.assertEqual(records[1]["num_keys"], 5)
 
+    def test_record_load_defaults_not_overlapped_to_duration(self):
+        stats = AscendStoreKVConnectorStats()
+        stats.record_load(0.5, 10, path="async")
+        record = stats.data["load"][0]
+        self.assertEqual(record["not_overlapped_seconds"], 0.5)
+        stats.record_load(0.25, 5, path="layerwise", not_overlapped_seconds=0.1)
+        self.assertEqual(stats.data["load"][1]["not_overlapped_seconds"], 0.1)
+
     def test_record_delayed_release_overwrites(self):
         stats = AscendStoreKVConnectorStats()
         stats.record_delayed_release(3)
@@ -158,6 +166,24 @@ class TestAscendStoreKVConnectorStats(unittest.TestCase):
         self.assertAlmostEqual(reduced["load_p90_ms"], 900.0)
         self.assertEqual(reduced["load_keys"], 20)
         self.assertEqual(reduced["load_failed_keys"], 10)
+
+    def test_reduce_not_overlapped_and_overlap_ratio(self):
+        stats = AscendStoreKVConnectorStats()
+        # Half-covered layerwise load and a fully covered one.
+        stats.record_load(0.1, 2, path="layerwise", not_overlapped_seconds=0.05)
+        stats.record_load(0.2, 3, path="layerwise", not_overlapped_seconds=0.0)
+        reduced = stats.reduce()
+        self.assertAlmostEqual(reduced["not_overlapped_avg_ms"], 25.0)
+        self.assertAlmostEqual(reduced["not_overlapped_p90_ms"], 50.0)
+        # ratios = [0.5, 1.0] -> avg 0.75
+        self.assertAlmostEqual(reduced["overlap_ratio_avg"], 0.75)
+
+    def test_reduce_overlap_ratio_sync_defaults_to_zero(self):
+        stats = AscendStoreKVConnectorStats()
+        # sync/async loads block compute for the whole duration: ratio 0.
+        stats.record_load(0.1, 2, path="sync")
+        stats.record_load(0.2, 3, path="async")
+        self.assertAlmostEqual(stats.reduce()["overlap_ratio_avg"], 0.0)
 
     def test_reduce_delayed_release_only(self):
         stats = AscendStoreKVConnectorStats()
@@ -233,6 +259,40 @@ class TestAscendStorePromMetrics(unittest.TestCase):
         self.assertEqual(prom._counter_load_keys.name, "vllm:kv_pool_load_keys_total")
         self.assertEqual(prom._counter_load_failed_keys.name, "vllm:kv_pool_load_failed_keys_total")
         self.assertEqual(prom._gauge_delayed_release.name, "vllm:kv_pool_delayed_release_requests")
+        self.assertEqual(prom._histogram_load_not_overlapped.name, "vllm:kv_pool_load_not_overlapped_seconds")
+        self.assertEqual(prom._histogram_load_overlap_ratio.name, "vllm:kv_pool_load_overlap_ratio")
+
+    def test_observe_records_not_overlapped_metrics(self):
+        prom = _make_prom_metrics()
+        prom.observe(
+            {
+                "load": [
+                    {
+                        "duration_seconds": 0.1,
+                        "num_keys": 4,
+                        "num_failed_keys": 0,
+                        "path": "layerwise",
+                        "not_overlapped_seconds": 0.04,
+                    },
+                    # Legacy record without the field: falls back to duration.
+                    {
+                        "duration_seconds": 0.2,
+                        "num_keys": 4,
+                        "num_failed_keys": 0,
+                        "path": "sync",
+                    },
+                ]
+            }
+        )
+        lw_not_overlapped = prom._histogram_load_not_overlapped.children[("test-model", "layerwise")]
+        self.assertEqual(lw_not_overlapped.observations, [0.04])
+        lw_ratio = prom._histogram_load_overlap_ratio.children[("test-model", "layerwise")]
+        self.assertEqual(len(lw_ratio.observations), 1)
+        self.assertAlmostEqual(lw_ratio.observations[0], 0.6)
+        sync_not_overlapped = prom._histogram_load_not_overlapped.children[("test-model", "sync")]
+        self.assertEqual(sync_not_overlapped.observations, [0.2])
+        sync_ratio = prom._histogram_load_overlap_ratio.children[("test-model", "sync")]
+        self.assertEqual(sync_ratio.observations, [0.0])
 
 
 class TestKVPoolWorkerLoadTiming(unittest.TestCase):
@@ -408,6 +468,162 @@ class TestKVPoolWorkerLoadTiming(unittest.TestCase):
         self.assertLess(record["duration_seconds"], 0.15)
         self.assertEqual(record["num_keys"], 3)
         self.assertEqual(record["path"], "layerwise")
+
+    def test_not_overlapped_accumulates_layer_stalls(self):
+        """Only layers finishing after their wait entry contribute a stall.
+
+        Layer 1's transfer completes before compute starts waiting on it
+        (fully overlapped, zero stall); layer 0's transfer completes 0.02s
+        after the wait entry (0.02s stall).
+        """
+        worker = self._make_worker()
+
+        block_range = MagicMock()
+        block_range.request.req_id = "req-lw"
+        block_range.start_block = 0
+        block_range.end_block = 3
+        block_range.partial_block_index = None
+        task = MagicMock()
+        task.block_ranges = [block_range]
+        worker.layer_load_tasks = [[task]]
+
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+            _TimedLayerLoadEvent,
+        )
+
+        events = [_TimedLayerLoadEvent() for _ in range(2)]
+        worker.layer_load_finished_events = events
+
+        worker._record_layerwise_load_started()
+        # Layer 1's transfer finishes first ...
+        time.sleep(0.01)
+        events[1].set()
+        time.sleep(0.01)
+        # ... compute starts waiting on layer 0 ...
+        wait_enter_0 = time.perf_counter()
+        time.sleep(0.02)
+        events[0].set()
+        # ... compute only reaches layer 1's wait long after it finished.
+        wait_enter_1 = time.perf_counter()
+
+        worker._accumulate_layer_stall(0, wait_enter_0)
+        worker._accumulate_layer_stall(1, wait_enter_1)
+        worker._record_layerwise_load_finished()
+
+        stats = worker.get_stats()
+        self.assertIsNotNone(stats)
+        record = stats.data["load"][0]
+        # Only layer 0's stall counts (~0.02s); layer 1 contributes zero.
+        self.assertGreaterEqual(record["not_overlapped_seconds"], 0.02)
+        self.assertLess(record["not_overlapped_seconds"], 0.1)
+        # Invariant: the stalled portion never exceeds the total duration.
+        self.assertLess(record["not_overlapped_seconds"], record["duration_seconds"])
+
+    def test_not_overlapped_zero_when_fully_overlapped(self):
+        """Events set before the waits entered: no stall, ratio 1."""
+        worker = self._make_worker()
+
+        block_range = MagicMock()
+        block_range.request.req_id = "req-lw"
+        block_range.start_block = 0
+        block_range.end_block = 1
+        block_range.partial_block_index = None
+        task = MagicMock()
+        task.block_ranges = [block_range]
+        worker.layer_load_tasks = [[task]]
+
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+            _TimedLayerLoadEvent,
+        )
+
+        events = [_TimedLayerLoadEvent() for _ in range(2)]
+        worker.layer_load_finished_events = events
+
+        worker._record_layerwise_load_started()
+        # Both transfers finish before compute starts waiting.
+        time.sleep(0.01)
+        events[0].set()
+        events[1].set()
+        time.sleep(0.01)
+        wait_enter = time.perf_counter()
+        worker._accumulate_layer_stall(0, wait_enter)
+        worker._accumulate_layer_stall(1, wait_enter)
+        worker._record_layerwise_load_finished()
+
+        stats = worker.get_stats()
+        self.assertIsNotNone(stats)
+        record = stats.data["load"][0]
+        self.assertEqual(record["not_overlapped_seconds"], 0.0)
+        self.assertAlmostEqual(stats.reduce()["overlap_ratio_avg"], 1.0)
+
+    def test_step_not_overlapped_reset_between_steps(self):
+        """The per-step accumulator must not leak into the next step.
+
+        start_load_kv resets ``_step_not_overlapped_s`` for every layerwise
+        step; simulate the reset the same way and verify the second step's
+        record is unaffected by the first step's stall.
+        """
+        worker = self._make_worker()
+
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+            _TimedLayerLoadEvent,
+        )
+
+        events = [_TimedLayerLoadEvent() for _ in range(2)]
+        worker.layer_load_finished_events = events
+
+        block_range = MagicMock()
+        block_range.request.req_id = "req-lw"
+        block_range.start_block = 0
+        block_range.end_block = 1
+        block_range.partial_block_index = None
+        task = MagicMock()
+        task.block_ranges = [block_range]
+
+        # Step 1: layer 0 stalls ~0.02s.
+        worker.layer_load_tasks = [[task]]
+        worker._record_layerwise_load_started()
+        wait_enter = time.perf_counter()
+        time.sleep(0.02)
+        events[0].set()
+        worker._accumulate_layer_stall(0, wait_enter)
+        worker._record_layerwise_load_finished()
+        step1 = worker.get_stats()
+        self.assertGreaterEqual(step1.data["load"][0]["not_overlapped_seconds"], 0.02)
+
+        # Step 2 (fresh events, reset accumulator as start_load_kv does).
+        worker._step_not_overlapped_s = 0.0
+        events = [_TimedLayerLoadEvent() for _ in range(2)]
+        worker.layer_load_finished_events = events
+        worker.layer_load_tasks = [[task]]
+        worker._record_layerwise_load_started()
+        time.sleep(0.01)
+        events[0].set()
+        wait_enter = time.perf_counter()
+        time.sleep(0.01)
+        worker._accumulate_layer_stall(0, wait_enter)
+        worker._record_layerwise_load_finished()
+        step2 = worker.get_stats()
+        # Fully overlapped step 2 must not inherit step 1's stall.
+        self.assertEqual(step2.data["load"][0]["not_overlapped_seconds"], 0.0)
+
+    def test_accumulate_layer_stall_ignores_plain_events(self):
+        """Plain Events (no set_time) contribute no stall and never raise."""
+        import threading
+
+        worker = self._make_worker()
+        worker.layer_load_finished_events = [threading.Event(), threading.Event()]
+        worker._accumulate_layer_stall(0, time.perf_counter())
+        self.assertEqual(worker._step_not_overlapped_s, 0.0)
+
+    def test_sync_path_not_overlapped_equals_duration(self):
+        """sync/async records default to not_overlapped == duration."""
+        worker = self._make_worker()
+        worker._record_load_started("req-1")
+        time.sleep(0.01)
+        worker._record_load_finished("req-1", 4, path="sync")
+        record = worker.get_stats().data["load"][0]
+        self.assertEqual(record["not_overlapped_seconds"], record["duration_seconds"])
 
 
 class TestKVPoolSchedulerDelayedRelease(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_metrics.py
+++ b/tests/ut/distributed/ascend_store/test_metrics.py
@@ -361,6 +361,54 @@ class TestKVPoolWorkerLoadTiming(unittest.TestCase):
         self.assertEqual(records[0]["num_keys"], 3)  # 2 full + 1 partial
         self.assertEqual(records[0]["path"], "layerwise")
 
+    def test_layerwise_duration_uses_event_set_time(self):
+        """Layerwise end time must be the transfer-thread event set time.
+
+        The load threads record their completion timestamp when they set
+        the per-layer event. The metric must use that timestamp (the max
+        across layers) instead of the compute-side wait return time, so a
+        long compute tail after the load already finished does not stretch
+        the sample.
+        """
+        worker = self._make_worker()
+
+        block_range = MagicMock()
+        block_range.request.req_id = "req-lw"
+        block_range.start_block = 0
+        block_range.end_block = 3
+        block_range.partial_block_index = None
+        task = MagicMock()
+        task.block_ranges = [block_range]
+        worker.layer_load_tasks = [[task]]
+
+        from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker import (
+            _TimedLayerLoadEvent,
+        )
+
+        events = [_TimedLayerLoadEvent() for _ in range(2)]
+        worker.layer_load_finished_events = events
+
+        worker._record_layerwise_load_started()
+        # Layer 1's transfer finishes first ...
+        time.sleep(0.02)
+        events[1].set()
+        # ... then layer 0's transfer finishes later (max wins) ...
+        time.sleep(0.03)
+        events[0].set()
+        # ... and compute keeps running long after the loads finished.
+        time.sleep(0.2)
+        worker._record_layerwise_load_finished()
+
+        stats = worker.get_stats()
+        self.assertIsNotNone(stats)
+        record = stats.data["load"][0]
+        # Duration must reflect the latest event set time (~0.05s), not
+        # the wait-return time (~0.25s) and not layer 1 alone (~0.02s).
+        self.assertGreaterEqual(record["duration_seconds"], 0.05)
+        self.assertLess(record["duration_seconds"], 0.15)
+        self.assertEqual(record["num_keys"], 3)
+        self.assertEqual(record["path"], "layerwise")
+
 
 class TestKVPoolSchedulerDelayedRelease(unittest.TestCase):
     """Verify the delayed-release gauge snapshot on KVPoolScheduler."""

--- a/tests/ut/distributed/ascend_store/test_metrics.py
+++ b/tests/ut/distributed/ascend_store/test_metrics.py
@@ -322,6 +322,7 @@ class TestKVPoolWorkerLoadTiming(unittest.TestCase):
         block_range.request.req_id = "req-lw"
         block_range.start_block = 0
         block_range.end_block = 3
+        block_range.partial_block_index = None
         task = MagicMock()
         task.block_ranges = [block_range]
         worker.layer_load_tasks = [[task]]
@@ -340,6 +341,30 @@ class TestKVPoolWorkerLoadTiming(unittest.TestCase):
         # Both bookkeeping dicts are drained.
         self.assertEqual(worker._load_start_times, {})
         self.assertEqual(worker._layerwise_load_keys, {})
+
+    def test_layerwise_partial_block_counted(self):
+        """Verify partial_block_index adds 1 to the key count."""
+        worker = self._make_worker()
+
+        block_range = MagicMock()
+        block_range.request.req_id = "req-pw"
+        block_range.start_block = 0
+        block_range.end_block = 2
+        block_range.partial_block_index = 5  # extra partial block
+        task = MagicMock()
+        task.block_ranges = [block_range]
+        worker.layer_load_tasks = [[task]]
+
+        worker._record_layerwise_load_started()
+        time.sleep(0.01)
+        worker._record_layerwise_load_finished()
+
+        stats = worker.get_stats()
+        self.assertIsNotNone(stats)
+        records = stats.data["load"]
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["num_keys"], 3)  # 2 full + 1 partial
+        self.assertEqual(records[0]["path"], "layerwise")
 
 
 class TestKVPoolSchedulerDelayedRelease(unittest.TestCase):

--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -162,6 +162,8 @@ class TestKVPoolWorkerHelpers(unittest.TestCase):
         worker.kv_recv_thread = MagicMock()
         worker.external_slot_release_waiter = MagicMock()
         worker._submit_ready_layer_loads = MagicMock()
+        worker._load_start_times = {}
+        worker._layerwise_load_keys = {}
 
         worker.wait_for_layer_load()
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -34,11 +34,11 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackDecoder
 
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import AscendStoreKVConnectorWorkerMetadata
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
     AscendStoreKVConnectorStats,
     AscendStorePromMetrics,
 )
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import AscendStoreKVConnectorWorkerMetadata
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler import (
     KVPoolScheduler,
     get_zmq_rpc_path_lookup,
@@ -315,9 +315,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         return self.connector_worker.get_stats()
 
     @classmethod
-    def build_kv_connector_stats(
-        cls, data: dict[str, Any] | None = None
-    ) -> KVConnectorStats | None:
+    def build_kv_connector_stats(cls, data: dict[str, Any] | None = None) -> KVConnectorStats | None:
         return AscendStoreKVConnectorStats(data=data or {})
 
     @classmethod
@@ -328,9 +326,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         labelnames: list[str],
         per_engine_labelvalues: dict[int, list[object]],
     ) -> KVConnectorPromMetrics:
-        return AscendStorePromMetrics(
-            vllm_config, metric_types, labelnames, per_engine_labelvalues
-        )
+        return AscendStorePromMetrics(vllm_config, metric_types, labelnames, per_engine_labelvalues)
 
 
 class LookupKeyServer:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -212,7 +212,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
     # Worker Side Methods
     ############################################################
     def set_external_slot_release_waiter(self, waiter: Callable[[int], None]) -> bool:
-        if not self.use_gva_layerwise or getattr(self, "connector_worker", None) is None:
+        if not self.use_gva_layerwise or self.connector_worker is None:
             return False
         self.connector_worker.set_external_slot_release_waiter(waiter)
         return True
@@ -243,6 +243,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def wait_for_layer_load(self, layer_name: str) -> None:
         if not self.use_layerwise:
             return
+        assert self.connector_worker is not None
         self.connector_worker.wait_for_layer_load()
 
     def save_kv_layer(
@@ -254,6 +255,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         if self.kv_role == "kv_consumer" and not self.consumer_is_to_put:
             # A load-only consumer does not publish KV.
             return
+        assert self.connector_worker is not None
         self.connector_worker.save_kv_layer(self._get_connector_metadata())
 
     def wait_for_save(self):
@@ -264,6 +266,7 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         if self.use_layerwise:
             return
 
+        assert self.connector_worker is not None
         self.connector_worker.wait_for_save(self._get_connector_metadata())
 
     def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str], set[str]]:
@@ -287,10 +290,10 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
         """
         Get the KV connector kv cache events collected during the last interval.
         """
+        assert self.connector_worker is not None
         events = self.connector_worker.get_kv_events()
         if not events:
             return None
-
         ascend_store_kv_events = AscendStoreKVEvents(num_workers=1)
         ascend_store_kv_events.add_events(events)
         return ascend_store_kv_events

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -16,6 +16,12 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
 from vllm.forward_context import ForwardContext
 from vllm.logger import logger
 from vllm.utils.network_utils import make_zmq_socket
@@ -28,6 +34,10 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.serial_utils import MsgpackDecoder
 
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
+    AscendStoreKVConnectorStats,
+    AscendStorePromMetrics,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import AscendStoreKVConnectorWorkerMetadata
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_scheduler import (
     KVPoolScheduler,
@@ -286,6 +296,35 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
     def build_connector_worker_meta(self) -> AscendStoreKVConnectorWorkerMetadata | None:
         assert self.connector_worker is not None
         return self.connector_worker.build_connector_worker_meta()
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        """Return KV pool stats collected since the last call.
+
+        Worker side: per-request pool load durations. Scheduler side:
+        delayed-release gauge snapshots.
+        """
+        if self.connector_scheduler is not None:
+            return self.connector_scheduler.get_stats()
+        assert self.connector_worker is not None
+        return self.connector_worker.get_stats()
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        return AscendStoreKVConnectorStats(data=data or {})
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        return AscendStorePromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
 
 
 class LookupKeyServer:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/ascend_store_connector.py
@@ -111,6 +111,12 @@ class AscendStoreConnector(KVConnectorBase_V1, SupportsHMA):
 
         self._current_step_has_real_forward = False
 
+        # Both sides are declared up-front: the upstream metrics framework
+        # calls get_kv_connector_stats() on worker-role instances too, so the
+        # "other" attribute must exist (None) rather than be absent.
+        self.connector_scheduler: KVPoolScheduler | None = None
+        self.connector_worker: KVPoolWorker | None = None
+
         if role == KVConnectorRole.SCHEDULER:
             assert kv_cache_config is not None
             self.connector_scheduler = KVPoolScheduler(vllm_config, self.use_layerwise, kv_cache_config)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -893,12 +893,25 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         self._invalid_block_ids_lock = invalid_block_ids_lock or threading.Lock()
         self.worker = worker
 
+    def _record_load_finished(
+        self,
+        req_id: str,
+        num_keys: int,
+        num_failed_keys: int = 0,
+        path: str = "async",
+    ) -> None:
+        if self.worker is not None:
+            self.worker._record_load_finished(
+                req_id, num_keys, num_failed_keys=num_failed_keys, path=path
+            )
+
     def _handle_request(self, req_meta: ReqMeta):
         try:
             load_spec = req_meta.load_spec
             req_id = req_meta.req_id
             if load_spec is None:
                 logger.error("KV pool async recv request %s has no load spec; skip load.", req_id)
+                self._record_load_finished(req_id, 0)
                 self.set_finished_request(req_id)
                 return
 
@@ -906,12 +919,13 @@ class KVCacheStoreRecvingThread(KVTransferThread):
             if self.worker is not None and getattr(self.worker, "tp_mismatch", False):
                 group_block_size = self._get_block_size(0)
                 mask_num = load_spec.vllm_cached_tokens // group_block_size * group_block_size
-                self.worker._load_kv_tp_mismatch(
+                num_keys, num_failed_keys = self.worker._load_kv_tp_mismatch(
                     req_meta.block_hashes,
                     req_meta.block_ids_by_group[0],
                     token_len,
                     mask_num,
                 )
+                self._record_load_finished(req_id, num_keys, num_failed_keys=num_failed_keys)
                 self.set_finished_request(req_id)
                 return
 
@@ -951,6 +965,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                     size_list.append(size)
                     block_id_list.append(block_id)
             if not key_list:
+                self._record_load_finished(req_id, 0)
                 self.set_finished_request(req_id)
                 return
             key_list_c = key_list[self.tp_rank % len(key_list) :] + key_list[: self.tp_rank % len(key_list)]
@@ -1006,6 +1021,12 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 token_len,
                 req_meta.kv_cache_group_ids or [0],
                 len(key_list_c),
+            )
+            num_failed_keys = (
+                sum(1 for r in ret if r != 0) if ret is not None else len(key_list_c)
+            )
+            self._record_load_finished(
+                req_id, len(key_list_c), num_failed_keys=num_failed_keys
             )
             self.set_finished_request(req_id)
         finally:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/kv_transfer.py
@@ -901,9 +901,7 @@ class KVCacheStoreRecvingThread(KVTransferThread):
         path: str = "async",
     ) -> None:
         if self.worker is not None:
-            self.worker._record_load_finished(
-                req_id, num_keys, num_failed_keys=num_failed_keys, path=path
-            )
+            self.worker._record_load_finished(req_id, num_keys, num_failed_keys=num_failed_keys, path=path)
 
     def _handle_request(self, req_meta: ReqMeta):
         try:
@@ -1022,12 +1020,8 @@ class KVCacheStoreRecvingThread(KVTransferThread):
                 req_meta.kv_cache_group_ids or [0],
                 len(key_list_c),
             )
-            num_failed_keys = (
-                sum(1 for r in ret if r != 0) if ret is not None else len(key_list_c)
-            )
-            self._record_load_finished(
-                req_id, len(key_list_c), num_failed_keys=num_failed_keys
-            )
+            num_failed_keys = sum(1 for r in ret if r != 0) if ret is not None else len(key_list_c)
+            self._record_load_finished(req_id, len(key_list_c), num_failed_keys=num_failed_keys)
             self.set_finished_request(req_id)
         finally:
             self.request_queue.task_done()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
@@ -4,11 +4,14 @@
 
 Two families of telemetry are collected:
 
-- ``load``: per-request wall-clock duration of loading KV cache blocks
-  from the KV pool backend (``m_store.get``), together with the number of
-  keys touched and keys that failed to load. One record per request, with
-  the loading path (``sync`` / ``async`` / ``layerwise``) attached as a
-  label.
+- ``load``: per-request wall-clock duration of a KV pool load, together
+  with the number of keys touched and keys that failed to load. One
+  record per request, with the loading path (``sync`` / ``async`` /
+  ``layerwise``) attached as a label. The measured span is the full load
+  path on this rank: ``sync`` includes key preparation before
+  ``m_store.get``; ``async`` additionally includes receive-thread queueing
+  time; ``layerwise`` spans from task submission to the last layer's load
+  completion.
 - ``delayed_release``: latest snapshot of the number of requests whose KV
   blocks are held in the delayed-release window on the scheduler side
   (i.e. ``len(pool_scheduler._delayed_free_req_ids)``).
@@ -121,13 +124,23 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
     Metrics:
 
     - ``vllm:kv_pool_load_duration_seconds`` (Histogram, label ``path``):
-      per-request KV pool load wall-clock duration.
+      per-request KV pool load wall-clock duration. Measured spans differ
+      per path: ``sync`` covers key preparation plus ``m_store.get``;
+      ``async`` additionally includes queueing time in the receiving
+      thread; ``layerwise`` covers from layer-task submission to the last
+      layer's load completion (end-to-end span, compute may overlap).
     - ``vllm:kv_pool_load_keys_total`` (Counter, label ``path``): number of
-      pool keys loaded per request.
+      pool keys loaded. ``sync``/``async`` count this rank's key chunks
+      (keys are circular-shifted across TP ranks, so sums across ranks
+      equal the global key count); ``layerwise`` counts per-layer block
+      transfers (approx. blocks x layers), which is not directly
+      comparable with the other paths.
     - ``vllm:kv_pool_load_failed_keys_total`` (Counter, label ``path``):
       number of pool keys that failed to load.
     - ``vllm:kv_pool_delayed_release_requests`` (Gauge): number of requests
       whose KV blocks are currently held in the delayed-release window.
+      Latest-snapshot semantics: reflects the most recent scheduling step,
+      not the peak within a scrape interval.
     """
 
     def __init__(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
@@ -10,8 +10,11 @@ Two families of telemetry are collected:
   ``layerwise``) attached as a label. The measured span is the full load
   path on this rank: ``sync`` includes key preparation before
   ``m_store.get``; ``async`` additionally includes receive-thread queueing
-  time; ``layerwise`` spans from task submission to the last layer's load
-  completion.
+  time; ``layerwise`` spans from task submission to the completion of the
+  last layer transfer (the transfer thread's completion timestamp, not
+  the compute-side wait return, so compute running past a finished load
+  no longer stretches the sample; prefetch layers may still include
+  waiting for the attention-start gate).
 - ``delayed_release``: latest snapshot of the number of requests whose KV
   blocks are held in the delayed-release window on the scheduler side
   (i.e. ``len(pool_scheduler._delayed_free_req_ids)``).
@@ -121,8 +124,9 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
       per-request KV pool load wall-clock duration. Measured spans differ
       per path: ``sync`` covers key preparation plus ``m_store.get``;
       ``async`` additionally includes queueing time in the receiving
-      thread; ``layerwise`` covers from layer-task submission to the last
-      layer's load completion (end-to-end span, compute may overlap).
+      thread; ``layerwise`` covers from layer-task submission to the
+      completion of the last layer transfer (transfer-thread completion
+      time; compute overlap no longer stretches the sample).
     - ``vllm:kv_pool_load_keys_total`` (Counter, label ``path``): number of
       pool keys loaded. ``sync``/``async`` count this rank's key chunks
       (keys are circular-shifted across TP ranks, so sums across ranks
@@ -130,7 +134,10 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
       transfers (approx. blocks x layers), which is not directly
       comparable with the other paths.
     - ``vllm:kv_pool_load_failed_keys_total`` (Counter, label ``path``):
-      number of pool keys that failed to load.
+      number of pool keys that failed to load. Only meaningful for
+      ``sync``/``async``; on the ``layerwise`` path a transfer failure is
+      fatal (the transfer thread raises), so this counter is expected to
+      stay 0 there.
     - ``vllm:kv_pool_delayed_release_requests`` (Gauge): number of requests
       whose KV blocks are currently held in the delayed-release window.
       Latest-snapshot semantics: reflects the most recent scheduling step,
@@ -201,7 +208,10 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
         if not transfer_stats_data:
             return
         for record in transfer_stats_data.get("load", []):
-            assert isinstance(record, dict)
+            if not isinstance(record, dict):
+                # Malformed entry after deserialization; skip it rather than
+                # crash the metrics pipeline (assert would vanish under -O).
+                continue
             metrics = self._get_load_metrics(engine_idx, str(record["path"]))
             metrics["duration"].observe(float(record["duration_seconds"]))
             metrics["keys"].inc(int(record["num_keys"]))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
@@ -38,9 +38,7 @@ def _nearest_rank_percentile(values: list[float], percentile: float) -> float:
     if not values:
         return 0.0
     sorted_values = sorted(values)
-    rank = max(
-        0, min(len(sorted_values) - 1, int(percentile * len(sorted_values) - 1e-12))
-    )
+    rank = max(0, min(len(sorted_values) - 1, int(percentile * len(sorted_values) - 1e-12)))
     return sorted_values[rank]
 
 
@@ -85,13 +83,9 @@ class AscendStoreKVConnectorStats(KVConnectorStats):
             durations = [float(record["duration_seconds"]) for record in records]
             reduced["load_count"] = len(records)
             reduced["load_avg_ms"] = round(fmean(durations) * 1e3, 3)
-            reduced["load_p90_ms"] = round(
-                _nearest_rank_percentile(durations, 0.9) * 1e3, 3
-            )
+            reduced["load_p90_ms"] = round(_nearest_rank_percentile(durations, 0.9) * 1e3, 3)
             reduced["load_keys"] = sum(int(record["num_keys"]) for record in records)
-            reduced["load_failed_keys"] = sum(
-                int(record["num_failed_keys"]) for record in records
-            )
+            reduced["load_failed_keys"] = sum(int(record["num_failed_keys"]) for record in records)
         delayed_release = self.data.get("delayed_release")
         if delayed_release is not None:
             reduced["delayed_release_requests"] = int(delayed_release["num_requests"])
@@ -156,8 +150,7 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
 
         self._histogram_load_duration = self._histogram_cls(
             name="vllm:kv_pool_load_duration_seconds",
-            documentation="Histogram of per-request KV cache load duration "
-            "from the KV pool.",
+            documentation="Histogram of per-request KV cache load duration from the KV pool.",
             buckets=[
                 1e-3,
                 5e-3,
@@ -188,13 +181,10 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
         )
         self._gauge_delayed_release = self._gauge_cls(
             name="vllm:kv_pool_delayed_release_requests",
-            documentation="Number of requests whose KV blocks are currently "
-            "held in the delayed-release window.",
+            documentation="Number of requests whose KV blocks are currently held in the delayed-release window.",
             labelnames=labelnames,
         )
-        self._delayed_release_per_engine = create_metric_per_engine(
-            self._gauge_delayed_release, per_engine_labelvalues
-        )
+        self._delayed_release_per_engine = create_metric_per_engine(self._gauge_delayed_release, per_engine_labelvalues)
 
     def _get_load_metrics(self, engine_idx: int, path: str) -> dict[str, PromMetric]:
         cache_key = (engine_idx, path)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM-Ascend project
+"""Observability metrics for the AscendStore KV pool connector.
+
+Two families of telemetry are collected:
+
+- ``load``: per-request wall-clock duration of loading KV cache blocks
+  from the KV pool backend (``m_store.get``), together with the number of
+  keys touched and keys that failed to load. One record per request, with
+  the loading path (``sync`` / ``async`` / ``layerwise``) attached as a
+  label.
+- ``delayed_release``: latest snapshot of the number of requests whose KV
+  blocks are held in the delayed-release window on the scheduler side
+  (i.e. ``len(pool_scheduler._delayed_free_req_ids)``).
+
+``data`` only contains primitives so it can cross process boundaries
+(worker -> scheduler -> engine core -> API server) via msgpack.
+"""
+
+from dataclasses import dataclass
+from statistics import fmean
+from typing import Any
+
+from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.v1.metrics.utils import create_metric_per_engine
+
+
+def _nearest_rank_percentile(values: list[float], percentile: float) -> float:
+    if not values:
+        return 0.0
+    sorted_values = sorted(values)
+    rank = max(
+        0, min(len(sorted_values) - 1, int(percentile * len(sorted_values) - 1e-12))
+    )
+    return sorted_values[rank]
+
+
+@dataclass
+class AscendStoreKVConnectorStats(KVConnectorStats):
+    """Serializable KV pool telemetry.
+
+    Layout of ``data`` (all values are primitives):
+
+    - ``load``: ``list`` of ``{duration_seconds: float, num_keys: int,
+      num_failed_keys: int, path: str}``, one entry per request whose KV
+      cache was actually loaded from the pool (``num_keys > 0``).
+    - ``delayed_release``: ``{num_requests: int}`` gauge snapshot recorded
+      by the scheduler; the latest snapshot wins during aggregation.
+    """
+
+    def __post_init__(self):
+        if not self.data:
+            self.reset()
+
+    def reset(self):
+        self.data: dict[str, Any] = {}
+
+    def is_empty(self) -> bool:
+        return not self.data
+
+    def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        if other.is_empty():
+            return self
+        for key, value in other.data.items():
+            if isinstance(value, list):
+                self.data.setdefault(key, []).extend(value)
+            else:
+                # Gauge snapshot: the latest observation wins.
+                self.data[key] = value
+        return self
+
+    def reduce(self) -> dict[str, int | float]:
+        reduced: dict[str, int | float] = {}
+        records = self.data.get("load")
+        if records:
+            durations = [float(record["duration_seconds"]) for record in records]
+            reduced["load_count"] = len(records)
+            reduced["load_avg_ms"] = round(fmean(durations) * 1e3, 3)
+            reduced["load_p90_ms"] = round(
+                _nearest_rank_percentile(durations, 0.9) * 1e3, 3
+            )
+            reduced["load_keys"] = sum(int(record["num_keys"]) for record in records)
+            reduced["load_failed_keys"] = sum(
+                int(record["num_failed_keys"]) for record in records
+            )
+        delayed_release = self.data.get("delayed_release")
+        if delayed_release is not None:
+            reduced["delayed_release_requests"] = int(delayed_release["num_requests"])
+        return reduced
+
+    def record_load(
+        self,
+        duration_seconds: float,
+        num_keys: int,
+        *,
+        num_failed_keys: int = 0,
+        path: str = "sync",
+    ) -> None:
+        self.data.setdefault("load", []).append(
+            {
+                "duration_seconds": duration_seconds,
+                "num_keys": num_keys,
+                "num_failed_keys": num_failed_keys,
+                "path": path,
+            }
+        )
+
+    def record_delayed_release(self, num_requests: int) -> None:
+        self.data["delayed_release"] = {"num_requests": int(num_requests)}
+
+
+class AscendStorePromMetrics(KVConnectorPromMetrics):
+    """Prometheus metrics for the AscendStore KV pool.
+
+    Metrics:
+
+    - ``vllm:kv_pool_load_duration_seconds`` (Histogram, label ``path``):
+      per-request KV pool load wall-clock duration.
+    - ``vllm:kv_pool_load_keys_total`` (Counter, label ``path``): number of
+      pool keys loaded per request.
+    - ``vllm:kv_pool_load_failed_keys_total`` (Counter, label ``path``):
+      number of pool keys that failed to load.
+    - ``vllm:kv_pool_delayed_release_requests`` (Gauge): number of requests
+      whose KV blocks are currently held in the delayed-release window.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ):
+        super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
+        metric_labelnames = labelnames + ["path"]
+        self._metric_cache: dict[tuple[int, str], dict[str, PromMetric]] = {}
+
+        self._histogram_load_duration = self._histogram_cls(
+            name="vllm:kv_pool_load_duration_seconds",
+            documentation="Histogram of per-request KV cache load duration "
+            "from the KV pool.",
+            buckets=[
+                1e-3,
+                5e-3,
+                1e-2,
+                2.5e-2,
+                5e-2,
+                7.5e-2,
+                1e-1,
+                2e-1,
+                3e-1,
+                5e-1,
+                7.5e-1,
+                1.0,
+                2.5,
+                5.0,
+            ],
+            labelnames=metric_labelnames,
+        )
+        self._counter_load_keys = self._counter_cls(
+            name="vllm:kv_pool_load_keys_total",
+            documentation="Number of KV pool keys loaded per request.",
+            labelnames=metric_labelnames,
+        )
+        self._counter_load_failed_keys = self._counter_cls(
+            name="vllm:kv_pool_load_failed_keys_total",
+            documentation="Number of KV pool keys that failed to load.",
+            labelnames=metric_labelnames,
+        )
+        self._gauge_delayed_release = self._gauge_cls(
+            name="vllm:kv_pool_delayed_release_requests",
+            documentation="Number of requests whose KV blocks are currently "
+            "held in the delayed-release window.",
+            labelnames=labelnames,
+        )
+        self._delayed_release_per_engine = create_metric_per_engine(
+            self._gauge_delayed_release, per_engine_labelvalues
+        )
+
+    def _get_load_metrics(self, engine_idx: int, path: str) -> dict[str, PromMetric]:
+        cache_key = (engine_idx, path)
+        if cache_key not in self._metric_cache:
+            label_values = self.per_engine_labelvalues[engine_idx] + [path]
+            self._metric_cache[cache_key] = {
+                "duration": self._histogram_load_duration.labels(*label_values),
+                "keys": self._counter_load_keys.labels(*label_values),
+                "failed_keys": self._counter_load_failed_keys.labels(*label_values),
+            }
+        return self._metric_cache[cache_key]
+
+    def observe(self, transfer_stats_data: dict[str, Any] | None, engine_idx: int = 0):
+        if not transfer_stats_data:
+            return
+        for record in transfer_stats_data.get("load", []):
+            assert isinstance(record, dict)
+            metrics = self._get_load_metrics(engine_idx, str(record["path"]))
+            metrics["duration"].observe(float(record["duration_seconds"]))
+            metrics["keys"].inc(int(record["num_keys"]))
+            metrics["failed_keys"].inc(int(record["num_failed_keys"]))
+        delayed_release = transfer_stats_data.get("delayed_release")
+        if delayed_release is not None:
+            gauge = self._delayed_release_per_engine.get(engine_idx)
+            if gauge is not None:
+                gauge.set(int(delayed_release["num_requests"]))

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/metrics.py
@@ -15,6 +15,11 @@ Two families of telemetry are collected:
   the compute-side wait return, so compute running past a finished load
   no longer stretches the sample; prefetch layers may still include
   waiting for the attention-start gate).
+  Each record also carries ``not_overlapped_seconds``: the portion of the
+  load the compute thread actually stalled on. ``layerwise`` sums the
+  per-layer ``wait_for_layer_load`` stalls (wait entry -> event set);
+  ``sync``/``async`` loads block the compute thread for their whole
+  duration, so theirs defaults to ``duration_seconds``.
 - ``delayed_release``: latest snapshot of the number of requests whose KV
   blocks are held in the delayed-release window on the scheduler side
   (i.e. ``len(pool_scheduler._delayed_free_req_ids)``).
@@ -52,8 +57,9 @@ class AscendStoreKVConnectorStats(KVConnectorStats):
     Layout of ``data`` (all values are primitives):
 
     - ``load``: ``list`` of ``{duration_seconds: float, num_keys: int,
-      num_failed_keys: int, path: str}``, one entry per request whose KV
-      cache was actually loaded from the pool (``num_keys > 0``).
+      num_failed_keys: int, path: str, not_overlapped_seconds: float}``,
+      one entry per request whose KV cache was actually loaded from the
+      pool (``num_keys > 0``).
     - ``delayed_release``: ``{num_requests: int}`` gauge snapshot recorded
       by the scheduler; the latest snapshot wins during aggregation.
     """
@@ -89,6 +95,12 @@ class AscendStoreKVConnectorStats(KVConnectorStats):
             reduced["load_p90_ms"] = round(_nearest_rank_percentile(durations, 0.9) * 1e3, 3)
             reduced["load_keys"] = sum(int(record["num_keys"]) for record in records)
             reduced["load_failed_keys"] = sum(int(record["num_failed_keys"]) for record in records)
+            not_overlapped = [float(record["not_overlapped_seconds"]) for record in records]
+            reduced["not_overlapped_avg_ms"] = round(fmean(not_overlapped) * 1e3, 3)
+            reduced["not_overlapped_p90_ms"] = round(_nearest_rank_percentile(not_overlapped, 0.9) * 1e3, 3)
+            ratios = [1.0 - no / d for no, d in zip(not_overlapped, durations) if d > 0]
+            if ratios:
+                reduced["overlap_ratio_avg"] = round(fmean(ratios), 4)
         delayed_release = self.data.get("delayed_release")
         if delayed_release is not None:
             reduced["delayed_release_requests"] = int(delayed_release["num_requests"])
@@ -101,13 +113,19 @@ class AscendStoreKVConnectorStats(KVConnectorStats):
         *,
         num_failed_keys: int = 0,
         path: str = "sync",
+        not_overlapped_seconds: float | None = None,
     ) -> None:
+        # sync/async loads block the compute thread for the whole duration,
+        # so their not-overlapped time defaults to the duration itself.
+        if not_overlapped_seconds is None:
+            not_overlapped_seconds = duration_seconds
         self.data.setdefault("load", []).append(
             {
                 "duration_seconds": duration_seconds,
                 "num_keys": num_keys,
                 "num_failed_keys": num_failed_keys,
                 "path": path,
+                "not_overlapped_seconds": not_overlapped_seconds,
             }
         )
 
@@ -138,6 +156,16 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
       ``sync``/``async``; on the ``layerwise`` path a transfer failure is
       fatal (the transfer thread raises), so this counter is expected to
       stay 0 there.
+    - ``vllm:kv_pool_load_not_overlapped_seconds`` (Histogram, label
+      ``path``): per-request portion of the pool load the compute thread
+      actually stalled on. ``layerwise`` sums the per-layer
+      ``wait_for_layer_load`` stalls; ``sync``/``async`` equal the full
+      duration. Near-zero ``layerwise`` samples mean the transfers were
+      effectively hidden behind compute.
+    - ``vllm:kv_pool_load_overlap_ratio`` (Histogram, label ``path``):
+      ``1 - not_overlapped / duration`` per request. 1.0 means the load
+      was fully overlapped with compute; ``sync``/``async`` stay near 0
+      by construction.
     - ``vllm:kv_pool_delayed_release_requests`` (Gauge): number of requests
       whose KV blocks are currently held in the delayed-release window.
       Latest-snapshot semantics: reflects the most recent scheduling step,
@@ -186,6 +214,31 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
             documentation="Number of KV pool keys that failed to load.",
             labelnames=metric_labelnames,
         )
+        self._histogram_load_not_overlapped = self._histogram_cls(
+            name="vllm:kv_pool_load_not_overlapped_seconds",
+            documentation="Histogram of per-request KV pool load time not overlapped with compute.",
+            buckets=[
+                1e-3,
+                5e-3,
+                1e-2,
+                2.5e-2,
+                5e-2,
+                7.5e-2,
+                1e-1,
+                2e-1,
+                5e-1,
+                1.0,
+                2.5,
+                5.0,
+            ],
+            labelnames=metric_labelnames,
+        )
+        self._histogram_load_overlap_ratio = self._histogram_cls(
+            name="vllm:kv_pool_load_overlap_ratio",
+            documentation="Histogram of per-request KV pool load overlap ratio (1 - not_overlapped/duration).",
+            buckets=[0.0, 0.25, 0.5, 0.75, 0.9, 0.95, 0.99, 1.0],
+            labelnames=metric_labelnames,
+        )
         self._gauge_delayed_release = self._gauge_cls(
             name="vllm:kv_pool_delayed_release_requests",
             documentation="Number of requests whose KV blocks are currently held in the delayed-release window.",
@@ -201,6 +254,8 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
                 "duration": self._histogram_load_duration.labels(*label_values),
                 "keys": self._counter_load_keys.labels(*label_values),
                 "failed_keys": self._counter_load_failed_keys.labels(*label_values),
+                "not_overlapped": self._histogram_load_not_overlapped.labels(*label_values),
+                "overlap_ratio": self._histogram_load_overlap_ratio.labels(*label_values),
             }
         return self._metric_cache[cache_key]
 
@@ -213,9 +268,14 @@ class AscendStorePromMetrics(KVConnectorPromMetrics):
                 # crash the metrics pipeline (assert would vanish under -O).
                 continue
             metrics = self._get_load_metrics(engine_idx, str(record["path"]))
-            metrics["duration"].observe(float(record["duration_seconds"]))
+            duration = float(record["duration_seconds"])
+            not_overlapped = float(record.get("not_overlapped_seconds", duration))
+            metrics["duration"].observe(duration)
             metrics["keys"].inc(int(record["num_keys"]))
             metrics["failed_keys"].inc(int(record["num_failed_keys"]))
+            metrics["not_overlapped"].observe(not_overlapped)
+            if duration > 0:
+                metrics["overlap_ratio"].observe(1.0 - not_overlapped / duration)
         delayed_release = transfer_stats_data.get("delayed_release")
         if delayed_release is not None:
             gauge = self._delayed_release_per_engine.get(engine_idx)

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -32,9 +32,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     get_gva_layerwise_config,
     get_layerwise_kv_cache_specs,
 )
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
-    AscendStoreKVConnectorStats,
-)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
@@ -53,6 +50,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     infer_tp_mismatch_info,
     normalize_block_ids_by_group,
     uses_hybrid_kv_cache,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
+    AscendStoreKVConnectorStats,
 )
 
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_scheduler.py
@@ -32,6 +32,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     get_gva_layerwise_config,
     get_layerwise_kv_cache_specs,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
+    AscendStoreKVConnectorStats,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
@@ -138,6 +141,8 @@ class KVPoolScheduler:
         self._unfinished_requests: dict[str, tuple[Request, list[list[int]]]] = {}
         self._loading_req_ids: set[str] = set()
         self._delayed_free_req_ids: set[str] = set()
+        # KV pool observability: delayed-release gauge snapshots.
+        self._kv_stats = AscendStoreKVConnectorStats()
 
         self._block_pool: BlockPool | None = None
         self.sending_event_id = 0
@@ -870,7 +875,16 @@ class KVPoolScheduler:
                     self.touch_sending_mamba_blocks(req_meta)
                     meta.add_request(req_meta)
 
+        # KV pool observability: snapshot the delayed-release window size
+        # for this scheduling step.
+        self._kv_stats.record_delayed_release(len(self._delayed_free_req_ids))
         return meta
+
+    def get_stats(self) -> AscendStoreKVConnectorStats:
+        """Return the latest delayed-release snapshot (and reset it)."""
+        stats = self._kv_stats
+        self._kv_stats = AscendStoreKVConnectorStats()
+        return stats
 
     def get_sending_event_id(self):
         """

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1023,15 +1023,14 @@ class KVPoolWorker:
             for task in layer_tasks:
                 for block_range in task.block_ranges:
                     req_id = block_range.request.req_id
+                    num_blocks = (block_range.end_block - block_range.start_block) + (
+                        1 if block_range.partial_block_index is not None else 0
+                    )
                     if req_id in self._load_start_times:
-                        self._layerwise_load_keys[req_id] += (
-                            block_range.end_block - block_range.start_block
-                        )
+                        self._layerwise_load_keys[req_id] += num_blocks
                     else:
                         self._load_start_times[req_id] = start_time
-                        self._layerwise_load_keys[req_id] = (
-                            block_range.end_block - block_range.start_block
-                        )
+                        self._layerwise_load_keys[req_id] = num_blocks
 
     def _record_layerwise_load_finished(self) -> None:
         # Called after the last layer's load has been waited for: all
@@ -1041,7 +1040,7 @@ class KVPoolWorker:
         end_time = time.perf_counter()
         for req_id, num_keys in self._layerwise_load_keys.items():
             start_time = self._load_start_times.pop(req_id, None)
-            if start_time is None:
+            if start_time is None or num_keys <= 0:
                 continue
             with self._kv_stats_lock:
                 self._kv_stats.record_load(

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -158,6 +158,9 @@ class KVPoolWorker:
         self._kv_stats_lock = threading.Lock()
         self._load_start_times: dict[str, float] = {}
         self._layerwise_load_keys: dict[str, int] = {}
+        # Layerwise not-overlapped time: per-step sum of the compute thread's
+        # stalls while waiting for layer loads (wait() entry -> event set).
+        self._step_not_overlapped_s = 0.0
 
     def _init_parallelism_info(self, model_config, parallel_config) -> None:
         self.local_rank = envs.LOCAL_RANK
@@ -863,6 +866,7 @@ class KVPoolWorker:
             # newly prepared loads/saves and leave a reused buffer stale.
             self.layer_save_tasks = [[] for _ in range(self.num_layers)]
             self.layer_load_tasks = [[] for _ in range(self.num_layers)]
+            self._step_not_overlapped_s = 0.0
             reset_attention_compute_start_gate()
         logger.debug("KV pool worker start_load_kv requests=%d", len(metadata.requests))
         if len(metadata.requests) == 0:
@@ -1063,6 +1067,20 @@ class KVPoolWorker:
         ]
         return max(times) if times else None
 
+    def _accumulate_layer_stall(self, layer_id: int, wait_enter: float) -> None:
+        """Accumulate the compute thread's stall for one layer's load.
+
+        The stall is the time the compute thread spent blocked in
+        ``wait_for_layer_load`` before the transfer thread finished that
+        layer's load. A layer whose event was already set when the wait
+        entered contributes zero (the load was fully overlapped). Plain
+        Events without ``set_time`` (tests) contribute nothing.
+        """
+        event = self.layer_load_finished_events[layer_id]
+        set_time = getattr(event, "set_time", None)
+        if set_time is not None:
+            self._step_not_overlapped_s += max(0.0, set_time - wait_enter)
+
     def _record_layerwise_load_finished(self) -> None:
         # Called after the last layer's load has been waited for: all
         # requests of this step finish together. The end time is the latest
@@ -1075,12 +1093,18 @@ class KVPoolWorker:
         if end_time is None or end_time < min(self._load_start_times.values()):
             # No usable event timestamps for this step; fall back to now.
             end_time = time.perf_counter()
+        not_overlapped_s = self._step_not_overlapped_s
         for req_id, num_keys in self._layerwise_load_keys.items():
             start_time = self._load_start_times.pop(req_id, None)
             if start_time is None or num_keys <= 0:
                 continue
             with self._kv_stats_lock:
-                self._kv_stats.record_load(end_time - start_time, num_keys, path="layerwise")
+                self._kv_stats.record_load(
+                    end_time - start_time,
+                    num_keys,
+                    not_overlapped_seconds=not_overlapped_s,
+                    path="layerwise",
+                )
         self._layerwise_load_keys.clear()
         # Drain leftovers (e.g. requests preempted mid-layerwise) so the
         # next step starts from a clean slate.
@@ -1790,9 +1814,11 @@ class KVPoolWorker:
             if is_last_layer:
                 self._record_layerwise_load_finished()
             return
+        wait_enter = time.perf_counter()
         while not self.layer_load_finished_events[self.current_layer].wait(timeout=10):
             self.kv_recv_thread.raise_if_failed()
             logger.info("Layerwise %d load not done, keep waiting", self.current_layer)
+        self._accumulate_layer_stall(self.current_layer, wait_enter)
         self.layer_load_finished_events[self.current_layer].clear()
         if is_last_layer:
             self._record_layerwise_load_finished()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -55,6 +55,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     get_layerwise_kv_cache_specs,
     get_layerwise_physical_layer_index,
 )
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
+    AscendStoreKVConnectorStats,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
@@ -124,6 +127,16 @@ class KVPoolWorker:
         self._init_kv_events(vllm_config)
         self._init_state_vars()
         self._init_layerwise_config()
+        self._init_kv_stats()
+
+    def _init_kv_stats(self) -> None:
+        # KV pool observability state. ``_load_start_times`` is also read and
+        # popped by the async recving thread; plain dict get/pop are
+        # GIL-atomic so no extra lock is needed for it.
+        self._kv_stats = AscendStoreKVConnectorStats()
+        self._kv_stats_lock = threading.Lock()
+        self._load_start_times: dict[str, float] = {}
+        self._layerwise_load_keys: dict[str, int] = {}
 
     def _init_parallelism_info(self, model_config, parallel_config) -> None:
         self.local_rank = envs.LOCAL_RANK
@@ -578,6 +591,7 @@ class KVPoolWorker:
                     ready_event,
                     invalid_block_ids=self._invalid_block_ids,
                     invalid_block_ids_lock=self._invalid_block_ids_lock,
+                    worker=self,
                 )
                 self.kv_recv_thread.start()
                 ready_event.wait()
@@ -834,6 +848,7 @@ class KVPoolWorker:
             return
         if self.use_layerwise:
             self.process_layer_data(metadata.requests)
+            self._record_layerwise_load_started()
             return
         for request in metadata.requests:
             load_spec = request.load_spec
@@ -844,6 +859,7 @@ class KVPoolWorker:
                     "no_load_spec" if load_spec is None else f"can_load={load_spec.can_load}",
                 )
                 continue
+            self._record_load_started(request.req_id)
             request.skip_null_blocks_by_group = self.group_uses_align_state
             load_group_ids = request.kv_cache_group_ids or [0]
             token_len = request.token_len_chunk
@@ -914,6 +930,9 @@ class KVPoolWorker:
                     size_list.append(size)
                     block_id_list.append(block_id)
             if not key_list:
+                # Nothing to load from the pool for this request; drop the
+                # pending start time without recording a sample.
+                self._record_load_finished(request.req_id, 0)
                 continue
             key_list_c = _circular_shift(key_list, self.tp_rank % len(key_list))
             addr_list_c = _circular_shift(addr_list, self.tp_rank % len(addr_list))
@@ -928,6 +947,15 @@ class KVPoolWorker:
                 key_list_c[:3],
             )
             ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
+            num_failed_keys = (
+                sum(1 for r in ret if r != 0) if ret is not None else len(key_list_c)
+            )
+            self._record_load_finished(
+                request.req_id,
+                len(key_list_c),
+                num_failed_keys=num_failed_keys,
+                path="sync",
+            )
             if ret is not None and any(r != 0 for r in ret):
                 missing_block_ids = record_failed_blocks(
                     block_id_list_c,
@@ -965,6 +993,73 @@ class KVPoolWorker:
                 load_group_ids,
                 len(key_list_c),
             )
+
+    def _record_load_started(self, req_id: str) -> None:
+        self._load_start_times[req_id] = time.perf_counter()
+
+    def _record_load_finished(
+        self,
+        req_id: str,
+        num_keys: int,
+        num_failed_keys: int = 0,
+        path: str = "sync",
+    ) -> None:
+        start_time = self._load_start_times.pop(req_id, None)
+        if start_time is None or num_keys <= 0:
+            return
+        with self._kv_stats_lock:
+            self._kv_stats.record_load(
+                time.perf_counter() - start_time,
+                num_keys,
+                num_failed_keys=num_failed_keys,
+                path=path,
+            )
+
+    def _record_layerwise_load_started(self) -> None:
+        # Layerwise loads a request's blocks once per layer, so the recorded
+        # key count is the number of per-layer block transfers.
+        start_time = time.perf_counter()
+        for layer_tasks in self.layer_load_tasks:
+            for task in layer_tasks:
+                for block_range in task.block_ranges:
+                    req_id = block_range.request.req_id
+                    if req_id in self._load_start_times:
+                        self._layerwise_load_keys[req_id] += (
+                            block_range.end_block - block_range.start_block
+                        )
+                    else:
+                        self._load_start_times[req_id] = start_time
+                        self._layerwise_load_keys[req_id] = (
+                            block_range.end_block - block_range.start_block
+                        )
+
+    def _record_layerwise_load_finished(self) -> None:
+        # Called after the last layer's load has been waited for: all
+        # requests of this step finish together.
+        if not self._load_start_times:
+            return
+        end_time = time.perf_counter()
+        for req_id, num_keys in self._layerwise_load_keys.items():
+            start_time = self._load_start_times.pop(req_id, None)
+            if start_time is None:
+                continue
+            with self._kv_stats_lock:
+                self._kv_stats.record_load(
+                    end_time - start_time, num_keys, path="layerwise"
+                )
+        self._layerwise_load_keys.clear()
+        # Drain leftovers (e.g. requests preempted mid-layerwise) so the
+        # next step starts from a clean slate.
+        self._load_start_times.clear()
+
+    def get_stats(self) -> AscendStoreKVConnectorStats | None:
+        """Return KV pool stats collected since the last call, or None."""
+        with self._kv_stats_lock:
+            if self._kv_stats.is_empty():
+                return None
+            stats = self._kv_stats
+            self._kv_stats = AscendStoreKVConnectorStats()
+            return stats
 
     def _process_save_for_layer_batch(
         self,
@@ -1653,15 +1748,20 @@ class KVPoolWorker:
         reset_attention_compute_start_gate()
         self._submit_ready_layer_loads()
         should_wait = bool(self.layer_load_tasks[self.current_layer]) or self.current_layer in self.prefetch_layer_map
+        is_last_layer = self.current_layer == self.num_layers - 1
         if not should_wait:
             self.layer_load_finished_events[self.current_layer].clear()
             if self.external_slot_release_waiter is not None:
                 self.external_slot_release_waiter(self.current_layer)
+            if is_last_layer:
+                self._record_layerwise_load_finished()
             return
         while not self.layer_load_finished_events[self.current_layer].wait(timeout=10):
             self.kv_recv_thread.raise_if_failed()
             logger.info("Layerwise %d load not done, keep waiting", self.current_layer)
         self.layer_load_finished_events[self.current_layer].clear()
+        if is_last_layer:
+            self._record_layerwise_load_finished()
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         with self._invalid_block_ids_lock:
@@ -1929,12 +2029,12 @@ class KVPoolWorker:
         block_ids: list[int],
         token_len: int,
         mask_num: int,
-    ) -> None:
+    ) -> tuple[int, int]:
         keys, addrs, sizes, key_block_ids = self._build_tp_mismatch_keys_and_addrs(
             block_hashes, block_ids, token_len, mask_num
         )
         if not keys:
-            return
+            return 0, 0
         offset = self.tp_rank % len(keys)
         keys_c = keys[offset:] + keys[:offset]
         addrs_c = addrs[offset:] + addrs[:offset]
@@ -1946,6 +2046,9 @@ class KVPoolWorker:
             keys_c[:3],
         )
         ret = self.m_store.get(keys_c, addrs_c, sizes_c)
+        num_failed_keys = (
+            sum(1 for r in ret if r != 0) if ret is not None else len(keys_c)
+        )
         if ret is not None and any(r != 0 for r in ret):
             missing_block_ids = record_failed_blocks(block_ids_c, ret)
             with self._invalid_block_ids_lock:
@@ -1958,6 +2061,7 @@ class KVPoolWorker:
             "KV pool worker tp_mismatch get returned keys=%d",
             len(keys_c),
         )
+        return len(keys_c), num_failed_keys
 
     def _store_kv_tp_mismatch(self, req_meta: ReqMeta) -> None:
         send_thread = self.kv_send_thread
@@ -2045,6 +2149,10 @@ class KVPoolWorker:
             self.kv_recv_thread.discard_finished_requests(meta.preempted_req_ids)
             if self.load_async:
                 done_recving = self.kv_recv_thread.get_and_clear_finished_requests(meta.loading_req_ids)
+
+        # Drop pending load timers for preempted requests to avoid leaks.
+        for req_id in meta.preempted_req_ids:
+            self._load_start_times.pop(req_id, None)
 
         logger.debug(
             "Number of completed KV cache send requests: %d, receive requests: %d, tp_rank:%d",

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1076,8 +1076,8 @@ class KVPoolWorker:
         entered contributes zero (the load was fully overlapped). Plain
         Events without ``set_time`` (tests) contribute nothing.
         """
-        event = self.layer_load_finished_events[layer_id]
-        set_time = getattr(event, "set_time", None)
+        event = self.layer_load_finished_events[layer_id] if self.layer_load_finished_events else None
+        set_time = getattr(event, "set_time", None) if event is not None else None
         if set_time is not None:
             self._step_not_overlapped_s += max(0.0, set_time - wait_enter)
 

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -55,9 +55,6 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.layerwise_cache_la
     get_layerwise_kv_cache_specs,
     get_layerwise_physical_layer_index,
 )
-from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
-    AscendStoreKVConnectorStats,
-)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
     AscendStoreKVConnectorWorkerMetadata,
@@ -78,6 +75,9 @@ from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     infer_group_cache_families,
     infer_tp_mismatch_info,
     uses_hybrid_kv_cache,
+)
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metrics import (
+    AscendStoreKVConnectorStats,
 )
 from vllm_ascend.distributed.utils import (
     get_decode_context_model_parallel_rank,
@@ -947,9 +947,7 @@ class KVPoolWorker:
                 key_list_c[:3],
             )
             ret = self.m_store.get(key_list_c, addr_list_c, size_list_c)
-            num_failed_keys = (
-                sum(1 for r in ret if r != 0) if ret is not None else len(key_list_c)
-            )
+            num_failed_keys = sum(1 for r in ret if r != 0) if ret is not None else len(key_list_c)
             self._record_load_finished(
                 request.req_id,
                 len(key_list_c),
@@ -1043,9 +1041,7 @@ class KVPoolWorker:
             if start_time is None or num_keys <= 0:
                 continue
             with self._kv_stats_lock:
-                self._kv_stats.record_load(
-                    end_time - start_time, num_keys, path="layerwise"
-                )
+                self._kv_stats.record_load(end_time - start_time, num_keys, path="layerwise")
         self._layerwise_load_keys.clear()
         # Drain leftovers (e.g. requests preempted mid-layerwise) so the
         # next step starts from a clean slate.
@@ -2045,9 +2041,7 @@ class KVPoolWorker:
             keys_c[:3],
         )
         ret = self.m_store.get(keys_c, addrs_c, sizes_c)
-        num_failed_keys = (
-            sum(1 for r in ret if r != 0) if ret is not None else len(keys_c)
-        )
+        num_failed_keys = sum(1 for r in ret if r != 0) if ret is not None else len(keys_c)
         if ret is not None and any(r != 0 for r in ret):
             missing_block_ids = record_failed_blocks(block_ids_c, ret)
             with self._invalid_block_ids_lock:

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -96,6 +96,27 @@ PARTIAL_LEASE_RETRY_COUNT = 10
 PARTIAL_LEASE_RETRY_INTERVAL_S = 0.001
 
 
+class _TimedLayerLoadEvent(threading.Event):
+    """Layer-load finished event that records when it was set.
+
+    The timestamp is written by the transfer thread right before the event
+    is set, i.e. the true completion time of that layer's pool load. The
+    layerwise load-duration metric uses it as the end time so the measured
+    span is not stretched by compute-side waits that return after the load
+    already finished. ``clear()`` intentionally keeps the last set time:
+    earlier layers are cleared while the last layer is still being waited
+    for, and the metric takes the max over all layers.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_time: float | None = None
+
+    def set(self) -> None:
+        self.set_time = time.perf_counter()
+        super().set()
+
+
 class KVPoolWorker:
     # The main class for the cache engine.
 
@@ -479,7 +500,7 @@ class KVPoolWorker:
 
         if self.use_layerwise:
             self.get_event = threading.Event()
-            self.layer_load_finished_events = [threading.Event() for i in range(self.num_layers)]
+            self.layer_load_finished_events = [_TimedLayerLoadEvent() for _ in range(self.num_layers)]
             self.layer_save_finished_events = [threading.Event() for i in range(self.num_layers)]
             self.sync_save_events = [torch.npu.Event() for i in range(self.num_layers)]
             can_save = self.kv_role in ["kv_producer", "kv_both"] or self.consumer_is_to_put
@@ -1030,12 +1051,30 @@ class KVPoolWorker:
                         self._load_start_times[req_id] = start_time
                         self._layerwise_load_keys[req_id] = num_blocks
 
+    def _latest_layer_load_finish_time(self) -> float | None:
+        """Latest layer-load completion timestamp set by the transfer threads.
+
+        Returns None when no layer recorded a completion time (e.g. plain
+        Events in tests, or the timed events never being set this step).
+        """
+        events = self.layer_load_finished_events or []
+        times = [
+            event.set_time for event in events if isinstance(event, _TimedLayerLoadEvent) and event.set_time is not None
+        ]
+        return max(times) if times else None
+
     def _record_layerwise_load_finished(self) -> None:
         # Called after the last layer's load has been waited for: all
-        # requests of this step finish together.
+        # requests of this step finish together. The end time is the latest
+        # transfer-thread completion timestamp (event set time), not the
+        # compute-side wait return time, so the duration is not stretched
+        # when compute keeps running after the loads already finished.
         if not self._load_start_times:
             return
-        end_time = time.perf_counter()
+        end_time = self._latest_layer_load_finish_time()
+        if end_time is None or end_time < min(self._load_start_times.values()):
+            # No usable event timestamps for this step; fall back to now.
+            end_time = time.perf_counter()
         for req_id, num_keys in self._layerwise_load_keys.items():
             start_time = self._load_start_times.pop(req_id, None)
             if start_time is None or num_keys <= 0:


### PR DESCRIPTION
### What this PR does / why we need it?

Follow-up to #14912: adds the layerwise not-overlapped load time and overlap ratio metrics on top of the KV pool load-duration/delayed-release metrics.

The load-duration metric alone cannot tell whether layerwise transfers were actually hidden behind compute. This adds:

- `vllm:kv_pool_load_not_overlapped_seconds` (Histogram, `path`) - portion of the load the compute thread actually stalled on; layerwise sums the per-layer `wait_for_layer_load` stalls
- `vllm:kv_pool_load_overlap_ratio` (Histogram, `path`) - `1 - not_overlapped/duration`; ~1 means transfers fully hidden behind compute

sync/async loads block compute for their whole duration, so their not-overlapped time defaults to the duration (ratio 0); an ideal layerwise run approaches ratio 1.

This branch currently also carries the #14912 commits (rebased onto latest main); once #14912 merges, it will be rebased so only the not-overlapped commits remain.

### Does this PR introduce *any* user-facing change?

Yes. Adds 2 Prometheus metrics via the `/metrics` endpoint. No config or behavior change.

### How was this patch tested?

**UT**: `pytest tests/ut/distributed/ascend_store/` -> **331 passed**

- vLLM version: v0.27.1
- vLLM main: vllm-project/vllm@ba07e4a