### PR TITLE
[Doc][Misc] Update Ascend environment for Qwen3 and MiniMax-M2/M3

### DIFF
--- a/docs/source/tutorials/models/MiniMax-M2.md
+++ b/docs/source/tutorials/models/MiniMax-M2.md
@@ -167,14 +167,15 @@ Notes:
 - If you only care about short-context low latency, you can set `--max-model-len 32768`, `--tensor-parallel-size 4`, and `--data-parallel-size 4`.
 
 ```bash
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_BUFFSIZE=1024
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
+
+export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --served-model-name "MiniMax-M2.7" \
@@ -185,8 +186,8 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --compilation-config '{"cudagraph_mode": "FULL_DECODE_ONLY"}' \
     --additional-config '{"scheduler_config":{"enable_balance_scheduling":false},
                           "enable_cpu_binding":true,
-                          "enable_fused_mc2":true,
-                          "weight_nz_mode":true}' \
+                          "enable_fused_mc2":1,
+                          "weight_nz_mode":1}' \
     --enable-expert-parallel \
     --tensor-parallel-size 4 \
     --data-parallel-size 4 \
@@ -210,14 +211,14 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
 #### A2 (single node)
 
 ```bash
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_BUFFSIZE=512
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
+
+export HCCL_BUFFSIZE=512
+export HCCL_OP_EXPANSION_MODE="AIV"
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_INTRA_ROCE_ENABLE=0
 
 vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --served-model-name MiniMax-M2.7 \
@@ -265,27 +266,25 @@ Then prepare `run_dp_template.sh` on each node.
 
 ```bash
 unset http_proxy https_proxy ftp_proxy
-
-nic_name="<your_nic_name>"
-local_ip="<your_ip>"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-
-export HCCL_BUFFSIZE=1024
-export HCCL_OP_EXPANSION_MODE="AIV"
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-export PYTHONHASHSEED=0
+nic_name="<your_nic_name>"
+local_ip="<your_ip>"
 
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
 export ASCEND_RT_VISIBLE_DEVICES=$1
+
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export PYTHONHASHSEED=0
 
 vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --host 0.0.0.0 \
@@ -323,27 +322,25 @@ vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
 
 ```bash
 unset http_proxy https_proxy ftp_proxy
-
-nic_name="<your_nic_name>"
-local_ip="<your_ip>"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-
-export HCCL_BUFFSIZE=2048
-export HCCL_OP_EXPANSION_MODE="AIV"
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
 
-export PYTHONHASHSEED=0
+nic_name="<your_nic_name>"
+local_ip="<your_ip>"
 
+export HCCL_BUFFSIZE=2048
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
 export ASCEND_RT_VISIBLE_DEVICES=$1
+
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+export PYTHONHASHSEED=0
 
 vllm serve /path/to/weight/MiniMax-M2.7-w8a8-QuaRot \
     --host 0.0.0.0 \
@@ -554,6 +551,7 @@ vllm bench serve \
 
 The following configurations are validated in internal testing and are categorized by use case.
 
+| Scenario | Input/Output | Deployment | NPUs | P Config | D Config | Max Batched Tokens | Max Num Seqs (P/D) | Max Model Len | EAGLE3 | FUSED_MC2 | FlashComm1 | Async Scheduling |
 |----------|-------------|------------|------|----------|----------|-------------------|----------------|---------------|--------|-----------|------------|------------------|
 | Short Seq High Throughput | 3.5k → 1.5k | 1P2D PD separation | 24 (A3) | DP8TP2EP16 | DP32TP1EP32 | 16384 | 128 / 128 | 32k | 3 | On | On | On |
 | Short Seq Low Latency | 3.5k → 1.5k | 1P2D PD separation | 24 (A3) | DP4TP4EP16 | DP8TP4EP32 | 16384 | 128 / 128 | 32k | 3 | On | On | On |
@@ -586,8 +584,8 @@ The following optimizations are enabled by default and require no additional con
 
 | Optimization Technique | Applicable Scenarios | Enablement Method | Technical Principle | Precautions |
 | ---------------------- | -------------------- | ----------------- | ------------------- | ----------- |
-| Fused MC2 | TP ≥ 4 scenarios | `--additional-config '{"enable_fused_mc2": true}'` | Fuses multiple communication and computation operations | Recommended for A3; not applicable for A2 |
-| Balanced Scheduling | High DP scenarios | `--additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}'` | Enhances scheduling capacity between prefill and decode | Currently disabled by default (`0`). Set to `1` only when concurrency ≈ DP × max-num-seqs. Disable for long-context scenarios |
+| Fused MC2 | TP ≥ 4 scenarios | `--additional-config '{"enable_fused_mc2": 1}'` | Fuses multiple communication and computation operations | Recommended for A3; not applicable for A2 |
+| Balanced Scheduling | High DP scenarios | `--additional-config '{"scheduler_config":{"enable_balance_scheduling":true}}'` | Enhances scheduling capacity between prefill and decode | Currently disabled by default (`false`). Set to `true` only when concurrency ≈ DP × max-num-seqs. Disable for long-context scenarios |
 | EAGLE3 Speculative Decoding | All scenarios | `--speculative_config '{"method": "eagle3", "model": "/path/to/Eagle3/", "num_speculative_tokens": 3}'` | Uses a draft model to predict future tokens | 1–3 tokens for long context; 3 tokens for short context |
 | jemalloc Preload | All scenarios | `export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2` | Replaces default memory allocator to reduce fragmentation | Ensure jemalloc is installed in the container |
 

