### PR TITLE
[CI][Misc] Remove the gitleaks binary, add it to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ vllm_ascend.egg-info/
 # Linting
 actionlint
 shellcheck*/
+gitleaks
 
 
 # Python gitignore


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes an incorrectly tracked binary `gitleaks` and adds it to `.gitignore` to prevent future occurrences.

The binary was merged in PR #14852.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

No runtime change. The binary should be installed per dev env for local CI only.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
