### PR TITLE
[Feature][Model] Support Qwen3-VL DSpARK on Ascend v0.26

### DIFF
--- a/tests/ut/model_executor/test_qwen3_dspark.py
+++ b/tests/ut/model_executor/test_qwen3_dspark.py
@@ -23,11 +23,21 @@ from unittest.mock import patch
 
 import torch
 
+import vllm_ascend.models as ascend_models
 import vllm_ascend.models.qwen3_dspark as qwen3_dspark
 
 
 class TestQwen3DSparkWeightLoading:
     """Tests for Qwen3 DSpark weight loading."""
+
+    def test_qwen3_vl_uses_qwen3_dspark_runtime(self) -> None:
+        with patch.object(ascend_models.ModelRegistry, "register_model") as mock_register_model:
+            ascend_models.register_model()
+
+        mock_register_model.assert_any_call(
+            "Qwen3VLDSparkModel",
+            "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM",
+        )
 
     def test_rotates_only_fc_weights(self) -> None:
         """Rotate FC weights and preserve all other weights before delegation."""

--- a/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
+++ b/tests/ut/patch/platform/test_patch_speculative_config_dspark.py
@@ -1,7 +1,14 @@
+from types import SimpleNamespace
+
+import pytest
 from transformers import Qwen3Config
 from vllm.config import SpeculativeConfig
 
-from vllm_ascend.patch.platform.patch_speculative_config import hf_config_override
+from vllm_ascend.patch.platform import patch_speculative_config
+from vllm_ascend.patch.platform.patch_speculative_config import (
+    _dspark_post_init,
+    hf_config_override,
+)
 from vllm_ascend.transformers_utils.configs.kimi_k3 import K3DSparkConfig
 
 
@@ -54,3 +61,55 @@ def test_legacy_qwen3_dspark_config_is_normalized_before_model_inspection():
     assert normalized.target_layer_ids == [7, 23, 51, 67, 83]
     assert normalized.block_size == 7
     assert normalized.pad_token_id == 163839
