### PR TITLE
feat: support Kimi-K3 DSpark Block5

### DIFF
--- a/tests/ut/models/test_kimi_k3_dspark.py
+++ b/tests/ut/models/test_kimi_k3_dspark.py
@@ -4,13 +4,40 @@ from vllm_ascend.models.kimi_k3_dspark import K3DSparkForCausalLM, K3DSparkModel
 
 
 def test_k3_mla_draft_reports_non_causal_attention_per_layer():
-    draft_model = SimpleNamespace(layers=[object(), object(), object()])
+    draft_model = SimpleNamespace(
+        config=SimpleNamespace(),
+        layers=[object(), object(), object()],
+    )
 
     assert K3DSparkModel.get_draft_attn_causal(draft_model) == [False, False, False]
 
 
+def test_k3_mla_block5_draft_reports_causal_attention_per_layer():
+    draft_model = SimpleNamespace(
+        config=SimpleNamespace(
+            full_attention_causal=True,
+            dflash_config={"causal": True},
+        ),
+        layers=[object(), object(), object()],
+    )
+
+    assert K3DSparkModel.get_draft_attn_causal(draft_model) == [True, True, True]
+
+
+def test_k3_mla_dflash_causality_overrides_training_config():
+    draft_model = SimpleNamespace(
+        config=SimpleNamespace(
+            full_attention_causal=True,
+            dflash_config={"causal": False},
+        ),
+        layers=[object(), object()],
+    )
+
+    assert K3DSparkModel.get_draft_attn_causal(draft_model) == [False, False]
+
+
 def test_k3_mla_causal_lm_forwards_attention_causality():
-    draft_model = SimpleNamespace(get_draft_attn_causal=lambda: [False, False])
+    draft_model = SimpleNamespace(get_draft_attn_causal=lambda: [True, True, True])
     causal_lm = SimpleNamespace(model=draft_model)
 
-    assert K3DSparkForCausalLM.get_draft_attn_causal(causal_lm) == [False, False]
+    assert K3DSparkForCausalLM.get_draft_attn_causal(causal_lm) == [True, True, True]

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -5,33 +5,60 @@ from vllm_ascend.patch.platform.patch_speculative_config import hf_config_overri
 from vllm_ascend.transformers_utils.configs.kimi_k3 import K3DSparkConfig
 
 
-def make_k3_dspark_config() -> K3DSparkConfig:
-    return K3DSparkConfig(
-        architectures=["K3DSparkModel"],
-        hidden_size=7168,
-        intermediate_size=14336,
-        kv_lora_rank=512,
-        markov_rank=256,
-        num_attention_heads=64,
-        num_hidden_layers=5,
-        num_target_layers=5,
-        q_lora_rank=1536,
-        qk_nope_head_dim=128,
-        qk_rope_head_dim=64,
-        rms_norm_eps=1e-5,
-        rope_parameters={"rope_type": "yarn", "factor": 32},
-        target_hidden_size=7168,
-        v_head_dim=128,
-        vocab_size=163840,
-    )
+def make_k3_dspark_config(**overrides) -> K3DSparkConfig:
+    config = {
+        "architectures": ["K3DSparkModel"],
+        "hidden_size": 7168,
+        "intermediate_size": 14336,
+        "kv_lora_rank": 512,
+        "markov_rank": 256,
+        "num_attention_heads": 64,
+        "num_hidden_layers": 5,
+        "num_target_layers": 5,
+        "q_lora_rank": 1536,
+        "qk_nope_head_dim": 128,
+        "qk_rope_head_dim": 64,
+        "rms_norm_eps": 1e-5,
+        "rope_parameters": {"rope_type": "yarn", "factor": 32},
+        "target_hidden_size": 7168,
+        "v_head_dim": 128,
+        "vocab_size": 163840,
+    }
+    config.update(overrides)
+    return K3DSparkConfig(**config)
 
 
 def test_k3_dspark_config_with_required_fields_supports_repr():
     config = make_k3_dspark_config()
 
     assert K3DSparkConfig.has_no_defaults_at_init is True
+    assert config.full_attention_causal is False
     assert "K3DSparkConfig" in repr(config)
     assert config.to_diff_dict()["hidden_size"] == 7168
