### PR TITLE
[v0.26.0rc][BugFix][Spec Decode] Skip unused MTP draft logits on prefill workers

### DIFF
--- a/tests/ut/spec_decode/a2/test_eagle_proposer.py
+++ b/tests/ut/spec_decode/a2/test_eagle_proposer.py
@@ -2783,6 +2783,31 @@ class TestRunMergedDraft(TestBase):
         )
         self.assertIs(forward_context.attn_metadata, multi_steps_attn_metadata[2])
 
+    def test_run_merged_draft_skips_output_gather_on_prefill_only_mtp(self):
+        self.proposer.method = "mtp"
+        self.proposer.num_speculative_tokens = 1
+        self.proposer.runner._is_pd_prefill_worker.return_value = True
+        self.proposer.model = MockDraftModel(returns_tuple=False)
+        self.proposer.input_ids[:4] = torch.tensor([279, 1196, 374, 8014], dtype=torch.int32)
+        self.proposer.positions[:4] = torch.tensor([17, 18, 19, 20], dtype=torch.int64)
+        self.proposer.hidden_states[:4] = torch.arange(16, dtype=torch.float32).view(4, 4)
+        self.proposer.maybe_all_gather_and_unpad.reset_mock()
+
+        draft_token_ids = self.proposer._run_merged_draft(
+            num_input_tokens=4,
+            batch_size=2,
+            token_indices_to_sample=torch.tensor([1, 3], dtype=torch.int64),
+            target_positions=self.proposer.positions[:4],
+            inputs_embeds=None,
+            multi_steps_attn_metadata=None,
+            num_tokens=4,
+            is_prefill=True,
+        )
+
+        self.assertEqual(tuple(draft_token_ids.shape), (2, 0))
+        self.assertEqual(len(self.proposer.model.calls), 1)
+        self.proposer.maybe_all_gather_and_unpad.assert_not_called()
+
     def test_run_merged_draft_early_return_conditions(self):
         test_cases = [
             (1, False, torch.tensor([1, 3], dtype=torch.int64), (2, 1)),

--- a/tests/ut/spec_decode/test_step3p5_source_regression.py
+++ b/tests/ut/spec_decode/test_step3p5_source_regression.py
@@ -83,6 +83,7 @@ def test_step3p5_draft_window_and_config_contracts() -> None:
     create_config = _src(_method(STEP3P5, "AscendStep3p5MTPProposer", "_create_draft_vllm_config"))
 
     assert [arg.arg for arg in step_run.args.args] == [arg.arg for arg in base_run.args.args]
+    assert "_is_prefill_only_mtp()" in _src(step_run)
     assert "multi_steps_attn_metadata.append(per_step_attn_metadata)" in build_metadata
     assert "multi_steps_attn_metadata[spec_step_idx]" in run_window
     assert "self.input_ids[token_indices_to_sample]" in roll_inputs

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -740,6 +740,9 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             return self.model.unwrap()
         return self.model
 
+    def _is_prefill_only_mtp(self) -> bool:
+        return self.method == "mtp" and self.num_speculative_tokens == 1 and self.runner._is_pd_prefill_worker() is True
+
     def shallow_copy_metadata(self, attn_metadata):
         # Currently, new objects will be assigned to the lists in attn_metadata
         # when update. So we can use the shallow copy.
@@ -1351,6 +1354,13 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
         draft_model = getattr(self.model, "model", None)
         if self._share_mtp_indices and draft_model is not None and hasattr(draft_model, "set_skip_topk"):
             draft_model.set_skip_topk(True)
+
+        # A pure prefill worker needs the MTP forward to populate the draft
+        # layer KV cache, but it does not consume or transfer draft tokens.
+        # Avoid restoring the sequence-parallel hidden states solely for
+        # sampling an unused draft token.
+        if self._is_prefill_only_mtp():
+            return torch.empty((batch_size, 0), dtype=torch.int64, device=last_hidden_states.device)
 
         if self.method != "dflash":
             last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(

--- a/vllm_ascend/spec_decode/step3p5.py
+++ b/vllm_ascend/spec_decode/step3p5.py
@@ -530,6 +530,9 @@ class AscendStep3p5MTPProposer(AscendEagleProposer):
         else:
             last_hidden_states, hidden_states = ret_hidden_states
 
+        if self._is_prefill_only_mtp():
+            return torch.empty((batch_size, 0), dtype=torch.int64, device=last_hidden_states.device)
+
         last_hidden_states, model_positions, hidden_states = self.maybe_all_gather_and_unpad(
             last_hidden_states, model_positions, hidden_states
         )

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -2290,7 +2290,10 @@ class NPUModelRunner(GPUModelRunner):
                 sample_hidden_states,
                 batch_desc,
             )
-            self._copy_draft_token_ids_to_cpu(scheduler_output)
+            if isinstance(self._draft_token_ids, torch.Tensor) and self._draft_token_ids.shape[-1] == 0:
+                self._draft_token_ids = None
+            if self._draft_token_ids is not None:
+                self._copy_draft_token_ids_to_cpu(scheduler_output)
 
         output_spec_token_ids = None
         use_padded_batch = False


### PR DESCRIPTION
### What this PR does / why we need it?

This is the v0.26.0rc release-branch counterpart of #15031.

Pure KV-producer workers still need the single-step MTP forward pass to populate the draft-layer KV cache, but they do not consume MTP draft tokens or draft logits.

During dummy execution, the synthetic draft batch can be much larger than max_num_seqs. Computing and TP-all-gathering its full-vocabulary logits can therefore request several GiB of unnecessary HBM.

For the observed GLM-5.2 failure with BF16, TP16, 32,768 dummy tokens, and 16,384 synthetic sample rows, the early return avoids these per-rank allocations:

| Avoided allocation | Approximate HBM per rank |
| --- | ---: |
| MTP hidden-state sequence-parallel all-gather | 384 MiB |
| Sample hidden states | 192 MiB |
| Local vocabulary logits | 302.5 MiB |
| Full-vocabulary logits TP all-gather | 4.73 GiB |
| Position all-gather | 0.25 MiB |
| Total direct allocations | about 5.58 GiB |

The exact saving scales with dummy token count, vocabulary size, dtype, and parallel configuration. The 4.73 GiB full-vocabulary logits allocation was the immediate OOM request in this failure.

This PR:

- keeps the single-step MTP forward pass on pure KV producers so draft KV caches are populated;
- returns before sequence-parallel output gathering, LM Head, logits gathering, and draft sampling;
- applies the same behavior to the Step3.5 proposer;
- converts the empty draft result to None so no draft-token CPU copy is scheduled.

The optimization is restricted to MTP with one speculative token on a producer-only PD worker. Multi-step MTP and decode workers keep their existing behavior.

### Does this PR introduce _any_ user-facing change?

No API or configuration change. Pure prefill workers use less peak HBM and avoid computing unused MTP draft logits.

### How was this patch tested?

- Added a unit regression that verifies the MTP forward still runs while output all-gather is skipped on a pure prefill worker.
- Added a Step3.5 source-contract regression for the same early-return behavior.
- Ran the source-level regression tests successfully.
- Ran bash format.sh ci successfully; all checks passed.
- The local host has no Ascend NPU runtime, so full GLM-5.2 TP16 startup validation is left to CI and NPU hardware testing.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
