### PR TITLE
[BugFix][Spec Decode] Guard DSpark request metadata before RoPE

### DIFF
--- a/tests/ut/spec_decode/test_dspark_proposer.py
+++ b/tests/ut/spec_decode/test_dspark_proposer.py
@@ -28,8 +28,15 @@ import pytest
 import torch
 
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dspark_inputs_kernel_by_request,
+)
+from vllm_ascend.spec_decode import dspark_proposer as dspark_proposer_module
 from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
-from vllm_ascend.spec_decode.dspark_proposer import AscendDSparkProposer
+from vllm_ascend.spec_decode.dspark_proposer import (
+    AscendDSparkProposer,
+    _compute_dspark_num_programs,
+)
 from vllm_ascend.spec_decode.llm_base_proposer import AscendSpecDecodeBaseProposer
 
 # 0 = single-DP (no padding); >0 = multi-DP where num_input_tokens >
@@ -41,6 +48,18 @@ _MAX_NUM_TOKENS = 8
 _HIDDEN_SIZE = 16
 
 
+def test_dspark_uses_request_local_guarded_input_kernel():
+    assert dspark_proposer_module.copy_and_expand_dflash_and_dspark_inputs_kernel is (
+        copy_and_expand_dspark_inputs_kernel_by_request
+    )
+
+
+def test_dspark_grid_covers_context_tiles_and_requests():
+    assert _compute_dspark_num_programs(num_context_tokens=45, batch_size=6) == 6
+    assert _compute_dspark_num_programs(num_context_tokens=8192, batch_size=1) == 8
+    assert _compute_dspark_num_programs(num_context_tokens=45, batch_size=16) == 8
+
+
 @pytest.fixture(autouse=True)
 def _stub_device_properties(monkeypatch):
     """CPU CI has no NPU: ``init_device_properties_triton`` is skipped when
@@ -48,8 +67,7 @@ def _stub_device_properties(monkeypatch):
     ``get_vectorcore_num`` asserts. ``set_inputs_first_pass`` sizes the kernel
     grid via ``_compute_num_programs`` -> ``get_vectorcore_num``; stub the
     device-property globals so the grid computation runs on CPU. The kernel
-    itself is mocked per-test, and the small inputs here yield a ``(1,)`` grid
-    either way (matching ``test_kernel_called_with_has_num_rejected``)."""
+    itself is mocked per-test."""
     monkeypatch.setattr("vllm_ascend.ops.triton.triton_utils._NUM_AICORE", 8)
     monkeypatch.setattr("vllm_ascend.ops.triton.triton_utils._NUM_VECTORCORE", 8)
 
@@ -676,14 +694,14 @@ class TestSetInputsFirstPassRejectedTokens(_DSparkProposerTestBase):
         self._invoke_set_inputs_first_pass(
             proposer, num_reqs=num_reqs, block_size=block_size, num_rejected=rejected
         )
-        # The proposer calls the kernel as ``kernel[1,](...)`` (Triton-style
-        # grid indexing), so the call lands on the indexed sub-mock.
-        sub = kernel[1,]
+        # Four request-local programs are selected for this four-request batch.
+        sub = kernel[(4,)]
         assert sub.called
         kwargs = sub.call_args.kwargs
         assert kwargs["HAS_NUM_REJECTED"] is True
         assert kwargs["num_rejected_tokens_ptr"] is rejected
         assert kwargs["SAMPLE_FROM_ANCHOR"] is True
+        assert kwargs["error_ptr"] is proposer._copy_expand_error
 
 
 class TestInitializeAttnBackendErrors(_DSparkProposerTestBase):

--- a/vllm_ascend/ops/triton/spec_decode/utils.py
+++ b/vllm_ascend/ops/triton/spec_decode/utils.py
@@ -177,6 +177,128 @@ def copy_and_expand_dflash_and_dspark_inputs_kernel(
         block_start += block_start_step
 
 
+@triton.jit
+def copy_and_expand_dspark_inputs_kernel_by_request(
+    next_token_ids_ptr,
+    target_positions_ptr,
+    context_slot_mapping_ptr,
+    out_input_ids_ptr,
+    out_context_positions_ptr,
+    out_query_positions_ptr,
+    out_context_slot_mapping_ptr,
+    out_query_slot_mapping_ptr,
+    out_token_indices_ptr,
+    block_table_ptr,
+    block_table_stride,
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    num_rejected_tokens_ptr,
+    error_ptr,
+    parallel_drafting_token_id,
+    block_size,
+    num_query_per_req,
+    num_speculative_tokens,
+    total_input_tokens,
+    batch_size,
+    HAS_NUM_REJECTED: tl.constexpr = False,
+    SAMPLE_FROM_ANCHOR: tl.constexpr = False,
+    TILE_SIZE: tl.constexpr = 256,
+):
+    """Copy context in parallel and expand each request independently.
+
+    Keeping query metadata request-local avoids cross-request gathers for
+    ``valid_ctx_end`` and position ids. Invalid metadata produces safe
+    sentinels and records the one-based request index in ``error_ptr`` so the
+    caller can fail asynchronously before RoPE consumes an invalid address.
+    """
+    pid = tl.program_id(axis=0)
+    num_programs = tl.num_programs(axis=0)
+
+    block_start = pid * TILE_SIZE
+    block_start_step = num_programs * TILE_SIZE
+    while block_start < total_input_tokens:
+        offsets = block_start + tl.arange(0, TILE_SIZE)
+        mask = offsets < total_input_tokens
+        positions = tl.load(target_positions_ptr + offsets, mask=mask)
+        slots = tl.load(context_slot_mapping_ptr + offsets, mask=mask)
+        tl.store(out_context_positions_ptr + offsets, positions, mask=mask)
+        tl.store(out_context_slot_mapping_ptr + offsets, slots, mask=mask)
+        block_start += block_start_step
+
+    req_idx = pid
+    while req_idx < batch_size:
+        ctx_start = tl.load(query_start_loc_ptr + req_idx)
+        ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
+        num_ctx = ctx_end - ctx_start
+        if HAS_NUM_REJECTED:
+            num_rejected = tl.load(num_rejected_tokens_ptr + req_idx)
+        else:
+            num_rejected = 0
+
+        seq_len = tl.load(seq_lens_ptr + req_idx)
+        valid_ctx_end = ctx_end - num_rejected
+        metadata_valid = (
+            (ctx_start >= 0)
+            & (ctx_start < ctx_end)
+            & (ctx_end <= total_input_tokens)
+            & (num_rejected >= 0)
+            & (num_rejected < num_ctx)
+            & (seq_len >= num_rejected)
+        )
+        tl.atomic_max(error_ptr, tl.where(metadata_valid, 0, req_idx + 1))
+
+        last_pos = tl.load(
+            target_positions_ptr + valid_ctx_end - 1,
+            mask=metadata_valid,
+            other=-1,
+        )
+        effective_seq_len = seq_len - num_rejected
+
+        for q_idx in range(0, num_query_per_req):
+            query_out_idx = req_idx * num_query_per_req + q_idx
+            query_pos = last_pos + 1 + q_idx
+            query_pos_valid = metadata_valid & (query_pos >= 0)
+            tl.atomic_max(error_ptr, tl.where(query_pos_valid, 0, req_idx + 1))
+            tl.store(
+                out_query_positions_ptr + query_out_idx,
+                tl.where(query_pos_valid, query_pos, 0),
+            )
+
+            query_cache_pos = effective_seq_len + q_idx
+            block_num_q = query_cache_pos // block_size
+            block_valid = (
+                metadata_valid
+                & (query_cache_pos >= 0)
+                & (block_num_q >= 0)
+                & (block_num_q < block_table_stride)
+            )
+            tl.atomic_max(error_ptr, tl.where(block_valid, 0, req_idx + 1))
+            block_id_q = tl.load(
+                block_table_ptr + req_idx * block_table_stride + block_num_q,
+                mask=block_valid,
+                other=0,
+            ).to(tl.int64)
+            slot_q = block_id_q * block_size + (query_cache_pos % block_size)
+            tl.store(
+                out_query_slot_mapping_ptr + query_out_idx,
+                tl.where(block_valid, slot_q, -1),
+            )
+
+            bonus_token = tl.load(next_token_ids_ptr + req_idx)
+            input_id = tl.where(q_idx == 0, bonus_token, parallel_drafting_token_id)
+            tl.store(out_input_ids_ptr + query_out_idx, input_id)
+
+            if SAMPLE_FROM_ANCHOR:
+                sample_out_idx = req_idx * num_speculative_tokens + q_idx
+                tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+            else:
+                if q_idx > 0:
+                    sample_out_idx = req_idx * num_speculative_tokens + q_idx - 1
+                    tl.store(out_token_indices_ptr + sample_out_idx, query_out_idx)
+
+        req_idx += num_programs
+
+
 @triton.jit(do_not_specialize=["num_reqs"])
 def dflash2_greedy_selector_walk_kernel(
     scores_ptr,

--- a/vllm_ascend/spec_decode/dspark_proposer.py
+++ b/vllm_ascend/spec_decode/dspark_proposer.py
@@ -6,6 +6,7 @@ from typing import Any
 import torch
 from vllm.config import CUDAGraphMode, VllmConfig, get_layers_from_vllm_config
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.triton_utils import triton
 from vllm.v1.attention.backends.utils import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import UniformTypeKVCacheSpecs
 from vllm.v1.worker.utils import AttentionGroup
@@ -13,9 +14,21 @@ from vllm.v1.worker.utils import AttentionGroup
 from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import set_ascend_forward_context
 from vllm_ascend.attention.attention_v1 import AscendAttentionState
-from vllm_ascend.ops.triton.spec_decode.utils import copy_and_expand_dflash_and_dspark_inputs_kernel
-from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer, _compute_num_programs
+from vllm_ascend.ops.triton.spec_decode.utils import (
+    copy_and_expand_dspark_inputs_kernel_by_request as copy_and_expand_dflash_and_dspark_inputs_kernel,
+)
+from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num, init_device_properties_triton
+from vllm_ascend.spec_decode.dflash_proposer import AscendDflashProposer
 from vllm_ascend.spec_decode.utils import DynamicSpecScheduler
+
+_DSPARK_CONTEXT_TILE_SIZE = 256
+
+
+def _compute_dspark_num_programs(num_context_tokens: int, batch_size: int) -> int:
+    """Cover context tiles while reserving request-local query programs."""
+    init_device_properties_triton()
+    context_programs = triton.cdiv(num_context_tokens, _DSPARK_CONTEXT_TILE_SIZE)
+    return min(max(context_programs, batch_size, 1), get_vectorcore_num())
 
 
 class AscendDSparkProposer(AscendDflashProposer):
@@ -86,6 +99,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             dtype=torch.int32,
             device=device,
         )
+        self._copy_expand_error = torch.zeros(1, dtype=torch.int32, device=device)
 
         # TODO simplify these comments
         # block_table / slot_mapping bookkeeping (10 dicts below). v1 self-
@@ -253,6 +267,8 @@ class AscendDSparkProposer(AscendDflashProposer):
             dtype=torch.int32,
             device=self.device,
         )
+        self._copy_expand_error.zero_()
+        grid = (_compute_dspark_num_programs(self._dflash_num_context, batch_size),)
 
         # Query block: reuse the DFlash inputs kernel logic (host-side ref)
         # per kv-cache-group to fill positions / input_ids / query slot_mapping
@@ -264,9 +280,7 @@ class AscendDSparkProposer(AscendDflashProposer):
             if gid_block_table is None:
                 continue
             kv_block_size = int(attn_group.kv_cache_spec.block_size)
-            copy_and_expand_dflash_and_dspark_inputs_kernel[
-                (_compute_num_programs(self._dflash_num_context, num_query_total),)
-            ](
+            copy_and_expand_dflash_and_dspark_inputs_kernel[grid](
                 # Inputs
                 next_token_ids_ptr=next_token_ids,
                 target_positions_ptr=target_positions,
@@ -285,6 +299,7 @@ class AscendDSparkProposer(AscendDflashProposer):
                 query_start_loc_ptr=cad.query_start_loc,
                 seq_lens_ptr=cad.seq_lens,
                 num_rejected_tokens_ptr=num_rejected_tokens_gpu,
+                error_ptr=self._copy_expand_error,
                 # Scalars
                 parallel_drafting_token_id=self.parallel_drafting_token_id,
                 block_size=kv_block_size,
@@ -295,6 +310,10 @@ class AscendDSparkProposer(AscendDflashProposer):
                 HAS_NUM_REJECTED=has_num_rejected,
                 SAMPLE_FROM_ANCHOR=self.sample_from_anchor,
             )
+        torch._assert_async(
+            self._copy_expand_error == 0,
+            "Invalid DSpark input metadata: request-local context, rejected-token, position, or block-table bounds failed.",
+        )
         # to compute self._context_slot_mapping_buffers from dict to list
         self._context_slot_mapping_buffers = [
             self._per_group_context_slot_mapping_buffers[gidx] for gidx in self._layer_group_idx


### PR DESCRIPTION
### What this PR does / why we need it?

DSpark's vectorized input expansion recovers request IDs from flattened query offsets. In mixed cached-decode and newly transferred remote-prefill batches, invalid or misaligned rejection metadata can produce an out-of-range `valid_ctx_end` or block-table index. RoPE then consumes the invalid position and the NPU reports AIVEC/MTE 507035.

This PR:
- keeps context copies tiled;
- expands query positions and slots request-locally;
- validates context, rejected-token, position, and block-table bounds and writes safe sentinels;
- reports the one-based failing request before RoPE using a device error buffer and `torch._assert_async`;
- leaves DFlash on the existing vectorized kernel.

Scope note: this is a safety and diagnostic fix. It prevents the device-side invalid access, but does not repair the upstream mixed-batch rejection metadata producer/remapping issue. In the observed GPQA run it converted `_triton_rope` 507035 into the deterministic `Invalid DSpark input metadata` error.

### Does this PR introduce _any_ user-facing change?

No API change. Invalid DSpark metadata now fails deterministically before RoPE instead of surfacing as an asynchronous NPU 507035 or heap-corruption cascade.

### How was this patch tested?

- Latest `main` (`f8958a8496bad5d2c5a7939e8aa53d8168c5c813`):
  - `python -m py_compile` on the three changed files
  - `git diff --check`
- Eight-node P/D environment on the validated integration head:
  - all eight nodes: four focused DSpark tests passed
  - all eight nodes: `py_compile` and `git diff --check`
- Real Ascend NPU, exact failure shape:
  - batch 6, context lengths `[8, 8, 8, 8, 8, 5]`, 7 speculative tokens
  - legal metadata: error buffer 0 and outputs matched
  - invalid request 6: error buffer 6 before RoPE
- Eight-node service startup and minimal inference passed.
- GPQA reproduced the remaining upstream metadata issue; no `_triton_rope` 507035 occurred after this guard.

Local Ruff was unavailable for the latest-main checkout; CI is expected to run repository lint checks.

  https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
