### PR TITLE
[BugFix] Fix BF16 MegaMoe quant settings

### DIFF
--- a/tests/ut/ops/test_moe_utils.py
+++ b/tests/ut/ops/test_moe_utils.py
@@ -1,0 +1,6 @@
+from vllm_ascend.ops.fused_moe.moe_utils import _get_cann_mega_moe_quant_settings
+from vllm_ascend.quantization.quant_type import QuantType
+
+
+def test_cann_mega_moe_quant_settings_none():
+    assert _get_cann_mega_moe_quant_settings(QuantType.NONE) == (0, None, None)

--- a/vllm_ascend/ops/fused_moe/moe_utils.py
+++ b/vllm_ascend/ops/fused_moe/moe_utils.py
@@ -131,6 +131,8 @@ def _get_cann_mega_moe_quant_settings(quant_type: QuantType) -> tuple[int, int |
     # NOT fix the W4A8 accuracy issue and slowed graph capture (see bug_a3.md),
     # so keep the working values until the W4A8 accuracy root cause is found on
     # the operator side.
+    if quant_type == QuantType.NONE:
+        return (0, None, None)
     if quant_type == QuantType.W8A8:
         return (_CANN_MEGA_MOE_QUANT_MODE_INT8, _CANN_ACL_INT8, _CANN_ACL_INT8)
     if quant_type == QuantType.W4A8:


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes BF16 / unquantized MegaMoe handling when fused MC2 is enabled.

The BF16 MoE path uses `QuantType.NONE`, but `_get_cann_mega_moe_quant_settings()` previously only handled `QuantType.W8A8` and `QuantType.W4A8`. As a result, the MegaMoe path could fail with:

`RuntimeError: Unsupported quant type: QuantType.NONE.`

This PR adds handling for `QuantType.NONE` by returning MegaMoe's non-quantized settings:

`(0, None, None)`

A regression test is also added to cover this case.

Fixes #13924

### Does this PR introduce _any_ user-facing change?

Yes.

BF16 / unquantized MoE models using the MegaMoe fused MC2 path will no longer fail because `QuantType.NONE` is rejected. Existing W8A8 and W4A8 behavior is unchanged.

### How was this patch tested?

Added a unit test in `tests/ut/ops/test_moe_utils.py` to verify:

`_get_cann_mega_moe_quant_settings(QuantType.NONE) == (0, None, None)`

The regression test was verified to fail on the original code with:

`RuntimeError: Unsupported quant type: QuantType.NONE.`

and pass after applying this fix.

Also ran the related MoE unit tests:

```bash
pytest -q tests/ut/ops/test_moe_utils.py tests/ut/ops/test_moe_comm_method.py tests/ut/ops/test_fused_moe.py
```

Result:

`38 passed, 14 warnings`

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
