### PR TITLE
[Feat][MoE] Add DSA-CP MoE dual micro-batch overlap

### DIFF
--- a/tests/ut/ops/test_dsa_cp_moe_dbo.py
+++ b/tests/ut/ops/test_dsa_cp_moe_dbo.py
@@ -1,0 +1,364 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, PropertyMock, patch
+
+import numpy as np
+import pytest
+import torch
+
+from vllm_ascend.ascend_config import AscendConfig
+from vllm_ascend.ops.fused_moe.dataclass.fused_experts import MoEFusedExpertsInput, MoEWeights
+from vllm_ascend.ops.fused_moe.dataclass.moe_quant import MoEQuantParams
+from vllm_ascend.ops.fused_moe.dataclass.router_input import MoeRouterInput
+from vllm_ascend.ops.fused_moe.dataclass.token_dispatcher import (
+    MoEAllToAllCombineMetadata,
+    MoETokenDispatchInput,
+    MoETokenDispatchOutput,
+)
+from vllm_ascend.ops.fused_moe.fused_moe import AscendMoERunner
+from vllm_ascend.ops.fused_moe.moe_comm_method import (
+    AlltoAllCommImpl,
+    MoECommMethod,
+    _split_fused_experts_input,
+)
+from vllm_ascend.ops.fused_moe.shared_experts import FusedMoEEvents
+from vllm_ascend.ops.fused_moe.token_dispatcher import TokenDispatcherWithAll2AllV
+
+
+def _make_fused_experts_input(
+    num_tokens: int,
+    *,
+    dynamic_eplb: bool = False,
+    lora_context=None,
+) -> MoEFusedExpertsInput:
+    return MoEFusedExpertsInput(
+        hidden_states=torch.arange(num_tokens * 4, dtype=torch.float32).view(num_tokens, 4),
+        topk_weights=torch.arange(num_tokens * 2, dtype=torch.float32).view(num_tokens, 2) / 10,
+        topk_ids=torch.arange(num_tokens * 2, dtype=torch.int64).view(num_tokens, 2) % 4,
+        weights=MoEWeights(w1=torch.ones(1), w2=torch.ones(1)),
+        routing=MoeRouterInput(
+            expert_map=None,
+            global_redundant_expert_num=0,
+            mc2_mask=None,
+            apply_router_weight_on_input=False,
+            pertoken_scale=torch.arange(num_tokens, dtype=torch.float32),
+        ),
+        quant=MoEQuantParams(),
+        dynamic_eplb=dynamic_eplb,
+        lora_context=lora_context,
+    )
+
+
+def _make_token_dispatch_input(num_tokens: int) -> MoETokenDispatchInput:
+    fused_input = _make_fused_experts_input(num_tokens)
+    return MoETokenDispatchInput(
+        hidden_states=fused_input.hidden_states,
+        topk_weights=fused_input.topk_weights,
+        topk_ids=fused_input.topk_ids,
+        routing=fused_input.routing,
+        quant=fused_input.quant,
+    )
+
+
+def _make_combine_metadata(num_tokens: int) -> MoEAllToAllCombineMetadata:
+    return MoEAllToAllCombineMetadata(
+        input_splits=np.array([num_tokens, 0]),
+        output_splits=np.array([num_tokens, 0]),
+        topk_weights=torch.ones(num_tokens, 1),
+        reversed_local_input_permutation_mapping=torch.arange(num_tokens),
+        reversed_global_input_permutation_mapping=None,
+        hidden_shape=torch.Size([num_tokens, 4]),
+        hidden_shape_before_permute=torch.Size([num_tokens, 4]),
+    )
+
+
+@pytest.mark.parametrize("num_tokens,expected_sizes", [(4, (2, 2)), (5, (3, 2))])
+def test_split_fused_experts_input_keeps_token_metadata_aligned(num_tokens, expected_sizes):
+    fused_input = _make_fused_experts_input(num_tokens)
+
+    micro_batch0, micro_batch1 = _split_fused_experts_input(fused_input)
+
+    assert (micro_batch0.hidden_states.shape[0], micro_batch1.hidden_states.shape[0]) == expected_sizes
+    assert torch.equal(
+        torch.cat((micro_batch0.hidden_states, micro_batch1.hidden_states)),
+        fused_input.hidden_states,
+    )
+    assert torch.equal(torch.cat((micro_batch0.topk_ids, micro_batch1.topk_ids)), fused_input.topk_ids)
+    assert torch.equal(
+        torch.cat((micro_batch0.topk_weights, micro_batch1.topk_weights)),
+        fused_input.topk_weights,
+    )
+    assert torch.equal(
+        torch.cat((micro_batch0.routing.pertoken_scale, micro_batch1.routing.pertoken_scale)),
+        fused_input.routing.pertoken_scale,
+    )
+
+
+def test_dispatch_start_defers_wait_and_sync_wrapper_finishes():
+    dispatcher = object.__new__(TokenDispatcherWithAll2AllV)
+    dispatcher.lora_context = None
+    dispatcher._comm_stream = MagicMock()
+    dispatcher._dispatch_preprocess = MagicMock(
+        return_value=(
+            torch.ones(4, 4),
+            torch.arange(4),
+            torch.tensor([2, 2]),
+            np.array([2, 2]),
+            np.array([2, 2]),
+            None,
+            torch.Size([2, 4]),
+            torch.Size([2, 4]),
+        )
+    )
+    dispatcher._dispatch_postprocess = MagicMock(side_effect=lambda hidden, scale, *_args: (hidden, scale, None))
+    work = MagicMock()
+    collective_output = torch.full((4, 4), 7.0)
+    token_input = _make_token_dispatch_input(2)
+
+    with (
+        patch.object(TokenDispatcherWithAll2AllV, "ep_group", new_callable=PropertyMock, return_value=MagicMock()),
+        patch("torch.npu.current_stream") as current_stream,
+        patch(
+            "vllm_ascend.ops.fused_moe.token_dispatcher.async_all_to_all",
+            return_value=(torch.ones(4, 4), collective_output, work),
+        ),
+    ):
+        current_stream.return_value.record_event.return_value = MagicMock()
+        handle = dispatcher.dispatch_start(token_input)
+        work.wait.assert_not_called()
+        output = dispatcher.dispatch_finish(handle)
+        work.wait.assert_called_once_with()
+        assert output.hidden_states is collective_output
+
+        start_result = MagicMock()
+        finish_result = MagicMock()
+        with (
+            patch.object(dispatcher, "dispatch_start", return_value=start_result) as start,
+            patch.object(dispatcher, "dispatch_finish", return_value=finish_result) as finish,
+        ):
+            assert dispatcher.token_dispatch(token_input) is finish_result
+            start.assert_called_once_with(token_input)
+            finish.assert_called_once_with(start_result)
+
+
+def test_combine_start_defers_wait_and_sync_wrapper_finishes():
+    dispatcher = object.__new__(TokenDispatcherWithAll2AllV)
+    dispatcher._comm_stream = MagicMock()
+    dispatcher._combine_preprocess = MagicMock(side_effect=lambda hidden, _metadata: hidden)
+    dispatcher._combine_postprocess = MagicMock(side_effect=lambda hidden, _metadata: hidden)
+    metadata = _make_combine_metadata(2)
+    work = MagicMock()
+    collective_output = torch.full((2, 4), 9.0)
+
+    with (
+        patch.object(TokenDispatcherWithAll2AllV, "ep_group", new_callable=PropertyMock, return_value=MagicMock()),
+        patch("torch.npu.current_stream") as current_stream,
+        patch(
+            "vllm_ascend.ops.fused_moe.token_dispatcher.async_all_to_all",
+            return_value=(torch.ones(2, 4), collective_output, work),
+        ),
+    ):
+        current_stream.return_value.record_event.return_value = MagicMock()
+        handle = dispatcher.combine_start(torch.ones(2, 4), metadata)
+        work.wait.assert_not_called()
+        output = dispatcher.combine_finish(handle)
+        work.wait.assert_called_once_with()
+        assert output is collective_output
+
+        start_result = MagicMock()
+        finish_result = MagicMock()
+        with (
+            patch.object(dispatcher, "combine_start", return_value=start_result) as start,
+            patch.object(dispatcher, "combine_finish", return_value=finish_result) as finish,
+        ):
+            hidden_states = torch.ones(2, 4)
+            assert dispatcher.token_combine(hidden_states, metadata) is finish_result
+            start.assert_called_once_with(hidden_states, metadata, None)
+            finish.assert_called_once_with(start_result)
+
+
+@pytest.mark.parametrize("defer_final_combine", [False, True])
+def test_moe_dbo_pipeline_has_fixed_collective_order_and_restores_tokens(defer_final_combine):
+    fused_input = _make_fused_experts_input(5)
+    dispatcher = object.__new__(TokenDispatcherWithAll2AllV)
+    order = []
+    dispatch_count = 0
+    finish_count = 0
+    combine_start_count = 0
+    combine_finish_count = 0
+
+    def dispatch_start(token_input):
+        nonlocal dispatch_count
+        index = dispatch_count
+        dispatch_count += 1
+        order.append(f"Dstart{index}")
+        return token_input
+
+    def dispatch_finish(token_input):
+        nonlocal finish_count
+        index = finish_count
+        finish_count += 1
+        order.append(f"Dfinish{index}")
+        num_tokens = token_input.hidden_states.shape[0]
+        return MoETokenDispatchOutput(
+            hidden_states=token_input.hidden_states,
+            group_list=torch.tensor([num_tokens, 0]),
+            group_list_type=1,
+            combine_metadata=_make_combine_metadata(num_tokens),
+        )
+
+    def combine_start(hidden_states, _metadata):
+        nonlocal combine_start_count
+        index = combine_start_count
+        combine_start_count += 1
+        order.append(f"Cstart{index}")
+        return hidden_states
+
+    def combine_finish(hidden_states):
+        nonlocal combine_finish_count
+        index = combine_finish_count
+        combine_finish_count += 1
+        order.append(f"Cfinish{index}")
+        return hidden_states
+
+    dispatcher.dispatch_start = MagicMock(side_effect=dispatch_start)
+    dispatcher.dispatch_finish = MagicMock(side_effect=dispatch_finish)
+    dispatcher.combine_start = MagicMock(side_effect=combine_start)
+    dispatcher.combine_finish = MagicMock(side_effect=combine_finish)
+
+    comm_impl = object.__new__(AlltoAllCommImpl)
+    comm_impl.token_dispatcher = dispatcher
+    comm_impl.moe_config = SimpleNamespace()
+    comm_impl._apply_mlp = MagicMock(
+        side_effect=lambda mlp_input: (
+            order.append(f"MLP{sum(item.startswith('MLP') for item in order)}") or mlp_input.hidden_states,
+            MagicMock(),
+        )
+    )
+
+    ascend_config = SimpleNamespace(enable_dsa_cp_moe_dbo_shared_expert_overlap=defer_final_combine)
+    with (
+        patch("torch.npu.current_stream") as current_stream,
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.get_ascend_config", return_value=ascend_config),
+    ):
+        current_stream.return_value.record_event.return_value = MagicMock()
+        result = comm_impl._fused_experts_dsa_cp_moe_dbo(fused_input)
+
+    expected_order = [
+        "Dstart0",
+        "Dstart1",
+        "Dfinish0",
+        "MLP0",
+        "Dfinish1",
+        "Cstart0",
+        "MLP1",
+        "Cstart1",
+        "Cfinish0",
+    ]
+    if not defer_final_combine:
+        expected_order.append("Cfinish1")
+    assert order == expected_order
+
+    if defer_final_combine:
+        assert result.routed_out is None
+        assert result.finish_routed_out is not None
+        order.append("SHARED_FULL_BATCH")
+        routed_out = result.finish_routed_out()
+        assert result.finish_routed_out() is routed_out
+        assert order[-2:] == ["SHARED_FULL_BATCH", "Cfinish1"]
+    else:
+        assert result.finish_routed_out is None
+        routed_out = result.routed_out
+    assert torch.equal(routed_out, fused_input.hidden_states)
+    assert torch.equal(result.expert_tokens, torch.tensor([5, 0]))
+
+
+def test_shared_expert_can_cover_deferred_c1_finish():
+    order = []
+    routed_out = torch.full((2, 4), 3.0)
+
+    def finish_routed_out():
+        order.append("C1_FINISH")
+        return routed_out
+
+    events = FusedMoEEvents(
+        before_routed_experts=MagicMock(),
+        finish_routed_out=finish_routed_out,
+    )
+    order.append("SHARED_FULL_BATCH")
+    actual = AscendMoERunner._finish_deferred_routed_out(None, events)
+
+    assert order == ["SHARED_FULL_BATCH", "C1_FINISH"]
+    assert actual is routed_out
+
+
+def test_eligibility_is_rank_coordinated_and_cached_once_per_forward():
+    fused_input = _make_fused_experts_input(5)
+    comm_impl = object.__new__(AlltoAllCommImpl)
+    comm_impl.token_dispatcher = MagicMock()
+    forward_context = SimpleNamespace()
+    ascend_config = SimpleNamespace(enable_dsa_cp_moe_dbo=True)
+
+    with (
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.get_ascend_config", return_value=ascend_config),
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.get_forward_context", return_value=forward_context),
+        patch.object(comm_impl, "_local_dsa_cp_moe_dbo_candidate", return_value=(True, "eligible")),
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.dist.all_reduce") as all_reduce,
+    ):
+        assert comm_impl._dsa_cp_moe_dbo_eligible(fused_input)
+        assert comm_impl._dsa_cp_moe_dbo_eligible(fused_input)
+        all_reduce.assert_called_once()
+
+
+def test_switch_off_falls_back_to_synchronous_path():
+    fused_input = _make_fused_experts_input(5)
+    comm_impl = object.__new__(AlltoAllCommImpl)
+    sentinel = MagicMock()
+
+    with (
+        patch(
+            "vllm_ascend.ops.fused_moe.moe_comm_method.get_ascend_config",
+            return_value=SimpleNamespace(enable_dsa_cp_moe_dbo=False),
+        ),
+        patch.object(MoECommMethod, "fused_experts", return_value=sentinel) as synchronous,
+    ):
+        assert comm_impl.fused_experts(fused_input) is sentinel
+        synchronous.assert_called_once_with(fused_input)
+
+
+def test_any_rank_can_force_consistent_fallback():
+    fused_input = _make_fused_experts_input(5)
+    comm_impl = object.__new__(AlltoAllCommImpl)
+    comm_impl.token_dispatcher = MagicMock()
+    forward_context = SimpleNamespace()
+
+    def reject_on_remote_rank(eligibility, **_kwargs):
+        eligibility.zero_()
+
+    with (
+        patch(
+            "vllm_ascend.ops.fused_moe.moe_comm_method.get_ascend_config",
+            return_value=SimpleNamespace(enable_dsa_cp_moe_dbo=True),
+        ),
+        patch("vllm_ascend.ops.fused_moe.moe_comm_method.get_forward_context", return_value=forward_context),
+        patch.object(comm_impl, "_local_dsa_cp_moe_dbo_candidate", return_value=(True, "eligible")),
+        patch(
+            "vllm_ascend.ops.fused_moe.moe_comm_method.dist.all_reduce",
+            side_effect=reject_on_remote_rank,
+        ) as all_reduce,
+    ):
+        assert not comm_impl._dsa_cp_moe_dbo_eligible(fused_input)
+        assert not comm_impl._dsa_cp_moe_dbo_eligible(fused_input)
+        all_reduce.assert_called_once()
+
+
+def test_dsa_cp_moe_dbo_config_defaults_and_threshold_validation():
+    config = AscendConfig(sparse_kv_offload_config=SimpleNamespace(enabled=False))
+    assert not config.enable_dsa_cp_moe_dbo
+    assert not config.enable_dsa_cp_moe_dbo_shared_expert_overlap
+    assert config.dsa_cp_moe_dbo_token_threshold == 32
+
+    with pytest.raises(ValueError, match="must be at least 2"):
+        AscendConfig(
+            sparse_kv_offload_config=SimpleNamespace(enabled=False),
+            dsa_cp_moe_dbo_token_threshold=1,
+        )

