### PR TITLE
[Feature][Model] Support Qwen3.8 Flash-Next

### DIFF
--- a/tests/ut/models/test_qwen4_exp_hc.py
+++ b/tests/ut/models/test_qwen4_exp_hc.py
@@ -1,0 +1,86 @@
+import torch
+
+from vllm_ascend import models
+from vllm_ascend.ops.triton.qwen4_exp.hc import (
+    grouped_gemma_rmsnorm,
+    hc_combine,
+    hc_combine_norm,
+    hc_gate_mix,
+    hc_silu,
+)
+
+
+def test_qwen4_exp_architectures_are_registered(monkeypatch) -> None:
+    registered: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        models.ModelRegistry,
+        "register_model",
+        lambda architecture, target: registered.__setitem__(architecture, target),
+    )
+
+    models.register_model()
+
+    assert registered["Qwen4ExpForCausalLM"] == ("vllm_ascend.models.qwen4_exp:AscendQwen4ExpForCausalLM")
+    assert registered["Qwen4ExpForConditionalGeneration"] == (
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpForConditionalGeneration"
+    )
+    assert registered["Qwen4ExpMTP"] == ("vllm_ascend.models.qwen4_exp:AscendQwen4ExpMTP")
+
+
+def test_hyperconnection_ops_match_torch_reference() -> None:
+    torch.manual_seed(0)
+    hc_count = 4
+    group_dim = 8
+    residual = torch.randn(3, hc_count * group_dim, dtype=torch.bfloat16)
+    gate = torch.randn_like(residual)
+    block_output = torch.randn(3, group_dim, dtype=torch.bfloat16)
+    injection = torch.randn(3, hc_count, dtype=torch.bfloat16)
+    weight = torch.randn(hc_count * group_dim, dtype=torch.bfloat16)
+    eps = 1e-6
+
+    actual_silu = hc_silu(gate, hc_count)
+    expected_silu = torch.nn.functional.silu(gate.float() / hc_count).to(gate.dtype)
+    torch.testing.assert_close(actual_silu, expected_silu)
+
+    actual_mix = hc_gate_mix(residual, gate, hc_count)
+    expected_mix = (
+        (torch.sigmoid(gate.float()) * residual.float()).view(3, hc_count, group_dim).mean(1).to(residual.dtype)
+    )
+    torch.testing.assert_close(actual_mix, expected_mix)
+
+    actual_combined = hc_combine(residual, block_output, injection, hc_count)
+    expected_injection = 2 * torch.sigmoid(injection.float() / hc_count)
+    expected_combined = residual.float().view(3, hc_count, group_dim)
+    expected_combined = expected_combined + (block_output.float().unsqueeze(1) * expected_injection.unsqueeze(-1))
+    expected_combined = expected_combined.to(residual.dtype).view_as(residual)
+    torch.testing.assert_close(actual_combined, expected_combined)
+
+    actual_norm = grouped_gemma_rmsnorm(actual_combined, weight, eps, hc_count)
+    grouped = actual_combined.float().view(3, hc_count, group_dim)
+    expected_norm = grouped * torch.rsqrt(grouped.square().mean(-1, keepdim=True) + eps)
+    expected_norm = (
+        (expected_norm * (1 + weight.float().view(1, hc_count, group_dim))).to(residual.dtype).view_as(residual)
+    )
+    torch.testing.assert_close(actual_norm, expected_norm)
+
+    combined, normalized = hc_combine_norm(
+        residual,
+        block_output,
+        injection,
+        weight,
+        eps,
+        hc_count,
+    )
+    torch.testing.assert_close(combined, actual_combined)
+    torch.testing.assert_close(normalized, actual_norm)
+
+
+def test_grouped_norm_accepts_shared_affine() -> None:
+    x = torch.randn(2, 16, dtype=torch.bfloat16)
+    shared_weight = torch.randn(4, dtype=torch.bfloat16)
+
+    result = grouped_gemma_rmsnorm(x, shared_weight, 1e-6, 4)
+
+    assert result.shape == x.shape
+    assert result.dtype == x.dtype

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -3,6 +3,18 @@ from vllm import ModelRegistry
 
 def register_model():
     ModelRegistry.register_model(
+        "Qwen4ExpForCausalLM",
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpForCausalLM",
+    )
+    ModelRegistry.register_model(
+        "Qwen4ExpForConditionalGeneration",
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpForConditionalGeneration",
+    )
+    ModelRegistry.register_model(
+        "Qwen4ExpMTP",
+        "vllm_ascend.models.qwen4_exp:AscendQwen4ExpMTP",
+    )
+    ModelRegistry.register_model(
         "DeepseekV4ForCausalLM", "vllm_ascend.models.deepseek_v4.model:AscendDeepseekV4ForCausalLM"
     )
     ModelRegistry.register_model(

--- a/vllm_ascend/models/qwen4_exp.py
+++ b/vllm_ascend/models/qwen4_exp.py
@@ -1,0 +1,142 @@
+"""Ascend adaptation for the experimental Qwen3.8 Flash-Next model.
+
+The model definition is owned by vLLM.  This module replaces only the
+CUDA-specific glue used by that definition and then registers thin Ascend
+subclasses, keeping checkpoint mapping and model behavior aligned upstream.
+"""
+# mypy: disable-error-code=import-not-found
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import torch
+import vllm.envs as vllm_envs
+from vllm.model_executor.layers.ple_offload_layer import PleOffloadLayer
+
+from vllm_ascend.ops.triton.qwen4_exp import hc as ascend_hc_ops
+from vllm_ascend.ops.triton.qwen4_exp import qsa as ascend_qsa_ops
+
+
+def _disable_cuda_low_latency_gemm(*args: Any, **kwargs: Any) -> None:
+    del args, kwargs
+
+
+# Install the NPU operator modules before importing the upstream NVIDIA model.
+# Its relative imports then resolve to implementations with the same contract,
+# without copying the model definition into the hardware plugin.
+sys.modules["vllm.models.qwen4_exp.nvidia.ops.hc"] = ascend_hc_ops
+sys.modules["vllm.models.qwen4_exp.nvidia.ops.qsa"] = ascend_qsa_ops
+low_latency_gemm = types.ModuleType("vllm.models.qwen4_exp.nvidia.low_latency_gemm")
+setattr(  # noqa: B010
+    low_latency_gemm,
+    "enable_qwen4_exp_low_latency_gemm",
+    _disable_cuda_low_latency_gemm,
+)
+sys.modules[low_latency_gemm.__name__] = low_latency_gemm
+
+from vllm.models.qwen4_exp.common import qsa_cache  # noqa: E402
+from vllm.models.qwen4_exp.nvidia import model as upstream_model  # noqa: E402
+from vllm.models.qwen4_exp.nvidia import mtp as upstream_mtp  # noqa: E402
+from vllm.models.qwen4_exp.nvidia import qsa as upstream_qsa  # noqa: E402
+
+# The upstream Triton metadata builder uses CUDA graph dependency control.
+# The torch implementation is device-agnostic and remains graphable by the
+# Ascend runner, so select it once outside the per-step path.
+qsa_cache.build_qsa_metadata = qsa_cache._build_qsa_metadata_torch
+
+
+def _ple_target_device(cls: type[PleOffloadLayer]) -> torch.device:
+    del cls
+    if vllm_envs.VLLM_PLE_CPU_OFFLOAD:
+        return torch.device("cpu")
+    return torch.device("npu", torch.npu.current_device())
+
+
+PleOffloadLayer.get_target_device = classmethod(_ple_target_device)
+
+
+def _ascend_qsa_impl_init(
+    self: upstream_qsa.Qwen4ExpQSAFlashAttentionImpl,
+    num_heads: int,
+    head_size: int,
+    scale: float,
+    num_kv_heads: int,
+    alibi_slopes: Any,
+    sliding_window: Any,
+    kv_cache_dtype: str,
+    blocksparse_params: Any,
+    attn_type: Any,
+    kv_sharing_target_layer_name: Any,
+    **kwargs: Any,
+) -> None:
+    del blocksparse_params, attn_type, kv_sharing_target_layer_name, kwargs
+    self.num_heads = num_heads
+    self.head_size = head_size
+    self.scale = scale
+    self.num_kv_heads = num_kv_heads
+    self.alibi_slopes = alibi_slopes
+    self.sliding_window = sliding_window or (-1, -1)
+    self.kv_cache_dtype = kv_cache_dtype
+    self.sinks = None
+    self.dcp_world_size = 1
+    self.supports_quant_query_input = False
+
+
+def _ascend_qsa_cache_update(
+    self: upstream_qsa.Qwen4ExpQSAFlashAttentionImpl,
+    layer: torch.nn.Module,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    *args: Any,
+    **kwargs: Any,
+) -> None:
+    del layer, args, kwargs
+    key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
+    slots = slot_mapping[: key.shape[0]].long()
+    valid = slots >= 0
+    slots = slots[valid]
+    page_size = key_cache.shape[1]
+    block_ids = torch.div(slots, page_size, rounding_mode="floor")
+    block_offsets = slots.remainder(page_size)
+    key_cache[block_ids, block_offsets, :, :] = key[valid]
+    value_cache[block_ids, block_offsets, :, :] = value[valid]
+
+
+upstream_qsa.Qwen4ExpQSAFlashAttentionImpl.__init__ = _ascend_qsa_impl_init
+upstream_qsa.Qwen4ExpQSAFlashAttentionImpl.do_kv_cache_update = _ascend_qsa_cache_update
+
+
+def _ascend_model_state_cls():
+    from vllm_ascend.models.qwen4_exp_model_state import (
+        AscendQwen4ExpModelState,
+    )
+
+    return AscendQwen4ExpModelState
+
+
+class AscendQwen4ExpForCausalLM(upstream_model.Qwen4ExpForCausalLM):
+    """Qwen3.8 Flash-Next text model using Ascend runtime state."""
+
+    get_model_state_cls = staticmethod(_ascend_model_state_cls)
+
+
+class AscendQwen4ExpForConditionalGeneration(upstream_model.Qwen4ExpForConditionalGeneration):
+    """Qwen3.8 Flash-Next multimodal model using Ascend runtime state."""
+
+    get_model_state_cls = staticmethod(_ascend_model_state_cls)
+
+
+class AscendQwen4ExpMTP(upstream_mtp.Qwen4ExpMTP):
+    """Qwen3.8 Flash-Next multi-token predictor for Ascend."""
+
+
+__all__ = [
+    "AscendQwen4ExpForCausalLM",
+    "AscendQwen4ExpForConditionalGeneration",
+    "AscendQwen4ExpMTP",
+]

--- a/vllm_ascend/models/qwen4_exp_model_state.py
+++ b/vllm_ascend/models/qwen4_exp_model_state.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Model-runner state for Qwen4Exp PLE inputs."""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+from vllm.v1.worker.gpu.states import RequestState
+
+from vllm_ascend.worker.v2.model_states.mamba_hybrid import AscendMambaHybridModelState
+
+
+class AscendQwen4ExpModelState(AscendMambaHybridModelState):
+    """Add rollback-safe PLE n-gram context to the model inputs."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: nn.Module,
+        encoder_cache: EncoderCache | None,
+        device: torch.device,
+    ) -> None:
+        super().__init__(vllm_config, model, encoder_cache, device)
+        config = self.model_config.hf_text_config
+        self.uses_ngram_embedding = bool(config.ple_layer_ids)
+        if not self.uses_ngram_embedding:
+            self.ngram_context_len = 0
+            self.ngram_eos_token_id = 0
+            return
+
+        if vllm_config.parallel_config.pipeline_parallel_size > 1:
+            raise RuntimeError(
+                "N-gram PLE embedding currently requires "
+                "pipeline_parallel_size=1 because non-first pipeline ranks do "
+                "not receive the raw input_ids required by PLE. Please run "
+                "with PP=1."
+            )
+
+        self.ngram_context_len = int(config.ngram_size) - 1
+        if self.ngram_context_len <= 0:
+            raise ValueError("N-gram embedding requires context length >= 1.")
+        self.ngram_eos_token_id = int(config.eos_token_id)
+        self.ngram_context = torch.full(
+            (self.max_num_reqs, self.ngram_context_len),
+            self.ngram_eos_token_id,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.ngram_context_offsets = torch.arange(
+            -self.ngram_context_len,
+            0,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.ple_query_start_loc = torch.zeros(
+            self.max_num_reqs + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def _prepare_ngram_context(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> torch.Tensor:
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        context = self.ngram_context[:num_reqs_padded]
+        context.fill_(self.ngram_eos_token_id)
+        if num_reqs == 0:
+            return context
+
+        request_indices = input_batch.idx_mapping[:num_reqs].long()
+        context_end = req_states.num_computed_tokens.gpu[request_indices].long()
+        token_indices = context_end.unsqueeze(1) + self.ngram_context_offsets
+        valid_tokens = token_indices >= 0
+        token_indices.clamp_min_(0)
+        context_tokens = req_states.all_token_ids.gpu[request_indices.unsqueeze(1), token_indices]
+        context[:num_reqs].copy_(
+            torch.where(
+                valid_tokens,
+                context_tokens,
+                context_tokens.new_full((), self.ngram_eos_token_id),
+            )
+        )
+        return context
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_inputs(input_batch, req_states)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        query_start_loc = self.ple_query_start_loc[: num_reqs_padded + 1]
+        query_start_loc.copy_(input_batch.query_start_loc[: num_reqs_padded + 1])
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=self._prepare_ngram_context(input_batch, req_states),
+        )
+        return model_inputs
+
+    def prepare_dummy_inputs(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_dummy_inputs(num_reqs, num_tokens)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        query_start_loc = self.ple_query_start_loc[: num_reqs + 1]
+        query_start_loc[0] = 0
+        tokens_per_req, num_extra_tokens = divmod(num_tokens, num_reqs)
+        query_lens = torch.full(
+            (num_reqs,),
+            tokens_per_req,
+            dtype=query_start_loc.dtype,
+            device=query_start_loc.device,
+        )
+        if num_extra_tokens > 0:
+            query_lens[-num_extra_tokens:] += 1
+        torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
+
+        ngram_context = self.ngram_context[:num_reqs]
+        ngram_context.fill_(self.ngram_eos_token_id)
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=ngram_context,
+        )
+        return model_inputs
+
+
+__all__ = ["AscendQwen4ExpModelState"]

--- a/vllm_ascend/ops/triton/qwen4_exp/__init__.py
+++ b/vllm_ascend/ops/triton/qwen4_exp/__init__.py
@@ -1,0 +1,1 @@
+"""Ascend kernels used by the experimental Qwen3.8 Flash-Next model."""

--- a/vllm_ascend/ops/triton/qwen4_exp/hc.py
+++ b/vllm_ascend/ops/triton/qwen4_exp/hc.py
@@ -1,0 +1,81 @@
+"""Torch implementations of the Qwen4Exp HyperConnection glue operations.
+
+The CUDA implementation uses PDL-enabled Triton kernels.  Keeping these
+small elementwise operations in PyTorch lets torch-npu compile them into the
+surrounding graph without importing CUDA-only ``tl.extra.cuda`` primitives.
+"""
+
+import torch
+import torch.nn.functional as F
+
+
+def grouped_gemma_rmsnorm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+    num_groups: int,
+) -> torch.Tensor:
+    rows, dim = x.shape
+    if dim % num_groups:
+        raise ValueError(f"hidden dimension {dim} is not divisible by {num_groups}")
+    group_dim = dim // num_groups
+    grouped = x.float().view(rows, num_groups, group_dim)
+    normalized = grouped * torch.rsqrt(grouped.square().mean(-1, keepdim=True) + eps)
+    if weight.numel() == group_dim:
+        affine = weight.float().view(1, 1, group_dim)
+    elif weight.numel() == dim:
+        affine = weight.float().view(1, num_groups, group_dim)
+    else:
+        raise ValueError(f"expected {group_dim} or {dim} norm weights, got {weight.numel()}")
+    return (normalized * (1 + affine)).to(x.dtype).view_as(x)
+
+
+def hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return F.silu(x.float() / hc_count).to(x.dtype)
+
+
+def hc_gate_mix(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    if x.shape != gate.shape:
+        raise ValueError("HyperConnection input and gate shapes must match")
+    group_dim = x.shape[-1] // hc_count
+    mixed = torch.sigmoid(gate.float()) * x.float()
+    return mixed.view(-1, hc_count, group_dim).mean(1).to(x.dtype)
+
+
+def hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    group_dim = residual.shape[-1] // hc_count
+    injection = 2 * torch.sigmoid(injection_logits.float() / hc_count)
+    combined = residual.float().view(-1, hc_count, group_dim)
+    combined = combined + block_output.float().unsqueeze(1) * injection.unsqueeze(-1)
+    return combined.to(residual.dtype).view_as(residual)
+
+
+def hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    combined = hc_combine(residual, block_output, injection_logits, hc_count)
+    normalized = grouped_gemma_rmsnorm(combined, norm_weight, eps, hc_count)
+    return combined, normalized
+
+
+__all__ = [
+    "grouped_gemma_rmsnorm",
+    "hc_combine",
+    "hc_combine_norm",
+    "hc_gate_mix",
+    "hc_silu",
+]

--- a/vllm_ascend/ops/triton/qwen4_exp/qsa.py
+++ b/vllm_ascend/ops/triton/qwen4_exp/qsa.py
@@ -1,0 +1,1036 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernels for the Qwen4Exp weight-free QSA path.
+
+Adapted from ``vllm/models/qwen4_exp/nvidia/ops/qsa.py``.  The kernels are
+shared with upstream; device validation and top-k dispatch are specialized
+for triton-ascend and torch-npu.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_LOGITS_WORKSPACE_BYTES = 128 * 1024 * 1024
+
+
+@triton.jit
+def _qsa_mqa_paged_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    TILES_PER_PROG: tl.constexpr,
+    STAGES: tl.constexpr,
+    MAX_N: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    heads = tl.arange(0, MAX_N)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    tile_start = tl.program_id(1) * TILES_PER_PROG
+    # Top-k is bounded by visible_blocks, so columns beyond it need no value.
+    if tile_start * BLOCK_N >= visible:
+        return
+    tile_end = tl.minimum(tile_start + TILES_PER_PROG, tl.cdiv(visible, BLOCK_N))
+    tile_end = tl.minimum(tile_end, tl.cdiv(num_columns, BLOCK_N))
+
+    # Pad the small head axis to a tensor-core-compatible N dimension.
+    query = tl.load(
+        q_ptr + row * stride_q_row + heads[None, :] * stride_q_head + dims[:, None] * stride_q_dim,
+        mask=(heads[None, :] < NUM_HEADS) & (dims[:, None] < HEAD_DIM),
+        other=0.0,
+    )
+    column_offsets = tl.arange(0, BLOCK_N)
+    for tile in tl.range(tile_start, tile_end, num_stages=STAGES):
+        columns = tile * BLOCK_N + column_offsets
+        live = columns < visible
+        logical_page = tl.minimum(columns // PAGE_SIZE, PAGE_TABLE_WIDTH - 1)
+        page_offset = columns % PAGE_SIZE
+        physical_page = tl.load(
+            page_table_ptr + safe_request * stride_table_req + logical_page * stride_table_page,
+            mask=live,
+            other=-1,
+        )
+        page_valid = live & (physical_page >= 0) & (physical_page < num_pages)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_physical_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_physical_page[:, None] * stride_cache_block
+            + page_offset[:, None] * stride_cache_token
+            + dims[None, :] * stride_cache_dim,
+            mask=page_valid[:, None] & (dims[None, :] < HEAD_DIM),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        scores = tl.dot(keys, query, out_dtype=tl.float32)
+        scores = tl.where(heads[None, :] < NUM_HEADS, tl.maximum(scores, 0.0), 0.0)
+        score = tl.sum(scores, axis=1) / score_divisor
+        tl.store(
+            logits_ptr + row * stride_logits_row + columns,
+            tl.where(page_valid, score, -float("inf")),
+            mask=live & (columns < num_columns),
+        )
+
+
+@triton.jit
+def _expand_qsa_indices_kernel(
+    block_indices_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    token_to_req_ptr,
+    output_ptr,
+    stride_blocks_row,
+    stride_blocks_column,
+    stride_output_row,
+    stride_output_column,
+    rows,
+    num_requests,
+    BLOCK_TOPK: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    TOKEN_TOPK: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    COLUMN_BLOCK: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * COLUMN_BLOCK + tl.arange(0, COLUMN_BLOCK)
+    query_position = tl.load(query_positions_ptr + row)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    complete_blocks = tl.minimum(
+        tl.minimum(
+            (query_position + 1) // COMPRESS_RATIO,
+            sequence_length // COMPRESS_RATIO,
+        ),
+        BLOCK_TOPK,
+    )
+    expanded_count = complete_blocks * COMPRESS_RATIO
+    tail_start = ((query_position + 1) // COMPRESS_RATIO) * COMPRESS_RATIO
+    tail_count = (query_position + 1) - tail_start
+
+    is_expanded = columns < expanded_count
+    block_rank = columns // COMPRESS_RATIO
+    offset = columns % COMPRESS_RATIO
+    safe_rank = tl.minimum(block_rank, BLOCK_TOPK - 1)
+    block = tl.load(
+        block_indices_ptr + row * stride_blocks_row + safe_rank * stride_blocks_column,
+        mask=(row < rows) & is_expanded,
+        other=-1,
+    )
+    expanded = block * COMPRESS_RATIO + offset
+    tail_offset = columns - expanded_count
+    is_tail = (columns >= expanded_count) & (tail_offset < tail_count) & (tail_offset < COMPRESS_RATIO - 1)
+    token = tl.where(is_expanded, expanded, tail_start + tail_offset)
+    valid = (row < rows) & (columns < OUTPUT_WIDTH) & (is_expanded | is_tail) & (token >= 0) & (token < sequence_length)
+    tl.store(
+        output_ptr + row * stride_output_row + columns * stride_output_column,
+        tl.where(valid, token, -1),
+        mask=(row < rows) & (columns < OUTPUT_WIDTH),
+    )
+
+
+@triton.jit
+def _qsa_sparse_paged_gqa_splitk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    indices_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_k_block,
+    stride_k_token,
+    stride_k_head,
+    stride_v_block,
+    stride_v_token,
+    stride_v_head,
+    stride_indices_row,
+    stride_table_req,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    num_cache_blocks,
+    num_requests,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    split_id = tl.program_id(2)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+
+    head_offsets = tl.arange(0, BLOCK_M)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    column_offsets = tl.arange(0, BLOCK_N)
+    first_head = kv_head * GROUP_SIZE
+    query = tl.load(
+        q_ptr + row * stride_q_row + (first_head + head_offsets[:, None]) * stride_q_head + dim_offsets[None, :],
+        mask=head_offsets[:, None] < GROUP_SIZE,
+        other=0.0,
+    )
+
+    max_value = tl.full((BLOCK_M,), -1.0e20, dtype=tl.float32)
+    normalizer = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    accumulator = tl.zeros((BLOCK_M, HEAD_DIM), dtype=tl.float32)
+    softmax_scale_log2: tl.constexpr = (HEAD_DIM**-0.5) * 1.4426950408889634
+
+    # Dynamic bounds avoid padded main-loop iterations for uneven splits.
+    split_tile_start = split_id * NUM_TILES // NUM_SPLITS
+    split_tile_end = (split_id + 1) * NUM_TILES // NUM_SPLITS
+    for tile in range(split_tile_start, split_tile_end):
+        columns = tile * BLOCK_N + column_offsets
+        logical_token = tl.load(
+            indices_ptr + row * stride_indices_row + columns,
+            mask=columns < TOPK,
+            other=-1,
+        )
+        safe_token = tl.maximum(logical_token, 0)
+        logical_page = safe_token // PAGE_SIZE
+        page_offset = safe_token % PAGE_SIZE
+        valid = (request >= 0) & (request < num_requests) & (logical_token >= 0) & (logical_page < PAGE_TABLE_WIDTH)
+        physical_page = tl.load(
+            block_table_ptr + safe_request * stride_table_req + tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1),
+            mask=valid,
+            other=-1,
+        )
+        valid &= (physical_page >= 0) & (physical_page < num_cache_blocks)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_page[None, :] * stride_k_block
+            + page_offset[None, :] * stride_k_token
+            + kv_head * stride_k_head
+            + dim_offsets[:, None],
+            mask=valid[None, :],
+            other=0.0,
+        )
+        values = tl.load(
+            v_cache_ptr
+            + safe_page[:, None] * stride_v_block
+            + page_offset[:, None] * stride_v_token
+            + kv_head * stride_v_head
+            + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0.0,
+        )
+        scores = tl.dot(query, keys)
+        # Scaling scores avoids re-quantizing a scaled query to BF16.
+        scores *= softmax_scale_log2
+        scores = tl.where(valid[None, :], scores, -1.0e20)
+        next_max = tl.maximum(max_value, tl.max(scores, axis=1))
+        alpha = tl.math.exp2(max_value - next_max)
+        probabilities = tl.where(valid[None, :], tl.math.exp2(scores - next_max[:, None]), 0.0)
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            acc=accumulator * alpha[:, None],
+        )
+        normalizer = normalizer * alpha + tl.sum(probabilities, axis=1)
+        max_value = next_max
+
+    has_values = normalizer > 0
+    normalized_output = tl.where(
+        has_values[:, None],
+        accumulator / tl.maximum(normalizer[:, None], 1.0e-20),
+        0.0,
+    )
+    output_mask = head_offsets[:, None] < GROUP_SIZE
+    if NUM_SPLITS == 1:
+        tl.store(
+            output_ptr
+            + row * stride_output_row
+            + (first_head + head_offsets[:, None]) * stride_output_head
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+    else:
+        partial_lse = tl.where(
+            has_values,
+            max_value + tl.math.log2(tl.maximum(normalizer, 1.0e-20)),
+            -float("inf"),
+        )
+        tl.store(
+            partial_output_ptr
+            + ((split_id * num_rows + row) * NUM_QUERY_HEADS + first_head + head_offsets[:, None]) * HEAD_DIM
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+        tl.store(
+            partial_lse_ptr + (split_id * num_rows + row) * NUM_QUERY_HEADS + first_head + head_offsets,
+            partial_lse,
+            mask=head_offsets < GROUP_SIZE,
+        )
+
+
+@triton.jit
+def _qsa_merge_splitk_kernel(
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    BLOCK_SPLITS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    split_offsets = tl.arange(0, BLOCK_SPLITS)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    split_mask = split_offsets < NUM_SPLITS
+    lse = tl.load(
+        partial_lse_ptr + (split_offsets * num_rows + row) * NUM_QUERY_HEADS + head,
+        mask=split_mask,
+        other=-float("inf"),
+    )
+    lse_max = tl.max(lse, axis=0)
+    has_values = lse_max > -float("inf")
+    shifted = tl.where(split_mask & has_values, lse - lse_max, -float("inf"))
+    weights = tl.math.exp2(shifted)
+    denominator = tl.sum(weights, axis=0)
+    partial_output = tl.load(
+        partial_output_ptr
+        + ((split_offsets[:, None] * num_rows + row) * NUM_QUERY_HEADS + head) * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=split_mask[:, None],
+        other=0.0,
+    )
+    merged = tl.sum(partial_output * weights[:, None], axis=0)
+    merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    tl.store(
+        output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
+        merged,
+    )
+
+
+@triton.jit
+def _store_qsa_rows_kernel(
+    cache_ptr,
+    slots_ptr,
+    rows_ptr,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_rows_row,
+    stride_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    values = tl.load(
+        rows_ptr + row * stride_rows_row + dims * stride_rows_dim,
+        mask=valid & (dims < WIDTH),
+        other=0,
+    )
+    tl.store(
+        cache_ptr + block * stride_cache_block + token * stride_cache_token + dims * stride_cache_dim,
+        values,
+        mask=valid & (dims < WIDTH),
+    )
+
+
+@triton.jit
+def _compress_qsa_groups_kernel(
+    raw_keys_ptr,  # this step's raw key rows, straight from activations
+    raw_positions_ptr,  # this step's per-token positions
+    compressor_state_cache_ptr,  # per-request ring of previous raw keys
+    rope_cache_ptr,  # packed RoPE position tail of the ring
+    compressor_state_table_ptr,
+    token_to_req_ptr,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    pooled_ptr,
+    first_positions_ptr,
+    stride_raw_row,
+    stride_raw_dim,
+    stride_raw_positions_row,
+    stride_raw_positions_dim,
+    stride_compressor_state_block,
+    stride_compressor_state_token,
+    stride_compressor_state_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_compressor_state_table_req,
+    stride_pooled_row,
+    stride_pooled_dim,
+    stride_positions_row,
+    stride_positions_dim,
+    num_rows,
+    num_compressor_state_blocks,
+    num_requests,
+    COMPRESSOR_STATE_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    LOAD_ROPE_POSITIONS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_request = (request >= 0) & (request < num_requests)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_row_start = tl.load(query_start_loc_ptr + safe_request, mask=valid_request, other=0)
+    query_row_end = tl.load(query_start_loc_ptr + safe_request + 1, mask=valid_request, other=0)
+    chunk_start_position = end_position - (row - query_row_start)
+    compressor_state_block = tl.load(
+        compressor_state_table_ptr + safe_request * stride_compressor_state_table_req,
+        mask=valid_request,
+        other=-1,
+    )
+    valid_compressor_state_block = (compressor_state_block >= 0) & (
+        compressor_state_block < num_compressor_state_blocks
+    )
+    valid_row = (
+        (row < num_rows)
+        & valid_request
+        & (row >= query_row_start)
+        & (row < query_row_end)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    # A group can span the compressor-state ring (older members) and this
+    # step's raw rows (members at positions >= chunk_start_position).
+    for group_offset in tl.range(0, COMPRESS_RATIO):
+        position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+        use_raw = position >= chunk_start_position
+        raw_row = query_row_start + position - chunk_start_position
+        raw_values = tl.load(
+            raw_keys_ptr + raw_row * stride_raw_row + dims * stride_raw_dim,
+            mask=valid_row
+            & use_raw
+            & (raw_row >= query_row_start)
+            & (raw_row < query_row_end)
+            & (raw_row < num_rows)
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        compressor_state_values = tl.load(
+            compressor_state_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_compressor_state_block
+            + (position % COMPRESSOR_STATE_SIZE) * stride_compressor_state_token
+            + dims * stride_compressor_state_dim,
+            mask=valid_row & ~use_raw & valid_compressor_state_block & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.where(use_raw, raw_values, compressor_state_values)
+
+    tl.store(
+        pooled_ptr + row * stride_pooled_row + dims * stride_pooled_dim,
+        accumulator / COMPRESS_RATIO,
+        mask=(row < num_rows) & (dims < HEAD_DIM),
+    )
+
+    position_dims = tl.arange(0, 4)
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_ROPE_POSITIONS:
+        first_from_raw = first_position >= chunk_start_position
+        raw_first_row = query_row_start + first_position - chunk_start_position
+        raw_position_values = tl.load(
+            raw_positions_ptr + raw_first_row * stride_raw_positions_row + position_dims * stride_raw_positions_dim,
+            mask=valid_row
+            & first_from_raw
+            & (raw_first_row >= query_row_start)
+            & (raw_first_row < query_row_end)
+            & (raw_first_row < num_rows)
+            & (position_dims < 3),
+            other=0,
+        )
+        compressor_state_position_values = tl.load(
+            rope_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_rope_block
+            + (first_position % COMPRESSOR_STATE_SIZE) * stride_rope_token
+            + position_dims * stride_rope_dim,
+            mask=valid_row & ~first_from_raw & valid_compressor_state_block & (position_dims < 3),
+            other=0,
+        )
+        position_values = tl.where(
+            first_from_raw,
+            raw_position_values,
+            compressor_state_position_values,
+        )
+    else:
+        position_values = tl.where(valid_row, first_position, 0)
+    tl.store(
+        first_positions_ptr + row * stride_positions_row + position_dims * stride_positions_dim,
+        position_values,
+        mask=(row < num_rows) & (position_dims < 3),
+    )
+
+
+def _validate_mqa(q: torch.Tensor) -> None:
+    if q.ndim != 3 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("QSA query must be [rows, heads, head_dim]")
+
+
+def qsa_mqa_paged(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+    num_columns: int | None = None,
+    score_scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute QSA scores directly from a paged compressed-key cache."""
+
+    _validate_mqa(q)
+    if q.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("paged QSA scoring requires NPU and Triton")
+    if k_cache.ndim != 4 or k_cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, head_dim]")
+    if k_cache.shape[3] != q.shape[2]:
+        raise ValueError("QSA query and cache dimensions must match")
+    if page_table.ndim != 2:
+        raise ValueError("QSA page table must be two-dimensional")
+    if q.shape[0] and (not all(k_cache.shape[:2]) or not all(page_table.shape)):
+        raise ValueError("QSA paged scoring cache and page table must be nonempty")
+    if token_to_req.shape != (q.shape[0],):
+        raise ValueError("QSA request mapping must match query rows")
+    if query_positions.shape != (q.shape[0],):
+        raise ValueError("QSA query positions must match query rows")
+    if sequence_lengths.shape != (page_table.shape[0],):
+        raise ValueError("QSA sequence lengths must match page-table requests")
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    score_divisor = math.sqrt(q.shape[2]) if score_scale is None else score_scale
+    if score_divisor <= 0:
+        raise ValueError("QSA score scale must be positive")
+
+    capacity = page_table.shape[1] * k_cache.shape[1]
+    columns = capacity if num_columns is None else num_columns
+    if columns < 0:
+        raise ValueError("QSA score width must be non-negative")
+    logits = torch.empty((q.shape[0], columns), dtype=torch.float32, device=q.device)
+    visible_blocks = torch.empty(q.shape[0], dtype=torch.int32, device=q.device)
+    if not q.shape[0] or not columns:
+        return logits, visible_blocks
+    BLOCK_N = 64
+    BLOCK_D = max(16, triton.next_power_of_2(q.shape[2]))
+    MAX_N = max(16, triton.next_power_of_2(q.shape[1]))
+    # Tuned on GB300: larger row batches provide enough parallelism to reuse Q.
+    tiles_per_program = 1 if q.shape[0] <= 32 else 8
+    _qsa_mqa_paged_kernel[(q.shape[0], triton.cdiv(columns, BLOCK_N * tiles_per_program))](
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(3),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        q.shape[0],
+        columns,
+        k_cache.shape[0],
+        page_table.shape[0],
+        float(score_divisor),
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=BLOCK_N,
+        BLOCK_D=BLOCK_D,
+        TILES_PER_PROG=tiles_per_program,
+        STAGES=2,
+        MAX_N=MAX_N,
+        COMPRESS_RATIO=compress_ratio,
+        num_warps=2,
+    )
+    return logits, visible_blocks
+
+
+def expand_qsa_block_indices_npu(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    compress_ratio: int,
+    token_topk: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand compressed blocks and compact the causal tail of the open group."""
+
+    if block_indices.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("QSA NPU expansion requires Triton")
+    if token_topk % compress_ratio:
+        raise ValueError("QSA token top-k must be divisible by compression ratio")
+    block_topk = token_topk // compress_ratio
+    output_width = token_topk + compress_ratio - 1
+    if block_indices.shape != (query_positions.numel(), block_topk):
+        raise ValueError("QSA compressed top-k has an invalid shape")
+    if token_to_req.shape != query_positions.shape:
+        raise ValueError("QSA request mapping must match query positions")
+    if sequence_lengths.ndim != 1 or not sequence_lengths.shape[0]:
+        raise ValueError("QSA request sequence lengths must be nonempty")
+    if out is None:
+        out = torch.empty(
+            (block_indices.shape[0], output_width),
+            dtype=torch.int32,
+            device=block_indices.device,
+        )
+    elif out.shape != (block_indices.shape[0], output_width):
+        raise ValueError("QSA expansion output has an invalid shape")
+    if not block_indices.shape[0]:
+        return out
+    column_block = 256
+    _expand_qsa_indices_kernel[(block_indices.shape[0], triton.cdiv(output_width, column_block))](
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        out,
+        block_indices.stride(0),
+        block_indices.stride(1),
+        out.stride(0),
+        out.stride(1),
+        block_indices.shape[0],
+        sequence_lengths.shape[0],
+        BLOCK_TOPK=block_topk,
+        COMPRESS_RATIO=compress_ratio,
+        TOKEN_TOPK=token_topk,
+        OUTPUT_WIDTH=output_width,
+        COLUMN_BLOCK=column_block,
+        num_warps=4,
+    )
+    return out
+
+
+def qsa_select_paged_tokens(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Score, select, and expand QSA indices without host synchronization."""
+
+    rows = q.shape[0]
+    output_width = token_topk + compress_ratio - 1
+    if out is None:
+        out = torch.empty((rows, output_width), dtype=torch.int32, device=q.device)
+    if out.shape != (rows, output_width):
+        raise ValueError("QSA selection output has an invalid shape")
+    if not rows:
+        return out
+
+    columns = page_table.shape[1] * k_cache.shape[1]
+    block_topk = token_topk // compress_ratio
+    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(columns * 4, 1))
+    chunk_rows = min(rows, rows_per_chunk)
+    blocks_buffer = torch.empty((chunk_rows, block_topk), dtype=torch.int32, device=q.device)
+    for row_start in range(0, rows, rows_per_chunk):
+        row_end = min(row_start + rows_per_chunk, rows)
+        row_slice = slice(row_start, row_end)
+        logits, visible_blocks = qsa_mqa_paged(
+            q[row_slice],
+            k_cache,
+            page_table,
+            token_to_req[row_slice],
+            query_positions[row_slice],
+            sequence_lengths,
+            compress_ratio,
+        )
+        blocks = blocks_buffer[: row_end - row_start]
+        blocks.copy_(torch.topk(logits, block_topk, dim=-1).indices.to(torch.int32))
+        topk_rank = torch.arange(block_topk, device=q.device)
+        blocks.masked_fill_(
+            topk_rank.unsqueeze(0) >= visible_blocks.unsqueeze(1),
+            -1,
+        )
+        expand_qsa_block_indices_npu(
+            blocks,
+            query_positions[row_slice],
+            sequence_lengths,
+            token_to_req[row_slice],
+            compress_ratio,
+            token_topk,
+            out[row_slice],
+        )
+    return out
+
+
+def qsa_sparse_paged_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    logical_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run sparse GQA directly over paged BF16 K/V caches."""
+
+    if q.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("paged QSA sparse attention requires NPU and Triton")
+    if q.ndim != 3 or k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+        raise ValueError("QSA sparse attention received invalid Q/K/V shapes")
+    if logical_indices.ndim != 2 or logical_indices.shape[0] != q.shape[0]:
+        raise ValueError("QSA indices must have one row per query")
+    if token_to_req.shape != (q.shape[0],) or block_table.ndim != 2:
+        raise ValueError("QSA sparse attention metadata has invalid shapes")
+    if not all(k_cache.shape[:3]) or not all(block_table.shape):
+        raise ValueError("QSA sparse attention cache and block table must be nonempty")
+    if logical_indices.shape[1] <= 0:
+        raise ValueError("QSA sparse attention requires a positive selection width")
+    if q.shape[2] != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
+        raise ValueError("QSA sparse attention requires valid grouped-query heads")
+    head_dim = q.shape[2]
+    assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
+    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    assert logical_indices.dtype == block_table.dtype == torch.int32
+    assert token_to_req.dtype == torch.int32
+    assert q.device == k_cache.device == v_cache.device
+    assert q.device == logical_indices.device == block_table.device
+    assert q.device == token_to_req.device
+    assert q.stride(2) == k_cache.stride(3) == v_cache.stride(3) == 1
+    assert logical_indices.stride(1) == block_table.stride(1) == 1
+    assert token_to_req.stride(0) == 1
+    if out is None:
+        out = torch.empty_like(q)
+    if out.shape != q.shape:
+        raise ValueError("QSA sparse output must match its query")
+    assert out.dtype == q.dtype and out.device == q.device
+    assert out.stride(2) == 1
+    if not q.shape[0]:
+        return out
+
+    group_size = q.shape[1] // k_cache.shape[2]
+    block_m = triton.next_power_of_2(group_size)
+    base_programs = q.shape[0] * k_cache.shape[2]
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+
+    num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
+    # Avoid empty splits when the selection width is smaller than the profile.
+    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
+    num_splits = min(max_useful_splits, target_splits)
+
+    # Split=1 writes output directly and compiles out all workspace accesses.
+    if num_splits == 1:
+        partial_output = out
+        partial_lse = out
+    else:
+        # FP32 partials preserve accuracy when merging independently normalized
+        # splits.
+        partial_output = torch.empty((num_splits, *q.shape), dtype=torch.float32, device=q.device)
+        partial_lse = torch.empty(
+            (num_splits, q.shape[0], q.shape[1]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    partial_grid = (q.shape[0], k_cache.shape[2], num_splits)
+    _qsa_sparse_paged_gqa_splitk_kernel[partial_grid](
+        q,
+        k_cache,
+        v_cache,
+        logical_indices,
+        block_table,
+        token_to_req,
+        partial_output,
+        partial_lse,
+        out,
+        q.stride(0),
+        q.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        logical_indices.stride(0),
+        block_table.stride(0),
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        k_cache.shape[0],
+        block_table.shape[0],
+        TOPK=logical_indices.shape[1],
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=block_table.shape[1],
+        GROUP_SIZE=group_size,
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        NUM_TILES=num_tiles,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=partial_warps,
+        num_stages=2,
+    )
+    if num_splits == 1:
+        return out
+
+    _qsa_merge_splitk_kernel[(q.shape[0], q.shape[1])](
+        partial_output,
+        partial_lse,
+        out,
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+        num_warps=2,
+        num_stages=1,
+    )
+    return out
+
+
+def qsa_store_cache_rows(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    rows: torch.Tensor,
+) -> None:
+    """Store fixed-width rows in a QSA cache without boolean indexing."""
+
+    if cache.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("QSA NPU cache stores require Triton")
+    if cache.ndim != 4 or cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, width]")
+    if not all(cache.shape):
+        raise ValueError("QSA cache dimensions must be nonzero")
+    if rows.ndim == 3:
+        if rows.shape[1] != 1:
+            raise ValueError("QSA cache rows must have one head")
+        rows = rows[:, 0]
+    if rows.shape != (slot_mapping.numel(), cache.shape[3]):
+        raise ValueError("QSA cache rows and slots have incompatible shapes")
+    if not rows.shape[0]:
+        return
+    _store_qsa_rows_kernel[(rows.shape[0],)](
+        cache,
+        slot_mapping,
+        rows,
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(3),
+        rows.stride(0),
+        rows.stride(1),
+        rows.shape[0],
+        cache.shape[0],
+        PAGE_SIZE=cache.shape[1],
+        WIDTH=cache.shape[3],
+        BLOCK_D=triton.next_power_of_2(cache.shape[3]),
+        num_warps=4,
+    )
+
+
+def qsa_compress_groups_with_ratio(
+    raw_keys: torch.Tensor,  # this step's raw key rows [rows, 1, head_size]
+    raw_positions: torch.Tensor,  # this step's positions [rows, 1, 3] int64
+    compressor_state_cache: torch.Tensor,
+    compressor_state_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compress_ratio: int,
+    rope_cache: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pool completed groups from the compressor-state ring and raw token rows."""
+
+    if raw_keys.device.type != "npu" or not HAS_TRITON:
+        raise RuntimeError("QSA NPU compression requires Triton")
+    rows = token_to_req.numel()
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    if raw_keys.ndim != 3 or raw_keys.shape[:2] != (rows, 1):
+        raise ValueError("QSA raw keys must be [rows, 1, head_size]")
+    if raw_positions.shape != (rows, 1, 3) or raw_positions.dtype != torch.int64:
+        raise ValueError("QSA raw positions must be [rows, 1, 3] int64")
+    if logical_positions.shape != (rows,) or compressed_slots.shape != (rows,):
+        raise ValueError("QSA compression metadata must match token rows")
+    if compressor_state_cache.ndim != 4 or compressor_state_cache.shape[2] != 1:
+        raise ValueError("QSA compressor-state cache has an invalid shape")
+    if (
+        # The ring is wider than one group so speculative rows cannot alias
+        # onto the committed keys of the group still being collected.
+        compressor_state_cache.shape[1] < compress_ratio
+        or compressor_state_cache.shape[3] != raw_keys.shape[2]
+        or compressor_state_cache.dtype != raw_keys.dtype
+    ):
+        raise ValueError("QSA compressor-state cache does not match the compression layout")
+    if compressor_state_block_table.ndim != 2 or compressor_state_block_table.shape[1] < 1:
+        raise ValueError("QSA compressor-state block table must contain one block per request")
+    if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+        raise ValueError("QSA query starts must contain a terminal offset")
+    num_requests = query_start_loc.shape[0] - 1
+    if compressor_state_block_table.shape[0] < num_requests:
+        raise ValueError("QSA compressor-state block table has too few request rows")
+    if rope_cache is not None and (
+        rope_cache.ndim != 4
+        or rope_cache.shape[:3] != compressor_state_cache.shape[:3]
+        or rope_cache.shape[3] != 3
+        or rope_cache.dtype != torch.int64
+    ):
+        raise ValueError("QSA packed position view has an invalid shape or dtype")
+    if rows and (not all(compressor_state_cache.shape) or not all(compressor_state_block_table.shape)):
+        raise ValueError("QSA compressor-state cache and block table must be nonempty")
+    pooled = torch.empty(
+        (rows, 1, raw_keys.shape[2]),
+        dtype=raw_keys.dtype,
+        device=raw_keys.device,
+    )
+    first_positions = torch.empty((rows, 3), dtype=torch.int64, device=raw_keys.device)
+    if not rows:
+        return pooled, first_positions
+    if rope_cache is None:
+        rope_cache = compressor_state_cache
+        load_rope_positions = False
+    else:
+        load_rope_positions = True
+    _compress_qsa_groups_kernel[(rows,)](
+        raw_keys,
+        raw_positions,
+        compressor_state_cache,
+        rope_cache,
+        compressor_state_block_table,
+        token_to_req,
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        pooled,
+        first_positions,
+        raw_keys.stride(0),
+        raw_keys.stride(2),
+        raw_positions.stride(0),
+        raw_positions.stride(2),
+        compressor_state_cache.stride(0),
+        compressor_state_cache.stride(1),
+        compressor_state_cache.stride(3),
+        rope_cache.stride(0),
+        rope_cache.stride(1),
+        rope_cache.stride(3),
+        compressor_state_block_table.stride(0),
+        pooled.stride(0),
+        pooled.stride(2),
+        first_positions.stride(0),
+        first_positions.stride(1),
+        rows,
+        compressor_state_cache.shape[0],
+        num_requests,
+        COMPRESSOR_STATE_SIZE=compressor_state_cache.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=raw_keys.shape[2],
+        LOAD_ROPE_POSITIONS=load_rope_positions,
+        BLOCK_D=triton.next_power_of_2(raw_keys.shape[2]),
+        num_warps=4,
+    )
+    return pooled, first_positions
+
+
+__all__ = [
+    "expand_qsa_block_indices_npu",
+    "qsa_compress_groups_with_ratio",
+    "qsa_mqa_paged",
+    "qsa_select_paged_tokens",
+    "qsa_sparse_paged_attention",
+    "qsa_store_cache_rows",
+]


### PR DESCRIPTION
### What this PR does / why we need it?

Adds the vLLM Ascend adaptation for Qwen3.8 Flash-Next introduced by vLLM PRs [#53896](https://github.com/vllm-project/vllm/pull/53896) and [#53899](https://github.com/vllm-project/vllm/pull/53899).

- Registers `Qwen4ExpForCausalLM`, `Qwen4ExpForConditionalGeneration`, and `Qwen4ExpMTP` with Ascend implementations.
- Reuses the upstream model definition while replacing CUDA-only QSA and HyperConnection glue with triton-ascend / torch-npu implementations.
- Uses the device-agnostic QSA metadata path and an NPU KV-cache update path.
- Adds an Ascend MRV2 model state for rollback-safe PLE n-gram inputs.
- Places regular PLE embedding storage on NPU after the PLE-Offload refactor in #53899.

`VLLM_PLE_CPU_OFFLOAD` itself remains unsupported on Ascend because #53899's cross-process semaphore and connector use CUDA Driver IPC. This PR does not silently enable that CUDA-only protocol.

This PR is draft while the two dependent vLLM PRs are open.

### Does this PR introduce _any_ user-facing change?

Yes. With the dependent vLLM changes installed, Qwen3.8 Flash-Next text, multimodal, and MTP architectures can resolve to the Ascend model path.

### How was this patch tested?

- `ruff check` on all changed Python files: passed.
- `py_compile` on all changed Python files: passed.
- Added `tests/ut/models/test_qwen4_exp_hc.py` for model registration and HyperConnection math.
- Ran a standalone CPU smoke test for the HyperConnection combine/mix/norm path: passed.
- NPU kernel and end-to-end model validation require Ascend hardware and the two dependent vLLM PRs; these have not been run locally.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
