### PR TITLE
[BugFix][GDN] Avoid fused chunk op for float16 inputs

### DIFF
--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -131,6 +131,7 @@ def test_fused_gdn_chunk_is_not_used_for_float16_inputs():
     with patch.object(AscendGatedDeltaNetAttention, "_probe_fused_chunk", return_value=True):
         assert AscendGatedDeltaNetAttention._can_use_fused_chunk(torch.empty(1, dtype=torch.bfloat16))
         assert not AscendGatedDeltaNetAttention._can_use_fused_chunk(torch.empty(1, dtype=torch.float16))
+        assert not AscendGatedDeltaNetAttention._can_use_fused_chunk(None)
 
 
 def test_connector_observes_updated_gdn_state_for_each_compiled_call():

--- a/tests/ut/ops/test_gdn_layerwise_kv.py
+++ b/tests/ut/ops/test_gdn_layerwise_kv.py
@@ -127,6 +127,12 @@ def _make_prefill_metadata(device: torch.device | str = "cpu") -> GDNAttentionMe
     return metadata
 
 
+def test_fused_gdn_chunk_is_not_used_for_float16_inputs():
+    with patch.object(AscendGatedDeltaNetAttention, "_probe_fused_chunk", return_value=True):
+        assert AscendGatedDeltaNetAttention._can_use_fused_chunk(torch.empty(1, dtype=torch.bfloat16))
+        assert not AscendGatedDeltaNetAttention._can_use_fused_chunk(torch.empty(1, dtype=torch.float16))
+
+
 def test_connector_observes_updated_gdn_state_for_each_compiled_call():
     # vLLM registers this production dispatcher for NPU only. Keep a CPU
     # registration alive for this test so Inductor sees the same custom op.

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -91,14 +91,14 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
         return cls._fused_chunk_available
 
     @classmethod
-    def _can_use_fused_chunk(cls, query: torch.Tensor) -> bool:
+    def _can_use_fused_chunk(cls, query: torch.Tensor | None) -> bool:
         """Whether the fused operator is available for the input dtype.
 
         The current ACLNN implementation accepts BF16 query/key/value tensors
         only. The probe intentionally uses BF16, so checking only its result
         would incorrectly enable the fused path for FP16 inputs.
         """
-        return query.dtype == torch.bfloat16 and cls._probe_fused_chunk()
+        return query is not None and query.dtype == torch.bfloat16 and cls._probe_fused_chunk()
 
     @staticmethod
     def _chunk_gated_delta_rule_fused(

--- a/vllm_ascend/ops/gdn.py
+++ b/vllm_ascend/ops/gdn.py
@@ -90,6 +90,16 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             cls._fused_chunk_available = False
         return cls._fused_chunk_available
 
+    @classmethod
+    def _can_use_fused_chunk(cls, query: torch.Tensor) -> bool:
+        """Whether the fused operator is available for the input dtype.
+
+        The current ACLNN implementation accepts BF16 query/key/value tensors
+        only. The probe intentionally uses BF16, so checking only its result
+        would incorrectly enable the fused path for FP16 inputs.
+        """
+        return query.dtype == torch.bfloat16 and cls._probe_fused_chunk()
+
     @staticmethod
     def _chunk_gated_delta_rule_fused(
         q: torch.Tensor,
@@ -512,7 +522,9 @@ class AscendGatedDeltaNetAttention(GatedDeltaNetAttention):
             # Use the fused CANN operator when available (probed once, cached on
             # the class) and applicable. It only supports the non-PCP case; fall
             # back to the Triton pipeline under PCP or if the op is unavailable.
-            use_fused_chunk = AscendGatedDeltaNetAttention._probe_fused_chunk() and get_pcp_group().world_size == 1
+            use_fused_chunk = (
+                AscendGatedDeltaNetAttention._can_use_fused_chunk(query_non_spec) and get_pcp_group().world_size == 1
+            )
             if use_fused_chunk:
                 # The fused op's state layout [N, Nv, Dv, Dk] matches ssm_state
                 # directly, so no transpose is needed. Advanced indexing already


### PR DESCRIPTION
### What this PR does / why we need it?

The fused `aclnnChunkGatedDeltaRule` implementation currently supports bfloat16 query/key/value tensors only. The existing availability probe also uses bfloat16, so a successful probe incorrectly enabled the fused path for float16 requests and produced ACLNN parameter error 161002.

This change gates fused dispatch on the query dtype in addition to the cached availability probe. Float16 inputs now use the existing Triton implementation, while bfloat16 inputs retain the fused path. A focused unit test covers both dispatch decisions.

Fixes #14456

### Does this PR introduce _any_ user-facing change?

No. This is a compatibility fix for the Ascend GDN prefill implementation. Float16 requests no longer fail in the fused operator; bfloat16 behavior is unchanged.

### How was this patch tested?

- `git diff --check origin/main...HEAD`
- `python -m py_compile vllm_ascend/ops/gdn.py tests/ut/ops/test_gdn_layerwise_kv.py`
- `ruff check vllm_ascend/ops/gdn.py tests/ut/ops/test_gdn_layerwise_kv.py`
- `ruff format --check vllm_ascend/ops/gdn.py tests/ut/ops/test_gdn_layerwise_kv.py`
- The focused pytest was attempted. Collection is blocked on this Windows host by the repository's NPU/vLLM test bootstrap: `vllm.v1.utils` imports unavailable Windows-only `uvloop`, and after the supported dependency attempt, the installed vLLM package is missing the expected `FusedMoEFactory` API. No selected test executed locally.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
