### PR TITLE
[v0.26.0rc][Performance][Attention] Reuse DSV4 compressor metadata across layers

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -825,6 +825,7 @@ estimated_times:
   tests/ut/attention/a2/test_attention_v1.py: 30
   tests/ut/attention/a2/test_attention_v1_precision.py: 430
   tests/ut/attention/a2/test_common_cp.py: 30
+  tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py: 30
   tests/ut/attention/a2/test_mla_cp.py: 40
   tests/ut/attention/a2/test_mla_cp_precision.py: 30
   tests/ut/attention/a2/test_mla_fia_split.py: 60

--- a/tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py
+++ b/tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from vllm.forward_context import ForwardContext, override_forward_context
+
+from vllm_ascend.attention.dsa_v1 import (
+    get_or_compute_compressor_metadata,
+    reset_compressor_metadata_cache,
+)
+from vllm_ascend.device.device_op import DeviceOperator
+
+
+def _make_forward_context() -> ForwardContext:
+    return ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        additional_kwargs={},
+    )
+
+
+def test_reuses_by_cache_group_and_resets_between_substeps():
+    metadata = SimpleNamespace(
+        cache_group_key="model.layers.0.self_attn.attn",
+        full_compress_cos=torch.zeros((2, 1, 1, 4)),
+        full_compress_sin=torch.zeros((2, 1, 1, 4)),
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        start_pos=torch.tensor([0], dtype=torch.int32),
+        block_table=torch.tensor([[0]], dtype=torch.int32),
+        block_size=32,
+        num_compressed_tokens=1,
+        num_reqs_actual=1,
+    )
+    same_group_metadata = SimpleNamespace(**vars(metadata))
+    other_group_metadata = SimpleNamespace(
+        **{
+            **vars(metadata),
+            "cache_group_key": "model.layers.0.self_attn.indexer.k_cache",
+        }
+    )
+    outputs = [(torch.full((1,), value),) * 3 for value in range(4)]
+
+    with (
+        patch.object(
+            DeviceOperator,
+            "get_dsa_compressor_slot_mapping_format",
+            return_value=0,
+        ),
+        patch.object(
+            torch.ops._C_ascend,
+            "compressor_metadata",
+            create=True,
+            side_effect=outputs,
+        ) as metadata_op,
+    ):
+        with override_forward_context(_make_forward_context()):
+            first = get_or_compute_compressor_metadata(metadata, 4)
+            reused = get_or_compute_compressor_metadata(same_group_metadata, 4)
+            isolated = get_or_compute_compressor_metadata(other_group_metadata, 4)
+            reset_compressor_metadata_cache()
+            next_substep = get_or_compute_compressor_metadata(metadata, 4)
+        with override_forward_context(_make_forward_context()):
+            next_forward = get_or_compute_compressor_metadata(metadata, 4)
+
+    assert first is reused
+    assert isolated is not first
+    assert next_substep is not first
+    assert next_forward is not first
+    assert metadata_op.call_count == 4

--- a/tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py
+++ b/tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py
@@ -24,7 +24,13 @@ def _make_forward_context() -> ForwardContext:
 
 
 def test_reuses_by_cache_group_and_resets_between_substeps():