--- a/docs/source/tutorials/models/MiniMax-M3.md
+++ b/docs/source/tutorials/models/MiniMax-M3.md
@@ -120,9 +120,9 @@ Single-node deployment completes both Prefill and Decode within the same node. B
 === "BF16 Deployment"
 
   ```bash
-  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
   vllm serve ${WEIGHT_PATH} \
     --served-model-name minimax-m3 \
@@ -153,9 +153,9 @@ Single-node deployment completes both Prefill and Decode within the same node. B
 === "W8A8 Deployment"
 
   ```bash
-  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
   export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
   vllm serve ${WEIGHT_PATH} \
   --served-model-name minimax-m3 \
@@ -206,12 +206,12 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
 
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
-  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export HCCL_OP_EXPANSION_MODE="AIV"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-  export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
   vllm serve ${WEIGHT_PATH} \
     --host 0.0.0.0 \
@@ -242,12 +242,12 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
 
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
-  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export HCCL_OP_EXPANSION_MODE="AIV"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-  export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
   vllm serve ${WEIGHT_PATH} \
     --host 0.0.0.0 \
@@ -281,13 +281,12 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
 
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
-  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export HCCL_OP_EXPANSION_MODE="AIV"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
-  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-  export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
   vllm serve ${WEIGHT_PATH} \
     --host 0.0.0.0 \
@@ -319,13 +318,13 @@ Deploying the float model on Ascend A2 servers requires at least two nodes. Mult
 
   export HCCL_IF_IP=$local_ip
   export IFNAME="${NETWORK_INTERFACE}"
-  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export HCCL_OP_EXPANSION_MODE="AIV"
   export HCCL_SOCKET_IFNAME="$IFNAME"
   export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
-  export VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=3000
-  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-  export HCCL_OP_EXPANSION_MODE="AIV"
   export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+  export GLOO_SOCKET_IFNAME="$IFNAME"
+  export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
 
   vllm serve ${WEIGHT_PATH} \
     --host 0.0.0.0 \

--- a/docs/source/tutorials/models/Qwen3-235B-A22B.md
+++ b/docs/source/tutorials/models/Qwen3-235B-A22B.md
@@ -204,9 +204,9 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 Atlas 800I A2/A3:
 
 ```shell
+export HCCL_BUFFSIZE=512
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_BUFFSIZE=512
 
 vllm serve your_model_path \
     --host <host_ip> \
@@ -319,25 +319,24 @@ Then prepare `run_dp_template.sh` on each node.
 **Prefill node** (set `nic_name` and `local_ip` to your own):
 
 ```bash
-nic_name="<your_nic_name>"
-local_ip="<your_ip>"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-
-export HCCL_BUFFSIZE=512
-export HCCL_OP_EXPANSION_MODE="AIV"
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+
+nic_name="<your_nic_name>"
+local_ip="<your_ip>"
+
+export HCCL_BUFFSIZE=512
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
 
 export ASCEND_RT_VISIBLE_DEVICES=$1
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve "/data/weights/Qwen3-235B-A22B-w8a8-rot" \
     --host 0.0.0.0 \
@@ -380,24 +379,24 @@ vllm serve "/data/weights/Qwen3-235B-A22B-w8a8-rot" \
 **Decode node 0** (set `nic_name` and `local_ip` to your own):
 
 ```bash
-nic_name="<your_nic_name>"
-local_ip="<your_ip>"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_BUFFSIZE=1024
-export HCCL_OP_EXPANSION_MODE="AIV"
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+
+nic_name="<your_nic_name>"
+local_ip="<your_ip>"
+
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
 
 export ASCEND_RT_VISIBLE_DEVICES=$1
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve "/data/weights/Qwen3-235B-A22B-w8a8-rot" \
     --host 0.0.0.0 \
@@ -440,24 +439,24 @@ vllm serve "/data/weights/Qwen3-235B-A22B-w8a8-rot" \
 **Decode node 1** (set `nic_name` and `local_ip` to your own):
 
 ```bash
-nic_name="<your_nic_name>"
-local_ip="<your_ip>"
-
-export HCCL_IF_IP=$local_ip
-export GLOO_SOCKET_IFNAME=$nic_name
-export HCCL_SOCKET_IFNAME=$nic_name
-export HCCL_BUFFSIZE=1024
-export HCCL_OP_EXPANSION_MODE="AIV"
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
-export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+
+nic_name="<your_nic_name>"
+local_ip="<your_ip>"
+
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
 
 export ASCEND_RT_VISIBLE_DEVICES=$1
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages/mooncake:$LD_LIBRARY_PATH
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve "/data/weights/Qwen3-235B-A22B-w8a8-rot" \
     --host 0.0.0.0 \
