### PR TITLE
[Test] Set the e2e case 'test_dflash2_acceptance' to eager mode

### DIFF
--- a/tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py
+++ b/tests/e2e/pull_request/two_card/spec_decode/test_spec_decode.py
@@ -596,6 +596,7 @@ def test_dflash2_acceptance(
 
     with VllmRunner(
         main_model_name,
+        enforce_eager=True,
         max_model_len=2048,
         disable_log_stats=False,
         tensor_parallel_size=2,


### PR DESCRIPTION
### What this PR does / why we need it?
The e2e test case 'test_dflash2_acceptance' runs Qwen3.8-27B (hybrid GDN attention) with DFlash2 and TP2 under cudagraph_mode=PIECEWISE and cudagraph_capture_sizes=[9]. 
Graph capture succeeds at init, but the first generate step—a 23-token prefill—hits an AI Core illegal memory access on device (507011 / MTE invalid GM). 
Other GDN tests in this family typically use FULL_DECODE_ONLY or eager. 
Switch this case to eager so CI is not broken by graph mode.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
