### PR TITLE
[Feature][MRV1] Add Super Kernel optimization support for Ascend backend

### DIFF
--- a/docs/source/user_guide/configuration/additional_config.md
+++ b/docs/source/user_guide/configuration/additional_config.md
@@ -107,6 +107,7 @@ The details of each configuration option are as follows:
 | ---- | ---- | ------- | ----------- |
 | `enable_npugraph_ex`               | bool | `True` | Whether to enable npugraph_ex backend.                                                 |
 | `enable_static_kernel` | bool | `False` | Whether to enable static kernel. Suitable for scenarios where shape changes are minimal and some time is available for static kernel compilation. |
+| `enable_super_kernel` | bool | Inherits `enable_static_kernel` | Whether to enable Super Kernel optimization. When omitted, it follows `enable_static_kernel`; set it explicitly to override that behavior. Super Kernel requires static kernel. |
 | `fuse_norm_quant`  | bool | `True` | Whether to enable fuse_norm_quant pass. |
 | `fuse_qknorm_rope` | bool | `True` | Whether to enable fuse_qknorm_rope pass. If Triton is not in the environment, set it to False. |
 | `fuse_muls_add` | bool | `True` | Whether to enable fuse_muls_add pass.|

--- a/docs/source/user_guide/feature_guide/graph_mode.md
+++ b/docs/source/user_guide/feature_guide/graph_mode.md
@@ -183,6 +183,8 @@ Static kernel compilation is an **optional** feature that pre-compiles operator 
 
     Enabling static kernel triggers a compilation pass during the graph capture phase at service startup. This may add **several minutes to tens of minutes** to the startup time depending on the number of operators to compile and model complexity. Once completed, subsequent request processing is not affected.
 
