### PR TITLE
[Refactor] Precompute layerwise GVA block keys to avoid repeated block_hash_to_str in KV pool worker

### DIFF
--- a/tests/ut/distributed/ascend_store/test_pool_worker.py
+++ b/tests/ut/distributed/ascend_store/test_pool_worker.py
@@ -23,6 +23,9 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 
 import tests.ut.distributed.ascend_store._mock_deps  # noqa: F401, E402
+from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store import (
+    pool_worker as pool_worker_module,
+)
 from vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.metadata import (
     AscendConnectorMetadata,
     LayerTransferTask,
@@ -1433,6 +1436,224 @@ class TestKVPoolWorkerProcessLayerData(unittest.TestCase):
         worker.m_store.batch_alloc.assert_called_once_with([key], [64])
         self.assertEqual(worker._allocated_gvas[key], 202)
         self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [202])
+
+    def _run_alloc_for_save_with_counter(self, worker, request):
+        """Run _alloc_gvas_for_save with a counting wrapper on block_hash_to_str."""
+        module = "vllm_ascend.distributed.kv_transfer.kv_pool.ascend_store.pool_worker"
+        original = pool_worker_module.block_hash_to_str
+        calls = []
+
+        def counting(block_hash):
+            calls.append(block_hash)
+            return original(block_hash)
+
+        with patch(f"{module}.block_hash_to_str", side_effect=counting):
+            worker._alloc_gvas_for_save([request])
+        return calls
+
+    def test_alloc_gvas_for_save_converts_each_hash_once(self):
+        worker = self._make_gva_worker()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=64,
+            target_token_len=64,
+            block_ids=[7, 8, 9, 10],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            can_save=True,
+            block_ids_np=np.asarray([7, 8, 9, 10], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8, 9, 10], dtype=np.int64)],
+        )
+        worker.m_store.batch_alloc.return_value = [301, 302, 303, 304]
+        worker.m_store.batch_is_exist.return_value = [1, 1, 1, 1]
+
+        calls = self._run_alloc_for_save_with_counter(worker, request)
+
+        self.assertEqual(calls, ["h0", "h1", "h2", "h3"])
+
+    def test_alloc_gvas_for_save_converts_each_hash_once_with_cached_prefix(self):
+        worker = self._make_gva_worker()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=64,
+            target_token_len=64,
+            block_ids=[7, 8, 9, 10],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            can_save=True,
+            block_ids_np=np.asarray([7, 8, 9, 10], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8, 9, 10], dtype=np.int64)],
+        )
+        for hash_str, gva in (("h0", 101), ("h1", 102)):
+            key = worker._make_layerwise_gva_key(0, hash_str)
+            worker._allocated_gvas[key] = gva
+        worker.m_store.batch_is_exist.return_value = [1, 1]
+        worker.m_store.batch_alloc.return_value = [303, 304]
+
+        calls = self._run_alloc_for_save_with_counter(worker, request)
+
+        self.assertEqual(calls, ["h0", "h1", "h2", "h3"])
+        # Blocks skipped by the cached-prefix while loop keep GVA 0 in the
+        # transfer array; their GVAs are reused via _allocated_gvas instead.
+        self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [0, 0, 303, 304])
+
+    def test_alloc_gvas_for_save_converts_each_hash_once_all_cached(self):
+        worker = self._make_gva_worker()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=64,
+            target_token_len=64,
+            block_ids=[7, 8, 9, 10],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            can_save=True,
+            block_ids_np=np.asarray([7, 8, 9, 10], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8, 9, 10], dtype=np.int64)],
+        )
+        for hash_str, gva in (("h0", 101), ("h1", 102), ("h2", 103), ("h3", 104)):
+            key = worker._make_layerwise_gva_key(0, hash_str)
+            worker._allocated_gvas[key] = gva
+        worker.m_store.batch_is_exist.return_value = [1, 1, 1, 1]
+
+        calls = self._run_alloc_for_save_with_counter(worker, request)
+
+        self.assertEqual(calls, ["h0", "h1", "h2", "h3"])
+        worker.m_store.batch_alloc.assert_not_called()
+        # All blocks are skipped by the while loop; the transfer array keeps 0.
+        self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [0, 0, 0, 0])
+
+    def test_alloc_gvas_for_save_skips_scan_when_start_block_lifted_beyond_end(self):
+        worker = self._make_gva_worker()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=16,
+            target_token_len=16,
+            block_ids=[7, 8, 9, 10],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            can_save=True,
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=64,
+                can_load=True,
+                kvpool_store_skip_tokens=64,
+            ),
+            block_ids_np=np.asarray([7, 8, 9, 10], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8, 9, 10], dtype=np.int64)],
+        )
+
+        calls = self._run_alloc_for_save_with_counter(worker, request)
+
+        self.assertEqual(calls, [])
+        worker.m_store.batch_alloc.assert_not_called()
+
+    def test_alloc_gvas_for_save_with_partial_lift_keeps_key_offsets_aligned(self):
+        # hit_full_blocks lifts scan_start to 1 while blocks 1..3 still need
+        # saving: exercises the non-zero index offset into the precomputed
+        # block_keys list (a missing "- scan_start" would silently pick the
+        # wrong key instead of raising).
+        worker = self._make_gva_worker()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=64,
+            target_token_len=64,
+            block_ids=[7, 8, 9, 10],
+            block_hashes=["h0", "h1", "h2", "h3"],
+            can_save=True,
+            load_spec=LoadSpec(
+                vllm_cached_tokens=0,
+                kvpool_cached_tokens=16,
+                can_load=True,
+                kvpool_store_skip_tokens=16,
+            ),
+            block_ids_np=np.asarray([7, 8, 9, 10], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8, 9, 10], dtype=np.int64)],
+        )
+        worker.m_store.batch_alloc.return_value = [303, 304]
+        worker.m_store.batch_is_exist.return_value = [1, 1, 1]
+
+        calls = self._run_alloc_for_save_with_counter(worker, request)
+
+        self.assertEqual(calls, ["h1", "h2", "h3"])
+        alloc_keys = worker.m_store.batch_alloc.call_args.args[0]
+        self.assertEqual(
+            alloc_keys,
+            [
+                worker._make_layerwise_gva_key(0, "h1"),
+                worker._make_layerwise_gva_key(0, "h2"),
+                worker._make_layerwise_gva_key(0, "h3"),
+            ],
+        )
+        self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [0, 303, 304, 0])
+
+    def test_alloc_gvas_for_save_converts_each_hash_once_duplicate_hashes(self):
+        worker = self._make_gva_worker()
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=64,
+            target_token_len=64,
+            block_ids=[7, 8, 9, 10],
+            block_hashes=["h0", "h1", "h0", "h2"],
+            can_save=True,
+            block_ids_np=np.asarray([7, 8, 9, 10], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8, 9, 10], dtype=np.int64)],
+        )
+        worker.m_store.batch_alloc.return_value = [301, 302, 303, 304]
+        worker.m_store.batch_is_exist.return_value = [1, 1, 1, 1]
+
+        calls = self._run_alloc_for_save_with_counter(worker, request)
+
+        self.assertEqual(calls, ["h0", "h1", "h0", "h2"])
+        alloc_keys = worker.m_store.batch_alloc.call_args.args[0]
+        self.assertEqual(
+            alloc_keys,
+            [
+                worker._make_layerwise_gva_key(0, "h0"),
+                worker._make_layerwise_gva_key(0, "h1"),
+                worker._make_layerwise_gva_key(0, "h0"),
+                worker._make_layerwise_gva_key(0, "h2"),
+            ],
+        )
+        self.assertEqual(request.block_gvas_by_group_np[0].tolist(), [301, 302, 303, 304])
+
+    def test_alloc_gvas_for_save_keys_unchanged_multi_group(self):
+        worker = self._make_gva_worker(2)
+        worker.m_store.batch_alloc.return_value = [301, 302, 303, 304]
+        worker.m_store.batch_is_exist.return_value = [1, 1, 1, 1]
+        request = ReqMeta(
+            req_id="r1",
+            token_len_chunk=64,
+            save_start_token=0,
+            save_end_token=64,
+            target_token_len=64,
+            block_ids=[7, 8],
+            block_ids_by_group=[[7, 8], [9, 10]],
+            block_hashes=["h0", "h1"],
+            can_save=True,
+            block_ids_np=np.asarray([7, 8], dtype=np.int64),
+            block_ids_by_group_np=[np.asarray([7, 8], dtype=np.int64), np.asarray([9, 10], dtype=np.int64)],
+        )
+
+        calls = self._run_alloc_for_save_with_counter(worker, request)
+
+        self.assertEqual(calls, ["h0", "h1", "h0", "h1"])
+        self.assertEqual(
+            request.save_keys,
+            [
+                worker._make_layerwise_gva_key(0, "h0"),
+                worker._make_layerwise_gva_key(0, "h1"),
+                worker._make_layerwise_gva_key(1, "h0"),
+                worker._make_layerwise_gva_key(1, "h1"),
+            ],
+        )
 
     def test_partial_decode_is_saved_and_loaded_for_reused_layer(self):
         worker = self._make_worker()

