### PR TITLE
[CI][MRV2] Temporarily skip DeepSeek V4 MTP eager test

### DIFF
--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -31,7 +31,7 @@ DSPARK_MAIN_MODEL = ["UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test"]
 MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
 
 
-@pytest.mark.skip(Temporarily skip this DeepSeek V4 test.)
+@pytest.mark.skip("Temporarily skip this DeepSeek V4 test.")
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",

--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -31,6 +31,10 @@ DSPARK_MAIN_MODEL = ["UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test"]
 MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
 
 
+@pytest.mark.skip(
+    reason="Temporarily skipped due to Ascend vector core timeout in "
+    "https://github.com/vllm-project/vllm-ascend/actions/runs/32917991546/job/98027616603"
+)
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",

--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -31,10 +31,7 @@ DSPARK_MAIN_MODEL = ["UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test"]
 MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
 
 
-@pytest.mark.skip(
-    reason="Temporarily skipped due to Ascend vector core timeout in "
-    "https://github.com/vllm-project/vllm-ascend/actions/runs/32917991546/job/98027616603"
-)
+@pytest.mark.skip(Temporarily skip this DeepSeek V4 test.)
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",


### PR DESCRIPTION
### What this PR does / why we need it?

Temporarily skips `test_deepseek_v4_mtp_eager` to unblock pull request CI while the Ascend vector core timeout is investigated.

Failure log: https://github.com/vllm-project/vllm-ascend/actions/runs/32917991546/job/98027616603

The skip is scoped to the single four-card ModelRunner V2 DeepSeek V4 MTP eager test.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m py_compile tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py`
- `python -m ruff format --check tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py`
- `git diff --check`

The four-card NPU E2E test was not run locally; this change only marks the existing failing test as skipped.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
