### PR TITLE
[BugFix] Cast uint8 probs to float32 in AllGather MoE token combine

### DIFF
--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -449,10 +449,17 @@ class TokenDispatcherWithAllGather(MoETokenDispatcher[MoEAllGatherCombineMetadat
         )
 
     def token_combine(self, hidden_states, combine_metadata, bias=None):
+        probs = combine_metadata.topk_weights
+        # aclnnMoeTokenUnpermute only accepts FP16/BF16/FP32 probs. On the
+        # W4A4 MXFP4 packed path (uint8 activations), topk_weights is carried
+        # as uint8 after the routed-expert dtype cast, so restore a float
+        # dtype here.
+        if probs.dtype == torch.uint8:
+            probs = probs.to(torch.float32)
         final_hidden_states = DeviceOperator.npu_moe_token_unpermute(
             permuted_tokens=hidden_states,
             sorted_indices=combine_metadata.expanded_row_idx,
-            probs=combine_metadata.topk_weights,
+            probs=probs,
         )
         if len(combine_metadata.restore_shape) == 3:
             final_hidden_states = final_hidden_states.view(combine_metadata.restore_shape)


### PR DESCRIPTION
 ### What this PR does / why we need it?
  Fixes the A5 nightly failure for the W4A4C8 (MXFP4 packed) GLM-5.1 testcase
  (run 31765231994): vllm serve crashes during `profile_run` with                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 RuntimeError: npu_moe_token_unpermute ... AclNN_Parameter_Error(EZ1001):
  Tensor probsOptional not implemented for DT_UINT8, should be in dtype
  support list [DT_FLOAT16,DT_BFLOAT16,DT_FLOAT,]

  `aclnnMoeTokenUnpermute` only accepts FP16/BF16/FP32 for `probs`. On the
  W4A4 MXFP4 packed path (uint8 activations), `topk_weights` is carried as
  uint8 after the routed-expert dtype cast, and was passed to the operator                                                                                                                                                                                                                unmodified from `TokenDispatcherWithAllGather.token_combine`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   This PR restores a float32 dtype for `probs` at the combine boundary, where
  the NPU operator contract is enforced. The cast is skipped on all normal
  (non-uint8) paths, so there is no overhead for existing deployments.
                                                                                                                                                                                                                                                                                          Introduced by #11287 (dfccd03e6).

  ### Does this PR introduce _any_ user-facing change?
  No. Bug fix only.

  ### How was this patch tested?
  - `python -m py_compile vllm_ascend/ops/fused_moe/token_dispatcher.py`
  - Unit tests: `tests/ut/ops/a2/test_token_dispatcher.py`
  - Nightly A5 testcase `GLM5_1_W4A4_A5` (needs A5 hardware, pending)                                                                                       
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
