### PR TITLE
[v0.26.0rc][bugfix] correct _is_decode_only_node check so megaMoE buffer is sized by num_batched_tokens

### DIFF
--- a/tests/ut/test_ascend_forward_context.py
+++ b/tests/ut/test_ascend_forward_context.py
@@ -133,6 +133,15 @@ def test_set_mc2_tokens_capacity_prefill_mc2_uses_max_num_batched_tokens(monkeyp
 
 def test_set_mc2_tokens_capacity_decode_only_uses_cudagraph_capture_size(monkeypatch):
     monkeypatch.setattr(afc, "use_cann_megamoe", lambda _: True)
+    monkeypatch.setattr(
+        afc,
+        "get_ascend_config",
+        lambda: SimpleNamespace(
+            enable_prefill_mc2=False,
+            enable_fused_mc2=0,
+            scheduler_config=SimpleNamespace(recompute_scheduler_enable=True),
+        ),
+    )
     vllm_config = _make_vllm_config(
         tensor_parallel_size=8,
         cudagraph_capture_sizes=[1, 2],
@@ -149,6 +158,15 @@ def test_set_mc2_tokens_capacity_decode_only_uses_cudagraph_capture_size(monkeyp
 
 def test_set_mc2_tokens_capacity_decode_only_without_cudagraph_uses_decode_shape(monkeypatch):
     monkeypatch.setattr(afc, "use_cann_megamoe", lambda _: True)
+    monkeypatch.setattr(
+        afc,
+        "get_ascend_config",
+        lambda: SimpleNamespace(
+            enable_prefill_mc2=False,
+            enable_fused_mc2=0,
+            scheduler_config=SimpleNamespace(recompute_scheduler_enable=True),
+        ),
+    )
     vllm_config = _make_vllm_config(
         tensor_parallel_size=4,
         max_num_batched_tokens=8192,
@@ -161,7 +179,7 @@ def test_set_mc2_tokens_capacity_decode_only_without_cudagraph_uses_decode_shape
     assert afc.get_mc2_tokens_capacity() == 32
 
 
-def test_set_mc2_tokens_capacity_recompute_decode_uses_max_num_batched_tokens(monkeypatch):
+def test_set_mc2_tokens_capacity_disable_recompute_decode_uses_max_num_batched_tokens(monkeypatch):
     monkeypatch.setattr(afc, "use_cann_megamoe", lambda _: True)
     monkeypatch.setattr(
         afc,
@@ -169,7 +187,7 @@ def test_set_mc2_tokens_capacity_recompute_decode_uses_max_num_batched_tokens(mo
         lambda: SimpleNamespace(
             enable_prefill_mc2=False,
             enable_fused_mc2=1,
-            scheduler_config=SimpleNamespace(recompute_scheduler_enable=True),
+            scheduler_config=SimpleNamespace(recompute_scheduler_enable=False),
         ),
     )
     vllm_config = _make_vllm_config(
@@ -179,7 +197,7 @@ def test_set_mc2_tokens_capacity_recompute_decode_uses_max_num_batched_tokens(mo
         max_num_batched_tokens=8192,
         kv_connector="DecodeBenchConnector",
         kv_role="kv_both",
-        recompute_scheduler_enable=True,
+        recompute_scheduler_enable=False,
     )
 
     afc.set_mc2_tokens_capacity(vllm_config, max_num_reqs=16, uniform_decode_query_len=1)

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -54,7 +54,7 @@ def _is_decode_only_node(vllm_config: VllmConfig) -> bool:
         return False
 
     scheduler_config = getattr(get_ascend_config(), "scheduler_config", None)
-    return not bool(getattr(scheduler_config, "recompute_scheduler_enable", False))
+    return bool(getattr(scheduler_config, "recompute_scheduler_enable", False))
 
 
 @contextmanager

--- a/vllm_ascend/ascend_forward_context.py
+++ b/vllm_ascend/ascend_forward_context.py
@@ -54,6 +54,10 @@ def _is_decode_only_node(vllm_config: VllmConfig) -> bool:
         return False
 
     scheduler_config = getattr(get_ascend_config(), "scheduler_config", None)
+    # Actual semantics of `recompute_scheduler_enable`:
+    # - Enabled: when preemption occurs on the decode node, the request is sent back
+    #     to the P node to redo prefill, so the decode node only ever decodes;
+    # - Disabled: prefill is executed locally on the decode node.
     return bool(getattr(scheduler_config, "recompute_scheduler_enable", False))
 
 


### PR DESCRIPTION
The original implementation returned
  `not bool(recompute_scheduler_enable)`. The `not` inversion made the result
  contradict the semantics above: the case where the decode node executes prefill
  locally was misclassified as decode-only, so the megaMoE buffer size no longer
  matched the prefill load the node actually handles.

  | recompute_scheduler_enable | Actual behavior | Old result | Fixed result |
  |---|---|---|---|
  | true | Preemption sends requests back to the P node to redo prefill; decode node is decode-only | not decode-only ❌ | decode-only ✅ |
  | false | Prefill runs locally on the decode node | decode-only ❌ | not decode-only ✅ |

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