+
+
+def test_k3_dspark_block5_causality_fields_survive_config_parse():
+    config = make_k3_dspark_config(
+        num_hidden_layers=3,
+        num_attention_heads=96,
+        num_key_value_heads=96,
+        num_target_layers=3,
+        target_layer_ids=[71, 87, 91],
+        markov_rank=512,
+        block_size=5,
+        sample_from_anchor=True,
+        full_attention_causal=True,
+        dflash_config={"causal": True},
+    )
+
+    assert config.num_hidden_layers == 3
+    assert config.num_attention_heads == 96
+    assert config.num_key_value_heads == 96
+    assert config.target_layer_ids == [71, 87, 91]
+    assert config.block_size == 5
+    assert config.sample_from_anchor is True
+    assert config.full_attention_causal is True
+    assert config.dflash_config == {"causal": True}
 
 
 def test_legacy_qwen3_dspark_config_is_normalized_before_model_inspection():

--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -51,7 +51,11 @@ class _DSparkProposerTestBase:
         """Build the minimal config consumed by the DSpark initializer."""
         draft_model_config = SimpleNamespace(hf_config=hf_config, get_hidden_size=lambda: _HIDDEN_SIZE)
         return SimpleNamespace(
-            speculative_config=SimpleNamespace(draft_sample_method="greedy", draft_model_config=draft_model_config)
+            speculative_config=SimpleNamespace(
+                draft_sample_method="greedy",
+                draft_model_config=draft_model_config,
+                num_speculative_tokens=_NUM_SPECULATIVE_TOKENS,
+            ),
         )
 
     @classmethod
@@ -378,6 +382,38 @@ class TestDSparkInitialization(_DSparkProposerTestBase):
 
         parent_init.assert_not_called()
 