+
+
+def _make_qwen3_vl_dspark_config(num_speculative_tokens: int):
+    draft_hf_config = SimpleNamespace(
+        model_type="qwen3_vl_dflash",
+        architectures=["Qwen3VLDSparkModel"],
+        block_size=16,
+        mask_token_id=151669,
+        ptd_token_id=None,
+    )
+    config = SimpleNamespace(
+        use_dspark=lambda: True,
+        draft_model_config=SimpleNamespace(hf_config=draft_hf_config),
+        num_speculative_tokens=num_speculative_tokens,
+    )
+    return config, draft_hf_config
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [1, 15])
+def test_qwen3_vl_dspark_accepts_tokens_up_to_checkpoint_block_size(
+    monkeypatch: pytest.MonkeyPatch,
+    num_speculative_tokens: int,
+):
+    monkeypatch.setattr(patch_speculative_config, "_orig_post_init", lambda self: None)
+    config, draft_hf_config = _make_qwen3_vl_dspark_config(num_speculative_tokens)
+
+    _dspark_post_init(config)
+
+    assert config.num_speculative_tokens == num_speculative_tokens
+    assert draft_hf_config.ptd_token_id == 151669
+
+
+def test_qwen3_vl_dspark_rejects_tokens_above_checkpoint_block_size(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(patch_speculative_config, "_orig_post_init", lambda self: None)
+    config, _ = _make_qwen3_vl_dspark_config(17)
+
+    with pytest.raises(ValueError, match=r"no greater than the trained block_size"):
+        _dspark_post_init(config)
+
+
+def test_qwen3_vl_dspark_caps_tokens_to_fia_tnd_limit(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(patch_speculative_config, "_orig_post_init", lambda self: None)
+    config, draft_hf_config = _make_qwen3_vl_dspark_config(16)
+
+    _dspark_post_init(config)
+
+    assert config.num_speculative_tokens == 15
+    assert draft_hf_config.ptd_token_id == 151669

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -29,6 +29,10 @@ def register_model():
     )
     ModelRegistry.register_model("Qwen3DSparkModel", "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM")
     ModelRegistry.register_model(
+        "Qwen3VLDSparkModel",
+        "vllm_ascend.models.qwen3_dspark:AscendQwen3DSparkForCausalLM",
+    )
+    ModelRegistry.register_model(
         "K3DSparkModel",
         "vllm_ascend.models.kimi_k3_dspark:K3DSparkForCausalLM",
     )

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Any
 
 from vllm.config.speculative import SpeculativeConfig
+from vllm.logger import init_logger
 from vllm.transformers_utils.configs.speculators import algos as speculator_algos
 from vllm.utils.import_utils import LazyLoader
 
@@ -10,6 +11,10 @@ from vllm_ascend.transformers_utils.configs.kimi_k3 import (
 )
 
 _orig_post_init = SpeculativeConfig.__post_init__
+logger = init_logger(__name__)
+
+_MAX_FIA_TND_DECODE_QUERY_LEN = 16
+_MAX_FIA_TND_SPECULATIVE_TOKENS = _MAX_FIA_TND_DECODE_QUERY_LEN - 1
 
 if TYPE_CHECKING:
     import vllm.model_executor.layers.quantization as me_quant
@@ -205,6 +210,34 @@ def _dspark_post_init(self):
             draft_hf_config.model_type = K3DSparkConfig.model_type
             draft_hf_config.architectures = ["K3DSparkModel"]
             self.update_arch_()
+        architectures = getattr(draft_hf_config, "architectures", ()) or ()
+        is_qwen3_vl_dspark = (
+            getattr(draft_hf_config, "model_type", None) == "qwen3_vl_dflash" and "Qwen3VLDSparkModel" in architectures
+        )
+        if is_qwen3_vl_dspark:
+            block_size = getattr(draft_hf_config, "block_size", None)
+            if not isinstance(block_size, int) or isinstance(block_size, bool) or block_size <= 0:
+                raise ValueError("Qwen3-VL DSpark requires a positive integer block_size in the draft config.")
+            if self.num_speculative_tokens > block_size:
+                raise ValueError(
+                    "Qwen3-VL DSpark requires num_speculative_tokens to be no "
+                    f"greater than the trained block_size ({block_size}); got "
+                    f"{self.num_speculative_tokens}."
+                )
+            if self.num_speculative_tokens > _MAX_FIA_TND_SPECULATIVE_TOKENS:
+                logger.warning(
+                    "Ascend FIA TND supports at most %d query tokens during "
+                    "decode. Reducing Qwen3-VL DSpark "
+                    "num_speculative_tokens from %d to %d so the verification "
+                    "query (draft tokens + 1) stays within the kernel limit. "
+                    "The checkpoint supports truncation up to its trained "
+                    "block_size=%d.",
+                    _MAX_FIA_TND_DECODE_QUERY_LEN,
+                    self.num_speculative_tokens,
+                    _MAX_FIA_TND_SPECULATIVE_TOKENS,
+                    block_size,
+                )
+                self.num_speculative_tokens = _MAX_FIA_TND_SPECULATIVE_TOKENS
 
 
 SpeculativeConfig.hf_config_override = hf_config_override


### PR DESCRIPTION
### What this PR does / why we need it?

Depends on vllm-project/vllm#53720.

This PR adds the Ascend integration for Qwen3-VL DSpARK:

- registers `Qwen3VLDSparkModel` to the existing Ascend Qwen3 DSpARK runtime;
- recognizes the standalone `qwen3_vl_dflash` draft configuration;
- enforces the Qwen3-VL trained-block contract and keeps its verification query within the Ascend FIA TND limit.

### Does this PR introduce _any_ user-facing change?

Yes. Qwen3-VL users can select a compatible standalone DSpARK checkpoint for speculative decoding on Ascend.

### How was this patch tested?

- A trained Qwen3-VL DSpARK checkpoint successfully completed service startup and inference.
- Focused registry and speculative-configuration coverage is included.
- Ruff check, Ruff format check, and `git diff --check` passed for every changed file.

- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
