### PR TITLE
[BugFix] Align routing weights with model activation dtype

### DIFF
--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -484,7 +484,7 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         # may already have been replaced by the quantized tensor from
         # moe_comm_method.prepare() (fp8/fp4), and routing weights must never
         # take a quantized dtype: `topk_weights * mask` in token_dispatch would
-        # fail on Float8 type promotion. Callers pass the pre-quantization dtype.
+        # fail. Callers pass the pre-quantization dtype.
         if activation_dtype is None:
             activation_dtype = hidden_states.dtype
         topk_weights = topk_weights.to(activation_dtype)

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -441,6 +441,7 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         router_logits: torch.Tensor,
         enable_force_load_balance: bool,
         input_ids: torch.Tensor | None = None,
+        activation_dtype: torch.dtype | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if self.router is None:
             raise RuntimeError("AscendRoutedExperts requires a router for expert selection.")
@@ -479,7 +480,15 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             topk_ids = torch.cat([topk_ids, shared_expert_ids], dim=1)
             topk_weights = torch.cat([topk_weights, shared_expert_weights], dim=1)
 
-        topk_weights = topk_weights.to(hidden_states.dtype)
+        # Align routing weights with the model activation dtype. `hidden_states`
+        # may already have been replaced by the quantized tensor from
+        # moe_comm_method.prepare() (fp8/fp4), and routing weights must never
+        # take a quantized dtype: `topk_weights * mask` in token_dispatch would
+        # fail on Float8 type promotion. Callers pass the pre-quantization dtype.
+        if activation_dtype is None:
+            activation_dtype = hidden_states.dtype
+        topk_weights = topk_weights.to(activation_dtype)
+        
         # This is a naive implementation for experts load balance so as to
         # avoid accumulating too much tokens on a single rank. It is only
         # activated when doing profile runs.
@@ -514,6 +523,10 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
         if lora_context is not None:
             sync_lora_context(self.quant_method, lora_context)
 
+        # prepare() may hand back a quantized hidden_states; remember the
+        # activation dtype that routing weights have to match.
+        activation_dtype = hidden_states.dtype
+
         prepare_output = _EXTRA_CTX.moe_comm_method.prepare(
             hidden_states=hidden_states,
             router_logits=router_logits,
@@ -533,6 +546,7 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             router_logits=router_logits,
             enable_force_load_balance=enable_force_load_balance,
             input_ids=input_ids,
+            activation_dtype=activation_dtype,
         )
         self.ascend_pertoken_scale = pertoken_scale
         self.ascend_mc2_mask = mc2_mask


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces an `activation_dtype` parameter to `_select_experts` in `vllm_ascend/ops/fused_moe/routed_experts.py` to ensure routing weights are aligned with the pre-quantization model activation dtype. This prevents type promotion errors (such as Float8 promotion failures) when `hidden_states` is replaced by a quantized tensor during `moe_comm_method.prepare()`.

Additionally, we suggest adding a robust guard to ensure `activation_dtype` is never a quantized or float8 dtype, falling back to `topk_weights.dtype` if a quantized dtype is detected, to prevent potential type promotion errors during routing weight operations.

**The background information is as follows:**
When running the DeepSeek-V4-Flash model on an A5 machine with the configuration of TP=4, DP=1, the following error occurs.
>File ".../vllm_ascend/ops/fused_moe/token_dispatcher.py", line 417, in token_dispatch
      topk_weights = topk_weights * mask
  RuntimeError: Promotion for Float8 Types is not supported,
                attempted to promote Float8_e4m3fn and Bool

The routing operator moe_gating_top_k_hash correctly returns topk_weights in bf16. In its meta implementation, y uses x.options(), and the TORCH_CHECK restricts x to only fp16/fp32/bf16 types.
### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