@@ -730,19 +729,19 @@ After several minutes, you will get the performance evaluation result.
 Single-node PD hybrid deployment optimized for maximum throughput on Atlas 800I A3 (64GB × 16):
 
 ```bash
-export HCCL_IF_IP=<node_ip>
-export GLOO_SOCKET_IFNAME=<ifname>
-export HCCL_SOCKET_IFNAME=<ifname>
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_BUFFSIZE=1024
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
+
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
+
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
     --served-model-name qwen3 \
@@ -771,19 +770,19 @@ vllm serve your_model_path \
 Single-node PD hybrid deployment optimized for low latency with speculative decoding (Eagle3):
 
 ```bash
-export HCCL_IF_IP=<node_ip>
-export GLOO_SOCKET_IFNAME=<ifname>
-export HCCL_SOCKET_IFNAME=<ifname>
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_BUFFSIZE=1024
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
+
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
+
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
     --served-model-name qwen3 \
@@ -813,19 +812,19 @@ vllm serve your_model_path \
 Single-node PD hybrid deployment optimized for long context with Context Parallelism and yarn rope-scaling:
 
 ```bash
-export HCCL_IF_IP=<node_ip>
-export GLOO_SOCKET_IFNAME=<ifname>
-export HCCL_SOCKET_IFNAME=<ifname>
-
-export HCCL_OP_EXPANSION_MODE="AIV"
-export HCCL_BUFFSIZE=1024
-export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-
 echo performance | tee /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor
 sysctl -w vm.swappiness=0
 sysctl -w kernel.numa_balancing=0
 sysctl kernel.sched_migration_cost_ns=50000
+
+export HCCL_BUFFSIZE=1024
+export HCCL_IF_IP=$local_ip
+export HCCL_OP_EXPANSION_MODE="AIV"
+export HCCL_SOCKET_IFNAME=$nic_name
+
 export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so.2:$LD_PRELOAD
+export GLOO_SOCKET_IFNAME=$nic_name
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
     --served-model-name qwen3 \

--- a/docs/source/tutorials/models/Qwen3-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-30B-A3B.md
@@ -226,9 +226,9 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 === "Atlas 800I A2/A3"
 
     ```bash
-    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-    export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
     export HCCL_BUFFSIZE=1024
+    export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
+    export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
     export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
     vllm serve your_model_path \
@@ -516,9 +516,9 @@ vllm bench serve \
 **Low Latency Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -550,9 +550,9 @@ vllm serve your_model_path \
 **High Throughput Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -583,9 +583,9 @@ vllm serve your_model_path \
 **Long Context Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \

--- a/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
+++ b/docs/source/tutorials/models/Qwen3-Coder-30B-A3B.md
@@ -187,9 +187,9 @@ Single-node deployment completes both Prefill and Decode within the same node, s
 **Atlas 800I A2/A3:**
 
 ```bash
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
 export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"  # not needed on A2
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -444,9 +444,9 @@ vllm bench serve \
 **Low Latency Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -478,9 +478,9 @@ vllm serve your_model_path \
 **High Throughput Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \
@@ -511,9 +511,9 @@ vllm serve your_model_path \
 **Long Context Configuration:**
 
 ```shell
-export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
-export HCCL_OP_EXPANSION_MODE="AIV"
 export HCCL_BUFFSIZE=1024
+export HCCL_OP_EXPANSION_MODE="AIV"
+export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
 
 vllm serve your_model_path \

--- a/docs/source/tutorials/models/Qwen3-Dense.md
+++ b/docs/source/tutorials/models/Qwen3-Dense.md
@@ -520,9 +520,9 @@ For detailed parameter descriptions, please refer to the deployment examples in 
 <u>High Throughput Configuration:</u>
 
 ```bash
+export HCCL_OP_EXPANSION_MODE="AIV"
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
     --served-model-name qwen3 \
@@ -544,9 +544,9 @@ vllm serve your_model_path \
 <u>Long Context Configuration:</u>
 
 ```bash
+export HCCL_OP_EXPANSION_MODE="AIV"
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
     --host <host_ip> \
@@ -569,9 +569,9 @@ vllm serve your_model_path \
 <u>Low Latency Configuration:</u>
 
 ```bash
+export HCCL_OP_EXPANSION_MODE="AIV"
 export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
 export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
-export HCCL_OP_EXPANSION_MODE="AIV"
 
 vllm serve your_model_path \
     --served-model-name qwen3 \


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates and cleans up the recommended Ascend environment variables and configuration parameters for Qwen3 and MiniMax-M2/M3 models to align with the latest vLLM-Ascend configurations.

- Corrects the usage of some configuration parameters(such as `enable_balance_scheduling` and `enable_fused_mc2`).
- Corrects the table of Recommended Configurations.
- Deletes some environment variable configurations(such as `HCCL_INTRA_ROCE_ENABLE` and `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS`).
- sorts the configuration of environment variables as required.

### Does this PR introduce _any_ user-facing change?
No, These are Documentation-only updates.

### How was this patch tested?
Documentation changes only.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
