### PR TITLE
[BugFix][CI] Restore VLLM_VERSION after version adapter test

### DIFF
--- a/tests/ut/tools/bisect/test_version_compat.py
+++ b/tests/ut/tools/bisect/test_version_compat.py
@@ -86,6 +86,7 @@ def test_adapter_switches_mismatched_vllm_and_torch_npu(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ):
+    monkeypatch.delenv("VLLM_VERSION", raising=False)
     commands: list[list[str]] = []
     monkeypatch.setattr("tools.bisect.version_compat.installed_vllm_version", lambda: "0.24.0")
     monkeypatch.setattr("tools.bisect.version_compat.installed_torch_npu_version", lambda: "2.10.0.post1")


### PR DESCRIPTION
### What this PR does / why we need it?
Restore VLLM_VERSION after version adapter test
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