--- a/vllm_ascend/ascend_config.py
+++ b/vllm_ascend/ascend_config.py
@@ -242,6 +242,11 @@ class AscendConfig:
     enable_mc2_hierarchy_comm: bool = False
     enable_reduce_sample: bool = False
     enable_dsa_cp: bool = False
+    # Experimental DSA-CP MoE-only dual micro-batch overlap. These switches
+    # are independent of upstream model-runner DBO, which Ascend disables.
+    enable_dsa_cp_moe_dbo: bool = False
+    enable_dsa_cp_moe_dbo_shared_expert_overlap: bool = False
+    dsa_cp_moe_dbo_token_threshold: int = 32
     draft_window_size: int | None = None
     mix_placement: bool = False
     pa_shape_list: list[Any] = dataclasses.field(default_factory=list)
@@ -326,6 +331,10 @@ class AscendConfig:
     def _validate_user_input_ranges(self):
         if self.weight_nz_mode not in (0, 1, 2):
             raise ValueError(f"weight_nz_mode must be one of 0, 1, or 2; got {self.weight_nz_mode}")
+        if self.dsa_cp_moe_dbo_token_threshold < 2:
+            raise ValueError(
+                f"dsa_cp_moe_dbo_token_threshold must be at least 2; got {self.dsa_cp_moe_dbo_token_threshold}"
+            )
         return self
 
     # ---- derivations + cross-config downgrades/mutex ----

