### PR TITLE
[CI] fix nightly bug from sp enabled

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
@@ -57,7 +57,7 @@ _benchmarks_aime: &benchmarks_aime
 # ==========================================
 
 test_cases:
-  - name: "MTPX-DeepSeek-R1-0528-W8A8-mtp2"
+  - name: "MTPX-DeepSeek-R1-0528-W8A8-mtp1"
     model: "vllm-ascend/DeepSeek-R1-0528-W8A8"
     envs:
       <<: *envs

--- a/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MTPX-DeepSeek-R1-0528-W8A8.yaml
@@ -66,7 +66,7 @@ test_cases:
       - "--max-num-batched-tokens"
       - "4096"
       - "--speculative-config"
-      - '{"num_speculative_tokens": 2, "method": "mtp"}'
+      - '{"num_speculative_tokens": 1, "method": "mtp"}'
       - "--gpu-memory-utilization"
       - "0.92"
     benchmarks:


### PR DESCRIPTION
### What this PR does / why we need it?
SP enabled auto, so the speculative num should be changed. tp should be divided by (k+1) 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
ut and tests

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