+    def test_rejects_k3_checkpoint_block_size_mismatch_before_parent_initialization(
+        self,
+        monkeypatch,
+    ) -> None:
+        class FakeK3DSparkConfig(SimpleNamespace):
+            pass
+
+        monkeypatch.setattr(
+            dspark_proposer_module,
+            "K3DSparkConfig",
+            FakeK3DSparkConfig,
+        )
+        vllm_config = self._make_vllm_config(
+            FakeK3DSparkConfig(
+                block_size=5,
+            )
+        )
+        vllm_config.speculative_config.num_speculative_tokens = 7
+        parent_init = MagicMock()
+
+        with (
+            pytest.raises(ValueError, match="checkpoint block_size \\(5\\); got 7"),
+            patch.object(
+                AscendDSparkProposer.__base__,
+                "__init__",
+                parent_init,
+            ),
+        ):
+            AscendDSparkProposer(vllm_config, torch.device("cpu"))
+
+        parent_init.assert_not_called()
+
     @pytest.mark.parametrize(
         ("hf_config", "expected_sample_from_anchor", "expected_num_query_per_req"),
         [
@@ -560,8 +596,7 @@ class TestDSparkInitValidation:
 
 class TestSetInputsFirstPassOutputs(_DSparkProposerTestBase):
     """``set_inputs_first_pass`` returns the anchor-first query budget and
-    rewrites the common attention metadata into the DSpark cross-attention
-    shape (N query tokens per request, non-causal, chunked-prefill state)."""
+    rewrites the common attention metadata into the DSpark query-block shape."""
 
     @pytest.fixture(autouse=True)
     def _mock_kernel(self, monkeypatch):

--- a/vllm_ascend/models/kimi_k3_dspark.py
+++ b/vllm_ascend/models/kimi_k3_dspark.py
@@ -9,20 +9,20 @@ output gate (``use_output_gate=False``, no ``g_proj``).
 
 Execution shape (v1 ``AscendDSparkProposer``):
   * ``combine_hidden_states`` projects the target's concatenated aux hidden
-    states (5 x 7168) into the draft width (``context_proj`` + ``context_norm``).
+    states into the draft width (``context_proj`` + ``context_norm``).
   * ``precompute_and_store_context_kv`` writes the projected context straight
     into each draft layer's latent KV cache through the Ascend impl's
     ``exec_kv_prefill`` (fused kv_a_layernorm + YaRN RoPE + paged-cache
     insert). No attention is computed for context tokens.
-  * The (per request) 7-token draft block then runs one bidirectional forward:
-    the draft attention metadata's ``causal=False`` drives ``sparse_mode=0``
-    in ``mla_v1.py``, and the draft attention-group metadata builders are
-    flipped to ``use_mla_rope=True`` so the block's q_pe/k_pe receive the same
-    YaRN rotations as the precomputed context KV.
+  * The per-request draft block then runs one forward. Attention causality is
+    read from the checkpoint (older checkpoints default to bidirectional), and
+    the draft attention-group metadata builders are flipped to
+    ``use_mla_rope=True`` so the block's q_pe/k_pe receive the same YaRN
+    rotations as the precomputed context KV.
 """
 
 import math
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import torch
 import torch.nn as nn
@@ -456,9 +456,25 @@ class K3DSparkModel(nn.Module):
         return [layer.self_attn.attn.layer_name for layer in self.layers]
 
     def get_draft_attn_causal(self) -> list[bool]:
-        # K3 MLA drafts verify the speculative block bidirectionally. Keep the
-        # per-layer contract aligned with get_draft_kv_cache_layer_names().
-        return [False] * len(self.layers)
+        """Return per-layer causality from the draft checkpoint.
+
+        The first K3 MLA DSpark checkpoint used bidirectional draft attention
+        and did not serialize a causality flag. Newer checkpoints such as
+        ``Inferact/Kimi-K3-DSpark-Block5`` are trained with full causal
+        attention and serialize ``dflash_config.causal=true`` (as well as the
+        training-side ``full_attention_causal`` mirror). Follow the same
+        precedence as vLLM's DFlash models: the runtime ``dflash_config`` value
+        wins, then the full-attention field, with ``False`` preserving legacy
+        checkpoint behavior.
+        """
+        dflash_config = getattr(self.config, "dflash_config", None) or {}
+        if isinstance(dflash_config, Mapping):
+            causal = dflash_config.get("causal")
+        else:
+            causal = getattr(dflash_config, "causal", None)
+        if causal is None:
+            causal = getattr(self.config, "full_attention_causal", False)
+        return [bool(causal)] * len(self.layers)
 
     def markov_embed(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_head.embed(token_ids)

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -57,6 +57,17 @@ class AscendDSparkProposer(AscendDflashProposer):
                 "DSpark probabilistic draft sampling is not supported on the v1 "
                 "model runner; use greedy (the default) instead."
             )
+        draft_hf_config = vllm_config.speculative_config.draft_model_config.hf_config
+        if isinstance(draft_hf_config, K3DSparkConfig):
+            # This is the trained draft length, not the KV-cache page size.
+            checkpoint_block_size = getattr(draft_hf_config, "block_size", None)
+            configured_block_size = vllm_config.speculative_config.num_speculative_tokens
+            if checkpoint_block_size is not None and configured_block_size != checkpoint_block_size:
+                raise ValueError(
+                    "K3 DSpark requires num_speculative_tokens to match the "
+                    f"checkpoint block_size ({checkpoint_block_size}); got "
+                    f"{configured_block_size}."
+                )
         super().__init__(vllm_config, device, runner=runner)
         self.sample_from_anchor = getattr(self.draft_model_config.hf_config, "sample_from_anchor", True)
         if self.sample_from_anchor:

--- a/vllm_ascend/transformers_utils/configs/kimi_k3.py
+++ b/vllm_ascend/transformers_utils/configs/kimi_k3.py
@@ -72,9 +72,14 @@ class K3DSparkConfig(PretrainedConfig):
     # the concrete config class preserves direct attribute access when older
     # checkpoints omit the corresponding serialized field.
     max_position_embeddings: int = K3_DSPARK_MAX_POSITION_EMBEDDINGS
+    # The original K3 DSpark checkpoint is bidirectional and omits this field;
+    # causal checkpoints override it in config.json.
+    full_attention_causal: bool = False
 
     hidden_size: int
     intermediate_size: int
+    block_size: int
+    dflash_config: dict[str, Any]
     kv_lora_rank: int
     markov_rank: int
     num_attention_heads: int
@@ -85,7 +90,9 @@ class K3DSparkConfig(PretrainedConfig):
     qk_rope_head_dim: int
     rms_norm_eps: float
     rope_parameters: dict[str, Any]
+    sample_from_anchor: bool
     target_hidden_size: int
+    target_layer_ids: list[int]
     v_head_dim: int
     vocab_size: int
 


### PR DESCRIPTION
This PR adds support for the [Kimi-K3-DSpark-Block5](https://huggingface.co/Inferact/Kimi-K3-DSpark-Block5) draft model.
- Read causal attention settings from the checkpoint configuration.
- Validate that the trained DSpark block size matches num_speculative_tokens.
- Preserve compatibility with legacy checkpoints.
- Add unit tests for Kimi-K3 DSpark configuration and block-size validation.
- Preserve the existing greedy-only DSpark sampling behavior.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