--- a/vllm_ascend/ops/fused_moe/dataclass/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/dataclass/token_dispatcher.py
@@ -18,7 +18,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import numpy as np
 import torch
@@ -61,6 +61,38 @@ class MoEAllToAllCombineMetadata:
     reversed_global_input_permutation_mapping: torch.Tensor | None
     hidden_shape: torch.Size
     hidden_shape_before_permute: torch.Size
+
+
+@dataclass(frozen=True, slots=True)
+class MoEAllToAllDispatchHandle:
+    """Per-micro-batch state kept alive until dispatch completion."""
+
+    token_dispatch_input: MoETokenDispatchInput
+    hidden_input: torch.Tensor
+    global_input_tokens: torch.Tensor
+    hidden_work: Any
+    scale_input: torch.Tensor | None
+    dynamic_scale_after_all2all: torch.Tensor | None
+    scale_work: Any | None
+    reversed_local_input_permutation_mapping: torch.Tensor
+    tokens_per_expert: torch.Tensor
+    input_splits: np.ndarray
+    output_splits: np.ndarray
+    global_input_tokens_local_experts_indices: torch.Tensor | None
+    hidden_shape: torch.Size
+    hidden_shape_before_permute: torch.Size
+    with_quant: bool
+    dst_type: torch.dtype | None
+
+
+@dataclass(frozen=True, slots=True)
+class MoEAllToAllCombineHandle:
+    """Per-micro-batch state kept alive until combine completion."""
+
+    hidden_input: torch.Tensor
+    permutated_local_input_tokens: torch.Tensor
+    work: Any
+    combine_metadata: MoEAllToAllCombineMetadata
 
 
 @dataclass(frozen=True, slots=True)

