### PR TITLE
[BugFix][Config] Disable static kernel for MiniMax tests

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A2.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A2.yaml
@@ -50,7 +50,7 @@ test_cases:
       - "--compilation-config"
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - "--additional-config"
-      - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true},"enable_fused_mc2":1}'
+      - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false},"enable_fused_mc2":1}'
     benchmarks:
       acc:
         case_type: accuracy

--- a/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml
@@ -39,7 +39,7 @@ _server_cmd: &server_cmd
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--additional-config"
-  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
+  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
 
 _benchmarks_3500: &benchmarks_3500
   perf_50:

--- a/tests/e2e/weekly/single_node/configs/Minimax_M2.7_w8a8_A3.yaml
+++ b/tests/e2e/weekly/single_node/configs/Minimax_M2.7_w8a8_A3.yaml
@@ -39,7 +39,7 @@ _server_cmd: &server_cmd
   - "--compilation-config"
   - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
   - "--additional-config"
-  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": true}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
+  - '{"enable_cpu_binding": true, "ascend_compilation_config": {"enable_npugraph_ex": true, "enable_static_kernel": false}, "enable_fused_mc2": true, "weight_nz_mode": 1, "enable_flashcomm1": true}'
 
 
 _benchmarks_acc: &benchmarks_acc


### PR DESCRIPTION
### What this PR does / why we need it?

Disable `ascend_compilation_config.enable_static_kernel` in the following MiniMax weekly/nightly test configurations:

- `tests/e2e/weekly/single_node/configs/Minimax_M2.7_w8a8_A3.yaml`
- `tests/e2e/nightly/single_node/models/configs/MiniMax-M2.5-w8a8-QuaRot-A2.yaml`
- `tests/e2e/nightly/single_node/models/configs/Minimax_m2.7_w8a8_A3.yaml`

The change is limited to setting the existing schema-valid option from `true` to `false`.

### Does this PR introduce _any_ user-facing change?

No. This only updates nightly and weekly test configurations.

### How was this patch tested?

- Parsed all three changed YAML files.
- Parsed all three embedded `--additional-config` JSON objects.
- Constructed the current `AscendCompilationConfig` for each changed value and verified `enable_npugraph_ex=true` and `enable_static_kernel=false`.
- `git diff --check`.
- Pre-commit checks on the three changed YAML files passed.

NPU execution is left to CI because the local WSL environment does not provide `torch_npu`.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
