### PR TITLE
[Test][BugFix] Remove invalid finegrained_tp_config from Kimi-K2.6 test config

### DIFF
--- a/tests/e2e/nightly/multi_node/external_dp/config/Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
+++ b/tests/e2e/nightly/multi_node/external_dp/config/Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
@@ -132,7 +132,7 @@ templates:
       - --compilation-config
       - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
       - --additional-config
-      - '{"recompute_scheduler_enable":true, "finegrained_tp_config": {"lmhead_tensor_parallel_size":16},"enable_fused_mc2":1}'
+      - '{"recompute_scheduler_enable":true, "enable_fused_mc2":1}'
       - --kv-transfer-config
       - '{"kv_connector": "MooncakeConnectorV1","kv_role": "kv_consumer","kv_port": "30100","engine_id": "1","kv_connector_extra_config": {"use_ascend_direct": true,"prefill": {"dp_size": 2,"tp_size": 8},"decode": {"dp_size": 4,"tp_size": 4}}}'
 


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes the invalid `\"finegrained_tp_config\": {\"lmhead_tensor_parallel_size\":16}` from the decode node's additional configuration in `Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml`. The decode node is configured with `tp_size: 4`, so setting `lmhead_tensor_parallel_size` to 16 is invalid and causes configuration mismatches.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Nightly multi-node end-to-end tests.