--- a/vllm_ascend/ops/fused_moe/fused_moe.py
+++ b/vllm_ascend/ops/fused_moe/fused_moe.py
@@ -25,6 +25,7 @@ from vllm.distributed import (
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig, FusedMoERouter
 from vllm.model_executor.layers.fused_moe.layer import MoERunner
 
+from vllm_ascend.ascend_config import get_ascend_config
 from vllm_ascend.ascend_forward_context import _EXTRA_CTX, MoECommType
 from vllm_ascend.distributed.parallel_state import get_mc2_group
 from vllm_ascend.ops.fused_moe.moe_comm_method import get_moe_comm_method, setup_moe_comm_method
@@ -79,6 +80,9 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         self.ascend_shared_experts = None
         if shared_experts is not None:
             routed_experts.return_with_event = True
+            routed_experts.defer_dsa_cp_moe_dbo_final_combine = (
+                get_ascend_config().enable_dsa_cp_moe_dbo_shared_expert_overlap
+            )
             self.ascend_shared_experts = AscendSharedExperts(
                 shared_experts,
                 self.moe_config,
@@ -213,6 +217,16 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
         if self.ascend_shared_experts is not None:
             self.ascend_shared_experts.set_lora_context(lora_context)
 
+    @staticmethod
+    def _finish_deferred_routed_out(
+        routed_out: torch.Tensor | None,
+        fused_moe_events,
+    ) -> torch.Tensor:
+        if routed_out is None:
+            assert fused_moe_events.finish_routed_out is not None
+            routed_out = fused_moe_events.finish_routed_out()
+        return routed_out
+
     if vllm_version_is("0.27.1"):
 
         def _forward_impl(
@@ -257,6 +271,7 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     hidden_states,
                     fused_moe_events,
                 )
+                routed_out = self._finish_deferred_routed_out(routed_out, fused_moe_events)
                 return shared_out, routed_out
 
     else:
@@ -315,4 +330,5 @@ class AscendMoERunner(MoERunner):  # type: ignore[no-redef]
                     hidden_states,
                     fused_moe_events,
                 )
+                routed_out = self._finish_deferred_routed_out(routed_out, fused_moe_events)
                 return shared_out, routed_out

--- a/vllm_ascend/ops/fused_moe/moe_comm_method.py
+++ b/vllm_ascend/ops/fused_moe/moe_comm_method.py
@@ -16,9 +16,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, replace
 
 import torch
+import torch.distributed as dist
+from vllm.config import get_current_vllm_config
+from vllm.forward_context import get_forward_context
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import FusedMoEConfig
 
@@ -44,6 +48,7 @@ from vllm_ascend.ops.fused_moe.token_dispatcher import (
     TokenDispatcherWithMC2,
 )
 from vllm_ascend.quantization.quant_type import QuantType
+from vllm_ascend.utils import AscendDeviceType, enable_dsa_cp, get_ascend_device_type
 
 _MoECommMethods: dict[MoECommType | None, MoECommMethod] = {}
 
@@ -64,7 +69,10 @@ def setup_moe_comm_method(moe_config):
 
 @dataclass
 class FusedExpertsResult:
-    routed_out: torch.Tensor
+    routed_out: torch.Tensor | None
+    # DSA-CP MoE DBO can leave C1 in flight while independent full-batch
+    # shared-expert work runs.
+    finish_routed_out: Callable[[], torch.Tensor] | None = None
     # This field is for shared experts and should be set by the MoE
     # communication method that supports shared experts in parallel with routed
     # experts.
@@ -74,6 +82,34 @@ class FusedExpertsResult:
     # For dynamic_eplb
     group_list_type: int = 1
     expert_tokens: torch.Tensor | None = None
+
+
+def _split_fused_experts_input(
+    fused_experts_input: MoEFusedExpertsInput,
+) -> tuple[MoEFusedExpertsInput, MoEFusedExpertsInput]:
+    """Split token-indexed MoE inputs while preserving original token order."""
+
+    num_tokens = fused_experts_input.hidden_states.shape[0]
+    split_point = (num_tokens + 1) // 2
+    token_slices = (slice(0, split_point), slice(split_point, num_tokens))
+    micro_batches = []
+    for token_slice in token_slices:
+        pertoken_scale = fused_experts_input.routing.pertoken_scale
+        if pertoken_scale is not None:
+            pertoken_scale = pertoken_scale[token_slice]
+        micro_batches.append(
+            replace(
+                fused_experts_input,
+                hidden_states=fused_experts_input.hidden_states[token_slice],
+                topk_ids=fused_experts_input.topk_ids[token_slice],
+                topk_weights=fused_experts_input.topk_weights[token_slice],
+                routing=replace(
+                    fused_experts_input.routing,
+                    pertoken_scale=pertoken_scale,
+                ),
+            )
+        )
+    return micro_batches[0], micro_batches[1]
 
 
 class MoECommMethod(ABC):
@@ -245,6 +281,161 @@ class AlltoAllCommImpl(MoECommMethod):
 
     def _get_prepare_finalize(self):
         return PrepareAndFinalizeWithAll2All(self.moe_config)
+
+    def _local_dsa_cp_moe_dbo_candidate(
+        self,
+        fused_experts_input: MoEFusedExpertsInput,
+    ) -> tuple[bool, str]:
+        ascend_config = get_ascend_config()
+        vllm_config = get_current_vllm_config()
+        hidden_states = fused_experts_input.hidden_states
+        num_tokens = hidden_states.shape[0] if hidden_states.ndim > 0 else 0
+
+        if get_ascend_device_type() != AscendDeviceType.A5:
+            return False, "only A5 is supported"
+        if not enable_dsa_cp():
+            return False, "DSA-CP is disabled"
+        if _EXTRA_CTX.moe_comm_type != MoECommType.ALLTOALL:
+            return False, "the selected MoE communication method is not AllToAllV"
+        if not vllm_config.model_config.enforce_eager:
+            return False, "only eager execution is supported"
+        if self.moe_config.ep_size <= 1:
+            return False, "EP size must be greater than one"
+        if fused_experts_input.lora_context is not None or self.lora_context is not None:
+            return False, "LoRA is unsupported"
+        if fused_experts_input.dynamic_eplb:
+            return False, "dynamic EPLB is unsupported"
+        if ascend_config.multistream_overlap_shared_expert:
+            return False, "shared-expert multistream overlap is unsupported"
+        if hidden_states.ndim != 2:
+            return False, "hidden states must be token-major 2-D"
+        if fused_experts_input.topk_ids.shape[0] != num_tokens:
+            return False, "top-k ids are not token-aligned"
+        if fused_experts_input.topk_weights.shape[0] != num_tokens:
+            return False, "top-k weights are not token-aligned"
+        if fused_experts_input.routing.mc2_mask is not None:
+            return False, "MC2 mask is incompatible with AllToAllV DBO"
+        pertoken_scale = fused_experts_input.routing.pertoken_scale
+        if pertoken_scale is not None and pertoken_scale.shape[0] != num_tokens:
+            return False, "per-token scale is not token-aligned"
+        if num_tokens < ascend_config.dsa_cp_moe_dbo_token_threshold:
+            return False, "local token count is below the configured threshold"
+        split_point = (num_tokens + 1) // 2
+        if split_point <= 0 or split_point >= num_tokens:
+            return False, "the second micro-batch would be empty"
+        return True, "eligible"
+
+    def _dsa_cp_moe_dbo_eligible(self, fused_experts_input: MoEFusedExpertsInput) -> bool:
+        if not get_ascend_config().enable_dsa_cp_moe_dbo:
+            return False
+
+        forward_context = get_forward_context()
+        cache_attr = "_ascend_dsa_cp_moe_dbo_eligible"
+        cached = getattr(forward_context, cache_attr, None)
+        if isinstance(cached, bool):
+            return cached
+
+        local_eligible, local_reason = self._local_dsa_cp_moe_dbo_candidate(fused_experts_input)
+        eligibility = torch.tensor(
+            int(local_eligible),
+            dtype=torch.int32,
+            device=fused_experts_input.hidden_states.device,
+        )
+        # This synchronization occurs once per forward and is cached. It is
+        # required so every EP rank chooses the same collective protocol even
+        # when DSA-CP gives ranks different local token payloads.
+        dist.all_reduce(
+            eligibility,
+            op=dist.ReduceOp.MIN,
+            group=self.token_dispatcher.ep_group,
+        )
+        globally_eligible = bool(eligibility.item())
+        setattr(forward_context, cache_attr, globally_eligible)
+        if globally_eligible:
+            logger.info_once(
+                "DSA-CP MoE DBO is active: ep_size=%d, local_tokens=%d, collective_order=D0,D1,C0,C1",
+                self.moe_config.ep_size,
+                fused_experts_input.hidden_states.shape[0],
+            )
+        else:
+            logger.debug(
+                "DSA-CP MoE DBO falls back to synchronous AllToAllV. local_reason=%s",
+                local_reason,
+            )
+        return globally_eligible
+
+    def _fused_experts_dsa_cp_moe_dbo(
+        self,
+        fused_experts_input: MoEFusedExpertsInput,
+    ) -> FusedExpertsResult:
+        assert isinstance(self.token_dispatcher, TokenDispatcherWithAll2AllV)
+        before_dispatch_evt = torch.npu.current_stream().record_event()
+        micro_batch0, micro_batch1 = _split_fused_experts_input(fused_experts_input)
+
+        # Every rank launches the same global collective order: D0, D1, C0,
+        # C1. Payload sizes are allowed to differ across DSA-CP ranks.
+        dispatch0 = self.token_dispatcher.dispatch_start(build_token_dispatch_input(fused_experts_input=micro_batch0))
+        dispatch1 = self.token_dispatcher.dispatch_start(build_token_dispatch_input(fused_experts_input=micro_batch1))
+
+        dispatch_output0 = self.token_dispatcher.dispatch_finish(dispatch0)
+        mlp_output0, before_gmm2_evt = self._apply_mlp(
+            build_mlp_compute_input(
+                fused_experts_input=micro_batch0,
+                token_dispatch_output=dispatch_output0,
+                moe_config=self.moe_config,
+            )
+        )
+
+        # D1 overlaps MLP0. C0 then overlaps MLP1.
+        dispatch_output1 = self.token_dispatcher.dispatch_finish(dispatch1)
+        before_combine_evt = torch.npu.current_stream().record_event()
+        combine0 = self.token_dispatcher.combine_start(
+            mlp_output0,
+            dispatch_output0.combine_metadata,
+        )
+        mlp_output1, _ = self._apply_mlp(
+            build_mlp_compute_input(
+                fused_experts_input=micro_batch1,
+                token_dispatch_output=dispatch_output1,
+                moe_config=self.moe_config,
+            )
+        )
+        combine1 = self.token_dispatcher.combine_start(
+            mlp_output1,
+            dispatch_output1.combine_metadata,
+        )
+        routed_out0 = self.token_dispatcher.combine_finish(combine0)
+
+        routed_out: torch.Tensor | None = None
+
+        def finish_routed_out() -> torch.Tensor:
+            nonlocal routed_out
+            if routed_out is None:
+                routed_out1 = self.token_dispatcher.combine_finish(combine1)
+                routed_out = torch.cat((routed_out0, routed_out1), dim=0)
+            return routed_out
+
+        defer_final_combine = get_ascend_config().enable_dsa_cp_moe_dbo_shared_expert_overlap
+        if not defer_final_combine:
+            routed_out = finish_routed_out()
+
+        return FusedExpertsResult(
+            routed_out=routed_out,
+            finish_routed_out=finish_routed_out if defer_final_combine else None,
+            before_dispatch_evt=before_dispatch_evt,
+            before_gmm2_evt=before_gmm2_evt,
+            before_combine_evt=before_combine_evt,
+            group_list_type=dispatch_output0.group_list_type,
+            expert_tokens=dispatch_output0.group_list + dispatch_output1.group_list,
+        )
+
+    def fused_experts(
+        self,
+        fused_experts_input: MoEFusedExpertsInput,
+    ):
+        if not self._dsa_cp_moe_dbo_eligible(fused_experts_input):
+            return super().fused_experts(fused_experts_input)
+        return self._fused_experts_dsa_cp_moe_dbo(fused_experts_input)
 
 
 class FusedMC2CommImpl(MoECommMethod):

--- a/vllm_ascend/ops/fused_moe/moe_utils.py
+++ b/vllm_ascend/ops/fused_moe/moe_utils.py
@@ -33,7 +33,14 @@ _CANN_MEGA_MOE_QUANT_MODE_None = 0
 _CANN_MEGA_MOE_QUANT_MODE_INT8 = 2
 
 
-def async_all_to_all(input_, output_split_sizes, input_split_sizes, group, event=None):
+def async_all_to_all(
+    input_,
+    output_split_sizes,
+    input_split_sizes,
+    group,
+    event=None,
+    comm_stream=None,
+):
     if output_split_sizes is None:
         # Equal split (all2all)
         a2a_out = torch.empty_like(input_)
@@ -45,16 +52,23 @@ def async_all_to_all(input_, output_split_sizes, input_split_sizes, group, event
             device=torch.npu.current_device(),
         )
 
+    # Keep the exact storage submitted to HCCL alive until the returned work
+    # handle completes. Returning ``input_`` is insufficient when contiguous()
+    # has to allocate a temporary tensor.
+    input_contiguous = input_.contiguous()
+
     if event:
         # multi stream wait event
         global COMM_STREAM
-        if COMM_STREAM is None:
-            COMM_STREAM = torch_npu.npu.Stream(device=torch.npu.current_device())
-        with torch_npu.npu.stream(COMM_STREAM):
+        if comm_stream is None:
+            if COMM_STREAM is None:
+                COMM_STREAM = torch_npu.npu.Stream(device=torch.npu.current_device())
+            comm_stream = COMM_STREAM
+        with torch_npu.npu.stream(comm_stream):
             event.wait()
             handle = dist.all_to_all_single(
                 a2a_out,
-                input_.contiguous(),
+                input_contiguous,
                 output_split_sizes=output_split_sizes,
                 input_split_sizes=input_split_sizes,
                 group=group,
@@ -63,13 +77,13 @@ def async_all_to_all(input_, output_split_sizes, input_split_sizes, group, event
     else:
         handle = dist.all_to_all_single(
             a2a_out,
-            input_.contiguous(),
+            input_contiguous,
             output_split_sizes=output_split_sizes,
             input_split_sizes=input_split_sizes,
             group=group,
             async_op=True,
         )
-    return input_, a2a_out, handle
+    return input_contiguous, a2a_out, handle
 
 
 def _gather_along_first_dim(input_, group, output_split_sizes=None):

--- a/vllm_ascend/ops/fused_moe/routed_experts.py
+++ b/vllm_ascend/ops/fused_moe/routed_experts.py
@@ -588,11 +588,29 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
             else:
                 self.moe_load.add_(local_load)
 
-        routed_out = _EXTRA_CTX.moe_comm_method.finalize(
-            hidden_states=fused_experts_results.routed_out,
-            reduce_results=isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl),
-            padded_hidden_states_shape=padded_hidden_states_shape,
+        routed_out: torch.Tensor | None = None
+
+        def finish_routed_out() -> torch.Tensor:
+            nonlocal routed_out
+            if routed_out is None:
+                raw_routed_out = fused_experts_results.routed_out
+                if raw_routed_out is None:
+                    assert fused_experts_results.finish_routed_out is not None
+                    raw_routed_out = fused_experts_results.finish_routed_out()
+                routed_out = _EXTRA_CTX.moe_comm_method.finalize(
+                    hidden_states=raw_routed_out,
+                    reduce_results=isinstance(_EXTRA_CTX.moe_comm_method, AllGatherCommImpl),
+                    padded_hidden_states_shape=padded_hidden_states_shape,
+                )
+            return routed_out
+
+        defer_routed_out = (
+            self.return_with_event
+            and getattr(self, "defer_dsa_cp_moe_dbo_final_combine", False)
+            and fused_experts_results.finish_routed_out is not None
         )
+        if not defer_routed_out:
+            routed_out = finish_routed_out()
 
         # Clear per-forward LoRA state from long-lived singletons.
         if lora_context is not None:
@@ -605,7 +623,9 @@ class AscendRoutedExperts(RoutedExperts):  # type: ignore[no-redef]
                 before_dispatch=fused_experts_results.before_dispatch_evt,
                 before_gmm2=fused_experts_results.before_gmm2_evt,
                 before_combine=fused_experts_results.before_combine_evt,
+                finish_routed_out=finish_routed_out if defer_routed_out else None,
             )
 
         # The vLLM FusedMoE forward_impl does not return events.
+        assert routed_out is not None
         return routed_out

--- a/vllm_ascend/ops/fused_moe/shared_experts.py
+++ b/vllm_ascend/ops/fused_moe/shared_experts.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum, auto
 from functools import wraps
@@ -44,6 +45,7 @@ class FusedMoEEvents:
     before_dispatch: torch.npu.Event | None = field(default=None)
     before_gmm2: torch.npu.Event | None = field(default=None)
     before_combine: torch.npu.Event | None = field(default=None)
+    finish_routed_out: Callable[[], torch.Tensor] | None = field(default=None)
 
 
 class SharedExpertParallelMode(Enum):

--- a/vllm_ascend/ops/fused_moe/token_dispatcher.py
+++ b/vllm_ascend/ops/fused_moe/token_dispatcher.py
@@ -41,7 +41,9 @@ from vllm_ascend.lora.fused_moe import (
 from vllm_ascend.lora.quant_moe import validate_quant_moe_lora_activation_input
 from vllm_ascend.ops.fused_moe.dataclass.token_dispatcher import (
     MoEAllGatherCombineMetadata,
+    MoEAllToAllCombineHandle,
     MoEAllToAllCombineMetadata,
+    MoEAllToAllDispatchHandle,
     MoEMC2CombineMetadata,
     MoETokenDispatchInput,
     MoETokenDispatchOutput,
@@ -471,6 +473,7 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.num_local_experts = kwargs.get("num_local_experts", 0)
+        self._comm_stream = None
 
         assert self.num_local_experts > 0, "Expected at least one expert"
         if self.num_local_experts > 1:
@@ -494,10 +497,15 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         backend = self.ep_group._get_backend(torch.device("npu"))
         self.moe_all_to_all_group_name = backend.get_hccl_comm_name(local_rank)
 
-    def token_dispatch(
+    def _get_comm_stream(self):
+        if self._comm_stream is None:
+            self._comm_stream = torch_npu.npu.Stream(device=torch.npu.current_device())
+        return self._comm_stream
+
+    def dispatch_start(
         self,
         token_dispatch_input: MoETokenDispatchInput,
-    ):
+    ) -> MoEAllToAllDispatchHandle:
         use_mxfp_quant = token_dispatch_input.quant.is_mxfp
         with_quant = token_dispatch_input.quant.dispatch_with_quant
         if has_lora(self.lora_context) and token_dispatch_input.quant.is_quant:
@@ -512,7 +520,6 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
             with_quant = False
         dst_type = token_dispatch_input.quant.get_dst_type
         hidden_states = token_dispatch_input.hidden_states
-        topk_weights = token_dispatch_input.topk_weights
         topk_ids = token_dispatch_input.topk_ids
 
         (
@@ -527,77 +534,131 @@ class TokenDispatcherWithAll2AllV(MoETokenDispatcher[MoEAllToAllCombineMetadata]
         ) = self._dispatch_preprocess(hidden_states, topk_ids)
 
         dynamic_scale_after_all2all = None
+        scale_input = None
+        scale_work = None
         if with_quant:
             permutated_local_input_tokens, dynamic_scale = DeviceOperator.npu_dynamic_quant(
                 permutated_local_input_tokens, act_quant_type=dst_type, use_mxfp_quant=use_mxfp_quant
             )
-            _, dynamic_scale_after_all2all, permute2_ep_all_to_all_handle = async_all_to_all(
-                dynamic_scale, output_splits, input_splits, self.ep_group
-            )
-            permute2_ep_all_to_all_handle.wait()
-            dynamic_scale.untyped_storage().resize_(0)
 
-        _, global_input_tokens, permute1_ep_all_to_all_handle = async_all_to_all(
-            permutated_local_input_tokens, output_splits, input_splits, self.ep_group
+        ready_event = torch.npu.current_stream().record_event()
+        comm_stream = self._get_comm_stream()
+        if with_quant:
+            scale_input, dynamic_scale_after_all2all, scale_work = async_all_to_all(
+                dynamic_scale,
+                output_splits,
+                input_splits,
+                self.ep_group,
+                event=ready_event,
+                comm_stream=comm_stream,
+            )
+
+        hidden_input, global_input_tokens, hidden_work = async_all_to_all(
+            permutated_local_input_tokens,
+            output_splits,
+            input_splits,
+            self.ep_group,
+            event=ready_event,
+            comm_stream=comm_stream,
         )
-        permute1_ep_all_to_all_handle.wait()
-        permutated_local_input_tokens.untyped_storage().resize_(0)
+
+        return MoEAllToAllDispatchHandle(
+            token_dispatch_input=token_dispatch_input,
+            hidden_input=hidden_input,
+            global_input_tokens=global_input_tokens,
+            hidden_work=hidden_work,
+            scale_input=scale_input,
+            dynamic_scale_after_all2all=dynamic_scale_after_all2all,
+            scale_work=scale_work,
+            reversed_local_input_permutation_mapping=reversed_local_input_permutation_mapping,
+            tokens_per_expert=tokens_per_expert,
+            input_splits=input_splits,
+            output_splits=output_splits,
+            global_input_tokens_local_experts_indices=global_input_tokens_local_experts_indices,
+            hidden_shape=hidden_shape,
+            hidden_shape_before_permute=hidden_shape_before_permute,
+            with_quant=with_quant,
+            dst_type=dst_type,
+        )
+
+    def dispatch_finish(
+        self,
+        dispatch_handle: MoEAllToAllDispatchHandle,
+    ) -> MoETokenDispatchOutput[MoEAllToAllCombineMetadata]:
+        token_dispatch_input = dispatch_handle.token_dispatch_input
+        if dispatch_handle.scale_work is not None:
+            dispatch_handle.scale_work.wait()
+        dispatch_handle.hidden_work.wait()
 
         if self.lora_context is not None:
             all2all_lora_indices(
                 self.lora_context,
-                output_splits=output_splits,
-                input_splits=input_splits,
+                output_splits=dispatch_handle.output_splits,
+                input_splits=dispatch_handle.input_splits,
                 ep_group=self.ep_group,
             )
 
-        # Postprocess
         global_input_tokens, dynamic_scale_final, reversed_global_input_permutation_mapping = (
             self._dispatch_postprocess(
-                global_input_tokens,
-                dynamic_scale_after_all2all,
-                global_input_tokens_local_experts_indices,
-                with_quant,
-                dst_type,
+                dispatch_handle.global_input_tokens,
+                dispatch_handle.dynamic_scale_after_all2all,
+                dispatch_handle.global_input_tokens_local_experts_indices,
+                dispatch_handle.with_quant,
+                dispatch_handle.dst_type,
             )
         )
 
         return MoETokenDispatchOutput(
             hidden_states=global_input_tokens,
             dynamic_scale=dynamic_scale_final,
-            group_list=tokens_per_expert,
+            group_list=dispatch_handle.tokens_per_expert,
             group_list_type=1,
             combine_metadata=MoEAllToAllCombineMetadata(
-                input_splits=input_splits,
-                output_splits=output_splits,
-                topk_weights=topk_weights,
-                reversed_local_input_permutation_mapping=reversed_local_input_permutation_mapping,
+                input_splits=dispatch_handle.input_splits,
+                output_splits=dispatch_handle.output_splits,
+                topk_weights=token_dispatch_input.topk_weights,
+                reversed_local_input_permutation_mapping=dispatch_handle.reversed_local_input_permutation_mapping,
                 reversed_global_input_permutation_mapping=reversed_global_input_permutation_mapping,
-                hidden_shape=hidden_shape,
-                hidden_shape_before_permute=hidden_shape_before_permute,
+                hidden_shape=dispatch_handle.hidden_shape,
+                hidden_shape_before_permute=dispatch_handle.hidden_shape_before_permute,
             ),
         )
 
-    def token_combine(self, hidden_states, combine_metadata, bias=None):
+    def token_dispatch(
+        self,
+        token_dispatch_input: MoETokenDispatchInput,
+    ):
+        return self.dispatch_finish(self.dispatch_start(token_dispatch_input))
+
+    def combine_start(self, hidden_states, combine_metadata, bias=None) -> MoEAllToAllCombineHandle:
         assert bias is None, "Bias is not supported in MoEAlltoAllvTokenDispatcher."
 
-        # 1. Preprocess using metadata
         hidden_states = self._combine_preprocess(hidden_states, combine_metadata)
-
-        # 2. AllToAll
-        _, permutated_local_input_tokens, handle = async_all_to_all(
+        ready_event = torch.npu.current_stream().record_event()
+        hidden_input, permutated_local_input_tokens, work = async_all_to_all(
             hidden_states,
             combine_metadata.input_splits,
             combine_metadata.output_splits,
             self.ep_group,
+            event=ready_event,
+            comm_stream=self._get_comm_stream(),
         )
-        handle.wait()
-        hidden_states.untyped_storage().resize_(0)
+        return MoEAllToAllCombineHandle(
+            hidden_input=hidden_input,
+            permutated_local_input_tokens=permutated_local_input_tokens,
+            work=work,
+            combine_metadata=combine_metadata,
+        )
 
-        # 3. Postprocess using metadata
-        output = self._combine_postprocess(permutated_local_input_tokens, combine_metadata)
+    def combine_finish(self, combine_handle: MoEAllToAllCombineHandle) -> torch.Tensor:
+        combine_handle.work.wait()
+        return self._combine_postprocess(
+            combine_handle.permutated_local_input_tokens,
+            combine_handle.combine_metadata,
+        )
 
-        return output
+    def token_combine(self, hidden_states, combine_metadata, bias=None):
+        return self.combine_finish(self.combine_start(hidden_states, combine_metadata, bias))
 
     def _dispatch_preprocess(self, hidden_states, topk_ids):
         hidden_shape = hidden_states.shape


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds an experimental A5 DSA-CP MoE-only dual micro-batch pipeline for the eager AllToAllV path.

After prepare and routing run once, token-aligned MoE inputs are split into two local micro-batches. All EP ranks preserve the same collective order:

`Dispatch(0) -> Dispatch(1) -> Combine(0) -> Combine(1)`

This overlaps Dispatch(1) with ExpertMLP(0), Combine(0) with ExpertMLP(1), and can optionally defer the final Combine(1) completion so the existing full-batch shared expert covers its tail.

The existing synchronous dispatcher APIs remain start+finish wrappers. Eligibility is coordinated across the EP group once per forward so all ranks either use the new protocol or fall back together.

Initial supported scope:
- Ascend A5
- DSA-CP enabled
- eager execution
- AllToAllV with EP > 1

The path falls back to the existing synchronous implementation for LoRA, dynamic EPLB, MC2/FusedMC2, ACL Graph, shared-expert multistream overlap, empty or undersized second micro-batches, or malformed token-aligned metadata.

### Does this PR introduce _any_ user-facing change?

Yes. It adds opt-in `additional_config` settings:
- `enable_dsa_cp_moe_dbo` (default: `false`)
- `enable_dsa_cp_moe_dbo_shared_expert_overlap` (default: `false`)
- `dsa_cp_moe_dbo_token_threshold` (default: `32`)

Existing behavior is unchanged by default.

### How was this patch tested?

Added `tests/ut/ops/test_dsa_cp_moe_dbo.py`, covering:
- odd/even token split and token-aligned metadata
- asynchronous dispatch/combine start-finish semantics and synchronous wrappers
- fixed D0-D1-C0-C1 ordering
- split/concat output restoration
- deferred C1 completion under full-batch shared-expert work
- rank-coordinated eligibility caching and fallback
- disabled-switch and threshold validation

Local checks:
- `ruff format --check ...` — passed
- `ruff check ...` — passed
- `python3 -m compileall ...` — passed
- `git diff --check` — passed

The matching vLLM v0.27.1 pytest environment was not available locally; the new mock unit tests are pending CI execution. No NPU performance claim is made by this PR.


- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
