### PR TITLE
[Performance][Attention] Avoid QLI metadata host synchronization

### DIFF
--- a/vllm_ascend/attention/context_parallel/dsa_cp.py
+++ b/vllm_ascend/attention/context_parallel/dsa_cp.py
@@ -776,7 +776,8 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         qli_metadata = self._build_qli_metadata(
             query_start_loc=local_query_start_loc,
             seq_lens=local_seq_lens,
-            seq_lens_q=local_seq_lens_q,
+            max_seqlen_q=max_local_query_len,
+            max_seqlen_k=max_local_seq_lens,
             num_reqs=num_reqs,
         )
 
@@ -996,7 +997,7 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         self.req_sas_metadata[:1024] = metadata
         return self.req_sas_metadata[:1024]
 
-    def _build_qli_metadata(self, query_start_loc, seq_lens, seq_lens_q, num_reqs):
+    def _build_qli_metadata(self, query_start_loc, seq_lens, max_seqlen_q, max_seqlen_k, num_reqs):
         if self.compressor_ratio != 4:
             return None
 
@@ -1004,8 +1005,6 @@ class AscendDSACPMetadataBuilder(AttentionMetadataBuilder[AscendDSAMetadata]):
         metadata = self.common_ratio_to_sas_metadata.get(cache_key)
 
         if metadata is None:
-            max_seqlen_q = max(1, int(seq_lens_q.max().item()))
-            max_seqlen_k = max(1, int(seq_lens.max().item()))
             metadata = torch.ops._C_ascend.npu_vllm_quant_lightning_indexer_metadata(
                 actual_seq_lengths_query=query_start_loc[1:].clone(),
                 actual_seq_lengths_key=seq_lens.clone(),


### PR DESCRIPTION
### What this PR does / why we need it?

The DSA context-parallel QLI metadata path derives `max_seqlen_q` and `max_seqlen_k` from NPU tensors with `max().item()`. Since these values are consumed as integer attributes by the QLI metadata operator, each device scalar read synchronizes the host with the NPU and blocks enqueue-ahead. In the baseline profile, 13 QLI metadata builds corresponded to 26 stream synchronizations on each sampled rank.

This patch reuses `max_local_query_len` and `max_local_seq_lens`, which are already computed from the CPU mirrors of the same local sequence-length metadata for the SAS path. The QLI operator continues to receive `local_query_start_loc` and `local_seq_lens` as NPU tensor inputs for the actual query and key sequence lengths; only the two maximum-length integer attributes avoid the device scalar reads. The existing `max(1, ...)` bounds are preserved where the CPU values are computed.

This restores the focused optimization previously introduced by #12536 and later reverted by #13290 against the current `main` implementation, without changing the NPU tensor inputs to the QLI metadata operator.

### Does this PR introduce _any_ user-facing change?

No. This is an internal performance optimization for DSA context-parallel QLI metadata construction.

### How was this patch tested?

- `ruff check --output-format github vllm_ascend/attention/context_parallel/dsa_cp.py`
- `ruff format --check vllm_ascend/attention/context_parallel/dsa_cp.py`
- `codespell` on `vllm_ascend/attention/context_parallel/dsa_cp.py`
- `git diff --check github/main...HEAD`
- `python3 -m py_compile vllm_ascend/attention/context_parallel/dsa_cp.py`
- Static AST validation that `_build_qli_metadata` no longer contains device `max()` or `item()` scalar extraction

A post-change NPU profiler comparison has not yet been captured.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
