### PR TITLE
[Performance] add fused update_num_computed_tokens_for_batch_change impl

### DIFF
--- a/vllm_ascend/ops/triton/update_num_computed_tokens.py
+++ b/vllm_ascend/ops/triton/update_num_computed_tokens.py
@@ -1,0 +1,63 @@
+
+
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import next_power_of_2
+
+_DEFAULT_BLOCK_SIZE = 1024
+
+
+@triton.jit(do_not_specialize=["n_elements"])
+def _update_num_computed_tokens_kernel(
+    num_computed_tokens_ptr,  
+    num_accepted_tokens_ptr,  
+    prev_positions_ptr,  
+    valid_sampled_token_count_ptr,  
+    prev_num_draft_tokens_ptr,  
+    cpu_num_computed_tokens_ptr, 
+    n_elements,  
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    prev_pos = tl.load(prev_positions_ptr + offsets, mask=mask, other=0)
+    gather_idx = tl.maximum(prev_pos, 0)
+
+    valid_counts = tl.load(valid_sampled_token_count_ptr + gather_idx, mask=mask, other=0)
+    prev_computed = tl.load(num_computed_tokens_ptr + gather_idx, mask=mask, other=0)
+    prev_drafts = tl.load(prev_num_draft_tokens_ptr + gather_idx, mask=mask, other=0)
+    cpu_computed = tl.load(cpu_num_computed_tokens_ptr + offsets, mask=mask, other=0)
+    cur_accepted = tl.load(num_accepted_tokens_ptr + offsets, mask=mask, other=0)
+
+    participating = (prev_pos >= 0) & (prev_drafts > 0)
+    corrected = prev_computed + valid_counts.to(prev_computed.dtype)
+
+    out_computed = tl.where(participating, corrected, cpu_computed.to(prev_computed.dtype))
+    out_accepted = tl.where(participating, valid_counts.to(cur_accepted.dtype), cur_accepted)
+
+    tl.store(num_computed_tokens_ptr + offsets, out_computed, mask=mask)
+    tl.store(num_accepted_tokens_ptr + offsets, out_accepted, mask=mask)
+
+
+def update_num_computed_tokens_triton(
+    num_computed_tokens,
+    num_accepted_tokens,
+    prev_positions,
+    valid_sampled_token_count,
+    prev_num_draft_tokens,
+    cpu_num_computed_tokens,
+) -> None:
+    n = prev_positions.shape[0]
+    if n == 0:
+        return
+    block_size = max(_DEFAULT_BLOCK_SIZE, next_power_of_2(n))
+    _update_num_computed_tokens_kernel[(1,)](
+        num_computed_tokens,
+        num_accepted_tokens,
+        prev_positions,
+        valid_sampled_token_count,
+        prev_num_draft_tokens,
+        cpu_num_computed_tokens,
+        n,
+        BLOCK_SIZE=block_size,
+    )

--- a/vllm_ascend/spec_decode/utils.py
+++ b/vllm_ascend/spec_decode/utils.py
@@ -9,6 +9,14 @@ import numpy as np
 import torch
 import vllm.distributed.parallel_state as _ps  # type: ignore[import-not-found]
 from vllm.config import CompilationMode
+from vllm.triton_utils import HAS_TRITON
+
+if HAS_TRITON:
+    from vllm_ascend.ops.triton.update_num_computed_tokens import (
+        update_num_computed_tokens_triton,
+    )
+else:
+    update_num_computed_tokens_triton = None
 
 
 def update_num_computed_tokens_for_batch_change(
@@ -24,6 +32,16 @@ def update_num_computed_tokens_for_batch_change(
     Requests that had drafts: corrected = prev_gpu + valid_count.
     New requests or non-draft (e.g. prefills): use CPU value directly.
     """
+    if update_num_computed_tokens_triton is not None and num_computed_tokens.device.type != "cpu":
+        update_num_computed_tokens_triton(
+            num_computed_tokens,
+            num_accepted_tokens,
+            prev_positions,
+            valid_sampled_token_count,
+            prev_num_draft_tokens,
+            cpu_num_computed_tokens,
+        )
+        return
     # Clamp because prev_positions can be -1 for new requests
     gather_indices = prev_positions.clamp(min=0)
 


### PR DESCRIPTION
### What this PR does / why we need it?
There are 10+ kernel launch in update_num_computed_tokens_for_batch_change and one h2d copy, fused them into one triton kernel.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Launch deepseek v4 dspark w4a8 model, send request to  chat/completions api, and run vllm bench serve.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