-    metadata = SimpleNamespace(
+    class PrefillMetadata(SimpleNamespace):
+        pass
+
+    class DecodeMetadata(SimpleNamespace):
+        pass
+
+    metadata = PrefillMetadata(
         cache_group_key="model.layers.0.self_attn.attn",
         full_compress_cos=torch.zeros((2, 1, 1, 4)),
         full_compress_sin=torch.zeros((2, 1, 1, 4)),
@@ -35,14 +41,15 @@ def test_reuses_by_cache_group_and_resets_between_substeps():
         num_compressed_tokens=1,
         num_reqs_actual=1,
     )
-    same_group_metadata = SimpleNamespace(**vars(metadata))
-    other_group_metadata = SimpleNamespace(
+    same_group_metadata = PrefillMetadata(**vars(metadata))
+    same_group_decode_metadata = DecodeMetadata(**vars(metadata))
+    other_group_metadata = PrefillMetadata(
         **{
             **vars(metadata),
             "cache_group_key": "model.layers.0.self_attn.indexer.k_cache",
         }
     )
-    outputs = [(torch.full((1,), value),) * 3 for value in range(4)]
+    outputs = [(torch.full((1,), value),) * 3 for value in range(5)]
 
     with (
         patch.object(
@@ -60,6 +67,7 @@ def test_reuses_by_cache_group_and_resets_between_substeps():
         with override_forward_context(_make_forward_context()):
             first = get_or_compute_compressor_metadata(metadata, 4)
             reused = get_or_compute_compressor_metadata(same_group_metadata, 4)
+            decode = get_or_compute_compressor_metadata(same_group_decode_metadata, 4)
             isolated = get_or_compute_compressor_metadata(other_group_metadata, 4)
             reset_compressor_metadata_cache()
             next_substep = get_or_compute_compressor_metadata(metadata, 4)
@@ -67,7 +75,8 @@ def test_reuses_by_cache_group_and_resets_between_substeps():
             next_forward = get_or_compute_compressor_metadata(metadata, 4)
 
     assert first is reused
+    assert decode is not first
     assert isolated is not first
     assert next_substep is not first
     assert next_forward is not first
-    assert metadata_op.call_count == 4
+    assert metadata_op.call_count == 5

--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -2286,6 +2286,7 @@ class TestRunMergedDraft(TestBase):
         self.vllm_config.cache_config = MagicMock(spec=CacheConfig)
         self.vllm_config.scheduler_config = MagicMock()
         self.vllm_config.model_config = MagicMock()
+        self.vllm_config.model_config.hf_config = MagicMock(spec=[])
         self.vllm_config.model_config.hf_text_config = MagicMock(spec=[])
         self.vllm_config.model_config.hf_text_config.to_dict = MagicMock(return_value={})
         self.vllm_config.compilation_config = MagicMock()

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -17,6 +17,7 @@ from vllm_ascend.attention.attention_v1 import AscendAttentionState
 from vllm_ascend.attention.dsa_v1 import (
     build_dspark_swa_indices,
     get_dspark_sparse_sas_window,
+    get_or_compute_compressor_metadata,
 )
 from vllm_ascend.attention.utils import (
     AscendCommonAttentionMetadata,
@@ -93,6 +94,7 @@ class AscendDSAReqMetadata:
     block_size: int
     query_start_loc: torch.Tensor
     cp_metadata: DSACPMetadata
+    cache_group_key: str = ""
     num_compressed_tokens: int | None = None
     sin: torch.Tensor = None
     cos: torch.Tensor = None
@@ -191,6 +193,10 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.seq_lens_cpu: torch.Tensor = None
 
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
+        if not layer_names:
+            raise ValueError("DSA-CP metadata builder requires at least one layer name")
+        # vLLM assigns one builder result to every layer in an attention group.
+        self.cache_group_key = layer_names[0]
         hf_config = self.model_config.hf_config
 
         if AscendDSACPMetadataBuilder.hadamard is None:
@@ -575,6 +581,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens[:num_reqs],
             query_start_loc=query_start_loc,
             cp_metadata=cp_metadata,
+            cache_group_key=self.cache_group_key,
             sin=sin,
             cos=cos,
             start_pos=start_pos,
@@ -791,6 +798,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             seq_lens=self.seq_lens[:num_reqs],
             query_start_loc=query_start_loc,
             cp_metadata=cp_metadata,
+            cache_group_key=self.cache_group_key,
             sin=sin,
             cos=cos,
             full_compress_sin=full_compress_sin,
@@ -1150,31 +1158,7 @@ class AscendDSACPImpl(DSAAttentionImpl):
         self,
         metadata: AscendDSAReqMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        assert metadata.full_compress_cos is not None
-        assert metadata.full_compress_sin is not None
-        assert metadata.num_compressed_tokens is not None
-        assert metadata.start_pos is not None
-        assert metadata.num_reqs_actual is not None
-        full_compress_cos = metadata.full_compress_cos.view(
-            metadata.full_compress_cos.shape[0],
-            metadata.full_compress_cos.shape[-1],
-        )
-        full_compress_sin = metadata.full_compress_sin.view(
-            metadata.full_compress_sin.shape[0],
-            metadata.full_compress_sin.shape[-1],
-        )
-        return torch.ops._C_ascend.compressor_metadata(
-            full_compress_cos,
-            full_compress_sin,
-            metadata.query_start_loc,
-            metadata.start_pos,
-            metadata.block_table,
-            metadata.block_size,
-            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
-            self.compress_ratio,
-            metadata.num_compressed_tokens,
-            metadata.num_reqs_actual,
-        )
+        return get_or_compute_compressor_metadata(metadata, self.compress_ratio)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         if self.attn_sink.numel() != self.num_heads:

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -72,13 +72,17 @@ def get_or_compute_compressor_metadata(
 ) -> CompressorMetadataOutput:
     """Build compressor metadata once per cache group in the current substep."""
     forward_context = get_forward_context()
-    cache: dict[str, CompressorMetadataOutput] = forward_context.additional_kwargs.setdefault(
+    cache: dict[tuple[str, type], CompressorMetadataOutput] = forward_context.additional_kwargs.setdefault(
         _COMPRESSOR_METADATA_CACHE_KEY,
         {},
     )
-    cache_key = metadata.cache_group_key
-    if not cache_key:
+    cache_group_key = metadata.cache_group_key
+    if not cache_group_key:
         raise ValueError("DSV4 compressor metadata requires a cache-group key")
+    # The pre-refactor v0.26 DSA path invokes prefill and decode separately
+    # within one mixed-batch forward. They share a cache group but require
+    # different compressor metadata, so keep the metadata phases isolated.
+    cache_key = (cache_group_key, type(metadata))
     cached_metadata = cache.get(cache_key)
     if cached_metadata is not None:
         return cached_metadata

--- a/vllm_ascend/attention/dsa_v1.py
+++ b/vllm_ascend/attention/dsa_v1.py
@@ -57,6 +57,59 @@ BUILD_METADATA_STEP_PREFILL = 0
 BUILD_METADATA_STEP_DECODE = 1
 
 _DSV4_DSA_OVERLAP_STREAM = None
+CompressorMetadataOutput = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+_COMPRESSOR_METADATA_CACHE_KEY = "dsv4_compressor_metadata_cache"
+
+
+def reset_compressor_metadata_cache() -> None:
+    """Release metadata outputs before a composite forward changes substeps."""
+    get_forward_context().additional_kwargs.pop(_COMPRESSOR_METADATA_CACHE_KEY, None)
+
+
+def get_or_compute_compressor_metadata(
+    metadata: Any,
+    compress_ratio: int,
+) -> CompressorMetadataOutput:
+    """Build compressor metadata once per cache group in the current substep."""
+    forward_context = get_forward_context()
+    cache: dict[str, CompressorMetadataOutput] = forward_context.additional_kwargs.setdefault(
+        _COMPRESSOR_METADATA_CACHE_KEY,
+        {},
+    )
+    cache_key = metadata.cache_group_key
+    if not cache_key:
+        raise ValueError("DSV4 compressor metadata requires a cache-group key")
+    cached_metadata = cache.get(cache_key)
+    if cached_metadata is not None:
+        return cached_metadata
+
+    assert metadata.full_compress_cos is not None
+    assert metadata.full_compress_sin is not None
+    assert metadata.num_compressed_tokens is not None
+    assert metadata.start_pos is not None
+    assert metadata.num_reqs_actual is not None
+    full_compress_cos = metadata.full_compress_cos.view(
+        metadata.full_compress_cos.shape[0],
+        metadata.full_compress_cos.shape[-1],
+    )
+    full_compress_sin = metadata.full_compress_sin.view(
+        metadata.full_compress_sin.shape[0],
+        metadata.full_compress_sin.shape[-1],
+    )
+    computed_metadata = torch.ops._C_ascend.compressor_metadata(
+        full_compress_cos,
+        full_compress_sin,
+        metadata.query_start_loc,
+        metadata.start_pos,
+        metadata.block_table,
+        metadata.block_size,
+        DeviceOperator.get_dsa_compressor_slot_mapping_format(),
+        compress_ratio,
+        metadata.num_compressed_tokens,
+        metadata.num_reqs_actual,
+    )
+    cache[cache_key] = computed_metadata
+    return computed_metadata
 
 
 def dsv4_dsa_overlap_stream() -> torch.npu.Stream:
@@ -247,6 +300,7 @@ class AscendDSAPrefillMetadata:
     max_query_len: int
     max_seq_lens: int
 
+    cache_group_key: str = ""
     num_compressed_tokens: int | None = None
     sin: torch.Tensor = None
     cos: torch.Tensor = None
@@ -277,6 +331,7 @@ class AscendDSADecodeMetadata:
     slot_mapping: torch.Tensor | None
     block_size: int
 
+    cache_group_key: str = ""
     num_compressed_tokens: int | None = None
     query_start_loc: torch.tensor = None
     query_start_loc_cpu: torch.tensor = None
@@ -503,6 +558,10 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.attn_mask_builder = AttentionMaskBuilder(self.device)
 
         self.compressor_ratio = getattr(kv_cache_spec, "compress_ratio", 0)
+        if not layer_names:
+            raise ValueError("DSA metadata builder requires at least one layer name")
+        # vLLM assigns one builder result to every layer in an attention group.
+        self.cache_group_key = layer_names[0]
         hf_config = self.model_config.hf_config
 
         if AscendDSAMetadataBuilder.hadamard is None:
@@ -923,6 +982,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             block_table=self.block_table[reqs_start:, ...],
             slot_mapping=prefill_slot_mapping,
             block_size=self.block_size,
+            cache_group_key=self.cache_group_key,
             num_compressed_tokens=num_compressed_tokens,
             max_query_len=max_query_len,
             max_seq_lens=max_seq_lens,
@@ -1149,6 +1209,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             block_table=self.block_table[:block_table_size, ...],
             slot_mapping=slot_mapping,
             block_size=self.block_size,
+            cache_group_key=self.cache_group_key,
             num_compressed_tokens=num_compressed_tokens,
             seq_lens=self.seq_lens[: self.num_decodes],  # cached
             seq_lens_list=seq_lens_list,
@@ -1303,6 +1364,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             block_table=block_table[reqs_start:, ...],
             slot_mapping=prefill_slot_mapping,
             block_size=self.block_size,
+            cache_group_key=self.cache_group_key,
             max_query_len=None,  # type: ignore[arg-type]
             max_seq_lens=None,  # type: ignore[arg-type]
             query_start_loc=prefill_query_start_loc,
@@ -1401,6 +1463,7 @@ class AscendDSAMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
             block_table=block_table[:num_decodes, ...],
             slot_mapping=slot_mapping,
             block_size=self.block_size,
+            cache_group_key=self.cache_group_key,
             seq_lens=seq_lens[:num_decodes],
             seq_lens_list=None,  # type: ignore[arg-type]
             max_seq_lens=None,  # type: ignore[arg-type]
@@ -1597,31 +1660,7 @@ class AscendDSAImpl(DSAAttentionImpl):
         self,
         metadata: AscendDSAPrefillMetadata | AscendDSADecodeMetadata,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        assert metadata.full_compress_cos is not None
-        assert metadata.full_compress_sin is not None
-        assert metadata.num_compressed_tokens is not None
-        assert metadata.start_pos is not None
-        assert metadata.num_reqs_actual is not None
-        full_compress_cos = metadata.full_compress_cos.view(
-            metadata.full_compress_cos.shape[0],
-            metadata.full_compress_cos.shape[-1],
-        )
-        full_compress_sin = metadata.full_compress_sin.view(
-            metadata.full_compress_sin.shape[0],
-            metadata.full_compress_sin.shape[-1],
-        )
-        return torch.ops._C_ascend.compressor_metadata(
-            full_compress_cos,
-            full_compress_sin,
-            metadata.query_start_loc,
-            metadata.start_pos,
-            metadata.block_table,
-            metadata.block_size,
-            DeviceOperator.get_dsa_compressor_slot_mapping_format(),
-            self.compress_ratio,
-            metadata.num_compressed_tokens,
-            metadata.num_reqs_actual,
-        )
+        return get_or_compute_compressor_metadata(metadata, self.compress_ratio)
 
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         # Attention impls are not walked by vllm's process_weights_after_loading

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1524,6 +1524,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             forward_context.attn_metadata = (
                 multi_steps_attn_metadata[draft_index + 1] if multi_steps_attn_metadata else None
             )
+            if self.use_compress:
+                # A merged speculative forward reuses one ForwardContext while
+                # each substep has different compressor inputs. Drop the prior
+                # substep's outputs before entering the next model invocation.
+                from vllm_ascend.attention.dsa_v1 import reset_compressor_metadata_cache
+
+                reset_compressor_metadata_cache()
 
             model_kwargs = {
                 "input_ids": model_input_ids,


### PR DESCRIPTION
### What this PR does / why we need it?

Backports #14932 to `releases/v0.26.0rc` and adapts the change to the pre-refactor DSV4 implementation on this branch.

- Cache `compressor_metadata` outputs once per semantic attention cache group and speculative substep.
- Reuse the cached tensors across DSV4 layers in both the regular DSA and DSA-CP paths.
- Reset the cache when merged MTP or DSpark execution switches substeps, because each substep has different cos/sin and slot-mapping inputs.
- Keep different compressor/indexer cache groups isolated.
- Keep prefill and decode metadata isolated inside one mixed-batch forward by including the metadata type in the cache key. This fixes decode reusing prefill `ropeSin`/slot-mapping tensors.
- Prevent unrelated Eagle/MTP unit tests from entering the compressor path through an unconstrained `MagicMock`.

### Does this PR introduce _any_ user-facing change?

No. This is an internal DSV4 performance optimization and correctness fix for mixed prefill/decode execution.

### How was this patch tested?

- Added `tests/ut/attention/a2/test_dsv4_compressor_metadata_cache.py` to cover same-phase reuse, prefill/decode isolation, group isolation, substep reset, and forward-context lifetime.
- `bash format.sh ci`
- A3 targeted NPU tests in the combined #14994 + #15001 worktree: `4 passed, 10 deselected` for `compressor_metadata` and DSV4 scatter coverage.
- Single-node A3 GPQA-Diamond with `DeepSeek-V4-Flash-w8a8-mtp`, DP4 x TP4, EP, MTP=1, and `FULL_DECODE_ONLY`, combined with #15001:
  - Complete dataset: 198/198 unique cases, IDs 0-197, no missing or duplicate IDs.
  - Result: 98/198 correct, 49.4949% accuracy, 0 request errors.
  - Strict nightly `Answer: [A-D]` parser: 89 missing predictions and 11 parsed wrong answers; missing predictions are counted as incorrect and were not reparsed from `\boxed{}` output.
  - Finish reasons: 138 `stop` and 60 `length`; all 60 responses that reached the 65,536-token limit were missing predictions. The 109 parsed responses contain 98 correct answers (89.91%), but this diagnostic does not replace the official 49.4949% result.
  - Dataset SHA256: `41d1213cd7a4998605a26c2798500652572007161b3a92817ba46b35befcd305`.
  - Full service-log scan: no traceback, compressor shape error, ASC scatter error, or HTTP 5xx.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
