### PR TITLE
[Performance]compressor: split projection and compression

### DIFF
--- a/csrc/attention/compress_norm_rope/CMakeLists.txt
+++ b/csrc/attention/compress_norm_rope/CMakeLists.txt
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+file(GLOB CURRENT_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+if(NOT ENABLE_TEST AND NOT BENCHMARK)
+    list(REMOVE_ITEM CURRENT_DIRS tests)
+endif()
+foreach(SUB_DIR ${CURRENT_DIRS})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SUB_DIR}/CMakeLists.txt")
+        add_subdirectory(${SUB_DIR})
+    endif()
+endforeach()

--- a/csrc/attention/compress_norm_rope/op_host/CMakeLists.txt
+++ b/csrc/attention/compress_norm_rope/op_host/CMakeLists.txt
@@ -1,0 +1,40 @@
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+add_op_to_compiled_list()
+
+if (BUILD_OPEN_PROJECT)
+    target_sources(op_host_aclnn PRIVATE
+        compress_norm_rope_def.cpp
+    )
+endif()
+
+add_ops_compile_options(
+        OP_NAME CompressNormRope
+                OPTIONS -DDAY0_SCOPE
+                --cce-auto-sync=off
+                -Wno-deprecated-declarations
+                -mllvm -cce-aicore-hoist-movemask=false
+                --op_relocatable_kernel_binary=true
+)
+
+if (NOT BUILD_OPS_RTY_KERNEL)
+    set(SUPPORTED_ARCHS arch32)
+    add_modules_sources(OPTYPE compress_norm_rope ACLNNTYPE aclnn)
+    add_tiling_modules()
+
+    foreach(ARCH ${ARCH_DIRECTORY})
+        if(ARCH IN_LIST SUPPORTED_ARCHS)
+            target_sources(${OPHOST_NAME}_tiling_obj PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/${ARCH}/compress_norm_rope_tiling.cpp
+            )
+        endif()
+    endforeach()
+
+endif()

