### PR TITLE
[CI] Temporarily skip DeepSeek V4 DSpARK test

### DIFF
--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -99,6 +99,7 @@ def test_deepseek_v4_mtp_eager():
     assert match, f"acceptance_per_pos {acceptance_per_pos} below golden {golden}"
 
 
+@pytest.mark.skip("Temporarily skip this DeepSeek V4 test.")
 @pytest.mark.parametrize("model", DSPARK_MAIN_MODEL)
 @pytest.mark.parametrize("max_tokens", [1024])
 @pytest.mark.parametrize("enforce_eager", [True])


### PR DESCRIPTION
### What this PR does / why we need it?

Temporarily skips `test_dspark_spec_decoding` in the four-card model runner v2 DeepSeek V4 E2E suite using:

```python
@pytest.mark.skip("Temporarily skip this DeepSeek V4 test.")
```

All other DeepSeek V4 E2E tests remain unchanged.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m compileall -q tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py`
- `git diff --check origin/main...HEAD`

Full E2E execution was not run locally because it requires the NPU test environment.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