+    [Super kernel](https://www.hiascend.com/document/detail/zh/Pytorch/latest/devguide/TorchAir/docs/zh/npugraph_ex/advanced/superkernel.md) optimization follows `enable_static_kernel` by default. To use static kernel without super kernel, set `enable_super_kernel` to `false` explicitly. Super kernel cannot be enabled when static kernel is disabled.
+
 Offline example:
 
 ```python
@@ -205,6 +207,13 @@ Online example:
 ```bash
 vllm serve Qwen/Qwen2-7B-Instruct \
   --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":true, "enable_static_kernel":true}}'
+```
+
+To keep static kernel enabled while disabling Super Kernel explicitly:
+
+```bash
+vllm serve Qwen/Qwen2-7B-Instruct \
+  --additional-config '{"ascend_compilation_config":{"enable_npugraph_ex":true, "enable_static_kernel":true, "enable_super_kernel":false}}'
 ```
 
 #### Verifying static kernel is active

--- a/tests/ut/compilation/test_acl_graph.py
+++ b/tests/ut/compilation/test_acl_graph.py
@@ -118,6 +118,11 @@ class TestACLGraphWrapper(TestBase):
         """Set up test fixtures"""
         super().setUp()
 
+        self.get_ascend_config_patcher = patch("vllm_ascend.compilation.acl_graph.get_ascend_config")
+        self.mock_get_ascend_config = self.get_ascend_config_patcher.start()
+        self.addCleanup(self.get_ascend_config_patcher.stop)
+        self.mock_get_ascend_config.return_value.ascend_compilation_config.enable_super_kernel = False
+
         # Mock VllmConfig
         self.mock_vllm_config = MagicMock(spec=VllmConfig)
         self.mock_vllm_config.compilation_config = MagicMock()
@@ -326,6 +331,66 @@ class TestACLGraphWrapper(TestBase):
 
         # Should return the original output (not weak ref)
         self.assertEqual(result, "test_output")
+
+    @patch("vllm_ascend.compilation.acl_graph.torch")
+    @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")
+    @patch("vllm_ascend.compilation.acl_graph.get_forward_context")
+    @patch("vllm_ascend.ascend_forward_context.get_forward_context")
+    @patch("vllm_ascend.compilation.acl_graph.current_platform")
+    @patch("vllm_ascend.compilation.acl_graph.envs")
+    @patch("vllm_ascend.compilation.acl_graph.compilation_counter")
+    @patch("vllm_ascend.compilation.acl_graph.weak_ref_tensors")
+    def test_capture_respects_super_kernel_setting(
+        self,
+        mock_weak_ref_tensors,
+        mock_compilation_counter,
+        mock_envs,
+        mock_current_platform,
+        mock_get_forward_context,
+        mock_get_forward_context_2,
+        mock_validate_cudagraph_capturing_enabled,
+        mock_torch,
+    ):
+        mock_envs.VLLM_LOGGING_LEVEL = "INFO"
+        mock_current_platform.get_global_graph_pool.return_value = self.mock_graph_pool
+        mock_get_forward_context.return_value = self.mock_forward_context
+        mock_get_forward_context_2.return_value = self.mock_forward_context
+        mock_weak_ref_tensors.return_value = "weak_ref_output"
+        mock_torch.Tensor = torch.Tensor
+
+        for enabled in (False, True):
+            with self.subTest(enable_super_kernel=enabled):
+                mock_torch.reset_mock()
+                mock_validate_cudagraph_capturing_enabled.reset_mock()
+                self.mock_runnable.reset_mock()
+                mock_compilation_counter.num_cudagraph_captured = 0
+                self.mock_get_ascend_config.return_value.ascend_compilation_config.enable_super_kernel = enabled
+
+                mock_npu_graph = MagicMock()
+                mock_torch.npu.NPUGraph.return_value = mock_npu_graph
+                mock_graph_context = MagicMock()
+                mock_torch.npu.graph.return_value = mock_graph_context
+                mock_graph_context.__enter__ = Mock(return_value=None)
+                mock_graph_context.__exit__ = Mock(return_value=None)
+
+                wrapper = ACLGraphWrapper(
+                    runnable=self.mock_runnable,
+                    vllm_config=self.mock_vllm_config,
+                    runtime_mode=CUDAGraphMode.FULL,
+                    cudagraph_options=self.mock_cudagraph_options,
+                )
+                wrapper(torch.tensor([1, 2, 3]), "arg2")
+
+                if enabled:
+                    mock_torch.npu.super_kernel_scope_begin.assert_called_once_with("full_model")
+                    mock_torch.npu.super_kernel_scope_end.assert_called_once_with("full_model")
+                    mock_npu_graph.super_kernel_optimize.assert_called_once_with(
+                        optimize_options={"dcci_after_kernel_end": [".*"]},
+                    )
+                else:
+                    mock_torch.npu.super_kernel_scope_begin.assert_not_called()
+                    mock_torch.npu.super_kernel_scope_end.assert_not_called()
+                    mock_npu_graph.super_kernel_optimize.assert_not_called()
 
     @patch("vllm_ascend.compilation.acl_graph.torch")
     @patch("vllm_ascend.compilation.acl_graph.validate_cudagraph_capturing_enabled")

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -365,8 +365,11 @@ class TestAscendConfig(TestBase):
         self.assertTrue(ascend_compilation_config.enable_static_kernel)
         self.assertFalse(ascend_compilation_config.enable_super_kernel)
 
-    @patch("vllm_ascend.utils.is_310p", return_value=False)
-    def test_ascend_compilation_config_super_kernel_defaults_to_static_kernel(self, mock_is_310p):
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
+    def test_ascend_compilation_config_super_kernel_defaults_to_static_kernel(self, _mock_profile):
         cfg = AscendCompilationConfig(enable_static_kernel=True)
         self.assertTrue(cfg.enable_static_kernel)
         self.assertTrue(cfg.enable_super_kernel)
@@ -386,9 +389,12 @@ class TestAscendConfig(TestBase):
         self.assertFalse(cfg.enable_static_kernel)
         self.assertFalse(cfg.enable_super_kernel)
 
-    @patch("vllm_ascend.utils.is_310p", return_value=False)
-    def test_ascend_compilation_config_rejects_super_kernel_without_static_kernel(self, mock_is_310p):
-        with self.assertRaisesRegex(AssertionError, "Super kernel generation requires static kernel to be enabled"):
+    @patch(
+        "vllm_ascend.device.hardware_profile.get_current_hardware_profile",
+        return_value=get_hardware_profile(AscendDeviceType.A3),
+    )
+    def test_ascend_compilation_config_rejects_super_kernel_without_static_kernel(self, _mock_profile):
+        with self.assertRaisesRegex(ValueError, "Super kernel generation requires static kernel to be enabled"):
             AscendCompilationConfig(enable_static_kernel=False, enable_super_kernel=True)
 
     @_clean_up_ascend_config
@@ -516,7 +522,8 @@ class TestAscendConfig(TestBase):
             warning_messages,
         )
         self.assertIn(
-            "super kernel requires static kernel, which is not supported on Ascend 310P. Disabling it.",
+            "super kernel requires static kernel, which is not supported by the current hardware profile. "
+            "Disabling it.",
             warning_messages,
         )
 

--- a/tests/ut/test_ascend_config.py
+++ b/tests/ut/test_ascend_config.py
@@ -347,6 +347,49 @@ class TestAscendConfig(TestBase):
         ascend_compilation_config = init_ascend_config(test_vllm_config).ascend_compilation_config
         self.assertTrue(ascend_compilation_config.enable_npugraph_ex)
         self.assertTrue(ascend_compilation_config.enable_static_kernel)
+        self.assertTrue(ascend_compilation_config.enable_super_kernel)
+
+    @_clean_up_ascend_config
+    @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
+    def test_init_ascend_config_super_kernel_explicit_disable(self, mock_fix_incompatible_config):
+        test_vllm_config = VllmConfig()
+        test_vllm_config.additional_config = {
+            "ascend_compilation_config": {
+                "enable_npugraph_ex": True,
+                "enable_static_kernel": True,
+                "enable_super_kernel": False,
+            },
+            "refresh": True,
+        }
+        ascend_compilation_config = init_ascend_config(test_vllm_config).ascend_compilation_config
+        self.assertTrue(ascend_compilation_config.enable_static_kernel)
+        self.assertFalse(ascend_compilation_config.enable_super_kernel)
+
+    @patch("vllm_ascend.utils.is_310p", return_value=False)
+    def test_ascend_compilation_config_super_kernel_defaults_to_static_kernel(self, mock_is_310p):
+        cfg = AscendCompilationConfig(enable_static_kernel=True)
+        self.assertTrue(cfg.enable_static_kernel)
+        self.assertTrue(cfg.enable_super_kernel)
+
+        cfg = AscendCompilationConfig(enable_static_kernel=False)
+        self.assertFalse(cfg.enable_static_kernel)
+        self.assertFalse(cfg.enable_super_kernel)
+
+        cfg = AscendCompilationConfig(enable_static_kernel=True, enable_super_kernel=False)
+        self.assertTrue(cfg.enable_static_kernel)
+        self.assertFalse(cfg.enable_super_kernel)
+
+        cfg = AscendCompilationConfig(enable_static_kernel="true")
+        self.assertTrue(cfg.enable_super_kernel)
+
+        cfg = AscendCompilationConfig()
+        self.assertFalse(cfg.enable_static_kernel)
+        self.assertFalse(cfg.enable_super_kernel)
+
+    @patch("vllm_ascend.utils.is_310p", return_value=False)
+    def test_ascend_compilation_config_rejects_super_kernel_without_static_kernel(self, mock_is_310p):
+        with self.assertRaisesRegex(AssertionError, "Super kernel generation requires static kernel to be enabled"):
+            AscendCompilationConfig(enable_static_kernel=False, enable_super_kernel=True)
 
     @_clean_up_ascend_config
     @patch("vllm_ascend.platform.NPUPlatform.check_and_update_config")
@@ -465,10 +508,15 @@ class TestAscendConfig(TestBase):
 
         self.assertFalse(ascend_compilation_config.enable_npugraph_ex)
         self.assertFalse(ascend_compilation_config.enable_static_kernel)
+        self.assertFalse(ascend_compilation_config.enable_super_kernel)
         warning_messages = [call.args[0] for call in mock_warning.call_args_list]
         self.assertIn("npugraph_ex is not supported by the current hardware profile. Disabling it.", warning_messages)
         self.assertIn(
             "static kernel requires npugraph_ex, which is not supported by the current hardware profile. Disabling it.",
+            warning_messages,
+        )
+        self.assertIn(
+            "super kernel requires static kernel, which is not supported on Ascend 310P. Disabling it.",
             warning_messages,
         )
 

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -22,6 +22,7 @@ import os
 from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import ConfigDict, TypeAdapter, model_validator
+from pydantic_core import ArgsKwargs
 from vllm.logger import logger
 from vllm.utils.math_utils import cdiv
 
@@ -60,16 +61,33 @@ class AscendCompilationConfig:
     """Configuration for controlling the behavior of Ascend graph optimization.
 
     Migrated to ``@config`` (pydantic dataclass). Hardware-profile runtime
-    downgrades (disable npugraph_ex / static_kernel) and the
-    static_kernel→npugraph_ex dependency check are applied in an ``after``
-    model_validator.
+    downgrades (disable npugraph_ex / static_kernel / super_kernel) and the
+    super_kernel→static_kernel→npugraph_ex dependency checks are applied in
+    an ``after`` model_validator.
     """
 
     enable_npugraph_ex: bool = True
     enable_static_kernel: bool = False
+    enable_super_kernel: bool = False
     fuse_norm_quant: bool = True
     fuse_qknorm_rope: bool = True
     fuse_muls_add: bool = True
+
+    @model_validator(mode="before")
+    @classmethod
+    def _default_super_kernel_to_static_kernel(cls, data: Any) -> Any:
+        if isinstance(data, ArgsKwargs):
+            if data.kwargs is None:
+                return data
+            kw = dict(data.kwargs)
+            if "enable_super_kernel" not in kw and "enable_static_kernel" in kw:
+                kw["enable_super_kernel"] = kw["enable_static_kernel"]
+            return ArgsKwargs(data.args, kw)
+        if isinstance(data, dict):
+            if "enable_super_kernel" not in data and "enable_static_kernel" in data:
+                data = dict(data)
+                data["enable_super_kernel"] = data["enable_static_kernel"]
+        return data
 
     @model_validator(mode="after")
     def _apply_unsupported_hardware_downgrade_and_static_kernel_check(self):
@@ -83,10 +101,18 @@ class AscendCompilationConfig:
                     "static kernel requires npugraph_ex, which is not supported by the current hardware profile. "
                     "Disabling it."
                 )
+            if self.enable_super_kernel:
+                logger.warning(
+                    "super kernel requires static kernel, which is not supported by the current hardware profile. "
+                    "Disabling it."
+                )
             self.enable_npugraph_ex = False
             self.enable_static_kernel = False
+            self.enable_super_kernel = False
         if self.enable_static_kernel:
             assert self.enable_npugraph_ex, "Static kernel generation requires npugraph_ex to be enabled."
+        if self.enable_super_kernel:
+            assert self.enable_static_kernel, "Super kernel generation requires static kernel to be enabled."
         return self
 
 

--- a/vllm_ascend/compilation/acl_graph.py
+++ b/vllm_ascend/compilation/acl_graph.py
@@ -4,7 +4,7 @@
 import dataclasses
 import weakref
 from collections.abc import Callable
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from typing import Any
 from unittest.mock import patch
@@ -20,6 +20,7 @@ from vllm.forward_context import BatchDescriptor, get_forward_context
 from vllm.logger import logger
 from vllm.platforms import current_platform
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX
 
 from ..utils import weak_ref_tensors
@@ -31,6 +32,19 @@ _STREAM_RESOURCE_ERROR_MARKERS = (
     "stream resources are insufficient",
 )
 _OLD_HDK_CAPTURE_ERROR_MARKERS = ("alloc sq cq fail",)
+
+
+@contextmanager
+def _super_kernel_scope(scope: str, enabled: bool):
+    if not enabled:
+        yield
+        return
+
+    torch.npu.super_kernel_scope_begin(scope)
+    try:
+        yield
+    finally:
+        torch.npu.super_kernel_scope_end(scope)
 
 
 def _is_stream_resource_capture_error(exc: RuntimeError) -> bool:
@@ -95,15 +109,18 @@ class ACLGraphWrapper:
         self.runnable = runnable
         self.vllm_config = vllm_config
         self.runtime_mode = runtime_mode
+
+        # A NONE runtime mode does not use ACL Graph, so avoid initializing
+        # graph-specific state (including the Ascend config lookup).
+        assert self.runtime_mode != CUDAGraphMode.NONE
+
         self.compilation_config = vllm_config.compilation_config
+        self.enable_super_kernel = get_ascend_config().ascend_compilation_config.enable_super_kernel
 
         self.first_run_finished = False
         self.is_debugging_mode = envs.VLLM_LOGGING_LEVEL == "DEBUG"
         self._runnable_str = str(runnable) if self.is_debugging_mode else None
 
-        # assert runtime_mode is not NONE(no aclgraph), otherwise, we don't
-        # need to initialize a ACLGraphWrapper.
-        assert self.runtime_mode != CUDAGraphMode.NONE
         self.graph_pool = current_platform.get_global_graph_pool()
 
         if cudagraph_options is None:
@@ -186,7 +203,8 @@ class ACLGraphWrapper:
                 try:
                     with torch.npu.graph(aclgraph, pool=self.graph_pool):
                         # `output` is managed by pytorch's aclgraph pool
-                        output = self.runnable(*args, **kwargs)
+                        with _super_kernel_scope("full_model", self.enable_super_kernel):
+                            output = self.runnable(*args, **kwargs)
                         # Join offloader's copy stream after forward to avoid
                         # unjoined stream error. The last layer's start_prefetch
                         # forks copy_stream, but wait_prefetch only happens in
@@ -218,6 +236,13 @@ class ACLGraphWrapper:
                             f"Original error:\n{exc}"
                         ) from exc
                     raise
+
+            if self.enable_super_kernel:
+                aclgraph.super_kernel_optimize(
+                    optimize_options={
+                        "dcci_after_kernel_end": [".*"],
+                    },
+                )
 
             # here we always use weak ref for the workspaces
             # to save memory

--- a/vllm_ascend/compilation/compiler_interface.py
+++ b/vllm_ascend/compilation/compiler_interface.py
@@ -127,6 +127,11 @@ def _configure_backend(
             options["static_kernel_compile"] = True
             # Set sym_range to limit static kernel compilation to specified batch sizes.
             options["_vllm_aclnn_static_kernel_sym_range"] = _compute_decode_cudagraph_batch_sizes(vllm_config)
+            if ascend_compilation_config.enable_super_kernel:
+                options["super_kernel_optimize"] = True
+                options["super_kernel_optimize_options"] = {
+                    "dcci_after_kernel_end": [".*"],
+                }
         process_kwargs_options(config, {"options": options})
     else:
         # torchair (reduce-overhead): use nested config structure directly.
@@ -244,6 +249,7 @@ class AscendCompiler(CompilerInterface):
             "torch_npu_version": torch_npu.__version__,
             "enable_npugraph_ex": ascend_compilation_config.enable_npugraph_ex,
             "enable_static_kernel": ascend_compilation_config.enable_static_kernel,
+            "enable_super_kernel": ascend_compilation_config.enable_super_kernel,
         }
         logger.info("AscendCompiler hash factors: %s", factors)
         return sha256(str(factors).encode(), usedforsecurity=False).hexdigest()[:10]

--- a/vllm_ascend/platform.py
+++ b/vllm_ascend/platform.py
@@ -1184,6 +1184,7 @@ def _setup_compile_backend(
         compilation_config.mode = CompilationMode.NONE
         additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
         additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
+        additional_config["ascend_compilation_config"]["enable_super_kernel"] = False
     elif compilation_config.cudagraph_mode.requires_piecewise_compilation():
         # Our is_cuda_alike is False so we cannot reuse the assertion of upstream
         if compilation_config.mode != CompilationMode.VLLM_COMPILE and not envs_vllm.VLLM_USE_BREAKABLE_CUDAGRAPH:
@@ -1210,6 +1211,7 @@ def _setup_compile_backend(
             _prune_reduced_capture_sizes(vllm_config)
         additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
         additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
+        additional_config["ascend_compilation_config"]["enable_super_kernel"] = False
     elif compilation_config.cudagraph_mode.has_full_cudagraphs():
         # Don't split the FX graph for static kernel; it would compile multiple times.
         compilation_config.splitting_ops = []
@@ -1219,6 +1221,7 @@ def _setup_compile_backend(
         compilation_config.mode = CompilationMode.NONE
         additional_config["ascend_compilation_config"]["enable_npugraph_ex"] = False
         additional_config["ascend_compilation_config"]["enable_static_kernel"] = False
+        additional_config["ascend_compilation_config"]["enable_super_kernel"] = False
 
     # TODO: Remove this check when ACL Graph supports ASCEND_LAUNCH_BLOCKING=1
     if compilation_config.cudagraph_mode != CUDAGraphMode.NONE and os.environ.get("ASCEND_LAUNCH_BLOCKING", "0") == "1":


### PR DESCRIPTION
### What this PR does / why we need it?
This is a part of https://github.com/vllm-project/vllm-ascend/issues/4715#issue-3694310762:

1. Refactor the npugraph_ex config，modified the default configuration of the super kernel, new default value of super kernel is false.
2. Support online-infer with super kernel.
3. Super kernel optimization follows `enable_static_kernel` by default. To use static kernel without super kernel, set `enable_super_kernel` to `false` explicitly. Super kernel cannot be enabled when static kernel is disabled.

Includes the function of adapting GLM5.2 to SK in #15164 by qigangc.

### Does this PR introduce _any_ user-facing change?
yes，the new config of npugraph_ex is as follow:
```
additional_config={
            "ascend_compilation_config": {
                "enable_npugraph_ex": True,
                "enable_static_kernel": True
                "enable_super_kernel": True
            }
        }
```

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