--- a/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.cpp
+++ b/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.cpp
@@ -1,0 +1,376 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_tiling.cpp
+ * \brief CompressNormRope arch22 tiling（两阶段重构版）
+ *
+ *   - C4（coff=2）：按"组"均分任务（组数上界 = T/r + 2B，start_pos 未对齐跨组）
+ *   - C128（coff=1）：按"组×dChunk"均分任务（dChunk=64），压缩行经用户 workspace 中转二阶段
+ * 保留 vllm-ascend 的 ASCENDC_TPL template key 自动分发（FP16/BF16 × coff 1/2）。
+ */
+
+#include <algorithm>
+#include "log/log.h"
+#include "err/ops_err.h"
+#include "compress_norm_rope_tiling.h"
+
+using namespace ge;
+
+// 日志宏兼容层：vllm-ascend 无 OP_LOGE_FOR_INVALID_*_WITH_REASON，
+// 映射到 printf 风格的 OP_LOGE（值细节进日志，不影响返回 GRAPH_FAILED 语义）
+#define OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(opName, paramName, incorrectValue, reason) \
+    OP_LOGE((opName), "invalid " paramName " value, " reason)
+#define OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, paramName, reason) \
+    OP_LOGE((opName), "invalid " paramName ", " reason)
+#define OP_LOGE_FOR_INVALID_SHAPEDIM_WITH_REASON(opName, paramName, incorrectValue, reason) \
+    OP_LOGE((opName), "invalid " paramName " dim, " reason)
+
+namespace optiling {
+namespace {
+
+constexpr uint32_t DIM_INDEX_0 = 0;
+constexpr uint32_t DIM_INDEX_1 = 1;
+constexpr uint32_t DIM_NUM_2 = 2;
+constexpr uint32_t DIM_NUM_3 = 3;
+
+constexpr uint32_t ROTARY_MODE_HALF = 1;
+constexpr uint32_t ROTARY_MODE_INTERLEAVE = 2;
+constexpr uint32_t FP32_BLOCK = 8; // 32B / sizeof(float)
+
+ge::graphStatus CheckAttrSupport(gert::TilingContext *context, int64_t cmpRatio, int64_t coff, int64_t cacheMode,
+                                 int64_t ropeHeadDim, int64_t rotaryMode, uint32_t headDim)
+{
+    OP_CHECK_IF(cmpRatio != (int64_t)CMP_RATIO_C4 && cmpRatio != (int64_t)CMP_RATIO_C128,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(context->GetNodeName(), "cmp_ratio",
+                                                      std::to_string(cmpRatio), "only supports 4, 128"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(coff != (int64_t)COFF_DISABLE && coff != (int64_t)COFF_OVERLAP,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(context->GetNodeName(), "coff", std::to_string(coff),
+                                                      "only supports 1, 2"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(coff == (int64_t)COFF_OVERLAP && cmpRatio != (int64_t)CMP_RATIO_C4,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(context->GetNodeName(), "coff/cmp_ratio",
+                                                      std::to_string(coff) + "/" + std::to_string(cmpRatio),
+                                                      "coff=2 only supports cmp_ratio=4 (C4)"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(coff == (int64_t)COFF_DISABLE && cmpRatio != (int64_t)CMP_RATIO_C128,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(context->GetNodeName(), "coff/cmp_ratio",
+                                                      std::to_string(coff) + "/" + std::to_string(cmpRatio),
+                                                      "coff=1 only supports cmp_ratio=128 (C128)"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(cacheMode != 1,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(context->GetNodeName(), "cache_mode",
+                                                      std::to_string(cacheMode), "only supports 1 (LINEAR_BUFFER)"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(rotaryMode != (int64_t)ROTARY_MODE_HALF && rotaryMode != (int64_t)ROTARY_MODE_INTERLEAVE,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(context->GetNodeName(), "rotary_mode",
+                                                      std::to_string(rotaryMode),
+                                                      "only supports 1 (HALF), 2 (INTERLEAVE)"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(ropeHeadDim <= 0 || ropeHeadDim % (int64_t)(2 * FP32_BLOCK) != 0 ||
+                    (uint32_t)ropeHeadDim > headDim,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(context->GetNodeName(), "rope_head_dim",
+                                                      std::to_string(ropeHeadDim),
+                                                      "should be positive multiple of 16 and <= headDim"),
+                return ge::GRAPH_FAILED);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus ConvertContext(gert::TilingContext &context, CompressNormRopeContext &c)
+{
+    if (context.GetNodeName() == nullptr) {
+        OP_LOGE("CompressNormRope", "opName got from TilingContext is nullptr");
+        return ge::GRAPH_FAILED;
+    }
+    c.opName = context.GetNodeName();
+    c.opType = context.GetNodeType();
+    c.platformInfo = context.GetPlatformInfo();
+    auto fillRequired = [&](RequiredParaInfo &info, uint32_t idx) {
+        info.desc = context.GetRequiredInputDesc(idx);
+        info.shape = context.GetRequiredInputShape(idx);
+    };
+    fillRequired(c.mmKv, MM_KV_INPUT_INDEX);
+    fillRequired(c.mmScore, MM_SCORE_INPUT_INDEX);
+    fillRequired(c.stateCache, STATE_CACHE_INPUT_INDEX);
+    fillRequired(c.ape, APE_INPUT_INDEX);
+    fillRequired(c.normWeight, NORM_WEIGHT_INPUT_INDEX);
+    fillRequired(c.ropeSin, ROPE_SIN_INPUT_INDEX);
+    fillRequired(c.ropeCos, ROPE_COS_INPUT_INDEX);
+    auto fillOptional = [&](OptionalParaInfo &info, uint32_t idx) {
+        info.desc = context.GetOptionalInputDesc(idx);
+        info.shape = context.GetOptionalInputShape(idx);
+        info.tensor = context.GetOptionalInputTensor(idx);
+    };
+    fillOptional(c.stateBlockTable, STATE_BLOCK_TABLE_INPUT_INDEX);
+    fillOptional(c.cuSeqlens, CU_SEQ_LEN_INPUT_INDEX);
+    fillOptional(c.seqUsed, SEQ_USED_INPUT_INDEX);
+    fillOptional(c.startPos, START_POS_INPUT_INDEX);
+    c.cmpKv.desc = context.GetOutputDesc(CMP_KV_OUTPUT_INDEX);
+    c.cmpKv.shape = context.GetOutputShape(CMP_KV_OUTPUT_INDEX);
+
+    auto attrs = context.GetAttrs();
+    OP_CHECK_IF(attrs == nullptr, OP_LOGE(context.GetNodeName(), "attrs got from ge is nullptr"),
+               return ge::GRAPH_FAILED);
+    c.ropeHeadDim = attrs->GetAttrPointer<int>(ROPE_HEAD_DIM_ATTR_INDEX);
+    c.coff = attrs->GetAttrPointer<int>(COFF_ATTR_INDEX);
+    c.cmpRatio = attrs->GetAttrPointer<int>(CMP_RATIO_ATTR_INDEX);
+    c.normEps = attrs->GetAttrPointer<float>(NORM_EPS_ATTR_INDEX);
+    c.rotaryMode = attrs->GetAttrPointer<int>(ROTARY_MODE_ATTR_INDEX);
+    c.cacheMode = attrs->GetAttrPointer<int>(CACHE_MODE_ATTR_INDEX);
+    c.stateCacheStrideDim0 = attrs->GetAttrPointer<int>(STATE_CACHE_STRIDE_DIM0_ATTR_INDEX);
+    c.mmKvStrideDim0 = attrs->GetAttrPointer<int>(MM_KV_STRIDE_DIM0_ATTR_INDEX);
+    c.mmScoreStrideDim0 = attrs->GetAttrPointer<int>(MM_SCORE_STRIDE_DIM0_ATTR_INDEX);
+
+    OP_CHECK_IF(context.GetWorkspaceSizes(1) == nullptr,
+               OPS_REPORT_VECTOR_INNER_ERR(context.GetNodeName(), "workSpaceSize got from ge is nullptr"),
+               return ge::GRAPH_FAILED);
+    c.workSpaces = context.GetWorkspaceSizes(1);
+    return ge::GRAPH_SUCCESS;
+}
+
+} // namespace
+
+ge::graphStatus TilingCompressNormRope(gert::TilingContext *context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_VECTOR_INNER_ERR("CompressNormRope", "Context is nullptr."),
+               return ge::GRAPH_FAILED);
+    OP_LOGI("Getting Tiling");
+
+    CompressNormRopeContext c{};
+    if (ConvertContext(*context, c) != ge::GRAPH_SUCCESS) {
+        OP_LOGE(context->GetNodeName(), "Error occurred while converting tilingContext to CompressNormRope context");
+        return ge::GRAPH_FAILED;
+    }
+    const char *opName = c.opName;
+
+    // ── 平台信息 ──
+    OP_CHECK_IF(c.platformInfo == nullptr,
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "platformInfo", "is nullptr"),
+                return ge::GRAPH_FAILED);
+    auto ascendcPlatform = platform_ascendc::PlatformAscendC(c.platformInfo);
+    uint32_t aivNum = ascendcPlatform.GetCoreNumAiv();
+    OP_CHECK_IF(aivNum == 0, OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "aivNum", "is 0"),
+                return ge::GRAPH_FAILED);
+    size_t libapiSize = ascendcPlatform.GetLibApiWorkSpaceSize();
+
+    // ── 输入 shape / dtype ──
+    auto mmKvShape = c.mmKv.shape;
+    auto mmScoreShape = c.mmScore.shape;
+    auto stateCacheShape = c.stateCache.shape;
+    auto apeShape = c.ape.shape;
+    auto sbtShape = c.stateBlockTable.shape;
+    auto cuSeqlensShape = c.cuSeqlens.shape;
+    auto normWeightShape = c.normWeight.shape;
+    auto ropeSinShape = c.ropeSin.shape;
+    auto ropeCosShape = c.ropeCos.shape;
+    OP_CHECK_NULL_WITH_CONTEXT(context, mmKvShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, mmScoreShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, stateCacheShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, apeShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, sbtShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, cuSeqlensShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, normWeightShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, ropeSinShape);
+    OP_CHECK_NULL_WITH_CONTEXT(context, ropeCosShape);
+
+    OP_CHECK_IF(mmKvShape->GetStorageShape().GetDimNum() != DIM_NUM_2,
+                OP_LOGE_FOR_INVALID_SHAPEDIM_WITH_REASON(opName, "mm_kv",
+                                                         std::to_string(mmKvShape->GetStorageShape().GetDimNum()),
+                                                         "only supports 2D [T, coff*headDim] (TH layout)"),
+                return ge::GRAPH_FAILED);
+
+    // ── 属性（默认值对齐 def）──
+    int64_t ropeHeadDim = (c.ropeHeadDim != nullptr) ? *c.ropeHeadDim : 64;
+    int64_t cmpRatio = (c.cmpRatio != nullptr) ? *c.cmpRatio : (int64_t)CMP_RATIO_C4;
+    int64_t coff = (c.coff != nullptr) ? *c.coff : (int64_t)COFF_OVERLAP;
+    float normEps = (c.normEps != nullptr) ? *c.normEps : 1e-6f;
+    int64_t rotaryMode = (c.rotaryMode != nullptr) ? *c.rotaryMode : (int64_t)ROTARY_MODE_INTERLEAVE;
+    int64_t cacheMode = (c.cacheMode != nullptr) ? *c.cacheMode : 1;
+    int64_t strideDim0Attr = (c.stateCacheStrideDim0 != nullptr) ? *c.stateCacheStrideDim0 : 0;
+    int64_t mmKvStrideDim0Attr = (c.mmKvStrideDim0 != nullptr) ? *c.mmKvStrideDim0 : 0;
+    int64_t mmScoreStrideDim0Attr = (c.mmScoreStrideDim0 != nullptr) ? *c.mmScoreStrideDim0 : 0;
+
+    uint32_t t = mmKvShape->GetStorageShape().GetDim(DIM_INDEX_0);
+    uint32_t outDim = mmKvShape->GetStorageShape().GetDim(DIM_INDEX_1);
+    OP_CHECK_IF(outDim % coff != 0,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(opName, "mm_kv.dim(1)", std::to_string(outDim),
+                                                      "should be divisible by coff"),
+                return ge::GRAPH_FAILED);
+    uint32_t headDim = outDim / (uint32_t)coff;
+    uint64_t mmKvStrideDim0 = mmKvStrideDim0Attr > 0 ? (uint64_t)mmKvStrideDim0Attr : outDim;
+    uint64_t mmScoreStrideDim0 = mmScoreStrideDim0Attr > 0 ? (uint64_t)mmScoreStrideDim0Attr : outDim;
+    OP_CHECK_IF(mmKvStrideDim0 < outDim || mmKvStrideDim0 > UINT32_MAX,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(opName, "mm_kv_stride_dim0",
+                                                      std::to_string(mmKvStrideDim0),
+                                                      "should be in [mm_kv.dim(1), UINT32_MAX]"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(mmScoreStrideDim0 < outDim || mmScoreStrideDim0 > UINT32_MAX,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(opName, "mm_score_stride_dim0",
+                                                      std::to_string(mmScoreStrideDim0),
+                                                      "should be in [mm_score.dim(1), UINT32_MAX]"),
+                return ge::GRAPH_FAILED);
+    if (CheckAttrSupport(context, cmpRatio, coff, cacheMode, ropeHeadDim, rotaryMode, headDim) !=
+        ge::GRAPH_SUCCESS) {
+        return ge::GRAPH_FAILED;
+    }
+    OP_CHECK_IF(normWeightShape->GetStorageShape().GetDimNum() != 1 ||
+                    normWeightShape->GetStorageShape().GetDim(DIM_INDEX_0) != headDim,
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "norm_weight", "shape should be [headDim]"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(ropeSinShape->GetStorageShape().GetDimNum() != DIM_NUM_2 ||
+                    ropeSinShape->GetStorageShape().GetDim(DIM_INDEX_1) != ropeHeadDim,
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "rope_sin",
+                                                         "shape should be [scNum, rope_head_dim]"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(ropeCosShape->GetStorageShape().GetDim(DIM_INDEX_0) != ropeSinShape->GetStorageShape().GetDim(0) ||
+                    ropeCosShape->GetStorageShape().GetDim(DIM_INDEX_1) != ropeHeadDim,
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "rope_cos", "shape mismatch with rope_sin"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(headDim % D_CHUNK_SIZE_C128 != 0,
+                OP_LOGE_FOR_INVALID_VALUE_WITH_REASON(opName, "headDim", std::to_string(headDim),
+                                                      "should be divisible by 64"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(mmScoreShape->GetStorageShape().GetDim(DIM_INDEX_0) != t ||
+                    mmScoreShape->GetStorageShape().GetDim(DIM_INDEX_1) != outDim,
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "mm_score", "shape mismatch with mm_kv"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(apeShape->GetStorageShape().GetDim(DIM_INDEX_0) != cmpRatio ||
+                    apeShape->GetStorageShape().GetDim(DIM_INDEX_1) != outDim,
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "ape", "shape should be [cmp_ratio, coff*headDim]"),
+                return ge::GRAPH_FAILED);
+    OP_CHECK_IF(stateCacheShape->GetStorageShape().GetDimNum() != DIM_NUM_3 ||
+                    stateCacheShape->GetStorageShape().GetDim(DIM_INDEX_1) < 1 ||
+                    stateCacheShape->GetStorageShape().GetDim(2) != 2 * outDim,
+                OP_LOGE_FOR_INVALID_ARGUMENT_WITH_REASON(opName, "state_cache",
+                                                         "shape should be [blockNum, blockSize, 2*coff*headDim]"),
+                return ge::GRAPH_FAILED);
+
+    uint32_t batchSize = cuSeqlensShape->GetStorageShape().GetDim(DIM_INDEX_0) - 1;
+    uint32_t blockSize = stateCacheShape->GetStorageShape().GetDim(DIM_INDEX_1);
+    uint32_t maxBlockNumPerBatch = sbtShape->GetStorageShape().GetDim(DIM_INDEX_1);
+    uint64_t stateStride0 =
+        (strideDim0Attr > 0) ? (uint64_t)strideDim0Attr : (uint64_t)blockSize * 2 * outDim;
+
+    // ── 空 tensor（EMPTY_X 模板：kernel 直接返回，仅需合法 key）──
+    if (t == 0) {
+        c.templateId = TemplateId::EMPTY_X;
+        CompressNormRopeTilingData *tilingData = context->GetTilingData<CompressNormRopeTilingData>();
+        OP_CHECK_IF(tilingData == nullptr,
+                    OPS_REPORT_VECTOR_INNER_ERR(opName, "TilingData is nullptr."), return ge::GRAPH_FAILED);
+        tilingData->batchSize = batchSize;
+        tilingData->tokenSize = t;
+        tilingData->headDim = headDim;
+        tilingData->cmpRatio = (uint32_t)cmpRatio;
+        tilingData->usedCoreNum = 1;
+        tilingData->blockSize = blockSize;
+        tilingData->maxBlockNumPerBatch = maxBlockNumPerBatch;
+        tilingData->stateCacheStrideDim0 = stateStride0;
+        tilingData->mmKvStrideDim0 = mmKvStrideDim0;
+        tilingData->mmScoreStrideDim0 = mmScoreStrideDim0;
+        tilingData->dChunkSize = (coff == (int64_t)COFF_DISABLE) ? D_CHUNK_SIZE_C128 : headDim;
+        tilingData->dChunkNum = headDim / tilingData->dChunkSize;
+        tilingData->maxGroupTaskNum = 0;
+        tilingData->maxTaskNum = 0;
+        tilingData->taskPerCore = 0;
+        tilingData->taskRem = 0;
+        tilingData->ropeHeadDim = (uint32_t)ropeHeadDim;
+        tilingData->rotaryMode = (uint32_t)rotaryMode;
+        tilingData->normEps = normEps;
+        tilingData->maxScNum = 0;
+        // GetTilingData<T> 已指向 raw tiling data 内存，直接填充即可（vllm-ascend 惯例，无 SaveToBuffer）
+
+        const uint32_t xType = static_cast<uint32_t>(c.mmKv.desc->GetDataType());
+        const uint32_t normType = static_cast<uint32_t>(c.normWeight.desc->GetDataType());
+        const uint32_t ropeType = static_cast<uint32_t>(c.ropeSin.desc->GetDataType());
+        c.tilingKey = GET_TPL_TILING_KEY(xType, normType, ropeType, static_cast<uint32_t>(coff), 1U);
+        context->SetTilingKey(c.tilingKey);
+        context->SetBlockDim(1);
+        context->SetScheduleMode(BATCH_MODE_SCHEDULE);
+        OP_LOGI(opName, "[EMPTY_X] T:%u key:%lu", t, c.tilingKey);
+        return ge::GRAPH_SUCCESS;
+    }
+    c.templateId = TemplateId::NORMAL;
+
+    // ── 任务切分 ──
+    uint32_t dChunkSize = (coff == (int64_t)COFF_DISABLE) ? D_CHUNK_SIZE_C128 : headDim;
+    uint32_t dChunkNum = headDim / dChunkSize;
+    // 组数上界：start_pos 未按 r 对齐且 S 跨组边界时，单 batch 工作组数最坏 = S/r + 2
+    // （如 P%r=122, S=8 → 跨 2 组），故上界 = T/r + 2B（T/r + B 会漏组！）
+    uint32_t maxGroupTaskNum = t / cmpRatio + 2 * batchSize;
+    uint32_t maxTaskNum = maxGroupTaskNum * dChunkNum;
+    uint32_t blockDim = aivNum;
+    if (maxTaskNum < blockDim) {
+        blockDim = maxTaskNum == 0 ? 1 : maxTaskNum;
+    }
+    uint32_t taskPerCore = maxTaskNum / blockDim;
+    uint32_t taskRem = maxTaskNum % blockDim;
+    // 压缩行数上界（产出组数 ≤ S/r + 1 每 batch）：c128 二阶段 workspace 行数 & 行均分
+    uint32_t maxScNum = std::min(t, (uint32_t)(t / cmpRatio) + batchSize);
+
+    // ── tiling data ──
+    CompressNormRopeTilingData *tilingData = context->GetTilingData<CompressNormRopeTilingData>();
+    OP_CHECK_IF(tilingData == nullptr, OPS_REPORT_VECTOR_INNER_ERR(opName, "TilingData is nullptr."),
+                return ge::GRAPH_FAILED);
+    tilingData->batchSize = batchSize;
+    tilingData->tokenSize = t;
+    tilingData->headDim = headDim;
+    tilingData->cmpRatio = (uint32_t)cmpRatio;
+    tilingData->usedCoreNum = blockDim;
+    tilingData->blockSize = blockSize;
+    tilingData->maxBlockNumPerBatch = maxBlockNumPerBatch;
+    tilingData->stateCacheStrideDim0 = stateStride0;
+    tilingData->mmKvStrideDim0 = mmKvStrideDim0;
+    tilingData->mmScoreStrideDim0 = mmScoreStrideDim0;
+    tilingData->dChunkSize = dChunkSize;
+    tilingData->dChunkNum = dChunkNum;
+    tilingData->maxGroupTaskNum = maxGroupTaskNum;
+    tilingData->maxTaskNum = maxTaskNum;
+    tilingData->taskPerCore = taskPerCore;
+    tilingData->taskRem = taskRem;
+    tilingData->ropeHeadDim = (uint32_t)ropeHeadDim;
+    tilingData->rotaryMode = (uint32_t)rotaryMode;
+    tilingData->normEps = normEps;
+    tilingData->maxScNum = maxScNum;
+
+    // ── workspace：c128 压缩行（未 norm/rope fp32）中转 = maxScNum × headDim × 4B；c4 无用户 workspace ──
+    size_t userWs = (coff == (int64_t)COFF_DISABLE) ? (size_t)maxScNum * headDim * sizeof(float) : 0;
+    if (c.workSpaces != nullptr) {
+        c.workSpaces[0] = libapiSize + userWs;
+    }
+
+    // ── template tiling key / blockDim / schedule ──
+    const uint32_t xType = static_cast<uint32_t>(c.mmKv.desc->GetDataType());
+    const uint32_t normType = static_cast<uint32_t>(c.normWeight.desc->GetDataType());
+    const uint32_t ropeType = static_cast<uint32_t>(c.ropeSin.desc->GetDataType());
+    c.tilingKey = GET_TPL_TILING_KEY(xType, normType, ropeType, static_cast<uint32_t>(coff), 0U);
+    context->SetTilingKey(c.tilingKey);
+    context->SetBlockDim(blockDim);
+    // c128 二阶段 SyncAll 要求全核同调度（c4 无害）
+    context->SetScheduleMode(BATCH_MODE_SCHEDULE);
+
+    OP_LOGI(opName,
+            "[TILING] T:%u B:%u headDim:%u cmpRatio:%ld coff:%ld blockSize:%u dChunk:%ux%u maxTask:%u "
+            "blockDim:%u taskPerCore:%u rem:%u key:%lu ws:%zu",
+            t, batchSize, headDim, cmpRatio, coff, blockSize, dChunkSize, dChunkNum, maxTaskNum, blockDim,
+            taskPerCore, taskRem, c.tilingKey, libapiSize + userWs);
+    return ge::GRAPH_SUCCESS;
+}
+
+ge::graphStatus TilingPrepareForCompressNormRope(gert::TilingParseContext *context)
+{
+    (void)context;
+    return ge::GRAPH_SUCCESS;
+}
+
+IMPL_OP_OPTILING(CompressNormRope)
+    .Tiling(TilingCompressNormRope)
+    .TilingParse<CompressNormRopeCompileInfo>(TilingPrepareForCompressNormRope);
+} // namespace optiling

--- a/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.cpp
+++ b/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.cpp
@@ -10,7 +10,7 @@
 
 /*!
  * \file compress_norm_rope_tiling.cpp
- * \brief CompressNormRope arch22 tiling（两阶段重构版）
+ * \brief CompressNormRope A2/A3 tiling（两阶段重构版）
  *
  *   - C4（coff=2）：按"组"均分任务（组数上界 = T/r + 2B，start_pos 未对齐跨组）
  *   - C128（coff=1）：按"组×dChunk"均分任务（dChunk=64），压缩行经用户 workspace 中转二阶段

--- a/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.h
+++ b/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.h
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_tiling.h
+ * \brief CompressNormRope arch22 tiling 声明（两阶段重构版，扁平实现，保留 ASCENDC_TPL key 分发）
+ */
+
+#ifndef COMPRESS_NORM_ROPE_TILING_H
+#define COMPRESS_NORM_ROPE_TILING_H
+
+#include <cstdint>
+#include "register/tilingdata_base.h"
+#include "tiling/tiling_api.h"
+#include "exe_graph/runtime/tiling_context.h"
+#include "register/op_def_registry.h"
+#include "../../op_kernel/arch32/compress_norm_rope_template_tiling_key.h"
+#include "../../op_kernel/arch32/compress_norm_rope_tiling_data.h"
+#include "platform/platform_info.h"
+
+#ifdef ASCENDC_OP_TEST
+#define CMP_EXTERN_C extern "C"
+#else
+#define CMP_EXTERN_C
+#endif
+
+namespace optiling {
+
+// INPUT（顺序对齐 def）
+constexpr uint32_t MM_KV_INPUT_INDEX = 0;
+constexpr uint32_t MM_SCORE_INPUT_INDEX = 1;
+constexpr uint32_t STATE_CACHE_INPUT_INDEX = 2;
+constexpr uint32_t APE_INPUT_INDEX = 3;
+constexpr uint32_t NORM_WEIGHT_INPUT_INDEX = 4;
+constexpr uint32_t ROPE_SIN_INPUT_INDEX = 5;
+constexpr uint32_t ROPE_COS_INPUT_INDEX = 6;
+// INPUT(OPTION)
+constexpr uint32_t STATE_BLOCK_TABLE_INPUT_INDEX = 7;
+constexpr uint32_t CU_SEQ_LEN_INPUT_INDEX = 8;
+constexpr uint32_t SEQ_USED_INPUT_INDEX = 9;
+constexpr uint32_t START_POS_INPUT_INDEX = 10;
+
+// ATTR
+constexpr uint32_t ROPE_HEAD_DIM_ATTR_INDEX = 0;
+constexpr uint32_t CMP_RATIO_ATTR_INDEX = 1;
+constexpr uint32_t COFF_ATTR_INDEX = 2;
+constexpr uint32_t NORM_EPS_ATTR_INDEX = 3;
+constexpr uint32_t ROTARY_MODE_ATTR_INDEX = 4;
+constexpr uint32_t CACHE_MODE_ATTR_INDEX = 5;
+constexpr uint32_t STATE_CACHE_STRIDE_DIM0_ATTR_INDEX = 6;
+constexpr uint32_t MM_KV_STRIDE_DIM0_ATTR_INDEX = 7;
+constexpr uint32_t MM_SCORE_STRIDE_DIM0_ATTR_INDEX = 8;
+
+// OUTPUT
+constexpr uint32_t CMP_KV_OUTPUT_INDEX = 0;
+
+constexpr uint32_t COMPRESS_NORM_ROPE_DIM_NUM_1 = 1;
+constexpr uint32_t COMPRESS_NORM_ROPE_DIM_NUM_2 = 2;
+constexpr uint32_t COMPRESS_NORM_ROPE_DIM_NUM_3 = 3;
+constexpr uint32_t COMPRESS_NORM_ROPE_DIM_INDEX_0 = 0;
+constexpr uint32_t COMPRESS_NORM_ROPE_DIM_INDEX_1 = 1;
+constexpr uint32_t COMPRESS_NORM_ROPE_DIM_INDEX_2 = 2;
+
+// 生产实际调用组合（vllm-ascend RATIO_CONFIG）：c4={coff:2}, c128={coff:1}
+constexpr uint32_t CMP_RATIO_C4 = 4;
+constexpr uint32_t CMP_RATIO_C128 = 128;
+constexpr uint32_t COFF_OVERLAP = 2;
+constexpr uint32_t COFF_DISABLE = 1;
+constexpr uint32_t D_CHUNK_SIZE_C128 = 64;
+constexpr uint32_t BATCH_MODE_SCHEDULE = 1;  // SyncAll（c128 两阶段）需要 batch 调度
+
+struct CompressNormRopeCompileInfo {
+    int64_t core_num;
+};
+
+struct RequiredParaInfo {
+    const gert::CompileTimeTensorDesc *desc;
+    const gert::StorageShape *shape;
+};
+
+struct OptionalParaInfo {
+    const gert::CompileTimeTensorDesc *desc;
+    const gert::StorageShape *shape;
+    const gert::Tensor *tensor;
+};
+
+enum class TemplateId : uint8_t {
+    NORMAL = 0,
+    EMPTY_X = 1
+};
+
+struct CompressNormRopeContext {
+    const char *opName = nullptr;
+    const char *opType = nullptr;
+    fe::PlatFormInfos *platformInfo = nullptr;
+
+    RequiredParaInfo mmKv;
+    RequiredParaInfo mmScore;
+    RequiredParaInfo stateCache;
+    RequiredParaInfo ape;
+    RequiredParaInfo normWeight;
+    RequiredParaInfo ropeSin;
+    RequiredParaInfo ropeCos;
+    OptionalParaInfo stateBlockTable;
+    OptionalParaInfo cuSeqlens;
+    OptionalParaInfo seqUsed;
+    OptionalParaInfo startPos;
+    RequiredParaInfo cmpKv;
+
+    const int *ropeHeadDim = nullptr;
+    const int *coff = nullptr;
+    const int *cmpRatio = nullptr;
+    const float *normEps = nullptr;
+    const int *rotaryMode = nullptr;
+    const int *cacheMode = nullptr;
+    const int *stateCacheStrideDim0 = nullptr;
+    const int *mmKvStrideDim0 = nullptr;
+    const int *mmScoreStrideDim0 = nullptr;
+    TemplateId templateId = TemplateId::NORMAL;
+
+    ge::DataType dtype = ge::DT_BF16;
+    size_t *workSpaces = nullptr;
+    uint64_t tilingKey = 0;
+    uint32_t blockDim = 0;
+};
+
+CMP_EXTERN_C ge::graphStatus TilingCompressNormRope(gert::TilingContext *context);
+
+} // namespace optiling
+
+#endif // COMPRESS_NORM_ROPE_TILING_H

--- a/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.h
+++ b/csrc/attention/compress_norm_rope/op_host/arch32/compress_norm_rope_tiling.h
@@ -10,7 +10,7 @@
 
 /*!
  * \file compress_norm_rope_tiling.h
- * \brief CompressNormRope arch22 tiling 声明（两阶段重构版，扁平实现，保留 ASCENDC_TPL key 分发）
+ * \brief CompressNormRope A2/A3 tiling 声明（两阶段重构版，扁平实现，保留 ASCENDC_TPL key 分发）
  */
 
 #ifndef COMPRESS_NORM_ROPE_TILING_H

--- a/csrc/attention/compress_norm_rope/op_host/compress_norm_rope_def.cpp
+++ b/csrc/attention/compress_norm_rope/op_host/compress_norm_rope_def.cpp
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * Please refer to the License for details. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+#include "register/op_def_registry.h"
+
+namespace ops {
+class CompressNormRope : public OpDef {
+public:
+    static constexpr uint32_t ROPE_HEAD_DIM_VALUE = 64;
+    static constexpr uint32_t CMP_RATIO_VALUE = 4;
+    static constexpr uint32_t COFF_VALUE = 1;
+    static constexpr uint32_t ROTARY_MODE_VALUE = 1;
+    static constexpr uint32_t CACHE_MODE_VALUE = 1;
+    static constexpr uint32_t STATE_CACHE_STRIDE_DIM0 = 0;
+    static constexpr uint32_t MM_STRIDE_DIM0 = 0;
+
+    explicit CompressNormRope(const char *name) : OpDef(name)
+    {
+        this->Input("mm_kv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Input("mm_score")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Input("state_cache")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        this->Input("ape")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("norm_weight")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("rope_sin")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("rope_cos")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("state_block_table")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("cu_seqlens")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("seqused")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Input("start_pos")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        this->Output("cmp_kv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND});
+        this->Output("state_cache")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND});
+        this->Attr("rope_head_dim").AttrType(REQUIRED).Int(ROPE_HEAD_DIM_VALUE);
+        this->Attr("cmp_ratio").AttrType(REQUIRED).Int(CMP_RATIO_VALUE);
+        this->Attr("coff").AttrType(OPTIONAL).Int(COFF_VALUE);
+        this->Attr("norm_eps").AttrType(OPTIONAL).Float(1e-6f);
+        this->Attr("rotary_mode").AttrType(OPTIONAL).Int(ROTARY_MODE_VALUE);
+        this->Attr("cache_mode").AttrType(OPTIONAL).Int(CACHE_MODE_VALUE);
+        this->Attr("state_cache_stride_dim0").AttrType(OPTIONAL).Int(STATE_CACHE_STRIDE_DIM0);
+        this->Attr("mm_kv_stride_dim0").AttrType(OPTIONAL).Int(MM_STRIDE_DIM0);
+        this->Attr("mm_score_stride_dim0").AttrType(OPTIONAL).Int(MM_STRIDE_DIM0);
+        OpAICoreConfig aicore_config;
+        aicore_config.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");   // set value of aclnn support
+        // 910B：dtype 组合对齐 fused compressor（config910）：norm_weight/rope_sin/cos 与
+        // mm_kv 同精度（bf16/fp16）或 fp32（rope 另有 fp32 组合），kernel 内 cast 到 fp32。
+        // 950：全 FLOAT（kernel 直接 fp32 读法）。
+        OpAICoreConfig config910;
+        config910.Input("mm_kv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        config910.Input("mm_score")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        config910.Input("state_cache")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .IgnoreContiguous();
+        config910.Input("ape")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("norm_weight")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("rope_sin")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("rope_cos")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_FLOAT, ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("state_block_table")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("cu_seqlens")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("seqused")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Input("start_pos")
+            .ParamType(OPTIONAL)
+            .DataTypeList({ge::DT_INT32})
+            .FormatList({ge::FORMAT_ND})
+            .AutoContiguous();
+        config910.Output("cmp_kv")
+            .ParamType(REQUIRED)
+            .DataType({ge::DT_BF16, ge::DT_FLOAT16, ge::DT_BF16, ge::DT_FLOAT16})
+            .FormatList({ge::FORMAT_ND});
+        config910.Output("state_cache")
+            .ParamType(REQUIRED)
+            .DataTypeList({ge::DT_FLOAT})
+            .FormatList({ge::FORMAT_ND});
+        config910.DynamicCompileStaticFlag(true)
+            .DynamicFormatFlag(true)
+            .DynamicRankSupportFlag(true)
+            .DynamicShapeSupportFlag(true)
+            .NeedCheckSupportFlag(false)
+            .PrecisionReduceFlag(true)
+            .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");
+        this->AICore().AddConfig("ascend910b", config910);
+        this->AICore().AddConfig("ascend910_93", config910);
+        this->AICore().AddConfig("ascend950", aicore_config);
+    }
+};
+OP_ADD(CompressNormRope, optiling::CompressNormRopeCompileInfo);
+} // namespace ops

--- a/csrc/attention/compress_norm_rope/op_host/compress_norm_rope_def.cpp
+++ b/csrc/attention/compress_norm_rope/op_host/compress_norm_rope_def.cpp
@@ -106,7 +106,7 @@ public:
             .NeedCheckSupportFlag(false)
             .PrecisionReduceFlag(true)
             .ExtendCfgInfo("aclnnSupport.value", "support_aclnn");   // set value of aclnn support
-        // 910B：dtype 组合对齐 fused compressor（config910）：norm_weight/rope_sin/cos 与
+        // A2/A3：dtype 组合对齐 fused compressor（config910）：norm_weight/rope_sin/cos 与
         // mm_kv 同精度（bf16/fp16）或 fp32（rope 另有 fp32 组合），kernel 内 cast 到 fp32。
         // 950：全 FLOAT（kernel 直接 fp32 读法）。
         OpAICoreConfig config910;

--- a/csrc/attention/compress_norm_rope/op_host/compress_norm_rope_proto.cpp
+++ b/csrc/attention/compress_norm_rope/op_host/compress_norm_rope_proto.cpp
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#include <graph/utils/type_utils.h>
+#include <register/op_impl_registry.h>
+#include "log/ops_log.h"
+
+using namespace ge;
+
+namespace ops {
+    // INPUT
+    constexpr uint32_t MM_KV_INPUT_INDEX = 0;
+    constexpr uint32_t MM_SCORE_INPUT_INDEX = 1;
+
+    constexpr uint32_t STATE_CACHE_INPUT_INDEX = 2;
+
+    constexpr uint32_t APE_INPUT_INDEX = 3;
+    constexpr uint32_t NORM_WEIGHT_INPUT_INDEX = 4;
+    constexpr uint32_t ROPE_SIN_INPUT_INDEX = 5;
+    constexpr uint32_t ROPE_COS_INPUT_INDEX = 6;
+
+    // INPUT(OPTION)
+    constexpr uint32_t STATE_BLOCK_TABLE_INPUT_INDEX = 7;
+
+    constexpr uint32_t CU_SEQ_LEN_INPUT_INDEX = 8;
+    constexpr uint32_t SEQ_USED_INPUT_INDEX = 9;
+    constexpr uint32_t START_POS_INPUT_INDEX = 10;
+
+    // ATTR
+    constexpr uint32_t ROPE_HEAD_DIM_ATTR_INDEX = 0;
+    constexpr uint32_t CMP_RATIO_ATTR_INDEX = 1;
+    constexpr uint32_t COFF_ATTR_INDEX = 2;
+    constexpr uint32_t NORM_EPS_ATTR_INDEX = 3;
+    constexpr uint32_t ROTARY_MODE_ATTR_INDEX = 4;
+    constexpr uint32_t CACHE_MODE_ATTR_INDEX = 5;
+    constexpr uint32_t STATE_CACHE_STRIDE_DIM0_ATTR_INDEX = 6;
+
+    // OUTPUT
+    constexpr uint32_t CMP_KV_OUTPUT_INDEX = 0;
+
+    // ATTR DEFAULT VALUE
+    constexpr uint32_t CMP_RATIO_VALUE = 4;
+    constexpr uint32_t COFF_VALUE = 1;
+
+struct CompressNormRopeProtoShapeParam {
+    bool isBsMerge { false };
+    int64_t B { 0 };
+    int64_t T { 0 };
+    int64_t S { 0 };
+    int64_t Sr { 0 };
+    int64_t H { 0 };
+    int64_t D { 0 };
+};
+
+// tmp
+constexpr uint32_t DIM_NUM_1 = 1;
+constexpr uint32_t DIM_NUM_2 = 2;
+constexpr uint32_t DIM_NUM_3 = 3;
+constexpr uint32_t DIM_NUM_4 = 4;
+constexpr uint32_t DIM_INDEX_0 = 0;
+constexpr uint32_t DIM_INDEX_1 = 1;
+constexpr uint32_t DIM_INDEX_2 = 2;
+constexpr uint32_t DIM_INDEX_3 = 3;
+
+ge::graphStatus GetCompressNormRopeShapeDim(const gert::InferShapeContext* context, CompressNormRopeProtoShapeParam &shapeParam)
+{
+    auto xShape = context->GetRequiredInputShape(MM_KV_INPUT_INDEX);      // (B, S, coff*D) | (T, coff*D)
+    OPS_LOG_E_IF_NULL(context, xShape, return ge::GRAPH_FAILED)
+
+    auto stateCacheShape = context->GetRequiredInputShape(STATE_CACHE_INPUT_INDEX);    // (block_num, block_size, 2 * coff * D) | (B, tokrn_size, 2 * coff * D)
+    OPS_LOG_E_IF_NULL(context, stateCacheShape, return ge::GRAPH_FAILED)
+
+    auto apeShape = context->GetRequiredInputShape(APE_INPUT_INDEX);    // (r, coff * D)
+    OPS_LOG_E_IF_NULL(context, apeShape, return ge::GRAPH_FAILED)
+    auto normWeightShape = context->GetRequiredInputShape(NORM_WEIGHT_INPUT_INDEX);    // (D)
+    OPS_LOG_E_IF_NULL(context, normWeightShape, return ge::GRAPH_FAILED)
+    auto ropeSinShape = context->GetRequiredInputShape(ROPE_SIN_INPUT_INDEX);    // (B, ceil(S / r), rD) | (min(T, T/r + B), rD)
+    OPS_LOG_E_IF_NULL(context, ropeSinShape, return ge::GRAPH_FAILED)
+    auto ropeCosShape = context->GetRequiredInputShape(ROPE_COS_INPUT_INDEX);    // (B, ceil(S / r), rD) | (min(T, T/r + B), rD)
+    OPS_LOG_E_IF_NULL(context, ropeCosShape, return ge::GRAPH_FAILED)
+
+    auto stateBlockTableShape = context->GetRequiredInputShape(STATE_BLOCK_TABLE_INPUT_INDEX);    // (B, sMax/block_size) | (B, )
+    OPS_LOG_E_IF_NULL(context, stateBlockTableShape, return ge::GRAPH_FAILED)
+
+    auto cuSeqlensShape = context->GetRequiredInputShape(CU_SEQ_LEN_INPUT_INDEX);    // (B+1,)
+    OPS_LOG_E_IF_NULL(context, cuSeqlensShape, return ge::GRAPH_FAILED)
+    auto seqUsedShape = context->GetRequiredInputShape(SEQ_USED_INPUT_INDEX);    // (B,)
+    OPS_LOG_E_IF_NULL(context, seqUsedShape, return ge::GRAPH_FAILED)
+    auto startPosShape = context->GetRequiredInputShape(START_POS_INPUT_INDEX);    // (B,)
+    OPS_LOG_E_IF_NULL(context, startPosShape, return ge::GRAPH_FAILED)
+
+    if (xShape->GetDimNum() == DIM_NUM_3) {                // BS
+        shapeParam.isBsMerge = false;
+        shapeParam.B = xShape->GetDim(DIM_INDEX_0);
+        shapeParam.S = xShape->GetDim(DIM_INDEX_1);
+        shapeParam.H = xShape->GetDim(DIM_INDEX_2);
+        shapeParam.T = shapeParam.B * shapeParam.S;
+    } else {                                                    // T
+        shapeParam.isBsMerge = true;
+        shapeParam.T = xShape->GetDim(DIM_INDEX_0);
+        shapeParam.H = xShape->GetDim(DIM_INDEX_1);
+    }
+
+    shapeParam.D = normWeightShape->GetDim(DIM_INDEX_0);
+    if (shapeParam.isBsMerge) {
+        shapeParam.Sr = ropeSinShape->GetDim(DIM_INDEX_0);   // TH: (min(T, T/r + B), rD)
+    } else {
+        shapeParam.Sr = ropeSinShape->GetDim(DIM_INDEX_1);   // BSH: (B, ceil(S / r), rD)
+    }
+
+    return GRAPH_SUCCESS;
+}
+
+ge::graphStatus SetCompressNormRopeShapeDim(const CompressNormRopeProtoShapeParam &shapeParam, gert::InferShapeContext* context)
+{
+    auto cmpKvShape = context->GetOutputShape(CMP_KV_OUTPUT_INDEX);                 // query: (B, S, N, Hckv) | (T, N, Hckv)
+    OPS_LOG_E_IF_NULL(context, cmpKvShape, return ge::GRAPH_FAILED)
+    auto attr = context->GetAttrs();
+    const uint32_t *cmpRatioPtr = attr->GetAttrPointer<uint32_t>(CMP_RATIO_ATTR_INDEX);
+    uint32_t cmpRatio = (cmpRatioPtr != nullptr) ? *cmpRatioPtr : CMP_RATIO_VALUE;
+    const uint32_t *coffPtr = attr->GetAttrPointer<uint32_t>(COFF_ATTR_INDEX);
+    uint32_t coff = (coffPtr != nullptr) ? *coffPtr : COFF_VALUE;
+    // Set output shape
+    if (!shapeParam.isBsMerge) {
+        cmpKvShape->SetDimNum(DIM_NUM_3);                   // (B, Sr, H)
+        cmpKvShape->SetDim(DIM_INDEX_0, shapeParam.B);
+        cmpKvShape->SetDim(DIM_INDEX_1, shapeParam.Sr);
+        cmpKvShape->SetDim(DIM_INDEX_2, shapeParam.D);
+    } else {
+        cmpKvShape->SetDimNum(DIM_NUM_2);                   // (T, N, Hckv)
+        cmpKvShape->SetDim(DIM_INDEX_0, shapeParam.Sr);
+        cmpKvShape->SetDim(DIM_INDEX_1, shapeParam.D);
+    }
+
+    return GRAPH_SUCCESS;
+}
+
+ge::graphStatus InferDataTypeCompressNormRope(gert::InferDataTypeContext* context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_VECTOR_INNER_ERR("CompressNormRope", "Context is nullptr."),
+               return ge::GRAPH_FAILED);
+    OPS_LOG_I(context->GetNodeName(), "Enter CompressNormRope inferDataType impl.");
+
+    context->SetOutputDataType(CMP_KV_OUTPUT_INDEX, context->GetRequiredInputDataType(MM_KV_INPUT_INDEX));
+
+    return GRAPH_SUCCESS;
+}
+
+ge::graphStatus InferShapeCompressNormRope(gert::InferShapeContext* context)
+{
+    OP_CHECK_IF(context == nullptr, OPS_REPORT_VECTOR_INNER_ERR("CompressNormRope", "Context is nullptr."),
+               return ge::GRAPH_FAILED);
+    OPS_LOG_I(context->GetNodeName(), "Enter CompressNormRope infershape impl.");
+
+    CompressNormRopeProtoShapeParam shapeParam {};
+    auto apiRet = GetCompressNormRopeShapeDim(context, shapeParam);
+    OPS_LOG_E_IF((apiRet != GRAPH_SUCCESS), context, return ge::GRAPH_FAILED, "Context get input shape failed");
+
+    apiRet = SetCompressNormRopeShapeDim(shapeParam, context);
+    OPS_LOG_E_IF((apiRet != GRAPH_SUCCESS), context, return ge::GRAPH_FAILED, "Context set output shape failed");
+
+    return GRAPH_SUCCESS;
+}
+
+IMPL_OP_INFERSHAPE(CompressNormRope).InferShape(InferShapeCompressNormRope).InferDataType(InferDataTypeCompressNormRope);
+}  // namespace ops

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_comm.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_comm.h
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_comm.h
+ * \brief compress_norm_rope 公共定义：常量、对齐工具、DataCopy 帮助函数
+ *
+ * 算子语义：
+ *   输入 mm_kv/mm_score = 外部 GEMM 输出 [T, coff*headDim]（raw，不含 ape）
+ *   每个压缩组（cmpRatio 个 token）产出 1 行压缩 kv：
+ *     C4  (r=4,   coff=2): 窗口 8 行 = [前一组 4 行 coff0 | 当前组 4 行 coff1]
+ *     C128(r=128, coff=1): 窗口 128 行 = 当前组
+ *   score += ape（按组内位置）→ 逐列 ColumnSoftMax → p·kv 逐列求和 → cmp_kv
+ *   全部 token 的 [kv(raw) | score(+ape)] fp32 写回分页 state_cache（in-place）
+ */
+
+#ifndef COMPRESS_NORM_ROPE_COMM_H
+#define COMPRESS_NORM_ROPE_COMM_H
+
+#include "kernel_operator.h"
+
+using namespace AscendC;
+
+namespace CompressNormRope {
+
+template <typename T>
+__aicore__ inline T CeilDivT(T num1, T num2)
+{
+    if (num2 == 0) {
+        return static_cast<T>(0);
+    }
+    return (num1 + num2 - 1) / num2;
+}
+
+// BUFFER 字节数
+inline constexpr uint32_t BUFFER_SIZE_BYTE_1K = 1024;
+inline constexpr uint32_t BUFFER_SIZE_BYTE_2K = 2048;
+inline constexpr uint32_t BUFFER_SIZE_BYTE_4K = 4096;
+inline constexpr uint32_t BUFFER_SIZE_BYTE_8K = 8192;
+inline constexpr uint32_t BUFFER_SIZE_BYTE_16K = 16384;
+inline constexpr uint32_t BUFFER_SIZE_BYTE_32K = 32768;
+inline constexpr uint32_t BUFFER_SIZE_BYTE_64K = 65536;
+
+inline constexpr uint32_t BYTE_BLOCK = 32UL;
+inline constexpr uint32_t FP32_BLOCK_ELEMENT_NUM = BYTE_BLOCK / sizeof(float);      // 8
+inline constexpr uint32_t REPEAT_BLOCK_BYTE = 256U;
+inline constexpr uint32_t FP32_REPEAT_ELEMENT_NUM = REPEAT_BLOCK_BYTE / sizeof(float); // 64
+inline constexpr uint32_t REPEAT_STRIDE_NUM = REPEAT_BLOCK_BYTE / BYTE_BLOCK;          // 8
+inline constexpr uint32_t REPEAT_MAX_NUM = 255;
+inline constexpr uint32_t MAX_R = 256;
+
+inline constexpr float SOFTMAX_MIN_VALUE = -2e38f;
+inline constexpr float FLOAT_ZERO = 0.0f;
+inline constexpr uint32_t BRCB_NUM = 8; // Brcb 单指令广播元素数
+
+// rotary_mode 属性值
+enum class ROTARY_MODE : uint8_t {
+    HALF = 1,       // 半旋转：dst[i]=src[i]c[i]-src[i+h]s[i]
+    INTERLEAVE = 2, // 交错：dst[2k]=src[2k]c[2k]-src[2k+1]s[2k]
+};
+
+template <typename C>
+__aicore__ inline constexpr uint32_t BlockElementNum()
+{
+    return static_cast<uint32_t>(BYTE_BLOCK / sizeof(C));
+}
+
+// 二维 strided DataCopy 帮助函数（blockLen/gap 以 32B block 为单位）
+// 契约（调用侧保证）：copyRowCount >= 1；copyColCount 为 BlockElementNum<O>() 的整数倍且
+// 不超过 src/dst 行宽。
+template <typename O>
+__aicore__ inline void DataCopyAlignGmToUb(const LocalTensor<O> &dstLocal, const GlobalTensor<O> &srcGm,
+                                           uint32_t copyRowCount, uint32_t copyColCount, uint32_t srcSingleRowCount,
+                                           uint32_t dstSingleRowCount)
+{
+    DataCopyParams intriParams;
+    intriParams.blockCount = copyRowCount;
+    intriParams.blockLen = copyColCount / BlockElementNum<O>();
+    intriParams.dstGap = (dstSingleRowCount - copyColCount) / BlockElementNum<O>();
+    intriParams.srcGap = (srcSingleRowCount - copyColCount) / BlockElementNum<O>();
+    DataCopy(dstLocal, srcGm, intriParams);
+}
+
+template <typename O>
+__aicore__ inline void DataCopyAlignUbToGm(const GlobalTensor<O> &dstGm, const LocalTensor<O> &srcLocal,
+                                           uint32_t copyRowCount, uint32_t copyColCount, uint32_t srcSingleRowCount,
+                                           uint32_t dstSingleRowCount)
+{
+    DataCopyParams intriParams;
+    intriParams.blockCount = copyRowCount;
+    intriParams.blockLen = copyColCount / BlockElementNum<O>();
+    intriParams.dstGap = (dstSingleRowCount - copyColCount) / BlockElementNum<O>();
+    intriParams.srcGap = (srcSingleRowCount - copyColCount) / BlockElementNum<O>();
+    DataCopy(dstGm, srcLocal, intriParams);
+}
+
+template <typename O>
+__aicore__ inline void DataCopyAlignUbToUb(const LocalTensor<O> &dstLocal, const LocalTensor<O> &srcLocal,
+                                           uint32_t copyRowCount, uint32_t copyColCount, uint32_t srcSingleRowCount,
+                                           uint32_t dstSingleRowCount)
+{
+    DataCopyParams intriParams;
+    intriParams.blockCount = copyRowCount;
+    intriParams.blockLen = copyColCount / BlockElementNum<O>();
+    intriParams.dstGap = (dstSingleRowCount - copyColCount) / BlockElementNum<O>();
+    intriParams.srcGap = (srcSingleRowCount - copyColCount) / BlockElementNum<O>();
+    DataCopy(dstLocal, srcLocal, intriParams);
+}
+
+} // namespace CompressNormRope
+
+#endif // COMPRESS_NORM_ROPE_COMM_H

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_kernel_c128.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_kernel_c128.h
@@ -1,0 +1,479 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_kernel_c128.h
+ * \brief Kernel B：C128（cmpRatio=128, coff=1）——d 分块压缩 + workspace 中转两阶段 norm/rope
+ *
+ * 窗口 128 行 = 当前组（无 overlap）。窗口 128×512 fp32 = 256KB > UB，必须 d 分块：
+ *   阶段一：任务 = (组, dChunk 64 列)，窗口装配→列 softmax→加权和得 cmpRow[64] fp32，
+ *           写 GM workspace[scIdx*512 + dStart]（未 norm/rope）；state 写不变；
+ *   SyncAll：全核屏障（tiling SetScheduleMode(1) 保证同调度），workspace 跨核可见；
+ *   阶段二：压缩行按核均分（≤ maxScNum 行，C128 压缩比 128:1 行数很小），每行读回
+ *           完整 512 维 → RmsNorm → RoPE（cos/sin 行号=行序号）→ CAST_RINT → cmp_kv。
+ * 事件：阶段一同前（固定 id 自配对）；阶段二复用 ID0~ID3 相邻自配对，全局 1:1。
+ */
+
+#ifndef COMPRESS_NORM_ROPE_KERNEL_C128_H
+#define COMPRESS_NORM_ROPE_KERNEL_C128_H
+
+#include "compress_norm_rope_comm.h"
+#include "compress_norm_rope_tiling_data.h"
+#include "compress_norm_rope_tools.h"
+#include "compress_norm_rope_vector_comm.h"
+
+namespace CompressNormRope {
+
+using optiling::CompressNormRopeTilingData;
+
+template <typename T, typename T_NORM, typename T_ROPE>
+class CompressNormRopeKernelC128 {
+public:
+    __aicore__ inline void Init(TPipe *pipe, const CompressNormRopeTilingData *tilingData,
+                                __gm__ uint8_t *mmKv, __gm__ uint8_t *mmScore, __gm__ uint8_t *stateCache,
+                                __gm__ uint8_t *ape, __gm__ uint8_t *normWeight, __gm__ uint8_t *ropeSin,
+                                __gm__ uint8_t *ropeCos, __gm__ uint8_t *stateBlockTable,
+                                __gm__ uint8_t *cuSeqlens, __gm__ uint8_t *seqUsed, __gm__ uint8_t *startPos,
+                                __gm__ uint8_t *cmpKvOut, __gm__ uint8_t *workspace)
+    {
+        pipe_ = pipe;
+        batchSize_ = tilingData->batchSize;
+        headDim_ = tilingData->headDim;
+        cmpRatio_ = tilingData->cmpRatio;
+        blockSize_ = tilingData->blockSize;
+        maxBlockNumPerBatch_ = tilingData->maxBlockNumPerBatch;
+        stateStride0_ = tilingData->stateCacheStrideDim0;
+        mmKvStride0_ = tilingData->mmKvStrideDim0;
+        mmScoreStride0_ = tilingData->mmScoreStrideDim0;
+        dChunkSize_ = tilingData->dChunkSize;
+        maxGroupTaskNum_ = tilingData->maxGroupTaskNum;
+        usedCoreNum_ = tilingData->usedCoreNum;
+        ropeHeadDim_ = tilingData->ropeHeadDim;
+        rotaryMode_ = tilingData->rotaryMode;
+        normEps_ = tilingData->normEps;
+        maxScNum_ = tilingData->maxScNum;
+        rowLen_ = headDim_;          // coff=1：mm 行元素数
+        stateRowLen_ = 2 * headDim_; // state 行元素数（kv|score）
+
+        uint32_t coreIdx = GetBlockIdx();
+        taskStart_ = coreIdx * tilingData->taskPerCore +
+                     (coreIdx < tilingData->taskRem ? coreIdx : tilingData->taskRem);
+        taskEnd_ = taskStart_ + tilingData->taskPerCore + (coreIdx < tilingData->taskRem ? 1 : 0);
+
+        mmKvGm_.SetGlobalBuffer((__gm__ T *)mmKv);
+        mmScoreGm_.SetGlobalBuffer((__gm__ T *)mmScore);
+        stateGm_.SetGlobalBuffer((__gm__ float *)stateCache);
+        apeGm_.SetGlobalBuffer((__gm__ float *)ape);
+        normWeightGm_.SetGlobalBuffer((__gm__ T_NORM *)normWeight);
+        ropeSinGm_.SetGlobalBuffer((__gm__ T_ROPE *)ropeSin);
+        ropeCosGm_.SetGlobalBuffer((__gm__ T_ROPE *)ropeCos);
+        sbtGm_.SetGlobalBuffer((__gm__ int32_t *)stateBlockTable);
+        cmpKvOutGm_.SetGlobalBuffer((__gm__ T *)cmpKvOut);
+        wsGm_.SetGlobalBuffer((__gm__ float *)workspace);
+
+        iter_.Init(cuSeqlens, seqUsed, startPos, batchSize_, cmpRatio_);
+
+        // ── 统一 UB 池：单 TBuf 按阶段复用（GetWithOffset 切子视图）──
+        // 阶段一布局（字节）：[0,32K)apeChunk [32K,48K)kvStage0 [48K,64K)kvStage1
+        //   [64K,80K)scoreStage0 [80K,96K)scoreStage1 [96K,128K)kvRows
+        //   [128K,160K)scoreRows [160K,176K)tmp [176K,176.25K)cmp
+        //   [176.25K,178.25K)gamma [178.25K,178.5K)gatherOffset
+        // 阶段二复用（阶段一完成后）：[96K,104K)wsRow(NORM_BATCH 行)
+        //   [128K,144K)normTmp(RmsNorm 2×cnt) [160K,167K)cos/sin/raw/out
+        // 总量 178.5KB < 192KB
+        constexpr uint32_t KB = 1024;
+        pipe_->InitBuffer(ubBuf_, 179 * KB);
+        apeChunkUb_ = ubBuf_.GetWithOffset<float>(cmpRatio_ * dChunkSize_, 0);
+        kvStageUb_[0] = ubBuf_.GetWithOffset<T>(cmpRatio_ * dChunkSize_, 32 * KB);
+        kvStageUb_[1] = ubBuf_.GetWithOffset<T>(cmpRatio_ * dChunkSize_, 48 * KB);
+        scoreStageUb_[0] = ubBuf_.GetWithOffset<T>(cmpRatio_ * dChunkSize_, 64 * KB);
+        scoreStageUb_[1] = ubBuf_.GetWithOffset<T>(cmpRatio_ * dChunkSize_, 80 * KB);
+        kvRowsUb_ = ubBuf_.GetWithOffset<float>(cmpRatio_ * dChunkSize_, 96 * KB);
+        scoreRowsUb_ = ubBuf_.GetWithOffset<float>(cmpRatio_ * dChunkSize_, 128 * KB);
+        tmpUb_ = ubBuf_.GetWithOffset<float>((cmpRatio_ / 2) * dChunkSize_, 160 * KB);
+        cmpUb_ = ubBuf_.GetWithOffset<float>(dChunkSize_, 176 * KB);
+        gammaUb_ = ubBuf_.GetWithOffset<float>(headDim_, 176 * KB + 256);
+        gatherOffsetUb_ = ubBuf_.GetWithOffset<int32_t>(ropeHeadDim_, 178 * KB + 256);
+        // 阶段二子视图（同一 UB 池复用）
+        wsRowUb_ = kvRowsUb_;
+        normTmpUb_ = scoreRowsUb_;
+        cosUb_ = ubBuf_.GetWithOffset<float>(NORM_BATCH * ropeHeadDim_, 160 * KB);
+        sinUb_ = ubBuf_.GetWithOffset<float>(NORM_BATCH * ropeHeadDim_, 161 * KB);
+        ropeRawUb_ = ubBuf_.GetWithOffset<T_ROPE>(2 * NORM_BATCH * ropeHeadDim_, 162 * KB);
+        outRowUb_ = ubBuf_.GetWithOffset<T>(NORM_BATCH * headDim_, 163 * KB);
+
+        // 事件 ID：EVENT_ID0 load→cast 自配对；EVENT_ID1 V→save/out 自配对；
+        // EVENT_ID2 rows 复用自配对；EVENT_ID3 ape 加载自配对；EVENT_ID4/5 stage ping-pong
+        eventMTE2V_ = static_cast<event_t>(EVENT_ID0);
+        eventVMTE3_ = static_cast<event_t>(EVENT_ID1);
+        eventMTE3V_ = static_cast<event_t>(EVENT_ID2);
+        eventVMTE2_ = static_cast<event_t>(EVENT_ID3);
+        idVToMTE2_[0] = static_cast<event_t>(EVENT_ID4);
+        idVToMTE2_[1] = static_cast<event_t>(EVENT_ID5);
+        evtSToV_ = static_cast<event_t>(EVENT_ID0); // S_V 方向与 MTE2_V 物理 flag 独立，仅 Init 用一次
+        eventMTE3MTE2_ = static_cast<event_t>(EVENT_ID6); // MTE3_MTE2 方向独立 id 空间
+    }
+
+    // gamma 常驻 + INTERLEAVE 偏移表（启动一次性；复用 eventMTE2V_ 顺序自配对）
+    __aicore__ inline void InitNormRope()
+    {
+        LocalTensor<float> gammaUb = gammaUb_;
+        if constexpr (std::is_same_v<T_NORM, float>) {
+            DataCopy(gammaUb, normWeightGm_, headDim_);
+            SetFlag<HardEvent::MTE2_V>(eventMTE2V_);
+            WaitFlag<HardEvent::MTE2_V>(eventMTE2V_);
+        } else {
+            // bf16/fp16 输入：原始数据 copy 到 gamma fp32 buffer 后半段（T_NORM view 偏移
+            // headDim_，字节 1024 起 = 后半段），一次 Cast 到前半段 fp32（源/目标不重叠）
+            LocalTensor<T_NORM> gammaRawUb = gammaUb_.ReinterpretCast<T_NORM>();
+            DataCopy(gammaRawUb[headDim_], normWeightGm_, headDim_);
+            SetFlag<HardEvent::MTE2_V>(eventMTE2V_);
+            WaitFlag<HardEvent::MTE2_V>(eventMTE2V_);
+            Cast(gammaUb, gammaRawUb[headDim_], RoundMode::CAST_NONE, headDim_);
+        }
+        if (rotaryMode_ == (uint32_t)ROTARY_MODE::INTERLEAVE) {
+            LocalTensor<int32_t> gatherOffsetUb = gatherOffsetUb_;
+            SetGatherSrcOffset<float>(gatherOffsetUb, ropeHeadDim_, evtSToV_);
+        }
+    }
+
+    __aicore__ inline void Process()
+    {
+        // ── 阶段一：d 分块压缩（无任务的核也必须走到 SyncAll 判断点）──
+        if (taskStart_ < taskEnd_) {
+            Phase1Compress();
+        }
+        // totalSc 是纯标量推算（每核结果一致）：0 行时阶段二无工作，全核一致跳过屏障
+        // 无压缩行时省去 SyncAll。
+        uint32_t totalSc = iter_.Locate(0xFFFFFFFF);
+        if (totalSc == 0) {
+            return;
+        }
+        // 全核屏障：workspace 中所有压缩行 chunk 跨核可见（tiling 已 SetScheduleMode(1)）
+        SyncAll<true>();
+        // ── 阶段二：压缩行 RmsNorm + RoPE → cmp_kv ──
+        Phase2NormRope(totalSc);
+    }
+
+private:
+    __aicore__ inline void Phase1Compress()
+    {
+        // prime：stage ping-pong id 各 Set 一次（与前两次迭代的 wait 配对，配平末尾 drain）
+        SetFlag<HardEvent::V_MTE2>(idVToMTE2_[0]);
+        SetFlag<HardEvent::V_MTE2>(idVToMTE2_[1]);
+        LocalTensor<float> apeChunk = apeChunkUb_;
+        LocalTensor<T> kvStage[2] = {kvStageUb_[0], kvStageUb_[1]};
+        LocalTensor<T> scoreStage[2] = {scoreStageUb_[0], scoreStageUb_[1]};
+        uint32_t curDc = 0xFFFFFFFF;
+        uint32_t curHh = 0;
+        uint32_t curNTok = 0;
+        uint32_t buf = 0;
+        uint32_t task = taskStart_;
+        while (task < taskEnd_) {
+            // dChunk-major：task = dc * maxGroupTaskNum + groupIdx。同一 dc 内的
+            // groupIdx 连续，只 Locate 一次，后续用 Next 前进，避免每个
+            // (group, dc) 任务都从 batch 0 重新扫描。
+            uint32_t dc = task / maxGroupTaskNum_;
+            uint32_t dcTaskEnd = Std::min(taskEnd_, (dc + 1) * maxGroupTaskNum_);
+            iter_.Locate(task % maxGroupTaskNum_);
+            while (task < dcTaskEnd && !iter_.IsEnd()) {
+                uint32_t compressedCnt = iter_.CompCntBefore();
+                GroupInfo g;
+                iter_.GetGroupInfo(g);
+                iter_.Next();
+                task++;
+                if (g.nTok == 0) {
+                    continue;
+                }
+                if (dc != curDc || g.headHolder != curHh || g.nTok != curNTok) {
+                    // ape 只载本组需要的连续行 [hh, hh+nTok)，从整 chunk 32KB
+                    // 降到 nTok×256B；完整组 (0,128) 缓存键稳定，
+                    // 同核同 dc 连续任务仍只载一次
+                    SetFlag<HardEvent::V_MTE2>(eventVMTE2_);
+                    WaitFlag<HardEvent::V_MTE2>(eventVMTE2_);
+                    DataCopyAlignGmToUb(apeChunk, apeGm_[(uint64_t)g.headHolder * headDim_ + dc * dChunkSize_],
+                                        g.nTok, dChunkSize_, headDim_, dChunkSize_);
+                    SetFlag<HardEvent::MTE2_V>(eventMTE2V_);
+                    WaitFlag<HardEvent::MTE2_V>(eventMTE2V_);
+                    curDc = dc;
+                    curHh = g.headHolder;
+                    curNTok = g.nTok;
+                }
+                // 等 stage[buf] 可写（cast(任务 i-2) 完成；前两次迭代由 prime 配对）
+                WaitFlag<HardEvent::V_MTE2>(idVToMTE2_[buf]);
+                uint64_t kvSrcOff = (uint64_t)g.xRow * mmKvStride0_ + dc * dChunkSize_;
+                uint64_t scoreSrcOff = (uint64_t)g.xRow * mmScoreStride0_ + dc * dChunkSize_;
+                DataCopyAlignGmToUb(kvStage[buf], mmKvGm_[kvSrcOff], g.nTok, dChunkSize_, mmKvStride0_,
+                                    dChunkSize_);
+                DataCopyAlignGmToUb(scoreStage[buf], mmScoreGm_[scoreSrcOff], g.nTok, dChunkSize_,
+                                    mmScoreStride0_, dChunkSize_);
+                ProcessTask(g, dc, compressedCnt, apeChunk, kvStage[buf], scoreStage[buf]);
+                SetFlag<HardEvent::V_MTE2>(idVToMTE2_[buf]); // stage[buf] 可再写
+                buf = buf ^ 1;
+            }
+            // 跳过本 dc 中超出实际 group 数的 tiling padding 任务。
+            task = dcTaskEnd;
+        }
+        // drain：与 prime 配对（全局 Set:Wait 严格 1:1）
+        WaitFlag<HardEvent::V_MTE2>(idVToMTE2_[0]);
+        WaitFlag<HardEvent::V_MTE2>(idVToMTE2_[1]);
+    }
+
+    // 阶段二：压缩行按核均分，NORM_BATCH 行批量 RmsNorm→RoPE→CAST→cmp_kv
+    // （行数 ≤ maxScNum；批量摊销 barrier，与 C4 的 FlushNormRope 同模式）
+    __aicore__ inline void Phase2NormRope(uint32_t totalSc)
+    {
+        uint32_t coreIdx = GetBlockIdx();
+        uint32_t rowStart = coreIdx * (totalSc / usedCoreNum_) +
+                            (coreIdx < totalSc % usedCoreNum_ ? coreIdx : totalSc % usedCoreNum_);
+        uint32_t rowEnd = rowStart + totalSc / usedCoreNum_ + (coreIdx < totalSc % usedCoreNum_ ? 1 : 0);
+        // 只在实际分到阶段二行的核上加载 gamma/生成 gather offset。
+        if (rowStart >= rowEnd) {
+            return;
+        }
+        InitNormRope();
+        NormRopeRange(rowStart, rowEnd);
+    }
+
+    __aicore__ inline void NormRopeRange(uint32_t rowStart, uint32_t rowEnd)
+    {
+        LocalTensor<float> wsRowUb = wsRowUb_;
+        LocalTensor<float> tmpUb = normTmpUb_;
+        LocalTensor<float> gammaUb = gammaUb_;
+        LocalTensor<float> cosUb = cosUb_;
+        LocalTensor<float> sinUb = sinUb_;
+        LocalTensor<uint32_t> gatherOff = gatherOffsetUb_.ReinterpretCast<uint32_t>();
+        LocalTensor<T> outRow = outRowUb_;
+        RmsNormParam normParams{1.0f / (float)(int32_t)headDim_, normEps_, NORM_BATCH, headDim_};
+        uint64_t baseAddr = headDim_ - ropeHeadDim_;
+        uint32_t row = rowStart;
+        while (row < rowEnd) {
+            uint32_t cnt = (rowEnd - row) < NORM_BATCH ? (rowEnd - row) : NORM_BATCH;
+            // 等上一轮 V 完成（wsRow/rope 区可被 MTE2 重写）
+            SetFlag<HardEvent::V_MTE2>(eventVMTE2_);
+            WaitFlag<HardEvent::V_MTE2>(eventVMTE2_);
+            DataCopy(wsRowUb, wsGm_[(uint64_t)row * headDim_], cnt * headDim_);
+            uint64_t ropeOff = (uint64_t)row * ropeHeadDim_;
+            uint32_t cntRope = cnt * ropeHeadDim_;
+            if constexpr (std::is_same_v<T_ROPE, float>) {
+                DataCopy(cosUb, ropeCosGm_[ropeOff], cntRope);
+                DataCopy(sinUb, ropeSinGm_[ropeOff], cntRope);
+            } else {
+                // bf16/fp16 输入：cos/sin 原始数据 copy 到 raw 区（T_ROPE view），各一次 Cast 到 fp32
+                DataCopy(ropeRawUb_, ropeCosGm_[ropeOff], cntRope);
+                DataCopy(ropeRawUb_[NORM_BATCH * ropeHeadDim_], ropeSinGm_[ropeOff], cntRope);
+            }
+            SetFlag<HardEvent::MTE2_V>(eventMTE2V_);
+            WaitFlag<HardEvent::MTE2_V>(eventMTE2V_);
+            if constexpr (!std::is_same_v<T_ROPE, float>) {
+                Cast(cosUb, ropeRawUb_, RoundMode::CAST_NONE, cntRope);
+                Cast(sinUb, ropeRawUb_[NORM_BATCH * ropeHeadDim_], RoundMode::CAST_NONE, cntRope);
+            }
+            normParams.row = cnt;
+            RmsNorm(wsRowUb, wsRowUb, gammaUb, tmpUb, normParams);
+            PipeBarrier<PIPE_V>();
+            if (rotaryMode_ == (uint32_t)ROTARY_MODE::INTERLEAVE) {
+                RotaryPosEmb<ROTARY_MODE::INTERLEAVE>(wsRowUb, wsRowUb, cosUb, sinUb, tmpUb, gatherOff, cnt,
+                                                      ropeHeadDim_, headDim_, baseAddr);
+            } else {
+                RotaryPosEmb<ROTARY_MODE::HALF>(wsRowUb, wsRowUb, cosUb, sinUb, tmpUb, gatherOff, cnt,
+                                                ropeHeadDim_, headDim_, baseAddr);
+            }
+            PipeBarrier<PIPE_V>();
+            // 等上一轮输出写（MTE3 读 outRow）完成再 cast 重写
+            SetFlag<HardEvent::MTE3_V>(eventMTE3V_);
+            WaitFlag<HardEvent::MTE3_V>(eventMTE3V_);
+            Cast(outRow, wsRowUb, RoundMode::CAST_RINT, cnt * headDim_);
+            SetFlag<HardEvent::V_MTE3>(eventVMTE3_);
+            WaitFlag<HardEvent::V_MTE3>(eventVMTE3_);
+            DataCopy(cmpKvOutGm_[(uint64_t)row * headDim_], outRow, cnt * headDim_);
+            row += cnt;
+        }
+    }
+
+    static constexpr uint32_t NORM_BATCH = 4; // 阶段二批量行数（摊销 barrier；UB 受 tmp/out/rope 区限制）
+
+    __aicore__ inline void ProcessTask(const GroupInfo &g, uint32_t dc, uint32_t compressedCnt,
+                                       const LocalTensor<float> &apeChunk, const LocalTensor<T> &kvStage,
+                                       const LocalTensor<T> &scoreStage)
+    {
+        LocalTensor<float> kvRows = kvRowsUb_;
+        LocalTensor<float> scoreRows = scoreRowsUb_;
+        uint32_t dStart = dc * dChunkSize_;
+        uint32_t nTok = g.nTok;
+        uint32_t hh = g.headHolder;
+
+        // ── 自同步：上一任务 state 写（MTE3 读 rows）完成（rows 单缓冲复用）──
+        SetFlag<HardEvent::MTE3_V>(eventMTE3V_);
+        WaitFlag<HardEvent::MTE3_V>(eventMTE3V_);
+
+        // ── 1. 等本组 mm load（MTE2）完成 ──
+        SetFlag<HardEvent::MTE2_V>(eventMTE2V_);
+        WaitFlag<HardEvent::MTE2_V>(eventMTE2V_);
+
+        // ── 2. cast fp32 → 窗口行 [hh, hh+nTok)；score += ape ──
+        // （ape 按行切片缓存在 apeChunk[0..nTok)，与本组窗口行对齐）
+        Cast(kvRows[hh * dChunkSize_], kvStage, RoundMode::CAST_NONE, nTok * dChunkSize_);
+        Cast(scoreRows[hh * dChunkSize_], scoreStage, RoundMode::CAST_NONE, nTok * dChunkSize_);
+        PipeBarrier<PIPE_V>();
+        Add(scoreRows[hh * dChunkSize_], scoreRows[hh * dChunkSize_], apeChunk, nTok * dChunkSize_);
+        PipeBarrier<PIPE_V>();
+
+        // ── 3. 写 state（该 d 段）──
+        SetFlag<HardEvent::V_MTE3>(eventVMTE3_);
+        WaitFlag<HardEvent::V_MTE3>(eventVMTE3_);
+        SaveStateChunk(kvRows[hh * dChunkSize_], g, 0, dStart, nTok);
+        SaveStateChunk(scoreRows[hh * dChunkSize_], g, 1, dStart, nTok);
+        // state 写（MTE3 读 rows）完成后才能原地 softmax/Mul（V 写 rows）
+        SetFlag<HardEvent::MTE3_V>(eventMTE3V_);
+        WaitFlag<HardEvent::MTE3_V>(eventMTE3V_);
+
+        // ── 4. 压缩：首组 headHolder 历史行从 state 读入窗口前部 ──
+        if (g.produce) {
+            // 跨 pipe 守卫：此前任务的 SaveState（MTE3 读 rows[0..nTok)）可能未完成，
+            // 本任务 ReadStateChunk（MTE2 写 rows[0..hh)）与之区域可重叠（如前任务 hh=0、
+            // 本任务 hh=120 时 rows[0..2)∩rows[0..120)）——id4/5 只 gate MTE2 等 V，
+            // MTE3→MTE2 必须显式守卫（潜伏竞态，S=8 跨组尾 case 实测抓到）
+            SetFlag<HardEvent::MTE3_MTE2>(eventMTE3MTE2_);
+            WaitFlag<HardEvent::MTE3_MTE2>(eventMTE3MTE2_);
+            if (hh > 0) {
+                ReadStateChunk(kvRows, hh, g.gStart, 0, dStart, g.bIdx);
+                ReadStateChunk(scoreRows, hh, g.gStart, 1, dStart, g.bIdx);
+            }
+            SetFlag<HardEvent::MTE2_V>(eventMTE2V_);
+            WaitFlag<HardEvent::MTE2_V>(eventMTE2V_);
+            LocalTensor<float> tmpUb = tmpUb_;
+            LocalTensor<float> cmpRow = cmpUb_;
+            ColumnSoftMax(scoreRows, scoreRows, tmpUb, cmpRatio_, dChunkSize_);
+            PipeBarrier<PIPE_V>();
+            Mul(kvRows, kvRows, scoreRows, cmpRatio_ * dChunkSize_);
+            PipeBarrier<PIPE_V>();
+            ColumnSum(cmpRow, kvRows, tmpUb, cmpRatio_, dChunkSize_);
+            PipeBarrier<PIPE_V>();
+            // 压缩 chunk fp32 写 workspace（未 norm/rope）；cast 到 bf16 在阶段二整行完成后做
+            SetFlag<HardEvent::V_MTE3>(eventVMTE3_);
+            WaitFlag<HardEvent::V_MTE3>(eventVMTE3_);
+            DataCopy(wsGm_[(uint64_t)compressedCnt * headDim_ + dStart], cmpRow, dChunkSize_);
+        }
+    }
+
+    // 从分页 state 读历史行段（fp32，dChunk 列）
+    __aicore__ inline void ReadStateChunk(const LocalTensor<float> &dst, uint32_t rowCnt, uint32_t posStart,
+                                          uint32_t stateIdx, uint32_t dStart, uint32_t bIdx)
+    {
+        uint32_t p = posStart;
+        uint32_t done = 0;
+        while (done < rowCnt) {
+            uint32_t blk = p / blockSize_;
+            uint32_t rowInBlk = p % blockSize_;
+            int32_t blockId = sbtGm_.GetValue(bIdx * maxBlockNumPerBatch_ + blk);
+            uint32_t seg = blockSize_ - rowInBlk;
+            if (done + seg > rowCnt) {
+                seg = rowCnt - done;
+            }
+            uint64_t srcOff =
+                (uint64_t)blockId * stateStride0_ + rowInBlk * stateRowLen_ + stateIdx * rowLen_ + dStart;
+            DataCopyAlignGmToUb(dst[done * dChunkSize_], stateGm_[srcOff], seg, dChunkSize_, stateRowLen_,
+                                dChunkSize_);
+            done += seg;
+            p += seg;
+        }
+    }
+
+    // 写本组 token 的 d 段到分页 state（fp32；blockId==0 跳过）
+    __aicore__ inline void SaveStateChunk(const LocalTensor<float> &src, const GroupInfo &g, uint32_t stateIdx,
+                                          uint32_t dStart, uint32_t nTok)
+    {
+        uint32_t p = g.tokStart;
+        uint32_t done = 0;
+        while (done < nTok) {
+            uint32_t blk = p / blockSize_;
+            uint32_t rowInBlk = p % blockSize_;
+            int32_t blockId = sbtGm_.GetValue(g.bIdx * maxBlockNumPerBatch_ + blk);
+            uint32_t seg = blockSize_ - rowInBlk;
+            if (done + seg > nTok) {
+                seg = nTok - done;
+            }
+            if (blockId != 0) {
+                uint64_t dstOff =
+                    (uint64_t)blockId * stateStride0_ + rowInBlk * stateRowLen_ + stateIdx * rowLen_ + dStart;
+                DataCopyAlignUbToGm(stateGm_[dstOff], src[done * dChunkSize_], seg, dChunkSize_, dChunkSize_,
+                                    stateRowLen_);
+            }
+            done += seg;
+            p += seg;
+        }
+    }
+
+    TPipe *pipe_ = nullptr;
+    GroupIterator iter_;
+
+    GlobalTensor<T> mmKvGm_;
+    GlobalTensor<T> mmScoreGm_;
+    GlobalTensor<float> stateGm_;
+    GlobalTensor<float> apeGm_;
+    GlobalTensor<T_NORM> normWeightGm_;
+    GlobalTensor<T_ROPE> ropeSinGm_;
+    GlobalTensor<T_ROPE> ropeCosGm_;
+    GlobalTensor<int32_t> sbtGm_;
+    GlobalTensor<T> cmpKvOutGm_;
+    GlobalTensor<float> wsGm_;
+
+    // 统一 UB 池（GetWithOffset 切子视图，阶段一/二按生命周期复用）
+    TBuf<TPosition::VECCALC> ubBuf_;
+    LocalTensor<float> apeChunkUb_;
+    LocalTensor<T> kvStageUb_[2];
+    LocalTensor<T> scoreStageUb_[2];
+    LocalTensor<float> kvRowsUb_;
+    LocalTensor<float> scoreRowsUb_;
+    LocalTensor<float> tmpUb_;
+    LocalTensor<float> cmpUb_;
+    LocalTensor<float> gammaUb_;
+    LocalTensor<int32_t> gatherOffsetUb_;
+    // 阶段二复用子视图（阶段一完成后）
+    LocalTensor<float> wsRowUb_;
+    LocalTensor<float> normTmpUb_;
+    LocalTensor<float> cosUb_;
+    LocalTensor<float> sinUb_;
+    LocalTensor<T_ROPE> ropeRawUb_;
+    LocalTensor<T> outRowUb_;
+
+    event_t eventMTE2V_;
+    event_t eventVMTE3_;
+    event_t eventMTE3V_;
+    event_t eventVMTE2_;
+    event_t idVToMTE2_[2];
+    event_t evtSToV_;
+    event_t eventMTE3MTE2_;
+
+    uint32_t batchSize_ = 0;
+    uint32_t headDim_ = 0;
+    uint32_t cmpRatio_ = 0;
+    uint32_t blockSize_ = 0;
+    uint32_t maxBlockNumPerBatch_ = 0;
+    uint64_t stateStride0_ = 0;
+    uint32_t mmKvStride0_ = 0;
+    uint32_t mmScoreStride0_ = 0;
+    uint32_t dChunkSize_ = 0;
+    uint32_t maxGroupTaskNum_ = 0;
+    uint32_t usedCoreNum_ = 0;
+    uint32_t rowLen_ = 0;
+    uint32_t stateRowLen_ = 0;
+    uint32_t taskStart_ = 0;
+    uint32_t taskEnd_ = 0;
+    uint32_t ropeHeadDim_ = 0;
+    uint32_t rotaryMode_ = 0;
+    float normEps_ = 1e-6f;
+    uint32_t maxScNum_ = 0;
+};
+
+} // namespace CompressNormRope
+
+#endif // COMPRESS_NORM_ROPE_KERNEL_C128_H

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_kernel_c4.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_kernel_c4.h
@@ -1,0 +1,528 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_kernel_c4.h
+ * \brief Kernel A：C4（cmpRatio=4, coff=2, OVERLAP）——组流式 + 双缓冲流水
+ *
+ * 窗口 8 行 = [前一组 4 行 coff0 | 当前组 4 行 coff1]：
+ *   - 左半（前一组 coff0）：直接复用上一组双缓冲驻留 UB 的 cur 缓冲（零拷贝、零 GM 重读）；
+ *     本核首个任务的跨组前驱直接读 mm GM（只读输入，无跨核依赖）；
+ *     历史部分（p < start_pos）读分页 state_cache；p < 0 填 0（kv）/ -inf（score）。
+ *   - 右半（当前组 coff1）：本组已 cast/+ape 的 fp32 行（UB→UB 拼接）。
+ *
+ * 流水结构（每核组内，无 SyncAll、无跨核 flag、无 GM workspace）：
+ *   迭代 i:  MTE2 预取组 i+1 mm ║ V 处理组 i（cast/+ape/窗口/softmax/sum/RmsNorm/RoPE/cast）
+ *            ║ MTE3 写组 i state + cmp 行
+ *   压缩行后处理（UB 内融合）：ColumnSum 得全 512 维 → RmsNorm(gamma 常驻)
+ *            → RoPE（cos/sin 行号=compressedCnt_，作用于行尾 ropeHeadDim 维）→ CAST_RINT
+ *   事件协议（每 buffer 独立 id，配平：wait(b) ⟸ 该 buffer 上一次 set，1:1；结束 drain）：
+ *   - EVENT_ID0 evtMte2ToV_  : 本组 mm load → cast（每迭代自配对）；S_V 方向同号仅 Init 用一次
+ *   - EVENT_ID1 evtVToMte3_  : cast/+ape → state 写 / cmp 写（每迭代自配对）
+ *   - EVENT_ID2/3 idVToMTE2  : cast(b) 完成 → stage[b] 可再写（load 前按 stageUsed wait）
+ *   - EVENT_ID4/5 idMTE3ToV  : save/cmpout(b) 完成 → cur[b]/outStage[b] 可再写（按 curUsed wait）
+ *   - EVENT_ID6/7            : 窗口装配自配对 + rope cos/sin 加载自配对（时序上先后串行复用）
+ */
+
+#ifndef COMPRESS_NORM_ROPE_KERNEL_C4_H
+#define COMPRESS_NORM_ROPE_KERNEL_C4_H
+
+#include "compress_norm_rope_comm.h"
+#include "compress_norm_rope_tiling_data.h"
+#include "compress_norm_rope_tools.h"
+#include "compress_norm_rope_vector_comm.h"
+
+namespace CompressNormRope {
+
+using optiling::CompressNormRopeTilingData;
+
+template <typename T, typename T_NORM, typename T_ROPE>
+class CompressNormRopeKernelC4 {
+public:
+    __aicore__ inline void Init(TPipe *pipe, const CompressNormRopeTilingData *tilingData,
+                                __gm__ uint8_t *mmKv, __gm__ uint8_t *mmScore, __gm__ uint8_t *stateCache,
+                                __gm__ uint8_t *ape, __gm__ uint8_t *normWeight, __gm__ uint8_t *ropeSin,
+                                __gm__ uint8_t *ropeCos, __gm__ uint8_t *stateBlockTable,
+                                __gm__ uint8_t *cuSeqlens, __gm__ uint8_t *seqUsed, __gm__ uint8_t *startPos,
+                                __gm__ uint8_t *cmpKvOut)
+    {
+        pipe_ = pipe;
+        batchSize_ = tilingData->batchSize;
+        headDim_ = tilingData->headDim;
+        cmpRatio_ = tilingData->cmpRatio;
+        blockSize_ = tilingData->blockSize;
+        maxBlockNumPerBatch_ = tilingData->maxBlockNumPerBatch;
+        stateStride0_ = tilingData->stateCacheStrideDim0;
+        mmKvStride0_ = tilingData->mmKvStrideDim0;
+        mmScoreStride0_ = tilingData->mmScoreStrideDim0;
+        ropeHeadDim_ = tilingData->ropeHeadDim;
+        rotaryMode_ = tilingData->rotaryMode;
+        normEps_ = tilingData->normEps;
+        rowLen_ = COFF_NUM * headDim_;   // mm 行元素数（coff0|coff1）
+        stateRowLen_ = 2 * rowLen_;      // state 行元素数（kv|score）
+
+        uint32_t coreIdx = GetBlockIdx();
+        taskStart_ = coreIdx * tilingData->taskPerCore +
+                     (coreIdx < tilingData->taskRem ? coreIdx : tilingData->taskRem);
+        taskEnd_ = taskStart_ + tilingData->taskPerCore + (coreIdx < tilingData->taskRem ? 1 : 0);
+
+        mmKvGm_.SetGlobalBuffer((__gm__ T *)mmKv);
+        mmScoreGm_.SetGlobalBuffer((__gm__ T *)mmScore);
+        stateGm_.SetGlobalBuffer((__gm__ float *)stateCache);
+        apeGm_.SetGlobalBuffer((__gm__ float *)ape);
+        normWeightGm_.SetGlobalBuffer((__gm__ T_NORM *)normWeight);
+        ropeSinGm_.SetGlobalBuffer((__gm__ T_ROPE *)ropeSin);
+        ropeCosGm_.SetGlobalBuffer((__gm__ T_ROPE *)ropeCos);
+        sbtGm_.SetGlobalBuffer((__gm__ int32_t *)stateBlockTable);
+        cmpKvOutGm_.SetGlobalBuffer((__gm__ T *)cmpKvOut);
+
+        iter_.Init(cuSeqlens, seqUsed, startPos, batchSize_, cmpRatio_);
+
+        pipe_->InitBuffer(apeBuf_, cmpRatio_ * rowLen_ * sizeof(float));
+        pipe_->InitBuffer(kvStageBuf0_, cmpRatio_ * rowLen_ * sizeof(T));
+        pipe_->InitBuffer(kvStageBuf1_, cmpRatio_ * rowLen_ * sizeof(T));
+        pipe_->InitBuffer(scoreStageBuf0_, cmpRatio_ * rowLen_ * sizeof(T));
+        pipe_->InitBuffer(scoreStageBuf1_, cmpRatio_ * rowLen_ * sizeof(T));
+        pipe_->InitBuffer(kvCurBuf0_, cmpRatio_ * rowLen_ * sizeof(float));
+        pipe_->InitBuffer(kvCurBuf1_, cmpRatio_ * rowLen_ * sizeof(float));
+        pipe_->InitBuffer(scoreCurBuf0_, cmpRatio_ * rowLen_ * sizeof(float));
+        pipe_->InitBuffer(scoreCurBuf1_, cmpRatio_ * rowLen_ * sizeof(float));
+        pipe_->InitBuffer(kvWinBuf_, COFF_NUM * cmpRatio_ * headDim_ * sizeof(float));
+        pipe_->InitBuffer(scoreWinBuf_, COFF_NUM * cmpRatio_ * headDim_ * sizeof(float));
+        pipe_->InitBuffer(tmpBuf_, COFF_NUM * cmpRatio_ * headDim_ * sizeof(float));
+        pipe_->InitBuffer(cmpAccumBuf_, NORM_BATCH * headDim_ * sizeof(float));
+        pipe_->InitBuffer(outStageBuf0_, NORM_BATCH * headDim_ * sizeof(T));
+        pipe_->InitBuffer(outStageBuf1_, NORM_BATCH * headDim_ * sizeof(T));
+        pipe_->InitBuffer(kvLeftBuf_, cmpRatio_ * headDim_ * sizeof(T));
+        pipe_->InitBuffer(scoreLeftBuf_, cmpRatio_ * headDim_ * sizeof(T));
+        pipe_->InitBuffer(gammaBuf_, headDim_ * sizeof(float));
+        pipe_->InitBuffer(ropeStageBuf_, 3 * NORM_BATCH * ropeHeadDim_ * sizeof(float));
+        pipe_->InitBuffer(gatherOffsetBuf_, ropeHeadDim_ * sizeof(int32_t));
+
+        evtMte2ToV_ = static_cast<event_t>(EVENT_ID0);
+        evtVToMte3_ = static_cast<event_t>(EVENT_ID1);
+        eventIdVToMTE2_[0] = static_cast<event_t>(EVENT_ID2);
+        eventIdVToMTE2_[1] = static_cast<event_t>(EVENT_ID3);
+        eventIdMTE3ToV_[0] = static_cast<event_t>(EVENT_ID4);
+        eventIdMTE3ToV_[1] = static_cast<event_t>(EVENT_ID5);
+        evtVToMte2Win_ = static_cast<event_t>(EVENT_ID6);
+        evtMte2ToVWin_ = static_cast<event_t>(EVENT_ID7);
+        evtSToV_ = static_cast<event_t>(EVENT_ID0); // S_V 方向与 MTE2_V 物理 flag 独立，仅 Init 用一次
+    }
+
+    // gamma 常驻 + INTERLEAVE 偏移表（启动一次性；复用 evtMte2ToV_ 顺序自配对）
+    __aicore__ inline void InitNormRope()
+    {
+        LocalTensor<float> gammaUb = gammaBuf_.Get<float>();
+        if constexpr (std::is_same_v<T_NORM, float>) {
+            DataCopy(gammaUb, normWeightGm_, headDim_);
+            SetFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+            WaitFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+        } else {
+            // bf16/fp16 输入：原始数据 copy 到 gamma fp32 buffer 后半段（T_NORM view 偏移
+            // headDim_，字节 1024 起 = 后半段），一次 Cast 到前半段 fp32（源/目标不重叠）
+            LocalTensor<T_NORM> gammaRawUb = gammaBuf_.Get<T_NORM>();
+            DataCopy(gammaRawUb[headDim_], normWeightGm_, headDim_);
+            SetFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+            WaitFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+            Cast(gammaUb, gammaRawUb[headDim_], RoundMode::CAST_NONE, headDim_);
+        }
+        if (rotaryMode_ == (uint32_t)ROTARY_MODE::INTERLEAVE) {
+            LocalTensor<int32_t> gatherOffsetUb = gatherOffsetBuf_.Get<int32_t>();
+            SetGatherSrcOffset<float>(gatherOffsetUb, ropeHeadDim_, evtSToV_);
+        }
+    }
+
+    __aicore__ inline void Process()
+    {
+        if (taskStart_ >= taskEnd_) {
+            return;
+        }
+        compressedCnt_ = iter_.Locate(taskStart_);
+
+        LocalTensor<float> apeUb = apeBuf_.Get<float>();
+        DataCopy(apeUb, apeGm_, cmpRatio_ * rowLen_);
+        SetFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+        WaitFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+        InitNormRope();
+
+        LocalTensor<T> kvStage[2] = {kvStageBuf0_.Get<T>(), kvStageBuf1_.Get<T>()};
+        LocalTensor<T> scoreStage[2] = {scoreStageBuf0_.Get<T>(), scoreStageBuf1_.Get<T>()};
+        LocalTensor<float> kvCur[2] = {kvCurBuf0_.Get<float>(), kvCurBuf1_.Get<float>()};
+        LocalTensor<float> scoreCur[2] = {scoreCurBuf0_.Get<float>(), scoreCurBuf1_.Get<float>()};
+        LocalTensor<T> outStage[2] = {outStageBuf0_.Get<T>(), outStageBuf1_.Get<T>()};
+
+        // prime：每 ping-pong id 先 Set 一次（与前两次迭代的 wait 配对，并配平末尾 drain）
+        SetFlag<HardEvent::V_MTE2>(eventIdVToMTE2_[0]);
+        SetFlag<HardEvent::V_MTE2>(eventIdVToMTE2_[1]);
+        SetFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[0]);
+        SetFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[1]);
+
+        uint32_t buf = 0;
+        uint32_t prevBIdx = batchSize_; // 上一个处理组的 bIdx（无效初值 → 首组 prevContinues=false）
+        for (uint32_t task = taskStart_; task < taskEnd_; task++) {
+            GroupInfo g;
+            if (!FetchGroup(g)) {
+                break;
+            }
+            uint32_t nbuf = buf ^ 1;
+            // 上一组与本组同 batch 相邻 → 窗口左半可复用其 cur 缓冲（kvCur[nbuf]）
+            bool prevContinues = (prevBIdx == g.bIdx) && (g.nTok > 0);
+            if (g.nTok > 0) {
+                // ── 1. 等 stage[buf] 可写（cast(g_{i-2}) 完成；前两次迭代由 prime 配对）──
+                WaitFlag<HardEvent::V_MTE2>(eventIdVToMTE2_[buf]);
+                LoadMm(g, kvStage[buf], scoreStage[buf]);
+                // ── 2. 等 cur[buf]/outStage[buf] 可写（save/cmpout(g_{i-2}) 完成）──
+                WaitFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[buf]);
+                // ── 3. 等本组 mm load 完成，cast fp32；score 按组内位置加 ape ──
+                SetFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+                WaitFlag<HardEvent::MTE2_V>(evtMte2ToV_);
+                Cast(kvCur[buf], kvStage[buf], RoundMode::CAST_NONE, g.nTok * rowLen_);
+                Cast(scoreCur[buf], scoreStage[buf], RoundMode::CAST_NONE, g.nTok * rowLen_);
+                PipeBarrier<PIPE_V>();
+                AddApe(scoreCur[buf], g, apeUb);
+                PipeBarrier<PIPE_V>();
+                SetFlag<HardEvent::V_MTE2>(eventIdVToMTE2_[buf]); // stage[buf] 可再写
+                // ── 4. 写 state：kv 存 raw fp32，score 存 +ape fp32 ──
+                SetFlag<HardEvent::V_MTE3>(evtVToMte3_);
+                WaitFlag<HardEvent::V_MTE3>(evtVToMte3_);
+                SaveState(kvCur[buf], g, 0);
+                SaveState(scoreCur[buf], g, 1);
+                // ── 5. 窗口装配 + 逐列 softmax + 加权求和（直写行累积槽）──
+                if (g.produce) {
+                    AssembleWindow(g, kvCur[buf], scoreCur[buf], kvCur[nbuf], scoreCur[nbuf], prevContinues,
+                                   apeUb);
+                    LocalTensor<float> kvWin = kvWinBuf_.Get<float>();
+                    LocalTensor<float> scoreWin = scoreWinBuf_.Get<float>();
+                    LocalTensor<float> tmpUb = tmpBuf_.Get<float>();
+                    LocalTensor<float> cmpAccum = cmpAccumBuf_.Get<float>();
+                    ColumnSoftMax(scoreWin, scoreWin, tmpUb, COFF_NUM * cmpRatio_, headDim_);
+                    PipeBarrier<PIPE_V>();
+                    Mul(kvWin, kvWin, scoreWin, COFF_NUM * cmpRatio_ * headDim_);
+                    PipeBarrier<PIPE_V>();
+                    // 压缩行 fp32 直接落累积槽；RmsNorm+RoPE 按 NORM_BATCH 行批量做（摊销 barrier）
+                    ColumnSum(cmpAccum[accSlots_ * headDim_], kvWin, tmpUb, COFF_NUM * cmpRatio_, headDim_);
+                    PipeBarrier<PIPE_V>();
+                    accSlots_++;
+                    compressedCnt_++;
+                    if (accSlots_ == NORM_BATCH) {
+                        FlushNormRope(outStage[buf], compressedCnt_ - NORM_BATCH, NORM_BATCH);
+                        accSlots_ = 0;
+                    }
+                }
+                // 本组 MTE3 读取（save + cmpout）已全部发射，供复用该 buffer 的 iter i+2 等待
+                SetFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[buf]);
+            }
+            prevBIdx = g.bIdx;
+            buf = nbuf;
+        }
+        // 尾部不足一批的行：flush（先等同 buf 上一任务 cmpout MTE3 完成再重写 outStage）
+        if (accSlots_ > 0) {
+            WaitFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[buf]);
+            FlushNormRope(outStage[buf], compressedCnt_ - accSlots_, accSlots_);
+            SetFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[buf]); // 供 drain 消费，配平 1:1
+            accSlots_ = 0;
+        }
+        // drain：与 prime 配对，消费末尾未消费的 set（全局 Set:Wait 严格 1:1）
+        WaitFlag<HardEvent::V_MTE2>(eventIdVToMTE2_[0]);
+        WaitFlag<HardEvent::V_MTE2>(eventIdVToMTE2_[1]);
+        WaitFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[0]);
+        WaitFlag<HardEvent::MTE3_V>(eventIdMTE3ToV_[1]);
+    }
+
+private:
+    static constexpr uint32_t COFF_NUM = 2;
+    static constexpr uint32_t NORM_BATCH = 4; // RmsNorm/RoPE 批量行数（摊销 barrier；UB 受限）
+
+    // 批量 RmsNorm + RoPE + cast + 写出：行 firstRow..firstRow+cnt-1（GM 行号连续）
+    // 契约：调用点已保证 outStage 可写（任务顶部 id4/5 wait 或尾部 flush 的显式 wait）
+    __aicore__ inline void FlushNormRope(const LocalTensor<T> &outStage, uint32_t firstRow, uint32_t cnt)
+    {
+        LocalTensor<float> cmpAccum = cmpAccumBuf_.Get<float>();
+        LocalTensor<float> tmpUb = tmpBuf_.Get<float>();
+        LocalTensor<float> gammaUb = gammaBuf_.Get<float>();
+        LocalTensor<float> cosUb = ropeStageBuf_.Get<float>();
+        LocalTensor<float> sinUb = cosUb[NORM_BATCH * ropeHeadDim_];
+        LocalTensor<uint32_t> gatherOff = gatherOffsetBuf_.Get<uint32_t>();
+        // cos/sin 连续行一次载入；ropeStage 复用等上一轮 rope V 完成
+        SetFlag<HardEvent::V_MTE2>(evtVToMte2Win_);
+        WaitFlag<HardEvent::V_MTE2>(evtVToMte2Win_);
+        uint64_t ropeOff = (uint64_t)firstRow * ropeHeadDim_;
+        uint32_t cntRope = cnt * ropeHeadDim_;
+        if constexpr (std::is_same_v<T_ROPE, float>) {
+            DataCopy(cosUb, ropeCosGm_[ropeOff], cntRope);
+            DataCopy(sinUb, ropeSinGm_[ropeOff], cntRope);
+        } else {
+            // bf16/fp16 输入：cos/sin 原始数据 copy 到 buffer 后两块（T_ROPE view 偏移
+            // 4/5 * NORM_BATCH*ropeHeadDim_），各一次 Cast 到前两块 fp32（源/目标不重叠）
+            LocalTensor<T_ROPE> ropeRawUb = ropeStageBuf_.Get<T_ROPE>();
+            DataCopy(ropeRawUb[4 * NORM_BATCH * ropeHeadDim_], ropeCosGm_[ropeOff], cntRope);
+            DataCopy(ropeRawUb[5 * NORM_BATCH * ropeHeadDim_], ropeSinGm_[ropeOff], cntRope);
+        }
+        SetFlag<HardEvent::MTE2_V>(evtMte2ToVWin_);
+        WaitFlag<HardEvent::MTE2_V>(evtMte2ToVWin_);
+        if constexpr (!std::is_same_v<T_ROPE, float>) {
+            LocalTensor<T_ROPE> ropeRawUb = ropeStageBuf_.Get<T_ROPE>();
+            Cast(cosUb, ropeRawUb[4 * NORM_BATCH * ropeHeadDim_], RoundMode::CAST_NONE, cntRope);
+            Cast(sinUb, ropeRawUb[5 * NORM_BATCH * ropeHeadDim_], RoundMode::CAST_NONE, cntRope);
+        }
+        RmsNormParam normParams{1.0f / (float)(int32_t)headDim_, normEps_, cnt, headDim_};
+        RmsNorm(cmpAccum, cmpAccum, gammaUb, tmpUb, normParams);
+        PipeBarrier<PIPE_V>();
+        uint64_t baseAddr = headDim_ - ropeHeadDim_;
+        if (rotaryMode_ == (uint32_t)ROTARY_MODE::INTERLEAVE) {
+            RotaryPosEmb<ROTARY_MODE::INTERLEAVE>(cmpAccum, cmpAccum, cosUb, sinUb, tmpUb, gatherOff, cnt,
+                                                  ropeHeadDim_, headDim_, baseAddr);
+        } else {
+            RotaryPosEmb<ROTARY_MODE::HALF>(cmpAccum, cmpAccum, cosUb, sinUb, tmpUb, gatherOff, cnt,
+                                            ropeHeadDim_, headDim_, baseAddr);
+        }
+        PipeBarrier<PIPE_V>();
+        Cast(outStage, cmpAccum, RoundMode::CAST_RINT, cnt * headDim_);
+        SetFlag<HardEvent::V_MTE3>(evtVToMte3_);
+        WaitFlag<HardEvent::V_MTE3>(evtVToMte3_);
+        DataCopy(cmpKvOutGm_[(uint64_t)firstRow * headDim_], outStage, cnt * headDim_);
+    }
+
+    __aicore__ inline bool FetchGroup(GroupInfo &info)
+    {
+        if (iter_.IsEnd()) {
+            return false;
+        }
+        iter_.GetGroupInfo(info);
+        iter_.Next();
+        return true;
+    }
+
+    __aicore__ inline void LoadMm(const GroupInfo &g, const LocalTensor<T> &kvStage,
+                                  const LocalTensor<T> &scoreStage)
+    {
+        uint64_t kvSrcOff = (uint64_t)g.xRow * mmKvStride0_;
+        uint64_t scoreSrcOff = (uint64_t)g.xRow * mmScoreStride0_;
+        DataCopyAlignGmToUb(kvStage, mmKvGm_[kvSrcOff], g.nTok, rowLen_, mmKvStride0_, rowLen_);
+        DataCopyAlignGmToUb(scoreStage, mmScoreGm_[scoreSrcOff], g.nTok, rowLen_, mmScoreStride0_, rowLen_);
+    }
+
+    __aicore__ inline void AddApe(const LocalTensor<float> &scoreCur, const GroupInfo &g,
+                                  const LocalTensor<float> &apeUb)
+    {
+        uint32_t apeRow0 = g.tokStart % cmpRatio_;
+        if (apeRow0 == 0 && g.nTok == cmpRatio_) {
+            Add(scoreCur, scoreCur, apeUb, g.nTok * rowLen_);
+        } else {
+            for (uint32_t i = 0; i < g.nTok; i++) {
+                uint32_t apeRow = (apeRow0 + i) % cmpRatio_;
+                Add(scoreCur[i * rowLen_], scoreCur[i * rowLen_], apeUb[apeRow * rowLen_], rowLen_);
+            }
+        }
+    }
+
+    // 窗口装配：win rows [0,r) = 左半（位置 gStart-r..gStart-1，coff0）
+    //           win rows [r,2r) = 右半（位置 gStart..gStart+r-1，coff1）
+    __aicore__ inline void AssembleWindow(const GroupInfo &g, const LocalTensor<float> &kvCur,
+                                          const LocalTensor<float> &scoreCur, const LocalTensor<float> &kvPrevCur,
+                                          const LocalTensor<float> &scorePrevCur, bool prevContinues,
+                                          const LocalTensor<float> &apeUb)
+    {
+        LocalTensor<float> kvWin = kvWinBuf_.Get<float>();
+        LocalTensor<float> scoreWin = scoreWinBuf_.Get<float>();
+        uint32_t r = cmpRatio_;
+        uint32_t gStart = g.gStart;
+        uint32_t P = g.P;
+
+        // ── 左半 ──
+        int64_t leftFrom = (int64_t)gStart - (int64_t)r;
+        uint32_t pos = leftFrom < 0 ? 0 : (uint32_t)leftFrom;
+        uint32_t row = 0;
+        if (leftFrom < 0) {
+            // p < 0：kv 填 0、score 填 -inf（softmax 后贡献为 0）
+            uint32_t cntFill = (uint32_t)(-leftFrom);
+            Duplicate(kvWin, FLOAT_ZERO, cntFill * headDim_);
+            Duplicate(scoreWin, SOFTMAX_MIN_VALUE, cntFill * headDim_);
+            PipeBarrier<PIPE_V>();
+            row = cntFill;
+        }
+        uint32_t stateEndL = gStart < P ? gStart : P; // 历史行部分（p < P 且 p >= 0）
+        uint32_t cntPrev = gStart - (pos < stateEndL ? stateEndL : pos);
+        // state 历史读（MTE2 写 win）需等上一轮 V 读完 win
+        if (pos < stateEndL || g.headHolder > 0) {
+            SetFlag<HardEvent::V_MTE2>(evtVToMte2Win_);
+            WaitFlag<HardEvent::V_MTE2>(evtVToMte2Win_);
+        }
+        if (pos < stateEndL) {
+            ReadStateRows(kvWin[row * headDim_], stateEndL - pos, pos, 0, 0, g);
+            ReadStateRows(scoreWin[row * headDim_], stateEndL - pos, pos, 0, 1, g);
+            row += stateEndL - pos;
+            pos = stateEndL;
+        }
+        if (cntPrev > 0) {
+            if (prevContinues) {
+                // 左半 = 上一组 cur 的 coff0 半区（零拷贝复用双缓冲）
+                DataCopyAlignUbToUb(kvWin[row * headDim_], kvPrevCur, cntPrev, headDim_, rowLen_, headDim_);
+                DataCopyAlignUbToUb(scoreWin[row * headDim_], scorePrevCur, cntPrev, headDim_, rowLen_, headDim_);
+            } else {
+                // 本核首个任务的跨组前驱：直接读 mm GM（raw，score 补 ape）
+                LoadMmLeftHalf(kvWin[row * headDim_], scoreWin[row * headDim_], pos, cntPrev, g, apeUb);
+            }
+            row += cntPrev;
+        }
+
+        // ── 右半 ──
+        uint32_t rrow = r;
+        if (g.headHolder > 0) {
+            ReadStateRows(kvWin[rrow * headDim_], g.headHolder, gStart, 1, 0, g);
+            ReadStateRows(scoreWin[rrow * headDim_], g.headHolder, gStart, 1, 1, g);
+            rrow += g.headHolder;
+        }
+        DataCopyAlignUbToUb(kvWin[rrow * headDim_], kvCur[headDim_], g.nTok, headDim_, rowLen_, headDim_);
+        DataCopyAlignUbToUb(scoreWin[rrow * headDim_], scoreCur[headDim_], g.nTok, headDim_, rowLen_, headDim_);
+
+        // state 读（MTE2）→ 后续 V 计算
+        SetFlag<HardEvent::MTE2_V>(evtMte2ToVWin_);
+        WaitFlag<HardEvent::MTE2_V>(evtMte2ToVWin_);
+        PipeBarrier<PIPE_V>();
+    }
+
+    // 从 mm GM 读左半前驱行（bf16 raw → fp32；score 按位置补 ape 的 coff0 半区）
+    __aicore__ inline void LoadMmLeftHalf(const LocalTensor<float> &kvDst, const LocalTensor<float> &scoreDst,
+                                          uint32_t posStart, uint32_t rowCnt, const GroupInfo &g,
+                                          const LocalTensor<float> &apeUb)
+    {
+        LocalTensor<T> kvLeft = kvLeftBuf_.Get<T>();
+        LocalTensor<T> scoreLeft = scoreLeftBuf_.Get<T>();
+        // 专用 scratch 的上一个读者是 V（上一次 cast），self-sync 后即可让 MTE2 写入
+        SetFlag<HardEvent::V_MTE2>(evtVToMte2Win_);
+        WaitFlag<HardEvent::V_MTE2>(evtVToMte2Win_);
+        uint32_t xRowL = g.xRow - (g.tokStart - posStart); // = cu[b] + posStart - P
+        DataCopyAlignGmToUb(kvLeft, mmKvGm_[(uint64_t)xRowL * mmKvStride0_], rowCnt, headDim_,
+                            mmKvStride0_, headDim_);
+        DataCopyAlignGmToUb(scoreLeft, mmScoreGm_[(uint64_t)xRowL * mmScoreStride0_], rowCnt, headDim_,
+                            mmScoreStride0_, headDim_);
+        SetFlag<HardEvent::MTE2_V>(evtMte2ToVWin_);
+        WaitFlag<HardEvent::MTE2_V>(evtMte2ToVWin_);
+        Cast(kvDst, kvLeft, RoundMode::CAST_NONE, rowCnt * headDim_);
+        Cast(scoreDst, scoreLeft, RoundMode::CAST_NONE, rowCnt * headDim_);
+        PipeBarrier<PIPE_V>();
+        for (uint32_t j = 0; j < rowCnt; j++) {
+            uint32_t apeRow = (posStart + j) % cmpRatio_;
+            Add(scoreDst[j * headDim_], scoreDst[j * headDim_], apeUb[apeRow * rowLen_], headDim_);
+        }
+        PipeBarrier<PIPE_V>();
+    }
+
+    // 从分页 state 读历史行（fp32，coffHalf: 0=coff0, 1=coff1；stateIdx: 0=kv, 1=score）
+    __aicore__ inline void ReadStateRows(const LocalTensor<float> &dst, uint32_t rowCnt, uint32_t posStart,
+                                         uint32_t coffHalf, uint32_t stateIdx, const GroupInfo &g)
+    {
+        uint32_t p = posStart;
+        uint32_t done = 0;
+        while (done < rowCnt) {
+            uint32_t blk = p / blockSize_;
+            uint32_t rowInBlk = p % blockSize_;
+            int32_t blockId = sbtGm_.GetValue(g.bIdx * maxBlockNumPerBatch_ + blk);
+            uint32_t seg = blockSize_ - rowInBlk;
+            if (done + seg > rowCnt) {
+                seg = rowCnt - done;
+            }
+            uint64_t srcOff = (uint64_t)blockId * stateStride0_ + rowInBlk * stateRowLen_ + stateIdx * rowLen_ +
+                              coffHalf * headDim_;
+            DataCopyAlignGmToUb(dst[done * headDim_], stateGm_[srcOff], seg, headDim_, stateRowLen_, headDim_);
+            done += seg;
+            p += seg;
+        }
+    }
+
+    // 写本组 token 到分页 state（fp32 全行 rowLen 列；blockId==0 跳过）
+    __aicore__ inline void SaveState(const LocalTensor<float> &src, const GroupInfo &g, uint32_t stateIdx)
+    {
+        uint32_t p = g.tokStart;
+        uint32_t done = 0;
+        while (done < g.nTok) {
+            uint32_t blk = p / blockSize_;
+            uint32_t rowInBlk = p % blockSize_;
+            int32_t blockId = sbtGm_.GetValue(g.bIdx * maxBlockNumPerBatch_ + blk);
+            uint32_t seg = blockSize_ - rowInBlk;
+            if (done + seg > g.nTok) {
+                seg = g.nTok - done;
+            }
+            if (blockId != 0) {
+                uint64_t dstOff =
+                    (uint64_t)blockId * stateStride0_ + rowInBlk * stateRowLen_ + stateIdx * rowLen_;
+                DataCopyAlignUbToGm(stateGm_[dstOff], src[done * rowLen_], seg, rowLen_, rowLen_, stateRowLen_);
+            }
+            done += seg;
+            p += seg;
+        }
+    }
+
+    TPipe *pipe_ = nullptr;
+    GroupIterator iter_;
+
+    GlobalTensor<T> mmKvGm_;
+    GlobalTensor<T> mmScoreGm_;
+    GlobalTensor<float> stateGm_;
+    GlobalTensor<float> apeGm_;
+    GlobalTensor<T_NORM> normWeightGm_;
+    GlobalTensor<T_ROPE> ropeSinGm_;
+    GlobalTensor<T_ROPE> ropeCosGm_;
+    GlobalTensor<int32_t> sbtGm_;
+    GlobalTensor<T> cmpKvOutGm_;
+
+    TBuf<TPosition::VECCALC> apeBuf_;
+    TBuf<TPosition::VECCALC> kvStageBuf0_;
+    TBuf<TPosition::VECCALC> kvStageBuf1_;
+    TBuf<TPosition::VECCALC> scoreStageBuf0_;
+    TBuf<TPosition::VECCALC> scoreStageBuf1_;
+    TBuf<TPosition::VECCALC> kvCurBuf0_;
+    TBuf<TPosition::VECCALC> kvCurBuf1_;
+    TBuf<TPosition::VECCALC> scoreCurBuf0_;
+    TBuf<TPosition::VECCALC> scoreCurBuf1_;
+    TBuf<TPosition::VECCALC> kvWinBuf_;
+    TBuf<TPosition::VECCALC> scoreWinBuf_;
+    TBuf<TPosition::VECCALC> tmpBuf_;
+    TBuf<TPosition::VECCALC> cmpAccumBuf_;
+    TBuf<TPosition::VECCALC> outStageBuf0_;
+    TBuf<TPosition::VECCALC> outStageBuf1_;
+    TBuf<TPosition::VECCALC> kvLeftBuf_;
+    TBuf<TPosition::VECCALC> scoreLeftBuf_;
+    TBuf<TPosition::VECCALC> gammaBuf_;
+    TBuf<TPosition::VECCALC> ropeStageBuf_;
+    TBuf<TPosition::VECCALC> gatherOffsetBuf_;
+
+    event_t evtMte2ToV_;
+    event_t evtVToMte3_;
+    event_t eventIdVToMTE2_[2];
+    event_t eventIdMTE3ToV_[2];
+    event_t evtVToMte2Win_;
+    event_t evtMte2ToVWin_;
+    event_t evtSToV_;
+
+    uint32_t batchSize_ = 0;
+    uint32_t headDim_ = 0;
+    uint32_t cmpRatio_ = 0;
+    uint32_t blockSize_ = 0;
+    uint32_t maxBlockNumPerBatch_ = 0;
+    uint64_t stateStride0_ = 0;
+    uint32_t mmKvStride0_ = 0;
+    uint32_t mmScoreStride0_ = 0;
+    uint32_t rowLen_ = 0;
+    uint32_t stateRowLen_ = 0;
+    uint32_t taskStart_ = 0;
+    uint32_t taskEnd_ = 0;
+    uint32_t compressedCnt_ = 0;
+    uint32_t accSlots_ = 0;
+    uint32_t ropeHeadDim_ = 0;
+    uint32_t rotaryMode_ = 0;
+    float normEps_ = 1e-6f;
+};
+
+} // namespace CompressNormRope
+
+#endif // COMPRESS_NORM_ROPE_KERNEL_C4_H

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_template_tiling_key.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_template_tiling_key.h
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+#ifndef COMPRESS_NORM_ROPE_TEMPLATE_TILING_KEY_H
+#define COMPRESS_NORM_ROPE_TEMPLATE_TILING_KEY_H
+
+#include "ascendc/host_api/tiling/template_argument.h"
+
+#define CNR_TPL_FP32 0
+#define CNR_TPL_FP16 1
+#define CNR_TPL_BF16 27
+#define CNR_TPL_2_BW 2
+
+ASCENDC_TPL_ARGS_DECL(
+    compress_norm_rope,
+    ASCENDC_TPL_DTYPE_DECL(X_T, CNR_TPL_FP16, CNR_TPL_BF16),
+    ASCENDC_TPL_DTYPE_DECL(NORM_T, CNR_TPL_FP16, CNR_TPL_BF16),
+    ASCENDC_TPL_DTYPE_DECL(ROPE_T, CNR_TPL_FP32, CNR_TPL_FP16, CNR_TPL_BF16),
+    ASCENDC_TPL_UINT_DECL(COFF, CNR_TPL_2_BW, ASCENDC_TPL_UI_LIST, 1, 2),
+    ASCENDC_TPL_BOOL_DECL(EMPTY_X, 0, 1),
+);
+
+ASCENDC_TPL_SEL(
+    ASCENDC_TPL_ARGS_SEL(
+        ASCENDC_TPL_DTYPE_SEL(X_T, CNR_TPL_BF16),
+        ASCENDC_TPL_DTYPE_SEL(NORM_T, CNR_TPL_BF16),
+        ASCENDC_TPL_DTYPE_SEL(ROPE_T, CNR_TPL_BF16),
+        ASCENDC_TPL_UINT_SEL(COFF, ASCENDC_TPL_UI_LIST, 1, 2),
+        ASCENDC_TPL_BOOL_SEL(EMPTY_X, 0, 1),
+        ASCENDC_TPL_TILING_STRUCT_SEL(optiling::CompressNormRopeTilingData)),
+    ASCENDC_TPL_ARGS_SEL(
+        ASCENDC_TPL_DTYPE_SEL(X_T, CNR_TPL_BF16),
+        ASCENDC_TPL_DTYPE_SEL(NORM_T, CNR_TPL_BF16),
+        ASCENDC_TPL_DTYPE_SEL(ROPE_T, CNR_TPL_FP32),
+        ASCENDC_TPL_UINT_SEL(COFF, ASCENDC_TPL_UI_LIST, 1, 2),
+        ASCENDC_TPL_BOOL_SEL(EMPTY_X, 0, 1),
+        ASCENDC_TPL_TILING_STRUCT_SEL(optiling::CompressNormRopeTilingData)),
+    ASCENDC_TPL_ARGS_SEL(
+        ASCENDC_TPL_DTYPE_SEL(X_T, CNR_TPL_FP16),
+        ASCENDC_TPL_DTYPE_SEL(NORM_T, CNR_TPL_FP16),
+        ASCENDC_TPL_DTYPE_SEL(ROPE_T, CNR_TPL_FP16),
+        ASCENDC_TPL_UINT_SEL(COFF, ASCENDC_TPL_UI_LIST, 1, 2),
+        ASCENDC_TPL_BOOL_SEL(EMPTY_X, 0, 1),
+        ASCENDC_TPL_TILING_STRUCT_SEL(optiling::CompressNormRopeTilingData)),
+    ASCENDC_TPL_ARGS_SEL(
+        ASCENDC_TPL_DTYPE_SEL(X_T, CNR_TPL_FP16),
+        ASCENDC_TPL_DTYPE_SEL(NORM_T, CNR_TPL_FP16),
+        ASCENDC_TPL_DTYPE_SEL(ROPE_T, CNR_TPL_FP32),
+        ASCENDC_TPL_UINT_SEL(COFF, ASCENDC_TPL_UI_LIST, 1, 2),
+        ASCENDC_TPL_BOOL_SEL(EMPTY_X, 0, 1),
+        ASCENDC_TPL_TILING_STRUCT_SEL(optiling::CompressNormRopeTilingData)),
+);
+
+#endif // COMPRESS_NORM_ROPE_TEMPLATE_TILING_KEY_H

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_tiling_data.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_tiling_data.h
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_tiling_data.h
+ * \brief CompressNormRope tiling data（arch22 两阶段重构版，扁平结构，kernel/host 共用）
+ *
+ * C4（coff=2）按"组"均分任务；C128（coff=1）按"组×dChunk"均分任务 + workspace 中转两阶段。
+ */
+
+#ifndef COMPRESS_NORM_ROPE_TILING_DATA_H
+#define COMPRESS_NORM_ROPE_TILING_DATA_H
+#include <cstdint>
+
+namespace optiling {
+
+struct CompressNormRopeTilingData {
+    uint32_t batchSize = 0;             // B = cu_seqlens.dim(0) - 1
+    uint32_t tokenSize = 0;             // T = mm_kv.dim(0)
+    uint32_t headDim = 0;               // D = mm_kv.dim(1) / coff
+    uint32_t cmpRatio = 0;              // r: 4 (coff=2) | 128 (coff=1)
+    uint32_t usedCoreNum = 0;           // blockDim = aivNum
+    uint32_t blockSize = 0;             // state_cache 分页块行数（c4=8, c128=32）
+    uint32_t maxBlockNumPerBatch = 0;   // state_block_table.dim(1)
+    uint32_t stateCacheStrideDim0 = 0;  // state_cache 第 0 维 stride（元素数）；与 ref 一致用 uint32 避免 uint64 跨编译器对齐不一致
+    uint32_t mmKvStrideDim0 = 0;        // mm_kv 第 0 维 stride（元素数），支持 fused GEMM 输出切片
+    uint32_t mmScoreStrideDim0 = 0;     // mm_score 第 0 维 stride（元素数），支持 fused GEMM 输出切片
+    uint32_t dChunkSize = 0;            // c128 的 d 分块列数（64）；c4 = headDim
+    uint32_t dChunkNum = 0;             // headDim / dChunkSize（c4 = 1）
+    uint32_t maxGroupTaskNum = 0;       // 组数上界 = T/r + 2B（start_pos 未对齐跨组）
+    uint32_t maxTaskNum = 0;            // maxGroupTaskNum * dChunkNum
+    uint32_t taskPerCore = 0;           // maxTaskNum / usedCoreNum
+    uint32_t taskRem = 0;               // maxTaskNum % usedCoreNum
+    uint32_t ropeHeadDim = 0;           // rope 维度（生产=64），作用于行尾 [headDim-ropeHeadDim, headDim)
+    uint32_t rotaryMode = 0;            // 1=HALF | 2=INTERLEAVE（生产=2）
+    float normEps = 1e-6f;              // rms_norm eps
+    uint32_t maxScNum = 0;              // 压缩行数上界 = min(T, T/r + B)（c128 workspace 行数/二阶段分行）
+};
+
+} // namespace optiling
+
+#endif // COMPRESS_NORM_ROPE_TILING_DATA_H

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_tiling_data.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_tiling_data.h
@@ -10,7 +10,7 @@
 
 /*!
  * \file compress_norm_rope_tiling_data.h
- * \brief CompressNormRope tiling data（arch22 两阶段重构版，扁平结构，kernel/host 共用）
+ * \brief CompressNormRope tiling data（A2/A3 两阶段重构版，扁平结构，kernel/host 共用）
  *
  * C4（coff=2）按"组"均分任务；C128（coff=1）按"组×dChunk"均分任务 + workspace 中转两阶段。
  */

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_tools.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_tools.h
@@ -1,0 +1,196 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_tools.h
+ * \brief 组迭代器：把"全局压缩组序号"映射到 (batch, 组内序号)，并维护 compressedCnt
+ *
+ * 设计要点（相对 fused compressor 的 slice 迭代器的简化）：
+ *   - 任务配额直接以"组"为单位（fused 以 token 行为单位 + tailH/空洞对齐，~300 行）；
+ *   - seqused 空洞语义自然包含：组覆盖 [P, P+seqUsed) 之外无工作；
+ *   - 全部标量计算，每核一次 Locate + 逐组 Next。
+ *
+ * 每 batch b（start_pos=P, seq_used=S）：
+ *   gBase       = P / r                       （首个工作组的全局组号）
+ *   workGroups  = CeilDiv(P+S, r) - gBase     （工作组数 = 本核可能处理的组数）
+ *   compGroups  = (P+S) / r - gBase           （实际产出行数 = 完整覆盖的组数）
+ *   工作组 w（0 基）：gStart = (gBase+w)*r
+ *     tokStart  = max(gStart, P)              （本 call 首个 token 的全局位置）
+ *     nTok      = min(gStart+r, P+S) - tokStart
+ *     headHolder= tokStart - gStart           （窗口前部来自 state 的历史行数）
+ *     produce   = (gStart + r <= P + S)
+ */
+
+#ifndef COMPRESS_NORM_ROPE_TOOLS_H
+#define COMPRESS_NORM_ROPE_TOOLS_H
+
+#include "compress_norm_rope_comm.h"
+
+namespace CompressNormRope {
+
+struct GroupInfo {
+    uint32_t bIdx = 0;
+    uint32_t gStart = 0;     // 组起始全局位置（r 对齐）
+    uint32_t tokStart = 0;   // 本 call 首个 token 全局位置
+    uint32_t nTok = 0;       // 本组本 call token 数
+    uint32_t headHolder = 0; // 窗口前部历史行数（仅每 batch 首组可能 > 0）
+    uint32_t P = 0;          // start_pos
+    uint32_t xRow = 0;       // 本组首个 token 在 mm GM 中的行号
+    bool produce = false;    // 是否产出压缩行
+};
+
+class GroupIterator {
+public:
+    __aicore__ inline void Init(__gm__ uint8_t *cuSeqlens, __gm__ uint8_t *seqUsed, __gm__ uint8_t *startPos,
+                                uint32_t batchSize, uint32_t cmpRatio)
+    {
+        cuSeqlensGm_.SetGlobalBuffer((__gm__ int32_t *)cuSeqlens);
+        isExistSeqUsed_ = (seqUsed != nullptr);
+        if (isExistSeqUsed_) {
+            seqUsedGm_.SetGlobalBuffer((__gm__ int32_t *)seqUsed);
+        }
+        isExistStartPos_ = (startPos != nullptr);
+        if (isExistStartPos_) {
+            startPosGm_.SetGlobalBuffer((__gm__ int32_t *)startPos);
+        }
+        batchSize_ = batchSize;
+        cmpRatio_ = cmpRatio;
+    }
+
+    // 定位到全局组序号 targetGroup（0 基，跨 batch 按序展开），
+    // 返回该组之前已产出的压缩行数（= 该组的输出行号）。
+    // 同时把迭代器游标置于该组（bIdx_/wIdx_），并返回前置 compressedCnt。
+    __aicore__ inline uint32_t Locate(uint32_t targetGroup)
+    {
+        groupAcc_ = 0;
+        compAcc_ = 0;
+        bIdx_ = 0;
+        wIdx_ = 0;
+        LoadBatch(0);
+        while (bIdx_ < batchSize_) {
+            if (workGroups_ > 0 && targetGroup < groupAcc_ + workGroups_) {
+                wIdx_ = targetGroup - groupAcc_;
+                return CompCntBefore();
+            }
+            groupAcc_ += workGroups_;
+            compAcc_ += compGroups_;
+            LoadBatch(bIdx_ + 1);
+        }
+        // targetGroup 越界（超出实际总组数）：游标置于末尾，无工作
+        wIdx_ = workGroups_;
+        return compAcc_;
+    }
+
+    // 当前组的 compressedCnt（输出行号）
+    __aicore__ inline uint32_t CompCntBefore() const
+    {
+        uint32_t inBatch = wIdx_ < compGroups_ ? wIdx_ : compGroups_;
+        return compAcc_ + inBatch;
+    }
+
+    __aicore__ inline bool IsEnd() const
+    {
+        return bIdx_ >= batchSize_ || wIdx_ >= workGroups_;
+    }
+
+    // 当前组信息
+    __aicore__ inline void GetGroupInfo(GroupInfo &info) const
+    {
+        uint32_t gStart = (gBase_ + wIdx_) * cmpRatio_;
+        uint32_t tokStart = gStart > P_ ? gStart : P_;
+        uint32_t tokEnd = gStart + cmpRatio_ < P_ + S_ ? gStart + cmpRatio_ : P_ + S_;
+        info.bIdx = bIdx_;
+        info.gStart = gStart;
+        info.tokStart = tokStart;
+        info.nTok = tokEnd > tokStart ? tokEnd - tokStart : 0;
+        info.headHolder = tokStart - gStart;
+        info.P = P_;
+        info.xRow = cuStart_ + (tokStart - P_);
+        info.produce = (gStart + cmpRatio_ <= P_ + S_) && (info.nTok > 0);
+    }
+
+    // 前进一个工作组（跨 batch 时跳到下一个有工作的 batch）
+    __aicore__ inline void Next()
+    {
+        wIdx_++;
+        while (bIdx_ < batchSize_ && wIdx_ >= workGroups_) {
+            groupAcc_ += workGroups_;
+            compAcc_ += compGroups_;
+            LoadBatch(bIdx_ + 1);
+            wIdx_ = 0;
+        }
+    }
+
+    __aicore__ inline uint32_t GetBIdx() const
+    {
+        return bIdx_;
+    }
+
+    __aicore__ inline uint32_t GetStartPos() const
+    {
+        return P_;
+    }
+
+private:
+    __aicore__ inline void LoadBatch(uint32_t bIdx)
+    {
+        bIdx_ = bIdx;
+        workGroups_ = 0;
+        compGroups_ = 0;
+        P_ = 0;
+        S_ = 0;
+        gBase_ = 0;
+        while (bIdx_ < batchSize_) {
+            cuStart_ = (uint32_t)cuSeqlensGm_.GetValue(bIdx_);
+            S_ = isExistSeqUsed_ ? (uint32_t)seqUsedGm_.GetValue(bIdx_)
+                                 : (uint32_t)(cuSeqlensGm_.GetValue(bIdx_ + 1) - cuStart_);
+            P_ = isExistStartPos_ ? (uint32_t)startPosGm_.GetValue(bIdx_) : 0;
+            gBase_ = P_ / cmpRatio_;
+            // S==0 的 batch 无任何工作（其唯一工作组 nTok=0 是纯 no-op），直接跳过，
+            // 避免产生 phantom 组（nTok==0 会打断 ping-pong buffer 配对链）
+            if (S_ == 0) {
+                workGroups_ = 0;
+                compGroups_ = 0;
+                bIdx_++;
+                continue;
+            }
+            workGroups_ = CeilDivT(P_ + S_, cmpRatio_) - gBase_;
+            compGroups_ = (P_ + S_) / cmpRatio_ - gBase_;
+            if (workGroups_ > 0) {
+                return;
+            }
+            bIdx_++;
+        }
+    }
+
+    GlobalTensor<int32_t> cuSeqlensGm_;
+    GlobalTensor<int32_t> seqUsedGm_;
+    GlobalTensor<int32_t> startPosGm_;
+    bool isExistSeqUsed_ = false;
+    bool isExistStartPos_ = false;
+    uint32_t batchSize_ = 0;
+    uint32_t cmpRatio_ = 0;
+
+    // 游标
+    uint32_t bIdx_ = 0;
+    uint32_t wIdx_ = 0;
+    uint32_t P_ = 0;
+    uint32_t S_ = 0;
+    uint32_t gBase_ = 0;
+    uint32_t workGroups_ = 0;
+    uint32_t compGroups_ = 0;
+    uint32_t groupAcc_ = 0;
+    uint32_t compAcc_ = 0;
+    uint32_t cuStart_ = 0;
+};
+
+} // namespace CompressNormRope
+
+#endif // COMPRESS_NORM_ROPE_TOOLS_H

--- a/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_vector_comm.h
+++ b/csrc/attention/compress_norm_rope/op_kernel/arch32/compress_norm_rope_vector_comm.h
@@ -1,0 +1,392 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ */
+
+/*!
+ * \file compress_norm_rope_vector_comm.h
+ * \brief vector 公共组件：ColumnSoftMax/ColumnSum/RmsNorm/RoPE
+ */
+
+#ifndef COMPRESS_NORM_ROPE_VECTOR_COMM_H
+#define COMPRESS_NORM_ROPE_VECTOR_COMM_H
+
+#include "compress_norm_rope_comm.h"
+
+namespace CompressNormRope {
+
+struct MatRepeatParam {
+    uint32_t row;
+    uint32_t col;
+    uint32_t dtypeMask;
+    uint32_t loopTimes;
+    uint32_t colRemain;
+    uint8_t repeatStride;
+};
+
+/**
+ * @brief ColumnSum 对矩阵按列进行求和
+ * @param dstLocal 输出tensor [1, col]，支持和shareTmpUb是同一块空间
+ * @param srcLocal 输入tensor [row, col]
+ * @param shareTmpUb 临时buffer 内部需要的空间为 [ceil(row / 2) * col * sizeof(float)]
+ */
+__aicore__ inline void ColumnSum(const LocalTensor<float> &dstLocal, const LocalTensor<float> &srcLocal,
+                                 const LocalTensor<float> &shareTmpUb, uint32_t row, uint32_t col)
+{
+    if (unlikely(row == 1)) {
+        DataCopy(dstLocal, srcLocal, row * col);
+        PipeBarrier<PIPE_V>();
+        return;
+    }
+    for (uint32_t mask = MAX_R << 1; mask > 1; mask >>= 1) {
+        if (row & mask) {
+            Add(shareTmpUb, srcLocal, srcLocal[mask * col / 2], mask * col / 2); // 2:对矩阵按列做计算
+            PipeBarrier<PIPE_V>();
+            if (unlikely(row > mask)) {
+                if ((row - mask) > (mask >> 1)) {
+                    Add(shareTmpUb, shareTmpUb, srcLocal[mask * col], mask * col / 2); // 2:对矩阵按列做计算
+                    PipeBarrier<PIPE_V>();
+                    Add(shareTmpUb, shareTmpUb, srcLocal[(mask + (mask >> 1)) * col], (row - mask - (mask >> 1)) * col);
+                    PipeBarrier<PIPE_V>();
+                } else {
+                    Add(shareTmpUb, shareTmpUb, srcLocal[mask * col], (row - mask) * col);
+                    PipeBarrier<PIPE_V>();
+                }
+            }
+            for (uint32_t i = mask >> 2; i > 1; i >>= 1) {
+                Add(shareTmpUb, shareTmpUb, shareTmpUb[i * col], i * col);
+                PipeBarrier<PIPE_V>();
+            }
+            if (mask == 2) { // 2:最后一次矩阵运算处理
+                DataCopy(dstLocal, shareTmpUb, col);
+            } else {
+                Add(dstLocal, shareTmpUb, shareTmpUb[col], col);
+            }
+            PipeBarrier<PIPE_V>();
+            break;
+        }
+    }
+}
+
+/**
+ * @brief ColumnMax 对矩阵按列进行求最大值
+ * @param dstLocal 输出tensor [1, col]，支持和shareTmpUb是同一块空间
+ * @param srcLocal 输入tensor [row, col]
+ * @param shareTmpUb 临时buffer 内部需要的空间为 [ceil(row / 2) * col * sizeof(float)]
+ */
+__aicore__ inline void ColumnMax(const LocalTensor<float> &dstLocal, const LocalTensor<float> &srcLocal,
+                                 const LocalTensor<float> &shareTmpUb, uint32_t row, uint32_t col)
+{
+    if (unlikely(row == 1)) {
+        DataCopy(dstLocal, srcLocal, row * col);
+        PipeBarrier<PIPE_V>();
+        return;
+    }
+    for (uint32_t mask = MAX_R << 1; mask > 1; mask >>= 1) {
+        if (row & mask) {
+            Max(shareTmpUb, srcLocal, srcLocal[mask * col / 2], mask * col / 2); // 2:对矩阵按列做计算
+            PipeBarrier<PIPE_V>();
+            if (unlikely(row > mask)) {
+                if ((row - mask) > (mask >> 1)) {
+                    Max(shareTmpUb, shareTmpUb, srcLocal[mask * col], mask * col / 2); // 2:对矩阵按列做计算
+                    PipeBarrier<PIPE_V>();
+                    Max(shareTmpUb, shareTmpUb, srcLocal[(mask + (mask >> 1)) * col], (row - mask - (mask >> 1)) * col);
+                    PipeBarrier<PIPE_V>();
+                } else {
+                    Max(shareTmpUb, shareTmpUb, srcLocal[mask * col], (row - mask) * col);
+                    PipeBarrier<PIPE_V>();
+                }
+            }
+            for (uint32_t i = mask >> 2; i > 1; i >>= 1) {
+                Max(shareTmpUb, shareTmpUb, shareTmpUb[i * col], i * col);
+                PipeBarrier<PIPE_V>();
+            }
+            if (mask == 2) { // 2:最后一次矩阵运算处理
+                DataCopy(dstLocal, shareTmpUb, col);
+            } else {
+                Max(dstLocal, shareTmpUb, shareTmpUb[col], col);
+            }
+            PipeBarrier<PIPE_V>();
+            break;
+        }
+    }
+}
+
+/**
+ * @brief MatSubVec 矩阵逐行减向量
+ */
+__aicore__ inline void MatSubVec(const LocalTensor<float> &dstLocal, const LocalTensor<float> &src0Local,
+                                 const LocalTensor<float> &src1Local, const MatRepeatParam &repeatParam)
+{
+    for (uint32_t row = 0; row < repeatParam.row; row += REPEAT_MAX_NUM) {
+        uint32_t repeatRowTimes = Std::min(repeatParam.row - row, REPEAT_MAX_NUM);
+        uint32_t offset = 0;
+        for (uint32_t i = 0; i < repeatParam.loopTimes; i++) {
+            Sub(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local[offset],
+                repeatParam.dtypeMask, repeatRowTimes,
+                {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, 0});
+            offset += repeatParam.dtypeMask;
+        }
+        if (repeatParam.colRemain > 0) {
+            Sub(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local[offset],
+                repeatParam.colRemain, repeatRowTimes,
+                {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, 0});
+        }
+    }
+}
+
+/**
+ * @brief MatDivVec 矩阵逐行除以向量
+ */
+__aicore__ inline void MatDivVec(const LocalTensor<float> &dstLocal, const LocalTensor<float> &src0Local,
+                                 const LocalTensor<float> &src1Local, const MatRepeatParam &repeatParam)
+{
+    for (uint32_t row = 0; row < repeatParam.row; row += REPEAT_MAX_NUM) {
+        uint32_t repeatRowTimes = Std::min(repeatParam.row - row, REPEAT_MAX_NUM);
+        uint32_t offset = 0;
+        for (uint32_t i = 0; i < repeatParam.loopTimes; i++) {
+            Div(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local[offset],
+                repeatParam.dtypeMask, repeatRowTimes,
+                {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, 0});
+            offset += repeatParam.dtypeMask;
+        }
+        if (repeatParam.colRemain > 0) {
+            Div(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local[offset],
+                repeatParam.colRemain, repeatRowTimes,
+                {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, 0});
+        }
+    }
+}
+
+/**
+ * @brief ColumnSoftMax 对矩阵按列进行SoftMax
+ * @param dstLocal 输出tensor [row, col]，支持和srcLocal是同一块空间
+ * @param srcLocal 输入tensor [row, col]
+ * @param shareTmpUb 临时buffer 内部需要的空间为 [floor(row / 2) * col * sizeof(float)]
+ */
+__aicore__ inline void ColumnSoftMax(const LocalTensor<float> &dstLocal, const LocalTensor<float> &srcLocal,
+                                     const LocalTensor<float> &shareTmpUb, uint32_t row, uint32_t col)
+{
+    uint32_t dtypeMask = FP32_REPEAT_ELEMENT_NUM;
+    uint32_t dLoop = col / dtypeMask;
+    uint32_t dRemain = col % dtypeMask;
+    uint8_t repeatStride = col / FP32_BLOCK_ELEMENT_NUM;
+    ColumnMax(shareTmpUb, srcLocal, shareTmpUb, row, col);
+    PipeBarrier<PIPE_V>();
+    MatSubVec(dstLocal, srcLocal, shareTmpUb, {row, col, dtypeMask, dLoop, dRemain, repeatStride});
+    PipeBarrier<PIPE_V>();
+    Exp(dstLocal, dstLocal, row * col);
+    PipeBarrier<PIPE_V>();
+    ColumnSum(shareTmpUb, dstLocal, shareTmpUb, row, col);
+    PipeBarrier<PIPE_V>();
+    MatDivVec(dstLocal, dstLocal, shareTmpUb, {row, col, dtypeMask, dLoop, dRemain, repeatStride});
+}
+
+// ───────────────────── RmsNorm / RoPE（压缩行后处理，语义对齐 vllm-ascend）─────────────────────
+
+struct RmsNormParam {
+    float reciprocal; // 1/col
+    float epsilon;
+    uint32_t row;
+    uint32_t col;
+};
+
+// 矩阵逐行乘向量
+__aicore__ inline void MatMulVec(const LocalTensor<float> &dstLocal, const LocalTensor<float> &src0Local,
+                                 const LocalTensor<float> &src1Local, const MatRepeatParam &repeatParam)
+{
+    for (uint32_t row = 0; row < repeatParam.row; row += REPEAT_MAX_NUM) {
+        uint32_t repeatRowTimes = Std::min(repeatParam.row - row, REPEAT_MAX_NUM);
+        uint32_t offset = 0;
+        for (uint32_t i = 0; i < repeatParam.loopTimes; i++) {
+            Mul(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local[offset],
+                repeatParam.dtypeMask, repeatRowTimes,
+                {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, 0});
+            offset += repeatParam.dtypeMask;
+        }
+        if (repeatParam.colRemain > 0) {
+            Mul(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local[offset],
+                repeatParam.colRemain, repeatRowTimes,
+                {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, 0});
+        }
+    }
+}
+
+// 矩阵每行求和；srcLocal 与 shareTmpUb 必须别名同一块空间
+__aicore__ inline void RowSum(const LocalTensor<float> &dstLocal, const LocalTensor<float> &srcLocal,
+                              const LocalTensor<float> &shareTmpUb, const MatRepeatParam &repeatParam)
+{
+    uint32_t blockCount = repeatParam.loopTimes;
+    if (blockCount > 0 && repeatParam.colRemain > 0) {
+        Add(shareTmpUb, srcLocal, srcLocal[blockCount * repeatParam.dtypeMask], repeatParam.colRemain,
+            repeatParam.row,
+            {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, repeatParam.repeatStride});
+        PipeBarrier<PIPE_V>();
+    }
+    for (uint32_t loopCount = blockCount >> 1; loopCount > 0; loopCount = blockCount >> 1) {
+        blockCount = (blockCount + 1) >> 1;
+        for (uint32_t i = 0; i < loopCount; i++) {
+            Add(shareTmpUb[i * repeatParam.dtypeMask], srcLocal[i * repeatParam.dtypeMask],
+                srcLocal[(i + blockCount) * repeatParam.dtypeMask], repeatParam.dtypeMask, repeatParam.row,
+                {1, 1, 1, repeatParam.repeatStride, repeatParam.repeatStride, repeatParam.repeatStride});
+        }
+        PipeBarrier<PIPE_V>();
+    }
+    WholeReduceSum(dstLocal, shareTmpUb,
+                   (repeatParam.col < repeatParam.dtypeMask) ? repeatParam.col : repeatParam.dtypeMask,
+                   repeatParam.row, 1, 1, repeatParam.repeatStride);
+}
+
+// 矩阵每行除以对应元素（src1Local 需扩展到 [row, FP32_BLOCK_ELEMENT_NUM]）
+__aicore__ inline void RowDivs(const LocalTensor<float> &dstLocal, const LocalTensor<float> &src0Local,
+                               const LocalTensor<float> &src1Local, const MatRepeatParam &repeatParam)
+{
+    for (uint32_t row = 0; row < repeatParam.row; row += REPEAT_MAX_NUM) {
+        uint32_t repeatRowTimes = Std::min(repeatParam.row - row, REPEAT_MAX_NUM);
+        uint32_t offset = 0;
+        for (uint32_t i = 0; i < repeatParam.loopTimes; i++) {
+            Div(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local,
+                repeatParam.dtypeMask, repeatRowTimes,
+                {1, 1, 0, repeatParam.repeatStride, repeatParam.repeatStride, 1});
+            offset += repeatParam.dtypeMask;
+        }
+        if (repeatParam.colRemain > 0) {
+            Div(dstLocal[row * repeatParam.col + offset], src0Local[row * repeatParam.col + offset], src1Local,
+                repeatParam.colRemain, repeatRowTimes,
+                {1, 1, 0, repeatParam.repeatStride, repeatParam.repeatStride, 1});
+        }
+    }
+}
+
+// RmsNorm：dst = src / sqrt(mean(src^2)+eps) * gamma
+// shareTmpUb 需要 [(row*col + row) * sizeof(float)]；dst/src 可同空间
+__aicore__ inline void RmsNorm(const LocalTensor<float> &dstLocal, const LocalTensor<float> &srcLocal,
+                               const LocalTensor<float> &gammaLocal, const LocalTensor<float> &shareTmpUb,
+                               const RmsNormParam &rmsNormParams)
+{
+    uint64_t cnt = rmsNormParams.row * rmsNormParams.col;
+    LocalTensor<float> temp1Local = shareTmpUb.ReinterpretCast<float>();
+    LocalTensor<float> temp2Local = temp1Local[cnt];
+
+    Mul(temp1Local, srcLocal, srcLocal, cnt);
+    PipeBarrier<PIPE_V>();
+
+    MatRepeatParam repeatParams = {
+        rmsNormParams.row,                                          // row
+        rmsNormParams.col,                                          // col
+        FP32_REPEAT_ELEMENT_NUM,                                    // dtypeMask
+        rmsNormParams.col / FP32_REPEAT_ELEMENT_NUM,                // loopTimes
+        rmsNormParams.col % FP32_REPEAT_ELEMENT_NUM,                // colRemain
+        static_cast<uint8_t>(rmsNormParams.col / FP32_BLOCK_ELEMENT_NUM), // repeatStride
+    };
+
+    RowSum(temp2Local, temp1Local, temp1Local, repeatParams);
+    PipeBarrier<PIPE_V>();
+    Muls(temp2Local, temp2Local, rmsNormParams.reciprocal, rmsNormParams.row);
+    PipeBarrier<PIPE_V>();
+    Adds(temp2Local, temp2Local, rmsNormParams.epsilon, rmsNormParams.row);
+    PipeBarrier<PIPE_V>();
+    Sqrt(temp2Local, temp2Local, rmsNormParams.row);
+    PipeBarrier<PIPE_V>();
+    Brcb(temp1Local, temp2Local, CeilDivT(rmsNormParams.row, BRCB_NUM), {1, BRCB_NUM});
+    PipeBarrier<PIPE_V>();
+    RowDivs(dstLocal, srcLocal, temp1Local, repeatParams);
+    PipeBarrier<PIPE_V>();
+    MatMulVec(dstLocal, dstLocal, gammaLocal, repeatParams);
+}
+
+// INTERLEAVE 模式的 Gather 偏移
+// offset[i] = (i ^ 1) * sizeof(float)；evtSToV 为调用方分配的固定 S_V 事件 id（Set/Wait 各一次）
+template <typename T>
+__aicore__ inline void SetGatherSrcOffset(const LocalTensor<int32_t> &gatherOffsetLocal, uint32_t count,
+                                          event_t evtSToV)
+{
+    for (uint32_t i = 0; i < 8; i++) {
+        gatherOffsetLocal.SetValue(i, i ^ 1);
+    }
+    SetFlag<HardEvent::S_V>(evtSToV);
+    WaitFlag<HardEvent::S_V>(evtSToV);
+
+    int32_t scalarValue = 8;
+    while (scalarValue < (int32_t)count) {
+        int32_t nextValue = scalarValue * 2;
+        PipeBarrier<PIPE_V>();
+        if (nextValue < (int32_t)count) {
+            Adds(gatherOffsetLocal[scalarValue], gatherOffsetLocal, scalarValue, scalarValue);
+        } else {
+            Adds(gatherOffsetLocal[scalarValue], gatherOffsetLocal, scalarValue, count - scalarValue);
+            break;
+        }
+        scalarValue = nextValue;
+    }
+    PipeBarrier<PIPE_V>();
+    Muls(gatherOffsetLocal, gatherOffsetLocal, static_cast<int32_t>(sizeof(T)), count);
+}
+
+// 对 [row, actualCol] 的 [baseAddr, baseAddr+col) 段做 RoPE
+// shareTmpUb 需要 [row * col * sizeof(float)]；dst/src 可同空间
+template <ROTARY_MODE MODE>
+__aicore__ inline void RotaryPosEmb(const LocalTensor<float> &dstLocal, const LocalTensor<float> &srcLocal,
+                                    const LocalTensor<float> &cosLocal, const LocalTensor<float> &sinLocal,
+                                    const LocalTensor<float> &shareTmpUb,
+                                    const LocalTensor<uint32_t> &gatherOffsetcastLocal, uint32_t row, uint32_t col,
+                                    uint32_t actualCol, uint64_t baseAddr)
+{
+    uint64_t cnt = row * col;
+    uint32_t halfCol = col >> 1;
+    LocalTensor<float> reArrLocal = shareTmpUb.ReinterpretCast<float>();
+    if constexpr (MODE == ROTARY_MODE::HALF) {
+        DataCopy(reArrLocal, srcLocal[baseAddr + halfCol],
+                 {static_cast<uint16_t>(row), static_cast<uint16_t>(CeilDivT(halfCol, FP32_BLOCK_ELEMENT_NUM)),
+                  static_cast<uint16_t>(CeilDivT(actualCol - halfCol, FP32_BLOCK_ELEMENT_NUM)),
+                  static_cast<uint16_t>(CeilDivT(halfCol, FP32_BLOCK_ELEMENT_NUM))});
+        DataCopy(reArrLocal[halfCol], srcLocal[baseAddr],
+                 {static_cast<uint16_t>(row), static_cast<uint16_t>(CeilDivT(halfCol, FP32_BLOCK_ELEMENT_NUM)),
+                  static_cast<uint16_t>(CeilDivT(actualCol - halfCol, FP32_BLOCK_ELEMENT_NUM)),
+                  static_cast<uint16_t>(CeilDivT(halfCol, FP32_BLOCK_ELEMENT_NUM))});
+        PipeBarrier<PIPE_V>();
+        Muls(reArrLocal, reArrLocal, float(-1), halfCol, row,
+             {1, 1, static_cast<uint8_t>(CeilDivT(static_cast<uint32_t>(col), FP32_BLOCK_ELEMENT_NUM)),
+              static_cast<uint8_t>(CeilDivT(static_cast<uint32_t>(col), FP32_BLOCK_ELEMENT_NUM))});
+    } else if constexpr (MODE == ROTARY_MODE::INTERLEAVE) {
+        for (uint32_t i = 0; i < row; i++) {
+            Gather(reArrLocal[i * col], srcLocal[i * actualCol + baseAddr], gatherOffsetcastLocal, 0, col);
+        }
+        PipeBarrier<PIPE_V>();
+        uint32_t repeatTimes = cnt / FP32_REPEAT_ELEMENT_NUM;
+        uint32_t remainder = cnt % FP32_REPEAT_ELEMENT_NUM;
+        uint64_t fullMask = 0x5555555555555555;
+        uint64_t partialMask = 0x55;
+        SetVectorMask<float, MaskMode::NORMAL>(0, fullMask);
+        Muls<float, false>(reArrLocal, reArrLocal, float(-1), MASK_PLACEHOLDER, repeatTimes,
+                           {1, 1, FP32_BLOCK_ELEMENT_NUM, FP32_BLOCK_ELEMENT_NUM});
+        if (unlikely(remainder > 0)) {
+            SetVectorMask<float, MaskMode::NORMAL>(0, partialMask);
+            Muls<float, false>(reArrLocal[repeatTimes * FP32_REPEAT_ELEMENT_NUM],
+                               reArrLocal[repeatTimes * FP32_REPEAT_ELEMENT_NUM], float(-1), MASK_PLACEHOLDER,
+                               remainder / FP32_BLOCK_ELEMENT_NUM, {1, 1, 1, 1});
+        }
+        ResetMask();
+    }
+
+    PipeBarrier<PIPE_V>();
+    BinaryRepeatParams computeParams{1,
+                                     1,
+                                     1,
+                                     static_cast<uint8_t>(CeilDivT(actualCol, FP32_BLOCK_ELEMENT_NUM)),
+                                     static_cast<uint8_t>(CeilDivT(actualCol, FP32_BLOCK_ELEMENT_NUM)),
+                                     static_cast<uint8_t>(CeilDivT(col, FP32_BLOCK_ELEMENT_NUM))};
+    Mul(dstLocal[baseAddr], srcLocal[baseAddr], cosLocal, col, row, computeParams);
+    Mul(reArrLocal, reArrLocal, sinLocal, cnt);
+    PipeBarrier<PIPE_V>();
+    Add(dstLocal[baseAddr], dstLocal[baseAddr], reArrLocal, col, row, computeParams);
+}
+
+} // namespace CompressNormRope
+
+#endif // COMPRESS_NORM_ROPE_VECTOR_COMM_H

--- a/csrc/attention/compress_norm_rope/op_kernel/compress_norm_rope.cpp
+++ b/csrc/attention/compress_norm_rope/op_kernel/compress_norm_rope.cpp
@@ -17,7 +17,7 @@
  *        本算子只做 ape + softmax gate + 加权压缩 + state 递归 + rms_norm + rope。
  *        输入 mm_kv / mm_score 为 [tokenSize, coff*headDim] 的 bf16/fp16 GEMM 结果。
  *
- * arch22（910B）两阶段实现：
+ * A2/A3 两阶段实现：
  *   - C4（coff=2, cmpRatio=4）：组流式 + 双缓冲流水，UB 内融合 RmsNorm/RoPE/cast（无 SyncAll）
  *   - C128（coff=1, cmpRatio=128）：d 分块压缩 → GM workspace → SyncAll
  *     → 完整行高精度 RmsNorm/RoPE/cast
@@ -31,7 +31,7 @@
 #include "arch32/compress_norm_rope_kernel_c4.h"
 #include "arch32/compress_norm_rope_kernel_c128.h"
 #else
-#error "compress_norm_rope currently only supports arch22 (Ascend910B)"
+#error "compress_norm_rope currently only supports A2/A3"
 #endif
 
 using namespace CompressNormRope;

--- a/csrc/attention/compress_norm_rope/op_kernel/compress_norm_rope.cpp
+++ b/csrc/attention/compress_norm_rope/op_kernel/compress_norm_rope.cpp
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and limitations under the License.
+ */
+
+/*!
+ * \file compress_norm_rope.cpp
+ * \brief Compressor 的压缩计算：GEMM（x @ wkv / x @ wgate）由外部 MatMulV3 完成，
+ *        本算子只做 ape + softmax gate + 加权压缩 + state 递归 + rms_norm + rope。
+ *        输入 mm_kv / mm_score 为 [tokenSize, coff*headDim] 的 bf16/fp16 GEMM 结果。
+ *
+ * arch22（910B）两阶段实现：
+ *   - C4（coff=2, cmpRatio=4）：组流式 + 双缓冲流水，UB 内融合 RmsNorm/RoPE/cast（无 SyncAll）
+ *   - C128（coff=1, cmpRatio=128）：d 分块压缩 → GM workspace → SyncAll
+ *     → 完整行高精度 RmsNorm/RoPE/cast
+ * X_T/NORM_T/ROPE_T、coff 和空输入模式均由 ASCENDC_TPL template key 编译期分发。
+ */
+
+#include <type_traits>
+
+#if (__CCE_AICORE__ == 220)
+#include "arch32/compress_norm_rope_template_tiling_key.h"
+#include "arch32/compress_norm_rope_kernel_c4.h"
+#include "arch32/compress_norm_rope_kernel_c128.h"
+#else
+#error "compress_norm_rope currently only supports arch22 (Ascend910B)"
+#endif
+
+using namespace CompressNormRope;
+
+template <int X_T, int NORM_T, int ROPE_T, uint8_t Coff, uint8_t EmptyX>
+__global__ __aicore__ void compress_norm_rope(
+    __gm__ uint8_t *mmKv,
+    __gm__ uint8_t *mmScore,
+    __gm__ uint8_t *stateCache,
+    __gm__ uint8_t *ape,
+    __gm__ uint8_t *normWeight,
+    __gm__ uint8_t *ropeSin,
+    __gm__ uint8_t *ropeCos,
+    __gm__ uint8_t *stateBlockTable,
+    __gm__ uint8_t *cuSeqlens,
+    __gm__ uint8_t *seqUsed,
+    __gm__ uint8_t *startPos,
+    __gm__ uint8_t *cmpKvOut,
+    __gm__ uint8_t *stateCacheOut,
+    __gm__ uint8_t *workspace,
+    __gm__ uint8_t *tiling) {
+    REGISTER_TILING_DEFAULT(optiling::CompressNormRopeTilingData);
+    if constexpr (EmptyX != 0) {
+        return;
+    }
+    // C4 无 SyncAll，可使用 AIV_ONLY；C128 两阶段包含 SyncAll。
+    // SyncAll 需 MIX_AIV_1_0（全核同调度）。本 CANN 下 KERNEL_TASK_TYPE(key,..) 无法按 ASCENDC_TPL
+    // 编码 key 区分，统一用 MIX_AIV_1_0 默认（与 v2 旧代码一致，AIV 执行，taskRation 0:1）。
+    KERNEL_TASK_TYPE_DEFAULT(KERNEL_TYPE_MIX_AIV_1_0);
+    GET_TILING_DATA_WITH_STRUCT(optiling::CompressNormRopeTilingData, tilingDataIn, tiling);
+    const optiling::CompressNormRopeTilingData *__restrict tilingData = &tilingDataIn;
+    TPipe pipe;
+    using XType = std::conditional_t<X_T == CNR_TPL_BF16, bfloat16_t, half>;
+    using NormType = std::conditional_t<NORM_T == CNR_TPL_BF16, bfloat16_t, half>;
+    using RopeType = std::conditional_t<ROPE_T == CNR_TPL_FP32, float,
+                                        std::conditional_t<ROPE_T == CNR_TPL_BF16, bfloat16_t, half>>;
+    if constexpr (Coff == 2) {
+        CompressNormRopeKernelC4<XType, NormType, RopeType> op;
+        op.Init(&pipe, tilingData, mmKv, mmScore, stateCache, ape, normWeight, ropeSin, ropeCos, stateBlockTable,
+                cuSeqlens, seqUsed, startPos, cmpKvOut);
+        op.Process();
+    } else {
+        __gm__ uint8_t *userWs = GetUserWorkspace(workspace);
+        CompressNormRopeKernelC128<XType, NormType, RopeType> op;
+        op.Init(&pipe, tilingData, mmKv, mmScore, stateCache, ape, normWeight, ropeSin, ropeCos, stateBlockTable,
+                cuSeqlens, seqUsed, startPos, cmpKvOut, userWs);
+        op.Process();
+    }
+}

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -110,6 +110,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910b ]]; then
         "causal_conv1d"
         "lightning_indexer_quant"
         "compressor"
+        "compress_norm_rope"
         "compressor_metadata"
         "vllm_quant_lightning_indexer"
         "vllm_quant_lightning_indexer_metadata"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -159,6 +159,7 @@ elif [[ "$SOC_VERSION" =~ ^ascend910_93 ]]; then
         "moe_grouped_matmul"
         "lightning_indexer_quant"
         "compressor"
+        "compress_norm_rope"
         "compressor_metadata"
         "vllm_quant_lightning_indexer"
         "vllm_quant_lightning_indexer_metadata"

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -885,6 +885,52 @@ std::tuple<at::Tensor> compressor(const at::Tensor &x, const at::Tensor &wkv, co
     return std::tuple<at::Tensor>(cmp_kv);
 }
 
+std::tuple<at::Tensor> compress_norm_rope(const at::Tensor &mm_kv, const at::Tensor &mm_score,
+                                           at::Tensor &state_cache, const at::Tensor &ape, const at::Tensor &norm_weight,
+                                           const at::Tensor &rope_sin, const at::Tensor &rope_cos,
+                                           const c10::optional<at::Tensor> &state_block_table,
+                                           const c10::optional<at::Tensor> &cu_seqlens,
+                                           const c10::optional<at::Tensor> &seqused,
+                                           const c10::optional<at::Tensor> &start_pos, int64_t rope_head_dim,
+                                           int64_t cmp_ratio, int64_t coff, double norm_eps, int64_t rotary_mode,
+                                           int64_t cache_mode)
+{
+    constexpr int DIM_3 = 3;
+    auto x_dim = mm_kv.dim();
+    TORCH_CHECK(x_dim == 2 || x_dim == DIM_3, "mm_kv dim num[", x_dim, "] should be 2 or 3");
+    TORCH_CHECK(norm_weight.defined() && norm_weight.dim() == 1, "norm_weight should be 1D");
+    TORCH_CHECK(rope_sin.defined() && rope_sin.dim() == x_dim, "rope_sin dim should equal mm_kv dim");
+    TORCH_CHECK(cmp_ratio > 0, "cmp_ratio should be greater than 0");
+    TORCH_CHECK(mm_score.dim() == x_dim, "mm_score dim should equal mm_kv dim");
+    TORCH_CHECK(mm_kv.sizes() == mm_score.sizes(), "mm_score shape should equal mm_kv shape");
+    TORCH_CHECK(mm_kv.stride(-1) == 1, "mm_kv last dimension must be contiguous");
+    TORCH_CHECK(mm_score.stride(-1) == 1, "mm_score last dimension must be contiguous");
+
+    at::SmallVector<int64_t, 8> cmp_kv_size;
+    if (x_dim == DIM_3) {
+        auto cmp_s = (mm_kv.size(1) + cmp_ratio - 1) / cmp_ratio;
+        cmp_kv_size = {mm_kv.size(0), cmp_s, norm_weight.size(0)};
+    } else {
+        cmp_kv_size = {rope_sin.size(0), norm_weight.size(0)};
+    }
+    at::Tensor cmp_kv = at::empty(cmp_kv_size, mm_kv.options().dtype(mm_kv.dtype()));
+
+    TORCH_CHECK(state_cache.dim() == DIM_3, "state_cache dim num[", state_cache.dim(), "] should be 3");
+    int64_t state_cache_stride_dim0 = state_cache.stride(0);
+    int64_t mm_kv_stride_dim0 = mm_kv.stride(x_dim - 2);
+    int64_t mm_score_stride_dim0 = mm_score.stride(x_dim - 2);
+    TORCH_CHECK(mm_kv_stride_dim0 >= mm_kv.size(-1), "mm_kv row stride is smaller than its row width");
+    TORCH_CHECK(mm_score_stride_dim0 >= mm_score.size(-1),
+                "mm_score row stride is smaller than its row width");
+
+    EXEC_NPU_CMD(aclnnCompressNormRope, mm_kv, mm_score, state_cache, ape, norm_weight, rope_sin, rope_cos,
+                 state_block_table, cu_seqlens, seqused, start_pos, rope_head_dim, cmp_ratio, coff, norm_eps,
+                 rotary_mode, cache_mode, state_cache_stride_dim0, mm_kv_stride_dim0, mm_score_stride_dim0,
+                 cmp_kv);
+
+    return std::tuple<at::Tensor>(cmp_kv);
+}
+
 void check_compressor_metadata_common(
     const at::Tensor &rope_cos, const at::Tensor &rope_sin, const at::Tensor &cu_seqlens,
     const at::Tensor &start_pos, const at::Tensor &kv_block_table, int64_t kv_block_size,
@@ -2235,6 +2281,19 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         ") -> Tensor"
         );
     ops.impl("compressor", torch::kPrivateUse1, &vllm_ascend::compressor);
+
+    ops.def(
+        "compress_norm_rope("
+            "Tensor mm_kv, Tensor mm_score, "
+            "Tensor(a!) state_cache, Tensor ape, Tensor norm_weight, "
+            "Tensor rope_sin, Tensor rope_cos, "
+            "Tensor? state_block_table, Tensor? cu_seqlens, "
+            "Tensor? seqused, Tensor? start_pos, "
+            "int rope_head_dim, int cmp_ratio, int coff, "
+            "float norm_eps, int rotary_mode, int cache_mode"
+        ") -> Tensor"
+        );
+    ops.impl("compress_norm_rope", torch::kPrivateUse1, &vllm_ascend::compress_norm_rope);
 
     ops.def(
         "compressor_metadata("

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -773,6 +773,29 @@ compressor_meta(const at::Tensor &x, const at::Tensor &wkv, const at::Tensor &wg
     return output;
 }
 
+std::tuple<at::Tensor> compress_norm_rope_meta(const at::Tensor &mm_kv, const at::Tensor &mm_score,
+                                                at::Tensor &state_cache, const at::Tensor &ape,
+                                                const at::Tensor &norm_weight, const at::Tensor &rope_sin,
+                                                const at::Tensor &rope_cos,
+                                                const c10::optional<at::Tensor> &state_block_table,
+                                                const c10::optional<at::Tensor> &cu_seqlens,
+                                                const c10::optional<at::Tensor> &seqused,
+                                                const c10::optional<at::Tensor> &start_pos, int64_t rope_head_dim,
+                                                int64_t cmp_ratio, int64_t coff, double norm_eps, int64_t rotary_mode,
+                                                int64_t cache_mode)
+{
+    constexpr int DIM_3 = 3;
+    at::SmallVector<int64_t, 8> cmp_kv_size;
+    if (mm_kv.dim() == DIM_3) {
+        auto cmp_s = (mm_kv.size(1) + cmp_ratio - 1) / cmp_ratio;
+        cmp_kv_size = {mm_kv.size(0), cmp_s, norm_weight.size(0)};
+    } else {
+        cmp_kv_size = {rope_sin.size(0), norm_weight.size(0)};
+    }
+    at::Tensor cmp_kv = at::empty(cmp_kv_size, mm_kv.options().dtype(mm_kv.dtype()));
+    return std::tuple<at::Tensor>(cmp_kv);
+}
+
 std::tuple<at::Tensor, at::Tensor, at::Tensor> compressor_metadata_meta(
     const at::Tensor &rope_cos, const at::Tensor &rope_sin, const at::Tensor &cu_seqlens,
     const at::Tensor &start_pos, const at::Tensor &kv_block_table, int64_t kv_block_size,
@@ -1565,6 +1588,7 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("moe_grouped_matmul", &vllm_ascend::meta::moe_grouped_matmul_meta);
     ops.impl("moe_gating_top_k_hash", &vllm_ascend::meta::moe_gating_top_k_hash_meta);
     ops.impl("compressor", &vllm_ascend::meta::compressor_meta);
+    ops.impl("compress_norm_rope", &vllm_ascend::meta::compress_norm_rope_meta);
     ops.impl("compressor_metadata", &vllm_ascend::meta::compressor_metadata_meta);
     ops.impl("npu_vllm_quant_lightning_indexer", &vllm_ascend::meta::npu_vllm_quant_lightning_indexer_meta);
     ops.impl("npu_vllm_quant_lightning_indexer_metadata", &vllm_ascend::meta::npu_vllm_quant_lightning_indexer_metadata_meta);

--- a/tests/ut/models/test_deepseek_v4_compressor.py
+++ b/tests/ut/models/test_deepseek_v4_compressor.py
@@ -68,6 +68,38 @@ class TestCompressorMetadata:
 
 
 class TestCompressorForward:
+    def test_init_preallocates_packed_projection(self):
+        config = SimpleNamespace(hidden_size=1024, qk_rope_head_dim=64, rms_norm_eps=1e-6)
+        merged_projection = MagicMock()
+
+        with (
+            patch(
+                "vllm_ascend.models.deepseek_v4.compressor.MergedColumnParallelLinear",
+                return_value=merged_projection,
+            ) as merged_linear,
+            patch("vllm_ascend.models.deepseek_v4.compressor.RMSNorm"),
+            patch("vllm_ascend.models.deepseek_v4.compressor.AscendCompressorStateCache"),
+        ):
+            compressor = Compressor(
+                vllm_config=SimpleNamespace(),
+                config=config,
+                compress_ratio=4,
+                head_dim=512,
+                cache_config=SimpleNamespace(block_size=128),
+                prefix="model.layers.0.compressor",
+            )
+
+        assert compressor.fused_wkv_wgate is merged_projection
+        merged_linear.assert_called_once_with(
+            1024,
+            [1024, 1024],
+            bias=False,
+            quant_config=None,
+            prefix="model.layers.0.compressor.fused_wkv_wgate",
+            return_bias=False,
+            disable_tp=True,
+        )
+
     @pytest.mark.parametrize(
         ("compress_ratio", "overlap", "expected_coff"),
         [(4, True, 2), (128, False, 1)],
@@ -84,9 +116,12 @@ class TestCompressorForward:
         compressor.compress_ratio = compress_ratio
         compressor.rope_head_dim = 2
         compressor.norm_eps = 1e-6
-        compressor.ape = torch.ones((compress_ratio, 4))
-        compressor.wkv = SimpleNamespace(weight=torch.ones((4, 4)))
-        compressor.wgate = SimpleNamespace(weight=torch.ones((4, 4)))
+        projection_dim = expected_coff * 4
+        compressor.ape = torch.ones((compress_ratio, projection_dim))
+        fused_weight = torch.arange(2 * projection_dim * 4, dtype=torch.float32).view(
+            2 * projection_dim, 4
+        )
+        compressor.fused_wkv_wgate = SimpleNamespace(weight=fused_weight)
         compressor.norm = SimpleNamespace(weight=torch.ones(4))
         cache_req_metadata = SimpleNamespace(
             query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
@@ -106,29 +141,95 @@ class TestCompressorForward:
         compute_metadata = MagicMock(return_value=(compress_cos, compress_sin, slot_mapping))
         compressor._compute_metadata = compute_metadata
 
-        with patch.object(
-            torch.ops._C_ascend,
-            "compressor",
-            create=True,
-            return_value=compressed_kv,
-        ) as compressor_op:
-            actual_kv, actual_slot_mapping = compressor(
-                hidden_states=hidden_states,
-                state_cache=state_cache,
-                metadata=metadata,
-            )
+        with (
+            patch(
+                "vllm_ascend.models.deepseek_v4.compressor.envs_ascend.VLLM_ASCEND_DSA_COMPRESSOR_SPLIT",
+                False,
+            ),
+            patch.object(
+                torch.ops._C_ascend,
+                "compressor",
+                create=True,
+                return_value=compressed_kv,
+            ) as compressor_op,
+        ):
+            actual_kv, actual_slot_mapping = compressor(hidden_states, state_cache, metadata)
 
         assert actual_kv is compressed_kv
         assert actual_slot_mapping is slot_mapping
         compute_metadata.assert_called_once_with(cache_req_metadata)
         call = compressor_op.call_args
         assert call.args[0] is hidden_states
+        assert torch.equal(call.args[1], fused_weight[:projection_dim])
+        assert torch.equal(call.args[2], fused_weight[projection_dim:])
         assert torch.equal(call.args[3], state_cache.squeeze(-2))
         assert call.kwargs["state_block_table"] is state_req_metadata.block_table
         assert call.kwargs["cu_seqlens"] is cache_req_metadata.query_start_loc
         assert call.kwargs["start_pos"] is cache_req_metadata.start_pos
         assert call.kwargs["cmp_ratio"] == compress_ratio
         assert call.kwargs["coff"] == expected_coff
+
+    def test_split_path_uses_one_linear_and_noncontiguous_views(self):
+        compressor = Compressor.__new__(Compressor)
+        torch.nn.Module.__init__(compressor)
+        compressor.overlap = True
+        compressor.compress_ratio = 4
+        compressor.rope_head_dim = 2
+        compressor.norm_eps = 1e-6
+        compressor.ape = torch.ones((4, 8))
+        fused_weight = torch.arange(64, dtype=torch.float32).view(16, 4)
+        compressor.fused_wkv_wgate = SimpleNamespace(weight=fused_weight)
+        compressor.norm = SimpleNamespace(weight=torch.ones(4))
+
+        cache_req_metadata = SimpleNamespace(
+            query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+            start_pos=torch.tensor([1], dtype=torch.int32),
+        )
+        state_req_metadata = SimpleNamespace(block_table=torch.tensor([[3]], dtype=torch.int32))
+        metadata = AscendCompressorMetadata(
+            cache=SimpleNamespace(req_metadata=cache_req_metadata),
+            state=SimpleNamespace(req_metadata=state_req_metadata),
+        )
+        hidden_states = torch.ones((2, 4))
+        state_cache = torch.ones((1, 2, 1, 16))
+        compress_cos = torch.ones((1, 1, 2))
+        compress_sin = torch.zeros((1, 1, 2))
+        slot_mapping = torch.tensor([[0, 1]], dtype=torch.int32)
+        compressed_kv = torch.ones((1, 1, 4))
+        mm = torch.arange(32, dtype=torch.float32).view(2, 16)
+        compressor._compute_metadata = MagicMock(return_value=(compress_cos, compress_sin, slot_mapping))
+
+        with (
+            patch(
+                "vllm_ascend.models.deepseek_v4.compressor.envs_ascend.VLLM_ASCEND_DSA_COMPRESSOR_SPLIT",
+                True,
+            ),
+            patch(
+                "vllm_ascend.models.deepseek_v4.compressor.F.linear",
+                return_value=mm,
+            ) as linear,
+            patch.object(
+                torch.ops._C_ascend,
+                "compress_norm_rope",
+                create=True,
+                return_value=compressed_kv,
+            ) as compress_norm_rope,
+        ):
+            actual_kv, actual_slot_mapping = compressor(hidden_states, state_cache, metadata)
+
+        assert actual_kv is compressed_kv
+        assert actual_slot_mapping is slot_mapping
+        linear.assert_called_once_with(hidden_states, fused_weight)
+        call = compress_norm_rope.call_args
+        mm_kv, mm_score = call.args[:2]
+        assert torch.equal(mm_kv, mm[:, :8])
+        assert torch.equal(mm_score, mm[:, 8:])
+        assert mm_kv.stride() == (16, 1)
+        assert mm_score.stride() == (16, 1)
+        assert not mm_kv.is_contiguous()
+        assert not mm_score.is_contiguous()
+        assert call.kwargs["cmp_ratio"] == 4
+        assert call.kwargs["coff"] == 2
 
 
 class TestCompressorStateCache:

--- a/tests/ut/ops/a2/test_compress_norm_rope.py
+++ b/tests/ut/ops/a2/test_compress_norm_rope.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM Ascend project
+
+import pytest
+import torch
+import torch_npu  # noqa: F401
+
+from vllm_ascend.utils import enable_custom_op
+
+assert enable_custom_op()
+
+DEVICE = "npu"
+DTYPE = torch.bfloat16
+HIDDEN_SIZE = 1024
+HEAD_DIM = 512
+ROPE_HEAD_DIM = 64
+NORM_EPS = 1e-6
+RATIO_CONFIG = {4: (2, 8), 128: (1, 32)}
+
+
+def _build_case(
+    ratio: int,
+    lengths: list[int],
+    start_positions: list[int],
+) -> dict[str, torch.Tensor | int]:
+    torch.manual_seed(ratio + sum(lengths) + sum(start_positions))
+    batch_size = len(lengths)
+    token_count = sum(lengths)
+    coff, state_block_size = RATIO_CONFIG[ratio]
+    projection_size = coff * HEAD_DIM
+    state_size = 2 * projection_size
+    max_position = max(start + length for start, length in zip(start_positions, lengths))
+    blocks_per_request = max(1, (max_position + state_block_size - 1) // state_block_size)
+
+    hidden_states = torch.randn(token_count, HIDDEN_SIZE, dtype=DTYPE, device=DEVICE)
+    weight_scale = HIDDEN_SIZE**-0.5
+    wkv = torch.randn(projection_size, HIDDEN_SIZE, dtype=DTYPE, device=DEVICE) * weight_scale
+    wgate = torch.randn(projection_size, HIDDEN_SIZE, dtype=DTYPE, device=DEVICE) * weight_scale
+    packed_weight = torch.cat((wkv, wgate), dim=0).contiguous()
+    state_cache = torch.zeros(
+        batch_size * blocks_per_request + 1,
+        state_block_size,
+        state_size,
+        dtype=torch.float32,
+        device=DEVICE,
+    )
+    state_block_table = (
+        torch.arange(batch_size, dtype=torch.int32, device=DEVICE).unsqueeze(1) * blocks_per_request
+        + torch.arange(1, blocks_per_request + 1, dtype=torch.int32, device=DEVICE)
+    )
+    cu_seqlens = torch.tensor(
+        [0, *torch.tensor(lengths).cumsum(0).tolist()],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    start_pos = torch.tensor(start_positions, dtype=torch.int32, device=DEVICE)
+    rope_rows = min(token_count, token_count // ratio + batch_size)
+
+    return {
+        "hidden_states": hidden_states,
+        "wkv": wkv,
+        "wgate": wgate,
+        "packed_weight": packed_weight,
+        "state_cache": state_cache,
+        "ape": torch.randn(ratio, projection_size, dtype=torch.float32, device=DEVICE),
+        "norm_weight": torch.randn(HEAD_DIM, dtype=DTYPE, device=DEVICE),
+        "rope_sin": torch.randn(rope_rows, ROPE_HEAD_DIM, dtype=torch.float32, device=DEVICE),
+        "rope_cos": torch.randn(rope_rows, ROPE_HEAD_DIM, dtype=torch.float32, device=DEVICE),
+        "state_block_table": state_block_table,
+        "cu_seqlens": cu_seqlens,
+        "start_pos": start_pos,
+        "coff": coff,
+        "ratio": ratio,
+        "valid_rows": sum(
+            (start + length) // ratio - start // ratio
+            for start, length in zip(start_positions, lengths)
+        ),
+        "rope_rows": rope_rows,
+    }
+
+
+def _op_kwargs(case: dict[str, torch.Tensor | int]) -> dict[str, object]:
+    return {
+        "state_block_table": case["state_block_table"],
+        "cu_seqlens": case["cu_seqlens"],
+        "seqused": None,
+        "start_pos": case["start_pos"],
+        "rope_head_dim": ROPE_HEAD_DIM,
+        "cmp_ratio": case["ratio"],
+        "coff": case["coff"],
+        "norm_eps": NORM_EPS,
+        "rotary_mode": 2,
+        "cache_mode": 1,
+    }
+
+
+def _assert_max_relative_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    max_diff = (actual.float() - expected.float()).abs().max()
+    scale = expected.float().abs().max().clamp_min(1e-6)
+    assert (max_diff / scale).item() < 1e-2
+
+
+@pytest.mark.parametrize(
+    ("ratio", "lengths", "start_positions"),
+    [
+        pytest.param(4, [16], [0], id="c4-prefill"),
+        pytest.param(128, [256], [0], id="c128-prefill"),
+        pytest.param(4, [4, 4], [0, 0], id="c4-mtp"),
+        pytest.param(128, [4, 4], [124, 124], id="c128-mtp"),
+        pytest.param(128, [2, 2], [0, 0], id="c128-no-boundary"),
+    ],
+)
+def test_compress_norm_rope_matches_compressor(
+    ratio: int,
+    lengths: list[int],
+    start_positions: list[int],
+):
+    case = _build_case(ratio, lengths, start_positions)
+    reference_state = case["state_cache"].clone()
+    actual_state = case["state_cache"].clone()
+    kwargs = _op_kwargs(case)
+
+    reference = torch.ops._C_ascend.compressor(
+        case["hidden_states"],
+        case["wkv"],
+        case["wgate"],
+        reference_state,
+        case["ape"],
+        case["norm_weight"],
+        case["rope_sin"],
+        case["rope_cos"],
+        **kwargs,
+    )
+    projected = torch.nn.functional.linear(case["hidden_states"], case["packed_weight"])
+    mm_kv, mm_score = projected.chunk(2, dim=-1)
+    assert mm_kv.stride(0) == projected.shape[-1]
+    assert mm_score.stride(0) == projected.shape[-1]
+    assert not mm_kv.is_contiguous()
+    assert not mm_score.is_contiguous()
+    actual = torch.ops._C_ascend.compress_norm_rope(
+        mm_kv,
+        mm_score,
+        actual_state,
+        case["ape"],
+        case["norm_weight"],
+        case["rope_sin"],
+        case["rope_cos"],
+        **kwargs,
+    )
+    torch.npu.synchronize()
+
+    assert actual.shape == (case["rope_rows"], HEAD_DIM)
+    valid_rows = case["valid_rows"]
+    if valid_rows:
+        _assert_max_relative_close(actual[:valid_rows], reference[:valid_rows])
+    _assert_max_relative_close(actual_state, reference_state)
+
+
+def test_compress_norm_rope_rejects_noncontiguous_last_dimension():
+    case = _build_case(4, [4], [0])
+    projected = torch.nn.functional.linear(case["hidden_states"], case["packed_weight"])
+    mm_kv, mm_score = projected.chunk(2, dim=-1)
+
+    with pytest.raises(RuntimeError, match="last dimension must be contiguous"):
+        torch.ops._C_ascend.compress_norm_rope(
+            mm_kv[:, ::2],
+            mm_score[:, ::2],
+            case["state_cache"],
+            case["ape"][:, ::2].contiguous(),
+            case["norm_weight"][: HEAD_DIM // 2],
+            case["rope_sin"],
+            case["rope_cos"],
+            **_op_kwargs(case),
+        )

--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -1128,8 +1128,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
 
             # indexer_compressor
             self.indexcom_ape = self.indexer.compressor.ape
-            self.indexcom_wkv = self.indexer.compressor.wkv
-            self.indexcom_wgate = self.indexer.compressor.wgate
+            self.indexcom_fused_wkv_wgate = self.indexer.compressor.fused_wkv_wgate
             self.indexcom_norm = self.indexer.compressor.norm
 
             self.indexcom_head_dim = self.indexer.compressor.head_dim
@@ -1140,8 +1139,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             self.compressor_overlap = self.compressor.overlap
 
             self.compressor_ape = self.compressor.ape
-            self.compressor_wkv = self.compressor.wkv
-            self.compressor_wgate = self.compressor.wgate
+            self.compressor_fused_wkv_wgate = self.compressor.fused_wkv_wgate
             self.compressor_norm = self.compressor.norm
             self.compressor_norm_eps = self.compressor.norm_eps
 
@@ -1655,8 +1653,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
             )
             compressed_kv = torch.ops._C_ascend.compressor(
                 hidden_states_cache,
-                self.compressor_wkv.weight,
-                self.compressor_wgate.weight,
+                *self.compressor_fused_wkv_wgate.weight.chunk(2, dim=0),
                 state_cache.squeeze(-2),
                 self.compressor_ape,
                 self.compressor_norm.weight,
@@ -1806,8 +1803,7 @@ class AscendDSACPImpl(AttentionImplBase[Any]):
         )
         kv = torch.ops._C_ascend.compressor(
             x,
-            self.indexcom_wkv.weight,
-            self.indexcom_wgate.weight,
+            *self.indexcom_fused_wkv_wgate.weight.chunk(2, dim=0),
             indexer_state_cache.squeeze(-2),
             self.indexcom_ape,
             self.indexcom_norm.weight,

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -94,7 +94,7 @@ env_variables: dict[str, Callable[[], Any]] = {
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
     # Whether to split the DSA compressor into a packed GEMM and compress_norm_rope.
-    # 0 disables it (default), 1 enables it on Ascend 910B. This variable is not sensitive.
+    # 0 disables it (default), 1 enables it on A2/A3. This variable is not sensitive.
     "VLLM_ASCEND_DSA_COMPRESSOR_SPLIT": lambda: bool(int(os.getenv("VLLM_ASCEND_DSA_COMPRESSOR_SPLIT", "0"))),
 }
 

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -93,6 +93,9 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Whether to split the DSA compressor into a packed GEMM and compress_norm_rope.
+    # 0 disables it (default), 1 enables it on Ascend 910B. This variable is not sensitive.
+    "VLLM_ASCEND_DSA_COMPRESSOR_SPLIT": lambda: bool(int(os.getenv("VLLM_ASCEND_DSA_COMPRESSOR_SPLIT", "0"))),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/deepseek_v4/compressor.py
+++ b/vllm_ascend/models/deepseek_v4/compressor.py
@@ -27,16 +27,18 @@ import typing
 from dataclasses import dataclass
 
 import torch
+import torch.nn.functional as F
 from torch import nn
 from transformers import DeepseekV2Config, DeepseekV3Config
 from vllm.config import CacheConfig, VllmConfig
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.linear import MergedColumnParallelLinear
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.models.deepseek_v4.compressor import CompressorStateCache
 from vllm.transformers_utils.configs.deepseek_v4 import DeepseekV4Config
 from vllm.v1.kv_cache_interface import KVCacheSpec
 
+import vllm_ascend.envs as envs_ascend
 from vllm_ascend.core.kv_cache_interface import AscendSlidingWindowMLASpec
 from vllm_ascend.utils import AscendDeviceType, get_ascend_device_type
 
@@ -122,21 +124,15 @@ class Compressor(nn.Module):
         self.coff = 1 + self.overlap
 
         self.ape = nn.Parameter(torch.empty(compress_ratio, self.coff * self.head_dim, dtype=torch.float32))
-        self.wkv = ReplicatedLinear(
+        output_dim = self.coff * self.head_dim
+        self.fused_wkv_wgate = MergedColumnParallelLinear(
             self.dim,
-            self.coff * self.head_dim,
+            [output_dim, output_dim],
             bias=False,
             quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
-            prefix=f"{prefix}.wkv",
+            prefix=f"{prefix}.fused_wkv_wgate",
             return_bias=False,
-        )
-        self.wgate = ReplicatedLinear(
-            self.dim,
-            self.coff * self.head_dim,
-            bias=False,
-            quant_config=None if get_ascend_device_type() in {AscendDeviceType.A5} else quant_config,
-            prefix=f"{prefix}.wgate",
-            return_bias=False,
+            disable_tp=True,
         )
 
         # A5 compressor kernel needs float for norm_weight input
@@ -209,24 +205,41 @@ class Compressor(nn.Module):
         assert compressor_metadata is not None
         assert state_metadata is not None
         compress_cos, compress_sin, slot_mapping = self._compute_metadata(compressor_metadata)
-        compressed_kv = torch.ops._C_ascend.compressor(
-            hidden_states,
-            self.wkv.weight,
-            self.wgate.weight,
+        compressor_args = (
             state_cache.squeeze(-2),
             self.ape,
             self.norm.weight,
             compress_sin.view(-1, compress_sin.shape[-1]),
             compress_cos.view(-1, compress_cos.shape[-1]),
-            state_block_table=state_metadata.block_table,
-            cu_seqlens=compressor_metadata.query_start_loc,
-            seqused=None,
-            start_pos=compressor_metadata.start_pos,
-            rope_head_dim=self.rope_head_dim,
-            cmp_ratio=self.compress_ratio,
-            coff=2 if self.overlap else 1,
-            norm_eps=self.norm_eps,
-            rotary_mode=2,
-            cache_mode=1,
         )
+        compressor_kwargs = {
+            "state_block_table": state_metadata.block_table,
+            "cu_seqlens": compressor_metadata.query_start_loc,
+            "seqused": None,
+            "start_pos": compressor_metadata.start_pos,
+            "rope_head_dim": self.rope_head_dim,
+            "cmp_ratio": self.compress_ratio,
+            "coff": 2 if self.overlap else 1,
+            "norm_eps": self.norm_eps,
+            "rotary_mode": 2,
+            "cache_mode": 1,
+        }
+        if envs_ascend.VLLM_ASCEND_DSA_COMPRESSOR_SPLIT:
+            mm = F.linear(hidden_states, self.fused_wkv_wgate.weight)
+            mm_kv, mm_score = mm.chunk(2, dim=-1)
+            compressed_kv = torch.ops._C_ascend.compress_norm_rope(
+                mm_kv,
+                mm_score,
+                *compressor_args,
+                **compressor_kwargs,
+            )
+        else:
+            wkv_weight, wgate_weight = self.fused_wkv_wgate.weight.chunk(2, dim=0)
+            compressed_kv = torch.ops._C_ascend.compressor(
+                hidden_states,
+                wkv_weight,
+                wgate_weight,
+                *compressor_args,
+                **compressor_kwargs,
+            )
         return compressed_kv, slot_mapping

--- a/vllm_ascend/models/deepseek_v4/dspark.py
+++ b/vllm_ascend/models/deepseek_v4/dspark.py
@@ -415,12 +415,15 @@ class DSparkDeepseekV4ForCausalLM(nn.Module, DeepseekV2MixtureOfExperts, Support
         expert_mapping = self.model.get_expert_mapping()
 
         # (param_name, checkpoint shard name, shard_id) for non-expert
-        # stacked parameters. Ascend keeps wq_a and wkv as separate parameters.
+        # stacked parameters. Attention projections stay separate; compressor
+        # wkv/wgate are loaded into one pre-allocated fused parameter.
         stacked_params_mapping = [
             ("mlp.gate_up_proj", "mlp.gate_proj", 0),
             ("mlp.gate_up_proj", "mlp.up_proj", 1),
             ("shared_experts.gate_up_proj", "shared_experts.gate_proj", 0),
             ("shared_experts.gate_up_proj", "shared_experts.up_proj", 1),
+            ("compressor.fused_wkv_wgate", "compressor.wkv", 0),
+            ("compressor.fused_wkv_wgate", "compressor.wgate", 1),
         ]
 
         params_dict = dict(self.named_parameters())

--- a/vllm_ascend/models/deepseek_v4/model.py
+++ b/vllm_ascend/models/deepseek_v4/model.py
@@ -1045,6 +1045,8 @@ class AscendDeepseekV4ForCausalLM(nn.Module, SupportsPP, DeepseekV2MixtureOfExpe
         stacked_params_mapping = [
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
+            ("compressor.fused_wkv_wgate", "compressor.wkv", 0),
+            ("compressor.fused_wkv_wgate", "compressor.wgate", 1),
         ]
 
         # Params for weights, fp8 weight scales, fp8 activation scales

--- a/vllm_ascend/models/deepseek_v4/mtp.py
+++ b/vllm_ascend/models/deepseek_v4/mtp.py
@@ -262,6 +262,8 @@ class DeepSeekV4MTP(nn.Module, SupportsPP, DeepseekV2MixtureOfExperts):
         stacked_params_mapping = [
             ("gate_up_proj", "gate_proj", 0),
             ("gate_up_proj", "up_proj", 1),
+            ("compressor.fused_wkv_wgate", "compressor.wkv", 0),
+            ("compressor.fused_wkv_wgate", "compressor.wgate", 1),
         ]
 
         expert_params_mapping = fused_moe_make_expert_params_mapping(


### PR DESCRIPTION
### What this PR does / why we need it?

The existing DeepSeek V4 compressor performs the `wkv` and `wgate` matrix multiplications inside the custom compressor operator. Its Cube implementation is inefficient and becomes a significant bottleneck for both decode and prefill workloads.

This PR:

- pre-merges the `wkv` and `wgate` weights during model initialization and checkpoint loading;
- replaces the two compressor-internal projections with one packed `F.linear`;
- adds the `compress_norm_rope` custom operator to perform the remaining compression, state update, RMSNorm, and RoPE calculations;
- supports the non-contiguous `mm_kv` and `mm_score` views produced by splitting the packed `F.linear` output, without additional copies;
- provides specialized C4 and C128 templates, including compile-time input, norm, and RoPE data types;
- retains the original compressor implementation as the default fallback. The optimized path can be enabled with `VLLM_ASCEND_DSA_COMPRESSOR_SPLIT=1`.

The DeepSeek V4 compressor integration is currently scoped to **A2** and **A3**. 

NPU Graph replay measurements on A2 showed latency reductions across all covered cases:

| Scenario | Latency reduction | Speedup |
|---|---:|---:|
| C128 decode, including MTP q=1/2/4 | 13.9% - 44.4% | 1.16x - 1.80x |
| C128 prefill, 256-8192 tokens | 15.9% - 44.8% | 1.19x - 1.81x |
| C4 decode, including MTP q=1/2/4 | 25.9% - 46.2% | 1.35x - 1.86x |
| C4 prefill, 256-8192 tokens | 27.8% - 42.5% | 1.39x - 1.74x |

### Does this PR introduce _any_ user-facing change?

Yes. It adds an opt-in optimized DeepSeek V4 compressor implementation on A2/A3.

```bash
export VLLM_ASCEND_DSA_COMPRESSOR_SPLIT=1
```

The option is disabled by default, so existing behavior remains unchanged unless it is explicitly enabled.

### How was this patch tested?

CPU unit tests cover packed projection construction, checkpoint-compatible weight layout, fallback dispatch, the single-`F.linear` path, and non-contiguous projection views:

```bash
pytest -q \
  tests/ut/test_envs.py \
  tests/ut/models/test_deepseek_v4_compressor.py \
  tests/ut/models/test_deepseek_v4_indexer.py \
  tests/ut/attention/test_dsa_v1.py \
  tests/ut/attention/test_dsa_cp.py
```

Result: `54 passed`.

A2 NPU unit tests compare `compress_norm_rope` against the existing compressor implementation. They cover C4 and C128 prefill, MTP with multiple tokens per request, no-boundary state updates, packed non-contiguous inputs, and invalid input strides:

```bash
pytest -q tests/ut/ops/a2/test_compress_norm_rope.py
```

Result: `6 passed`.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
