### PR TITLE
[CI][Model] Stabilize MiniMax-M3 nightly smoke test

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-BF16-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-BF16-A3.yaml
@@ -80,5 +80,5 @@ test_cases:
         max_out_len: 128
         batch_size: 1
         request_rate: 0
-        baseline: 20.83
+        baseline: 18.13
         threshold: 0.97

--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-BF16-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M3-BF16-A3.yaml
@@ -41,6 +41,10 @@ test_cases:
       - '{"enable_cpu_binding":true,"ascend_compilation_config":{"enable_static_kernel":false,"fuse_norm_quant":false},"multistream_overlap_shared_expert":true,"weight_nz_mode":2,"enable_reduce_sample":false}'
     test_content:
       - chat_completion
+    api_keyword_args:
+      max_tokens: 10
+      chat_template_kwargs:
+        thinking_mode: disabled
     benchmarks:
       acc:
         case_type: accuracy


### PR DESCRIPTION
## Summary

Builds on #14930 and stabilizes the MiniMax-M3 BF16 nightly case in two ways:

- makes the chat-completions smoke request deterministic by setting `max_tokens: 10` and disabling thinking;
- recalibrates the performance baseline from `20.83` to `18.13` token/s using five repeated BF16 nightly runs with the current configuration.

The generic smoke request uses `max_tokens=10`. With MiniMax-M3 adaptive thinking and the `minimax_m3` reasoning parser, all 10 tokens can be returned as reasoning, leaving `message.content` null and failing the smoke assertion. Setting `chat_template_kwargs.thinking_mode: disabled` ensures a non-empty content response.

## Performance baseline

The performance reduction relative to the old baseline is expected for the current MiniMax-M3 BF16 validation configuration introduced by #14930. Five repeated nightly runs produced stable Output Token Throughput results:

| Run | Output Token Throughput |
| --- | ---: |
| [1](https://github.com/vllm-project/vllm-ascend/actions/runs/33035534563) | 17.9823 token/s |
| [2](https://github.com/vllm-project/vllm-ascend/actions/runs/33071251392) | 18.1860 token/s |
| [3](https://github.com/vllm-project/vllm-ascend/actions/runs/33080115364) | 18.1831 token/s |
| [4](https://github.com/vllm-project/vllm-ascend/actions/runs/33133138680) | 18.1032 token/s |
| [5](https://github.com/vllm-project/vllm-ascend/actions/runs/33136898007) | 18.2097 token/s |

Statistics:

- mean: 18.1329 token/s
- median: 18.1831 token/s
- minimum: 17.9823 token/s
- maximum: 18.2097 token/s
- range: 0.2274 token/s
- population standard deviation: 0.0834 token/s

The new baseline is rounded from the five-run mean to `18.13` token/s. The existing `threshold: 0.97` is retained, giving an effective pass floor of `17.5861` token/s. This accommodates the observed run-to-run variance while continuing to detect regressions greater than 3% from the recalibrated baseline.

## Validation

Across the five dedicated BF16 nightly runs:

- chat smoke passed with HTTP 200, non-empty `content`, and `reasoning=null`;
- GSM8K accuracy passed;
- TextVQA accuracy passed;
- performance results were stable and failed only against the obsolete `20.83` token/s baseline.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