--- a/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
+++ b/vllm_ascend/distributed/kv_transfer/kv_pool/ascend_store/pool_worker.py
@@ -1196,22 +1196,19 @@ class KVPoolWorker:
                     )
                     hit_full_blocks = pool_hit_tokens // effective_block_size
                     save_start_block = max(save_start_block, hit_full_blocks)
-                candidate_keys = [
-                    self._make_layerwise_gva_key(
-                        group_id,
-                        block_hash_to_str(group_block_hashes[block_idx]),
-                    )
-                    for block_idx in range(
-                        save_start_block,
-                        min(save_end_block, len(group_block_hashes)),
-                    )
+                scan_start = save_start_block
+                scan_end = min(save_end_block, len(group_block_hashes))
+                # Build each block key exactly once; the candidate refresh,
+                # the cached-prefix skip and the allocation loop below all
+                # reuse it.
+                block_keys = [
+                    self._make_layerwise_gva_key(group_id, block_hash_to_str(group_block_hashes[block_idx]))
+                    for block_idx in range(scan_start, scan_end)
                 ]
-                self._refresh_allocated_gvas(candidate_keys)
+                self._refresh_allocated_gvas(block_keys)
                 # Skip blocks that are still present and readable in MemCache.
                 while save_start_block < save_end_block and save_start_block < len(group_block_hashes):
-                    key = self._make_layerwise_gva_key(
-                        group_id, block_hash_to_str(group_block_hashes[save_start_block])
-                    )
+                    key = block_keys[save_start_block - scan_start]
                     if key in self._allocated_gvas:
                         save_start_block += 1
                     else:
@@ -1220,8 +1217,8 @@ class KVPoolWorker:
                 block_gvas: list[int] = []
                 new_keys: list[str] = []
                 new_positions: list[int] = []
-                for blk_idx in range(save_start_block, min(save_end_block, len(group_block_hashes))):
-                    key = self._make_layerwise_gva_key(group_id, block_hash_to_str(group_block_hashes[blk_idx]))
+                for blk_idx in range(save_start_block, scan_end):
+                    key = block_keys[blk_idx - scan_start]
                     cached = self._allocated_gvas.get(key)
                     if cached is not None:
                         block_gvas.append(cached)


### PR DESCRIPTION
## What this PR does / why we need it?

This PR optimizes the layerwise GVA allocation path in `KVPoolWorker` by precomputing each block key exactly once into a `block_keys` list and reusing it across three consumers: the candidate refresh, the cached-prefix skip loop, and the allocation loop. This avoids redundant `block_hash_to_str` calls (up to 3x per block per save operation).

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

- Added new unit tests in `tests/ut/distributed/ascend_store/test_pool_worker.py` covering the key precomputation and reuse paths.
- Verified that all existing `ascend_store` unit tests pass (`pytest tests/ut/distributed/ascend_store/` -> 331 passed).

vLLM version: v0.27.1
vLLM main: vllm-project/vllm@ba07e4a
