### PR TITLE
[BugFix][Mamba] Fix PtrOffsetInfo AxisInfo assertion failure

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_precopy.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_precopy.py
@@ -33,9 +33,13 @@ def _build_meta(convs, ssms, device, conv_dim_first):
     tensor = lambda values, dtype: torch.tensor(values, dtype=dtype, device=device)
     state_count = NUM_LAYERS * 2
     return (
-        tensor(base, torch.int64), tensor(block_stride, torch.int64), tensor(elem_size, torch.int32),
-        tensor(inner_size, torch.int64), tensor(conv_width, torch.int32),
-        torch.zeros(state_count, dtype=torch.int32, device=device), tensor(row_count, torch.int32),
+        tensor(base, torch.int64),
+        tensor(block_stride, torch.int64),
+        tensor(elem_size, torch.int32),
+        tensor(inner_size, torch.int64),
+        tensor(conv_width, torch.int32),
+        torch.zeros(state_count, dtype=torch.int32, device=device),
+        tensor(row_count, torch.int32),
         tensor(row_stride, torch.int64),
     )
 
@@ -72,7 +76,9 @@ def test_precopy_matches_reference(conv_dim_first, has_idx_mapping, temporal_til
     dst_col = torch.tensor([0, 1, 0, 0], dtype=torch.int32, device=device)
     bias = torch.tensor([0, 0, 1, 2], dtype=torch.int32, device=device)
     convs, ssms = _build_states(num_blocks, device, conv_dim_first)
-    conv_ref, ssm_ref = _reference(convs, ssms, block_table.cpu(), src_col.cpu(), dst_col.cpu(), bias.cpu(), conv_dim_first)
+    conv_ref, ssm_ref = _reference(
+        convs, ssms, block_table.cpu(), src_col.cpu(), dst_col.cpu(), bias.cpu(), conv_dim_first
+    )
     base, block_stride, elem_size, inner_size, conv_width, group, row_count, row_stride = _build_meta(
         convs, ssms, device, conv_dim_first
     )
@@ -80,10 +86,25 @@ def test_precopy_matches_reference(conv_dim_first, has_idx_mapping, temporal_til
     idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
     grid = (num_reqs, NUM_LAYERS * 2, temporal_tiles)
     precopy_mamba_align_fused_kernel[grid](
-        dst_col, src_col, bias, block_table_ptrs, block_table.stride(0), base, block_stride, elem_size,
-        inner_size, conv_width, group, row_count, row_stride, idx_mapping if has_idx_mapping else None,
-        num_reqs, COPY_BLOCK_SIZE=128, CONV_STATE_DIM_FIRST=conv_dim_first,
-        HAS_IDX_MAPPING=has_idx_mapping, TEMPORAL_TILES=temporal_tiles,
+        dst_col,
+        src_col,
+        bias,
+        block_table_ptrs,
+        block_table.stride(0),
+        base,
+        block_stride,
+        elem_size,
+        inner_size,
+        conv_width,
+        group,
+        row_count,
+        row_stride,
+        idx_mapping if has_idx_mapping else None,
+        num_reqs,
+        COPY_BLOCK_SIZE=128,
+        CONV_STATE_DIM_FIRST=conv_dim_first,
+        HAS_IDX_MAPPING=has_idx_mapping,
+        TEMPORAL_TILES=temporal_tiles,
     )
     torch.accelerator.synchronize()
     for layer in range(NUM_LAYERS):

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_precopy.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_precopy.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm_ascend.ops.triton.v2.mamba.precopy import precopy_mamba_align_fused_kernel
+
+NUM_LAYERS = 2
+CONV_WIDTH = 4
+CONV_DIM = 64
+SSM_SHAPE = (4, 16, 16)
+MAX_COLS = 8
+
+
+def _build_states(num_blocks, device, conv_dim_first):
+    conv_shape = (num_blocks, CONV_DIM, CONV_WIDTH) if conv_dim_first else (num_blocks, CONV_WIDTH, CONV_DIM)
+    convs = [torch.randn(conv_shape, dtype=torch.bfloat16, device=device) for _ in range(NUM_LAYERS)]
+    ssms = [torch.randn((num_blocks, *SSM_SHAPE), dtype=torch.float32, device=device) for _ in range(NUM_LAYERS)]
+    return convs, ssms
+
+
+def _build_meta(convs, ssms, device, conv_dim_first):
+    base, block_stride, elem_size, inner_size, conv_width, row_count, row_stride = [], [], [], [], [], [], []
+    for conv, ssm in zip(convs, ssms):
+        base.extend((conv.data_ptr(), ssm.data_ptr()))
+        block_stride.extend((conv.stride(0) * conv.element_size(), ssm.stride(0) * ssm.element_size()))
+        elem_size.extend((conv.element_size(), ssm.element_size()))
+        inner_size.extend((1 if conv_dim_first else conv.stride(1), ssm[0].numel()))
+        conv_width.extend((CONV_WIDTH, 0))
+        row_count.extend((CONV_DIM if conv_dim_first else 0, 0))
+        row_stride.extend((conv.stride(1) * conv.element_size() if conv_dim_first else 0, 0))
+    tensor = lambda values, dtype: torch.tensor(values, dtype=dtype, device=device)
+    state_count = NUM_LAYERS * 2
+    return (
+        tensor(base, torch.int64), tensor(block_stride, torch.int64), tensor(elem_size, torch.int32),
+        tensor(inner_size, torch.int64), tensor(conv_width, torch.int32),
+        torch.zeros(state_count, dtype=torch.int32, device=device), tensor(row_count, torch.int32),
+        tensor(row_stride, torch.int64),
+    )
+
+
+def _reference(convs, ssms, block_table, src_col, dst_col, bias, conv_dim_first):
+    conv_before, ssm_before = [state.clone() for state in convs], [state.clone() for state in ssms]
+    conv_ref, ssm_ref = [state.clone() for state in convs], [state.clone() for state in ssms]
+    for req_idx in range(len(src_col)):
+        src, dst, token_bias = int(src_col[req_idx]), int(dst_col[req_idx]), int(bias[req_idx])
+        if src < 0 or src == dst:
+            continue
+        src_block, dst_block = int(block_table[req_idx, src]), int(block_table[req_idx, dst])
+        temporal_block = int(block_table[req_idx, src + token_bias])
+        for layer in range(NUM_LAYERS):
+            if conv_dim_first:
+                conv_ref[layer][dst_block, :, : CONV_WIDTH - token_bias] = conv_before[layer][src_block, :, token_bias:]
+            else:
+                conv_ref[layer][dst_block, : CONV_WIDTH - token_bias] = conv_before[layer][src_block, token_bias:]
+            ssm_ref[layer][dst_block] = ssm_before[layer][temporal_block]
+    return conv_ref, ssm_ref
+
+
+@pytest.mark.parametrize("conv_dim_first", [False, True])
+@pytest.mark.parametrize("has_idx_mapping", [False, True])
+@pytest.mark.parametrize("temporal_tiles", [1, 4])
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+def test_precopy_matches_reference(conv_dim_first, has_idx_mapping, temporal_tiles):
+    device = torch.device("npu:0")
+    torch.manual_seed(0)
+    num_reqs = 4
+    num_blocks = num_reqs * MAX_COLS + 1
+    block_table = torch.arange(1, num_blocks, dtype=torch.int32, device=device).reshape(num_reqs, MAX_COLS)
+    src_col = torch.tensor([-1, 1, 1, 1], dtype=torch.int32, device=device)
+    dst_col = torch.tensor([0, 1, 0, 0], dtype=torch.int32, device=device)
+    bias = torch.tensor([0, 0, 1, 2], dtype=torch.int32, device=device)
+    convs, ssms = _build_states(num_blocks, device, conv_dim_first)
+    conv_ref, ssm_ref = _reference(convs, ssms, block_table.cpu(), src_col.cpu(), dst_col.cpu(), bias.cpu(), conv_dim_first)
+    base, block_stride, elem_size, inner_size, conv_width, group, row_count, row_stride = _build_meta(
+        convs, ssms, device, conv_dim_first
+    )
+    block_table_ptrs = torch.tensor([block_table.data_ptr()], dtype=torch.int64, device=device)
+    idx_mapping = torch.arange(num_reqs, dtype=torch.int32, device=device)
+    grid = (num_reqs, NUM_LAYERS * 2, temporal_tiles)
+    precopy_mamba_align_fused_kernel[grid](
+        dst_col, src_col, bias, block_table_ptrs, block_table.stride(0), base, block_stride, elem_size,
+        inner_size, conv_width, group, row_count, row_stride, idx_mapping if has_idx_mapping else None,
+        num_reqs, COPY_BLOCK_SIZE=128, CONV_STATE_DIM_FIRST=conv_dim_first,
+        HAS_IDX_MAPPING=has_idx_mapping, TEMPORAL_TILES=temporal_tiles,
+    )
+    torch.accelerator.synchronize()
+    for layer in range(NUM_LAYERS):
+        torch.testing.assert_close(convs[layer], conv_ref[layer], rtol=0, atol=0)
+        torch.testing.assert_close(ssms[layer], ssm_ref[layer], rtol=0, atol=0)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_precopy.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_precopy.py
@@ -21,7 +21,13 @@ def _build_states(num_blocks, device, conv_dim_first):
 
 
 def _build_meta(convs, ssms, device, conv_dim_first):
-    base, block_stride, elem_size, inner_size, conv_width, row_count, row_stride = [], [], [], [], [], [], []
+    base: list[int] = []
+    block_stride: list[int] = []
+    elem_size: list[int] = []
+    inner_size: list[int] = []
+    conv_width: list[int] = []
+    row_count: list[int] = []
+    row_stride: list[int] = []
     for conv, ssm in zip(convs, ssms):
         base.extend((conv.data_ptr(), ssm.data_ptr()))
         block_stride.extend((conv.stride(0) * conv.element_size(), ssm.stride(0) * ssm.element_size()))

--- a/tests/ut/patch/worker/test_patch_mamba_utils_source.py
+++ b/tests/ut/patch/worker/test_patch_mamba_utils_source.py
@@ -11,6 +11,7 @@ from vllm_ascend.utils import vllm_version_is
 ROOT = Path(__file__).resolve().parents[4]
 POSTPROCESS = ROOT / "vllm_ascend" / "ops" / "triton" / "mamba" / "postprocess.py"
 PATCH_MAMBA_UTILS = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_mamba_utils.py"
+PATCH_TRITON = ROOT / "vllm_ascend" / "patch" / "worker" / "patch_v2" / "patch_triton.py"
 
 
 def _top_level_functions(path: Path) -> dict[str, ast.FunctionDef]:
@@ -64,8 +65,9 @@ def test_postprocess_keeps_only_existing_ascend_precision_kernel() -> None:
 
 def test_patch_only_installs_existing_ascend_postprocess_kernel() -> None:
     patch_source = PATCH_MAMBA_UTILS.read_text()
+    patch_triton = PATCH_TRITON.read_text()
 
     assert "mamba_utils.postprocess_mamba_fused_kernel = postprocess_mamba_fused_kernel" in patch_source
     assert "MambaBase.bind_kv_cache" not in patch_source
     assert "mamba_utils._copy_mamba_state_block" not in patch_source
-    assert "mamba_utils.precopy_mamba_align_fused_kernel" in patch_source
+    assert "mamba_utils.precopy_mamba_align_fused_kernel" in patch_triton

--- a/vllm_ascend/ops/triton/v2/mamba/docs/mamba_precopy.md
+++ b/vllm_ascend/ops/triton/v2/mamba/docs/mamba_precopy.md
@@ -4,9 +4,9 @@
 
 - 算子功能：在 Mamba 前向计算前，将跨 block 请求的旧运行状态复制到目标 block；`src_col < 0` 或 `src_col == dst_col` 时跳过。
 - 计算公式：
-  - SD 卷积：`state[dst, :W-bias, ...] = state[src, bias:, ...]`。
-  - DS 卷积：`state[dst, row, :W-bias] = state[src, row, bias:]`。
-  - Temporal：`state[dst] = state[block_table[src_col+bias]]`。
+    - SD 卷积：`state[dst, :W-bias, ...] = state[src, bias:, ...]`。
+    - DS 卷积：`state[dst, row, :W-bias] = state[src, row, bias:]`。
+    - Temporal：`state[dst] = state[block_table[src_col+bias]]`。
 - 算法流程（逐请求、逐状态独立处理）：
   1. 从三维 grid 获取 `batch_idx`、`state_idx` 和 `tile_idx`。
   2. 可选地通过 `idx_mapping_ptr` 获取请求下标，并查询源、目标物理 block。

--- a/vllm_ascend/ops/triton/v2/mamba/docs/mamba_precopy.md
+++ b/vllm_ascend/ops/triton/v2/mamba/docs/mamba_precopy.md
@@ -1,0 +1,68 @@
+# precopy_mamba_align_fused_kernel
+
+## 功能说明
+
+- 算子功能：在 Mamba 前向计算前，将跨 block 请求的旧运行状态复制到目标 block；`src_col < 0` 或 `src_col == dst_col` 时跳过。
+- 计算公式：
+  - SD 卷积：`state[dst, :W-bias, ...] = state[src, bias:, ...]`。
+  - DS 卷积：`state[dst, row, :W-bias] = state[src, row, bias:]`。
+  - Temporal：`state[dst] = state[block_table[src_col+bias]]`。
+- 算法流程（逐请求、逐状态独立处理）：
+  1. 从三维 grid 获取 `batch_idx`、`state_idx` 和 `tile_idx`。
+  2. 可选地通过 `idx_mapping_ptr` 获取请求下标，并查询源、目标物理 block。
+  3. 卷积状态仅由 tile 0 复制；DS 布局逐 dim row 复制，SD 布局连续复制。
+  4. Temporal 状态由 `TEMPORAL_TILES` 个 CTA 分段复制，tail 由 tile 0 处理。
+- 支持模式：SD/DS 卷积布局、temporal 状态、V1/V2 请求索引、单 tile/多 tile temporal 复制。
+
+## 参数说明
+
+| 参数名 | 输入/输出/属性 | 描述 | 数据类型 | 数据格式 |
+|:--------|:----------------|:------|:---------|:---------|
+| mamba_state_idx_ptr | 输入 | 目标 block-table 列。 | INT32 | 1D |
+| src_col_ptr | 输入 | 源 block-table 列；负数表示跳过。 | INT32 | 1D |
+| token_bias_ptr | 输入 | 卷积切片或 temporal 源列偏移。 | INT32 | 1D |
+| block_table_ptrs_ptr | 输入 | 各 group 的 block-table 地址。 | INT64 | 1D |
+| block_table_stride_req | 输入 | block table 请求行步长。 | INT64 | Scalar |
+| state_base_addrs_ptr | 输入/输出 | 状态基地址，目标 block 原地更新。 | INT64 | 1D |
+| state_block_strides_ptr | 输入 | 状态 block 字节步长。 | INT64 | 1D |
+| state_elem_sizes_ptr | 输入 | 状态元素字节数。 | INT32 | 1D |
+| state_inner_sizes_ptr | 输入 | temporal block 元素数或卷积 inner size。 | INT64 | 1D |
+| state_conv_widths_ptr | 输入 | 卷积宽度；0 表示 temporal。 | INT32 | 1D |
+| state_group_indices_ptr | 输入 | state 到 block-table group 的映射。 | INT32 | 1D |
+| state_dim_row_count_ptr | 输入 | DS 卷积 dim row 数。 | INT32 | 1D |
+| state_dim_row_stride_ptr | 输入 | DS 卷积 dim row 字节步长。 | INT64 | 1D |
+| idx_mapping_ptr | 输入 | 可选的 batch 到请求槽位映射。 | INT32/None | 1D/- |
+| num_reqs | 输入 | 有效请求数。 | INT | Scalar |
+| COPY_BLOCK_SIZE | 属性 | 向量化复制宽度。 | tl.constexpr | Scalar |
+| CONV_STATE_DIM_FIRST | 属性 | 是否使用 DS 布局。 | tl.constexpr | Scalar |
+| HAS_IDX_MAPPING | 属性 | 是否使用请求映射。 | tl.constexpr | Scalar |
+| TEMPORAL_TILES | 属性 | temporal 复制 CTA 数量。 | tl.constexpr | Scalar |
+
+## 约束说明
+
+- grid 必须为 `(num_reqs, num_layers * num_state_types, TEMPORAL_TILES)`。
+- `COPY_BLOCK_SIZE`、`TEMPORAL_TILES` 必须为正整数编译期常量。
+- 有效请求的列下标、偏移和 block ID 必须在合法范围内；卷积要求 `0 <= token_bias < conv_width`。
+- DS 布局必须提供正确的 row count 和 row stride；各状态元数据长度必须一致。
+- Temporal 主体按 `uint64` 复制，剩余 0～7 字节按 `uint8` 复制。
+- 支持 Ascend NPU Triton JIT；图模式要求 grid 和编译期属性固定。
+
+## 调用示例
+
+```python
+grid = (num_reqs, num_layers * num_state_types, temporal_tiles)
+precopy_mamba_align_fused_kernel[grid](
+    dst_col, src_col, token_bias, block_table_ptrs, block_table_stride,
+    state_base_addrs, state_block_strides, state_elem_sizes, state_inner_sizes,
+    state_conv_widths, state_group_indices, state_dim_row_count,
+    state_dim_row_stride, idx_mapping, num_reqs, COPY_BLOCK_SIZE=128,
+    CONV_STATE_DIM_FIRST=False, HAS_IDX_MAPPING=True,
+    TEMPORAL_TILES=temporal_tiles,
+)
+```
+
+## test ut
+
+```bash
+pytest -sv tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_precopy.py
+```

--- a/vllm_ascend/ops/triton/v2/mamba/precopy.py
+++ b/vllm_ascend/ops/triton/v2/mamba/precopy.py
@@ -67,7 +67,6 @@ def _copy_mamba_state_block(
                 tl.store(row_dst + offset + offsets, data, mask=mask)
         return
 
-
     if is_conv_state:
         if tile_idx > 0:
             return

--- a/vllm_ascend/ops/triton/v2/mamba/precopy.py
+++ b/vllm_ascend/ops/triton/v2/mamba/precopy.py
@@ -90,9 +90,9 @@ def _copy_mamba_state_block(
     src_u64 = src_addr.to(tl.pointer_type(tl.uint64))
     dst_u64 = dst_addr.to(tl.pointer_type(tl.uint64))
 
-    per_tile_u64 = tl.cdiv(tl.cdiv(copy_size_u64, TEMPORAL_TILES), COPY_BLOCK_SIZE) * COPY_BLOCK_SIZE
-    tile_start = tile_idx.to(tl.int64) * per_tile_u64
-    tile_end = tl.minimum(tile_start + per_tile_u64, copy_size_u64)
+    work_per_tile = tl.cdiv(copy_size_u64, TEMPORAL_TILES)
+    tile_start = tile_idx.to(tl.int64) * work_per_tile
+    tile_end = tl.minimum(tile_start + work_per_tile, copy_size_u64)
     offsets = tl.arange(0, COPY_BLOCK_SIZE)
     for offset in range(tile_start, tile_end, COPY_BLOCK_SIZE):
         mask = offset + offsets < tile_end

--- a/vllm_ascend/ops/triton/v2/mamba/precopy.py
+++ b/vllm_ascend/ops/triton/v2/mamba/precopy.py
@@ -21,8 +21,10 @@ def _copy_mamba_state_block(
     state_group_indices_ptr,
     state_dim_row_count_ptr,
     state_dim_row_stride_ptr,
+    tile_idx,
     COPY_BLOCK_SIZE: tl.constexpr,
     CONV_STATE_DIM_FIRST: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr,
 ):
     """Copy one Mamba state block without casting pointers in copy loops.
 
@@ -45,120 +47,68 @@ def _copy_mamba_state_block(
     dst_addr = state_base_addr + dest_block_id * state_block_stride
 
     is_conv_state = conv_width > 0
-
     if CONV_STATE_DIM_FIRST and is_conv_state:
+        if tile_idx > 0:
+            return
         src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
-
         dim_rows = tl.load(state_dim_row_count_ptr + state_idx)
         row_stride = tl.load(state_dim_row_stride_ptr + state_idx)
-
         per_row_bytes = (conv_width - token_bias).to(tl.int64) * state_elem_size
-
         bias_bytes = token_bias.to(tl.int64) * state_elem_size
-
         src_block_addr = state_base_addr + src_block_id * state_block_stride
-
         offsets = tl.arange(0, COPY_BLOCK_SIZE)
 
         for row in range(0, dim_rows):
             row_src = (src_block_addr + row * row_stride + bias_bytes).to(tl.pointer_type(tl.uint8))
-
             row_dst = (dst_addr + row * row_stride).to(tl.pointer_type(tl.uint8))
-
             for offset in range(0, per_row_bytes, COPY_BLOCK_SIZE):
                 mask = offset + offsets < per_row_bytes
-
-                data = tl.load(
-                    row_src + offset + offsets,
-                    mask=mask,
-                )
-
-                tl.store(
-                    row_dst + offset + offsets,
-                    data,
-                    mask=mask,
-                )
-
+                data = tl.load(row_src + offset + offsets, mask=mask)
+                tl.store(row_dst + offset + offsets, data, mask=mask)
         return
 
+
     if is_conv_state:
+        if tile_idx > 0:
+            return
         src_block_id = tl.load(block_table_base + src_col).to(tl.int64)
-
         src_offset = token_bias.to(tl.int64) * state_inner_size * state_elem_size
-
         src_addr = state_base_addr + src_block_id * state_block_stride + src_offset
-
         copy_size = (conv_width - token_bias).to(tl.int64) * state_inner_size * state_elem_size
-
         offsets = tl.arange(0, COPY_BLOCK_SIZE)
-
         src_ptr = src_addr.to(tl.pointer_type(tl.uint8))
         dst_ptr = dst_addr.to(tl.pointer_type(tl.uint8))
-
         for offset in range(0, copy_size, COPY_BLOCK_SIZE):
             mask = offset + offsets < copy_size
-
-            data = tl.load(
-                src_ptr + offset + offsets,
-                mask=mask,
-            )
-
-            tl.store(
-                dst_ptr + offset + offsets,
-                data,
-                mask=mask,
-            )
-
+            data = tl.load(src_ptr + offset + offsets, mask=mask)
+            tl.store(dst_ptr + offset + offsets, data, mask=mask)
         return
 
     actual_src_block_id = tl.load(block_table_base + src_col + token_bias).to(tl.int64)
-
     src_addr = state_base_addr + actual_src_block_id * state_block_stride
-
     copy_size = state_inner_size * state_elem_size
-
     copy_size_u64 = copy_size // 8
-
     src_u64 = src_addr.to(tl.pointer_type(tl.uint64))
     dst_u64 = dst_addr.to(tl.pointer_type(tl.uint64))
 
+    per_tile_u64 = tl.cdiv(tl.cdiv(copy_size_u64, TEMPORAL_TILES), COPY_BLOCK_SIZE) * COPY_BLOCK_SIZE
+    tile_start = tile_idx.to(tl.int64) * per_tile_u64
+    tile_end = tl.minimum(tile_start + per_tile_u64, copy_size_u64)
     offsets = tl.arange(0, COPY_BLOCK_SIZE)
+    for offset in range(tile_start, tile_end, COPY_BLOCK_SIZE):
+        mask = offset + offsets < tile_end
+        data = tl.load(src_u64 + offset + offsets, mask=mask)
+        tl.store(dst_u64 + offset + offsets, data, mask=mask)
 
-    for offset in range(0, copy_size_u64, COPY_BLOCK_SIZE):
-        mask = offset + offsets < copy_size_u64
-
-        data = tl.load(
-            src_u64 + offset + offsets,
-            mask=mask,
-        )
-
-        tl.store(
-            dst_u64 + offset + offsets,
-            data,
-            mask=mask,
-        )
-
-    tail_start = copy_size_u64 * 8
-    tail_bytes = copy_size - tail_start
-
-    tail_offsets = tl.arange(0, 8)
-
-    tail_src = (src_addr + tail_start).to(tl.pointer_type(tl.uint8))
-
-    tail_dst = (dst_addr + tail_start).to(tl.pointer_type(tl.uint8))
-
-    tail_mask = tail_offsets < tail_bytes
-
-    tail_data = tl.load(
-        tail_src + tail_offsets,
-        mask=tail_mask,
-    )
-
-    tl.store(
-        tail_dst + tail_offsets,
-        tail_data,
-        mask=tail_mask,
-    )
+    if tile_idx == 0:
+        tail_start = copy_size_u64 * 8
+        tail_bytes = copy_size - tail_start
+        tail_offsets = tl.arange(0, 8)
+        tail_src = (src_addr + tail_start).to(tl.pointer_type(tl.uint8))
+        tail_dst = (dst_addr + tail_start).to(tl.pointer_type(tl.uint8))
+        tail_mask = tail_offsets < tail_bytes
+        tail_data = tl.load(tail_src + tail_offsets, mask=tail_mask)
+        tl.store(tail_dst + tail_offsets, tail_data, mask=tail_mask)
 
 
 @triton.jit
@@ -181,9 +131,11 @@ def precopy_mamba_align_fused_kernel(
     COPY_BLOCK_SIZE: tl.constexpr,
     CONV_STATE_DIM_FIRST: tl.constexpr,
     HAS_IDX_MAPPING: tl.constexpr,
+    TEMPORAL_TILES: tl.constexpr = 1,
 ):
     batch_idx = tl.program_id(0)
     state_idx = tl.program_id(1)
+    tile_idx = tl.program_id(2)
 
     if batch_idx >= num_reqs:
         return
@@ -197,7 +149,6 @@ def precopy_mamba_align_fused_kernel(
         req_idx = batch_idx
 
     src_col = tl.load(src_col_ptr + req_idx)
-
     dst_col = tl.load(mamba_state_idx_ptr + req_idx)
 
     if src_col < 0 or src_col == dst_col:
@@ -221,6 +172,8 @@ def precopy_mamba_align_fused_kernel(
         state_group_indices_ptr,
         state_dim_row_count_ptr,
         state_dim_row_stride_ptr,
+        tile_idx,
         COPY_BLOCK_SIZE,
         CONV_STATE_DIM_FIRST,
+        TEMPORAL_TILES,
     )

--- a/vllm_ascend/patch/worker/patch_mamba_utils.py
+++ b/vllm_ascend/patch/worker/patch_mamba_utils.py
@@ -16,7 +16,6 @@ from vllm.v1.worker.mamba_utils import MambaCopyBuffers
 
 from vllm_ascend.ops.triton.batch_memcpy import batch_memcpy_kernel
 from vllm_ascend.ops.triton.mamba.postprocess import postprocess_mamba_fused_kernel
-from vllm_ascend.ops.triton.mamba.precopy import precopy_mamba_align_fused_kernel
 from vllm_ascend.utils import is_310p
 
 
@@ -197,10 +196,8 @@ if _can_launch_triton_batch_memcpy():
     mamba_utils.batch_memcpy_kernel = batch_memcpy_kernel
     mamba_utils.batch_memcpy = _batch_memcpy_triton
     # Keep the existing Ascend postprocess precision fix. The shared copy
-    # helper and align pre-copy use Ascend-safe implementations which hoist
-    # pointer casts out of copy loops.
+    # helper and align pre-copy continue to use the upstream implementation.
     mamba_utils.postprocess_mamba_fused_kernel = postprocess_mamba_fused_kernel
-    mamba_utils.precopy_mamba_align_fused_kernel = precopy_mamba_align_fused_kernel
 else:
     mamba_utils.batch_memcpy = _batch_memcpy_unavailable
     mamba_utils.collect_mamba_copy_meta = _collect_mamba_copy_meta_torch

--- a/vllm_ascend/patch/worker/patch_v2/patch_triton.py
+++ b/vllm_ascend/patch/worker/patch_v2/patch_triton.py
@@ -1,11 +1,13 @@
 import vllm.v1.worker.gpu.spec_decode.speculator as base_speculator
 from vllm.v1.sample.ops import topk_topp_sampler
+from vllm.v1.worker import mamba_utils
 from vllm.v1.worker.gpu import structured_outputs
 from vllm.v1.worker.gpu.sample import bad_words, gumbel, logprob, penalties, prompt_logprob, sampler, states
 from vllm.v1.worker.gpu.spec_decode import rejection_sampler, rejection_sampler_utils
 from vllm.v1.worker.gpu.spec_decode.dflash import speculator as dflash_speculator
 from vllm.v1.worker.gpu.spec_decode.eagle import speculator
 
+from vllm_ascend.ops.triton.v2.mamba.precopy import precopy_mamba_align_fused_kernel
 from vllm_ascend.ops.triton.v2.metrics.num_nans import get_num_nans
 from vllm_ascend.ops.triton.v2.sample.apply_top_k_top_p_triton import apply_top_k_top_p_triton
 from vllm_ascend.ops.triton.v2.sample.fill_logprob_token_idx import _fill_logprob_token_ids_kernel
@@ -42,6 +44,7 @@ rejection_sampler.rejection_sample = npu_rejection_sample
 dflash_speculator._prepare_dflash_inputs_kernel = _prepare_dflash_inputs_kernel_ascend
 # triton ops that filed in ops/triton
 topk_topp_sampler.apply_top_k_top_p_triton = apply_top_k_top_p_triton
+mamba_utils.precopy_mamba_align_fused_kernel = precopy_mamba_align_fused_kernel
 # This patch may be revisited or reverted once the compiler and Triton Ascend toolkit
 # support the upstream implementation of fill_logprob_token_ids_kernel.
 # For now, use the Ascend-specific implementation.


### PR DESCRIPTION
### What this PR does / why we need it?

This PR fixes the following Triton Ascend assertion failure in the Mamba state pre-copy kernel:

```text
PtrOffsetInfo::AxisInfo::operator[]: Assertion `idx < size()` failed
```
This issue was also observed in #7103 and #10888 .
This PR also:
- Adds an end-to-end test covering the supported layouts and execution modes.
- Adds documentation for the kernel behavior, parameters, constraints, and usage.
This is a follow-up to #14649.

After these changes, V2 Runner inference works correctly. 
Below is the accuracy of Qwen3.5-27B on the GPQA benchmark.
<img width="312" height="62" alt="image" src="https://github.com/user-attachments/assets/9b5834ba-8421-4565-bb2b-62e7ddc4c564" />


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
