### PR TITLE
[Feature][Model] Add Qwen3.8 Flash Next model and MTP support on Ascend

### DIFF
--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -39,3 +39,7 @@ def register_model():
         "Qwen4ExpForConditionalGeneration",
         "vllm_ascend.models.qwen4_exp:Qwen4ExpForConditionalGeneration",
     )
+    ModelRegistry.register_model(
+        "Qwen4ExpMTP",
+        "vllm_ascend.models.qwen4_exp:Qwen4ExpMTP",
+    )

--- a/vllm_ascend/models/__init__.py
+++ b/vllm_ascend/models/__init__.py
@@ -31,3 +31,11 @@ def register_model():
     ModelRegistry.register_model(
         "Eagle3LlamaForCausalLM", "vllm_ascend.models.llama_eagle3:AscendEagle3LlamaForCausalLM"
     )
+    ModelRegistry.register_model(
+        "Qwen4ExpForCausalLM",
+        "vllm_ascend.models.qwen4_exp:Qwen4ExpForCausalLM",
+    )
+    ModelRegistry.register_model(
+        "Qwen4ExpForConditionalGeneration",
+        "vllm_ascend.models.qwen4_exp:Qwen4ExpForConditionalGeneration",
+    )

--- a/vllm_ascend/models/qwen4_exp/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/__init__.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp model package."""
+
+from typing import TYPE_CHECKING, Any
+
+from .common.hyperconnection import (
+    GatedResidual,
+    GroupedGemmaRMSNorm,
+    HyperConnectionBase,
+    HyperConnectionConfig,
+)
+
+if TYPE_CHECKING:
+    from .amd.model import (
+        Qwen4ExpForCausalLM,
+        Qwen4ExpForConditionalGeneration,
+    )
+    from .nvidia.mtp import Qwen4ExpMTP
+
+
+def __getattr__(name: str) -> Any:
+    if name in {
+        "Qwen4ExpForCausalLM",
+        "Qwen4ExpForConditionalGeneration",
+        "Qwen4ExpMTP",
+    }:
+        from vllm.platforms import current_platform
+
+        if current_platform.device_type in ("npu", "rocm"):
+            from .amd.model import (
+                Qwen4ExpForCausalLM,
+                Qwen4ExpForConditionalGeneration,
+            )
+            from .amd.mtp import Qwen4ExpMTP
+        elif current_platform.device_type == "cuda":
+            from .nvidia.model import (
+                Qwen4ExpForCausalLM,
+                Qwen4ExpForConditionalGeneration,
+            )
+            from .nvidia.mtp import Qwen4ExpMTP
+        else:
+            raise NotImplementedError(
+                "Qwen4Exp supports CUDA, ROCm, and NPU platforms"
+            )
+
+        return {
+            "Qwen4ExpForCausalLM": Qwen4ExpForCausalLM,
+            "Qwen4ExpForConditionalGeneration": (Qwen4ExpForConditionalGeneration),
+            "Qwen4ExpMTP": Qwen4ExpMTP,
+        }[name]
+    raise AttributeError(name)
+
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionBase",
+    "HyperConnectionConfig",
+    "Qwen4ExpForCausalLM",
+    "Qwen4ExpForConditionalGeneration",
+    "Qwen4ExpMTP",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/amd/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_ascend/models/qwen4_exp/amd/hyperconnection.py
+++ b/vllm_ascend/models/qwen4_exp/amd/hyperconnection.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HyperConnection (Gated Residual) utilities for the AMD model variant.
+
+Implements the HyperConnection residual scheme proposed in
+"HyperConnections" (https://arxiv.org/abs/2409.19606). This AMD variant
+delays each HC combine to the following HC mix boundary. HC glue kernels,
+including fused combine+RMSNorm, live in ``ops/hc.py``; projections remain
+standard vLLM Linear modules.
+
+Hidden states between layers have shape ``[..., HC*HS]`` with HS inner
+(HC outer, HS inner — checkpoint-native layout).
+
+Typical usage inside a transformer decoder layer::
+
+    self.attn_hc = GatedResidual(hc_config)
+
+    hidden_states, block_input, injection = self.attn_hc.mix(hidden_states)
+    attention_output = attention(block_input)
+    hidden_states, block_input, injection = self.mlp_hc.combine_and_mix(
+        hidden_states, attention_output, injection
+    )
+"""
+
+import torch
+from torch import nn
+
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    ReplicatedLinear,
+)
+from vllm.model_executor.models.utils import maybe_prefix
+
+from ..common.hyperconnection import (
+    GroupedGemmaRMSNorm,
+    HyperConnectionConfig,
+)
+from .ops.hc import (
+    grouped_gemma_rmsnorm,
+    hc_combine,
+    hc_combine_norm,
+    hc_gate_mix,
+    hc_silu,
+)
+
+
+# ---------------------------------------------------------------------------
+# Gated-residual variant
+# ---------------------------------------------------------------------------
+class GatedResidual(nn.Module):
+    """Gated HyperConnection with learnable low-rank mixing and injection.
+
+    ``combine_and_mix()`` runs the pre pipeline (grouped GemmaRMSNorm -> merged
+    low-rank down+inject GEMM -> silu -> up GEMM -> sigmoid -> gated mean
+    over the HC streams). When passed a pending block output and an injection,
+    it fuses their residual combine with the RMSNorm. Final mixers use
+    ``use_combine=False`` and do not produce a new injection.
+
+    Weights: the norm owns the grouped GemmaRMSNorm affine; the projections
+    are vLLM Linear modules (merged replicated linear for down+inject), so
+    GEMM dispatch (e.g. the low-latency skinny GEMM) applies through the
+    standard quant_method mechanism.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        use_combine: bool = True,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.lora_rank = config.hc_lowrank
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        self.use_combine = use_combine
+
+        norm_size = (
+            self.hyper_hidden_size if config.hc_per_branch_norm else config.hidden_size
+        )
+        group_size = config.hidden_size if config.hc_per_branch_norm else None
+        # Normalize each H-sized HC stream independently while retaining a
+        # separate affine weight for every element of the HC*H layout.
+        self.hc_norm = GroupedGemmaRMSNorm(
+            norm_size,
+            eps=config.rms_norm_eps,
+            group_size=group_size,
+            dtype=config.params_dtype,
+        )
+
+        # -- vLLM Linear weights --------------------------------------------
+        # The merged skinny-GEMM shape is physically padded to 16 rows for
+        # alignment and efficient backend dispatch.
+        self.pad_size = (-(self.lora_rank + self.hc_count)) % 16 if use_combine else 0
+        if use_combine:
+            self.input_mix_weight_down_block_inject = MergedColumnParallelLinear(
+                self.hyper_hidden_size,
+                [self.lora_rank, self.hc_count]
+                + ([self.pad_size] if self.pad_size else []),
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down_block_inject"),
+                return_bias=False,
+                disable_tp=True,
+            )
+        else:
+            self.input_mix_weight_down = ReplicatedLinear(
+                self.hyper_hidden_size,
+                self.lora_rank,
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down"),
+                return_bias=False,
+            )
+        self.input_mix_weight_up = ReplicatedLinear(
+            self.lora_rank,
+            self.hyper_hidden_size,
+            bias=False,
+            params_dtype=config.params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "input_mix_weight_up"),
+            return_bias=False,
+        )
+
+    def mix(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        xn = grouped_gemma_rmsnorm(
+            hidden_states,
+            self.hc_norm.weight,
+            self.config.rms_norm_eps,
+            self.hc_count,
+        )
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = hc_silu(lora, self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = hc_gate_mix(xn, gate, self.hc_count)
+
+        return hidden_states, block_input, injection
+
+    def combine_and_mix(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor,
+        prev_injection: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Consume a pending combine, then prepare the next block input.
+
+        ``hidden_states`` is the multi-stream state from before the pending
+        block's mix. Its combine with ``block_output`` is fused with this
+        module's input RMSNorm.
+        """
+        hidden_states, xn = hc_combine_norm(
+            hidden_states,
+            prev_block_output,
+            prev_injection,
+            self.hc_norm.weight,
+            self.config.rms_norm_eps,
+            self.hc_count,
+        )
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = hc_silu(lora, self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = hc_gate_mix(xn, gate, self.hc_count)
+
+        return hidden_states, block_input, injection
+
+    def combine(
+        self,
+        hidden_states: torch.Tensor,
+        block_output: torch.Tensor,
+        injection: torch.Tensor,
+    ) -> torch.Tensor:
+        return hc_combine(hidden_states, block_output, injection, self.hc_count)
+
+    @property
+    def hyper_hidden_size(self) -> int:
+        return self.hc_count * self.hidden_size
+
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/indexer_qsa.py
+++ b/vllm_ascend/models/qwen4_exp/amd/indexer_qsa.py
@@ -1,0 +1,321 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp weight-free QSA indexer."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+
+from ..common.qsa_cache import (
+    QSACompressedKeyCache,
+    QSAForwardMetadata,
+    QSAKeyStateCache,
+    canonical_qsa_rope_positions,
+)
+
+
+def apply_qsa_rope(
+    rotary_emb: nn.Module,
+    positions: torch.Tensor,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Apply the main attention's exact 1D/MRoPE composition to QSA heads."""
+
+    num_tokens, _, head_dim = tensor.shape
+    rotary_dim = rotary_emb.rotary_dim
+    cache = rotary_emb._match_cos_sin_cache_dtype(tensor)  # noqa: SLF001
+    cos_sin = cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if positions.ndim == 2:
+        shape = tensor.shape
+        tensor, _ = triton_mrope(
+            tensor.reshape(num_tokens, -1),
+            tensor.new_empty((num_tokens, head_dim)),
+            cos,
+            sin,
+            rotary_emb.mrope_section,
+            head_dim,
+            rotary_dim,
+            rotary_emb.mrope_interleaved,
+            rotary_emb.is_neox_style,
+        )
+        return tensor.reshape(shape)
+
+    rotated = rotary_emb.apply_rotary_emb(
+        tensor[..., :rotary_dim],
+        cos,
+        sin,
+    )
+    return torch.cat((rotated, tensor[..., rotary_dim:]), dim=-1)
+
+
+def apply_qsa_rmsnorm(
+    norm: GemmaRMSNorm,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Use vLLM's portable RMSNorm implementation on ROCm."""
+
+    return cast(torch.Tensor, norm(tensor))
+
+
+class QSAIndexer(nn.Module):
+    """Replicated Q/K projection plus paged, weight-free QSA selection.
+
+    ``prefix`` must be the checkpoint's indexer prefix, normally
+    ``model.layers.N.self_attn.indexer``.  Consequently the trainable names are
+    ``index_qk_proj``, ``q_layernorm`` and ``k_layernorm`` under that prefix.
+    """
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        rotary_emb: nn.Module,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if vllm_config.cache_config is None:
+            raise ValueError("QSA requires a paged KV cache")
+        if vllm_config.model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+
+        self.layer_id = int(layer_id)
+        self.index_n_heads = int(config.indexer_n_heads)
+        self.index_kv_heads = int(config.indexer_kv_heads)
+        self.index_head_dim = int(config.indexer_head_dim)
+        self.token_topk = int(config.indexer_budget)
+        self.compress_ratio = int(config.indexer_compress_ratio)
+        self.rotary_emb = rotary_emb
+        self.prefix = prefix
+        # MTP step 0 selects the target-aligned rows; later steps reuse them
+        # while continuing to update the QSA side cache.
+        self.skip_topk = False
+
+        self.index_qk_proj = ReplicatedLinear(
+            int(config.hidden_size),
+            (self.index_n_heads + self.index_kv_heads) * self.index_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.index_qk_proj" if prefix else "index_qk_proj",
+        )
+        self.q_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+        self.k_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+
+        cache_config = vllm_config.cache_config
+        cache_prefix = f"{prefix}." if prefix else ""
+        self.raw_key_cache = QSAKeyStateCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            cache_rope_positions=vllm_config.model_config.uses_mrope,
+            prefix=f"{cache_prefix}raw_key_cache",
+            cache_config=cache_config,
+            compress_ratio=self.compress_ratio,
+            vllm_config=vllm_config,
+        )
+        self.compressed_key_cache = QSACompressedKeyCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            compress_ratio=self.compress_ratio,
+            prefix=f"{cache_prefix}compressed_key_cache",
+            cache_config=cache_config,
+            vllm_config=vllm_config,
+        )
+
+    @property
+    def output_width(self) -> int:
+        return self.token_topk + self.compress_ratio - 1
+
+    def project_qk(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Project replicated Q/K, normalize+rotate Q, and preserve raw K."""
+
+        qk, _ = self.index_qk_proj(hidden_states)
+        q_raw, token_k = qk.split(
+            (
+                self.index_n_heads * self.index_head_dim,
+                self.index_kv_heads * self.index_head_dim,
+            ),
+            dim=-1,
+        )
+        q = q_raw.reshape(-1, self.index_n_heads, self.index_head_dim)
+        q = apply_qsa_rmsnorm(
+            self.q_layernorm,
+            q.reshape(-1, self.index_head_dim),
+        ).reshape_as(q)
+        q = apply_qsa_rope(self.rotary_emb, positions, q)
+        return q, token_k.reshape(-1, 1, self.index_head_dim)
+
+    def normalize_compressed_keys(
+        self,
+        compressed_keys: torch.Tensor,
+        first_rope_positions: torch.Tensor,
+    ) -> torch.Tensor:
+        """Normalize pooled K and apply the first token's exact group position."""
+
+        keys = compressed_keys.reshape(-1, self.index_head_dim)
+        keys = apply_qsa_rmsnorm(self.k_layernorm, keys).reshape(
+            -1, 1, self.index_head_dim
+        )
+        if getattr(self.rotary_emb, "mrope_section", None):
+            positions = first_rope_positions.transpose(0, 1)
+        else:
+            positions = first_rope_positions[:, 0]
+        return apply_qsa_rope(self.rotary_emb, positions, keys)
+
+    def _metadata(
+        self,
+    ) -> tuple[QSAForwardMetadata, QSAForwardMetadata] | None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            return None
+        raw = cast(QSAForwardMetadata, metadata[self.raw_key_cache.prefix])
+        compressed = cast(
+            QSAForwardMetadata, metadata[self.compressed_key_cache.prefix]
+        )
+        if raw.num_actual_tokens != compressed.num_actual_tokens:
+            raise RuntimeError("QSA side-cache metadata token counts disagree")
+        if not raw.logical_positions.is_cuda and (
+            not torch.equal(raw.logical_positions, compressed.logical_positions)
+        ):
+            raise RuntimeError("QSA side-cache metadata positions disagree")
+        return raw, compressed
+
+    def _update_and_compress(
+        self,
+        token_k: torch.Tensor,
+        positions: torch.Tensor,
+        raw_metadata: QSAForwardMetadata,
+        compressed_metadata: QSAForwardMetadata,
+    ) -> None:
+        num_tokens = raw_metadata.num_actual_tokens
+        raw_key_cache = self.raw_key_cache.key_cache
+        rope_position_cache = self.raw_key_cache.rope_position_cache
+        from .ops.qsa import qsa_compress_groups_with_ratio, qsa_store_cache_rows
+
+        if rope_position_cache is None:
+            position_rows = raw_metadata.logical_positions.view(-1, 1, 1).expand(
+                -1, 1, 3
+            )
+        else:
+            position_rows = canonical_qsa_rope_positions(positions)[:num_tokens].to(
+                device=raw_key_cache.device
+            )
+        pooled, first_positions = qsa_compress_groups_with_ratio(
+            token_k[:num_tokens],
+            position_rows,
+            raw_key_cache,
+            raw_metadata.block_table,
+            raw_metadata.token_to_req,
+            raw_metadata.query_start_loc,
+            raw_metadata.logical_positions,
+            compressed_metadata.slot_mapping,
+            self.compress_ratio,
+            rope_position_cache,
+        )
+        normalized = self.normalize_compressed_keys(pooled, first_positions)
+        qsa_store_cache_rows(
+            self.compressed_key_cache.kv_cache,
+            compressed_metadata.slot_mapping,
+            normalized,
+        )
+        qsa_store_cache_rows(
+            raw_key_cache,
+            raw_metadata.slot_mapping,
+            token_k[:num_tokens],
+        )
+        if rope_position_cache is not None:
+            qsa_store_cache_rows(
+                rope_position_cache,
+                raw_metadata.slot_mapping,
+                position_rows,
+            )
+
+    def _select(
+        self,
+        q: torch.Tensor,
+        metadata: QSAForwardMetadata,
+        out: torch.Tensor | None,
+    ) -> torch.Tensor:
+        from .ops.qsa import qsa_select_paged_tokens
+
+        return qsa_select_paged_tokens(
+            q,
+            self.compressed_key_cache.kv_cache,
+            metadata.block_table,
+            metadata.token_to_req,
+            metadata.logical_positions,
+            metadata.seq_lens,
+            self.token_topk,
+            self.compress_ratio,
+            out,
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return fixed-width request-relative token indices padded with ``-1``."""
+
+        metadata = self._metadata()
+        if metadata is None:
+            # Preserve step-0 indices when later MTP steps reuse the buffer.
+            if self.skip_topk and out is not None:
+                return out
+            result = torch.full(
+                (hidden_states.shape[0], self.output_width),
+                -1,
+                dtype=torch.int32,
+                device=hidden_states.device,
+            )
+            if out is not None:
+                out.copy_(result)
+                return out
+            return result
+        raw_metadata, compressed_metadata = metadata
+        num_tokens = raw_metadata.num_actual_tokens
+        q, token_k = self.project_qk(
+            hidden_states[:num_tokens], positions[..., :num_tokens]
+        )
+        self._update_and_compress(
+            token_k,
+            positions[..., :num_tokens],
+            raw_metadata,
+            compressed_metadata,
+        )
+        if self.skip_topk:
+            if out is None:
+                raise RuntimeError("QSA top-k reuse requires an output buffer")
+            return out
+        return self._select(q, compressed_metadata, out)
+
+
+__all__ = ["QSAIndexer", "apply_qsa_rope"]

--- a/vllm_ascend/models/qwen4_exp/amd/low_latency_gemm.py
+++ b/vllm_ascend/models/qwen4_exp/amd/low_latency_gemm.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp low-latency GEMM hook for AMD ROCm."""
+
+import torch
+from torch import nn
+
+
+def enable_qwen4_exp_low_latency_gemm(
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> None:
+    """Keep the standard vLLM linear methods on AMD ROCm."""
+
+    del module, dtype

--- a/vllm_ascend/models/qwen4_exp/amd/model.py
+++ b/vllm_ascend/models/qwen4_exp/amd/model.py
@@ -1,0 +1,1037 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp model."""
+
+from collections.abc import Iterable
+from itertools import islice
+
+import torch
+from torch import nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    QwenGatedDeltaNetAttention,
+)
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateCopyFuncsByType,
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    _require_is_multimodal,
+)
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5Model,
+)
+from vllm.model_executor.models.qwen3_next import (
+    Qwen3NextAttention,
+    Qwen3NextMLP,
+    Qwen3NextSparseMoeBlock,
+)
+from vllm.model_executor.models.qwen3_vl import (
+    Qwen3_VisionTransformer,
+    Qwen3VLDummyInputsBuilder,
+    Qwen3VLMultiModalProcessor,
+    Qwen3VLProcessingInfo,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    StageMissingLayer,
+    WeightsMapper,
+    _merge_multimodal_embeddings,
+    extract_layer_index,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.sequence import IntermediateTensors
+from vllm.tokenizers.registry import cached_tokenizer_from_config
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from ..config import Qwen4ExpConfig
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .ple_layer import Qwen4ExpPLELayer
+
+
+def without_modelopt_fp4(
+    quant_config: QuantizationConfig | None,
+) -> QuantizationConfig | None:
+    """Return ``None`` for weights excluded from Qwen4Exp ModelOpt-FP4."""
+
+    if quant_config is not None and quant_config.get_name() == "modelopt_fp4":
+        return None
+    return quant_config
+
+
+def _remap_qsa_cache_scale_name(
+    name: str,
+    qsa_layer_ids: frozenset[int],
+) -> str:
+    """Map serialized main-cache scales onto the merged QSA owner.
+
+    Regular attention keeps cache scales below its ``attn`` child. QSA owns
+    that cache directly, so only QSA layers need the final path component
+    moved to the owner's persistent ``_k_scale``/``_v_scale`` buffers.
+    """
+
+    scale_suffixes = {
+        "k_proj.k_scale": "_k_scale",
+        "k_proj.output_scale": "_k_scale",
+        "attn.k_scale": "_k_scale",
+        "attn._k_scale": "_k_scale",
+        "k_scale": "_k_scale",
+        "_k_scale": "_k_scale",
+        "v_proj.v_scale": "_v_scale",
+        "v_proj.output_scale": "_v_scale",
+        "attn.v_scale": "_v_scale",
+        "attn._v_scale": "_v_scale",
+        "v_scale": "_v_scale",
+        "_v_scale": "_v_scale",
+    }
+    for layer_id in qsa_layer_ids:
+        marker = f"layers.{layer_id}.self_attn."
+        marker_start = name.find(marker)
+        if marker_start < 0 or (marker_start > 0 and name[marker_start - 1] != "."):
+            continue
+        suffix = name[marker_start + len(marker) :]
+        mapped_suffix = scale_suffixes.get(suffix)
+        if mapped_suffix is not None:
+            return f"{name[: marker_start + len(marker)]}{mapped_suffix}"
+    return name
+
+
+_QWEN4_EXP_IGNORED_MISSING_SUFFIXES = [
+    ".bias",
+    "_bias",
+    ".k_scale",
+    "_k_scale",
+    ".v_scale",
+    "_v_scale",
+    "_weight_scale",
+    "_input_scale",
+]
+
+# The checkpoint keeps down and injection projections separate; runtime packs
+# them into adjacent logical shards of one MergedColumnParallelLinear.
+_HC_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_stacked={
+        "hyper_connection.input_mix_weight_down.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            0,
+        ),
+        "hyper_connection.block_inject_weight.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            1,
+        ),
+    }
+)
+
+
+class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
+    """Qwen3Next MoE with Qwen4Exp HC validation."""
+
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        config = vllm_config.model_config.hf_text_config
+        self.n_shared_experts = int(config.shared_expert_intermediate_size > 0)
+
+
+class Qwen4ExpDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        layer_type: str,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        self.config = config
+        self.layer_type = layer_type
+        self.layer_idx = extract_layer_index(prefix)
+        if vllm_config.parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        self.ple: Qwen4ExpPLELayer | None = None
+        ple_layer_ids = config.ple_layer_ids
+        if (self.layer_idx + 1) in ple_layer_ids:
+            ple_layer_ids_sorted = sorted(set(ple_layer_ids))
+            ple_dense_layer_id_map = {
+                abs_id: idx for idx, abs_id in enumerate(ple_layer_ids_sorted)
+            }
+            ple_dense_layer_id = ple_dense_layer_id_map[self.layer_idx + 1]
+            self.ple = Qwen4ExpPLELayer(
+                config,
+                vllm_config=vllm_config,
+                layer_idx=self.layer_idx,
+                ple_dense_layer_id=ple_dense_layer_id,
+                prefix=f"{prefix}.ple",
+            )
+
+        if layer_type == "linear_attention":
+            self.linear_attn = QwenGatedDeltaNetAttention(
+                config,
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.linear_attn",
+                gqa_interleaved_layout=False,
+            )
+        elif layer_type in ("full_attention", "qwen_sparse_attention"):
+            self.self_attn = Qwen3NextAttention(
+                config,
+                model_config=model_config,
+                cache_config=cache_config,
+                quant_config=quant_config,
+                prefix=f"{prefix}.self_attn",
+            )
+        else:
+            raise ValueError(f"Invalid layer_type {layer_type}")
+
+        mlp_only_layers = getattr(config, "mlp_only_layers", [])
+        num_experts = getattr(config, "num_experts", 0) or 0
+        absolute_layer_id = self.layer_idx + 1
+        is_moe_layer = self.layer_idx not in mlp_only_layers and (
+            num_experts > 0
+            and absolute_layer_id % getattr(config, "decoder_sparse_step", 1) == 0
+        )
+        if is_moe_layer:
+            self.mlp = Qwen4ExpSparseMoeBlock(
+                vllm_config=vllm_config, prefix=f"{prefix}.mlp"
+            )
+        else:
+            self.mlp = Qwen3NextMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.attn_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "attn_hyper_connection"),
+        )
+        self.mlp_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "mlp_hyper_connection"),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor | None,
+        prev_injection: torch.Tensor | None,
+        positions: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        query_start_loc: torch.Tensor | None,
+        ngram_context: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        attn_hc = self.attn_hyper_connection
+        if self.ple is not None:
+            # PLE adds directly to the multi-stream state, so pending HC state
+            # must be materialized before the addition.
+            if prev_block_output is not None and prev_injection is not None:
+                hidden_states = attn_hc.combine(
+                    hidden_states, prev_block_output, prev_injection
+                )
+                prev_block_output = prev_injection = None
+
+            if input_ids is None or query_start_loc is None or ngram_context is None:
+                raise RuntimeError("PLE inputs were not prepared")
+            hidden_states = hidden_states + self.ple(
+                hidden_states,
+                input_ids,
+                query_start_loc,
+                ngram_context,
+            )
+
+        # Fuse a pending combine with this HC module's mix when possible.
+        if prev_block_output is not None and prev_injection is not None:
+            hidden_states, block_input, injection = attn_hc.combine_and_mix(
+                hidden_states, prev_block_output, prev_injection
+            )
+        else:
+            hidden_states, block_input, injection = attn_hc.mix(hidden_states)
+
+        if self.layer_type == "linear_attention":
+            attn_out = self.linear_attn(hidden_states=block_input)
+        elif self.layer_type in ("full_attention", "qwen_sparse_attention"):
+            attn_out = self.self_attn(
+                hidden_states=block_input,
+                positions=positions,
+            )
+        else:
+            raise ValueError("Invalid layer_type")
+
+        mlp_hc = self.mlp_hyper_connection
+        hidden_states, block_input, injection = mlp_hc.combine_and_mix(
+            hidden_states, attn_out, injection
+        )
+        mlp_out = self.mlp(block_input)
+        return hidden_states, mlp_out, injection
+
+
+class Qwen4ExpMixtureOfExperts(MixtureOfExperts):
+    """Expose Qwen4Exp routed experts through vLLM's EPLB protocol."""
+
+    def set_moe_parameters(self, layers: Iterable[nn.Module]) -> None:
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in layers:
+            if isinstance(layer, Qwen4ExpDecoderLayer) and isinstance(
+                layer.mlp, Qwen4ExpSparseMoeBlock
+            ):
+                example_moe = layer.mlp
+                self.moe_mlp_layers.append(layer.mlp)
+                self.moe_layers.append(layer.mlp.experts)
+
+        self.num_moe_layers = len(self.moe_layers)
+        if example_moe is None:
+            self.num_expert_groups = 0
+            self.num_shared_experts = 0
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_redundant_experts = 0
+            return
+
+        self.num_expert_groups = 1
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_physical_experts = num_physical_experts
+            moe.n_local_physical_experts = num_local_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "query_start_loc": 0,
+        "ngram_context": 0,
+        "deepstack_input_embeds": 0,
+    }
+)
+class Qwen4ExpModel(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.num_redundant_experts = (
+            vllm_config.parallel_config.eplb_config.num_redundant_experts
+        )
+        self.vocab_size = config.vocab_size
+        self._qsa_layer_ids = frozenset(
+            layer_idx
+            for layer_idx, layer_type in enumerate(config.layer_types)
+            if layer_type == "full_attention"
+            and getattr(config, "indexer_n_heads", None) is not None
+        )
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, config.hidden_size)
+
+        def get_layer(prefix: str) -> Qwen4ExpDecoderLayer:
+            layer_idx = extract_layer_index(prefix)
+            return Qwen4ExpDecoderLayer(
+                vllm_config,
+                layer_type=config.layer_types[layer_idx],
+                prefix=prefix,
+            )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
+        )
+        intermediate_size = config.hidden_size * config.hc_count
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], intermediate_size
+        )
+
+        self.hyper_connection_mixer: GatedResidual | None
+        if get_pp_group().is_last_rank:
+            hc_config = HyperConnectionConfig(
+                hc_count=config.hc_count,
+                hidden_size=config.hidden_size,
+                params_dtype=torch.bfloat16,
+                hc_lowrank=config.hc_lowrank,
+                rms_norm_eps=config.rms_norm_eps,
+                hc_per_branch_norm=True,
+            )
+            self.hyper_connection_mixer = GatedResidual(
+                hc_config,
+                use_combine=False,
+                prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+            )
+        else:
+            self.hyper_connection_mixer = None
+
+        spec_config = vllm_config.speculative_config
+        # MTP HC multi-stream outputs: when speculative method=="mtp" and the
+        # model uses HC with hc_count>1, retain the pre-final-mixer multi-stream
+        # hidden state [T, hc_count*H] so the MTP drafter can feed a real
+        # multi-stream backbone hidden on its first step (scheme A). Derived
+        # purely from config (NOT node identity) so P/D nodes stay consistent.
+        needs_mtp_hidden = (
+            spec_config is not None
+            and getattr(spec_config, "method", None) == "mtp"
+            and get_pp_group().is_last_rank
+        )
+        if needs_mtp_hidden:
+            self._mtp_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                config.hc_count * config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+            )
+        else:
+            self._mtp_hidden_buffer = None
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        query_start_loc: torch.Tensor | None = None,
+        ngram_context: torch.Tensor | None = None,
+        deepstack_input_embeds: IntermediateTensors | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                if input_ids is None:
+                    raise ValueError("input_ids or inputs_embeds is required")
+                hidden_states = self.embed_input_ids(input_ids)
+            hidden_states = hidden_states.repeat(1, self.config.hc_count)
+        else:
+            if intermediate_tensors is None:
+                raise ValueError("pipeline stage requires intermediate tensors")
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        block_output = None
+        injection = None
+        last_layer = None
+        for layer_idx, layer in islice(
+            enumerate(self.layers), self.start_layer, self.end_layer
+        ):
+            last_layer = layer
+            hidden_states, block_output, injection = layer(
+                hidden_states=hidden_states,
+                prev_block_output=block_output,
+                prev_injection=injection,
+                positions=positions,
+                input_ids=input_ids,
+                query_start_loc=query_start_loc,
+                ngram_context=ngram_context,
+            )
+            if deepstack_input_embeds is not None and layer_idx < len(
+                deepstack_input_embeds
+            ):
+                deepstack_embed = deepstack_input_embeds[
+                    f"deepstack_input_embeds_{layer_idx}"
+                ]
+                deepstack_embed = (
+                    deepstack_embed.unsqueeze(-2)
+                    .expand(
+                        *deepstack_embed.shape[:-1],
+                        self.config.hc_count,
+                        self.config.hidden_size,
+                    )
+                    .flatten(-2)
+                )
+                # Deepstack is an external addition to the materialized
+                # multi-stream state and therefore terminates delayed combine.
+                hidden_states = layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+                block_output = None
+                injection = None
+                hidden_states = hidden_states + deepstack_embed
+
+        if not get_pp_group().is_last_rank:
+            # PP transports one tensor, not the delayed HC tuple. Materialize
+            # with the HC module that produced the pending injection.
+            if last_layer is not None and block_output is not None:
+                hidden_states = last_layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # The final mixer consumes the last pending combine and returns both
+        # the sampled single stream and the materialized multi-stream state.
+        final_mixer = self.hyper_connection_mixer
+        assert final_mixer is not None
+        multi_hidden, sample_hidden_states, _ = final_mixer.combine_and_mix(
+            hidden_states, block_output, injection
+        )
+        if self._mtp_hidden_buffer is not None:
+            # Capture the pre-final-mixer multi-stream hidden state
+            # [T, hc_count*H] for the MTP drafter (zero extra compute:
+            # this tensor is needed by the final mixer regardless).
+            num_tokens = multi_hidden.shape[0]
+            self._mtp_hidden_buffer[:num_tokens].copy_(multi_hidden)
+        return sample_hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = (
+            (
+                _remap_qsa_cache_scale_name(name, self._qsa_layer_ids),
+                weight,
+            )
+            for name, weight in weights
+        )
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        # Non-persistent PLE state rebuilt in __init__; skip any ckpt
+        # column for them.
+        skip_substrs = [
+            "hashstats_",
+            "token_lookup",
+            "ple.",
+            "self_attn.indexer.",
+        ]
+        if not get_pp_group().is_last_rank:
+            skip_substrs.append("hyper_connection_mixer.")
+        else:
+            skip_substrs.append("hyper_connection_mixer.block_inject_weight")
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=skip_substrs,
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        loaded = loader.load_weights(
+            weights,
+            mapper=self.hf_to_vllm_mapper,
+        )
+        return loaded
+
+
+class Qwen4ExpForCausalLM(
+    nn.Module,
+    HasInnerState,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    Qwen4ExpMixtureOfExperts,
+    IsHybrid,
+):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"model.language_model.": "model."}
+    )
+    requires_raw_input_tokens = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.quant_config = vllm_config.quant_config
+        self.config = config
+        self.scheduler_config = vllm_config.scheduler_config
+        if vllm_config.cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4Exp currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+        self.model = Qwen4ExpModel(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, self.model_config.dtype)
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        # Forward kwargs unchanged so the runner's _maybe_add_ngram_kwargs
+        # path (query_start_loc / ngram_context) reaches Qwen4ExpModel.
+        return self.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            **kwargs,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    @classmethod
+    def get_ple_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+
+    @classmethod
+    def get_ple_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int]]:
+        hf_config = vllm_config.model_config.hf_text_config
+        conv_kernel_size = hf_config.ple_conv_kernel_size
+        short_conv_dilation = hf_config.ngram_size
+        conv_state_len = (conv_kernel_size - 1) * short_conv_dilation
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        hc_count = hf_config.hc_count
+        hc_hidden_size = hf_config.hidden_size * hc_count
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=hc_hidden_size,
+            conv_kernel=conv_state_len + 1,
+            num_spec=num_spec,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_dtype_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        parallel_config = vllm_config.parallel_config
+        hf_config = vllm_config.model_config.hf_text_config
+        tp_size = parallel_config.tensor_parallel_size
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            tp_size,
+            hf_config.linear_num_key_heads,
+            hf_config.linear_num_value_heads,
+            hf_config.linear_key_head_dim,
+            hf_config.linear_value_head_dim,
+            hf_config.linear_conv_kernel_dim,
+            num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return cls.get_gdn_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return cls.get_gdn_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> MambaStateCopyFuncsByType:
+        copy_funcs_by_type = {
+            MambaAttentionBackendEnum.GDN_ATTN: cls.get_mamba_state_copy_func(),
+            MambaAttentionBackendEnum.SHORT_CONV: (
+                MambaStateCopyFuncCalculator.short_conv_state_copy_func()
+            ),
+        }
+        missing_types = mamba_types - copy_funcs_by_type.keys()
+        assert not missing_types, f"missing state copy funcs for {missing_types}"
+        return {
+            mamba_type: copy_funcs_by_type[mamba_type] for mamba_type in mamba_types
+        }
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        """Return all MambaSpecs for this model (GDN layers + PLE layer).
+
+        The PLE layer uses a separate short_conv MambaSpec whose page_size_bytes
+        may exceed the GDN spec; callers should take the maximum.
+        """
+        return (
+            MambaSpec(
+                shapes=cls.get_gdn_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_gdn_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+            ),
+            MambaSpec(
+                shapes=cls.get_ple_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_ple_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+                tp_replicated=True,
+            ),
+        )
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.model._mtp_hidden_buffer
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec],
+    ) -> tuple[torch.Tensor, int]:
+        positions = torch.arange(len(input_tokens), dtype=torch.long)
+        return positions.unsqueeze(0).expand(3, -1), 0
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["mtp.", "self_attn.indexer."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+class Qwen4ExpProcessingInfo(Qwen3VLProcessingInfo):
+    def get_hf_config(self) -> Qwen4ExpConfig:
+        return self.ctx.get_hf_config(Qwen4ExpConfig)
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen3VLMultiModalProcessor,
+    info=Qwen4ExpProcessingInfo,
+    dummy_inputs=Qwen3VLDummyInputsBuilder,
+)
+class Qwen4ExpForConditionalGeneration(
+    Qwen3_5ForConditionalGeneration,
+    HasInnerState,
+    Qwen4ExpMixtureOfExperts,
+):
+    """Qwen3-VL vision tower backed by the Qwen4Exp language model."""
+
+    requires_raw_input_tokens = True
+
+    packed_modules_mapping = Qwen3_5ForConditionalGeneration.packed_modules_mapping | {
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ]
+    }
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model") -> None:
+        nn.Module.__init__(self)
+        config: Qwen4ExpConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        if multimodal_config is None:
+            raise ValueError(
+                "Qwen4ExpForConditionalGeneration requires multimodal_config"
+            )
+
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.multimodal_config = multimodal_config
+        self.language_model_only = multimodal_config.language_model_only
+        if self.language_model_only:
+            self.use_data_parallel = False
+            self.is_multimodal_pruning_enabled = False
+            self.video_pruning_method = None
+            self.video_pruning_rate = 0.0
+            self._tokenizer = None
+            self.visual = StageMissingLayer("vision_tower")
+            self._tower_model_names = []
+        else:
+            self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+            self._init_video_pruning(multimodal_config)
+            self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+
+            with self._mark_tower_model(vllm_config, {"image", "video"}):
+                self.visual = Qwen3_VisionTransformer(
+                    config.vision_config,
+                    norm_eps=config.text_config.rms_norm_eps,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "visual"),
+                )
+
+        self.use_deepstack = (
+            not self.language_model_only
+            and bool(config.vision_config.deepstack_visual_indexes)
+            and not isinstance(self.visual, StageMissingLayer)
+        )
+        self.deepstack_num_level = (
+            len(config.vision_config.deepstack_visual_indexes)
+            if self.use_deepstack
+            else 0
+        )
+        self.visual_dim = config.vision_config.out_hidden_size
+        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+        if self.use_deepstack:
+            self.deepstack_input_embeds = [
+                torch.zeros(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    config.text_config.hidden_size,
+                )
+                for _ in range(self.deepstack_num_level)
+            ]
+            self.deepstack_input_embeds_num_tokens = 0
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = Qwen4ExpForCausalLM(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        if not get_pp_group().is_first_rank and self.use_deepstack:
+            assert self.language_model.model.start_layer >= len(
+                config.vision_config.deepstack_visual_indexes
+            ), (
+                "start_layer should be greater than or equal to "
+                "len(deepstack_visual_indexes)"
+            )
+        self.set_moe_parameters(self.language_model.model.layers)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.language_model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+        if self.language_model_only:
+            raise ValueError(
+                "Qwen4Exp language_model_only does not accept multimodal embeddings"
+            )
+
+        is_multimodal = _require_is_multimodal(is_multimodal)
+        if self.use_deepstack:
+            deepstack_input_embeds, multimodal_embeddings = (
+                self._compute_deepstack_embeds(
+                    inputs_embeds=inputs_embeds,
+                    multimodal_embeddings=multimodal_embeddings,
+                    is_multimodal=is_multimodal,
+                )
+            )
+        else:
+            deepstack_input_embeds = None
+
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+        if deepstack_input_embeds is not None:
+            self._set_deepstack_input_embeds(deepstack_input_embeds)
+        return inputs_embeds
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.language_model.get_mtp_target_hidden_states()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            deepstack_input_embeds = self._get_deepstack_input_embeds(
+                inputs_embeds.size(0)
+            )
+        else:
+            deepstack_input_embeds = None
+
+        hidden_states = self.language_model.model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            query_start_loc=kwargs.get("query_start_loc"),
+            ngram_context=kwargs.get("ngram_context"),
+            deepstack_input_embeds=deepstack_input_embeds,
+        )
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            self._clear_deepstack_input_embeds(inputs_embeds.size(0))
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["visual."] if self.language_model_only else None,
+            skip_substrs=["mtp.", "self_attn.indexer."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return Qwen4ExpForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return Qwen4ExpForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> MambaStateCopyFuncsByType:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_funcs(mamba_types)
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        return Qwen4ExpForCausalLM.get_mamba_specs_from_config(vllm_config)
+
+
+__all__ = [
+    "Qwen4ExpDecoderLayer",
+    "Qwen4ExpForCausalLM",
+    "Qwen4ExpForConditionalGeneration",
+    "Qwen4ExpMixtureOfExperts",
+    "Qwen4ExpModel",
+    "Qwen4ExpSparseMoeBlock",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/model_state.py
+++ b/vllm_ascend/models/qwen4_exp/amd/model_state.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Model-runner state for Qwen4Exp PLE inputs."""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
+from vllm.v1.worker.gpu.states import RequestState
+
+
+class Qwen4ExpModelState(MambaHybridModelState):
+    """Add rollback-safe PLE n-gram context to the model inputs."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: nn.Module,
+        encoder_cache: EncoderCache | None,
+        device: torch.device,
+    ) -> None:
+        super().__init__(vllm_config, model, encoder_cache, device)
+        config = self.model_config.hf_text_config
+        self.uses_ngram_embedding = bool(config.ple_layer_ids)
+        if not self.uses_ngram_embedding:
+            self.ngram_context_len = 0
+            self.ngram_eos_token_id = 0
+            return
+
+        if vllm_config.parallel_config.pipeline_parallel_size > 1:
+            raise RuntimeError(
+                "N-gram PLE embedding currently requires "
+                "pipeline_parallel_size=1 because non-first pipeline ranks do "
+                "not receive the raw input_ids required by PLE. Please run "
+                "with PP=1."
+            )
+
+        self.ngram_context_len = int(config.ngram_size) - 1
+        if self.ngram_context_len <= 0:
+            raise ValueError("N-gram embedding requires context length >= 1.")
+        self.ngram_eos_token_id = int(config.eos_token_id)
+        self.ngram_context = torch.full(
+            (self.max_num_reqs, self.ngram_context_len),
+            self.ngram_eos_token_id,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.ngram_context_offsets = torch.arange(
+            -self.ngram_context_len,
+            0,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.ple_query_start_loc = torch.zeros(
+            self.max_num_reqs + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def _prepare_ngram_context(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> torch.Tensor:
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        context = self.ngram_context[:num_reqs_padded]
+        context.fill_(self.ngram_eos_token_id)
+        if num_reqs == 0:
+            return context
+
+        request_indices = input_batch.idx_mapping[:num_reqs].long()
+        context_end = req_states.num_computed_tokens.gpu[request_indices].long()
+        token_indices = context_end.unsqueeze(1) + self.ngram_context_offsets
+        valid_tokens = token_indices >= 0
+        token_indices.clamp_min_(0)
+        context_tokens = req_states.all_token_ids.gpu[
+            request_indices.unsqueeze(1), token_indices
+        ]
+        context[:num_reqs].copy_(
+            torch.where(
+                valid_tokens,
+                context_tokens,
+                context_tokens.new_full((), self.ngram_eos_token_id),
+            )
+        )
+        return context
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_inputs(input_batch, req_states)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        query_start_loc = self.ple_query_start_loc[: num_reqs_padded + 1]
+        query_start_loc.copy_(input_batch.query_start_loc[: num_reqs_padded + 1])
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=self._prepare_ngram_context(input_batch, req_states),
+        )
+        return model_inputs
+
+    def prepare_dummy_inputs(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_dummy_inputs(num_reqs, num_tokens)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        query_start_loc = self.ple_query_start_loc[: num_reqs + 1]
+        query_start_loc[0] = 0
+        tokens_per_req, num_extra_tokens = divmod(num_tokens, num_reqs)
+        query_lens = torch.full(
+            (num_reqs,),
+            tokens_per_req,
+            dtype=query_start_loc.dtype,
+            device=query_start_loc.device,
+        )
+        if num_extra_tokens > 0:
+            query_lens[-num_extra_tokens:] += 1
+        torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
+
+        ngram_context = self.ngram_context[:num_reqs]
+        ngram_context.fill_(self.ngram_eos_token_id)
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=ngram_context,
+        )
+        return model_inputs
+
+
+__all__ = ["Qwen4ExpModelState"]

--- a/vllm_ascend/models/qwen4_exp/amd/mtp.py
+++ b/vllm_ascend/models/qwen4_exp/amd/mtp.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp MTP (Multi-Token Predictor) model.
+
+The MTP draft model reuses the Qwen4Exp backbone (PLE/HC/MoE) but:
+  - drops all multi-modal handling (text-only),
+  - forces PLE off while keeping the main model's HC stream count,
+  - fuses the backbone hidden and the new-token embedding via
+    ``residual_linear_shared`` (fc_embedding + shared fc_hidden) instead of
+    the ``Linear(2H, H)`` + repeat used by other MTP variants,
+  - emits TWO hidden streams per step (scheme A): a single stream [T, H]
+    (final-mixer collapsed, fed to the LM head) and a pre-final-mixer
+    multi stream [T, hc_count*H] (fed to the next draft step).
+"""
+
+from collections.abc import Iterable
+
+import regex as re
+import torch
+from torch import nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, replace, set_current_vllm_config
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.utils import configure_quant_config
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    get_draft_quant_config,
+    make_empty_intermediate_tensors_factory,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .model import (
+    _HC_WEIGHTS_MAPPER,
+    _QWEN4_EXP_IGNORED_MISSING_SUFFIXES,
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpMixtureOfExperts,
+)
+
+
+def _remap_ignored_layers(
+    ignored_layers: list[str],
+    mtp_start_layer_idx: int,
+) -> list[str]:
+    remapped: list[str] = []
+    for name in ignored_layers:
+        if name.startswith("mtp."):
+            new_name = re.sub(
+                r"(?<=\.layers\.)\d+",
+                lambda m: str(mtp_start_layer_idx + int(m.group(0))),
+                name,
+            )
+            remapped.append(new_name)
+        else:
+            remapped.append(name)
+    return remapped
+
+
+def _remap_mtp_weight_name(name: str) -> str | None:
+    """Map Qwen4Exp checkpoint paths into the standalone draft model."""
+
+    for checkpoint_prefix in (
+        "model.language_model.",
+        "language_model.",
+    ):
+        if name.startswith(checkpoint_prefix):
+            name = name.removeprefix(checkpoint_prefix)
+            break
+
+    if name.startswith("embed_tokens."):
+        name = f"model.{name}"
+    if name.startswith("model.mtp."):
+        name = name.removeprefix("model.")
+    if name.startswith("mtp.shared_head.head."):
+        return name.replace("mtp.shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.shared_head.head."):
+        return name.replace("model.shared_head.head.", "lm_head.", 1)
+    if name.startswith("shared_head.head."):
+        return name.replace("shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.lm_head."):
+        return name.removeprefix("model.")
+    if name.startswith("mtp."):
+        return name.replace("mtp.", "model.", 1)
+    if name.startswith("model.embed_tokens.") or name.startswith("lm_head."):
+        return name
+    return None
+
+
+def _make_draft_vllm_config(
+    vllm_config: VllmConfig,
+    mtp_start_layer_idx: int,
+) -> VllmConfig:
+    """Ensure that the draft model config is set in the vLLM config."""
+    speculative_config = vllm_config.speculative_config
+    if speculative_config is None or speculative_config.draft_model_config is None:
+        raise ValueError("speculative_config.draft_model_config must be set")
+
+    draft_quant_config = get_draft_quant_config(vllm_config)
+
+    # inject packed and ignored modules to the quantization config of draft model
+    if draft_quant_config is not None:
+        configure_quant_config(draft_quant_config, Qwen4ExpMTP)
+        ignored_layers = getattr(draft_quant_config, "ignored_layers", None)
+        if ignored_layers:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "ignored_layers",
+                _remap_ignored_layers(ignored_layers, mtp_start_layer_idx),
+            )
+        exclude_modules = getattr(draft_quant_config, "exclude_modules", None)
+        if exclude_modules:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "exclude_modules",
+                _remap_ignored_layers(exclude_modules, mtp_start_layer_idx),
+            )
+
+    draft_vllm_config = replace(
+        vllm_config,
+        model_config=speculative_config.draft_model_config,
+    )
+    # VllmConfig post-init derives the target quant config, so restore the
+    # independently resolved draft quant config after replacement.
+    draft_vllm_config.quant_config = draft_quant_config
+    return draft_vllm_config
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMultiTokenPredictor(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+
+        model_config = vllm_config.model_config
+        config: Qwen4ExpTextConfig = model_config.hf_text_config
+
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
+
+        self.hidden_size = config.hidden_size
+        self.hc_count = config.hc_count
+
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, self.hidden_size)
+        draft_vllm_config = _make_draft_vllm_config(
+            vllm_config,
+            self.mtp_start_layer_idx,
+        )
+        with set_current_vllm_config(draft_vllm_config, prefix=prefix):
+            # residual_linear_shared fusion: fc_embedding projects the token
+            # embedding, fc_hidden (shared across HC branches) projects the
+            # backbone hidden; the embedding is added as a residual to every
+            # branch (see mtp_residual_linear_shared.md).
+            self.fc_embedding = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_embedding",
+            )
+            self.fc_hidden = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_hidden",
+            )
+            self.layers = nn.ModuleList(
+                Qwen4ExpDecoderLayer(
+                    draft_vllm_config,
+                    layer_type="full_attention",
+                    prefix=f"{prefix}.layers.{self.mtp_start_layer_idx + idx}",
+                )
+                for idx in range(self.num_mtp_layers)
+            )
+
+        self.pre_fc_norm_embedding = GemmaRMSNorm(
+            self.hidden_size, eps=config.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = GemmaRMSNorm(
+            self.hidden_size * self.hc_count, eps=config.rms_norm_eps
+        )
+        # HC final mixer collapses the multi stream into [T, H] for the LM head.
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.hyper_connection_mixer = GatedResidual(
+            hc_config,
+            use_combine=False,
+            prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+        )
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], self.hidden_size * self.hc_count
+        )
+
+    def _iter_qsa_attentions(self):
+        """Yield MTP attention modules that own a QSA indexer."""
+
+        for layer in self.layers:
+            attention = getattr(layer, "self_attn", None)
+            if (
+                attention is not None
+                and getattr(attention, "indexer", None) is not None
+            ):
+                yield attention
+
+    def set_skip_topk(self, skip: bool) -> None:
+        """Select on MTP step 0 and reuse its QSA indices on later steps."""
+
+        for attention in self._iter_qsa_attentions():
+            attention.indexer.skip_topk = skip
+
+    def compact_topk_indices(self, row_indices: torch.Tensor) -> None:
+        """Keep each request's target-aligned step-0 sparse-index row."""
+
+        num_rows = row_indices.numel()
+        for attention in self._iter_qsa_attentions():
+            buffer = attention.topk_indices_buffer
+            selected = buffer.index_select(0, row_indices)
+            buffer[:num_rows].copy_(selected)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        hc_count = self.hc_count
+        hidden_size = self.hidden_size
+
+        if get_pp_group().is_first_rank:
+            assert hidden_states is not None
+            if inputs_embeds is None:
+                assert input_ids is not None
+                inputs_embeds = self.embed_input_ids(input_ids)
+            # Embedding branch: pre-norm -> fc_embedding -> [T, H].
+            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+            inputs_embeds = self.fc_embedding(inputs_embeds)
+
+            # Backbone hidden is multi-stream [T, hc_count*H] (scheme A:
+            # the main model truly emits the pre-final-mixer multi stream
+            # on the first step; subsequent steps reuse the prior draft
+            # step's multi stream).
+            num_tokens = hidden_states.shape[0]
+            hidden_states = hidden_states.view(num_tokens, hc_count, hidden_size)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2)).view(
+                num_tokens, hc_count, hidden_size
+            )
+            hidden_states = self.fc_hidden(hidden_states)
+            # Add the embedding residual to every branch, then fold back
+            # to [T, hc_count*H] (HC outer, HS inner) for the HC decoder.
+            hidden_states = inputs_embeds.unsqueeze(-2) + hidden_states
+            hidden_states = hidden_states.flatten(-2)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        layer = self.layers[current_step_idx]
+        hidden_states, block_output, injection = layer(
+            hidden_states=hidden_states,
+            prev_block_output=None,
+            prev_injection=None,
+            positions=positions,
+            input_ids=None,
+            query_start_loc=None,
+            ngram_context=None,
+        )
+        if not get_pp_group().is_last_rank:
+            # As in the target model, PP carries a materialized tensor rather
+            # than the delayed hidden/output/injection tuple.
+            hidden_states = layer.mlp_hyper_connection.combine(
+                hidden_states, block_output, injection
+            )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # Last PP rank finalize. Keep both:
+        #   (A) sample_hidden_states [T, H]  -> single stream for the LM head
+        #   (B) multi_hidden [T, hc_count*H] -> pre-final-mixer multi stream
+        #       for the next draft step (zero extra compute, just kept).
+        multi_hidden, sample_hidden_states, _ = (
+            self.hyper_connection_mixer.combine_and_mix(
+                hidden_states, block_output, injection
+            )
+        )
+        return sample_hidden_states, multi_hidden
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4ExpMTP currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+
+        self.quant_config = vllm_config.quant_config
+
+        super().__init__()
+        self.config = config
+        self.model = Qwen4ExpMultiTokenPredictor(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "mtp"),
+        )
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, vllm_config.model_config.dtype)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        return self.model(
+            input_ids,
+            positions,
+            hidden_states,
+            intermediate_tensors,
+            inputs_embeds,
+            spec_step_idx=spec_step_idx,
+        )
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        def remap_weight_names():
+            for name, weight in weights:
+                remapped_name = _remap_mtp_weight_name(name)
+                if remapped_name is not None:
+                    yield remapped_name, weight
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(remap_weight_names())
+
+
+__all__ = ["Qwen4ExpMTP", "Qwen4ExpMultiTokenPredictor"]

--- a/vllm_ascend/models/qwen4_exp/amd/mtp.py
+++ b/vllm_ascend/models/qwen4_exp/amd/mtp.py
@@ -84,6 +84,8 @@ def _remap_mtp_weight_name(name: str) -> str | None:
             name = name.removeprefix(checkpoint_prefix)
             break
 
+    if ".self_attn.indexer." in name:
+        return None
     if name.startswith("embed_tokens."):
         name = f"model.{name}"
     if name.startswith("model.mtp."):
@@ -285,11 +287,15 @@ class Qwen4ExpMultiTokenPredictor(nn.Module):
             # on the first step; subsequent steps reuse the prior draft
             # step's multi stream).
             num_tokens = hidden_states.shape[0]
+            if hidden_states.shape[-1] == hidden_size:
+                hidden_states = hidden_states.unsqueeze(-2).expand(
+                    num_tokens, hc_count, hidden_size
+                )
             hidden_states = hidden_states.view(num_tokens, hc_count, hidden_size)
-            hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2)).view(
-                num_tokens, hc_count, hidden_size
-            )
-            hidden_states = self.fc_hidden(hidden_states)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2))
+            hidden_states = self.fc_hidden(
+                hidden_states.reshape(-1, hidden_size)
+            ).reshape(num_tokens, hc_count, hidden_size)
             # Add the embedding residual to every branch, then fold back
             # to [T, hc_count*H] (HC outer, HS inner) for the HC decoder.
             hidden_states = inputs_embeds.unsqueeze(-2) + hidden_states

--- a/vllm_ascend/models/qwen4_exp/amd/ops/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ops/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMD ROCm Qwen4Exp kernels; import leaf modules directly."""

--- a/vllm_ascend/models/qwen4_exp/amd/ops/hc.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ops/hc.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PyTorch HyperConnection operations for the NPU bootstrap path."""
+
+import torch
+import torch.nn.functional as F
+
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+def _grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    if x.shape[-1] % num_groups:
+        raise ValueError("Grouped RMSNorm input is not divisible by num_groups")
+    group_dim = x.shape[-1] // num_groups
+    if weight.numel() not in (group_dim, x.shape[-1]):
+        raise ValueError("Grouped RMSNorm weight has an invalid size")
+    grouped = x.reshape(-1, num_groups, group_dim).float()
+    normalized = grouped * torch.rsqrt(grouped.square().mean(-1, keepdim=True) + eps)
+    affine = weight.float().reshape(1, -1, group_dim)
+    if weight.numel() == group_dim:
+        affine = affine[:, :1]
+    return (normalized * (1.0 + affine)).reshape_as(x).to(x.dtype)
+
+
+def _hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    if hc_count <= 0:
+        raise ValueError("hc_count must be positive")
+    return F.silu(x.float() / hc_count).to(x.dtype)
+
+
+def _hc_gate_mix(
+    x: torch.Tensor, gate: torch.Tensor, hc_count: int
+) -> torch.Tensor:
+    if x.shape != gate.shape or x.shape[-1] % hc_count:
+        raise ValueError("HC gate and input shapes are incompatible")
+    hidden_size = x.shape[-1] // hc_count
+    mixed = torch.sigmoid(gate.float()) * x.float()
+    return mixed.reshape(-1, hc_count, hidden_size).mean(1).to(x.dtype)
+
+
+def _hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    if residual.shape[-1] % hc_count:
+        raise ValueError("HC residual is not divisible by hc_count")
+    hidden_size = residual.shape[-1] // hc_count
+    if block_output.shape[-1] != hidden_size:
+        raise ValueError("HC block output has an invalid size")
+    injection = 2.0 * torch.sigmoid(injection_logits.float() / hc_count)
+    combined = residual.float().reshape(-1, hc_count, hidden_size)
+    combined = combined + block_output.float().unsqueeze(1) * injection.unsqueeze(-1)
+    return combined.reshape_as(residual).to(residual.dtype)
+
+
+def _hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    combined = _hc_combine(
+        residual, block_output, injection_logits, hc_count
+    )
+    normalized = _grouped_gemma_rmsnorm(
+        combined, norm_weight, eps, hc_count
+    )
+    return combined, normalized
+
+
+def _same_shape_fake(x: torch.Tensor, *args) -> torch.Tensor:
+    del args
+    return x.new_empty(x.shape)
+
+
+def _hc_gate_mix_fake(
+    x: torch.Tensor, gate: torch.Tensor, hc_count: int
+) -> torch.Tensor:
+    del gate
+    return x.new_empty((x.shape[0], x.shape[1] // hc_count))
+
+
+def _hc_combine_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    del block_output, injection_logits, hc_count
+    return residual.new_empty(residual.shape)
+
+
+def _hc_combine_norm_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del block_output, injection_logits, norm_weight, eps, hc_count
+    return residual.new_empty(residual.shape), residual.new_empty(residual.shape)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_grouped_gemma_rmsnorm",
+    op_func=_grouped_gemma_rmsnorm,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_silu",
+    op_func=_hc_silu,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_gate_mix",
+    op_func=_hc_gate_mix,
+    fake_impl=_hc_gate_mix_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine",
+    op_func=_hc_combine,
+    fake_impl=_hc_combine_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine_norm",
+    op_func=_hc_combine_norm,
+    fake_impl=_hc_combine_norm_fake,
+)
+
+
+def grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_grouped_gemma_rmsnorm(
+        x, weight, eps, num_groups
+    )
+
+
+def hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_silu(x, hc_count)
+
+
+def hc_gate_mix(x: torch.Tensor, gate: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_gate_mix(x, gate, hc_count)
+
+
+def hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_combine(
+        residual, block_output, injection_logits, hc_count
+    )
+
+
+def hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.vllm.qwen4_exp_hc_combine_norm(
+        residual,
+        block_output,
+        injection_logits,
+        norm_weight,
+        eps,
+        hc_count,
+    )
+
+
+__all__ = [
+    "grouped_gemma_rmsnorm",
+    "hc_combine",
+    "hc_combine_norm",
+    "hc_gate_mix",
+    "hc_silu",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/ops/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ops/qsa.py
@@ -1,0 +1,1128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernels for the Qwen4Exp weight-free QSA path."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_LOGITS_WORKSPACE_BYTES = 128 * 1024 * 1024
+_TOPK_WORKSPACE_BYTES = 1024 * 1024
+
+
+@triton.jit
+def _qsa_mqa_paged_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    logical_page = columns // PAGE_SIZE
+    page_offset = columns % PAGE_SIZE
+    valid = (
+        (row < num_rows)
+        & (columns < num_columns)
+        & (columns < visible)
+        & (request >= 0)
+        & (request < num_requests)
+        & (logical_page < PAGE_TABLE_WIDTH)
+    )
+    safe_logical_page = tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1)
+    physical_page = tl.load(
+        page_table_ptr
+        + safe_request * stride_table_req
+        + safe_logical_page * stride_table_page,
+        mask=valid,
+        other=-1,
+    )
+    valid &= (physical_page >= 0) & (physical_page < num_pages)
+    # physical_page * block stride can overflow int32 for large caches.
+    safe_physical_page = tl.maximum(physical_page, 0).to(tl.int64)
+    score = tl.zeros((BLOCK_N,), dtype=tl.float32)
+
+    for head in tl.static_range(0, NUM_HEADS):
+        query = tl.load(
+            q_ptr + row * stride_q_row + head * stride_q_head + dims * stride_q_dim,
+            mask=dims < HEAD_DIM,
+            other=0.0,
+        ).to(tl.float32)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_physical_page[:, None] * stride_cache_block
+            + page_offset[:, None] * stride_cache_token
+            + dims[None, :] * stride_cache_dim,
+            mask=valid[:, None] & (dims[None, :] < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        dot = tl.sum(keys * query[None, :], axis=1)
+        score += tl.maximum(dot, 0.0)
+
+    score /= score_divisor
+    tl.store(
+        logits_ptr + row * stride_logits_row + columns,
+        tl.where(valid, score, -float("inf")),
+        mask=(row < num_rows) & (columns < num_columns),
+    )
+
+
+@triton.jit
+def _expand_qsa_indices_kernel(
+    block_indices_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    token_to_req_ptr,
+    output_ptr,
+    stride_blocks_row,
+    stride_blocks_column,
+    stride_output_row,
+    stride_output_column,
+    rows,
+    num_requests,
+    BLOCK_TOPK: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    TOKEN_TOPK: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    COLUMN_BLOCK: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * COLUMN_BLOCK + tl.arange(0, COLUMN_BLOCK)
+    query_position = tl.load(query_positions_ptr + row)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    complete_blocks = tl.minimum(
+        tl.minimum(
+            (query_position + 1) // COMPRESS_RATIO,
+            sequence_length // COMPRESS_RATIO,
+        ),
+        BLOCK_TOPK,
+    )
+    expanded_count = complete_blocks * COMPRESS_RATIO
+    tail_start = ((query_position + 1) // COMPRESS_RATIO) * COMPRESS_RATIO
+    tail_count = (query_position + 1) - tail_start
+
+    is_expanded = columns < expanded_count
+    block_rank = columns // COMPRESS_RATIO
+    offset = columns % COMPRESS_RATIO
+    safe_rank = tl.minimum(block_rank, BLOCK_TOPK - 1)
+    block = tl.load(
+        block_indices_ptr + row * stride_blocks_row + safe_rank * stride_blocks_column,
+        mask=(row < rows) & is_expanded,
+        other=-1,
+    )
+    expanded = block * COMPRESS_RATIO + offset
+    tail_offset = columns - expanded_count
+    is_tail = (
+        (columns >= expanded_count)
+        & (tail_offset < tail_count)
+        & (tail_offset < COMPRESS_RATIO - 1)
+    )
+    token = tl.where(is_expanded, expanded, tail_start + tail_offset)
+    valid = (
+        (row < rows)
+        & (columns < OUTPUT_WIDTH)
+        & (is_expanded | is_tail)
+        & (token >= 0)
+        & (token < sequence_length)
+    )
+    tl.store(
+        output_ptr + row * stride_output_row + columns * stride_output_column,
+        tl.where(valid, token, -1),
+        mask=(row < rows) & (columns < OUTPUT_WIDTH),
+    )
+
+
+@triton.jit
+def _qsa_sparse_paged_gqa_splitk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    indices_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_k_block,
+    stride_k_token,
+    stride_k_head,
+    stride_v_block,
+    stride_v_token,
+    stride_v_head,
+    stride_indices_row,
+    stride_table_req,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    num_cache_blocks,
+    num_requests,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    split_id = tl.program_id(2)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+
+    head_offsets = tl.arange(0, BLOCK_M)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    column_offsets = tl.arange(0, BLOCK_N)
+    first_head = kv_head * GROUP_SIZE
+    query = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + (first_head + head_offsets[:, None]) * stride_q_head
+        + dim_offsets[None, :],
+        mask=head_offsets[:, None] < GROUP_SIZE,
+        other=0.0,
+    )
+
+    max_value = tl.full((BLOCK_M,), -1.0e20, dtype=tl.float32)
+    normalizer = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    accumulator = tl.zeros((BLOCK_M, HEAD_DIM), dtype=tl.float32)
+    softmax_scale_log2: tl.constexpr = (HEAD_DIM**-0.5) * 1.4426950408889634
+
+    # Dynamic bounds avoid padded main-loop iterations for uneven splits.
+    split_tile_start = split_id * NUM_TILES // NUM_SPLITS
+    split_tile_end = (split_id + 1) * NUM_TILES // NUM_SPLITS
+    for tile in range(split_tile_start, split_tile_end):
+        columns = tile * BLOCK_N + column_offsets
+        logical_token = tl.load(
+            indices_ptr + row * stride_indices_row + columns,
+            mask=columns < TOPK,
+            other=-1,
+        )
+        safe_token = tl.maximum(logical_token, 0)
+        logical_page = safe_token // PAGE_SIZE
+        page_offset = safe_token % PAGE_SIZE
+        valid = (
+            (request >= 0)
+            & (request < num_requests)
+            & (logical_token >= 0)
+            & (logical_page < PAGE_TABLE_WIDTH)
+        )
+        physical_page = tl.load(
+            block_table_ptr
+            + safe_request * stride_table_req
+            + tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1),
+            mask=valid,
+            other=-1,
+        )
+        valid &= (physical_page >= 0) & (physical_page < num_cache_blocks)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_page[None, :] * stride_k_block
+            + page_offset[None, :] * stride_k_token
+            + kv_head * stride_k_head
+            + dim_offsets[:, None],
+            mask=valid[None, :],
+            other=0.0,
+        )
+        values = tl.load(
+            v_cache_ptr
+            + safe_page[:, None] * stride_v_block
+            + page_offset[:, None] * stride_v_token
+            + kv_head * stride_v_head
+            + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0.0,
+        )
+        scores = tl.dot(query, keys)
+        # Scaling scores avoids re-quantizing a scaled query to BF16.
+        scores *= softmax_scale_log2
+        scores = tl.where(valid[None, :], scores, -1.0e20)
+        next_max = tl.maximum(max_value, tl.max(scores, axis=1))
+        alpha = tl.math.exp2(max_value - next_max)
+        probabilities = tl.where(
+            valid[None, :], tl.math.exp2(scores - next_max[:, None]), 0.0
+        )
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            acc=accumulator * alpha[:, None],
+        )
+        normalizer = normalizer * alpha + tl.sum(probabilities, axis=1)
+        max_value = next_max
+
+    has_values = normalizer > 0
+    normalized_output = tl.where(
+        has_values[:, None],
+        accumulator / tl.maximum(normalizer[:, None], 1.0e-20),
+        0.0,
+    )
+    output_mask = head_offsets[:, None] < GROUP_SIZE
+    if NUM_SPLITS == 1:
+        tl.store(
+            output_ptr
+            + row * stride_output_row
+            + (first_head + head_offsets[:, None]) * stride_output_head
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+    else:
+        partial_lse = tl.where(
+            has_values,
+            max_value + tl.math.log2(tl.maximum(normalizer, 1.0e-20)),
+            -float("inf"),
+        )
+        tl.store(
+            partial_output_ptr
+            + (
+                (split_id * num_rows + row) * NUM_QUERY_HEADS
+                + first_head
+                + head_offsets[:, None]
+            )
+            * HEAD_DIM
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+        tl.store(
+            partial_lse_ptr
+            + (split_id * num_rows + row) * NUM_QUERY_HEADS
+            + first_head
+            + head_offsets,
+            partial_lse,
+            mask=head_offsets < GROUP_SIZE,
+        )
+
+
+@triton.jit
+def _qsa_merge_splitk_kernel(
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    BLOCK_SPLITS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    split_offsets = tl.arange(0, BLOCK_SPLITS)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    split_mask = split_offsets < NUM_SPLITS
+    lse = tl.load(
+        partial_lse_ptr + (split_offsets * num_rows + row) * NUM_QUERY_HEADS + head,
+        mask=split_mask,
+        other=-float("inf"),
+    )
+    lse_max = tl.max(lse, axis=0)
+    has_values = lse_max > -float("inf")
+    shifted = tl.where(split_mask & has_values, lse - lse_max, -float("inf"))
+    weights = tl.math.exp2(shifted)
+    denominator = tl.sum(weights, axis=0)
+    partial_output = tl.load(
+        partial_output_ptr
+        + ((split_offsets[:, None] * num_rows + row) * NUM_QUERY_HEADS + head)
+        * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=split_mask[:, None],
+        other=0.0,
+    )
+    merged = tl.sum(partial_output * weights[:, None], axis=0)
+    merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    tl.store(
+        output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
+        merged,
+    )
+
+
+@triton.jit
+def _store_qsa_rows_kernel(
+    cache_ptr,
+    slots_ptr,
+    rows_ptr,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_rows_row,
+    stride_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    values = tl.load(
+        rows_ptr + row * stride_rows_row + dims * stride_rows_dim,
+        mask=valid & (dims < WIDTH),
+        other=0,
+    )
+    tl.store(
+        cache_ptr
+        + block * stride_cache_block
+        + token * stride_cache_token
+        + dims * stride_cache_dim,
+        values,
+        mask=valid & (dims < WIDTH),
+    )
+
+
+@triton.jit
+def _compress_qsa_groups_kernel(
+    raw_keys_ptr,  # this step's raw key rows, straight from activations
+    raw_positions_ptr,  # this step's per-token positions
+    compressor_state_cache_ptr,  # per-request ring of previous raw keys
+    rope_cache_ptr,  # packed RoPE position tail of the ring
+    compressor_state_table_ptr,
+    token_to_req_ptr,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    pooled_ptr,
+    first_positions_ptr,
+    stride_raw_row,
+    stride_raw_dim,
+    stride_raw_positions_row,
+    stride_raw_positions_dim,
+    stride_compressor_state_block,
+    stride_compressor_state_token,
+    stride_compressor_state_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_compressor_state_table_req,
+    stride_pooled_row,
+    stride_pooled_dim,
+    stride_positions_row,
+    stride_positions_dim,
+    num_rows,
+    num_compressor_state_blocks,
+    num_requests,
+    COMPRESSOR_STATE_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    LOAD_ROPE_POSITIONS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_request = (request >= 0) & (request < num_requests)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_row_start = tl.load(
+        query_start_loc_ptr + safe_request, mask=valid_request, other=0
+    )
+    query_row_end = tl.load(
+        query_start_loc_ptr + safe_request + 1, mask=valid_request, other=0
+    )
+    chunk_start_position = end_position - (row - query_row_start)
+    compressor_state_block = tl.load(
+        compressor_state_table_ptr + safe_request * stride_compressor_state_table_req,
+        mask=valid_request,
+        other=-1,
+    )
+    valid_compressor_state_block = (compressor_state_block >= 0) & (
+        compressor_state_block < num_compressor_state_blocks
+    )
+    valid_row = (
+        (row < num_rows)
+        & valid_request
+        & (row >= query_row_start)
+        & (row < query_row_end)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    # A group can span the compressor-state ring (older members) and this
+    # step's raw rows (members at positions >= chunk_start_position).
+    for group_offset in tl.range(0, COMPRESS_RATIO):
+        position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+        use_raw = position >= chunk_start_position
+        raw_row = query_row_start + position - chunk_start_position
+        raw_values = tl.load(
+            raw_keys_ptr + raw_row * stride_raw_row + dims * stride_raw_dim,
+            mask=valid_row
+            & use_raw
+            & (raw_row >= query_row_start)
+            & (raw_row < query_row_end)
+            & (raw_row < num_rows)
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        compressor_state_values = tl.load(
+            compressor_state_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64)
+            * stride_compressor_state_block
+            + (position % COMPRESSOR_STATE_SIZE) * stride_compressor_state_token
+            + dims * stride_compressor_state_dim,
+            mask=valid_row
+            & ~use_raw
+            & valid_compressor_state_block
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.where(use_raw, raw_values, compressor_state_values)
+
+    tl.store(
+        pooled_ptr + row * stride_pooled_row + dims * stride_pooled_dim,
+        accumulator / COMPRESS_RATIO,
+        mask=(row < num_rows) & (dims < HEAD_DIM),
+    )
+
+    position_dims = tl.arange(0, 4)
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_ROPE_POSITIONS:
+        first_from_raw = first_position >= chunk_start_position
+        raw_first_row = query_row_start + first_position - chunk_start_position
+        raw_position_values = tl.load(
+            raw_positions_ptr
+            + raw_first_row * stride_raw_positions_row
+            + position_dims * stride_raw_positions_dim,
+            mask=valid_row
+            & first_from_raw
+            & (raw_first_row >= query_row_start)
+            & (raw_first_row < query_row_end)
+            & (raw_first_row < num_rows)
+            & (position_dims < 3),
+            other=0,
+        )
+        compressor_state_position_values = tl.load(
+            rope_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_rope_block
+            + (first_position % COMPRESSOR_STATE_SIZE) * stride_rope_token
+            + position_dims * stride_rope_dim,
+            mask=valid_row
+            & ~first_from_raw
+            & valid_compressor_state_block
+            & (position_dims < 3),
+            other=0,
+        )
+        position_values = tl.where(
+            first_from_raw,
+            raw_position_values,
+            compressor_state_position_values,
+        )
+    else:
+        position_values = tl.where(valid_row, first_position, 0)
+    tl.store(
+        first_positions_ptr
+        + row * stride_positions_row
+        + position_dims * stride_positions_dim,
+        position_values,
+        mask=(row < num_rows) & (position_dims < 3),
+    )
+
+
+def _validate_mqa(q: torch.Tensor) -> None:
+    if q.ndim != 3 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("QSA query must be [rows, heads, head_dim]")
+
+
+def qsa_mqa_paged(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+    num_columns: int | None = None,
+    score_scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute QSA scores directly from a paged compressed-key cache."""
+
+    _validate_mqa(q)
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA scoring requires a GPU and Triton")
+    if k_cache.ndim != 4 or k_cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, head_dim]")
+    if k_cache.shape[3] != q.shape[2]:
+        raise ValueError("QSA query and cache dimensions must match")
+    if page_table.ndim != 2:
+        raise ValueError("QSA page table must be two-dimensional")
+    if q.shape[0] and (not all(k_cache.shape[:2]) or not all(page_table.shape)):
+        raise ValueError("QSA paged scoring cache and page table must be nonempty")
+    if token_to_req.shape != (q.shape[0],):
+        raise ValueError("QSA request mapping must match query rows")
+    if query_positions.shape != (q.shape[0],):
+        raise ValueError("QSA query positions must match query rows")
+    if sequence_lengths.shape != (page_table.shape[0],):
+        raise ValueError("QSA sequence lengths must match page-table requests")
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    score_divisor = math.sqrt(q.shape[2]) if score_scale is None else score_scale
+    if score_divisor <= 0:
+        raise ValueError("QSA score scale must be positive")
+
+    capacity = page_table.shape[1] * k_cache.shape[1]
+    columns = capacity if num_columns is None else num_columns
+    if columns < 0:
+        raise ValueError("QSA score width must be non-negative")
+    logits = torch.empty((q.shape[0], columns), dtype=torch.float32, device=q.device)
+    visible_blocks = torch.empty(q.shape[0], dtype=torch.int32, device=q.device)
+    if not q.shape[0] or not columns:
+        return logits, visible_blocks
+    block_n = 32
+    _qsa_mqa_paged_kernel[(q.shape[0], triton.cdiv(columns, block_n))](
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(3),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        q.shape[0],
+        columns,
+        k_cache.shape[0],
+        page_table.shape[0],
+        float(score_divisor),
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=block_n,
+        BLOCK_D=triton.next_power_of_2(q.shape[2]),
+        COMPRESS_RATIO=compress_ratio,
+        num_warps=4,
+    )
+    return logits, visible_blocks
+
+
+def expand_qsa_block_indices_cuda(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    compress_ratio: int,
+    token_topk: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand compressed blocks and compact the causal tail of the open group."""
+
+    if not block_indices.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA index expansion requires a GPU and Triton")
+    if token_topk % compress_ratio:
+        raise ValueError("QSA token top-k must be divisible by compression ratio")
+    block_topk = token_topk // compress_ratio
+    output_width = token_topk + compress_ratio - 1
+    if block_indices.shape != (query_positions.numel(), block_topk):
+        raise ValueError("QSA compressed top-k has an invalid shape")
+    if token_to_req.shape != query_positions.shape:
+        raise ValueError("QSA request mapping must match query positions")
+    if sequence_lengths.ndim != 1 or not sequence_lengths.shape[0]:
+        raise ValueError("QSA request sequence lengths must be nonempty")
+    if out is None:
+        out = torch.empty(
+            (block_indices.shape[0], output_width),
+            dtype=torch.int32,
+            device=block_indices.device,
+        )
+    elif out.shape != (block_indices.shape[0], output_width):
+        raise ValueError("QSA expansion output has an invalid shape")
+    if not block_indices.shape[0]:
+        return out
+    column_block = 256
+    _expand_qsa_indices_kernel[
+        (block_indices.shape[0], triton.cdiv(output_width, column_block))
+    ](
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        out,
+        block_indices.stride(0),
+        block_indices.stride(1),
+        out.stride(0),
+        out.stride(1),
+        block_indices.shape[0],
+        sequence_lengths.shape[0],
+        BLOCK_TOPK=block_topk,
+        COMPRESS_RATIO=compress_ratio,
+        TOKEN_TOPK=token_topk,
+        OUTPUT_WIDTH=output_width,
+        COLUMN_BLOCK=column_block,
+        num_warps=4,
+    )
+    return out
+
+
+def qsa_select_paged_tokens(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Score, select, and expand QSA indices without host synchronization."""
+
+    rows = q.shape[0]
+    output_width = token_topk + compress_ratio - 1
+    if out is None:
+        out = torch.empty((rows, output_width), dtype=torch.int32, device=q.device)
+    if out.shape != (rows, output_width):
+        raise ValueError("QSA selection output has an invalid shape")
+    if not rows:
+        return out
+
+    columns = page_table.shape[1] * k_cache.shape[1]
+    block_topk = token_topk // compress_ratio
+    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(columns * 4, 1))
+    chunk_rows = min(rows, rows_per_chunk)
+    blocks_buffer = torch.empty(
+        (chunk_rows, block_topk), dtype=torch.int32, device=q.device
+    )
+    topk_workspace = torch.empty(
+        (_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device
+    )
+    for row_start in range(0, rows, rows_per_chunk):
+        row_end = min(row_start + rows_per_chunk, rows)
+        row_slice = slice(row_start, row_end)
+        logits, visible_blocks = qsa_mqa_paged(
+            q[row_slice],
+            k_cache,
+            page_table,
+            token_to_req[row_slice],
+            query_positions[row_slice],
+            sequence_lengths,
+            compress_ratio,
+        )
+        blocks = blocks_buffer[: row_end - row_start]
+        use_cooperative_topk = (
+            current_platform.is_cuda()
+            and blocks.shape[0] <= 32
+            and logits.stride(0) % 4 == 0
+            and current_platform.has_device_capability(90)
+            and not current_platform.is_device_capability_family(120)
+        )
+        if use_cooperative_topk:
+            torch.ops._C.cooperative_topk(
+                logits,
+                visible_blocks,
+                blocks,
+                topk_workspace,
+                block_topk,
+                columns,
+            )
+        elif current_platform.is_cuda():
+            torch.ops._C.persistent_topk(
+                logits,
+                visible_blocks,
+                blocks,
+                topk_workspace,
+                block_topk,
+                columns,
+            )
+        else:
+            ops.top_k_per_row_decode(
+                logits,
+                1,
+                visible_blocks,
+                blocks,
+                blocks.shape[0],
+                logits.stride(0),
+                logits.stride(1),
+                block_topk,
+            )
+        expand_qsa_block_indices_cuda(
+            blocks,
+            query_positions[row_slice],
+            sequence_lengths,
+            token_to_req[row_slice],
+            compress_ratio,
+            token_topk,
+            out[row_slice],
+        )
+    return out
+
+
+def qsa_sparse_paged_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    logical_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run sparse GQA directly over paged BF16 K/V caches."""
+
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA sparse attention requires a GPU and Triton")
+    if q.ndim != 3 or k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+        raise ValueError("QSA sparse attention received invalid Q/K/V shapes")
+    if logical_indices.ndim != 2 or logical_indices.shape[0] != q.shape[0]:
+        raise ValueError("QSA indices must have one row per query")
+    if token_to_req.shape != (q.shape[0],) or block_table.ndim != 2:
+        raise ValueError("QSA sparse attention metadata has invalid shapes")
+    if not all(k_cache.shape[:3]) or not all(block_table.shape):
+        raise ValueError("QSA sparse attention cache and block table must be nonempty")
+    if logical_indices.shape[1] <= 0:
+        raise ValueError("QSA sparse attention requires a positive selection width")
+    if q.shape[2] != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
+        raise ValueError("QSA sparse attention requires valid grouped-query heads")
+    head_dim = q.shape[2]
+    assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
+    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    assert logical_indices.dtype == block_table.dtype == torch.int32
+    assert token_to_req.dtype == torch.int32
+    assert q.device == k_cache.device == v_cache.device
+    assert q.device == logical_indices.device == block_table.device
+    assert q.device == token_to_req.device
+    assert q.stride(2) == k_cache.stride(3) == v_cache.stride(3) == 1
+    assert logical_indices.stride(1) == block_table.stride(1) == 1
+    assert token_to_req.stride(0) == 1
+    if out is None:
+        out = torch.empty_like(q)
+    if out.shape != q.shape:
+        raise ValueError("QSA sparse output must match its query")
+    assert out.dtype == q.dtype and out.device == q.device
+    assert out.stride(2) == 1
+    if not q.shape[0]:
+        return out
+
+    group_size = q.shape[1] // k_cache.shape[2]
+    block_m = triton.next_power_of_2(group_size)
+    base_programs = q.shape[0] * k_cache.shape[2]
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+    # gfx942 and gfx950 have a 64 KiB LDS limit. One software-pipelining
+    # stage keeps the wide TP4 tile within that shared-memory budget.
+    partial_stages = 1 if current_platform.is_rocm() else 2
+
+    num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
+    # Avoid empty splits when the selection width is smaller than the profile.
+    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
+    num_splits = min(max_useful_splits, target_splits)
+
+    # Split=1 writes output directly and compiles out all workspace accesses.
+    if num_splits == 1:
+        partial_output = out
+        partial_lse = out
+    else:
+        # FP32 partials preserve accuracy when merging independently normalized
+        # splits.
+        partial_output = torch.empty(
+            (num_splits, *q.shape), dtype=torch.float32, device=q.device
+        )
+        partial_lse = torch.empty(
+            (num_splits, q.shape[0], q.shape[1]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    partial_grid = (q.shape[0], k_cache.shape[2], num_splits)
+    _qsa_sparse_paged_gqa_splitk_kernel[partial_grid](
+        q,
+        k_cache,
+        v_cache,
+        logical_indices,
+        block_table,
+        token_to_req,
+        partial_output,
+        partial_lse,
+        out,
+        q.stride(0),
+        q.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        logical_indices.stride(0),
+        block_table.stride(0),
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        k_cache.shape[0],
+        block_table.shape[0],
+        TOPK=logical_indices.shape[1],
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=block_table.shape[1],
+        GROUP_SIZE=group_size,
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        NUM_TILES=num_tiles,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=partial_warps,
+        num_stages=partial_stages,
+    )
+    if num_splits == 1:
+        return out
+
+    _qsa_merge_splitk_kernel[(q.shape[0], q.shape[1])](
+        partial_output,
+        partial_lse,
+        out,
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+        num_warps=2,
+        num_stages=1,
+    )
+    return out
+
+
+def qsa_store_cache_rows(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    rows: torch.Tensor,
+) -> None:
+    """Store fixed-width rows in a QSA cache without boolean indexing."""
+
+    if not cache.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA cache stores require a GPU and Triton")
+    if cache.ndim != 4 or cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, width]")
+    if not all(cache.shape):
+        raise ValueError("QSA cache dimensions must be nonzero")
+    if rows.ndim == 3:
+        if rows.shape[1] != 1:
+            raise ValueError("QSA cache rows must have one head")
+        rows = rows[:, 0]
+    if rows.shape != (slot_mapping.numel(), cache.shape[3]):
+        raise ValueError("QSA cache rows and slots have incompatible shapes")
+    if not rows.shape[0]:
+        return
+    _store_qsa_rows_kernel[(rows.shape[0],)](
+        cache,
+        slot_mapping,
+        rows,
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(3),
+        rows.stride(0),
+        rows.stride(1),
+        rows.shape[0],
+        cache.shape[0],
+        PAGE_SIZE=cache.shape[1],
+        WIDTH=cache.shape[3],
+        BLOCK_D=triton.next_power_of_2(cache.shape[3]),
+        num_warps=4,
+    )
+
+
+def qsa_compress_groups_with_ratio(
+    raw_keys: torch.Tensor,  # this step's raw key rows [rows, 1, head_size]
+    raw_positions: torch.Tensor,  # this step's positions [rows, 1, 3] int64
+    compressor_state_cache: torch.Tensor,
+    compressor_state_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compress_ratio: int,
+    rope_cache: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pool completed groups from the compressor-state ring and raw token rows."""
+
+    if not raw_keys.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA compression requires a GPU and Triton")
+    rows = token_to_req.numel()
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    if raw_keys.ndim != 3 or raw_keys.shape[:2] != (rows, 1):
+        raise ValueError("QSA raw keys must be [rows, 1, head_size]")
+    if raw_positions.shape != (rows, 1, 3) or raw_positions.dtype != torch.int64:
+        raise ValueError("QSA raw positions must be [rows, 1, 3] int64")
+    if logical_positions.shape != (rows,) or compressed_slots.shape != (rows,):
+        raise ValueError("QSA compression metadata must match token rows")
+    if compressor_state_cache.ndim != 4 or compressor_state_cache.shape[2] != 1:
+        raise ValueError("QSA compressor-state cache has an invalid shape")
+    if (
+        # The ring is wider than one group so speculative rows cannot alias
+        # onto the committed keys of the group still being collected.
+        compressor_state_cache.shape[1] < compress_ratio
+        or compressor_state_cache.shape[3] != raw_keys.shape[2]
+        or compressor_state_cache.dtype != raw_keys.dtype
+    ):
+        raise ValueError(
+            "QSA compressor-state cache does not match the compression layout"
+        )
+    if (
+        compressor_state_block_table.ndim != 2
+        or compressor_state_block_table.shape[1] < 1
+    ):
+        raise ValueError(
+            "QSA compressor-state block table must contain one block per request"
+        )
+    if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+        raise ValueError("QSA query starts must contain a terminal offset")
+    num_requests = query_start_loc.shape[0] - 1
+    if compressor_state_block_table.shape[0] < num_requests:
+        raise ValueError("QSA compressor-state block table has too few request rows")
+    if rope_cache is not None and (
+        rope_cache.ndim != 4
+        or rope_cache.shape[:3] != compressor_state_cache.shape[:3]
+        or rope_cache.shape[3] != 3
+        or rope_cache.dtype != torch.int64
+    ):
+        raise ValueError("QSA packed position view has an invalid shape or dtype")
+    if rows and (
+        not all(compressor_state_cache.shape)
+        or not all(compressor_state_block_table.shape)
+    ):
+        raise ValueError("QSA compressor-state cache and block table must be nonempty")
+    pooled = torch.empty(
+        (rows, 1, raw_keys.shape[2]),
+        dtype=raw_keys.dtype,
+        device=raw_keys.device,
+    )
+    first_positions = torch.empty((rows, 3), dtype=torch.int64, device=raw_keys.device)
+    if not rows:
+        return pooled, first_positions
+    if rope_cache is None:
+        rope_cache = compressor_state_cache
+        load_rope_positions = False
+    else:
+        load_rope_positions = True
+    _compress_qsa_groups_kernel[(rows,)](
+        raw_keys,
+        raw_positions,
+        compressor_state_cache,
+        rope_cache,
+        compressor_state_block_table,
+        token_to_req,
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        pooled,
+        first_positions,
+        raw_keys.stride(0),
+        raw_keys.stride(2),
+        raw_positions.stride(0),
+        raw_positions.stride(2),
+        compressor_state_cache.stride(0),
+        compressor_state_cache.stride(1),
+        compressor_state_cache.stride(3),
+        rope_cache.stride(0),
+        rope_cache.stride(1),
+        rope_cache.stride(3),
+        compressor_state_block_table.stride(0),
+        pooled.stride(0),
+        pooled.stride(2),
+        first_positions.stride(0),
+        first_positions.stride(1),
+        rows,
+        compressor_state_cache.shape[0],
+        num_requests,
+        COMPRESSOR_STATE_SIZE=compressor_state_cache.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=raw_keys.shape[2],
+        LOAD_ROPE_POSITIONS=load_rope_positions,
+        BLOCK_D=triton.next_power_of_2(raw_keys.shape[2]),
+        num_warps=4,
+    )
+    return pooled, first_positions
+
+
+__all__ = [
+    "expand_qsa_block_indices_cuda",
+    "qsa_compress_groups_with_ratio",
+    "qsa_mqa_paged",
+    "qsa_select_paged_tokens",
+    "qsa_sparse_paged_attention",
+    "qsa_store_cache_rows",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/ple_layer.py
+++ b/vllm_ascend/models/qwen4_exp/amd/ple_layer.py
@@ -1,0 +1,1104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU-resident Qwen4Exp position-learning enhancement layers."""
+
+import math
+from collections.abc import Iterable, Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+    is_conv_state_dim_first,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.backends.short_conv_attn import (
+    PleShortConvAttentionBackend,
+    PleShortConvAttentionMetadata,
+)
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+from ..common.ple import copy_ple_embedding_shard_
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PLE_LAYER_PRIME = 10007
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _is_prime_64(value: int) -> bool:
+    if value < 2:
+        return False
+    for prime in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37):
+        if value % prime == 0:
+            return value == prime
+    exponent = value - 1
+    shifts = 0
+    while exponent % 2 == 0:
+        exponent //= 2
+        shifts += 1
+    for base in (2, 325, 9375, 28178, 450775, 9780504, 1795265022):
+        if base % value == 0:
+            continue
+        witness = pow(base, exponent, value)
+        if witness in (1, value - 1):
+            continue
+        for _ in range(shifts - 1):
+            witness = pow(witness, 2, value)
+            if witness == value - 1:
+                break
+        else:
+            return False
+    return True
+
+
+def _nth_prime_after(start: int, count: int) -> int:
+    prime = int(start)
+    for _ in range(count):
+        candidate = prime + 1
+        if candidate <= 2:
+            prime = 2
+            continue
+        if candidate % 2 == 0:
+            candidate += 1
+        while not _is_prime_64(candidate):
+            candidate += 2
+        prime = candidate
+    return prime
+
+
+class Qwen4ExpPLEGroupedNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        group_size: int | None,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        if group_size is not None and hidden_size % group_size:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by "
+                f"group_size ({group_size})"
+            )
+        self.eps = eps
+        self.group_size = group_size
+        self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.float()
+        if self.group_size is None:
+            variance = hidden_states.square().mean(dim=-1, keepdim=True)
+            normalized = hidden_states * torch.rsqrt(variance + self.eps)
+        else:
+            grouped = hidden_states.unflatten(
+                -1, (hidden_states.shape[-1] // self.group_size, self.group_size)
+            )
+            variance = grouped.square().mean(dim=-1, keepdim=True)
+            normalized = (grouped * torch.rsqrt(variance + self.eps)).flatten(-2)
+        return (normalized * (1.0 + self.weight.float())).to(input_dtype)
+
+
+class Qwen4ExpNGramEmbedding(nn.Module):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        embedding_dim: int,
+        ple_dense_layer_id: int,
+        max_total_tokens: int,
+        max_num_reqs: int,
+        prefix: str,
+        layer_name: str,
+    ) -> None:
+        super().__init__()
+        self.embedding_dim = embedding_dim
+        self.layer_name = layer_name
+        self.ngram_size = int(config.ngram_size)
+        self.heads_per_ngram = int(config.heads_per_ngram)
+        self.ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ngram_size < 2:
+            raise ValueError(f"ngram_size must be >= 2, got {self.ngram_size}")
+        if self.heads_per_ngram <= 0:
+            raise ValueError(f"heads_per_ngram must be > 0, got {self.heads_per_ngram}")
+        if embedding_dim % self.ngram_heads:
+            raise ValueError(
+                "ple_embed_dim must be divisible by total ngram heads: "
+                f"{embedding_dim} % {self.ngram_heads} != 0"
+            )
+        self.head_dim = embedding_dim // self.ngram_heads
+        self.eos_token_id = int(config.eos_token_id)
+        self.unigram_vocab_size = int(config.vocab_size)
+        self.split_ngram_parts = int(getattr(config, "split_ngram_parts", 512))
+        if self.split_ngram_parts <= 0:
+            raise ValueError("split_ngram_parts must be positive")
+
+        max_multiplier = ((1 << 63) - 1) // self.unigram_vocab_size
+        half_bound = max(1, max_multiplier // 2)
+        seed = int(getattr(config, "seed", 1234))
+        base_seed = seed + _PLE_LAYER_PRIME * ple_dense_layer_id
+        multipliers = []
+        for index in range(self.ngram_size):
+            value = base_seed + _SPLITMIX_GAMMA * (index + 1)
+            multipliers.append(2 * (_splitmix64(value) % half_bound) + 1)
+        self.register_buffer(
+            "layer_multipliers",
+            torch.tensor(multipliers, dtype=torch.long),
+            persistent=True,
+        )
+
+        ngram_vocab_size_base = int(config.ngram_vocab_size_base)
+        sizes: list[int] = []
+        offsets: list[int] = []
+        offset = 0
+        for local_head in range(self.ngram_heads):
+            global_head = ple_dense_layer_id * self.ngram_heads + local_head
+            size = _nth_prime_after(ngram_vocab_size_base - 1, global_head + 1)
+            sizes.append(size)
+            offsets.append(offset)
+            offset += size
+        self.register_buffer(
+            "ngram_heads_vocab_sizes",
+            torch.tensor(sizes, dtype=torch.long),
+            persistent=True,
+        )
+        self.register_buffer(
+            "ngram_heads_offsets",
+            torch.tensor(offsets, dtype=torch.long),
+            persistent=True,
+        )
+        divisor = int(config.make_ngram_vocab_size_divisible_by)
+        padded_vocab_size = ((offset + divisor - 1) // divisor) * divisor
+        self.ngram_embedding = VocabParallelEmbedding(
+            padded_vocab_size,
+            self.head_dim,
+            padding_size=divisor,
+            prefix=f"{prefix}.ngram_embedding",
+        )
+        self.register_buffer(
+            "positions_buffer",
+            torch.arange(max_total_tokens, dtype=torch.int64),
+            persistent=False,
+        )
+        self.register_buffer(
+            "padded_buffer",
+            torch.full(
+                (max_num_reqs, max_total_tokens),
+                self.eos_token_id,
+                dtype=torch.int64,
+            ),
+            persistent=False,
+        )
+
+    @staticmethod
+    def _shift_precompute(
+        tokens: torch.Tensor, eos_token_id: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if tokens.dim() != 2:
+            raise ValueError("tokens must be a 2D tensor")
+        batch_size, seq_len = tokens.shape
+        positions = torch.arange(seq_len, device=tokens.device, dtype=torch.int64)
+        eos_positions = torch.where(tokens == eos_token_id, positions, -1)
+        previous_eos_inclusive = torch.cummax(eos_positions, dim=1).values
+        previous_eos = torch.cat(
+            [
+                eos_positions.new_full((batch_size, 1), -1),
+                previous_eos_inclusive[:, :-1],
+            ],
+            dim=1,
+        )
+        return positions, positions.unsqueeze(0) - previous_eos - 1
+
+    @staticmethod
+    def _shift_apply(
+        tokens: torch.Tensor,
+        positions: torch.Tensor,
+        position_in_segment: torch.Tensor,
+        shift: int,
+        eos_token_id: int,
+    ) -> torch.Tensor:
+        if shift == 0:
+            return tokens
+        source = positions - shift
+        gather_indices = source.clamp_min(0).unsqueeze(0).expand(tokens.shape[0], -1)
+        shifted = tokens.gather(1, gather_indices)
+        valid = (source.unsqueeze(0) >= 0) & (position_in_segment >= shift)
+        return torch.where(valid, shifted, tokens.new_full((), eos_token_id))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1).long()
+        query_start_loc = query_start_loc.long()
+        num_reqs = query_start_loc.numel() - 1
+        num_tokens = input_ids.shape[0]
+        if num_tokens > self.positions_buffer.numel():
+            raise ValueError(
+                f"PLE received {num_tokens} tokens, but its workspace supports "
+                f"at most {self.positions_buffer.numel()}"
+            )
+        if num_reqs > self.padded_buffer.shape[0]:
+            raise ValueError(
+                f"PLE received {num_reqs} requests, but its workspace supports "
+                f"at most {self.padded_buffer.shape[0]}"
+            )
+
+        positions = self.positions_buffer[:num_tokens]
+        packed = self.padded_buffer[:num_reqs]
+        packed.fill_(self.eos_token_id)
+        request_indices = torch.searchsorted(query_start_loc, positions, right=True) - 1
+        request_indices.clamp_(max=num_reqs - 1)
+        columns = (positions - query_start_loc[request_indices]).clamp(
+            0, packed.shape[1] - 1
+        )
+        packed[request_indices, columns] = input_ids
+        ngram_context = ngram_context[:num_reqs].to(
+            device=input_ids.device, dtype=torch.long
+        )
+
+        context = torch.cat([ngram_context, packed], dim=-1)
+        positions_2d, position_in_segment = self._shift_precompute(
+            context, self.eos_token_id
+        )
+        shifted = [context]
+        for shift in range(1, self.ngram_size):
+            shifted.append(
+                self._shift_apply(
+                    context,
+                    positions_2d,
+                    position_in_segment,
+                    shift,
+                    self.eos_token_id,
+                )
+            )
+        adjusted_columns = columns + self.ngram_size - 1
+        id_blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed = shifted[0] * self.layer_multipliers[0]
+            for index in range(1, ngram):
+                mixed = torch.bitwise_xor(
+                    mixed, shifted[index] * self.layer_multipliers[index]
+                )
+            sizes = self.ngram_heads_vocab_sizes[start:end]
+            offsets = self.ngram_heads_offsets[start:end]
+            ids = torch.remainder(mixed.unsqueeze(-1), sizes) + offsets
+            id_blocks.append(ids[request_indices, adjusted_columns])
+        ngram_ids = torch.cat(id_blocks, dim=-1)
+        output = ngram_ids.new_empty(
+            (ngram_ids.shape[0], self.embedding_dim),
+            dtype=self.ngram_embedding.params_dtype,
+        )
+        torch.ops.vllm.qwen4_exp_amd_ple_ngram_embedding(
+            ngram_ids,
+            output,
+            self.layer_name,
+        )
+        return output
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load hash buffers and checkpoint-split embedding rows."""
+
+        persistent_buffers = {
+            "layer_multipliers": self.layer_multipliers,
+            "ngram_heads_offsets": self.ngram_heads_offsets,
+            "ngram_heads_vocab_sizes": self.ngram_heads_vocab_sizes,
+        }
+        loaded: set[str] = set()
+        regular_weights: list[tuple[str, torch.Tensor]] = []
+        shard_prefix = "ngram_embedding.shard_"
+
+        for name, loaded_weight in weights:
+            leaf_name = name.rsplit(".", 1)[-1]
+            if leaf_name.startswith("hashstats_") or leaf_name == "token_lookup":
+                continue
+            if name in persistent_buffers:
+                buffer = persistent_buffers[name]
+                if buffer.shape != loaded_weight.shape:
+                    raise ValueError(
+                        f"Shape mismatch for {name}: expected "
+                        f"{tuple(buffer.shape)}, got {tuple(loaded_weight.shape)}"
+                    )
+                buffer.copy_(loaded_weight.to(device=buffer.device, dtype=buffer.dtype))
+                loaded.add(name)
+                continue
+            if name.startswith(shard_prefix) and name.endswith(".weight"):
+                shard_text = name[len(shard_prefix) : -len(".weight")]
+                if not shard_text.isdigit():
+                    regular_weights.append((name, loaded_weight))
+                    continue
+                shard_index = int(shard_text)
+                if shard_index >= self.split_ngram_parts:
+                    raise ValueError(
+                        f"PLE embedding shard index {shard_index} exceeds "
+                        f"split_ngram_parts={self.split_ngram_parts}"
+                    )
+                embedding = self.ngram_embedding
+                shard_size = (
+                    embedding.org_vocab_size + self.split_ngram_parts - 1
+                ) // self.split_ngram_parts
+                checkpoint_start = shard_index * shard_size
+                expected_rows = max(
+                    0,
+                    min(shard_size, embedding.org_vocab_size - checkpoint_start),
+                )
+                expected_shape = (expected_rows, embedding.embedding_dim)
+                if tuple(loaded_weight.shape) != expected_shape:
+                    raise ValueError(
+                        f"Shape mismatch for PLE embedding shard {shard_index}: "
+                        f"expected {expected_shape}, got "
+                        f"{tuple(loaded_weight.shape)}"
+                    )
+                copy_ple_embedding_shard_(
+                    embedding.weight.data,
+                    loaded_weight,
+                    checkpoint_start=checkpoint_start,
+                    tp_start=embedding.shard_indices.org_vocab_start_index,
+                    tp_end=embedding.shard_indices.org_vocab_end_index,
+                )
+                loaded.add("ngram_embedding.weight")
+                continue
+            regular_weights.append((name, loaded_weight))
+
+        if regular_weights:
+            loaded.update(AutoWeightsLoader(self).load_weights(regular_weights))
+        return loaded
+
+
+class Qwen4ExpPLELayer(nn.Module, MambaBase):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        vllm_config: VllmConfig,
+        layer_idx: int = 0,
+        ple_dense_layer_id: int | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.model_config: ModelConfig = model_config
+        self.cache_config: CacheConfig = cache_config
+        self.layer_idx = layer_idx
+        self.ple_dense_layer_id = (
+            int(ple_dense_layer_id)
+            if ple_dense_layer_id is not None
+            else int(layer_idx)
+        )
+        self.prefix = prefix
+        self.hidden_size = int(config.hidden_size)
+        self.hc_count = config.hc_count
+        self.hc_hidden_size = self.hidden_size * self.hc_count
+        self.conv_kernel_size = int(config.ple_conv_kernel_size)
+        self.short_conv_dilation = int(config.ngram_size)
+        self.conv_state_len = (self.conv_kernel_size - 1) * self.short_conv_dilation
+        self.num_spec_tokens = vllm_config.num_speculative_tokens
+        self.activation = "silu"
+        self.ple_embedding: nn.Module = Qwen4ExpNGramEmbedding(
+            config,
+            int(config.ple_embed_dim),
+            self.ple_dense_layer_id,
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            vllm_config.scheduler_config.max_num_seqs,
+            f"{prefix}.ple_embedding",
+            prefix,
+        )
+        self.key_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hc_hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.key_proj",
+        )
+        self.value_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.value_proj",
+        )
+        norm_args = (
+            self.hc_hidden_size,
+            config.rms_norm_eps,
+            self.hidden_size,
+            model_config.dtype,
+        )
+        self.norm_key = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_query = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_conv = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.conv1d = nn.Conv1d(
+            self.hc_hidden_size,
+            self.hc_hidden_size,
+            self.conv_kernel_size,
+            groups=self.hc_hidden_size,
+            padding=self.conv_state_len,
+            dilation=self.short_conv_dilation,
+            bias=False,
+            dtype=model_config.dtype,
+        )
+        nn.init.zeros_(self.conv1d.weight)
+        self.conv1d.weight._no_reinit = True
+        self.kv_cache = (torch.tensor([]),)
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    @property
+    def mamba_type(self) -> MambaAttentionBackendEnum:
+        return MambaAttentionBackendEnum.SHORT_CONV
+
+    @property
+    def is_kv_cache_tp_replicated(self) -> bool:
+        return True
+
+    def get_attn_backend(self) -> type[PleShortConvAttentionBackend]:
+        return PleShortConvAttentionBackend
+
+    def get_state_dtype(self) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            self.model_config.dtype, self.cache_config.mamba_cache_dtype
+        )
+
+    def get_state_shape(self) -> Sequence[tuple[int, ...]]:
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=self.hc_hidden_size,
+            conv_kernel=self.conv_state_len + 1,
+            num_spec=self.num_spec_tokens,
+        )
+
+    def _apply_norm(
+        self, norm: Qwen4ExpPLEGroupedNorm, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        shape = hidden_states.shape
+        return norm(hidden_states.flatten(-2)).reshape(shape)
+
+    def _short_conv_fallback(self, inputs: torch.Tensor) -> torch.Tensor:
+        # Profiling / CUDA graph capture only; conv state is not updated.
+        inputs_t = inputs.transpose(0, 1).unsqueeze(0)
+        output = self.conv1d(inputs_t)[..., : inputs_t.size(-1)]
+        return F.silu(output).squeeze(0).transpose(0, 1)
+
+    def _short_conv_dilated_decode_batched(
+        self,
+        x_d: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_d: torch.Tensor,
+        has_initial_states_d: torch.Tensor | None,
+    ) -> torch.Tensor:
+        state_indices = state_indices_tensor_d.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        # TODO: need double-check
+        # FULL cudagraph padded decode rows use NULL_BLOCK_ID. Remap them to
+        # slot 0 for a safe gather, then zero output and skip write-back.
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        if has_initial_states_d is None:
+            has_initial_state = valid_state
+        else:
+            if has_initial_states_d.numel() < state_indices_tensor_d.numel():
+                raise ValueError(
+                    "has_initial_states_d size mismatch: "
+                    f"got {has_initial_states_d.numel()}, "
+                    f"need >= {state_indices_tensor_d.numel()}."
+                )
+            has_initial_state = has_initial_states_d[
+                : state_indices_tensor_d.numel()
+            ].to(device=conv_state.device, dtype=torch.bool)
+            has_initial_state = has_initial_state & valid_state
+
+        cached_state = conv_state.index_select(0, state_indices)
+        state = cached_state[..., : self.conv_state_len].to(x_d.dtype)
+        if self.conv_state_len > 0:
+            initial_state = torch.where(
+                has_initial_state.view(-1, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, x_d.unsqueeze(-1)), dim=-1)
+        else:
+            history = x_d.unsqueeze(-1)
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        ).squeeze(-1)
+        output = F.silu(conv_output)
+        output = output * valid_state.view(-1, 1).to(output.dtype)
+
+        if self.conv_state_len > 0:
+            next_state = history[..., -self.conv_state_len :]
+            # Padded rows are remapped to the reserved null slot. Preserve its
+            # existing value while writing the new states for valid rows.
+            existing_base_state = cached_state[..., : self.conv_state_len]
+            safe_next_state = torch.where(
+                valid_state.view(-1, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            cached_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_prefill_batched(
+        self,
+        x_p: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_p: torch.Tensor,
+        num_prefills: int,
+        num_decode_tokens: int,
+        num_prefill_tokens: int,
+    ) -> torch.Tensor:
+        # ``non_spec_query_start_loc`` covers the non-spec (decode + prefill)
+        # requests and equals ``query_start_loc`` when spec-decode is inactive.
+        non_spec_query_start_loc = metadata.non_spec_query_start_loc
+        if non_spec_query_start_loc is None:
+            raise ValueError("query_start_loc is required for prefill short-conv")
+        query_start_loc_p = (
+            non_spec_query_start_loc[-num_prefills - 1 :] - num_decode_tokens
+        )
+        # The metadata builder guarantees that the prefill query offsets start
+        # at 0 and end at num_prefill_tokens. Avoid reading those values here,
+        # since doing so would force a device-to-host synchronization.
+        has_initial_states_p = metadata.has_initial_states_p
+        if has_initial_states_p is None:
+            raise ValueError("has_initial_states_p is required for prefill short-conv")
+
+        output = torch.empty_like(x_p)
+        q_starts = query_start_loc_p.to(torch.int64)
+        if state_indices_tensor_p.numel() < num_prefills:
+            raise ValueError(
+                "state_indices_tensor_p size mismatch: "
+                f"got {state_indices_tensor_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if has_initial_states_p.numel() < num_prefills:
+            raise ValueError(
+                "has_initial_states_p size mismatch: "
+                f"got {has_initial_states_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if num_prefills == 0 or x_p.numel() == 0:
+            return output
+        lengths = q_starts[1:] - q_starts[:-1]
+        # Use the CPU-computed packing width from the metadata builder instead
+        # of synchronizing on lengths.max().
+        max_len = metadata.max_prefill_query_len
+        if max_len <= 0:
+            return output
+
+        hidden_size = x_p.shape[1]
+        positions = torch.arange(
+            num_prefill_tokens, device=x_p.device, dtype=torch.int64
+        )
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        col_indices = positions - q_starts[req_indices]
+
+        packed_tokens = x_p.new_zeros((num_prefills, max_len, hidden_size))
+        packed_tokens[req_indices, col_indices] = x_p
+        packed_tokens = packed_tokens.transpose(1, 2).contiguous()
+
+        state_indices = state_indices_tensor_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        has_initial = has_initial_states_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.bool
+        )
+        if self.conv_state_len > 0:
+            if conv_state.shape[0] == 0:
+                state = conv_state.new_zeros(
+                    (num_prefills, hidden_size, self.conv_state_len),
+                    dtype=x_p.dtype,
+                )
+            else:
+                state = conv_state.index_select(0, state_indices)[
+                    ..., : self.conv_state_len
+                ].to(x_p.dtype)
+            use_initial_mask = (valid_state & has_initial).view(num_prefills, 1, 1)
+            initial_state = torch.where(
+                use_initial_mask,
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, packed_tokens), dim=-1)
+        else:
+            history = packed_tokens
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        token_positions = torch.arange(max_len, device=x_p.device, dtype=torch.int64)
+        valid_tokens = token_positions.view(1, max_len) < lengths.view(num_prefills, 1)
+        valid_output_mask = valid_tokens & valid_state.to(device=x_p.device).view(
+            num_prefills, 1
+        )
+        conv_output.masked_fill_(~valid_output_mask.unsqueeze(-1), 0)
+        output.copy_(conv_output[req_indices, col_indices])
+
+        if self.conv_state_len > 0 and conv_state.shape[0] > 0:
+            state_starts = lengths.to(device=history.device, dtype=torch.int64).view(
+                num_prefills, 1, 1
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=history.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            next_state = history.gather(
+                dim=2,
+                index=(state_starts + state_offsets).expand(-1, history.size(1), -1),
+            )
+            # Write back without a host synchronization. Valid, non-empty rows
+            # receive their new state; padding and zero-length rows keep the
+            # current cache value.
+            existing_state = conv_state.index_select(0, state_indices)
+            existing_base_state = existing_state[..., : self.conv_state_len]
+            update_mask = valid_state & (lengths.to(device=conv_state.device) > 0)
+            safe_next_state = torch.where(
+                update_mask.view(num_prefills, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            existing_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, existing_state)
+        return output
+
+    def _short_conv_dilated_spec_batched(
+        self,
+        x_spec: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        spec_state_indices_tensor: torch.Tensor,
+        spec_query_start_loc: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        spec_query_len: int,
+    ) -> torch.Tensor:
+        """Dilated short-conv for speculative-decode (MTP) requests.
+
+        Each spec request feeds multiple (draft + 1) query tokens. The conv
+        outputs are computed causally after rolling back the previous draft
+        state by ``num_accepted_tokens - 1``. The current candidate inputs stay
+        in the extended cache for the next forward, matching
+        ``causal_conv1d_update``.
+
+        ``spec_query_len`` (== num_speculative_tokens + 1) is the maximum query
+        length and is a Python int, so no host synchronization is needed; this
+        keeps the path safe for full CUDA-graph capture/replay where the buffers
+        are padded at the request level.
+        """
+        num_reqs = spec_state_indices_tensor.numel()
+        hidden_size = x_spec.size(-1)
+        # Use a fixed packing width instead of synchronizing on lengths.max().
+        max_len = spec_query_len
+        # Full CUDA graphs can pad these buffers. Only the first num_reqs
+        # accepted-token counts belong to actual speculative requests.
+        num_accepted_tokens = num_accepted_tokens[:num_reqs]
+        q_starts = spec_query_start_loc[: num_reqs + 1].to(torch.int64)
+        # Keep the number of real speculative tokens on the device.
+        total_real_tokens = q_starts[num_reqs]
+
+        state_indices = spec_state_indices_tensor.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        positions = torch.arange(
+            x_spec.size(0), device=x_spec.device, dtype=torch.int64
+        )
+        # Route graph-padded token rows to the discarded dummy request so that
+        # they cannot overwrite real packed data.
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        valid_tokens = (positions < total_real_tokens) & (req_indices < num_reqs)
+        clamped_req_indices = req_indices.clamp_max(max(num_reqs - 1, 0))
+        col_indices = (positions - q_starts[clamped_req_indices]).clamp_(0, max_len - 1)
+        pack_req_indices = torch.where(
+            valid_tokens,
+            clamped_req_indices,
+            torch.full_like(req_indices, num_reqs),
+        )
+        pack_col_indices = torch.where(
+            valid_tokens, col_indices, torch.zeros_like(col_indices)
+        )
+
+        # The last request row is the dummy sink for graph padding.
+        packed = x_spec.new_zeros((num_reqs + 1, max_len, hidden_size))
+        packed[pack_req_indices, pack_col_indices] = x_spec
+        packed = packed.transpose(1, 2).contiguous()
+
+        if self.conv_state_len > 0:
+            cached_state = conv_state.index_select(0, state_indices)
+            rollback_offsets = num_accepted_tokens.to(
+                device=conv_state.device, dtype=torch.int64
+            ).sub(1)
+            rollback_offsets = torch.where(
+                valid_state,
+                rollback_offsets.clamp_(0, max_len - 1),
+                torch.zeros_like(rollback_offsets),
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=conv_state.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            rollback_indices = rollback_offsets.view(-1, 1, 1) + state_offsets
+            state = cached_state.gather(
+                2, rollback_indices.expand(-1, hidden_size, -1)
+            ).to(x_spec.dtype)
+            state = torch.where(
+                valid_state.view(num_reqs, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            # Append a zeroed dummy-row state to match the [num_reqs + 1] pack.
+            dummy_state = state.new_zeros((1, hidden_size, self.conv_state_len))
+            state_full = torch.cat((state, dummy_state), dim=0)
+            history = torch.cat((state_full, packed), dim=-1)
+        else:
+            history = packed
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        output = conv_output[pack_req_indices, pack_col_indices]
+        output = output * valid_tokens.view(-1, 1).to(output.dtype)
+
+        # Keep all current candidate inputs in the extended state. On the next
+        # target forward, ``num_accepted_tokens - 1`` selects the rollback
+        # window before processing the newly scheduled tokens.
+        if self.conv_state_len > 0:
+            state_capacity = self.conv_state_len + max_len - 1
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache cannot retain speculative tokens: "
+                    f"got {conv_state.size(-1)}, need {state_capacity}."
+                )
+            candidate_state = history[:num_reqs, :, 1 : state_capacity + 1]
+            query_lengths = q_starts[1:] - q_starts[:-1]
+            state_positions = torch.arange(
+                state_capacity, device=history.device, dtype=torch.int64
+            ).view(1, 1, state_capacity)
+            update_lengths = (self.conv_state_len + query_lengths - 1).view(
+                num_reqs, 1, 1
+            )
+            update_mask = valid_state.view(num_reqs, 1, 1) & (
+                state_positions < update_lengths
+            )
+            existing_state = cached_state[..., :state_capacity]
+            next_state = torch.where(
+                update_mask,
+                candidate_state.to(conv_state.dtype),
+                existing_state,
+            )
+            cached_state[..., :state_capacity] = next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_dispatch(
+        self,
+        inputs: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        num_prefills = metadata.num_prefills
+        num_decodes = metadata.num_decodes
+        num_decode_tokens = metadata.num_decode_tokens
+        num_prefill_tokens = metadata.num_prefill_tokens
+        has_prefill = num_prefills > 0
+        has_decode = num_decodes > 0
+        has_spec = metadata.spec_sequence_masks is not None
+        x = inputs[: metadata.num_actual_tokens]
+
+        # Split spec / non-spec tokens.
+        if has_spec:
+            if has_prefill or has_decode:
+                assert metadata.spec_token_indx is not None
+                assert metadata.non_spec_token_indx is not None
+                x_spec = x.index_select(0, metadata.spec_token_indx.long())
+                x_non_spec = x.index_select(0, metadata.non_spec_token_indx.long())
+            else:
+                x_spec = x
+                x_non_spec = None
+        else:
+            x_spec = None
+            x_non_spec = x
+
+        spec_output = None
+        # 1. Run the multi-query speculative-decode part.
+        if has_spec:
+            assert metadata.spec_state_indices_tensor is not None
+            assert metadata.spec_query_start_loc is not None
+            assert metadata.num_accepted_tokens is not None
+            spec_output = self._short_conv_dilated_spec_batched(
+                x_spec=x_spec,
+                conv_state=conv_state,
+                conv_weights=conv_weights,
+                spec_state_indices_tensor=metadata.spec_state_indices_tensor[
+                    : metadata.num_spec_decodes
+                ],
+                spec_query_start_loc=metadata.spec_query_start_loc,
+                num_accepted_tokens=metadata.num_accepted_tokens,
+                spec_query_len=metadata.spec_query_len,
+            )
+
+        # 2. Run regular decode and prefill requests.
+        conv_out_non_spec = None
+        state_indices_tensor = metadata.state_indices_tensor
+        if x_non_spec is not None:
+            assert state_indices_tensor is not None
+            if has_prefill:
+                state_indices_tensor_d, state_indices_tensor_p = torch.split(
+                    state_indices_tensor,
+                    [num_decodes, num_prefills],
+                    dim=0,
+                )
+                x_d, x_p = torch.split(
+                    x_non_spec,
+                    [num_decode_tokens, num_prefill_tokens],
+                    dim=0,
+                )
+                non_spec_parts: list[torch.Tensor] = []
+                if has_decode:
+                    non_spec_parts.append(
+                        self._short_conv_dilated_decode_batched(
+                            x_d=x_d,
+                            conv_state=conv_state,
+                            conv_weights=conv_weights,
+                            state_indices_tensor_d=state_indices_tensor_d,
+                            has_initial_states_d=metadata.has_initial_states_d,
+                        )
+                    )
+                non_spec_parts.append(
+                    self._short_conv_dilated_prefill_batched(
+                        x_p=x_p,
+                        metadata=metadata,
+                        conv_state=conv_state,
+                        conv_weights=conv_weights,
+                        state_indices_tensor_p=state_indices_tensor_p,
+                        num_prefills=num_prefills,
+                        num_decode_tokens=num_decode_tokens,
+                        num_prefill_tokens=num_prefill_tokens,
+                    )
+                )
+                conv_out_non_spec = torch.vstack(non_spec_parts)
+            else:
+                conv_out_non_spec = self._short_conv_dilated_decode_batched(
+                    x_d=x_non_spec,
+                    conv_state=conv_state,
+                    conv_weights=conv_weights,
+                    state_indices_tensor_d=state_indices_tensor[: x_non_spec.size(0)],
+                    has_initial_states_d=metadata.has_initial_states_d,
+                )
+
+        # 3. Merge both parts back into the original token order.
+        if has_spec and conv_out_non_spec is not None:
+            assert metadata.spec_token_indx is not None
+            assert metadata.non_spec_token_indx is not None
+            assert spec_output is not None
+            output = x.new_empty((metadata.num_actual_tokens, x.size(-1)))
+            output.index_copy_(0, metadata.spec_token_indx, spec_output)
+            output.index_copy_(0, metadata.non_spec_token_indx, conv_out_non_spec)
+            return output
+        elif has_spec:
+            assert spec_output is not None
+            return spec_output
+        if conv_out_non_spec is None:
+            return x
+        return conv_out_non_spec
+
+    def _short_conv(self, inputs: torch.Tensor) -> torch.Tensor:
+        forward_context = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            return self._short_conv_fallback(inputs)
+
+        if not isinstance(attn_metadata, dict):
+            raise RuntimeError(
+                "PLE short-conv expects per-layer attention metadata dict "
+                f"during inference, got {type(attn_metadata).__name__}."
+            )
+
+        layer_attn_metadata = attn_metadata.get(self.prefix)
+        if layer_attn_metadata is None:
+            raise RuntimeError(
+                f"Missing short-conv metadata for layer '{self.prefix}'. "
+                "This would bypass conv-state updates and is not allowed."
+            )
+        if not isinstance(layer_attn_metadata, PleShortConvAttentionMetadata):
+            raise TypeError(
+                "Expected PleShortConvAttentionMetadata for layer "
+                f"'{self.prefix}', got "
+                f"{type(layer_attn_metadata).__name__}."
+            )
+
+        conv_state = self.kv_cache[0]
+        if not is_conv_state_dim_first():
+            conv_state = conv_state.transpose(-1, -2)
+        conv_weights = self.conv1d.weight.squeeze(1)
+
+        state_capacity = self.conv_state_len + self.num_spec_tokens
+        if state_capacity > 0:
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache is smaller than expected for "
+                    f"dilated convolution: got {conv_state.size(-1)}, "
+                    f"expect at least {state_capacity}."
+                )
+            conv_state = conv_state[..., -state_capacity:]
+        return self._short_conv_dilated_dispatch(
+            inputs,
+            layer_attn_metadata,
+            conv_state,
+            conv_weights.to(dtype=inputs.dtype),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1)
+        if input_ids.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                "PLE expects input_ids and hidden_states to have the same "
+                f"token length, got {input_ids.shape[0]} and "
+                f"{hidden_states.shape[0]}"
+            )
+        embeddings = self.ple_embedding(input_ids, query_start_loc, ngram_context)
+        key, _ = self.key_proj(embeddings)
+        value, _ = self.value_proj(embeddings)
+        token_count = hidden_states.shape[0]
+        key = key.reshape(token_count, self.hc_count, self.hidden_size)
+        query = hidden_states.reshape(token_count, self.hc_count, self.hidden_size)
+        key = self._apply_norm(self.norm_key, key)
+        query = self._apply_norm(self.norm_query, query)
+        gate = (key * query).sum(dim=-1, keepdim=True) / math.sqrt(self.hidden_size)
+        gate = torch.sigmoid(gate.sign() * gate.abs().clamp_min(1e-6).sqrt())
+        gated_value = gate * value.unsqueeze(-2)
+        normalized = self._apply_norm(self.norm_conv, gated_value).flatten(-2)
+        conv_output = torch.zeros_like(normalized)
+        torch.ops.vllm.qwen4_exp_ple_short_conv(
+            normalized,
+            conv_output,
+            self.prefix,
+        )
+        return gated_value.flatten(-2) + conv_output
+
+
+def qwen4_exp_amd_ple_ngram_embedding(
+    ngram_ids: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Run the large PLE embedding lookup outside Inductor's FX graph.
+
+    Keeping the embedding weight in ``static_forward_context`` prevents AOT
+    compile-time autotuning from materializing a synthetic copy of the weight.
+    """
+    layer = get_forward_context().no_compile_layers[layer_name]
+    if not isinstance(layer, Qwen4ExpPLELayer):
+        raise TypeError(f"{layer_name} is not a Qwen4Exp PLE owner")
+    result = layer.ple_embedding.ngram_embedding(ngram_ids).flatten(-2)
+    output.copy_(result)
+
+
+def qwen4_exp_amd_ple_ngram_embedding_fake(
+    ngram_ids: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+def qwen4_exp_ple_short_conv(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    layer = get_forward_context().no_compile_layers[layer_name]
+    result = layer._short_conv(inputs)
+    output[: result.shape[0]].copy_(result)
+
+
+def qwen4_exp_ple_short_conv_fake(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_amd_ple_ngram_embedding",
+    op_func=qwen4_exp_amd_ple_ngram_embedding,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_amd_ple_ngram_embedding_fake,
+)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_ple_short_conv",
+    op_func=qwen4_exp_ple_short_conv,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_ple_short_conv_fake,
+)
+
+
+__all__ = [
+    "Qwen4ExpNGramEmbedding",
+    "Qwen4ExpPLEGroupedNorm",
+    "Qwen4ExpPLELayer",
+]

--- a/vllm_ascend/models/qwen4_exp/amd/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/amd/qsa.py
@@ -1,0 +1,468 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""AMD ROCm QSA owner with Triton kernels."""
+
+from __future__ import annotations
+
+from typing import ClassVar, cast
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.attention.attention import (
+    set_default_quant_scales,
+)
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import get_rope
+from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
+from vllm.platforms import current_platform
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    canonicalize_singleton_dim_strides,
+    direct_register_custom_op,
+    kv_cache_dtype_str_to_dtype,
+)
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionType,
+)
+from vllm.v1.attention.backends.fa_utils import is_flash_attn_varlen_func_available
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionImpl,
+    FlashAttentionMetadata,
+    FlashAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    get_kv_quant_mode,
+)
+
+from ..common.qsa_cache import QSAForwardMetadata
+from . import model
+from .indexer_qsa import QSAIndexer
+
+
+class Qwen4ExpQSAMetadataBuilder(FlashAttentionMetadataBuilder):
+    """Flash metadata supporting uniform decode and target-verify graphs."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
+    """FullAttentionSpec backend used by the merged QSA owner."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "QWEN4_EXP_QSA_TRITON"
+
+    @staticmethod
+    def get_impl_cls() -> type[Qwen4ExpQSAFlashAttentionImpl]:
+        return Qwen4ExpQSAFlashAttentionImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[Qwen4ExpQSAMetadataBuilder]:
+        return Qwen4ExpQSAMetadataBuilder
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_kv_connector(cls) -> bool:
+        return False
+
+
+class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
+    """Run paged sparse GQA with the QSA Triton kernel."""
+
+    supports_dcp: bool = False
+    supports_pcp: bool = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if not is_flash_attn_varlen_func_available():
+            raise NotImplementedError("Qwen4Exp QSA requires FlashAttention")
+        if self.dcp_world_size != 1:
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support decode context parallelism"
+            )
+        if self.kv_cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        self.supports_quant_query_input = False
+
+    def forward_qsa(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        output: torch.Tensor,
+        token_to_req: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del key, value
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError("QSA does not support fused output quantization")
+        if self.alibi_slopes is not None or self.sinks is not None:
+            raise NotImplementedError("QSA does not support ALiBi or attention sinks")
+        if self.sliding_window != (-1, -1):
+            raise NotImplementedError("QSA does not support sliding-window attention")
+
+        num_tokens = attn_metadata.num_actual_tokens
+        output.zero_()
+        if num_tokens == 0:
+            return output
+
+        topk_buffer = getattr(layer, "topk_indices_buffer", None)
+        if topk_buffer is None:
+            raise RuntimeError("QSA owner did not provide its top-k buffer")
+        logical_indices = topk_buffer[:num_tokens]
+        token_to_req = token_to_req[:num_tokens]
+        key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
+        key_cache = canonicalize_singleton_dim_strides(key_cache)
+        value_cache = canonicalize_singleton_dim_strides(value_cache)
+        if key_cache.dtype != torch.bfloat16 or query.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 Q/K/V")
+
+        from .ops.qsa import qsa_sparse_paged_attention
+
+        qsa_sparse_paged_attention(
+            query[:num_tokens],
+            key_cache,
+            value_cache,
+            logical_indices,
+            attn_metadata.block_table,
+            token_to_req,
+            output[:num_tokens],
+        )
+        return output
+
+
+class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
+    """Merged Qwen full-attention owner with a QSA index side branch."""
+
+    supports_dcp = False
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        cache_config = vllm_config.cache_config
+        model_config = vllm_config.model_config
+        if cache_config is None:
+            raise ValueError("Qwen4Exp QSA requires a paged KV cache")
+        if model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+        if cache_config.cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if getattr(quant_config, "kv_cache_scheme", None) is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support KV quantization")
+        parallel_config = vllm_config.parallel_config
+        if (
+            parallel_config.prefill_context_parallel_size > 1
+            or parallel_config.decode_context_parallel_size > 1
+        ):
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support context parallelism"
+            )
+        if not getattr(config, "is_causal", True):
+            raise NotImplementedError("Qwen4Exp QSA requires causal decoder attention")
+
+        self.config = config
+        self.hidden_size = int(config.hidden_size)
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = int(config.num_attention_heads)
+        if self.total_num_heads % tp_size:
+            raise ValueError("QSA attention heads must be divisible by TP size")
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = int(config.num_key_value_heads)
+        if self.total_num_kv_heads >= tp_size:
+            if self.total_num_kv_heads % tp_size:
+                raise ValueError("QSA KV heads must be divisible by TP size")
+        elif tp_size % self.total_num_kv_heads:
+            raise ValueError("TP size must be divisible by replicated QSA KV heads")
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = int(config.head_dim or self.hidden_size // self.num_heads)
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.dual_chunk_attention_config = getattr(
+            config, "dual_chunk_attention_config", None
+        )
+        if self.dual_chunk_attention_config is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support dual-chunk RoPE")
+        # Qwen4Exp full-attention checkpoints always pack a sigmoid output
+        # gate next to Q, even when an inherited config default says otherwise.
+        self.attn_output_gate = True
+
+        self.qkv_proj = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads * (1 + self.attn_output_gate),
+            self.total_num_kv_heads,
+            bias=False,
+            quant_config=model.without_modelopt_fp4(quant_config),
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=False,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            max_position=config.max_position_embeddings,
+            rope_parameters=config.rope_parameters,
+        )
+        self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+        mm_config = model_config.multimodal_config
+        text_only = mm_config is None or mm_config.language_model_only
+        self.use_fused_qk_norm_rope_gate = (
+            self.attn_output_gate
+            and getattr(self.rotary_emb, "is_neox_style", False)
+            and current_platform.is_cuda()
+            and text_only
+        )
+
+        self.layer_name = f"{prefix}.attn"
+        self.attn_type = AttentionType.DECODER
+        self.kv_cache_dtype = cache_config.cache_dtype
+        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
+            self.kv_cache_dtype, model_config
+        )
+        if self.kv_cache_torch_dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 cache storage")
+        self.kv_sharing_target_layer_name = None
+        self.kv_cache = torch.tensor([])
+        set_default_quant_scales(self, register_buffer=True)
+
+        self.attn_backend = Qwen4ExpQSAFlashAttentionBackend
+        self.impl = Qwen4ExpQSAFlashAttentionImpl(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+            None,
+            None,
+            self.kv_cache_dtype,
+            None,
+            AttentionType.DECODER,
+            None,
+        )
+        self.indexer = QSAIndexer(
+            vllm_config=vllm_config,
+            config=config,
+            layer_id=layer_id,
+            rotary_emb=self.rotary_emb,
+            quant_config=quant_config,
+            prefix=f"{prefix}.indexer",
+        )
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.register_buffer(
+            "topk_indices_buffer",
+            torch.empty(
+                max_tokens,
+                self.indexer.output_width,
+                dtype=torch.int32,
+            ),
+            persistent=False,
+        )
+
+        static_context = vllm_config.compilation_config.static_forward_context
+        if self.layer_name in static_context:
+            raise ValueError(f"Duplicate layer name: {self.layer_name}")
+        static_context[self.layer_name] = self
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.attn_backend
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return FullAttentionSpec(
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.head_dim,
+            dtype=self.kv_cache_torch_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
+    def _run_qsa(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            output.zero_()
+            return
+        main_metadata = cast(FlashAttentionMetadata, metadata[self.layer_name])
+        if self.kv_cache.numel() == 0:
+            raise RuntimeError("QSA main K/V cache is not bound")
+
+        num_tokens = main_metadata.num_actual_tokens
+        side_metadata = cast(
+            QSAForwardMetadata,
+            metadata[self.indexer.raw_key_cache.prefix],
+        )
+        if side_metadata.num_actual_tokens != num_tokens:
+            raise RuntimeError("QSA main and side metadata token counts disagree")
+        selected = self.indexer(
+            hidden_states,
+            positions,
+            self.topk_indices_buffer[:num_tokens],
+        )
+        if selected.shape != (
+            num_tokens,
+            self.indexer.output_width,
+        ):
+            raise RuntimeError("QSA indexer returned an invalid selection shape")
+        impl = cast(Qwen4ExpQSAFlashAttentionImpl, self.impl)
+        impl.do_kv_cache_update(
+            self,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata.slot_mapping,
+        )
+        impl.forward_qsa(
+            self,
+            query,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata,
+            output,
+            token_to_req=side_metadata.token_to_req,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v, gate = self._project_qkv_gate(qkv, positions)
+        num_tokens = hidden_states.shape[0]
+        query = q.view(num_tokens, self.num_heads, self.head_dim)
+        key = k.view(num_tokens, self.num_kv_heads, self.head_dim)
+        value = v.view(num_tokens, self.num_kv_heads, self.head_dim)
+        attn_output = torch.empty_like(query)
+        encoded_layer_name = _encode_layer_name(self.layer_name)
+        if current_platform.opaque_attention_op():
+            torch.ops.vllm.qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        else:
+            qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        flat_output = attn_output.view(num_tokens, -1)
+        if gate is not None:
+            flat_output = flat_output * torch.sigmoid(gate)
+        output, _ = self.o_proj(flat_output)
+        return output
+
+
+def qwen4_exp_qsa_with_output(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    """Run the complete QSA state/update/attend transaction."""
+
+    layer_name = _resolve_layer_name(layer_name)
+    layer = get_forward_context().no_compile_layers[layer_name]
+    if not isinstance(layer, Qwen4ExpQSAAttention):
+        raise TypeError(f"{layer_name} is not a Qwen4Exp QSA owner")
+    layer._run_qsa(
+        hidden_states,
+        positions,
+        query,
+        key,
+        value,
+        output,
+    )
+
+
+def qwen4_exp_qsa_with_output_fake(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    del hidden_states, positions, query, key, value, output, layer_name
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_qsa_with_output",
+    op_func=qwen4_exp_qsa_with_output,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_qsa_with_output_fake,
+)
+
+
+__all__ = [
+    "QSAIndexer",
+    "Qwen4ExpQSAAttention",
+    "Qwen4ExpQSAFlashAttentionBackend",
+    "Qwen4ExpQSAFlashAttentionImpl",
+    "qwen4_exp_qsa_with_output",
+]

--- a/vllm_ascend/models/qwen4_exp/common/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/common/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Common Qwen4Exp model components."""
+
+from .hyperconnection import (
+    GatedResidual,
+    GroupedGemmaRMSNorm,
+    HyperConnectionBase,
+    HyperConnectionConfig,
+)
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionBase",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/common/hyperconnection.py
+++ b/vllm_ascend/models/qwen4_exp/common/hyperconnection.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HyperConnection (Gated Residual) utilities.
+
+Implements the HyperConnection residual scheme proposed in
+"HyperConnections" (https://arxiv.org/abs/2409.19606).
+
+The two concrete variants are:
+  - ``HyperConnectionBase``  - simple average pooling across hc_count parallel
+    streams (equivalent to hyperconnection_average).
+  - ``GatedResidual``  - learnable low-rank gated mixing and injection
+    (gated_residual).
+
+Hidden states between layers have shape ``[..., HC*HS]`` with HS inner
+(HC outer, HS inner — checkpoint-native layout). The local torch
+implementation consumes the hyper input viewed as ``[..., HC, HS]``.
+
+Typical usage inside a transformer decoder layer::
+
+    self.attn_hc = GatedResidual(hc_config, role="attn")
+    self.mlp_hc = GatedResidual(hc_config, role="mlp")
+
+    hidden_states, residual = self.attn_hc.mix(hidden_states)
+    hidden_states = attention(hidden_states)
+    hidden_states = self.attn_hc.combine(hidden_states, residual)
+
+    hidden_states, residual = self.mlp_hc.mix(hidden_states)
+    hidden_states = mlp(hidden_states)
+    hidden_states = self.mlp_hc.combine(hidden_states, residual)
+"""
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+@dataclass
+class HyperConnectionConfig:
+    """Configuration shared by all HyperConnection variants."""
+
+    hc_count: int = 4
+    hidden_size: int = 64
+    params_dtype: torch.dtype = torch.bfloat16
+    mtp_hc: bool = False
+    hc_lowrank: int = 16
+    rms_norm_eps: float = 1e-6
+    hc_per_branch_norm: bool = False
+
+
+class GroupedGemmaRMSNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        group_size: int | None,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        if group_size is not None and hidden_size % group_size:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by "
+                f"group_size ({group_size})"
+            )
+        self.variance_epsilon = eps
+        self.group_size = group_size
+        self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.float()
+        if self.group_size is None:
+            variance = hidden_states.square().mean(dim=-1, keepdim=True)
+            normalized = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        else:
+            grouped = hidden_states.unflatten(
+                -1, (hidden_states.shape[-1] // self.group_size, self.group_size)
+            )
+            variance = grouped.square().mean(dim=-1, keepdim=True)
+            normalized = (
+                grouped * torch.rsqrt(variance + self.variance_epsilon)
+            ).flatten(-2)
+        return (normalized * (1.0 + self.weight.float())).to(input_dtype)
+
+
+# ---------------------------------------------------------------------------
+# Average-pooling variant
+# ---------------------------------------------------------------------------
+class HyperConnectionBase(nn.Module):
+    """Average-pooling HyperConnection (``hyperconnection_average``).
+
+    Splits the incoming ``[..., HC*HS]`` tensor (HC outer, HS inner) into
+    ``HC`` parallel streams, averages them for the block input, and
+    broadcasts the block output back to every stream.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        layer_idx: int | None = None,
+        role: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        self.layer_idx = layer_idx
+        self.role = role
+
+    @property
+    def hyper_hidden_size(self) -> int:
+        return self.hc_count * self.hidden_size
+
+    def mix(self, hyper_input: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Average the HC streams into a single block input."""
+        assert hyper_input.shape[-1] == self.hc_count * self.hidden_size
+        # [*, HC, HS] — mean over HC (dim=-2).
+        unflat = hyper_input.unflatten(-1, (self.hc_count, self.hidden_size))
+        mixed_input = unflat.mean(dim=-2)
+        return mixed_input, hyper_input
+
+    def combine(
+        self, block_output: torch.Tensor, residual: torch.Tensor
+    ) -> torch.Tensor:
+        """Broadcast the block output back to every stream."""
+        assert residual.shape[-1] == self.hc_count * self.hidden_size
+        assert block_output.shape[-1] == self.hidden_size
+        residual_reshaped = residual.unflatten(-1, (self.hc_count, self.hidden_size))
+        combined = residual_reshaped + block_output.unsqueeze(-2)
+        return combined.flatten(-2)
+
+
+# ---------------------------------------------------------------------------
+# Gated-residual variant
+# ---------------------------------------------------------------------------
+class GatedResidual(HyperConnectionBase):
+    """Gated HyperConnection with learnable low-rank mixing and injection.
+
+    ``mix()`` applies GemmaRMSNorm per HC stream and projects through a
+    low-rank sigmoid gate to produce a single block input. ``combine()``
+    injects the block output back into each stream through a learned
+    per-stream injection weight.
+
+    This implementation uses only PyTorch operators. Tensor-parallel
+    collectives are supplied by its caller.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        layer_idx: int | None = None,
+        role: str | None = None,
+        use_mix: bool = True,
+        use_combine: bool = True,
+    ) -> None:
+        super().__init__(config, layer_idx, role)
+        norm_size = (
+            self.hyper_hidden_size if config.hc_per_branch_norm else config.hidden_size
+        )
+        group_size = config.hidden_size if config.hc_per_branch_norm else None
+        # Normalize each H-sized HC stream independently while retaining a
+        # separate affine weight for every element of the HC*H layout.
+        self.hc_norm = GroupedGemmaRMSNorm(
+            norm_size,
+            eps=config.rms_norm_eps,
+            group_size=group_size,
+            dtype=config.params_dtype,
+        )
+
+        # -- raw Linear weights (checkpoint-compatible) ----------------------
+        if use_mix:
+            self.input_mix_weight_down = nn.Linear(
+                self.hyper_hidden_size,
+                config.hc_lowrank,
+                bias=False,
+                dtype=config.params_dtype,
+            )
+            self.input_mix_weight_up = nn.Linear(
+                config.hc_lowrank,
+                self.hyper_hidden_size,
+                bias=False,
+                dtype=config.params_dtype,
+            )
+        if use_combine:
+            self.block_inject_weight = nn.Linear(
+                self.hyper_hidden_size,
+                self.hc_count,
+                bias=False,
+                dtype=config.params_dtype,
+            )
+
+    def _normalize(self, hyper_input: torch.Tensor) -> torch.Tensor:
+        if self.config.hc_per_branch_norm:
+            return self.hc_norm(hyper_input)
+        return self.hc_norm(
+            hyper_input.unflatten(-1, (self.hc_count, self.hidden_size))
+        ).flatten(-2)
+
+    def mix(
+        self, hyper_input: torch.Tensor
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        """Mix: RMSNorm -> low-rank gate -> gated mean."""
+        assert hyper_input.shape[-1] == self.hc_count * self.hidden_size
+        if not hasattr(self, "input_mix_weight_down"):
+            raise RuntimeError("mix was disabled for this hyper-connection")
+        hyper_input_normed = self._normalize(hyper_input)
+        # Gate — original mix order: linear+silu then linear+sigmoid.
+        gate = F.silu(
+            F.linear(hyper_input_normed, self.input_mix_weight_down.weight)
+            / self.hc_count
+        )
+        gate = torch.sigmoid(F.linear(gate, self.input_mix_weight_up.weight)).unflatten(
+            -1, (self.hc_count, self.hidden_size)
+        )
+        mixed_input = (
+            gate * hyper_input_normed.unflatten(-1, (self.hc_count, self.hidden_size))
+        ).mean(dim=-2)
+        return mixed_input.to(hyper_input.dtype), (hyper_input, hyper_input_normed)
+
+    def combine(
+        self,
+        block_output: torch.Tensor,
+        residuals: tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+        if not hasattr(self, "block_inject_weight"):
+            raise RuntimeError("combine was disabled for this hyper-connection")
+        hyper_input, hyper_input_normed = residuals
+        assert hyper_input.shape[-1] == self.hc_count * self.hidden_size
+        assert block_output.shape[-1] == self.hidden_size
+        residual = hyper_input.unflatten(-1, (self.hc_count, self.hidden_size))
+        # The paired mix keeps its normalized hyper input so combine uses the
+        # same HC module's injection weight.
+        injection_weight = 2.0 * torch.sigmoid(
+            F.linear(hyper_input_normed, self.block_inject_weight.weight)
+            / self.hc_count
+        )
+        output = residual + block_output.unsqueeze(-2) * injection_weight.unsqueeze(-1)
+        return output.flatten(-2).to(hyper_input.dtype)
+
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionBase",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/common/ple.py
+++ b/vllm_ascend/models/qwen4_exp/common/ple.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Common Qwen4Exp PLE helpers."""
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass(frozen=True)
+class PLEShardOverlap:
+    """Source and destination slices for one checkpoint embedding shard."""
+
+    source_start: int
+    destination_start: int
+    row_count: int
+
+
+def compute_ple_shard_overlap(
+    *,
+    checkpoint_start: int,
+    checkpoint_rows: int,
+    tp_start: int,
+    tp_end: int,
+) -> PLEShardOverlap | None:
+    """Compute the overlap of a checkpoint shard and one TP vocabulary range."""
+
+    if checkpoint_start < 0 or checkpoint_rows < 0:
+        raise ValueError("checkpoint shard bounds must be non-negative")
+    if tp_start < 0 or tp_end < tp_start:
+        raise ValueError("invalid TP vocabulary range")
+    checkpoint_end = checkpoint_start + checkpoint_rows
+    overlap_start = max(checkpoint_start, tp_start)
+    overlap_end = min(checkpoint_end, tp_end)
+    if overlap_start >= overlap_end:
+        return None
+    return PLEShardOverlap(
+        source_start=overlap_start - checkpoint_start,
+        destination_start=overlap_start - tp_start,
+        row_count=overlap_end - overlap_start,
+    )
+
+
+def copy_ple_embedding_shard_(
+    destination: torch.Tensor,
+    loaded_weight: torch.Tensor,
+    *,
+    checkpoint_start: int,
+    tp_start: int,
+    tp_end: int,
+) -> int:
+    """Copy the overlapping rows of a PLE checkpoint shard into a TP table."""
+
+    if destination.ndim == 0 or loaded_weight.ndim != destination.ndim:
+        raise ValueError("destination and loaded weight must have matching ranks")
+    if destination.shape[1:] != loaded_weight.shape[1:]:
+        raise ValueError(
+            "embedding shard dimensions do not match: "
+            f"{tuple(destination.shape[1:])} != {tuple(loaded_weight.shape[1:])}"
+        )
+    if destination.shape[0] < tp_end - tp_start:
+        raise ValueError("destination does not cover the requested TP range")
+    overlap = compute_ple_shard_overlap(
+        checkpoint_start=checkpoint_start,
+        checkpoint_rows=loaded_weight.shape[0],
+        tp_start=tp_start,
+        tp_end=tp_end,
+    )
+    if overlap is None:
+        return 0
+    source = loaded_weight.narrow(0, overlap.source_start, overlap.row_count)
+    target = destination.narrow(0, overlap.destination_start, overlap.row_count)
+    with torch.no_grad():
+        target.copy_(source.to(device=target.device, dtype=target.dtype))
+    return overlap.row_count

--- a/vllm_ascend/models/qwen4_exp/common/qsa_cache.py
+++ b/vllm_ascend/models/qwen4_exp/common/qsa_cache.py
@@ -1,0 +1,816 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Paged side-cache ownership and metadata for Qwen4Exp QSA.
+
+Each QSA layer keeps a fixed circular buffer of raw index keys (the
+compressor state) and one compressed key. MRoPE models pack exact three-axis
+positions beside the raw keys; text models derive group positions from
+logical positions. The compressor state uses one block per request, while
+the compressed owner uses ``MLAAttentionSpec.compress_ratio`` so its block
+table follows the main KV-cache lifecycle. Their physical tensor storage is
+shared by the generic cache-layout planner.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from functools import cache
+from typing import ClassVar
+
+import torch
+from torch import nn
+
+from vllm.config import CacheConfig, VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionMetadata,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
+    CircularBufferSpec,
+    KVCacheSpec,
+    MLAAttentionSpec,
+)
+
+
+def canonical_qsa_rope_positions(positions: torch.Tensor) -> torch.Tensor:
+    """Return exact per-token positions as ``[tokens, 1, 3]`` int64 rows."""
+
+    if positions.ndim == 1:
+        positions = positions.unsqueeze(0).expand(3, -1)
+    elif positions.ndim != 2 or positions.shape[0] not in (1, 3):
+        raise ValueError("QSA RoPE positions must be [tokens] or [1|3, tokens]")
+    if positions.shape[0] == 1:
+        positions = positions.expand(3, -1)
+    return positions.transpose(0, 1).unsqueeze(1).to(torch.int64)
+
+
+def _logical_positions(
+    query_start_loc: torch.Tensor,
+    seq_lens: torch.Tensor,
+    token_to_req: torch.Tensor,
+    num_tokens: int,
+) -> torch.Tensor:
+    if num_tokens == 0:
+        return seq_lens.new_empty((0,), dtype=torch.int64)
+    arange = torch.arange(num_tokens, device=query_start_loc.device)
+    requests = token_to_req[:num_tokens].long()
+    query_lens = torch.diff(query_start_loc)
+    within_query = arange - query_start_loc.index_select(0, requests)
+    return (
+        seq_lens.index_select(0, requests).long()
+        - query_lens.index_select(0, requests).long()
+        + within_query.long()
+    )
+
+
+def _logical_to_physical_qsa_slots(
+    block_table: torch.Tensor,
+    request_indices: torch.Tensor,
+    logical_positions: torch.Tensor,
+    block_size: int,
+) -> torch.Tensor:
+    if block_size <= 0:
+        raise ValueError("QSA cache block size must be positive")
+    if block_table.ndim != 2:
+        raise ValueError("QSA block table must be two-dimensional")
+    if request_indices.shape != logical_positions.shape:
+        request_indices = torch.broadcast_to(request_indices, logical_positions.shape)
+
+    requests = request_indices.to(device=block_table.device, dtype=torch.long)
+    positions = logical_positions.to(device=block_table.device, dtype=torch.long)
+    valid = (requests >= 0) & (requests < block_table.shape[0]) & (positions >= 0)
+    logical_blocks = torch.div(
+        positions.clamp_min(0), block_size, rounding_mode="floor"
+    )
+    valid &= logical_blocks < block_table.shape[1]
+    safe_requests = requests.clamp(0, max(block_table.shape[0] - 1, 0))
+    safe_blocks = logical_blocks.clamp(0, max(block_table.shape[1] - 1, 0))
+    if not all(block_table.shape):
+        return torch.full_like(positions, PAD_SLOT_ID)
+    physical_blocks = block_table[safe_requests, safe_blocks].long()
+    valid &= physical_blocks >= 0
+    slots = physical_blocks * block_size + positions.remainder(block_size)
+    return torch.where(valid, slots, PAD_SLOT_ID)
+
+
+def circular_qsa_slot_mapping(
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressor_state_size: int,
+    query_start_loc: torch.Tensor | None = None,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Map each request to its fixed physical block as a circular token ring."""
+
+    if compressor_state_size <= 0:
+        raise ValueError("QSA circular buffer size must be positive")
+    if block_table.ndim != 2:
+        raise ValueError("QSA block table must be two-dimensional")
+
+    requests = token_to_req.to(device=block_table.device, dtype=torch.long)
+    positions = logical_positions.to(device=block_table.device, dtype=torch.long)
+    if not all(block_table.shape):
+        slots = torch.full_like(positions, PAD_SLOT_ID)
+    else:
+        valid = (requests >= 0) & (requests < block_table.shape[0]) & (positions >= 0)
+        safe_requests = requests.clamp(0, block_table.shape[0] - 1)
+        physical_blocks = block_table[safe_requests, 0].long()
+        valid &= physical_blocks >= 0
+        slots = physical_blocks * compressor_state_size + positions.remainder(
+            compressor_state_size
+        )
+        slots = torch.where(valid, slots, PAD_SLOT_ID)
+
+    if query_start_loc is not None:
+        if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+            raise ValueError("QSA query starts must contain a terminal offset")
+        query_start_loc = query_start_loc.to(block_table.device)
+        num_requests = query_start_loc.shape[0] - 1
+        safe_requests = requests.clamp(0, num_requests - 1)
+        request_ends = query_start_loc.index_select(0, safe_requests + 1)
+        rows = torch.arange(slots.numel(), device=slots.device)
+        keep = (
+            (requests >= 0)
+            & (requests < num_requests)
+            & (rows + compressor_state_size >= request_ends)
+        )
+        slots = torch.where(keep, slots, PAD_SLOT_ID)
+
+    slots = slots.to(torch.int64)
+    if out is not None:
+        out.fill_(PAD_SLOT_ID)
+        out[: slots.numel()].copy_(slots)
+        return out[: slots.numel()]
+    return slots
+
+
+def compressed_qsa_slot_mapping(
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    logical_positions: torch.Tensor,
+    storage_block_size: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Build boundary-only slots for an ``MLAAttentionSpec`` QSA cache."""
+
+    if storage_block_size <= 0 or compress_ratio <= 0:
+        raise ValueError("QSA block size and compression ratio must be positive")
+    compressed_positions = torch.div(
+        logical_positions.clamp_min(0), compress_ratio, rounding_mode="floor"
+    )
+    slots = _logical_to_physical_qsa_slots(
+        block_table,
+        token_to_req,
+        compressed_positions,
+        storage_block_size,
+    )
+    valid = (logical_positions >= 0) & (
+        (logical_positions + 1).remainder(compress_ratio) == 0
+    )
+    slots = torch.where(valid, slots, PAD_SLOT_ID).to(torch.int64)
+    if out is not None:
+        out.fill_(PAD_SLOT_ID)
+        out[: slots.numel()].copy_(slots)
+        return out[: slots.numel()]
+    return slots
+
+
+@cache
+def _metadata_launch_pdl() -> bool:
+    return current_platform.is_arch_support_pdl()
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_reqs",
+        "num_mapped_tokens",
+        "num_tokens",
+        "max_num_work",
+        "num_search_steps",
+        "work_search_steps",
+    ]
+)
+def _build_qsa_metadata_kernel(
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    common_slot_mapping_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    logical_positions_ptr,
+    slot_mapping_ptr,
+    k_work_metadata_ptr,
+    block_table_stride_0: tl.constexpr,
+    block_table_stride_1: tl.constexpr,
+    num_reqs,
+    num_mapped_tokens,
+    num_tokens,
+    max_num_work,
+    num_search_steps,
+    work_search_steps,
+    storage_block_size: tl.constexpr,
+    compress_ratio: tl.constexpr,
+    circular_buffer_size: tl.constexpr,
+    num_block_table_columns: tl.constexpr,
+    launch_pdl: tl.constexpr,
+    TOKEN_BLOCK_SIZE: tl.constexpr,
+    REQUEST_SCAN_SIZE: tl.constexpr,
+    WORK_BLOCK_SIZE: tl.constexpr,
+):
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    pid = tl.program_id(0)
+    token_idx = pid * TOKEN_BLOCK_SIZE + tl.arange(0, TOKEN_BLOCK_SIZE)
+    store_mask = token_idx < num_tokens
+    mapped = token_idx < num_mapped_tokens
+    search_token_idx = tl.minimum(token_idx, num_mapped_tokens - 1)
+    request_idx = tl.zeros((TOKEN_BLOCK_SIZE,), tl.int32)
+    # Find the last query start at or before each token. The dynamic loop avoids
+    # compiling a kernel variant for every ceil(log2(num_reqs)).
+    for step in tl.range(0, num_search_steps):
+        candidate = request_idx + (1 << (num_search_steps - step - 1))
+        valid_candidate = candidate < num_reqs
+        candidate_start = tl.load(
+            query_start_loc_ptr + candidate,
+            mask=valid_candidate,
+            other=num_mapped_tokens + 1,
+        )
+        advance = valid_candidate & (candidate_start <= search_token_idx)
+        request_idx = tl.where(advance, candidate, request_idx)
+    query_start = tl.load(query_start_loc_ptr + request_idx, mask=mapped, other=0)
+    query_end = tl.load(query_start_loc_ptr + request_idx + 1, mask=mapped, other=0)
+    seq_len = tl.load(seq_lens_ptr + request_idx, mask=mapped, other=0)
+    logical_position = seq_len - (query_end - query_start) + token_idx - query_start
+    logical_position = tl.where(mapped, logical_position, -1)
+    tl.store(
+        token_to_req_ptr + token_idx,
+        tl.where(mapped, request_idx, 0),
+        mask=store_mask,
+    )
+    tl.store(
+        logical_positions_ptr + token_idx,
+        logical_position,
+        mask=store_mask,
+    )
+
+    # circular_buffer_size is constexpr, so each builder instance compiles out
+    # the other QSA cache owner's slot-mapping rule.
+    if circular_buffer_size > 0:
+        valid = (
+            mapped
+            & (logical_position >= 0)
+            & (token_idx + circular_buffer_size >= query_end)
+            & (num_block_table_columns > 0)
+        )
+        physical_block = tl.load(
+            block_table_ptr + request_idx * block_table_stride_0,
+            mask=valid,
+            other=-1,
+        )
+        valid &= physical_block >= 0
+        slot = physical_block * circular_buffer_size + (
+            logical_position % circular_buffer_size
+        )
+    elif compress_ratio != 1:
+        compressed_position = tl.maximum(logical_position, 0) // compress_ratio
+        logical_block = compressed_position // storage_block_size
+        valid = (
+            mapped
+            & (logical_position >= 0)
+            & ((logical_position + 1) % compress_ratio == 0)
+            & (logical_block < num_block_table_columns)
+        )
+        physical_block = tl.load(
+            block_table_ptr
+            + request_idx * block_table_stride_0
+            + logical_block * block_table_stride_1,
+            mask=valid,
+            other=-1,
+        )
+        valid &= physical_block >= 0
+        valid &= (
+            tl.load(common_slot_mapping_ptr + token_idx, mask=mapped, other=-1) >= 0
+        )
+        slot = physical_block * storage_block_size + (
+            compressed_position % storage_block_size
+        )
+    if (circular_buffer_size > 0) or (compress_ratio != 1):
+        tl.store(
+            slot_mapping_ptr + token_idx,
+            tl.where(valid, slot, -1),
+            mask=store_mask,
+        )
+    work_tile_start = pid * WORK_BLOCK_SIZE
+    has_work_tile = work_tile_start < max_num_work
+    if k_work_metadata_ptr is not None and has_work_tile:
+        # Every work CTA builds the request prefix in registers. Recomputing this
+        # small vector lets CTAs write disjoint work tiles without a grid barrier.
+        requests = tl.arange(0, REQUEST_SCAN_SIZE)
+        valid_request = requests < num_reqs
+        request_query_start = tl.load(
+            query_start_loc_ptr + requests, mask=valid_request, other=0
+        )
+        request_query_end = tl.load(
+            query_start_loc_ptr + requests + 1, mask=valid_request, other=0
+        )
+        request_seq_len = tl.load(seq_lens_ptr + requests, mask=valid_request, other=0)
+        request_query_len = request_query_end - request_query_start
+        chunk_start = request_seq_len - request_query_len
+        num_groups = request_seq_len // compress_ratio - chunk_start // compress_ratio
+        # Nonempty requests need one item even without a completed compression
+        # group because work item zero also commits the current raw-K suffix.
+        work_counts = tl.where(request_query_len > 0, tl.maximum(num_groups, 1), 0)
+        work_ends = tl.cumsum(tl.where(valid_request, work_counts, 0), axis=0)
+        total_work = tl.sum(tl.where(valid_request, work_counts, 0), axis=0)
+        work_offsets = tl.arange(0, WORK_BLOCK_SIZE)
+        work = work_tile_start + work_offsets
+        in_bounds = work < max_num_work
+        active = in_bounds & (work < total_work)
+        request = tl.zeros((WORK_BLOCK_SIZE,), dtype=tl.int32)
+        # Request zero starts at zero for every active work item. Descending
+        # steps find the last request starting at or before this item.
+        for step_idx in tl.range(0, work_search_steps):
+            step = 1 << (work_search_steps - step_idx - 1)
+            candidate = request + step
+            valid_candidate = candidate < num_reqs
+            candidate_start = tl.gather(work_ends, candidate - 1, 0)
+            advance = active & valid_candidate & (candidate_start <= work)
+            request = tl.where(advance, candidate, request)
+
+        if launch_pdl:
+            # Let the dependent grid start launch setup while these CTAs finish
+            # stores; its gdc_wait still orders access to the completed metadata.
+            tl.extra.cuda.gdc_launch_dependents()
+
+        owner_work_start = tl.gather(work_ends, tl.maximum(request - 1, 0), 0)
+        owner_work_start = tl.where(request == 0, 0, owner_work_start)
+        work_in_request = work - owner_work_start
+        tl.store(
+            k_work_metadata_ptr + work * 2,
+            tl.where(active, request, -1),
+            mask=in_bounds,
+        )
+        tl.store(
+            k_work_metadata_ptr + work * 2 + 1,
+            tl.where(active, work_in_request, -1),
+            mask=in_bounds,
+        )
+
+    else:
+        if launch_pdl:
+            # A dependent grid launches only after every CTA has signaled.
+            tl.extra.cuda.gdc_launch_dependents()
+
+
+def build_qsa_metadata_triton(
+    common_attn_metadata: CommonAttentionMetadata,
+    token_to_req_buffer: torch.Tensor,
+    logical_positions_buffer: torch.Tensor,
+    slot_mapping_buffer: torch.Tensor,
+    *,
+    storage_block_size: int,
+    compress_ratio: int,
+    circular_buffer_size: int = 0,
+    k_work_metadata_buffer: torch.Tensor | None = None,
+    request_capacity: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build QSA side-cache and optional pre-indexer work metadata."""
+    num_tokens = common_attn_metadata.num_actual_tokens
+    num_mapped_tokens = int(common_attn_metadata.query_start_loc_cpu[-1])
+    token_to_req = token_to_req_buffer[:num_tokens]
+    logical_positions = logical_positions_buffer[:num_tokens]
+    slot_mapping = slot_mapping_buffer[:num_tokens]
+    num_reqs = common_attn_metadata.query_start_loc.shape[0] - 1
+    assert num_reqs > 0
+
+    if k_work_metadata_buffer is not None:
+        if request_capacity is None:
+            request_capacity = num_reqs
+        assert request_capacity >= num_reqs
+        # Pad for tl.arange while keeping the scan width stable across live batches.
+        request_scan_size = 1 << int(math.ceil(math.log2(request_capacity)))
+        max_num_work = k_work_metadata_buffer.shape[0]
+    else:
+        request_scan_size = 1
+        max_num_work = 0
+
+    if num_tokens == 0 and k_work_metadata_buffer is None:
+        return token_to_req, logical_positions, slot_mapping
+
+    block_table = common_attn_metadata.block_table_tensor
+    num_search_steps = int(math.ceil(math.log2(num_reqs)))
+    work_search_steps = int(math.ceil(math.log2(num_reqs)))
+    # The same grid covers token tiles and, for the compressed cache, work tiles.
+    num_token_blocks = cdiv(num_tokens, 128)
+    num_work_blocks = (
+        cdiv(max_num_work, 256) if k_work_metadata_buffer is not None else 0
+    )
+    _build_qsa_metadata_kernel[(max(num_token_blocks, num_work_blocks, 1),)](
+        common_attn_metadata.query_start_loc,
+        common_attn_metadata.seq_lens,
+        common_attn_metadata.slot_mapping,
+        block_table,
+        token_to_req,
+        logical_positions,
+        slot_mapping,
+        k_work_metadata_buffer,
+        block_table.stride(0),
+        block_table.stride(1),
+        num_reqs,
+        num_mapped_tokens,
+        num_tokens,
+        max_num_work,
+        num_search_steps,
+        work_search_steps,
+        storage_block_size,
+        compress_ratio,
+        circular_buffer_size,
+        block_table.shape[1],
+        launch_pdl=_metadata_launch_pdl(),
+        TOKEN_BLOCK_SIZE=128,
+        REQUEST_SCAN_SIZE=request_scan_size,
+        WORK_BLOCK_SIZE=256,
+        num_warps=4,
+    )
+    if circular_buffer_size == 0 and compress_ratio == 1:
+        slot_mapping = common_attn_metadata.slot_mapping[:num_tokens]
+    return token_to_req, logical_positions, slot_mapping
+
+
+def _build_qsa_metadata_torch(
+    common_attn_metadata: CommonAttentionMetadata,
+    token_to_req_buffer: torch.Tensor,
+    logical_positions_buffer: torch.Tensor,
+    slot_mapping_buffer: torch.Tensor,
+    *,
+    storage_block_size: int,
+    compress_ratio: int,
+    circular_buffer_size: int = 0,
+    k_work_metadata_buffer: torch.Tensor | None = None,
+    request_capacity: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    del request_capacity
+    num_tokens = common_attn_metadata.num_actual_tokens
+    num_mapped_tokens = int(common_attn_metadata.query_start_loc_cpu[-1])
+    logical_positions = logical_positions_buffer[:num_tokens]
+
+    token_to_req = common_attn_metadata.token_to_req_indices(token_to_req_buffer)[
+        :num_tokens
+    ]
+    logical_positions[:num_mapped_tokens].copy_(
+        _logical_positions(
+            common_attn_metadata.query_start_loc,
+            common_attn_metadata.seq_lens,
+            token_to_req[:num_mapped_tokens],
+            num_mapped_tokens,
+        )
+    )
+    if num_mapped_tokens < num_tokens:
+        logical_positions[num_mapped_tokens:].fill_(-1)
+    if circular_buffer_size > 0:
+        slot_mapping = circular_qsa_slot_mapping(
+            common_attn_metadata.block_table_tensor,
+            token_to_req,
+            logical_positions,
+            circular_buffer_size,
+            query_start_loc=common_attn_metadata.query_start_loc,
+            out=slot_mapping_buffer,
+        )
+    elif compress_ratio == 1:
+        slot_mapping = common_attn_metadata.slot_mapping[:num_tokens]
+    else:
+        slot_mapping = compressed_qsa_slot_mapping(
+            common_attn_metadata.block_table_tensor,
+            token_to_req,
+            logical_positions,
+            storage_block_size,
+            compress_ratio,
+            slot_mapping_buffer,
+        )
+        slot_mapping.masked_fill_(
+            common_attn_metadata.slot_mapping[:num_tokens] < 0, -1
+        )
+    if k_work_metadata_buffer is not None:
+        query_lens = (
+            common_attn_metadata.query_start_loc[1:]
+            - common_attn_metadata.query_start_loc[:-1]
+        )
+        chunk_starts = common_attn_metadata.seq_lens - query_lens
+        num_work_per_request = (
+            common_attn_metadata.seq_lens // compress_ratio
+            - chunk_starts // compress_ratio
+        )
+        num_work_per_request = torch.where(
+            query_lens > 0, num_work_per_request.clamp_min(1), 0
+        )
+        k_start_loc = torch.empty(
+            query_lens.shape[0] + 1,
+            dtype=torch.int32,
+            device=query_lens.device,
+        )
+        k_start_loc[0] = 0
+        torch.cumsum(num_work_per_request, 0, out=k_start_loc[1:])
+        work = torch.arange(
+            k_work_metadata_buffer.shape[0],
+            device=k_work_metadata_buffer.device,
+        )
+        requests = torch.searchsorted(k_start_loc[1:], work, right=True)
+        active = work < k_start_loc[-1]
+        work_in_request = (
+            work - k_start_loc[requests.clamp_max(query_lens.shape[0] - 1)]
+        )
+        k_work_metadata_buffer[:, 0].copy_(
+            torch.where(active, requests, -1).to(torch.int32)
+        )
+        k_work_metadata_buffer[:, 1].copy_(
+            torch.where(active, work_in_request, -1).to(torch.int32)
+        )
+    return token_to_req, logical_positions, slot_mapping
+
+
+# Resolve the fallback outside the per-step metadata hot path.
+build_qsa_metadata = (
+    build_qsa_metadata_triton if HAS_TRITON else _build_qsa_metadata_torch
+)
+
+
+@dataclass
+class QSAForwardMetadata(AttentionMetadata):
+    """Common per-forward metadata for one QSA side cache."""
+
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+    seq_lens: torch.Tensor
+    query_start_loc: torch.Tensor
+    token_to_req: torch.Tensor
+    logical_positions: torch.Tensor
+    k_work_metadata: torch.Tensor
+    num_actual_tokens: int
+    storage_block_size: int
+    compress_ratio: int
+
+
+class QSAMetadataBuilder(AttentionMetadataBuilder[QSAForwardMetadata]):
+    """Build QSA metadata from vLLM's cache-group-specific common metadata."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ) -> None:
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        self.is_circular_buffer = isinstance(kv_cache_spec, CircularBufferSpec)
+        if isinstance(kv_cache_spec, MLAAttentionSpec):
+            self.compress_ratio = kv_cache_spec.compress_ratio
+        else:
+            self.compress_ratio = 1
+        self.storage_block_size = kv_cache_spec.storage_block_size
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.token_to_req_buffer = torch.empty(
+            max_tokens, dtype=torch.int32, device=device
+        )
+        self.slot_mapping_buffer = torch.empty(
+            max_tokens, dtype=torch.int64, device=device
+        )
+        self.logical_positions_buffer = torch.empty(
+            max_tokens, dtype=torch.int64, device=device
+        )
+        max_requests = vllm_config.scheduler_config.max_num_seqs
+        self.request_capacity = max_requests
+        if not self.is_circular_buffer and self.compress_ratio != 1:
+            max_k_work = (
+                max_tokens + (self.compress_ratio - 1) * max_requests
+            ) // self.compress_ratio
+            self.k_work_metadata_buffer = torch.empty(
+                max_k_work, 2, dtype=torch.int32, device=device
+            )
+        else:
+            self.k_work_metadata_buffer = torch.empty(
+                0, 2, dtype=torch.int32, device=device
+            )
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> QSAForwardMetadata:
+        del common_prefix_len, fast_build
+        num_tokens = common_attn_metadata.num_actual_tokens
+        build_k_work = not self.is_circular_buffer and self.compress_ratio != 1
+        k_work_metadata = self.k_work_metadata_buffer
+        request_capacity = None
+        if build_k_work:
+            num_requests = common_attn_metadata.query_start_loc.shape[0] - 1
+            request_capacity = self.request_capacity
+            max_num_work = (
+                num_tokens + (self.compress_ratio - 1) * num_requests
+            ) // self.compress_ratio
+            k_work_metadata = self.k_work_metadata_buffer[:max_num_work]
+        token_to_req, logical_positions, slot_mapping = build_qsa_metadata(
+            common_attn_metadata,
+            self.token_to_req_buffer,
+            self.logical_positions_buffer,
+            self.slot_mapping_buffer,
+            storage_block_size=self.storage_block_size,
+            compress_ratio=self.compress_ratio,
+            circular_buffer_size=(
+                self.kv_cache_spec.block_size if self.is_circular_buffer else 0
+            ),
+            k_work_metadata_buffer=k_work_metadata if build_k_work else None,
+            request_capacity=request_capacity,
+        )
+        return QSAForwardMetadata(
+            block_table=common_attn_metadata.block_table_tensor,
+            slot_mapping=slot_mapping,
+            seq_lens=common_attn_metadata.seq_lens,
+            query_start_loc=common_attn_metadata.query_start_loc,
+            token_to_req=token_to_req,
+            logical_positions=logical_positions,
+            k_work_metadata=k_work_metadata,
+            num_actual_tokens=num_tokens,
+            storage_block_size=self.storage_block_size,
+            compress_ratio=self.compress_ratio,
+        )
+
+
+class QSAStateBackend(AttentionBackend):
+    """Key-only dummy backend for out-of-band BF16 QSA side-cache operations."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "QWEN4_EXP_EXP_QSA_STATE"
+
+    @staticmethod
+    def get_impl_cls():
+        raise NotImplementedError(
+            "QSA state caches run out-of-band and have no attention impl"
+        )
+
+    @staticmethod
+    def get_builder_cls() -> type[QSAMetadataBuilder]:
+        return QSAMetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        del cache_dtype_str
+        if num_kv_heads != 1:
+            raise ValueError("QSA side caches require exactly one KV head")
+        return (num_blocks, block_size, num_kv_heads, head_size)
+
+    @classmethod
+    def indexes_kv_by_block_stride(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_kv_cache_stride_order(
+        include_num_layers_dimension: bool = False,
+    ) -> tuple[int, ...]:
+        if include_num_layers_dimension:
+            return (0, 1, 2, 3, 4)
+        return (0, 1, 2, 3)
+
+
+class _QSAStateCache(nn.Module, AttentionLayerBase):
+    supports_dcp = False
+
+    def __init__(
+        self,
+        *,
+        head_size: int,
+        dtype: torch.dtype,
+        cache_config: CacheConfig,
+        prefix: str,
+        vllm_config: VllmConfig,
+        compress_ratio: int = 1,
+    ) -> None:
+        super().__init__()
+        if head_size <= 0:
+            raise ValueError("QSA cache head size must be positive")
+        if compress_ratio <= 0:
+            raise ValueError("QSA compression ratio must be positive")
+        if cache_config.block_size % compress_ratio:
+            raise ValueError(
+                "QSA cache block size must be divisible by the compression ratio"
+            )
+        self.head_size = head_size
+        self.dtype = dtype
+        self.cache_config = cache_config
+        self.prefix = prefix
+        self.compress_ratio = compress_ratio
+        self.kv_cache = torch.tensor([])
+
+        static_context = vllm_config.compilation_config.static_forward_context
+        if prefix in static_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        static_context[prefix] = self
+
+    def forward(self) -> None: ...
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return QSAStateBackend
+
+
+class QSAKeyStateCache(_QSAStateCache):
+    """Raw BF16 key, optionally followed by exact int64 MRoPE positions."""
+
+    _BF16_PER_INT64 = 4
+    _NUM_ROPE_AXES = 3
+
+    def __init__(self, *, cache_rope_positions: bool = False, **kwargs) -> None:
+        key_head_size = int(kwargs.pop("head_size"))
+        self.key_head_size = key_head_size
+        self.cache_rope_positions = bool(cache_rope_positions)
+        self.rope_position_offset = (
+            (key_head_size + self._BF16_PER_INT64 - 1) // self._BF16_PER_INT64
+        ) * self._BF16_PER_INT64
+        storage_head_size = key_head_size
+        if self.cache_rope_positions:
+            storage_head_size = self.rope_position_offset + (
+                self._NUM_ROPE_AXES * self._BF16_PER_INT64
+            )
+        super().__init__(head_size=storage_head_size, **kwargs)
+
+    def bind_kv_cache(self, kv_cache: torch.Tensor) -> None:
+        if kv_cache.ndim != 4 or kv_cache.shape[2] != 1:
+            raise ValueError("QSA raw cache must be [blocks, block_size, 1, width]")
+        if kv_cache.dtype != torch.bfloat16 or kv_cache.shape[3] != self.head_size:
+            raise ValueError("QSA raw cache does not match its packed BF16 cache spec")
+        super().bind_kv_cache(kv_cache)
+        self.key_cache = kv_cache[..., : self.key_head_size]
+        if self.cache_rope_positions:
+            position_tail = kv_cache[..., self.rope_position_offset :]
+            self.rope_position_cache = position_tail.view(torch.int64)
+        else:
+            self.rope_position_cache = None
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        # Hold the open group's committed keys plus every row a speculative
+        # step stores before acceptance is known, rounded up to whole groups so
+        # the ring divides the attention block size (it joins the LCM that sets
+        # the scheduler block size). Anything narrower lets a rejected draft row
+        # overwrite a committed key the next step needs to close the group.
+        span = self.compress_ratio + vllm_config.num_speculative_tokens
+        capacity = self.compress_ratio * cdiv(span, self.compress_ratio)
+        assert self.cache_config.block_size % capacity == 0, (
+            f"QSA ring capacity {capacity} must divide the attention block "
+            f"size {self.cache_config.block_size}"
+        )
+        return CircularBufferSpec(
+            block_size=capacity,
+            num_kv_heads=1,
+            head_size=self.head_size,
+            dtype=self.dtype,
+        )
+
+
+class QSACompressedKeyCache(_QSAStateCache):
+    """Normalized, group-first-RoPE BF16 key at one row per complete group."""
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        del vllm_config
+        return MLAAttentionSpec(
+            block_size=self.cache_config.block_size,
+            num_kv_heads=1,
+            head_size=self.head_size,
+            dtype=self.dtype,
+            compress_ratio=self.compress_ratio,
+        )
+
+
+__all__ = [
+    "QSACompressedKeyCache",
+    "QSAForwardMetadata",
+    "QSAKeyStateCache",
+    "QSAMetadataBuilder",
+    "QSAStateBackend",
+    "canonical_qsa_rope_positions",
+    "circular_qsa_slot_mapping",
+    "compressed_qsa_slot_mapping",
+]

--- a/vllm_ascend/models/qwen4_exp/config.py
+++ b/vllm_ascend/models/qwen4_exp/config.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp model configuration."""
+
+from typing import Any, ClassVar, cast
+
+from transformers import PretrainedConfig
+from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+    Qwen3VLVisionConfig,
+)
+
+from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
+
+_QSA_CONFIG_FIELDS = (
+    "indexer_n_heads",
+    "indexer_kv_heads",
+    "indexer_head_dim",
+    "indexer_budget",
+    "indexer_compress_ratio",
+)
+
+
+class Qwen4ExpVisionConfig(Qwen3VLVisionConfig):
+    model_type = "qwen4_exp"
+    base_config_key = "vision_config"
+
+
+class Qwen4ExpTextConfig(Qwen3NextConfig):
+    model_type = "qwen4_exp_text"
+    base_config_key = "text_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        hc_count: int = 4,
+        hc_lowrank: int = 320,
+        ple_layer_ids: list[int] | None = None,
+        ple_embed_dim: int | None = None,
+        ple_conv_kernel_size: int = 4,
+        ngram_size: int = 3,
+        heads_per_ngram: int = 8,
+        ngram_vocab_size_base: int = 20_000_000,
+        make_ngram_vocab_size_divisible_by: int = 128,
+        output_gate_type: str = "sigmoid",
+        rope_parameters: dict[str, Any] | None = None,
+        layer_types: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if hc_count <= 1:
+            raise ValueError(f"Qwen4Exp requires hc_count > 1, got {hc_count}.")
+
+        if rope_parameters is not None:
+            if kwargs.get("rope_scaling") is None:
+                kwargs["rope_scaling"] = rope_parameters
+            if kwargs.get("rope_theta") is None and "rope_theta" in rope_parameters:
+                kwargs["rope_theta"] = rope_parameters["rope_theta"]
+            if (
+                kwargs.get("partial_rotary_factor") is None
+                and "partial_rotary_factor" in rope_parameters
+            ):
+                kwargs["partial_rotary_factor"] = rope_parameters[
+                    "partial_rotary_factor"
+                ]
+
+        rope_scaling = kwargs.get("rope_scaling")
+        rope_theta = kwargs.get("rope_theta", 10_000.0)
+        super().__init__(layer_types=layer_types, **kwargs)
+
+        normalized_rope_parameters = self.rope_parameters
+        self.rope_scaling = (
+            rope_scaling or rope_parameters or normalized_rope_parameters
+        )
+        self.rope_parameters = rope_parameters or normalized_rope_parameters
+        self.rope_theta = rope_theta
+
+        self.hc_count = hc_count
+        self.hc_lowrank = hc_lowrank
+        self.ple_layer_ids = ple_layer_ids or []
+        self.ple_embed_dim = (
+            self.hidden_size if ple_embed_dim is None else ple_embed_dim
+        )
+        self.ple_conv_kernel_size = ple_conv_kernel_size
+        self.ngram_size = ngram_size
+        self.heads_per_ngram = heads_per_ngram
+        self.ngram_vocab_size_base = ngram_vocab_size_base
+        self.make_ngram_vocab_size_divisible_by = make_ngram_vocab_size_divisible_by
+        self.output_gate_type = output_gate_type
+
+        self._validate_ple_config()
+        self._validate_ple_layer_ids()
+        self._validate_qsa_config()
+
+    def _validate_ple_config(self) -> None:
+        if self.hc_lowrank <= 0:
+            raise ValueError(f"hc_lowrank must be positive, got {self.hc_lowrank}")
+        if self.ngram_size < 2:
+            raise ValueError(f"ngram_size must be >= 2, got {self.ngram_size}")
+        if self.heads_per_ngram <= 0:
+            raise ValueError(
+                f"heads_per_ngram must be positive, got {self.heads_per_ngram}"
+            )
+        if self.ple_embed_dim <= 0:
+            raise ValueError(
+                f"ple_embed_dim must be positive, got {self.ple_embed_dim}"
+            )
+        ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ple_embed_dim % ngram_heads:
+            raise ValueError(
+                "ple_embed_dim must be divisible by total ngram heads: "
+                f"{self.ple_embed_dim} % {ngram_heads} != 0"
+            )
+        if self.ple_conv_kernel_size <= 0:
+            raise ValueError(
+                "ple_conv_kernel_size must be positive, got "
+                f"{self.ple_conv_kernel_size}"
+            )
+        if self.ngram_vocab_size_base <= 0:
+            raise ValueError("ngram_vocab_size_base must be positive")
+        if self.make_ngram_vocab_size_divisible_by <= 0:
+            raise ValueError("make_ngram_vocab_size_divisible_by must be positive")
+
+    def _validate_ple_layer_ids(self) -> None:
+        invalid = [
+            layer_id
+            for layer_id in self.ple_layer_ids
+            if not 1 <= int(layer_id) <= self.num_hidden_layers
+        ]
+        if invalid:
+            raise ValueError(
+                "ple_layer_ids are 1-based and must refer to an existing layer; "
+                f"got {invalid} for {self.num_hidden_layers} layers"
+            )
+
+    def _validate_qsa_config(self) -> None:
+        configured = {name: getattr(self, name, None) for name in _QSA_CONFIG_FIELDS}
+        if all(value is None for value in configured.values()):
+            return
+
+        missing = [name for name, value in configured.items() if value is None]
+        if missing:
+            raise ValueError(f"QSA config is missing required fields: {missing}")
+
+        values = {name: int(cast(int, value)) for name, value in configured.items()}
+        if any(value <= 0 for value in values.values()):
+            raise ValueError(f"QSA config values must be positive: {values}")
+        if values["indexer_kv_heads"] != 1:
+            raise ValueError("the QSA MQA operators require indexer_kv_heads=1")
+        if values["indexer_budget"] % values["indexer_compress_ratio"] != 0:
+            raise ValueError(
+                "indexer_budget must be divisible by indexer_compress_ratio"
+            )
+        block_topk = values["indexer_budget"] // values["indexer_compress_ratio"]
+        if block_topk not in (512, 2048):
+            raise ValueError(
+                "QSA requires indexer_budget / indexer_compress_ratio "
+                f"to be 512 or 2048, got {block_topk}"
+            )
+        rotary_dim = int(self.head_dim * self.partial_rotary_factor)
+        if rotary_dim > values["indexer_head_dim"]:
+            raise ValueError(
+                "QSA indexer_head_dim must cover the attention rotary "
+                f"dimension, got {values['indexer_head_dim']} < {rotary_dim}"
+            )
+
+    @property
+    def layers_block_type(self) -> list[str]:
+        return [
+            "attention" if layer_type == "full_attention" else layer_type
+            for layer_type in self.layer_types
+        ]
+
+    @property
+    def short_conv_layer_ids(self) -> list[int]:
+        if not self.ple_layer_ids:
+            return []
+        return sorted({int(layer_id) - 1 for layer_id in self.ple_layer_ids})
+
+    @property
+    def short_conv_state_shape(self) -> tuple[int, int] | None:
+        if not self.short_conv_layer_ids:
+            return None
+        ple_state_len = (self.ple_conv_kernel_size - 1) * self.ngram_size
+        ple_channels = self.hidden_size * self.hc_count
+        return ple_channels, ple_state_len
+
+    @property
+    def ngram_context_len(self) -> int:
+        if not self.ple_layer_ids:
+            return 0
+        return max(int(self.ngram_size) - 1, 0)
+
+
+class Qwen4ExpConfig(PretrainedConfig):
+    model_type = "qwen4_exp"
+    sub_configs: ClassVar[dict[str, type[PretrainedConfig]]] = {
+        "vision_config": Qwen4ExpVisionConfig,
+        "text_config": Qwen4ExpTextConfig,
+    }
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config: Qwen4ExpTextConfig | dict[str, Any] | None = None,
+        vision_config: Qwen4ExpVisionConfig | dict[str, Any] | None = None,
+        image_token_id: int = 248056,
+        video_token_id: int = 248057,
+        vision_start_token_id: int = 248053,
+        vision_end_token_id: int = 248054,
+        tie_word_embeddings: bool = False,
+        rope_parameters: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        if text_config is not None:
+            kwargs.pop("split_ngram_parts", None)
+
+        text_kwargs = (
+            dict(kwargs)
+            if text_config is None
+            and "hidden_size" in kwargs
+            and "num_hidden_layers" in kwargs
+            else {}
+        )
+
+        if isinstance(vision_config, dict):
+            self.vision_config = self.sub_configs["vision_config"](**vision_config)
+        elif vision_config is None:
+            self.vision_config = self.sub_configs["vision_config"]()
+        else:
+            self.vision_config = vision_config
+
+        if isinstance(text_config, dict):
+            self.text_config = self.sub_configs["text_config"](**text_config)
+        elif text_config is None:
+            self.text_config = self.sub_configs["text_config"](**text_kwargs)
+        else:
+            self.text_config = text_config
+
+        self.image_token_id = image_token_id
+        self.video_token_id = video_token_id
+        self.vision_start_token_id = vision_start_token_id
+        self.vision_end_token_id = vision_end_token_id
+        self.rope_parameters = rope_parameters or getattr(
+            self.text_config, "rope_parameters", {}
+        )
+        super().__init__(**kwargs, tie_word_embeddings=tie_word_embeddings)
+
+
+__all__ = [
+    "Qwen4ExpConfig",
+    "Qwen4ExpTextConfig",
+    "Qwen4ExpVisionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm_ascend/models/qwen4_exp/nvidia/hyperconnection.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/hyperconnection.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""HyperConnection (Gated Residual) utilities — NVIDIA model variant.
+
+Implements the HyperConnection residual scheme proposed in
+"HyperConnections" (https://arxiv.org/abs/2409.19606). This NVIDIA variant
+delays each HC combine to the following HC mix boundary. HC glue kernels,
+including fused combine+RMSNorm, live in ``ops/hc.py``; projections remain
+standard vLLM Linear modules.
+
+Hidden states between layers have shape ``[..., HC*HS]`` with HS inner
+(HC outer, HS inner — checkpoint-native layout).
+
+Typical usage inside a transformer decoder layer::
+
+    self.attn_hc = GatedResidual(hc_config)
+
+    hidden_states, block_input, injection = self.attn_hc.mix(hidden_states)
+    attention_output = attention(block_input)
+    hidden_states, block_input, injection = self.mlp_hc.combine_and_mix(
+        hidden_states, attention_output, injection
+    )
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.model_executor.layers.linear import (
+    MergedColumnParallelLinear,
+    ReplicatedLinear,
+)
+from vllm.model_executor.models.utils import maybe_prefix
+
+from ..common.hyperconnection import (
+    GroupedGemmaRMSNorm,
+    HyperConnectionConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Gated-residual variant
+# ---------------------------------------------------------------------------
+class GatedResidual(nn.Module):
+    """Gated HyperConnection with learnable low-rank mixing and injection.
+
+    ``combine_and_mix()`` runs the pre pipeline (grouped GemmaRMSNorm -> merged
+    low-rank down+inject GEMM -> silu -> up GEMM -> sigmoid -> gated mean
+    over the HC streams). When passed a pending block output and an injection,
+    it fuses their residual combine with the RMSNorm. Final mixers use
+    ``use_combine=False`` and do not produce a new injection.
+
+    Weights: the norm owns the grouped GemmaRMSNorm affine; the projections
+    are vLLM Linear modules (merged replicated linear for down+inject), so
+    GEMM dispatch (e.g. the low-latency skinny GEMM) applies through the
+    standard quant_method mechanism.
+    """
+
+    def __init__(
+        self,
+        config: HyperConnectionConfig,
+        use_combine: bool = True,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.lora_rank = config.hc_lowrank
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        self.use_combine = use_combine
+
+        norm_size = (
+            self.hyper_hidden_size if config.hc_per_branch_norm else config.hidden_size
+        )
+        group_size = config.hidden_size if config.hc_per_branch_norm else None
+        # Normalize each H-sized HC stream independently while retaining a
+        # separate affine weight for every element of the HC*H layout.
+        self.hc_norm = GroupedGemmaRMSNorm(
+            norm_size,
+            eps=config.rms_norm_eps,
+            group_size=group_size,
+            dtype=config.params_dtype,
+        )
+
+        # -- vLLM Linear weights --------------------------------------------
+        # The merged skinny-GEMM shape is physically padded to 16 rows to ensure
+        # good alignment and performant implementation chosen by CuBLAS heuristics.
+        self.pad_size = (-(self.lora_rank + self.hc_count)) % 16 if use_combine else 0
+        if use_combine:
+            self.input_mix_weight_down_block_inject = MergedColumnParallelLinear(
+                self.hyper_hidden_size,
+                [self.lora_rank, self.hc_count]
+                + ([self.pad_size] if self.pad_size else []),
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down_block_inject"),
+                return_bias=False,
+                disable_tp=True,
+            )
+        else:
+            self.input_mix_weight_down = ReplicatedLinear(
+                self.hyper_hidden_size,
+                self.lora_rank,
+                bias=False,
+                params_dtype=config.params_dtype,
+                quant_config=None,
+                prefix=maybe_prefix(prefix, "input_mix_weight_down"),
+                return_bias=False,
+            )
+        self.input_mix_weight_up = ReplicatedLinear(
+            self.lora_rank,
+            self.hyper_hidden_size,
+            bias=False,
+            params_dtype=config.params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "input_mix_weight_up"),
+            return_bias=False,
+        )
+
+    def mix(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        xn = self.hc_norm(hidden_states)
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = F.silu(lora / self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = (xn * torch.sigmoid(gate)).unflatten(-1, (self.hc_count, -1)).mean(dim=-2).flatten(-2)
+
+        return hidden_states, block_input, injection
+
+    def combine_and_mix(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor,
+        prev_injection: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
+        """Consume a pending combine, then prepare the next block input.
+
+        ``hidden_states`` is the multi-stream state from before the pending
+        block's mix. Its combine with ``block_output`` is fused with this
+        module's input RMSNorm.
+        """
+        hidden_states, xn = hc_combine_norm(
+            hidden_states,
+            prev_block_output,
+            prev_injection,
+            self.hc_norm.weight,
+            self.config.rms_norm_eps,
+            self.hc_count,
+        )
+
+        if self.use_combine:
+            # produce injection logits for combine
+            split_sizes = [self.lora_rank, self.hc_count, self.pad_size]
+            down_and_injection = self.input_mix_weight_down_block_inject(xn)
+            lora, injection, _ = down_and_injection.split(split_sizes, dim=-1)
+        else:
+            lora = self.input_mix_weight_down(xn)
+            injection = None
+
+        lora = hc_silu(lora, self.hc_count)
+        gate = self.input_mix_weight_up(lora)  # [M, D]
+        block_input = hc_gate_mix(xn, gate, self.hc_count)
+
+        return hidden_states, block_input, injection
+
+    def combine(
+        self,
+        hidden_states: torch.Tensor,
+        block_output: torch.Tensor,
+        injection: torch.Tensor,
+    ) -> torch.Tensor:
+        return hc_combine(hidden_states, block_output, injection, self.hc_count)
+
+    @property
+    def hyper_hidden_size(self) -> int:
+        return self.hc_count * self.hidden_size
+
+
+__all__ = [
+    "GatedResidual",
+    "GroupedGemmaRMSNorm",
+    "HyperConnectionConfig",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/indexer_qsa.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/indexer_qsa.py
@@ -1,0 +1,356 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp weight-free QSA indexer."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding.mrope import triton_mrope
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+
+from ..common.qsa_cache import (
+    QSACompressedKeyCache,
+    QSAForwardMetadata,
+    QSAKeyStateCache,
+    canonical_qsa_rope_positions,
+)
+from .ops.qsa_pre_indexer import qsa_pre_indexer
+
+
+def apply_qsa_rope(
+    rotary_emb: nn.Module,
+    positions: torch.Tensor,
+    tensor: torch.Tensor,
+) -> torch.Tensor:
+    """Apply the main attention's exact 1D/MRoPE composition to QSA heads."""
+
+    num_tokens, _, head_dim = tensor.shape
+    rotary_dim = rotary_emb.rotary_dim
+    cache = rotary_emb._match_cos_sin_cache_dtype(tensor)  # noqa: SLF001
+    cos_sin = cache[positions]
+    cos, sin = cos_sin.chunk(2, dim=-1)
+    if positions.ndim == 2:
+        shape = tensor.shape
+        tensor, _ = triton_mrope(
+            tensor.reshape(num_tokens, -1),
+            tensor.new_empty((num_tokens, head_dim)),
+            cos,
+            sin,
+            rotary_emb.mrope_section,
+            head_dim,
+            rotary_dim,
+            rotary_emb.mrope_interleaved,
+            rotary_emb.is_neox_style,
+        )
+        return tensor.reshape(shape)
+
+    rotated = rotary_emb.apply_rotary_emb.forward_cuda(
+        tensor[..., :rotary_dim],
+        cos,
+        sin,
+    )
+    return torch.cat((rotated, tensor[..., rotary_dim:]), dim=-1)
+
+
+def _supports_fused_pre_indexer(
+    rotary_emb: nn.Module,
+    head_dim: int,
+    num_kv_heads: int,
+    compress_ratio: int,
+) -> bool:
+    rotary_dim = int(rotary_emb.rotary_dim)
+    mrope_section = getattr(rotary_emb, "mrope_section", None)
+    return (
+        bool(getattr(rotary_emb, "is_neox_style", False))
+        and (
+            not mrope_section
+            or (
+                len(mrope_section) == 3
+                and sum(mrope_section) == rotary_dim // 2
+                and bool(getattr(rotary_emb, "mrope_interleaved", False))
+            )
+        )
+        and head_dim == 128
+        and rotary_dim == 64
+        and num_kv_heads == 1
+        and compress_ratio > 1
+        and compress_ratio & (compress_ratio - 1) == 0
+    )
+
+
+class QSAIndexer(nn.Module):
+    """Replicated Q/K projection plus paged, weight-free QSA selection.
+
+    ``prefix`` must be the checkpoint's indexer prefix, normally
+    ``model.layers.N.self_attn.indexer``.  Consequently the trainable names are
+    ``index_qk_proj``, ``q_layernorm`` and ``k_layernorm`` under that prefix.
+    """
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        rotary_emb: nn.Module,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        if vllm_config.cache_config is None:
+            raise ValueError("QSA requires a paged KV cache")
+        if vllm_config.model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+
+        self.layer_id = int(layer_id)
+        self.index_n_heads = int(config.indexer_n_heads)
+        self.index_kv_heads = int(config.indexer_kv_heads)
+        self.index_head_dim = int(config.indexer_head_dim)
+        self.token_topk = int(config.indexer_budget)
+        self.compress_ratio = int(config.indexer_compress_ratio)
+        self.rotary_emb = rotary_emb
+        self.use_fused_pre_indexer = _supports_fused_pre_indexer(
+            rotary_emb,
+            self.index_head_dim,
+            self.index_kv_heads,
+            self.compress_ratio,
+        )
+        self.prefix = prefix
+        # MTP step 0 selects the target-aligned rows; later steps reuse them
+        # while continuing to update the QSA side cache.
+        self.skip_topk = False
+
+        self.index_qk_proj = ReplicatedLinear(
+            int(config.hidden_size),
+            (self.index_n_heads + self.index_kv_heads) * self.index_head_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.index_qk_proj" if prefix else "index_qk_proj",
+        )
+        self.q_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+        self.k_layernorm = GemmaRMSNorm(
+            self.index_head_dim,
+            eps=float(getattr(config, "rms_norm_eps", 1e-6)),
+        )
+
+        cache_config = vllm_config.cache_config
+        cache_prefix = f"{prefix}." if prefix else ""
+        self.raw_key_cache = QSAKeyStateCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            cache_rope_positions=vllm_config.model_config.uses_mrope,
+            prefix=f"{cache_prefix}raw_key_cache",
+            cache_config=cache_config,
+            compress_ratio=self.compress_ratio,
+            vllm_config=vllm_config,
+        )
+        self.compressed_key_cache = QSACompressedKeyCache(
+            head_size=self.index_head_dim,
+            dtype=torch.bfloat16,
+            compress_ratio=self.compress_ratio,
+            prefix=f"{cache_prefix}compressed_key_cache",
+            cache_config=cache_config,
+            vllm_config=vllm_config,
+        )
+
+    @property
+    def output_width(self) -> int:
+        return self.token_topk + self.compress_ratio - 1
+
+    def _metadata(
+        self,
+    ) -> tuple[QSAForwardMetadata, QSAForwardMetadata] | None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            return None
+        raw = cast(QSAForwardMetadata, metadata[self.raw_key_cache.prefix])
+        compressed = cast(
+            QSAForwardMetadata, metadata[self.compressed_key_cache.prefix]
+        )
+        if raw.num_actual_tokens != compressed.num_actual_tokens:
+            raise RuntimeError("QSA side-cache metadata token counts disagree")
+        if not raw.logical_positions.is_cuda and (
+            not torch.equal(raw.logical_positions, compressed.logical_positions)
+        ):
+            raise RuntimeError("QSA side-cache metadata positions disagree")
+        return raw, compressed
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        out: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Return fixed-width request-relative token indices padded with ``-1``."""
+
+        metadata = self._metadata()
+        if metadata is None:
+            # Preserve step-0 indices when later MTP steps reuse the buffer.
+            if self.skip_topk and out is not None:
+                return out
+            result = torch.full(
+                (hidden_states.shape[0], self.output_width),
+                -1,
+                dtype=torch.int32,
+                device=hidden_states.device,
+            )
+            if out is not None:
+                out.copy_(result)
+                return out
+            return result
+
+        from .ops.qsa import (
+            qsa_compress_groups_with_ratio,
+            qsa_select_paged_tokens,
+            qsa_store_cache_rows,
+        )
+
+        raw_metadata, compressed_metadata = metadata
+        num_tokens = raw_metadata.num_actual_tokens
+        hidden_states = hidden_states[:num_tokens]
+        positions = positions[..., :num_tokens]
+
+        # Q/K projection
+        projected_qk, _ = self.index_qk_proj(hidden_states)
+        projected_q, raw_keys = projected_qk.split(
+            (
+                self.index_n_heads * self.index_head_dim,
+                self.index_kv_heads * self.index_head_dim,
+            ),
+            dim=-1,
+        )
+        raw_key_state_cache = self.raw_key_cache
+        compressed_key_cache = self.compressed_key_cache.kv_cache
+
+        if self.use_fused_pre_indexer:
+            q = projected_q.new_empty(
+                num_tokens,
+                self.index_n_heads,
+                self.index_head_dim,
+            )
+            qsa_pre_indexer(
+                projected_q,
+                raw_keys,
+                positions,
+                self.rotary_emb.cos_sin_cache,
+                self.q_layernorm.weight,
+                self.k_layernorm.weight,
+                self.q_layernorm.variance_epsilon,
+                q,
+                raw_key_state_cache.kv_cache,
+                raw_metadata.slot_mapping,
+                raw_metadata.block_table,
+                raw_metadata.query_start_loc,
+                raw_metadata.logical_positions,
+                compressed_key_cache,
+                compressed_metadata.slot_mapping,
+                compressed_metadata.k_work_metadata,
+                compress_ratio=self.compress_ratio,
+                mrope_section=getattr(self.rotary_emb, "mrope_section", None),
+                rope_pos_offset=(
+                    raw_key_state_cache.rope_position_offset
+                    if raw_key_state_cache.rope_position_cache is not None
+                    else None
+                ),
+            )
+        else:
+            # Unfused reference path
+            from flashinfer.norm import gemma_rmsnorm
+
+            q = projected_q.reshape(-1, self.index_n_heads, self.index_head_dim)
+            q = gemma_rmsnorm(
+                q.reshape(-1, self.index_head_dim),
+                self.q_layernorm.weight,
+                self.q_layernorm.variance_epsilon,
+            ).reshape_as(q)
+            q = apply_qsa_rope(self.rotary_emb, positions, q)
+
+            raw_key_cache = raw_key_state_cache.key_cache
+            rope_position_cache = raw_key_state_cache.rope_position_cache
+            if rope_position_cache is None:
+                position_rows = raw_metadata.logical_positions.view(-1, 1, 1).expand(
+                    -1, 1, 3
+                )
+            else:
+                position_rows = canonical_qsa_rope_positions(positions).to(
+                    device=raw_key_cache.device
+                )
+            pooled, first_positions = qsa_compress_groups_with_ratio(
+                raw_keys.reshape(-1, 1, self.index_head_dim),
+                position_rows,
+                raw_key_cache,
+                raw_metadata.block_table,
+                raw_metadata.token_to_req,
+                raw_metadata.query_start_loc,
+                raw_metadata.logical_positions,
+                compressed_metadata.slot_mapping,
+                self.compress_ratio,
+                rope_position_cache,
+            )
+            compressed_keys = gemma_rmsnorm(
+                pooled.reshape(-1, self.index_head_dim),
+                self.k_layernorm.weight,
+                self.k_layernorm.variance_epsilon,
+            ).reshape(-1, 1, self.index_head_dim)
+            if getattr(self.rotary_emb, "mrope_section", None):
+                first_positions = first_positions.transpose(0, 1)
+            else:
+                first_positions = first_positions[:, 0]
+            compressed_keys = apply_qsa_rope(
+                self.rotary_emb,
+                first_positions,
+                compressed_keys,
+            )
+            qsa_store_cache_rows(
+                compressed_key_cache,
+                compressed_metadata.slot_mapping,
+                compressed_keys,
+            )
+            qsa_store_cache_rows(
+                raw_key_cache,
+                raw_metadata.slot_mapping,
+                raw_keys,
+            )
+            if rope_position_cache is not None:
+                qsa_store_cache_rows(
+                    rope_position_cache,
+                    raw_metadata.slot_mapping,
+                    position_rows,
+                )
+
+        if self.skip_topk:
+            if out is None:
+                raise RuntimeError("QSA top-k reuse requires an output buffer")
+            return out
+
+        # Score compressed keys, select blocks, then expand them to token indices.
+        return qsa_select_paged_tokens(
+            q,
+            compressed_key_cache,
+            compressed_metadata.block_table,
+            compressed_metadata.token_to_req,
+            compressed_metadata.logical_positions,
+            compressed_metadata.seq_lens,
+            self.token_topk,
+            self.compress_ratio,
+            out,
+        )
+
+
+__all__ = ["QSAIndexer", "apply_qsa_rope"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/low_latency_gemm.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/low_latency_gemm.py
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Qwen4Exp low-latency GEMM hook for AMD ROCm."""
+
+import torch
+from torch import nn
+
+
+def enable_qwen4_exp_low_latency_gemm(
+    module: nn.Module,
+    dtype: torch.dtype,
+) -> None:
+    """Keep the standard vLLM linear methods on AMD ROCm."""
+
+    del module, dtype

--- a/vllm_ascend/models/qwen4_exp/nvidia/model.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/model.py
@@ -1,0 +1,1045 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp model."""
+
+from collections.abc import Iterable
+from itertools import islice
+
+import torch
+from torch import nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.gdn.qwen_gdn_linear_attn import (
+    QwenGatedDeltaNetAttention,
+)
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateCopyFuncsByType,
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsHybrid,
+    MixtureOfExperts,
+    MultiModalEmbeddings,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    _require_is_multimodal,
+)
+from vllm.model_executor.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5Model,
+)
+from vllm.model_executor.models.qwen3_next import (
+    Qwen3NextAttention,
+    Qwen3NextMLP,
+    Qwen3NextSparseMoeBlock,
+)
+from vllm.model_executor.models.qwen3_vl import (
+    Qwen3_VisionTransformer,
+    Qwen3VLDummyInputsBuilder,
+    Qwen3VLMultiModalProcessor,
+    Qwen3VLProcessingInfo,
+)
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    StageMissingLayer,
+    WeightsMapper,
+    _merge_multimodal_embeddings,
+    extract_layer_index,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import MultiModalFeatureSpec
+from vllm.sequence import IntermediateTensors
+from vllm.tokenizers.registry import cached_tokenizer_from_config
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.kv_cache_interface import MambaSpec
+
+from ..config import Qwen4ExpConfig
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .ple_layer import Qwen4ExpPLELayer
+from .qsa import Qwen4ExpQSAAttention
+
+
+def without_modelopt_fp4(
+    quant_config: QuantizationConfig | None,
+) -> QuantizationConfig | None:
+    """Return ``None`` for weights excluded from Qwen4Exp ModelOpt-FP4."""
+
+    if quant_config is not None and quant_config.get_name() == "modelopt_fp4":
+        return None
+    return quant_config
+
+
+def _remap_qsa_cache_scale_name(
+    name: str,
+    qsa_layer_ids: frozenset[int],
+) -> str:
+    """Map serialized main-cache scales onto the merged QSA owner.
+
+    Regular attention keeps cache scales below its ``attn`` child. QSA owns
+    that cache directly, so only QSA layers need the final path component
+    moved to the owner's persistent ``_k_scale``/``_v_scale`` buffers.
+    """
+
+    scale_suffixes = {
+        "k_proj.k_scale": "_k_scale",
+        "k_proj.output_scale": "_k_scale",
+        "attn.k_scale": "_k_scale",
+        "attn._k_scale": "_k_scale",
+        "k_scale": "_k_scale",
+        "_k_scale": "_k_scale",
+        "v_proj.v_scale": "_v_scale",
+        "v_proj.output_scale": "_v_scale",
+        "attn.v_scale": "_v_scale",
+        "attn._v_scale": "_v_scale",
+        "v_scale": "_v_scale",
+        "_v_scale": "_v_scale",
+    }
+    for layer_id in qsa_layer_ids:
+        marker = f"layers.{layer_id}.self_attn."
+        marker_start = name.find(marker)
+        if marker_start < 0 or (marker_start > 0 and name[marker_start - 1] != "."):
+            continue
+        suffix = name[marker_start + len(marker) :]
+        mapped_suffix = scale_suffixes.get(suffix)
+        if mapped_suffix is not None:
+            return f"{name[: marker_start + len(marker)]}{mapped_suffix}"
+    return name
+
+
+_QWEN4_EXP_IGNORED_MISSING_SUFFIXES = [
+    ".bias",
+    "_bias",
+    ".k_scale",
+    "_k_scale",
+    ".v_scale",
+    "_v_scale",
+    "_weight_scale",
+    "_input_scale",
+]
+
+# The checkpoint keeps down and injection projections separate; runtime packs
+# them into adjacent logical shards of one MergedColumnParallelLinear.
+_HC_WEIGHTS_MAPPER = WeightsMapper(
+    orig_to_new_stacked={
+        "hyper_connection.input_mix_weight_down.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            0,
+        ),
+        "hyper_connection.block_inject_weight.weight": (
+            "hyper_connection.input_mix_weight_down_block_inject.weight",
+            1,
+        ),
+    }
+)
+
+
+class Qwen4ExpSparseMoeBlock(Qwen3NextSparseMoeBlock):
+    """Qwen3Next MoE with Qwen4Exp HC validation."""
+
+    def __init__(self, vllm_config: VllmConfig, prefix: str = "") -> None:
+        parallel_config = vllm_config.parallel_config
+        if parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        config = vllm_config.model_config.hf_text_config
+        self.n_shared_experts = int(config.shared_expert_intermediate_size > 0)
+
+
+class Qwen4ExpDecoderLayer(nn.Module):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        layer_type: str,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+
+        self.config = config
+        self.layer_type = layer_type
+        self.layer_idx = extract_layer_index(prefix)
+        if vllm_config.parallel_config.use_sequence_parallel_moe:
+            raise NotImplementedError(
+                "Qwen4Exp HC does not support sequence-parallel MoE"
+            )
+        self.ple: Qwen4ExpPLELayer | None = None
+        ple_layer_ids = config.ple_layer_ids
+        if (self.layer_idx + 1) in ple_layer_ids:
+            ple_layer_ids_sorted = sorted(set(ple_layer_ids))
+            ple_dense_layer_id_map = {
+                abs_id: idx for idx, abs_id in enumerate(ple_layer_ids_sorted)
+            }
+            ple_dense_layer_id = ple_dense_layer_id_map[self.layer_idx + 1]
+            self.ple = Qwen4ExpPLELayer(
+                config,
+                vllm_config=vllm_config,
+                layer_idx=self.layer_idx,
+                ple_dense_layer_id=ple_dense_layer_id,
+                prefix=f"{prefix}.ple",
+            )
+
+        if layer_type == "linear_attention":
+            self.linear_attn = QwenGatedDeltaNetAttention(
+                config,
+                vllm_config=vllm_config,
+                prefix=f"{prefix}.linear_attn",
+                gqa_interleaved_layout=False,
+            )
+        elif layer_type in ("full_attention", "qwen_sparse_attention"):
+            use_qsa = getattr(config, "indexer_n_heads", None) is not None
+            if not use_qsa:
+                self.self_attn = Qwen3NextAttention(
+                    config,
+                    model_config=model_config,
+                    cache_config=cache_config,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.self_attn",
+                )
+            else:
+                self.self_attn = Qwen4ExpQSAAttention(
+                    vllm_config=vllm_config,
+                    config=config,
+                    layer_id=self.layer_idx,
+                    quant_config=quant_config,
+                    prefix=f"{prefix}.self_attn",
+                )
+        else:
+            raise ValueError(f"Invalid layer_type {layer_type}")
+
+        mlp_only_layers = getattr(config, "mlp_only_layers", [])
+        num_experts = getattr(config, "num_experts", 0) or 0
+        absolute_layer_id = self.layer_idx + 1
+        is_moe_layer = self.layer_idx not in mlp_only_layers and num_experts > 0
+        if is_moe_layer:
+            self.mlp = Qwen4ExpSparseMoeBlock(
+                vllm_config=vllm_config, prefix=f"{prefix}.mlp"
+            )
+        else:
+            self.mlp = Qwen3NextMLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=getattr(
+                    config, "intermediate_size", config.moe_intermediate_size
+                ),
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=f"{prefix}.mlp",
+            )
+
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.attn_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "attn_hyper_connection"),
+        )
+        self.mlp_hyper_connection = GatedResidual(
+            hc_config,
+            prefix=maybe_prefix(prefix, "mlp_hyper_connection"),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        prev_block_output: torch.Tensor | None,
+        prev_injection: torch.Tensor | None,
+        positions: torch.Tensor,
+        *,
+        input_ids: torch.Tensor | None,
+        query_start_loc: torch.Tensor | None,
+        ngram_context: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        attn_hc = self.attn_hyper_connection
+        if self.ple is not None:
+            # PLE adds directly to the multi-stream state, so pending HC state
+            # must be materialized before the addition.
+            if prev_block_output is not None and prev_injection is not None:
+                hidden_states = attn_hc.combine(
+                    hidden_states, prev_block_output, prev_injection
+                )
+                prev_block_output = prev_injection = None
+
+            if input_ids is None or query_start_loc is None or ngram_context is None:
+                raise RuntimeError("PLE inputs were not prepared")
+            hidden_states = hidden_states + self.ple(
+                hidden_states,
+                input_ids,
+                query_start_loc,
+                ngram_context,
+            )
+
+        # Fuse a pending combine with this HC module's mix when possible.
+        if prev_block_output is not None and prev_injection is not None:
+            hidden_states, block_input, injection = attn_hc.combine_and_mix(
+                hidden_states, prev_block_output, prev_injection
+            )
+        else:
+            hidden_states, block_input, injection = attn_hc.mix(hidden_states)
+
+        if self.layer_type == "linear_attention":
+            attn_out = self.linear_attn(hidden_states=block_input)
+        elif self.layer_type == "full_attention":
+            attn_out = self.self_attn(
+                hidden_states=block_input,
+                positions=positions,
+            )
+        else:
+            raise ValueError("Invalid layer_type")
+
+        mlp_hc = self.mlp_hyper_connection
+        hidden_states, block_input, injection = mlp_hc.combine_and_mix(
+            hidden_states, attn_out, injection
+        )
+        mlp_out = self.mlp(block_input)
+        return hidden_states, mlp_out, injection
+
+
+class Qwen4ExpMixtureOfExperts(MixtureOfExperts):
+    """Expose Qwen4Exp routed experts through vLLM's EPLB protocol."""
+
+    def set_moe_parameters(self, layers: Iterable[nn.Module]) -> None:
+        self.moe_layers = []
+        self.moe_mlp_layers = []
+        example_moe = None
+        for layer in layers:
+            if isinstance(layer, Qwen4ExpDecoderLayer) and isinstance(
+                layer.mlp, Qwen4ExpSparseMoeBlock
+            ):
+                example_moe = layer.mlp
+                self.moe_mlp_layers.append(layer.mlp)
+                self.moe_layers.append(layer.mlp.experts)
+
+        self.num_moe_layers = len(self.moe_layers)
+        if example_moe is None:
+            self.num_expert_groups = 0
+            self.num_shared_experts = 0
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_redundant_experts = 0
+            return
+
+        self.num_expert_groups = 1
+        self.num_shared_experts = example_moe.n_shared_experts
+        self.num_logical_experts = example_moe.n_logical_experts
+        self.num_physical_experts = example_moe.n_physical_experts
+        self.num_local_physical_experts = example_moe.n_local_physical_experts
+        self.num_routed_experts = example_moe.n_routed_experts
+        self.num_redundant_experts = example_moe.n_redundant_experts
+
+    def update_physical_experts_metadata(
+        self,
+        num_physical_experts: int,
+        num_local_physical_experts: int,
+    ) -> None:
+        assert self.num_local_physical_experts == num_local_physical_experts
+        self.num_physical_experts = num_physical_experts
+        self.num_local_physical_experts = num_local_physical_experts
+        self.num_redundant_experts = num_physical_experts - self.num_logical_experts
+        for moe in self.moe_mlp_layers:
+            moe.n_physical_experts = num_physical_experts
+            moe.n_local_physical_experts = num_local_physical_experts
+            moe.n_redundant_experts = self.num_redundant_experts
+            moe.experts.update_expert_map()
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "query_start_loc": 0,
+        "ngram_context": 0,
+        "deepstack_input_embeds": 0,
+    }
+)
+class Qwen4ExpModel(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.config = config
+        self.num_redundant_experts = (
+            vllm_config.parallel_config.eplb_config.num_redundant_experts
+        )
+        self.vocab_size = config.vocab_size
+        self._qsa_layer_ids = frozenset(
+            layer_idx
+            for layer_idx, layer_type in enumerate(config.layer_types)
+            if layer_type == "full_attention"
+            and getattr(config, "indexer_n_heads", None) is not None
+        )
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, config.hidden_size)
+
+        def get_layer(prefix: str) -> Qwen4ExpDecoderLayer:
+            layer_idx = extract_layer_index(prefix)
+            return Qwen4ExpDecoderLayer(
+                vllm_config,
+                layer_type=config.layer_types[layer_idx],
+                prefix=prefix,
+            )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers, get_layer, prefix=f"{prefix}.layers"
+        )
+        intermediate_size = config.hidden_size * config.hc_count
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], intermediate_size
+        )
+
+        self.hyper_connection_mixer: GatedResidual | None
+        if get_pp_group().is_last_rank:
+            hc_config = HyperConnectionConfig(
+                hc_count=config.hc_count,
+                hidden_size=config.hidden_size,
+                params_dtype=torch.bfloat16,
+                hc_lowrank=config.hc_lowrank,
+                rms_norm_eps=config.rms_norm_eps,
+                hc_per_branch_norm=True,
+            )
+            self.hyper_connection_mixer = GatedResidual(
+                hc_config,
+                use_combine=False,
+                prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+            )
+        else:
+            self.hyper_connection_mixer = None
+
+        spec_config = vllm_config.speculative_config
+        # MTP HC multi-stream outputs: when speculative method=="mtp" and the
+        # model uses HC with hc_count>1, retain the pre-final-mixer multi-stream
+        # hidden state [T, hc_count*H] so the MTP drafter can feed a real
+        # multi-stream backbone hidden on its first step (scheme A). Derived
+        # purely from config (NOT node identity) so P/D nodes stay consistent.
+        needs_mtp_hidden = (
+            spec_config is not None
+            and getattr(spec_config, "method", None) == "mtp"
+            and get_pp_group().is_last_rank
+        )
+        if needs_mtp_hidden:
+            self._mtp_hidden_buffer = torch.empty(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                config.hc_count * config.hidden_size,
+                dtype=vllm_config.model_config.dtype,
+            )
+        else:
+            self._mtp_hidden_buffer = None
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        query_start_loc: torch.Tensor | None = None,
+        ngram_context: torch.Tensor | None = None,
+        deepstack_input_embeds: IntermediateTensors | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                if input_ids is None:
+                    raise ValueError("input_ids or inputs_embeds is required")
+                hidden_states = self.embed_input_ids(input_ids)
+            hidden_states = hidden_states.repeat(1, self.config.hc_count)
+        else:
+            if intermediate_tensors is None:
+                raise ValueError("pipeline stage requires intermediate tensors")
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        block_output = None
+        injection = None
+        last_layer = None
+        for layer_idx, layer in islice(
+            enumerate(self.layers), self.start_layer, self.end_layer
+        ):
+            last_layer = layer
+            hidden_states, block_output, injection = layer(
+                hidden_states=hidden_states,
+                prev_block_output=block_output,
+                prev_injection=injection,
+                positions=positions,
+                input_ids=input_ids,
+                query_start_loc=query_start_loc,
+                ngram_context=ngram_context,
+            )
+            if deepstack_input_embeds is not None and layer_idx < len(
+                deepstack_input_embeds
+            ):
+                deepstack_embed = deepstack_input_embeds[
+                    f"deepstack_input_embeds_{layer_idx}"
+                ]
+                deepstack_embed = (
+                    deepstack_embed.unsqueeze(-2)
+                    .expand(
+                        *deepstack_embed.shape[:-1],
+                        self.config.hc_count,
+                        self.config.hidden_size,
+                    )
+                    .flatten(-2)
+                )
+                # Deepstack is an external addition to the materialized
+                # multi-stream state and therefore terminates delayed combine.
+                hidden_states = layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+                block_output = None
+                injection = None
+                hidden_states = hidden_states + deepstack_embed
+
+        if not get_pp_group().is_last_rank:
+            # PP transports one tensor, not the delayed HC tuple. Materialize
+            # with the HC module that produced the pending injection.
+            if last_layer is not None and block_output is not None:
+                hidden_states = last_layer.mlp_hyper_connection.combine(
+                    hidden_states, block_output, injection
+                )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # The final mixer consumes the last pending combine and returns both
+        # the sampled single stream and the materialized multi-stream state.
+        final_mixer = self.hyper_connection_mixer
+        assert final_mixer is not None
+        multi_hidden, sample_hidden_states, _ = final_mixer.combine_and_mix(
+            hidden_states, block_output, injection
+        )
+        if self._mtp_hidden_buffer is not None:
+            # Capture the pre-final-mixer multi-stream hidden state
+            # [T, hc_count*H] for the MTP drafter (zero extra compute:
+            # this tensor is needed by the final mixer regardless).
+            num_tokens = multi_hidden.shape[0]
+            self._mtp_hidden_buffer[:num_tokens].copy_(multi_hidden)
+        return sample_hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = (
+            (
+                _remap_qsa_cache_scale_name(name, self._qsa_layer_ids),
+                weight,
+            )
+            for name, weight in weights
+        )
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        # Non-persistent PLE state rebuilt in __init__; skip any ckpt
+        # column for them.
+        skip_substrs = [
+            "hashstats_",
+            "token_lookup",
+            "hyper_connection_mixer.block_inject_weight",
+        ]
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=skip_substrs,
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        loaded = loader.load_weights(
+            weights,
+            mapper=self.hf_to_vllm_mapper,
+        )
+        return loaded
+
+
+class Qwen4ExpForCausalLM(
+    nn.Module,
+    HasInnerState,
+    SupportsLoRA,
+    SupportsMRoPE,
+    SupportsPP,
+    Qwen4ExpMixtureOfExperts,
+    IsHybrid,
+):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={"model.language_model.": "model."}
+    )
+    requires_raw_input_tokens = True
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.quant_config = vllm_config.quant_config
+        self.config = config
+        self.scheduler_config = vllm_config.scheduler_config
+        if vllm_config.cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4Exp currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+        self.model = Qwen4ExpModel(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, self.model_config.dtype)
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        # Forward kwargs unchanged so the runner's _maybe_add_ngram_kwargs
+        # path (query_start_loc / ngram_context) reaches Qwen4ExpModel.
+        return self.model(
+            input_ids,
+            positions,
+            intermediate_tensors,
+            inputs_embeds,
+            **kwargs,
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    @classmethod
+    def get_ple_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+
+    @classmethod
+    def get_ple_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int]]:
+        hf_config = vllm_config.model_config.hf_text_config
+        conv_kernel_size = hf_config.ple_conv_kernel_size
+        short_conv_dilation = hf_config.ngram_size
+        conv_state_len = (conv_kernel_size - 1) * short_conv_dilation
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        hc_count = hf_config.hc_count
+        hc_hidden_size = hf_config.hidden_size * hc_count
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=hc_hidden_size,
+            conv_kernel=conv_state_len + 1,
+            num_spec=num_spec,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_dtype_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
+        )
+
+    @classmethod
+    def get_gdn_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        parallel_config = vllm_config.parallel_config
+        hf_config = vllm_config.model_config.hf_text_config
+        tp_size = parallel_config.tensor_parallel_size
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            tp_size,
+            hf_config.linear_num_key_heads,
+            hf_config.linear_num_value_heads,
+            hf_config.linear_key_head_dim,
+            hf_config.linear_value_head_dim,
+            hf_config.linear_conv_kernel_dim,
+            num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return cls.get_gdn_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return cls.get_gdn_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> MambaStateCopyFuncsByType:
+        copy_funcs_by_type = {
+            MambaAttentionBackendEnum.GDN_ATTN: cls.get_mamba_state_copy_func(),
+            MambaAttentionBackendEnum.SHORT_CONV: (
+                MambaStateCopyFuncCalculator.short_conv_state_copy_func()
+            ),
+        }
+        missing_types = mamba_types - copy_funcs_by_type.keys()
+        assert not missing_types, f"missing state copy funcs for {missing_types}"
+        return {
+            mamba_type: copy_funcs_by_type[mamba_type] for mamba_type in mamba_types
+        }
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        """Return all MambaSpecs for this model (GDN layers + PLE layer).
+
+        The PLE layer uses a separate short_conv MambaSpec whose page_size_bytes
+        may exceed the GDN spec; callers should take the maximum.
+        """
+        return (
+            MambaSpec(
+                shapes=cls.get_gdn_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_gdn_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+            ),
+            MambaSpec(
+                shapes=cls.get_ple_mamba_state_shape_from_config(vllm_config),
+                dtypes=cls.get_ple_mamba_state_dtype_from_config(vllm_config),
+                block_size=-1,
+                tp_replicated=True,
+            ),
+        )
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.model._mtp_hidden_buffer
+
+    def get_mrope_input_positions(
+        self,
+        input_tokens: list[int],
+        mm_features: list[MultiModalFeatureSpec],
+    ) -> tuple[torch.Tensor, int]:
+        positions = torch.arange(len(input_tokens), dtype=torch.long)
+        return positions.unsqueeze(0).expand(3, -1), 0
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["mtp."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+class Qwen4ExpProcessingInfo(Qwen3VLProcessingInfo):
+    def get_hf_config(self) -> Qwen4ExpConfig:
+        config = self.ctx.get_hf_config()
+        if not isinstance(config, Qwen4ExpConfig):
+            config = Qwen4ExpConfig(**config.to_dict())
+        return config
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    Qwen3VLMultiModalProcessor,
+    info=Qwen4ExpProcessingInfo,
+    dummy_inputs=Qwen3VLDummyInputsBuilder,
+)
+class Qwen4ExpForConditionalGeneration(
+    Qwen3_5ForConditionalGeneration,
+    HasInnerState,
+    Qwen4ExpMixtureOfExperts,
+):
+    """Qwen3-VL vision tower backed by the Qwen4Exp language model."""
+
+    requires_raw_input_tokens = True
+
+    packed_modules_mapping = Qwen3_5ForConditionalGeneration.packed_modules_mapping | {
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ]
+    }
+
+    @staticmethod
+    def get_model_state_cls():
+        from .model_state import Qwen4ExpModelState
+
+        return Qwen4ExpModelState
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "model") -> None:
+        nn.Module.__init__(self)
+        config: Qwen4ExpConfig = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        multimodal_config = vllm_config.model_config.multimodal_config
+        if multimodal_config is None:
+            raise ValueError(
+                "Qwen4ExpForConditionalGeneration requires multimodal_config"
+            )
+
+        self.config = config
+        self.model_config = vllm_config.model_config
+        self.multimodal_config = multimodal_config
+        self.language_model_only = multimodal_config.language_model_only
+        if self.language_model_only:
+            self.use_data_parallel = False
+            self.is_multimodal_pruning_enabled = False
+            self.video_pruning_method = None
+            self.video_pruning_rate = 0.0
+            self._tokenizer = None
+            self.visual = StageMissingLayer("vision_tower")
+            self._tower_model_names = []
+        else:
+            self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
+            self._init_video_pruning(multimodal_config)
+            self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
+
+            with self._mark_tower_model(vllm_config, {"image", "video"}):
+                self.visual = Qwen3_VisionTransformer(
+                    config.vision_config,
+                    norm_eps=config.text_config.rms_norm_eps,
+                    quant_config=quant_config,
+                    prefix=maybe_prefix(prefix, "visual"),
+                )
+
+        self.use_deepstack = (
+            not self.language_model_only
+            and bool(config.vision_config.deepstack_visual_indexes)
+            and not isinstance(self.visual, StageMissingLayer)
+        )
+        self.deepstack_num_level = (
+            len(config.vision_config.deepstack_visual_indexes)
+            if self.use_deepstack
+            else 0
+        )
+        self.visual_dim = config.vision_config.out_hidden_size
+        self.multiscale_dim = self.visual_dim * self.deepstack_num_level
+
+        if self.use_deepstack:
+            self.deepstack_input_embeds = [
+                torch.zeros(
+                    vllm_config.scheduler_config.max_num_batched_tokens,
+                    config.text_config.hidden_size,
+                )
+                for _ in range(self.deepstack_num_level)
+            ]
+            self.deepstack_input_embeds_num_tokens = 0
+
+        with self._mark_language_model(vllm_config):
+            self.language_model = Qwen4ExpForCausalLM(
+                vllm_config=vllm_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+            )
+
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        if not get_pp_group().is_first_rank and self.use_deepstack:
+            assert self.language_model.model.start_layer >= len(
+                config.vision_config.deepstack_visual_indexes
+            ), (
+                "start_layer should be greater than or equal to "
+                "len(deepstack_visual_indexes)"
+            )
+        self.set_moe_parameters(self.language_model.model.layers)
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.language_model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+        if self.language_model_only:
+            raise ValueError(
+                "Qwen4Exp language_model_only does not accept multimodal embeddings"
+            )
+
+        is_multimodal = _require_is_multimodal(is_multimodal)
+        if self.use_deepstack:
+            deepstack_input_embeds, multimodal_embeddings = (
+                self._compute_deepstack_embeds(
+                    inputs_embeds=inputs_embeds,
+                    multimodal_embeddings=multimodal_embeddings,
+                    is_multimodal=is_multimodal,
+                )
+            )
+        else:
+            deepstack_input_embeds = None
+
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+        if deepstack_input_embeds is not None:
+            self._set_deepstack_input_embeds(deepstack_input_embeds)
+        return inputs_embeds
+
+    def get_mtp_target_hidden_states(self) -> torch.Tensor | None:
+        return self.language_model.get_mtp_target_hidden_states()
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> torch.Tensor | IntermediateTensors:
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            deepstack_input_embeds = self._get_deepstack_input_embeds(
+                inputs_embeds.size(0)
+            )
+        else:
+            deepstack_input_embeds = None
+
+        hidden_states = self.language_model.model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+            query_start_loc=kwargs.get("query_start_loc"),
+            ngram_context=kwargs.get("ngram_context"),
+            deepstack_input_embeds=deepstack_input_embeds,
+        )
+        if inputs_embeds is not None and get_pp_group().is_first_rank:
+            self._clear_deepstack_input_embeds(inputs_embeds.size(0))
+        return hidden_states
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=["visual."] if self.language_model_only else None,
+            skip_substrs=["mtp."],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return Qwen4ExpForCausalLM.get_mamba_state_dtype_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: VllmConfig,
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        return Qwen4ExpForCausalLM.get_mamba_state_shape_from_config(vllm_config)
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_func()
+
+    @classmethod
+    def get_mamba_state_copy_funcs(
+        cls,
+        mamba_types: set[MambaAttentionBackendEnum],
+    ) -> MambaStateCopyFuncsByType:
+        return Qwen4ExpForCausalLM.get_mamba_state_copy_funcs(mamba_types)
+
+    @classmethod
+    def get_mamba_specs_from_config(
+        cls, vllm_config: VllmConfig
+    ) -> tuple[MambaSpec, ...]:
+        return Qwen4ExpForCausalLM.get_mamba_specs_from_config(vllm_config)
+
+
+__all__ = [
+    "Qwen4ExpDecoderLayer",
+    "Qwen4ExpForCausalLM",
+    "Qwen4ExpForConditionalGeneration",
+    "Qwen4ExpMixtureOfExperts",
+    "Qwen4ExpModel",
+    "Qwen4ExpSparseMoeBlock",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/model_state.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/model_state.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Model-runner state for Qwen4Exp PLE inputs."""
+
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.input_batch import InputBatch
+from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
+from vllm.v1.worker.gpu.model_states.mamba_hybrid import MambaHybridModelState
+from vllm.v1.worker.gpu.states import RequestState
+
+
+class Qwen4ExpModelState(MambaHybridModelState):
+    """Add rollback-safe PLE n-gram context to the model inputs."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        model: nn.Module,
+        encoder_cache: EncoderCache | None,
+        device: torch.device,
+    ) -> None:
+        super().__init__(vllm_config, model, encoder_cache, device)
+        config = self.model_config.hf_text_config
+        self.uses_ngram_embedding = bool(config.ple_layer_ids)
+        if not self.uses_ngram_embedding:
+            self.ngram_context_len = 0
+            self.ngram_eos_token_id = 0
+            return
+
+        if vllm_config.parallel_config.pipeline_parallel_size > 1:
+            raise RuntimeError(
+                "N-gram PLE embedding currently requires "
+                "pipeline_parallel_size=1 because non-first pipeline ranks do "
+                "not receive the raw input_ids required by PLE. Please run "
+                "with PP=1."
+            )
+
+        self.ngram_context_len = int(config.ngram_size) - 1
+        if self.ngram_context_len <= 0:
+            raise ValueError("N-gram embedding requires context length >= 1.")
+        self.ngram_eos_token_id = int(config.eos_token_id)
+        self.ngram_context = torch.full(
+            (self.max_num_reqs, self.ngram_context_len),
+            self.ngram_eos_token_id,
+            dtype=torch.int32,
+            device=self.device,
+        )
+        self.ngram_context_offsets = torch.arange(
+            -self.ngram_context_len,
+            0,
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.ple_query_start_loc = torch.zeros(
+            self.max_num_reqs + 1,
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+    def _prepare_ngram_context(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> torch.Tensor:
+        num_reqs = input_batch.num_reqs
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        context = self.ngram_context[:num_reqs_padded]
+        context.fill_(self.ngram_eos_token_id)
+        if num_reqs == 0:
+            return context
+
+        request_indices = input_batch.idx_mapping[:num_reqs].long()
+        context_end = req_states.num_computed_tokens.gpu[request_indices].long()
+        token_indices = context_end.unsqueeze(1) + self.ngram_context_offsets
+        valid_tokens = token_indices >= 0
+        token_indices.clamp_min_(0)
+        context_tokens = req_states.all_token_ids.gpu[
+            request_indices.unsqueeze(1), token_indices
+        ]
+        context[:num_reqs].copy_(
+            torch.where(
+                valid_tokens,
+                context_tokens,
+                context_tokens.new_full((), self.ngram_eos_token_id),
+            )
+        )
+        return context
+
+    def prepare_inputs(
+        self,
+        input_batch: InputBatch,
+        req_states: RequestState,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_inputs(input_batch, req_states)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        num_reqs_padded = input_batch.num_reqs_after_padding
+        query_start_loc = self.ple_query_start_loc[: num_reqs_padded + 1]
+        query_start_loc.copy_(input_batch.query_start_loc[: num_reqs_padded + 1])
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=self._prepare_ngram_context(input_batch, req_states),
+        )
+        return model_inputs
+
+    def prepare_dummy_inputs(
+        self,
+        num_reqs: int,
+        num_tokens: int,
+    ) -> dict[str, Any]:
+        model_inputs = super().prepare_dummy_inputs(num_reqs, num_tokens)
+        if not self.uses_ngram_embedding:
+            return model_inputs
+
+        query_start_loc = self.ple_query_start_loc[: num_reqs + 1]
+        query_start_loc[0] = 0
+        tokens_per_req, num_extra_tokens = divmod(num_tokens, num_reqs)
+        query_lens = torch.full(
+            (num_reqs,),
+            tokens_per_req,
+            dtype=query_start_loc.dtype,
+            device=query_start_loc.device,
+        )
+        if num_extra_tokens > 0:
+            query_lens[-num_extra_tokens:] += 1
+        torch.cumsum(query_lens, dim=0, out=query_start_loc[1:])
+
+        ngram_context = self.ngram_context[:num_reqs]
+        ngram_context.fill_(self.ngram_eos_token_id)
+        model_inputs.update(
+            query_start_loc=query_start_loc,
+            ngram_context=ngram_context,
+        )
+        return model_inputs
+
+
+__all__ = ["Qwen4ExpModelState"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/mtp.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/mtp.py
@@ -1,0 +1,447 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Inference-only Qwen4Exp MTP (Multi-Token Predictor) model.
+
+The MTP draft model reuses the Qwen4Exp backbone (PLE/HC/MoE) but:
+  - drops all multi-modal handling (text-only),
+  - forces PLE off while keeping the main model's HC stream count,
+  - fuses the backbone hidden and the new-token embedding via
+    ``residual_linear_shared`` (fc_embedding + shared fc_hidden) instead of
+    the ``Linear(2H, H)`` + repeat used by other MTP variants,
+  - emits TWO hidden streams per step (scheme A): a single stream [T, H]
+    (final-mixer collapsed, fed to the LM head) and a pre-final-mixer
+    multi stream [T, hc_count*H] (fed to the next draft step).
+"""
+
+from collections.abc import Iterable
+
+import regex as re
+import torch
+from torch import nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, replace, set_current_vllm_config
+from vllm.distributed import get_pp_group
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.utils import configure_quant_config
+from vllm.model_executor.models.interfaces import SupportsPP
+from vllm.model_executor.models.qwen3_5 import Qwen3_5Model
+from vllm.model_executor.models.utils import (
+    AutoWeightsLoader,
+    PPMissingLayer,
+    get_draft_quant_config,
+    make_empty_intermediate_tensors_factory,
+    maybe_fuse_shared_experts,
+    maybe_prefix,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+
+from .hyperconnection import GatedResidual, HyperConnectionConfig
+from .low_latency_gemm import enable_qwen4_exp_low_latency_gemm
+from .model import (
+    _HC_WEIGHTS_MAPPER,
+    _QWEN4_EXP_IGNORED_MISSING_SUFFIXES,
+    Qwen4ExpDecoderLayer,
+    Qwen4ExpMixtureOfExperts,
+)
+
+
+def _remap_ignored_layers(
+    ignored_layers: list[str],
+    mtp_start_layer_idx: int,
+) -> list[str]:
+    remapped: list[str] = []
+    for name in ignored_layers:
+        if name.startswith("mtp."):
+            new_name = re.sub(
+                r"(?<=\.layers\.)\d+",
+                lambda m: str(mtp_start_layer_idx + int(m.group(0))),
+                name,
+            )
+            remapped.append(new_name)
+        else:
+            remapped.append(name)
+    return remapped
+
+
+def _remap_mtp_weight_name(name: str) -> str | None:
+    """Map Qwen4Exp checkpoint paths into the standalone draft model."""
+
+    for checkpoint_prefix in (
+        "model.language_model.",
+        "language_model.",
+    ):
+        if name.startswith(checkpoint_prefix):
+            name = name.removeprefix(checkpoint_prefix)
+            break
+
+    if name.startswith("embed_tokens."):
+        name = f"model.{name}"
+    if name.startswith("model.mtp."):
+        name = name.removeprefix("model.")
+    if name.startswith("mtp.shared_head.head."):
+        return name.replace("mtp.shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.shared_head.head."):
+        return name.replace("model.shared_head.head.", "lm_head.", 1)
+    if name.startswith("shared_head.head."):
+        return name.replace("shared_head.head.", "lm_head.", 1)
+    if name.startswith("model.lm_head."):
+        return name.removeprefix("model.")
+    if name.startswith("mtp."):
+        return name.replace("mtp.", "model.", 1)
+    if name.startswith("model.embed_tokens.") or name.startswith("lm_head."):
+        return name
+    return None
+
+
+def _make_draft_vllm_config(
+    vllm_config: VllmConfig,
+    mtp_start_layer_idx: int,
+) -> VllmConfig:
+    """Ensure that the draft model config is set in the vLLM config."""
+    speculative_config = vllm_config.speculative_config
+    if speculative_config is None or speculative_config.draft_model_config is None:
+        raise ValueError("speculative_config.draft_model_config must be set")
+
+    draft_quant_config = get_draft_quant_config(vllm_config)
+
+    # inject packed and ignored modules to the quantization config of draft model
+    if draft_quant_config is not None:
+        configure_quant_config(draft_quant_config, Qwen4ExpMTP)
+        ignored_layers = getattr(draft_quant_config, "ignored_layers", None)
+        if ignored_layers:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "ignored_layers",
+                _remap_ignored_layers(ignored_layers, mtp_start_layer_idx),
+            )
+        exclude_modules = getattr(draft_quant_config, "exclude_modules", None)
+        if exclude_modules:
+            setattr(  # noqa: B010
+                draft_quant_config,
+                "exclude_modules",
+                _remap_ignored_layers(exclude_modules, mtp_start_layer_idx),
+            )
+
+    draft_vllm_config = replace(
+        vllm_config,
+        model_config=speculative_config.draft_model_config,
+    )
+    # VllmConfig post-init derives the target quant config, so restore the
+    # independently resolved draft quant config after replacement.
+    draft_vllm_config.quant_config = draft_quant_config
+    return draft_vllm_config
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMultiTokenPredictor(nn.Module):
+    hf_to_vllm_mapper = Qwen3_5Model.hf_to_vllm_mapper | _HC_WEIGHTS_MAPPER
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__()
+
+        model_config = vllm_config.model_config
+        config: Qwen4ExpTextConfig = model_config.hf_text_config
+
+        self.config = config
+        self.vocab_size = config.vocab_size
+
+        self.mtp_start_layer_idx = config.num_hidden_layers
+        self.num_mtp_layers = getattr(config, "mtp_num_hidden_layers", 1)
+
+        self.hidden_size = config.hidden_size
+        self.hc_count = config.hc_count
+
+        self.embed_tokens = VocabParallelEmbedding(self.vocab_size, self.hidden_size)
+        draft_vllm_config = _make_draft_vllm_config(
+            vllm_config,
+            self.mtp_start_layer_idx,
+        )
+        with set_current_vllm_config(draft_vllm_config, prefix=prefix):
+            # residual_linear_shared fusion: fc_embedding projects the token
+            # embedding, fc_hidden (shared across HC branches) projects the
+            # backbone hidden; the embedding is added as a residual to every
+            # branch (see mtp_residual_linear_shared.md).
+            self.fc_embedding = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_embedding",
+            )
+            self.fc_hidden = ColumnParallelLinear(
+                self.hidden_size,
+                self.hidden_size,
+                gather_output=True,
+                bias=False,
+                return_bias=False,
+                quant_config=draft_vllm_config.quant_config,
+                prefix=f"{prefix}.fc_hidden",
+            )
+            self.layers = nn.ModuleList(
+                Qwen4ExpDecoderLayer(
+                    draft_vllm_config,
+                    layer_type="full_attention",
+                    prefix=f"{prefix}.layers.{self.mtp_start_layer_idx + idx}",
+                )
+                for idx in range(self.num_mtp_layers)
+            )
+
+        self.pre_fc_norm_embedding = GemmaRMSNorm(
+            self.hidden_size, eps=config.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = GemmaRMSNorm(
+            self.hidden_size * self.hc_count, eps=config.rms_norm_eps
+        )
+        # HC final mixer collapses the multi stream into [T, H] for the LM head.
+        hc_config = HyperConnectionConfig(
+            hc_count=config.hc_count,
+            hidden_size=config.hidden_size,
+            params_dtype=torch.bfloat16,
+            hc_lowrank=config.hc_lowrank,
+            rms_norm_eps=config.rms_norm_eps,
+            hc_per_branch_norm=True,
+        )
+        self.hyper_connection_mixer = GatedResidual(
+            hc_config,
+            use_combine=False,
+            prefix=maybe_prefix(prefix, "hyper_connection_mixer"),
+        )
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states"], self.hidden_size * self.hc_count
+        )
+
+    def _iter_qsa_attentions(self):
+        """Yield MTP attention modules that own a QSA indexer."""
+
+        for layer in self.layers:
+            attention = getattr(layer, "self_attn", None)
+            if (
+                attention is not None
+                and getattr(attention, "indexer", None) is not None
+            ):
+                yield attention
+
+    def set_skip_topk(self, skip: bool) -> None:
+        """Select on MTP step 0 and reuse its QSA indices on later steps."""
+
+        for attention in self._iter_qsa_attentions():
+            attention.indexer.skip_topk = skip
+
+    def compact_topk_indices(self, row_indices: torch.Tensor) -> None:
+        """Keep each request's target-aligned step-0 sparse-index row."""
+
+        num_rows = row_indices.numel()
+        for attention in self._iter_qsa_attentions():
+            buffer = attention.topk_indices_buffer
+            selected = buffer.index_select(0, row_indices)
+            buffer[:num_rows].copy_(selected)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        hc_count = self.hc_count
+        hidden_size = self.hidden_size
+
+        if get_pp_group().is_first_rank:
+            assert hidden_states is not None
+            if inputs_embeds is None:
+                assert input_ids is not None
+                inputs_embeds = self.embed_input_ids(input_ids)
+            # Embedding branch: pre-norm -> fc_embedding -> [T, H].
+            inputs_embeds = self.pre_fc_norm_embedding(inputs_embeds)
+            inputs_embeds = self.fc_embedding(inputs_embeds)
+
+            # Backbone hidden is multi-stream [T, hc_count*H] (scheme A:
+            # the main model truly emits the pre-final-mixer multi stream
+            # on the first step; subsequent steps reuse the prior draft
+            # step's multi stream).
+            num_tokens = hidden_states.shape[0]
+            hidden_states = hidden_states.view(num_tokens, hc_count, hidden_size)
+            hidden_states = self.pre_fc_norm_hidden(hidden_states.flatten(-2)).view(
+                num_tokens, hc_count, hidden_size
+            )
+            hidden_states = self.fc_hidden(hidden_states)
+            # Add the embedding residual to every branch, then fold back
+            # to [T, hc_count*H] (HC outer, HS inner) for the HC decoder.
+            hidden_states = inputs_embeds.unsqueeze(-2) + hidden_states
+            hidden_states = hidden_states.flatten(-2)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        layer = self.layers[current_step_idx]
+        hidden_states, block_output, injection = layer(
+            hidden_states=hidden_states,
+            prev_block_output=None,
+            prev_injection=None,
+            positions=positions,
+            input_ids=None,
+            query_start_loc=None,
+            ngram_context=None,
+        )
+        if not get_pp_group().is_last_rank:
+            # As in the target model, PP carries a materialized tensor rather
+            # than the delayed hidden/output/injection tuple.
+            hidden_states = layer.mlp_hyper_connection.combine(
+                hidden_states, block_output, injection
+            )
+            return IntermediateTensors({"hidden_states": hidden_states})
+
+        # Last PP rank finalize. Keep both:
+        #   (A) sample_hidden_states [T, H]  -> single stream for the LM head
+        #   (B) multi_hidden [T, hc_count*H] -> pre-final-mixer multi stream
+        #       for the next draft step (zero extra compute, just kept).
+        multi_hidden, sample_hidden_states, _ = (
+            self.hyper_connection_mixer.combine_and_mix(
+                hidden_states, block_output, injection
+            )
+        )
+        return sample_hidden_states, multi_hidden
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        weights = maybe_fuse_shared_experts(
+            weights,
+            n_routed_experts=getattr(self.config, "num_experts", 0) or 0,
+            n_shared_experts=1,
+            ckpt_prefix="mlp.shared_expert",
+        )
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
+
+
+@support_torch_compile(
+    dynamic_arg_dims={
+        "input_ids": 0,
+        "positions": -1,
+        "intermediate_tensors": 0,
+        "inputs_embeds": 0,
+        "hidden_states": 0,
+    }
+)
+class Qwen4ExpMTP(nn.Module, SupportsPP, Qwen4ExpMixtureOfExperts):
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+        "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+        "in_proj_ba": ["in_proj_b", "in_proj_a"],
+        "input_mix_weight_down_block_inject": [
+            "input_mix_weight_down",
+            "block_inject_weight",
+            "_input_mix_padding",
+        ],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        config: Qwen4ExpTextConfig = vllm_config.model_config.hf_text_config
+        self.vllm_config = vllm_config
+        cache_config = vllm_config.cache_config
+        if cache_config.mamba_cache_mode == "all":
+            raise NotImplementedError(
+                "Qwen4ExpMTP currently does not support 'all' prefix caching, "
+                "please use '--mamba-cache-mode=align' instead"
+            )
+
+        self.quant_config = vllm_config.quant_config
+
+        super().__init__()
+        self.config = config
+        self.model = Qwen4ExpMultiTokenPredictor(
+            vllm_config=vllm_config,
+            prefix=maybe_prefix(prefix, "mtp"),
+        )
+
+        if get_pp_group().is_last_rank:
+            if config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    prefix=maybe_prefix(prefix, "lm_head"),
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+        self.set_moe_parameters(self.model.layers)
+        enable_qwen4_exp_low_latency_gemm(self, vllm_config.model_config.dtype)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor | None = None,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor] | IntermediateTensors:
+        return self.model(
+            input_ids,
+            positions,
+            hidden_states,
+            intermediate_tensors,
+            inputs_embeds,
+            spec_step_idx=spec_step_idx,
+        )
+
+    def compute_logits(
+        self, hidden_states: torch.Tensor, spec_step_idx: int = 0
+    ) -> torch.Tensor | None:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        def remap_weight_names():
+            for name, weight in weights:
+                remapped_name = _remap_mtp_weight_name(name)
+                if remapped_name is not None:
+                    yield remapped_name, weight
+
+        loader = AutoWeightsLoader(
+            self,
+            skip_substrs=["hyper_connection_mixer.block_inject_weight"],
+            ignore_unexpected_suffixes=_QWEN4_EXP_IGNORED_MISSING_SUFFIXES.copy(),
+        )
+        return loader.load_weights(remap_weight_names())
+
+
+__all__ = ["Qwen4ExpMTP", "Qwen4ExpMultiTokenPredictor"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/__init__.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVIDIA-only Qwen4Exp kernels; import leaf modules directly."""

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/hc.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/hc.py
@@ -1,0 +1,487 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVIDIA HyperConnection kernels for Qwen4Exp."""
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
+
+
+@triton.jit
+def _grouped_gemma_rmsnorm_kernel(
+    x_ptr,
+    w_ptr,
+    y_ptr,
+    stride_x,
+    stride_y,
+    DIM: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    W_SHARED: tl.constexpr,
+    EPS: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    GROUP_DIM: tl.constexpr = DIM // NUM_GROUPS
+    BLOCK_SIZE: tl.constexpr = triton.next_power_of_2(GROUP_DIM)
+
+    pid = tl.program_id(0)
+    group_id = pid % NUM_GROUPS
+    row = pid // NUM_GROUPS
+
+    offs_g = tl.arange(0, BLOCK_SIZE)
+    offsets = group_id * GROUP_DIM + offs_g
+    mask = offs_g < GROUP_DIM
+    # A [GROUP_DIM] affine is shared; a [DIM] affine follows the grouped
+    # checkpoint layout.
+    w_offs = offs_g if W_SHARED else offsets
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    x = tl.load(x_ptr + row * stride_x + offsets, mask, other=0.0).to(tl.float32)
+    w = tl.load(w_ptr + w_offs, mask, other=0.0)
+
+    rrms = tl.rsqrt(tl.sum(x * x) / GROUP_DIM + EPS)
+    # Gemma's (1 + w) affine is written this way to lower to an FMA.
+    y = x * rrms
+    y += y * w.to(tl.float32)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offsets, y, mask)
+
+
+def _grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    N, DIM = x.shape
+    assert x.stride(1) == 1, "grouped Gemma RMSNorm requires unit inner stride"
+    assert weight.is_contiguous(), "grouped Gemma RMSNorm weight must be contiguous"
+    assert DIM % num_groups == 0
+    group_dim = DIM // num_groups
+    assert weight.numel() in (group_dim, DIM)
+
+    y = x.new_empty(x.shape)
+    _grouped_gemma_rmsnorm_kernel[(N * num_groups,)](
+        x,
+        weight,
+        y,
+        x.stride(0),
+        y.stride(0),
+        DIM,
+        num_groups,
+        W_SHARED=weight.numel() == group_dim,
+        EPS=eps,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return y
+
+
+@triton.jit
+def _hc_silu_kernel(
+    x_ptr,
+    y_ptr,
+    stride_x,
+    stride_y,
+    DIM: tl.constexpr,
+    HC: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    BLOCK_SIZE: tl.constexpr = triton.next_power_of_2(DIM)
+
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < DIM
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    x = tl.load(x_ptr + row * stride_x + offs, mask).to(tl.float32) / HC
+    y = x * tl.sigmoid(x)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offs, y, mask)
+
+
+def _hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    num_tokens, DIM = x.shape
+    assert x.stride(1) == 1
+
+    output = x.new_empty(x.shape)
+    _hc_silu_kernel[(num_tokens,)](
+        x,
+        output,
+        x.stride(0),
+        output.stride(0),
+        DIM=DIM,
+        HC=hc_count,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return output
+
+
+@triton.jit
+def _hc_gate_mix_kernel(
+    x_ptr,
+    g_ptr,
+    y_ptr,
+    stride_x,
+    stride_g,
+    stride_y,
+    DIM: tl.constexpr,
+    HC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_DIM: tl.constexpr = DIM // HC
+
+    row = tl.program_id(0)
+    tile_id = tl.program_id(1)
+    offs_inner = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs_inner < HC_DIM
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    # The constexpr loop is unrolled and keeps one stream live at a time.
+    # Materializing [HC, BLOCK_SIZE] more than doubles latency at large M.
+    acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for stream in tl.static_range(HC):
+        offsets = stream * HC_DIM + offs_inner
+        g = tl.load(g_ptr + row * stride_g + offsets, mask, other=0.0)
+        x = tl.load(x_ptr + row * stride_x + offsets, mask, other=0.0)
+        acc += tl.sigmoid(g.to(tl.float32)) * x.to(tl.float32)
+    acc /= HC
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(y_ptr + row * stride_y + offs_inner, acc, mask)
+
+
+def _hc_gate_mix(x: torch.Tensor, gate: torch.Tensor, hc_count: int) -> torch.Tensor:
+    N, DIM = gate.shape
+    assert x.shape == gate.shape
+    assert DIM % hc_count == 0
+    assert x.stride(1) == 1
+    assert gate.stride(1) == 1
+
+    HC_DIM = DIM // hc_count
+    out = x.new_empty(N, HC_DIM)
+    BLOCK_SIZE = 512
+    _hc_gate_mix_kernel[(N, triton.cdiv(HC_DIM, BLOCK_SIZE))](
+        x,
+        gate,
+        out,
+        x.stride(0),
+        gate.stride(0),
+        out.stride(0),
+        DIM,
+        hc_count,
+        BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out
+
+
+@triton.jit
+def _hc_combine_kernel(
+    block_ptr,
+    res_ptr,
+    inj_ptr,
+    out_ptr,
+    stride_block,
+    stride_res,
+    stride_inj,
+    stride_out,
+    HC_DIM: tl.constexpr,
+    HC: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_PAD: tl.constexpr = triton.next_power_of_2(HC)
+
+    row = tl.program_id(0)
+    tile_id = tl.program_id(1)
+
+    offs_inner = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask_inner = offs_inner < HC_DIM
+    offs_hc = tl.arange(0, HC_PAD)
+    mask_hc = offs_hc < HC
+    offs = offs_hc[:, None] * HC_DIM + offs_inner[None, :]
+    mask = mask_hc[:, None] & mask_inner[None, :]
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    inj = tl.load(inj_ptr + row * stride_inj + offs_hc, mask_hc, other=0.0)
+    block = tl.load(block_ptr + row * stride_block + offs_inner, mask_inner, other=0.0)
+    res = tl.load(res_ptr + row * stride_res + offs, mask, other=0.0)
+
+    # Keeping HC as a broadcast dimension is faster here than four separate
+    # residual load/store sequences.
+    inj = 2.0 * tl.sigmoid(inj.to(tl.float32) / HC)
+    out = res.to(tl.float32) + block.to(tl.float32)[None, :] * inj[:, None]
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+    tl.store(out_ptr + row * stride_out + offs, out, mask=mask)
+
+
+def _hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    N, DIM = residual.shape
+    assert DIM % hc_count == 0
+    hc_dim = DIM // hc_count
+    assert block_output.shape == (N, hc_dim)
+    assert injection_logits.shape == (N, hc_count)
+    assert residual.stride(1) == 1
+    assert block_output.stride(1) == 1
+    assert injection_logits.stride(1) == 1
+
+    out = residual.new_empty(residual.shape)
+    BLOCK_SIZE = 512
+    _hc_combine_kernel[(N, triton.cdiv(hc_dim, BLOCK_SIZE))](
+        block_output,
+        residual,
+        injection_logits,
+        out,
+        block_output.stride(0),
+        residual.stride(0),
+        injection_logits.stride(0),
+        out.stride(0),
+        hc_dim,
+        hc_count,
+        BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out
+
+
+@triton.jit
+def _hc_combine_norm_kernel(
+    block_ptr,
+    res_ptr,
+    inj_ptr,
+    w_ptr,
+    out_ptr,
+    y_ptr,
+    stride_block,
+    stride_res,
+    stride_inj,
+    stride_out,
+    stride_y,
+    HC_DIM: tl.constexpr,
+    HC: tl.constexpr,
+    W_SHARED: tl.constexpr,
+    EPS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    launch_pdl: tl.constexpr,
+) -> None:
+    HC_PAD: tl.constexpr = triton.next_power_of_2(HC)
+    NUM_TILES: tl.constexpr = triton.cdiv(HC_DIM, BLOCK_SIZE)
+    NUM_TILES_PAD: tl.constexpr = triton.next_power_of_2(NUM_TILES)
+
+    row = tl.program_id(0)
+    stream = tl.program_id(1)
+    offs_hc = tl.arange(0, HC_PAD)
+    mask_hc = offs_hc < HC
+    tile_ids = tl.arange(0, NUM_TILES_PAD)
+    offs_inner = tile_ids[:, None] * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)[None, :]
+    mask_inner = offs_inner < HC_DIM
+    offs = stream * HC_DIM + offs_inner
+    # Shared norm weights repeat across streams; per-branch weights use the
+    # same flattened HC layout as the residual.
+    w_offs = offs_inner if W_SHARED else offs
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_wait()
+
+    # Start the uncached residual load first, then issue the other combine
+    # loads before consuming any of them.
+    res = tl.load(res_ptr + row * stride_res + offs, mask_inner, other=0.0)
+    inj = tl.load(inj_ptr + row * stride_inj + offs_hc, mask_hc, other=0.0)
+    block = tl.load(block_ptr + row * stride_block + offs_inner, mask_inner, other=0.0)
+    inj = 2.0 * tl.sigmoid(inj.to(tl.float32) / HC)
+    inj = tl.sum(tl.where(offs_hc == stream, inj, 0.0))
+    # Round the materialized combine result before normalization. This matches
+    # the unfused combine -> RMSNorm boundary.
+    out = (res.to(tl.float32) + block.to(tl.float32) * inj).to(out_ptr.dtype.element_ty)
+    tl.store(out_ptr + row * stride_out + offs, out, mask=mask_inner)
+
+    out = out.to(tl.float32)
+    # Keep the two-axis reduction: flattening the padded tile is ~40% slower
+    # at decode sizes.
+    sum_sq = tl.sum(tl.sum(out * out, axis=1), axis=0)
+    rrms = tl.rsqrt(sum_sq / HC_DIM + EPS)
+
+    if launch_pdl:
+        tl.extra.cuda.gdc_launch_dependents()
+
+    # Loading the weight earlier helps decode but keeps the tile live across
+    # the reduction and regresses larger batches, so defer it to the norm.
+    w = tl.load(w_ptr + w_offs, mask_inner, other=0.0)
+    y = out * rrms
+    y += y * w.to(tl.float32)
+    tl.store(y_ptr + row * stride_y + offs, y, mask_inner)
+
+
+def _hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    N, DIM = residual.shape
+    assert DIM % hc_count == 0
+    hc_dim = DIM // hc_count
+    assert block_output.shape == (N, hc_dim)
+    assert injection_logits.shape == (N, hc_count)
+    assert residual.stride(1) == 1
+    assert block_output.stride(1) == 1
+    assert injection_logits.stride(1) == 1
+    assert norm_weight.is_contiguous()
+    assert norm_weight.numel() in (hc_dim, DIM)
+
+    out = residual.new_empty(residual.shape)
+    y = residual.new_empty(residual.shape)
+    BLOCK_SIZE = 512
+    _hc_combine_norm_kernel[(N, hc_count)](
+        block_output,
+        residual,
+        injection_logits,
+        norm_weight,
+        out,
+        y,
+        block_output.stride(0),
+        residual.stride(0),
+        injection_logits.stride(0),
+        out.stride(0),
+        y.stride(0),
+        hc_dim,
+        hc_count,
+        W_SHARED=norm_weight.numel() == hc_dim,
+        EPS=eps,
+        BLOCK_SIZE=BLOCK_SIZE,
+        launch_pdl=current_platform.is_arch_support_pdl(),
+    )
+    return out, y
+
+
+def _same_shape_fake(x: torch.Tensor, *args) -> torch.Tensor:
+    return x.new_empty(x.shape)
+
+
+def _hc_gate_mix_fake(
+    x: torch.Tensor, gate: torch.Tensor, hc_count: int
+) -> torch.Tensor:
+    del gate
+    return x.new_empty((x.shape[0], x.shape[1] // hc_count))
+
+
+def _hc_combine_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    del block_output, injection_logits, hc_count
+    return residual.new_empty(residual.shape)
+
+
+def _hc_combine_norm_fake(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del block_output, injection_logits, norm_weight, eps, hc_count
+    return residual.new_empty(residual.shape), residual.new_empty(residual.shape)
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_grouped_gemma_rmsnorm",
+    op_func=_grouped_gemma_rmsnorm,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_silu",
+    op_func=_hc_silu,
+    fake_impl=_same_shape_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_gate_mix",
+    op_func=_hc_gate_mix,
+    fake_impl=_hc_gate_mix_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine",
+    op_func=_hc_combine,
+    fake_impl=_hc_combine_fake,
+)
+direct_register_custom_op(
+    op_name="qwen4_exp_hc_combine_norm",
+    op_func=_hc_combine_norm,
+    fake_impl=_hc_combine_norm_fake,
+)
+
+
+def grouped_gemma_rmsnorm(
+    x: torch.Tensor, weight: torch.Tensor, eps: float, num_groups: int
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_grouped_gemma_rmsnorm(x, weight, eps, num_groups)
+
+
+def hc_silu(x: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_silu(x, hc_count)
+
+
+def hc_gate_mix(x: torch.Tensor, gate: torch.Tensor, hc_count: int) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_gate_mix(x, gate, hc_count)
+
+
+def hc_combine(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    hc_count: int,
+) -> torch.Tensor:
+    return torch.ops.vllm.qwen4_exp_hc_combine(
+        residual, block_output, injection_logits, hc_count
+    )
+
+
+def hc_combine_norm(
+    residual: torch.Tensor,
+    block_output: torch.Tensor,
+    injection_logits: torch.Tensor,
+    norm_weight: torch.Tensor,
+    eps: float,
+    hc_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.vllm.qwen4_exp_hc_combine_norm(
+        residual,
+        block_output,
+        injection_logits,
+        norm_weight,
+        eps,
+        hc_count,
+    )
+
+
+__all__ = [
+    "grouped_gemma_rmsnorm",
+    "hc_combine",
+    "hc_combine_norm",
+    "hc_gate_mix",
+    "hc_silu",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa.py
@@ -1,0 +1,1115 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton kernels for the Qwen4Exp weight-free QSA path."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from vllm.platforms import current_platform
+from vllm.triton_utils import HAS_TRITON, tl, triton
+
+_LOGITS_WORKSPACE_BYTES = 128 * 1024 * 1024
+_TOPK_WORKSPACE_BYTES = 1024 * 1024
+
+
+@triton.jit
+def _qsa_mqa_paged_kernel(
+    q_ptr,
+    k_cache_ptr,
+    page_table_ptr,
+    token_to_req_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    visible_blocks_ptr,
+    logits_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_q_dim,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_table_req,
+    stride_table_page,
+    stride_logits_row,
+    num_rows,
+    num_columns,
+    num_pages,
+    num_requests,
+    score_divisor,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    NUM_HEADS: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    TILES_PER_PROG: tl.constexpr,
+    STAGES: tl.constexpr,
+    MAX_N: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    heads = tl.arange(0, MAX_N)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_position = tl.load(query_positions_ptr + row)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    visible = tl.minimum(
+        (query_position + 1) // COMPRESS_RATIO,
+        sequence_length // COMPRESS_RATIO,
+    )
+    if tl.program_id(1) == 0:
+        tl.store(visible_blocks_ptr + row, visible)
+    tile_start = tl.program_id(1) * TILES_PER_PROG
+    # Top-k is bounded by visible_blocks, so columns beyond it need no value.
+    if tile_start * BLOCK_N >= visible:
+        return
+    tile_end = tl.minimum(tile_start + TILES_PER_PROG, tl.cdiv(visible, BLOCK_N))
+    tile_end = tl.minimum(tile_end, tl.cdiv(num_columns, BLOCK_N))
+
+    # Pad the small head axis to a tensor-core-compatible N dimension.
+    query = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + heads[None, :] * stride_q_head
+        + dims[:, None] * stride_q_dim,
+        mask=(heads[None, :] < NUM_HEADS) & (dims[:, None] < HEAD_DIM),
+        other=0.0,
+    )
+    column_offsets = tl.arange(0, BLOCK_N)
+    for tile in tl.range(tile_start, tile_end, num_stages=STAGES):
+        columns = tile * BLOCK_N + column_offsets
+        live = columns < visible
+        logical_page = tl.minimum(columns // PAGE_SIZE, PAGE_TABLE_WIDTH - 1)
+        page_offset = columns % PAGE_SIZE
+        physical_page = tl.load(
+            page_table_ptr
+            + safe_request * stride_table_req
+            + logical_page * stride_table_page,
+            mask=live,
+            other=-1,
+        )
+        page_valid = live & (physical_page >= 0) & (physical_page < num_pages)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_physical_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_physical_page[:, None] * stride_cache_block
+            + page_offset[:, None] * stride_cache_token
+            + dims[None, :] * stride_cache_dim,
+            mask=page_valid[:, None] & (dims[None, :] < HEAD_DIM),
+            other=0.0,
+            eviction_policy="evict_first",
+        )
+        scores = tl.dot(keys, query, out_dtype=tl.float32)
+        scores = tl.where(heads[None, :] < NUM_HEADS, tl.maximum(scores, 0.0), 0.0)
+        score = tl.sum(scores, axis=1) / score_divisor
+        tl.store(
+            logits_ptr + row * stride_logits_row + columns,
+            tl.where(page_valid, score, -float("inf")),
+            mask=live & (columns < num_columns),
+        )
+
+
+@triton.jit
+def _expand_qsa_indices_kernel(
+    block_indices_ptr,
+    query_positions_ptr,
+    sequence_lengths_ptr,
+    token_to_req_ptr,
+    output_ptr,
+    stride_blocks_row,
+    stride_blocks_column,
+    stride_output_row,
+    stride_output_column,
+    rows,
+    num_requests,
+    BLOCK_TOPK: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    TOKEN_TOPK: tl.constexpr,
+    OUTPUT_WIDTH: tl.constexpr,
+    COLUMN_BLOCK: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    columns = tl.program_id(1) * COLUMN_BLOCK + tl.arange(0, COLUMN_BLOCK)
+    query_position = tl.load(query_positions_ptr + row)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    sequence_length = tl.load(
+        sequence_lengths_ptr + safe_request,
+        mask=(request >= 0) & (request < num_requests),
+        other=0,
+    )
+    complete_blocks = tl.minimum(
+        tl.minimum(
+            (query_position + 1) // COMPRESS_RATIO,
+            sequence_length // COMPRESS_RATIO,
+        ),
+        BLOCK_TOPK,
+    )
+    expanded_count = complete_blocks * COMPRESS_RATIO
+    tail_start = ((query_position + 1) // COMPRESS_RATIO) * COMPRESS_RATIO
+    tail_count = (query_position + 1) - tail_start
+
+    is_expanded = columns < expanded_count
+    block_rank = columns // COMPRESS_RATIO
+    offset = columns % COMPRESS_RATIO
+    safe_rank = tl.minimum(block_rank, BLOCK_TOPK - 1)
+    block = tl.load(
+        block_indices_ptr + row * stride_blocks_row + safe_rank * stride_blocks_column,
+        mask=(row < rows) & is_expanded,
+        other=-1,
+    )
+    expanded = block * COMPRESS_RATIO + offset
+    tail_offset = columns - expanded_count
+    is_tail = (
+        (columns >= expanded_count)
+        & (tail_offset < tail_count)
+        & (tail_offset < COMPRESS_RATIO - 1)
+    )
+    token = tl.where(is_expanded, expanded, tail_start + tail_offset)
+    valid = (
+        (row < rows)
+        & (columns < OUTPUT_WIDTH)
+        & (is_expanded | is_tail)
+        & (token >= 0)
+        & (token < sequence_length)
+    )
+    tl.store(
+        output_ptr + row * stride_output_row + columns * stride_output_column,
+        tl.where(valid, token, -1),
+        mask=(row < rows) & (columns < OUTPUT_WIDTH),
+    )
+
+
+@triton.jit
+def _qsa_sparse_paged_gqa_splitk_kernel(
+    q_ptr,
+    k_cache_ptr,
+    v_cache_ptr,
+    indices_ptr,
+    block_table_ptr,
+    token_to_req_ptr,
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_q_row,
+    stride_q_head,
+    stride_k_block,
+    stride_k_token,
+    stride_k_head,
+    stride_v_block,
+    stride_v_token,
+    stride_v_head,
+    stride_indices_row,
+    stride_table_req,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    num_cache_blocks,
+    num_requests,
+    TOPK: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    PAGE_TABLE_WIDTH: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    split_id = tl.program_id(2)
+    request = tl.load(token_to_req_ptr + row)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+
+    head_offsets = tl.arange(0, BLOCK_M)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    column_offsets = tl.arange(0, BLOCK_N)
+    first_head = kv_head * GROUP_SIZE
+    query = tl.load(
+        q_ptr
+        + row * stride_q_row
+        + (first_head + head_offsets[:, None]) * stride_q_head
+        + dim_offsets[None, :],
+        mask=head_offsets[:, None] < GROUP_SIZE,
+        other=0.0,
+    )
+
+    max_value = tl.full((BLOCK_M,), -1.0e20, dtype=tl.float32)
+    normalizer = tl.zeros((BLOCK_M,), dtype=tl.float32)
+    accumulator = tl.zeros((BLOCK_M, HEAD_DIM), dtype=tl.float32)
+    softmax_scale_log2: tl.constexpr = (HEAD_DIM**-0.5) * 1.4426950408889634
+
+    # Dynamic bounds avoid padded main-loop iterations for uneven splits.
+    split_tile_start = split_id * NUM_TILES // NUM_SPLITS
+    split_tile_end = (split_id + 1) * NUM_TILES // NUM_SPLITS
+    for tile in range(split_tile_start, split_tile_end):
+        columns = tile * BLOCK_N + column_offsets
+        logical_token = tl.load(
+            indices_ptr + row * stride_indices_row + columns,
+            mask=columns < TOPK,
+            other=-1,
+        )
+        safe_token = tl.maximum(logical_token, 0)
+        logical_page = safe_token // PAGE_SIZE
+        page_offset = safe_token % PAGE_SIZE
+        valid = (
+            (request >= 0)
+            & (request < num_requests)
+            & (logical_token >= 0)
+            & (logical_page < PAGE_TABLE_WIDTH)
+        )
+        physical_page = tl.load(
+            block_table_ptr
+            + safe_request * stride_table_req
+            + tl.minimum(logical_page, PAGE_TABLE_WIDTH - 1),
+            mask=valid,
+            other=-1,
+        )
+        valid &= (physical_page >= 0) & (physical_page < num_cache_blocks)
+        # physical_page * block stride can overflow int32 for large caches.
+        safe_page = tl.maximum(physical_page, 0).to(tl.int64)
+        keys = tl.load(
+            k_cache_ptr
+            + safe_page[None, :] * stride_k_block
+            + page_offset[None, :] * stride_k_token
+            + kv_head * stride_k_head
+            + dim_offsets[:, None],
+            mask=valid[None, :],
+            other=0.0,
+        )
+        values = tl.load(
+            v_cache_ptr
+            + safe_page[:, None] * stride_v_block
+            + page_offset[:, None] * stride_v_token
+            + kv_head * stride_v_head
+            + dim_offsets[None, :],
+            mask=valid[:, None],
+            other=0.0,
+        )
+        scores = tl.dot(query, keys)
+        # Scaling scores avoids re-quantizing a scaled query to BF16.
+        scores *= softmax_scale_log2
+        scores = tl.where(valid[None, :], scores, -1.0e20)
+        next_max = tl.maximum(max_value, tl.max(scores, axis=1))
+        alpha = tl.math.exp2(max_value - next_max)
+        probabilities = tl.where(
+            valid[None, :], tl.math.exp2(scores - next_max[:, None]), 0.0
+        )
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            acc=accumulator * alpha[:, None],
+        )
+        normalizer = normalizer * alpha + tl.sum(probabilities, axis=1)
+        max_value = next_max
+
+    has_values = normalizer > 0
+    normalized_output = tl.where(
+        has_values[:, None],
+        accumulator / tl.maximum(normalizer[:, None], 1.0e-20),
+        0.0,
+    )
+    output_mask = head_offsets[:, None] < GROUP_SIZE
+    if NUM_SPLITS == 1:
+        tl.store(
+            output_ptr
+            + row * stride_output_row
+            + (first_head + head_offsets[:, None]) * stride_output_head
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+    else:
+        partial_lse = tl.where(
+            has_values,
+            max_value + tl.math.log2(tl.maximum(normalizer, 1.0e-20)),
+            -float("inf"),
+        )
+        tl.store(
+            partial_output_ptr
+            + (
+                (split_id * num_rows + row) * NUM_QUERY_HEADS
+                + first_head
+                + head_offsets[:, None]
+            )
+            * HEAD_DIM
+            + dim_offsets[None, :],
+            normalized_output,
+            mask=output_mask,
+        )
+        tl.store(
+            partial_lse_ptr
+            + (split_id * num_rows + row) * NUM_QUERY_HEADS
+            + first_head
+            + head_offsets,
+            partial_lse,
+            mask=head_offsets < GROUP_SIZE,
+        )
+
+
+@triton.jit
+def _qsa_merge_splitk_kernel(
+    partial_output_ptr,
+    partial_lse_ptr,
+    output_ptr,
+    stride_output_row,
+    stride_output_head,
+    num_rows,
+    HEAD_DIM: tl.constexpr,
+    NUM_QUERY_HEADS: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    BLOCK_SPLITS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    head = tl.program_id(1)
+    split_offsets = tl.arange(0, BLOCK_SPLITS)
+    dim_offsets = tl.arange(0, HEAD_DIM)
+    split_mask = split_offsets < NUM_SPLITS
+    lse = tl.load(
+        partial_lse_ptr + (split_offsets * num_rows + row) * NUM_QUERY_HEADS + head,
+        mask=split_mask,
+        other=-float("inf"),
+    )
+    lse_max = tl.max(lse, axis=0)
+    has_values = lse_max > -float("inf")
+    shifted = tl.where(split_mask & has_values, lse - lse_max, -float("inf"))
+    weights = tl.math.exp2(shifted)
+    denominator = tl.sum(weights, axis=0)
+    partial_output = tl.load(
+        partial_output_ptr
+        + ((split_offsets[:, None] * num_rows + row) * NUM_QUERY_HEADS + head)
+        * HEAD_DIM
+        + dim_offsets[None, :],
+        mask=split_mask[:, None],
+        other=0.0,
+    )
+    merged = tl.sum(partial_output * weights[:, None], axis=0)
+    merged = tl.where(denominator > 0, merged / denominator, 0.0)
+    tl.store(
+        output_ptr + row * stride_output_row + head * stride_output_head + dim_offsets,
+        merged,
+    )
+
+
+@triton.jit
+def _store_qsa_rows_kernel(
+    cache_ptr,
+    slots_ptr,
+    rows_ptr,
+    stride_cache_block,
+    stride_cache_token,
+    stride_cache_dim,
+    stride_rows_row,
+    stride_rows_dim,
+    num_rows,
+    num_blocks,
+    PAGE_SIZE: tl.constexpr,
+    WIDTH: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    slot = tl.load(slots_ptr + row)
+    valid = (row < num_rows) & (slot >= 0) & (slot < num_blocks * PAGE_SIZE)
+    block = tl.maximum(slot, 0) // PAGE_SIZE
+    token = tl.maximum(slot, 0) % PAGE_SIZE
+    values = tl.load(
+        rows_ptr + row * stride_rows_row + dims * stride_rows_dim,
+        mask=valid & (dims < WIDTH),
+        other=0,
+    )
+    tl.store(
+        cache_ptr
+        + block * stride_cache_block
+        + token * stride_cache_token
+        + dims * stride_cache_dim,
+        values,
+        mask=valid & (dims < WIDTH),
+    )
+
+
+@triton.jit
+def _compress_qsa_groups_kernel(
+    raw_keys_ptr,  # this step's raw key rows, straight from activations
+    raw_positions_ptr,  # this step's per-token positions
+    compressor_state_cache_ptr,  # per-request ring of previous raw keys
+    rope_cache_ptr,  # packed RoPE position tail of the ring
+    compressor_state_table_ptr,
+    token_to_req_ptr,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    pooled_ptr,
+    first_positions_ptr,
+    stride_raw_row,
+    stride_raw_dim,
+    stride_raw_positions_row,
+    stride_raw_positions_dim,
+    stride_compressor_state_block,
+    stride_compressor_state_token,
+    stride_compressor_state_dim,
+    stride_rope_block,
+    stride_rope_token,
+    stride_rope_dim,
+    stride_compressor_state_table_req,
+    stride_pooled_row,
+    stride_pooled_dim,
+    stride_positions_row,
+    stride_positions_dim,
+    num_rows,
+    num_compressor_state_blocks,
+    num_requests,
+    COMPRESSOR_STATE_SIZE: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    LOAD_ROPE_POSITIONS: tl.constexpr,
+) -> None:
+    row = tl.program_id(0)
+    dims = tl.arange(0, BLOCK_D)
+    request = tl.load(token_to_req_ptr + row)
+    end_position = tl.load(logical_positions_ptr + row)
+    compressed_slot = tl.load(compressed_slots_ptr + row)
+    valid_request = (request >= 0) & (request < num_requests)
+    safe_request = tl.minimum(tl.maximum(request, 0), num_requests - 1)
+    query_row_start = tl.load(
+        query_start_loc_ptr + safe_request, mask=valid_request, other=0
+    )
+    query_row_end = tl.load(
+        query_start_loc_ptr + safe_request + 1, mask=valid_request, other=0
+    )
+    chunk_start_position = end_position - (row - query_row_start)
+    compressor_state_block = tl.load(
+        compressor_state_table_ptr + safe_request * stride_compressor_state_table_req,
+        mask=valid_request,
+        other=-1,
+    )
+    valid_compressor_state_block = (compressor_state_block >= 0) & (
+        compressor_state_block < num_compressor_state_blocks
+    )
+    valid_row = (
+        (row < num_rows)
+        & valid_request
+        & (row >= query_row_start)
+        & (row < query_row_end)
+        & (end_position >= COMPRESS_RATIO - 1)
+        & (compressed_slot >= 0)
+    )
+    accumulator = tl.zeros((BLOCK_D,), dtype=tl.float32)
+
+    # A group can span the compressor-state ring (older members) and this
+    # step's raw rows (members at positions >= chunk_start_position).
+    for group_offset in tl.range(0, COMPRESS_RATIO):
+        position = end_position - (COMPRESS_RATIO - 1 - group_offset)
+        use_raw = position >= chunk_start_position
+        raw_row = query_row_start + position - chunk_start_position
+        raw_values = tl.load(
+            raw_keys_ptr + raw_row * stride_raw_row + dims * stride_raw_dim,
+            mask=valid_row
+            & use_raw
+            & (raw_row >= query_row_start)
+            & (raw_row < query_row_end)
+            & (raw_row < num_rows)
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        compressor_state_values = tl.load(
+            compressor_state_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64)
+            * stride_compressor_state_block
+            + (position % COMPRESSOR_STATE_SIZE) * stride_compressor_state_token
+            + dims * stride_compressor_state_dim,
+            mask=valid_row
+            & ~use_raw
+            & valid_compressor_state_block
+            & (dims < HEAD_DIM),
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += tl.where(use_raw, raw_values, compressor_state_values)
+
+    tl.store(
+        pooled_ptr + row * stride_pooled_row + dims * stride_pooled_dim,
+        accumulator / COMPRESS_RATIO,
+        mask=(row < num_rows) & (dims < HEAD_DIM),
+    )
+
+    position_dims = tl.arange(0, 4)
+    first_position = end_position - COMPRESS_RATIO + 1
+    if LOAD_ROPE_POSITIONS:
+        first_from_raw = first_position >= chunk_start_position
+        raw_first_row = query_row_start + first_position - chunk_start_position
+        raw_position_values = tl.load(
+            raw_positions_ptr
+            + raw_first_row * stride_raw_positions_row
+            + position_dims * stride_raw_positions_dim,
+            mask=valid_row
+            & first_from_raw
+            & (raw_first_row >= query_row_start)
+            & (raw_first_row < query_row_end)
+            & (raw_first_row < num_rows)
+            & (position_dims < 3),
+            other=0,
+        )
+        compressor_state_position_values = tl.load(
+            rope_cache_ptr
+            + tl.maximum(compressor_state_block, 0).to(tl.int64) * stride_rope_block
+            + (first_position % COMPRESSOR_STATE_SIZE) * stride_rope_token
+            + position_dims * stride_rope_dim,
+            mask=valid_row
+            & ~first_from_raw
+            & valid_compressor_state_block
+            & (position_dims < 3),
+            other=0,
+        )
+        position_values = tl.where(
+            first_from_raw,
+            raw_position_values,
+            compressor_state_position_values,
+        )
+    else:
+        position_values = tl.where(valid_row, first_position, 0)
+    tl.store(
+        first_positions_ptr
+        + row * stride_positions_row
+        + position_dims * stride_positions_dim,
+        position_values,
+        mask=(row < num_rows) & (position_dims < 3),
+    )
+
+
+def _validate_mqa(q: torch.Tensor) -> None:
+    if q.ndim != 3 or q.shape[1] <= 0 or q.shape[2] <= 0:
+        raise ValueError("QSA query must be [rows, heads, head_dim]")
+
+
+def qsa_mqa_paged(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+    num_columns: int | None = None,
+    score_scale: float | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute QSA scores directly from a paged compressed-key cache."""
+
+    _validate_mqa(q)
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA scoring requires CUDA and Triton")
+    if k_cache.ndim != 4 or k_cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, head_dim]")
+    if k_cache.shape[3] != q.shape[2]:
+        raise ValueError("QSA query and cache dimensions must match")
+    if page_table.ndim != 2:
+        raise ValueError("QSA page table must be two-dimensional")
+    if q.shape[0] and (not all(k_cache.shape[:2]) or not all(page_table.shape)):
+        raise ValueError("QSA paged scoring cache and page table must be nonempty")
+    if token_to_req.shape != (q.shape[0],):
+        raise ValueError("QSA request mapping must match query rows")
+    if query_positions.shape != (q.shape[0],):
+        raise ValueError("QSA query positions must match query rows")
+    if sequence_lengths.shape != (page_table.shape[0],):
+        raise ValueError("QSA sequence lengths must match page-table requests")
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    score_divisor = math.sqrt(q.shape[2]) if score_scale is None else score_scale
+    if score_divisor <= 0:
+        raise ValueError("QSA score scale must be positive")
+
+    capacity = page_table.shape[1] * k_cache.shape[1]
+    columns = capacity if num_columns is None else num_columns
+    if columns < 0:
+        raise ValueError("QSA score width must be non-negative")
+    logits = torch.empty((q.shape[0], columns), dtype=torch.float32, device=q.device)
+    visible_blocks = torch.empty(q.shape[0], dtype=torch.int32, device=q.device)
+    if not q.shape[0] or not columns:
+        return logits, visible_blocks
+    BLOCK_N = 64
+    BLOCK_D = max(16, triton.next_power_of_2(q.shape[2]))
+    MAX_N = max(16, triton.next_power_of_2(q.shape[1]))
+    # Tuned on GB300: larger row batches provide enough parallelism to reuse Q.
+    tiles_per_program = 1 if q.shape[0] <= 32 else 8
+    _qsa_mqa_paged_kernel[
+        (q.shape[0], triton.cdiv(columns, BLOCK_N * tiles_per_program))
+    ](
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(3),
+        page_table.stride(0),
+        page_table.stride(1),
+        logits.stride(0),
+        q.shape[0],
+        columns,
+        k_cache.shape[0],
+        page_table.shape[0],
+        float(score_divisor),
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=page_table.shape[1],
+        NUM_HEADS=q.shape[1],
+        HEAD_DIM=q.shape[2],
+        BLOCK_N=BLOCK_N,
+        BLOCK_D=BLOCK_D,
+        TILES_PER_PROG=tiles_per_program,
+        STAGES=2,
+        MAX_N=MAX_N,
+        COMPRESS_RATIO=compress_ratio,
+        num_warps=2,
+    )
+    return logits, visible_blocks
+
+
+def expand_qsa_block_indices_cuda(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    compress_ratio: int,
+    token_topk: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Expand compressed blocks and compact the causal tail of the open group."""
+
+    if not block_indices.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA CUDA expansion requires Triton")
+    if token_topk % compress_ratio:
+        raise ValueError("QSA token top-k must be divisible by compression ratio")
+    block_topk = token_topk // compress_ratio
+    output_width = token_topk + compress_ratio - 1
+    if block_indices.shape != (query_positions.numel(), block_topk):
+        raise ValueError("QSA compressed top-k has an invalid shape")
+    if token_to_req.shape != query_positions.shape:
+        raise ValueError("QSA request mapping must match query positions")
+    if sequence_lengths.ndim != 1 or not sequence_lengths.shape[0]:
+        raise ValueError("QSA request sequence lengths must be nonempty")
+    if out is None:
+        out = torch.empty(
+            (block_indices.shape[0], output_width),
+            dtype=torch.int32,
+            device=block_indices.device,
+        )
+    elif out.shape != (block_indices.shape[0], output_width):
+        raise ValueError("QSA expansion output has an invalid shape")
+    if not block_indices.shape[0]:
+        return out
+    column_block = 256
+    _expand_qsa_indices_kernel[
+        (block_indices.shape[0], triton.cdiv(output_width, column_block))
+    ](
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        out,
+        block_indices.stride(0),
+        block_indices.stride(1),
+        out.stride(0),
+        out.stride(1),
+        block_indices.shape[0],
+        sequence_lengths.shape[0],
+        BLOCK_TOPK=block_topk,
+        COMPRESS_RATIO=compress_ratio,
+        TOKEN_TOPK=token_topk,
+        OUTPUT_WIDTH=output_width,
+        COLUMN_BLOCK=column_block,
+        num_warps=4,
+    )
+    return out
+
+
+def qsa_select_paged_tokens(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_topk: int,
+    compress_ratio: int,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Score, select, and expand QSA indices without host synchronization."""
+
+    rows = q.shape[0]
+    output_width = token_topk + compress_ratio - 1
+    if out is None:
+        out = torch.empty((rows, output_width), dtype=torch.int32, device=q.device)
+    if out.shape != (rows, output_width):
+        raise ValueError("QSA selection output has an invalid shape")
+    if not rows:
+        return out
+
+    columns = page_table.shape[1] * k_cache.shape[1]
+    block_topk = token_topk // compress_ratio
+    rows_per_chunk = max(1, _LOGITS_WORKSPACE_BYTES // max(columns * 4, 1))
+    chunk_rows = min(rows, rows_per_chunk)
+    blocks_buffer = torch.empty(
+        (chunk_rows, block_topk), dtype=torch.int32, device=q.device
+    )
+    topk_workspace = torch.empty(
+        (_TOPK_WORKSPACE_BYTES,), dtype=torch.uint8, device=q.device
+    )
+    for row_start in range(0, rows, rows_per_chunk):
+        row_end = min(row_start + rows_per_chunk, rows)
+        row_slice = slice(row_start, row_end)
+        logits, visible_blocks = qsa_mqa_paged(
+            q[row_slice],
+            k_cache,
+            page_table,
+            token_to_req[row_slice],
+            query_positions[row_slice],
+            sequence_lengths,
+            compress_ratio,
+        )
+        blocks = blocks_buffer[: row_end - row_start]
+        use_cooperative_topk = (
+            blocks.shape[0] <= 32
+            and logits.stride(0) % 4 == 0
+            and current_platform.has_device_capability(90)
+            and not current_platform.is_device_capability_family(120)
+        )
+        topk_op = (
+            torch.ops._C.cooperative_topk
+            if use_cooperative_topk
+            else torch.ops._C.persistent_topk
+        )
+        topk_op(logits, visible_blocks, blocks, topk_workspace, block_topk, columns)
+        expand_qsa_block_indices_cuda(
+            blocks,
+            query_positions[row_slice],
+            sequence_lengths,
+            token_to_req[row_slice],
+            compress_ratio,
+            token_topk,
+            out[row_slice],
+        )
+    return out
+
+
+def qsa_sparse_paged_attention(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    logical_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Run sparse GQA directly over paged BF16 K/V caches."""
+
+    if not q.is_cuda or not HAS_TRITON:
+        raise RuntimeError("paged QSA sparse attention requires CUDA and Triton")
+    if q.ndim != 3 or k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+        raise ValueError("QSA sparse attention received invalid Q/K/V shapes")
+    if logical_indices.ndim != 2 or logical_indices.shape[0] != q.shape[0]:
+        raise ValueError("QSA indices must have one row per query")
+    if token_to_req.shape != (q.shape[0],) or block_table.ndim != 2:
+        raise ValueError("QSA sparse attention metadata has invalid shapes")
+    if not all(k_cache.shape[:3]) or not all(block_table.shape):
+        raise ValueError("QSA sparse attention cache and block table must be nonempty")
+    if logical_indices.shape[1] <= 0:
+        raise ValueError("QSA sparse attention requires a positive selection width")
+    if q.shape[2] != k_cache.shape[3] or q.shape[1] % k_cache.shape[2]:
+        raise ValueError("QSA sparse attention requires valid grouped-query heads")
+    head_dim = q.shape[2]
+    assert head_dim >= 16 and (head_dim & (head_dim - 1)) == 0
+    assert q.dtype == k_cache.dtype == v_cache.dtype == torch.bfloat16
+    assert logical_indices.dtype == block_table.dtype == torch.int32
+    assert token_to_req.dtype == torch.int32
+    assert q.device == k_cache.device == v_cache.device
+    assert q.device == logical_indices.device == block_table.device
+    assert q.device == token_to_req.device
+    assert q.stride(2) == k_cache.stride(3) == v_cache.stride(3) == 1
+    assert logical_indices.stride(1) == block_table.stride(1) == 1
+    assert token_to_req.stride(0) == 1
+    if out is None:
+        out = torch.empty_like(q)
+    if out.shape != q.shape:
+        raise ValueError("QSA sparse output must match its query")
+    assert out.dtype == q.dtype and out.device == q.device
+    assert out.stride(2) == 1
+    if not q.shape[0]:
+        return out
+
+    group_size = q.shape[1] // k_cache.shape[2]
+    block_m = triton.next_power_of_2(group_size)
+    base_programs = q.shape[0] * k_cache.shape[2]
+    small_profile_limit = 8 if block_m <= 8 else 4
+
+    # Tuned on GB300 for the Qwen-Air TP1, TP2, and TP4 attention shapes.
+    # Narrow tiles favor decode; wide tiles improve throughput for prefill.
+    if base_programs <= small_profile_limit:
+        block_n, target_splits, partial_warps = 16, 64, 4
+    elif base_programs < 32:
+        block_n, target_splits, partial_warps = 16, 32, 4
+    elif base_programs <= 256:
+        block_n, target_splits, partial_warps = 64, 8, 2
+    elif base_programs <= 512:
+        block_n, target_splits, partial_warps = 64, 4, 2
+    else:
+        block_n, target_splits, partial_warps = 64, 1, 2
+
+    num_tiles = triton.cdiv(logical_indices.shape[1], block_n)
+    # Avoid empty splits when the selection width is smaller than the profile.
+    max_useful_splits = 1 << (num_tiles.bit_length() - 1)
+    num_splits = min(max_useful_splits, target_splits)
+
+    # Split=1 writes output directly and compiles out all workspace accesses.
+    if num_splits == 1:
+        partial_output = out
+        partial_lse = out
+    else:
+        # FP32 partials preserve accuracy when merging independently normalized
+        # splits.
+        partial_output = torch.empty(
+            (num_splits, *q.shape), dtype=torch.float32, device=q.device
+        )
+        partial_lse = torch.empty(
+            (num_splits, q.shape[0], q.shape[1]),
+            dtype=torch.float32,
+            device=q.device,
+        )
+
+    partial_grid = (q.shape[0], k_cache.shape[2], num_splits)
+    _qsa_sparse_paged_gqa_splitk_kernel[partial_grid](
+        q,
+        k_cache,
+        v_cache,
+        logical_indices,
+        block_table,
+        token_to_req,
+        partial_output,
+        partial_lse,
+        out,
+        q.stride(0),
+        q.stride(1),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        logical_indices.stride(0),
+        block_table.stride(0),
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        k_cache.shape[0],
+        block_table.shape[0],
+        TOPK=logical_indices.shape[1],
+        PAGE_SIZE=k_cache.shape[1],
+        PAGE_TABLE_WIDTH=block_table.shape[1],
+        GROUP_SIZE=group_size,
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        NUM_TILES=num_tiles,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        num_warps=partial_warps,
+        num_stages=2,
+    )
+    if num_splits == 1:
+        return out
+
+    _qsa_merge_splitk_kernel[(q.shape[0], q.shape[1])](
+        partial_output,
+        partial_lse,
+        out,
+        out.stride(0),
+        out.stride(1),
+        q.shape[0],
+        HEAD_DIM=q.shape[2],
+        NUM_QUERY_HEADS=q.shape[1],
+        NUM_SPLITS=num_splits,
+        BLOCK_SPLITS=triton.next_power_of_2(num_splits),
+        num_warps=2,
+        num_stages=1,
+    )
+    return out
+
+
+def qsa_store_cache_rows(
+    cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    rows: torch.Tensor,
+) -> None:
+    """Store fixed-width rows in a QSA cache without boolean indexing."""
+
+    if not cache.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA CUDA cache stores require Triton")
+    if cache.ndim != 4 or cache.shape[2] != 1:
+        raise ValueError("QSA cache must be [pages, page_size, 1, width]")
+    if not all(cache.shape):
+        raise ValueError("QSA cache dimensions must be nonzero")
+    if rows.ndim == 3:
+        if rows.shape[1] != 1:
+            raise ValueError("QSA cache rows must have one head")
+        rows = rows[:, 0]
+    if rows.shape != (slot_mapping.numel(), cache.shape[3]):
+        raise ValueError("QSA cache rows and slots have incompatible shapes")
+    if not rows.shape[0]:
+        return
+    _store_qsa_rows_kernel[(rows.shape[0],)](
+        cache,
+        slot_mapping,
+        rows,
+        cache.stride(0),
+        cache.stride(1),
+        cache.stride(3),
+        rows.stride(0),
+        rows.stride(1),
+        rows.shape[0],
+        cache.shape[0],
+        PAGE_SIZE=cache.shape[1],
+        WIDTH=cache.shape[3],
+        BLOCK_D=triton.next_power_of_2(cache.shape[3]),
+        num_warps=4,
+    )
+
+
+def qsa_compress_groups_with_ratio(
+    raw_keys: torch.Tensor,  # this step's raw key rows [rows, 1, head_size]
+    raw_positions: torch.Tensor,  # this step's positions [rows, 1, 3] int64
+    compressor_state_cache: torch.Tensor,
+    compressor_state_block_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    compress_ratio: int,
+    rope_cache: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pool completed groups from the compressor-state ring and raw token rows."""
+
+    if not raw_keys.is_cuda or not HAS_TRITON:
+        raise RuntimeError("QSA CUDA compression requires Triton")
+    rows = token_to_req.numel()
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    if raw_keys.ndim != 3 or raw_keys.shape[:2] != (rows, 1):
+        raise ValueError("QSA raw keys must be [rows, 1, head_size]")
+    if raw_positions.shape != (rows, 1, 3) or raw_positions.dtype != torch.int64:
+        raise ValueError("QSA raw positions must be [rows, 1, 3] int64")
+    if logical_positions.shape != (rows,) or compressed_slots.shape != (rows,):
+        raise ValueError("QSA compression metadata must match token rows")
+    if compressor_state_cache.ndim != 4 or compressor_state_cache.shape[2] != 1:
+        raise ValueError("QSA compressor-state cache has an invalid shape")
+    if (
+        # The ring is wider than one group so speculative rows cannot alias
+        # onto the committed keys of the group still being collected.
+        compressor_state_cache.shape[1] < compress_ratio
+        or compressor_state_cache.shape[3] != raw_keys.shape[2]
+        or compressor_state_cache.dtype != raw_keys.dtype
+    ):
+        raise ValueError(
+            "QSA compressor-state cache does not match the compression layout"
+        )
+    if (
+        compressor_state_block_table.ndim != 2
+        or compressor_state_block_table.shape[1] < 1
+    ):
+        raise ValueError(
+            "QSA compressor-state block table must contain one block per request"
+        )
+    if query_start_loc.ndim != 1 or query_start_loc.shape[0] < 2:
+        raise ValueError("QSA query starts must contain a terminal offset")
+    num_requests = query_start_loc.shape[0] - 1
+    if compressor_state_block_table.shape[0] < num_requests:
+        raise ValueError("QSA compressor-state block table has too few request rows")
+    if rope_cache is not None and (
+        rope_cache.ndim != 4
+        or rope_cache.shape[:3] != compressor_state_cache.shape[:3]
+        or rope_cache.shape[3] != 3
+        or rope_cache.dtype != torch.int64
+    ):
+        raise ValueError("QSA packed position view has an invalid shape or dtype")
+    if rows and (
+        not all(compressor_state_cache.shape)
+        or not all(compressor_state_block_table.shape)
+    ):
+        raise ValueError("QSA compressor-state cache and block table must be nonempty")
+    pooled = torch.empty(
+        (rows, 1, raw_keys.shape[2]),
+        dtype=raw_keys.dtype,
+        device=raw_keys.device,
+    )
+    first_positions = torch.empty((rows, 3), dtype=torch.int64, device=raw_keys.device)
+    if not rows:
+        return pooled, first_positions
+    if rope_cache is None:
+        rope_cache = compressor_state_cache
+        load_rope_positions = False
+    else:
+        load_rope_positions = True
+    _compress_qsa_groups_kernel[(rows,)](
+        raw_keys,
+        raw_positions,
+        compressor_state_cache,
+        rope_cache,
+        compressor_state_block_table,
+        token_to_req,
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        pooled,
+        first_positions,
+        raw_keys.stride(0),
+        raw_keys.stride(2),
+        raw_positions.stride(0),
+        raw_positions.stride(2),
+        compressor_state_cache.stride(0),
+        compressor_state_cache.stride(1),
+        compressor_state_cache.stride(3),
+        rope_cache.stride(0),
+        rope_cache.stride(1),
+        rope_cache.stride(3),
+        compressor_state_block_table.stride(0),
+        pooled.stride(0),
+        pooled.stride(2),
+        first_positions.stride(0),
+        first_positions.stride(1),
+        rows,
+        compressor_state_cache.shape[0],
+        num_requests,
+        COMPRESSOR_STATE_SIZE=compressor_state_cache.shape[1],
+        COMPRESS_RATIO=compress_ratio,
+        HEAD_DIM=raw_keys.shape[2],
+        LOAD_ROPE_POSITIONS=load_rope_positions,
+        BLOCK_D=triton.next_power_of_2(raw_keys.shape[2]),
+        num_warps=4,
+    )
+    return pooled, first_positions
+
+
+__all__ = [
+    "expand_qsa_block_indices_cuda",
+    "qsa_compress_groups_with_ratio",
+    "qsa_mqa_paged",
+    "qsa_select_paged_tokens",
+    "qsa_sparse_paged_attention",
+    "qsa_store_cache_rows",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa_pre_indexer.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ops/qsa_pre_indexer.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused QSA pre-indexer kernel for Qwen4Exp."""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+
+@triton.jit
+def _norm_rope(
+    x,
+    pos_t,
+    pos_h,
+    pos_w,
+    cos_sin_ptr,
+    cos_sin_stride,
+    norm_weight_ptr,
+    eps,
+    IS_MROPE: tl.constexpr,
+    MROPE_H: tl.constexpr,
+    MROPE_W: tl.constexpr,
+):
+    """Apply Gemma RMSNorm and selected-axis NeoX RoPE to register rows."""
+    TILE_T: tl.constexpr = x.shape[0]
+    TILE_H: tl.constexpr = x.shape[1]
+    D: tl.constexpr = x.shape[2]
+    ROWS: tl.constexpr = TILE_T * TILE_H
+    HALF: tl.constexpr = D // 2
+    QUARTER: tl.constexpr = D // 4
+    pairs = tl.arange(0, QUARTER)
+    if IS_MROPE:
+        # Qwen interleaves temporal, height, and width rotary pairs. Each axis
+        # still indexes the same position-major cos/sin table.
+        h_mask = ((pairs % 3) == 1) & (pairs <= 3 * MROPE_H)
+        w_mask = ((pairs % 3) == 2) & (pairs <= 3 * MROPE_W)
+        t_mask = ~(h_mask | w_mask)
+        base = cos_sin_ptr + pairs[None, :]
+        pos_rows = (pos_t, pos_h, pos_w)
+        axis_masks = (t_mask, h_mask, w_mask)
+        cos = tl.zeros((TILE_T, QUARTER), dtype=cos_sin_ptr.dtype.element_ty)
+        sin = tl.zeros((TILE_T, QUARTER), dtype=cos_sin_ptr.dtype.element_ty)
+        for axis in tl.static_range(3):
+            cos += tl.load(
+                base + pos_rows[axis][:, None] * cos_sin_stride,
+                mask=axis_masks[axis][None, :],
+                other=0,
+            )
+            sin += tl.load(
+                base + pos_rows[axis][:, None] * cos_sin_stride + QUARTER,
+                mask=axis_masks[axis][None, :],
+                other=0,
+            )
+    else:
+        cos = tl.load(cos_sin_ptr + pos_t[:, None] * cos_sin_stride + pairs[None, :])
+        sin = tl.load(
+            cos_sin_ptr + pos_t[:, None] * cos_sin_stride + QUARTER + pairs[None, :]
+        )
+
+    cos = tl.reshape(
+        tl.broadcast_to(cos[:, None, :], (TILE_T, TILE_H, QUARTER)),
+        (ROWS, QUARTER),
+    )
+    sin = tl.reshape(
+        tl.broadcast_to(sin[:, None, :], (TILE_T, TILE_H, QUARTER)),
+        (ROWS, QUARTER),
+    )
+    x = tl.reshape(x, (ROWS, D)).to(tl.float32)
+    weight = tl.load(norm_weight_ptr + tl.arange(0, D)).to(tl.float32) + 1.0
+    rrms = tl.rsqrt(tl.sum(x * x, axis=1) / D + eps)
+    y = (x * rrms[:, None] * weight[None, :]).to(cos.dtype)
+    rotated, passthrough = tl.split(
+        tl.permute(tl.reshape(y, (ROWS, 2, HALF)), (0, 2, 1))
+    )
+    r0, r1 = tl.split(tl.permute(tl.reshape(rotated, (ROWS, 2, QUARTER)), (0, 2, 1)))
+    out0 = r0 * cos - r1 * sin
+    out1 = r1 * cos + r0 * sin
+    rotated = tl.reshape(tl.permute(tl.join(out0, out1), (0, 2, 1)), (ROWS, HALF))
+    result = tl.reshape(tl.permute(tl.join(rotated, passthrough), (0, 2, 1)), (ROWS, D))
+    return tl.reshape(result, (TILE_T, TILE_H, D))
+
+
+@triton.jit(
+    do_not_specialize=[
+        "num_tokens",
+        "num_state_blocks",
+        "num_compressed_blocks",
+        "num_k_work",
+    ]
+)
+def _qsa_pre_indexer_kernel(
+    q_ptr,
+    q_stride_token,
+    k_ptr,
+    k_stride_token,
+    pos_ptr,
+    pos_stride_axis,
+    pos_stride_token,
+    cos_sin_ptr,
+    q_norm_weight_ptr,
+    k_norm_weight_ptr,
+    eps,
+    q_out_ptr,
+    q_out_stride_token,
+    q_out_stride_head,
+    state_cache_ptr,
+    state_cache_stride_block,
+    state_cache_stride_token,
+    state_slots_ptr,
+    state_table_ptr,
+    state_table_stride_req,
+    query_start_loc_ptr,
+    logical_positions_ptr,
+    compressed_slots_ptr,
+    k_work_metadata_ptr,
+    compressed_cache_ptr,
+    compressed_cache_stride_block,
+    compressed_cache_stride_token,
+    num_tokens,
+    num_state_blocks,
+    num_compressed_blocks,
+    num_k_work,
+    HQ: tl.constexpr,
+    D: tl.constexpr,
+    TILE_T_Q: tl.constexpr,
+    TILE_H_Q: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    STATE_SIZE: tl.constexpr,
+    COMP_PAGE_SIZE: tl.constexpr,
+    IS_2D_POSITIONS: tl.constexpr,
+    IS_K_MROPE: tl.constexpr,
+    CACHE_HAS_ROPE_POS: tl.constexpr,
+    MROPE_H: tl.constexpr,
+    MROPE_W: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    # K work occupies the first programs; the remaining programs tile Q. This
+    # keeps both paths in one launch while leaving their register shapes
+    # independent.
+    if pid >= num_k_work:
+        q_pid = pid - num_k_work
+        num_head_tiles: tl.constexpr = tl.cdiv(HQ, TILE_H_Q)
+        token_tile = q_pid // num_head_tiles
+        head_tile = q_pid % num_head_tiles
+        tokens = token_tile * TILE_T_Q + tl.arange(0, TILE_T_Q)
+        heads = head_tile * TILE_H_Q + tl.arange(0, TILE_H_Q)
+        valid_tokens = tokens < num_tokens
+        valid_heads = heads < HQ
+        dims = tl.arange(0, D)
+        mask = valid_tokens[:, None, None] & valid_heads[None, :, None]
+        x = tl.load(
+            q_ptr
+            + tokens[:, None, None] * q_stride_token
+            + heads[None, :, None] * D
+            + dims[None, None, :],
+            mask=mask,
+            other=0.0,
+        )
+        pos_t = tl.load(pos_ptr + tokens * pos_stride_token, mask=valid_tokens, other=0)
+        if IS_2D_POSITIONS:
+            pos_h = tl.load(
+                pos_ptr + pos_stride_axis + tokens * pos_stride_token,
+                mask=valid_tokens,
+                other=0,
+            )
+            pos_w = tl.load(
+                pos_ptr + 2 * pos_stride_axis + tokens * pos_stride_token,
+                mask=valid_tokens,
+                other=0,
+            )
+        else:
+            pos_h = pos_t
+            pos_w = pos_t
+        y = _norm_rope(
+            x,
+            pos_t,
+            pos_h,
+            pos_w,
+            cos_sin_ptr,
+            D // 2,
+            q_norm_weight_ptr,
+            eps,
+            IS_2D_POSITIONS,
+            MROPE_H,
+            MROPE_W,
+        )
+        tl.store(
+            q_out_ptr
+            + tokens[:, None, None] * q_out_stride_token
+            + heads[None, :, None] * q_out_stride_head
+            + dims[None, None, :],
+            y,
+            mask=mask,
+        )
+
+    if pid < num_k_work:
+        # One work item owns one completed compression group. Work item zero
+        # additionally commits the request's current raw-K suffix below.
+        work_metadata = tl.load(k_work_metadata_ptr + pid * 2 + tl.arange(0, 2))
+        request, work_in_request = tl.split(work_metadata)
+        if request < 0:
+            return
+
+        query_start = tl.load(query_start_loc_ptr + request)
+        query_end = tl.load(query_start_loc_ptr + request + 1)
+        query_len = query_end - query_start
+        chunk_end = tl.load(logical_positions_ptr + query_end - 1)
+        chunk_start = chunk_end - query_len + 1
+        num_groups = (chunk_end + 1) // COMPRESS_RATIO - chunk_start // COMPRESS_RATIO
+        dims = tl.arange(0, D)
+
+        if work_in_request < num_groups:
+            first_boundary = (
+                (chunk_start + COMPRESS_RATIO) // COMPRESS_RATIO
+            ) * COMPRESS_RATIO - 1
+            end_position = first_boundary + work_in_request * COMPRESS_RATIO
+            boundary_token = query_start + end_position - chunk_start
+            valid_token = (
+                (boundary_token >= query_start)
+                & (boundary_token < query_end)
+                & (boundary_token < num_tokens)
+            )
+            compressed_slot = tl.load(
+                compressed_slots_ptr + boundary_token,
+                mask=valid_token,
+                other=-1,
+            )
+            valid = (
+                valid_token
+                & (compressed_slot >= 0)
+                & (compressed_slot < num_compressed_blocks * COMP_PAGE_SIZE)
+            )
+            state_block = tl.load(state_table_ptr + request * state_table_stride_req)
+            state_block_valid = (state_block >= 0) & (state_block < num_state_blocks)
+            safe_state_block = tl.maximum(state_block, 0).to(tl.int64)
+            group_offsets = tl.arange(0, COMPRESS_RATIO)
+            source_positions = end_position - (COMPRESS_RATIO - 1) + group_offsets
+            source_in_chunk = source_positions >= chunk_start
+            source_tokens = query_start + source_positions - chunk_start
+            source_tokens_valid = (
+                (source_tokens >= query_start)
+                & (source_tokens < query_end)
+                & (source_tokens < num_tokens)
+            )
+            current_base = (
+                k_ptr + tl.maximum(source_tokens, 0)[:, None] * k_stride_token
+            )
+            cached_base = (
+                state_cache_ptr
+                + safe_state_block * state_cache_stride_block
+                + (source_positions % STATE_SIZE)[:, None] * state_cache_stride_token
+            )
+            # Only the first completed group can cross the chunk boundary. Select
+            # historical rows from the ring without issuing two masked loads.
+            source_base = tl.where(source_in_chunk[:, None], current_base, cached_base)
+            # Pointer selection obscures alignment from Triton's analysis.
+            source_base = tl.multiple_of(source_base, (8, 8))
+            source_valid = tl.where(
+                source_in_chunk, source_tokens_valid, state_block_valid
+            )
+            source = tl.load(
+                source_base + dims[None, :],
+                mask=valid & source_valid[:, None],
+                other=0.0,
+            ).to(tl.float32)
+            # Match the unfused path's BF16 pooled tensor before RMSNorm.
+            pooled = (
+                (tl.sum(source, axis=0) / COMPRESS_RATIO).to(tl.bfloat16).to(tl.float32)
+            )
+
+            first_position = end_position - (COMPRESS_RATIO - 1)
+            if CACHE_HAS_ROPE_POS:
+                # RoPE uses the first token in the pooled group. Its exact MRoPE
+                # coordinates may live in this chunk or the raw-state ring.
+                first_in_chunk = first_position >= chunk_start
+                first_token = query_start + first_position - chunk_start
+                first_token_valid = (
+                    (first_token >= query_start)
+                    & (first_token < query_end)
+                    & (first_token < num_tokens)
+                )
+                safe_first_token = tl.maximum(first_token, 0)
+                load_current_position = first_in_chunk & first_token_valid
+                first_pos_t = tl.load(
+                    pos_ptr + safe_first_token * pos_stride_token,
+                    mask=load_current_position,
+                    other=0,
+                )
+                if IS_2D_POSITIONS:
+                    first_pos_h = tl.load(
+                        pos_ptr + pos_stride_axis + safe_first_token * pos_stride_token,
+                        mask=load_current_position,
+                        other=0,
+                    )
+                    first_pos_w = tl.load(
+                        pos_ptr
+                        + 2 * pos_stride_axis
+                        + safe_first_token * pos_stride_token,
+                        mask=load_current_position,
+                        other=0,
+                    )
+                else:
+                    first_pos_h = first_pos_t
+                    first_pos_w = first_pos_t
+                tail = (
+                    state_cache_ptr
+                    + safe_state_block * state_cache_stride_block
+                    + (first_position % STATE_SIZE) * state_cache_stride_token
+                    + D
+                ).to(tl.pointer_type(tl.int64))
+                load_cached_position = ~first_in_chunk & state_block_valid
+                cached_pos_t = tl.load(tail, mask=load_cached_position, other=0)
+                cached_pos_h = tl.load(tail + 1, mask=load_cached_position, other=0)
+                cached_pos_w = tl.load(tail + 2, mask=load_cached_position, other=0)
+                pos_t = tl.where(first_in_chunk, first_pos_t.to(tl.int64), cached_pos_t)
+                pos_h = tl.where(first_in_chunk, first_pos_h.to(tl.int64), cached_pos_h)
+                pos_w = tl.where(first_in_chunk, first_pos_w.to(tl.int64), cached_pos_w)
+            else:
+                pos_t = first_position
+                pos_h = first_position
+                pos_w = first_position
+            y = _norm_rope(
+                tl.reshape(pooled, (1, 1, D)),
+                pos_t + tl.arange(0, 1),
+                pos_h + tl.arange(0, 1),
+                pos_w + tl.arange(0, 1),
+                cos_sin_ptr,
+                D // 2,
+                k_norm_weight_ptr,
+                eps,
+                IS_K_MROPE,
+                MROPE_H,
+                MROPE_W,
+            )
+            compressed_block = (compressed_slot // COMP_PAGE_SIZE).to(tl.int64)
+            compressed_row = compressed_slot % COMP_PAGE_SIZE
+            tl.store(
+                compressed_cache_ptr
+                + compressed_block * compressed_cache_stride_block
+                + compressed_row * compressed_cache_stride_token
+                + dims,
+                tl.reshape(y, (D,)),
+                mask=valid,
+            )
+
+        if work_in_request == 0:
+            # This CTA may have just read historical rows from the circular buffer.
+            # Keep every lane past those loads before overwriting the same ring.
+            tl.debug_barrier()
+            # One CTA per request commits only the suffix retained by the ring.
+            num_state_rows = tl.minimum(query_len, STATE_SIZE)
+            for state_offset in tl.range(0, num_state_rows):
+                token = query_end - num_state_rows + state_offset
+                valid_token = (
+                    (token >= query_start) & (token < query_end) & (token < num_tokens)
+                )
+                slot = tl.load(state_slots_ptr + token, mask=valid_token, other=-1)
+                valid_slot = (
+                    valid_token & (slot >= 0) & (slot < num_state_blocks * STATE_SIZE)
+                )
+                safe_slot = tl.maximum(slot, 0)
+                state_row = (
+                    state_cache_ptr
+                    + (safe_slot // STATE_SIZE).to(tl.int64) * state_cache_stride_block
+                    + (safe_slot % STATE_SIZE) * state_cache_stride_token
+                )
+                k = tl.load(
+                    k_ptr + tl.maximum(token, 0) * k_stride_token + dims,
+                    mask=valid_slot,
+                    other=0.0,
+                )
+                tl.store(state_row + dims, k, mask=valid_slot)
+                if CACHE_HAS_ROPE_POS:
+                    pos_t = tl.load(
+                        pos_ptr + tl.maximum(token, 0) * pos_stride_token,
+                        mask=valid_slot,
+                        other=0,
+                    )
+                    if IS_2D_POSITIONS:
+                        pos_h = tl.load(
+                            pos_ptr
+                            + pos_stride_axis
+                            + tl.maximum(token, 0) * pos_stride_token,
+                            mask=valid_slot,
+                            other=0,
+                        )
+                        pos_w = tl.load(
+                            pos_ptr
+                            + 2 * pos_stride_axis
+                            + tl.maximum(token, 0) * pos_stride_token,
+                            mask=valid_slot,
+                            other=0,
+                        )
+                    else:
+                        pos_h = pos_t
+                        pos_w = pos_t
+                    tail = (state_row + D).to(tl.pointer_type(tl.int64))
+                    tl.store(tail, pos_t.to(tl.int64), mask=valid_slot)
+                    tl.store(tail + 1, pos_h.to(tl.int64), mask=valid_slot)
+                    tl.store(tail + 2, pos_w.to(tl.int64), mask=valid_slot)
+
+
+def qsa_pre_indexer(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    eps: float,
+    q_out: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_slots: torch.Tensor,
+    state_block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_cache: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    k_work_metadata: torch.Tensor,
+    *,
+    compress_ratio: int,
+    mrope_section: tuple[int, int, int] | None,
+    rope_pos_offset: int | None,
+) -> None:
+    """Normalize Q, compress K, then update the circular raw state."""
+    num_tokens = q.shape[0]
+    if num_tokens == 0:
+        return
+    num_q_heads, head_dim = q_out.shape[1:]
+    assert cos_sin_cache.shape[-1] * 2 == head_dim
+    assert q.shape == (num_tokens, num_q_heads * head_dim)
+    assert k.shape == (num_tokens, head_dim)
+    assert q.stride(-1) == 1
+    assert k.stride(-1) == 1
+    assert q_out.stride(-1) == 1
+    assert cos_sin_cache.is_contiguous()
+    assert state_cache.stride(-1) == 1
+    assert compressed_cache.stride(-1) == 1
+    assert k_work_metadata.ndim == 2 and k_work_metadata.shape[1] == 2
+    is_2d_positions = positions.ndim == 2
+    is_k_mrope = bool(mrope_section)
+    cache_has_rope_pos = rope_pos_offset is not None
+    assert rope_pos_offset is None or rope_pos_offset == head_dim
+    if is_2d_positions:
+        assert positions.shape == (3, num_tokens)
+        assert is_k_mrope
+        pos_stride_axis, pos_stride_token = positions.stride()
+    else:
+        assert positions.shape == (num_tokens,)
+        pos_stride_axis, pos_stride_token = 0, positions.stride(0)
+    section = mrope_section if mrope_section is not None else (0, 0, 0)
+    assert len(section) == 3
+
+    if num_tokens <= 4096:
+        TILE_T_Q, TILE_H_Q = 2, 2
+    else:
+        TILE_T_Q, TILE_H_Q = 2, 4
+    num_k_work = k_work_metadata.shape[0]
+    num_q_work = triton.cdiv(num_tokens, TILE_T_Q) * triton.cdiv(num_q_heads, TILE_H_Q)
+    _qsa_pre_indexer_kernel[(num_k_work + num_q_work,)](
+        q,
+        q.stride(0),
+        k,
+        k.stride(0),
+        positions,
+        pos_stride_axis,
+        pos_stride_token,
+        cos_sin_cache,
+        q_norm_weight,
+        k_norm_weight,
+        eps,
+        q_out,
+        q_out.stride(0),
+        q_out.stride(1),
+        state_cache,
+        state_cache.stride(0),
+        state_cache.stride(1),
+        state_slots,
+        state_block_table,
+        state_block_table.stride(0),
+        query_start_loc,
+        logical_positions,
+        compressed_slots,
+        k_work_metadata,
+        compressed_cache,
+        compressed_cache.stride(0),
+        compressed_cache.stride(1),
+        num_tokens,
+        state_cache.shape[0],
+        compressed_cache.shape[0],
+        num_k_work,
+        HQ=num_q_heads,
+        D=head_dim,
+        TILE_T_Q=TILE_T_Q,
+        TILE_H_Q=TILE_H_Q,
+        COMPRESS_RATIO=compress_ratio,
+        STATE_SIZE=state_cache.shape[1],
+        COMP_PAGE_SIZE=compressed_cache.shape[1],
+        IS_2D_POSITIONS=is_2d_positions,
+        IS_K_MROPE=is_k_mrope,
+        CACHE_HAS_ROPE_POS=cache_has_rope_pos,
+        MROPE_H=section[1],
+        MROPE_W=section[2],
+        num_warps=1,
+    )
+
+
+__all__ = ["qsa_pre_indexer"]

--- a/vllm_ascend/models/qwen4_exp/nvidia/ple_layer.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/ple_layer.py
@@ -1,0 +1,1170 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU-resident Qwen4Exp position-learning enhancement layers."""
+
+import math
+from collections.abc import Iterable, Sequence
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.config import CacheConfig, ModelConfig, VllmConfig, get_current_vllm_config
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+    is_conv_state_dim_first,
+)
+from vllm.model_executor.layers.quantization.base_config import (
+    QuantizationConfig,
+    QuantizeMethodBase,
+)
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    create_fp8_scale_parameter,
+    create_fp8_weight_parameter,
+    is_fp8,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    is_layer_skipped,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.model_executor.parameter import PerTensorScaleParameter
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.backends.short_conv_attn import (
+    PleShortConvAttentionBackend,
+    PleShortConvAttentionMetadata,
+)
+from vllm.v1.attention.backends.utils import NULL_BLOCK_ID
+
+from ..common.ple import copy_ple_embedding_shard_
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PLE_LAYER_PRIME = 10007
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _is_prime_64(value: int) -> bool:
+    if value < 2:
+        return False
+    for prime in (2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37):
+        if value % prime == 0:
+            return value == prime
+    exponent = value - 1
+    shifts = 0
+    while exponent % 2 == 0:
+        exponent //= 2
+        shifts += 1
+    for base in (2, 325, 9375, 28178, 450775, 9780504, 1795265022):
+        if base % value == 0:
+            continue
+        witness = pow(base, exponent, value)
+        if witness in (1, value - 1):
+            continue
+        for _ in range(shifts - 1):
+            witness = pow(witness, 2, value)
+            if witness == value - 1:
+                break
+        else:
+            return False
+    return True
+
+
+def _nth_prime_after(start: int, count: int) -> int:
+    prime = int(start)
+    for _ in range(count):
+        candidate = prime + 1
+        if candidate <= 2:
+            prime = 2
+            continue
+        if candidate % 2 == 0:
+            candidate += 1
+        while not _is_prime_64(candidate):
+            candidate += 2
+        prime = candidate
+    return prime
+
+
+class Qwen4ExpPLEGroupedNorm(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float,
+        group_size: int | None,
+        dtype: torch.dtype | None,
+    ) -> None:
+        super().__init__()
+        if group_size is not None and hidden_size % group_size:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by "
+                f"group_size ({group_size})"
+            )
+        self.eps = eps
+        self.group_size = group_size
+        self.weight = nn.Parameter(torch.zeros(hidden_size, dtype=dtype))
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.float()
+        if self.group_size is None:
+            variance = hidden_states.square().mean(dim=-1, keepdim=True)
+            normalized = hidden_states * torch.rsqrt(variance + self.eps)
+        else:
+            grouped = hidden_states.unflatten(
+                -1, (hidden_states.shape[-1] // self.group_size, self.group_size)
+            )
+            variance = grouped.square().mean(dim=-1, keepdim=True)
+            normalized = (grouped * torch.rsqrt(variance + self.eps)).flatten(-2)
+        return (normalized * (1.0 + self.weight.float())).to(input_dtype)
+
+
+class Qwen4ExpPLEFp8EmbeddingMethod(QuantizeMethodBase):
+    """FP8 PLE embedding with one global checkpoint scale."""
+
+    def create_weights(
+        self,
+        layer: nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        del input_size, output_size, params_dtype
+        weight_loader = extra_weight_attrs.get("weight_loader")
+        weight = create_fp8_weight_parameter(
+            sum(output_partition_sizes), input_size_per_partition, weight_loader
+        )
+        layer.register_parameter("weight", weight)
+
+        weight_scale = create_fp8_scale_parameter(
+            PerTensorScaleParameter,
+            output_partition_sizes,
+            input_size_per_partition,
+            None,
+            weight_loader,
+            scale_dtype=torch.bfloat16,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError("PLE FP8 weights only support embedding lookup")
+
+    def embedding(self, layer: nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        return F.embedding(input_, layer.weight)
+
+
+def _get_ple_embedding_quant_method(
+    quant_config: QuantizationConfig | None,
+    prefix: str,
+) -> QuantizeMethodBase | None:
+    """Select global-scale FP8 only for quantized PLE checkpoint shards."""
+
+    if not isinstance(quant_config, Fp8Config):
+        return None
+    if not quant_config.is_checkpoint_fp8_serialized:
+        return None
+
+    ignored_layers = quant_config.ignored_layers
+    if is_layer_skipped(
+        prefix,
+        ignored_layers,
+        quant_config.packed_modules_mapping,
+        match_mode=quant_config.ignored_layers_match_mode,
+    ):
+        return None
+    # PLE checkpoint shards form one runtime embedding parameter.
+    shard_prefix = f"{prefix}.shard_"
+    if any(name.startswith(shard_prefix) for name in ignored_layers):
+        return None
+    return Qwen4ExpPLEFp8EmbeddingMethod()
+
+
+class Qwen4ExpNGramEmbedding(nn.Module):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        embedding_dim: int,
+        ple_dense_layer_id: int,
+        max_total_tokens: int,
+        max_num_reqs: int,
+        prefix: str,
+        quant_config: QuantizationConfig | None = None,
+        params_dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        self.embedding_dim = embedding_dim
+        self.ngram_size = int(config.ngram_size)
+        self.heads_per_ngram = int(config.heads_per_ngram)
+        self.ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ngram_size < 2:
+            raise ValueError(f"ngram_size must be >= 2, got {self.ngram_size}")
+        if self.heads_per_ngram <= 0:
+            raise ValueError(f"heads_per_ngram must be > 0, got {self.heads_per_ngram}")
+        if embedding_dim % self.ngram_heads:
+            raise ValueError(
+                "ple_embed_dim must be divisible by total ngram heads: "
+                f"{embedding_dim} % {self.ngram_heads} != 0"
+            )
+        self.head_dim = embedding_dim // self.ngram_heads
+        self.eos_token_id = int(config.eos_token_id)
+        self.unigram_vocab_size = int(config.vocab_size)
+        self.split_ngram_parts = int(getattr(config, "split_ngram_parts", 512))
+        if self.split_ngram_parts <= 0:
+            raise ValueError("split_ngram_parts must be positive")
+
+        max_multiplier = ((1 << 63) - 1) // self.unigram_vocab_size
+        half_bound = max(1, max_multiplier // 2)
+        seed = int(getattr(config, "seed", 1234))
+        base_seed = seed + _PLE_LAYER_PRIME * ple_dense_layer_id
+        multipliers = []
+        for index in range(self.ngram_size):
+            value = base_seed + _SPLITMIX_GAMMA * (index + 1)
+            multipliers.append(2 * (_splitmix64(value) % half_bound) + 1)
+        self.register_buffer(
+            "layer_multipliers",
+            torch.tensor(multipliers, dtype=torch.long),
+            persistent=True,
+        )
+
+        ngram_vocab_size_base = int(config.ngram_vocab_size_base)
+        sizes: list[int] = []
+        offsets: list[int] = []
+        offset = 0
+        for local_head in range(self.ngram_heads):
+            global_head = ple_dense_layer_id * self.ngram_heads + local_head
+            size = _nth_prime_after(ngram_vocab_size_base - 1, global_head + 1)
+            sizes.append(size)
+            offsets.append(offset)
+            offset += size
+        self.register_buffer(
+            "ngram_heads_vocab_sizes",
+            torch.tensor(sizes, dtype=torch.long),
+            persistent=True,
+        )
+        self.register_buffer(
+            "ngram_heads_offsets",
+            torch.tensor(offsets, dtype=torch.long),
+            persistent=True,
+        )
+        divisor = int(config.make_ngram_vocab_size_divisible_by)
+        padded_vocab_size = ((offset + divisor - 1) // divisor) * divisor
+        self.ngram_embedding = VocabParallelEmbedding(
+            padded_vocab_size,
+            self.head_dim,
+            params_dtype=params_dtype,
+            padding_size=divisor,
+            prefix=f"{prefix}.ngram_embedding",
+            quant_method=_get_ple_embedding_quant_method(
+                quant_config, f"{prefix}.ngram_embedding"
+            ),
+        )
+        self.register_buffer(
+            "positions_buffer",
+            torch.arange(max_total_tokens, dtype=torch.int64),
+            persistent=False,
+        )
+        self.register_buffer(
+            "padded_buffer",
+            torch.full(
+                (max_num_reqs, max_total_tokens),
+                self.eos_token_id,
+                dtype=torch.int64,
+            ),
+            persistent=False,
+        )
+
+    @staticmethod
+    def _shift_precompute(
+        tokens: torch.Tensor, eos_token_id: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if tokens.dim() != 2:
+            raise ValueError("tokens must be a 2D tensor")
+        batch_size, seq_len = tokens.shape
+        positions = torch.arange(seq_len, device=tokens.device, dtype=torch.int64)
+        eos_positions = torch.where(tokens == eos_token_id, positions, -1)
+        previous_eos_inclusive = torch.cummax(eos_positions, dim=1).values
+        previous_eos = torch.cat(
+            [
+                eos_positions.new_full((batch_size, 1), -1),
+                previous_eos_inclusive[:, :-1],
+            ],
+            dim=1,
+        )
+        return positions, positions.unsqueeze(0) - previous_eos - 1
+
+    @staticmethod
+    def _shift_apply(
+        tokens: torch.Tensor,
+        positions: torch.Tensor,
+        position_in_segment: torch.Tensor,
+        shift: int,
+        eos_token_id: int,
+    ) -> torch.Tensor:
+        if shift == 0:
+            return tokens
+        source = positions - shift
+        gather_indices = source.clamp_min(0).unsqueeze(0).expand(tokens.shape[0], -1)
+        shifted = tokens.gather(1, gather_indices)
+        valid = (source.unsqueeze(0) >= 0) & (position_in_segment >= shift)
+        return torch.where(valid, shifted, tokens.new_full((), eos_token_id))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1).long()
+        query_start_loc = query_start_loc.long()
+        num_reqs = query_start_loc.numel() - 1
+        num_tokens = input_ids.shape[0]
+        if num_tokens > self.positions_buffer.numel():
+            raise ValueError(
+                f"PLE received {num_tokens} tokens, but its workspace supports "
+                f"at most {self.positions_buffer.numel()}"
+            )
+        if num_reqs > self.padded_buffer.shape[0]:
+            raise ValueError(
+                f"PLE received {num_reqs} requests, but its workspace supports "
+                f"at most {self.padded_buffer.shape[0]}"
+            )
+
+        positions = self.positions_buffer[:num_tokens]
+        packed = self.padded_buffer[:num_reqs]
+        packed.fill_(self.eos_token_id)
+        request_indices = torch.searchsorted(query_start_loc, positions, right=True) - 1
+        request_indices.clamp_(max=num_reqs - 1)
+        columns = (positions - query_start_loc[request_indices]).clamp(
+            0, packed.shape[1] - 1
+        )
+        packed[request_indices, columns] = input_ids
+        ngram_context = ngram_context[:num_reqs].to(
+            device=input_ids.device, dtype=torch.long
+        )
+
+        context = torch.cat([ngram_context, packed], dim=-1)
+        positions_2d, position_in_segment = self._shift_precompute(
+            context, self.eos_token_id
+        )
+        shifted = [context]
+        for shift in range(1, self.ngram_size):
+            shifted.append(
+                self._shift_apply(
+                    context,
+                    positions_2d,
+                    position_in_segment,
+                    shift,
+                    self.eos_token_id,
+                )
+            )
+        adjusted_columns = columns + self.ngram_size - 1
+        id_blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed = shifted[0] * self.layer_multipliers[0]
+            for index in range(1, ngram):
+                mixed = torch.bitwise_xor(
+                    mixed, shifted[index] * self.layer_multipliers[index]
+                )
+            sizes = self.ngram_heads_vocab_sizes[start:end]
+            offsets = self.ngram_heads_offsets[start:end]
+            ids = torch.remainder(mixed.unsqueeze(-1), sizes) + offsets
+            id_blocks.append(ids[request_indices, adjusted_columns])
+        ngram_ids = torch.cat(id_blocks, dim=-1)
+        return self.ngram_embedding(ngram_ids).flatten(-2)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        """Load hash buffers and checkpoint-split embedding rows."""
+
+        persistent_buffers = {
+            "layer_multipliers": self.layer_multipliers,
+            "ngram_heads_offsets": self.ngram_heads_offsets,
+            "ngram_heads_vocab_sizes": self.ngram_heads_vocab_sizes,
+        }
+        loaded: set[str] = set()
+        regular_weights: list[tuple[str, torch.Tensor]] = []
+        shard_prefix = "ngram_embedding.shard_"
+
+        for name, loaded_weight in weights:
+            leaf_name = name.rsplit(".", 1)[-1]
+            if leaf_name.startswith("hashstats_") or leaf_name == "token_lookup":
+                continue
+            if name in persistent_buffers:
+                buffer = persistent_buffers[name]
+                if buffer.shape != loaded_weight.shape:
+                    raise ValueError(
+                        f"Shape mismatch for {name}: expected "
+                        f"{tuple(buffer.shape)}, got {tuple(loaded_weight.shape)}"
+                    )
+                buffer.copy_(loaded_weight.to(device=buffer.device, dtype=buffer.dtype))
+                loaded.add(name)
+                continue
+            if name.startswith(shard_prefix) and name.endswith(".weight"):
+                shard_text = name[len(shard_prefix) : -len(".weight")]
+                if not shard_text.isdigit():
+                    regular_weights.append((name, loaded_weight))
+                    continue
+                shard_index = int(shard_text)
+                if shard_index >= self.split_ngram_parts:
+                    raise ValueError(
+                        f"PLE embedding shard index {shard_index} exceeds "
+                        f"split_ngram_parts={self.split_ngram_parts}"
+                    )
+                embedding = self.ngram_embedding
+                shard_size = (
+                    embedding.org_vocab_size + self.split_ngram_parts - 1
+                ) // self.split_ngram_parts
+                checkpoint_start = shard_index * shard_size
+                expected_rows = max(
+                    0,
+                    min(shard_size, embedding.org_vocab_size - checkpoint_start),
+                )
+                expected_shape = (expected_rows, embedding.embedding_dim)
+                if tuple(loaded_weight.shape) != expected_shape:
+                    raise ValueError(
+                        f"Shape mismatch for PLE embedding shard {shard_index}: "
+                        f"expected {expected_shape}, got "
+                        f"{tuple(loaded_weight.shape)}"
+                    )
+                copy_ple_embedding_shard_(
+                    embedding.weight.data,
+                    loaded_weight,
+                    checkpoint_start=checkpoint_start,
+                    tp_start=embedding.shard_indices.org_vocab_start_index,
+                    tp_end=embedding.shard_indices.org_vocab_end_index,
+                )
+                loaded.add("ngram_embedding.weight")
+                continue
+            regular_weights.append((name, loaded_weight))
+
+        if regular_weights:
+            loaded.update(AutoWeightsLoader(self).load_weights(regular_weights))
+        return loaded
+
+
+class Qwen4ExpPLELayer(nn.Module, MambaBase):
+    def __init__(
+        self,
+        config: Qwen4ExpTextConfig,
+        vllm_config: VllmConfig,
+        layer_idx: int = 0,
+        ple_dense_layer_id: int | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        model_config = vllm_config.model_config
+        cache_config = vllm_config.cache_config
+        quant_config = vllm_config.quant_config
+        self.model_config: ModelConfig = model_config
+        self.cache_config: CacheConfig = cache_config
+        self.layer_idx = layer_idx
+        self.ple_dense_layer_id = (
+            int(ple_dense_layer_id)
+            if ple_dense_layer_id is not None
+            else int(layer_idx)
+        )
+        self.prefix = prefix
+        self.hidden_size = int(config.hidden_size)
+        self.hc_count = config.hc_count
+        self.hc_hidden_size = self.hidden_size * self.hc_count
+        self.conv_kernel_size = int(config.ple_conv_kernel_size)
+        self.short_conv_dilation = int(config.ngram_size)
+        self.conv_state_len = (self.conv_kernel_size - 1) * self.short_conv_dilation
+        self.num_spec_tokens = vllm_config.num_speculative_tokens
+        self.activation = "silu"
+        self.ple_embedding: nn.Module = Qwen4ExpNGramEmbedding(
+            config,
+            int(config.ple_embed_dim),
+            self.ple_dense_layer_id,
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            vllm_config.scheduler_config.max_num_seqs,
+            f"{prefix}.ple_embedding",
+            quant_config=quant_config,
+            params_dtype=model_config.dtype,
+        )
+        self.key_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hc_hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.key_proj",
+        )
+        self.value_proj = ReplicatedLinear(
+            int(config.ple_embed_dim),
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.value_proj",
+        )
+        norm_args = (
+            self.hc_hidden_size,
+            config.rms_norm_eps,
+            self.hidden_size,
+            model_config.dtype,
+        )
+        self.norm_key = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_query = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.norm_conv = Qwen4ExpPLEGroupedNorm(*norm_args)
+        self.conv1d = nn.Conv1d(
+            self.hc_hidden_size,
+            self.hc_hidden_size,
+            self.conv_kernel_size,
+            groups=self.hc_hidden_size,
+            padding=self.conv_state_len,
+            dilation=self.short_conv_dilation,
+            bias=False,
+            dtype=model_config.dtype,
+        )
+        nn.init.zeros_(self.conv1d.weight)
+        self.conv1d.weight._no_reinit = True
+        self.kv_cache = (torch.tensor([]),)
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def _get_embedding_weight_scale(self) -> torch.Tensor | None:
+        embedding = getattr(self.ple_embedding, "ngram_embedding", None)
+        return getattr(embedding, "weight_scale", None)
+
+    def _dequantize_embeddings(
+        self,
+        embeddings: torch.Tensor,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        """Dequantize PLE lookup output."""
+
+        if not is_fp8(embeddings):
+            return embeddings
+        weight_scale = self._get_embedding_weight_scale()
+        if weight_scale is None:
+            raise RuntimeError("FP8 PLE embedding is missing its global scale")
+        if weight_scale.device != embeddings.device:
+            raise RuntimeError("FP8 PLE embedding scale must be on the output device")
+        return embeddings.to(output_dtype) * weight_scale.to(output_dtype)
+
+    @property
+    def mamba_type(self) -> MambaAttentionBackendEnum:
+        return MambaAttentionBackendEnum.SHORT_CONV
+
+    @property
+    def is_kv_cache_tp_replicated(self) -> bool:
+        return True
+
+    def get_attn_backend(self) -> type[PleShortConvAttentionBackend]:
+        return PleShortConvAttentionBackend
+
+    def get_state_dtype(self) -> tuple[torch.dtype, ...]:
+        return MambaStateDtypeCalculator.short_conv_state_dtype(
+            self.model_config.dtype, self.cache_config.mamba_cache_dtype
+        )
+
+    def get_state_shape(self) -> Sequence[tuple[int, ...]]:
+        return MambaStateShapeCalculator.short_conv_state_shape(
+            tp_world_size=1,
+            intermediate_size=self.hc_hidden_size,
+            conv_kernel=self.conv_state_len + 1,
+            num_spec=self.num_spec_tokens,
+        )
+
+    def _apply_norm(
+        self, norm: Qwen4ExpPLEGroupedNorm, hidden_states: torch.Tensor
+    ) -> torch.Tensor:
+        shape = hidden_states.shape
+        return norm(hidden_states.flatten(-2)).reshape(shape)
+
+    def _short_conv_fallback(self, inputs: torch.Tensor) -> torch.Tensor:
+        # Profiling / CUDA graph capture only; conv state is not updated.
+        inputs_t = inputs.transpose(0, 1).unsqueeze(0)
+        output = self.conv1d(inputs_t)[..., : inputs_t.size(-1)]
+        return F.silu(output).squeeze(0).transpose(0, 1)
+
+    def _short_conv_dilated_decode_batched(
+        self,
+        x_d: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_d: torch.Tensor,
+        has_initial_states_d: torch.Tensor | None,
+    ) -> torch.Tensor:
+        state_indices = state_indices_tensor_d.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        # TODO: need double-check
+        # FULL cudagraph padded decode rows use NULL_BLOCK_ID. Remap them to
+        # slot 0 for a safe gather, then zero output and skip write-back.
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        if has_initial_states_d is None:
+            has_initial_state = valid_state
+        else:
+            if has_initial_states_d.numel() < state_indices_tensor_d.numel():
+                raise ValueError(
+                    "has_initial_states_d size mismatch: "
+                    f"got {has_initial_states_d.numel()}, "
+                    f"need >= {state_indices_tensor_d.numel()}."
+                )
+            has_initial_state = has_initial_states_d[
+                : state_indices_tensor_d.numel()
+            ].to(device=conv_state.device, dtype=torch.bool)
+            has_initial_state = has_initial_state & valid_state
+
+        cached_state = conv_state.index_select(0, state_indices)
+        state = cached_state[..., : self.conv_state_len].to(x_d.dtype)
+        if self.conv_state_len > 0:
+            initial_state = torch.where(
+                has_initial_state.view(-1, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, x_d.unsqueeze(-1)), dim=-1)
+        else:
+            history = x_d.unsqueeze(-1)
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        ).squeeze(-1)
+        output = F.silu(conv_output)
+        output = output * valid_state.view(-1, 1).to(output.dtype)
+
+        if self.conv_state_len > 0:
+            next_state = history[..., -self.conv_state_len :]
+            # Padded rows are remapped to the reserved null slot. Preserve its
+            # existing value while writing the new states for valid rows.
+            existing_base_state = cached_state[..., : self.conv_state_len]
+            safe_next_state = torch.where(
+                valid_state.view(-1, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            cached_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_prefill_batched(
+        self,
+        x_p: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        state_indices_tensor_p: torch.Tensor,
+        num_prefills: int,
+        num_decode_tokens: int,
+        num_prefill_tokens: int,
+    ) -> torch.Tensor:
+        # ``non_spec_query_start_loc`` covers the non-spec (decode + prefill)
+        # requests and equals ``query_start_loc`` when spec-decode is inactive.
+        non_spec_query_start_loc = metadata.non_spec_query_start_loc
+        if non_spec_query_start_loc is None:
+            raise ValueError("query_start_loc is required for prefill short-conv")
+        query_start_loc_p = (
+            non_spec_query_start_loc[-num_prefills - 1 :] - num_decode_tokens
+        )
+        # The metadata builder guarantees that the prefill query offsets start
+        # at 0 and end at num_prefill_tokens. Avoid reading those values here,
+        # since doing so would force a device-to-host synchronization.
+        has_initial_states_p = metadata.has_initial_states_p
+        if has_initial_states_p is None:
+            raise ValueError("has_initial_states_p is required for prefill short-conv")
+
+        output = torch.empty_like(x_p)
+        q_starts = query_start_loc_p.to(torch.int64)
+        if state_indices_tensor_p.numel() < num_prefills:
+            raise ValueError(
+                "state_indices_tensor_p size mismatch: "
+                f"got {state_indices_tensor_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if has_initial_states_p.numel() < num_prefills:
+            raise ValueError(
+                "has_initial_states_p size mismatch: "
+                f"got {has_initial_states_p.numel()}, "
+                f"need >= {num_prefills}."
+            )
+        if num_prefills == 0 or x_p.numel() == 0:
+            return output
+        lengths = q_starts[1:] - q_starts[:-1]
+        # Use the CPU-computed packing width from the metadata builder instead
+        # of synchronizing on lengths.max().
+        max_len = metadata.max_prefill_query_len
+        if max_len <= 0:
+            return output
+
+        hidden_size = x_p.shape[1]
+        positions = torch.arange(
+            num_prefill_tokens, device=x_p.device, dtype=torch.int64
+        )
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        col_indices = positions - q_starts[req_indices]
+
+        packed_tokens = x_p.new_zeros((num_prefills, max_len, hidden_size))
+        packed_tokens[req_indices, col_indices] = x_p
+        packed_tokens = packed_tokens.transpose(1, 2).contiguous()
+
+        state_indices = state_indices_tensor_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        has_initial = has_initial_states_p[:num_prefills].to(
+            device=conv_state.device, dtype=torch.bool
+        )
+        if self.conv_state_len > 0:
+            if conv_state.shape[0] == 0:
+                state = conv_state.new_zeros(
+                    (num_prefills, hidden_size, self.conv_state_len),
+                    dtype=x_p.dtype,
+                )
+            else:
+                state = conv_state.index_select(0, state_indices)[
+                    ..., : self.conv_state_len
+                ].to(x_p.dtype)
+            use_initial_mask = (valid_state & has_initial).view(num_prefills, 1, 1)
+            initial_state = torch.where(
+                use_initial_mask,
+                state,
+                torch.zeros_like(state),
+            )
+            history = torch.cat((initial_state, packed_tokens), dim=-1)
+        else:
+            history = packed_tokens
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        token_positions = torch.arange(max_len, device=x_p.device, dtype=torch.int64)
+        valid_tokens = token_positions.view(1, max_len) < lengths.view(num_prefills, 1)
+        valid_output_mask = valid_tokens & valid_state.to(device=x_p.device).view(
+            num_prefills, 1
+        )
+        conv_output.masked_fill_(~valid_output_mask.unsqueeze(-1), 0)
+        output.copy_(conv_output[req_indices, col_indices])
+
+        if self.conv_state_len > 0 and conv_state.shape[0] > 0:
+            state_starts = lengths.to(device=history.device, dtype=torch.int64).view(
+                num_prefills, 1, 1
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=history.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            next_state = history.gather(
+                dim=2,
+                index=(state_starts + state_offsets).expand(-1, history.size(1), -1),
+            )
+            # Write back without a host synchronization. Valid, non-empty rows
+            # receive their new state; padding and zero-length rows keep the
+            # current cache value.
+            existing_state = conv_state.index_select(0, state_indices)
+            existing_base_state = existing_state[..., : self.conv_state_len]
+            update_mask = valid_state & (lengths.to(device=conv_state.device) > 0)
+            safe_next_state = torch.where(
+                update_mask.view(num_prefills, 1, 1),
+                next_state.to(conv_state.dtype),
+                existing_base_state,
+            )
+            existing_state[..., : self.conv_state_len] = safe_next_state
+            conv_state.index_copy_(0, state_indices, existing_state)
+        return output
+
+    def _short_conv_dilated_spec_batched(
+        self,
+        x_spec: torch.Tensor,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+        spec_state_indices_tensor: torch.Tensor,
+        spec_query_start_loc: torch.Tensor,
+        num_accepted_tokens: torch.Tensor,
+        spec_query_len: int,
+    ) -> torch.Tensor:
+        """Dilated short-conv for speculative-decode (MTP) requests.
+
+        Each spec request feeds multiple (draft + 1) query tokens. The conv
+        outputs are computed causally after rolling back the previous draft
+        state by ``num_accepted_tokens - 1``. The current candidate inputs stay
+        in the extended cache for the next forward, matching
+        ``causal_conv1d_update``.
+
+        ``spec_query_len`` (== num_speculative_tokens + 1) is the maximum query
+        length and is a Python int, so no host synchronization is needed; this
+        keeps the path safe for full CUDA-graph capture/replay where the buffers
+        are padded at the request level.
+        """
+        num_reqs = spec_state_indices_tensor.numel()
+        hidden_size = x_spec.size(-1)
+        # Use a fixed packing width instead of synchronizing on lengths.max().
+        max_len = spec_query_len
+        # Full CUDA graphs can pad these buffers. Only the first num_reqs
+        # accepted-token counts belong to actual speculative requests.
+        num_accepted_tokens = num_accepted_tokens[:num_reqs]
+        q_starts = spec_query_start_loc[: num_reqs + 1].to(torch.int64)
+        # Keep the number of real speculative tokens on the device.
+        total_real_tokens = q_starts[num_reqs]
+
+        state_indices = spec_state_indices_tensor.to(
+            device=conv_state.device, dtype=torch.int64
+        )
+        valid_state = state_indices != NULL_BLOCK_ID
+        state_indices = torch.where(
+            valid_state, state_indices, torch.zeros_like(state_indices)
+        )
+        positions = torch.arange(
+            x_spec.size(0), device=x_spec.device, dtype=torch.int64
+        )
+        # Route graph-padded token rows to the discarded dummy request so that
+        # they cannot overwrite real packed data.
+        req_indices = torch.searchsorted(q_starts[1:], positions, right=True)
+        valid_tokens = (positions < total_real_tokens) & (req_indices < num_reqs)
+        clamped_req_indices = req_indices.clamp_max(max(num_reqs - 1, 0))
+        col_indices = (positions - q_starts[clamped_req_indices]).clamp_(0, max_len - 1)
+        pack_req_indices = torch.where(
+            valid_tokens,
+            clamped_req_indices,
+            torch.full_like(req_indices, num_reqs),
+        )
+        pack_col_indices = torch.where(
+            valid_tokens, col_indices, torch.zeros_like(col_indices)
+        )
+
+        # The last request row is the dummy sink for graph padding.
+        packed = x_spec.new_zeros((num_reqs + 1, max_len, hidden_size))
+        packed[pack_req_indices, pack_col_indices] = x_spec
+        packed = packed.transpose(1, 2).contiguous()
+
+        if self.conv_state_len > 0:
+            cached_state = conv_state.index_select(0, state_indices)
+            rollback_offsets = num_accepted_tokens.to(
+                device=conv_state.device, dtype=torch.int64
+            ).sub(1)
+            rollback_offsets = torch.where(
+                valid_state,
+                rollback_offsets.clamp_(0, max_len - 1),
+                torch.zeros_like(rollback_offsets),
+            )
+            state_offsets = torch.arange(
+                self.conv_state_len, device=conv_state.device, dtype=torch.int64
+            ).view(1, 1, self.conv_state_len)
+            rollback_indices = rollback_offsets.view(-1, 1, 1) + state_offsets
+            state = cached_state.gather(
+                2, rollback_indices.expand(-1, hidden_size, -1)
+            ).to(x_spec.dtype)
+            state = torch.where(
+                valid_state.view(num_reqs, 1, 1),
+                state,
+                torch.zeros_like(state),
+            )
+            # Append a zeroed dummy-row state to match the [num_reqs + 1] pack.
+            dummy_state = state.new_zeros((1, hidden_size, self.conv_state_len))
+            state_full = torch.cat((state, dummy_state), dim=0)
+            history = torch.cat((state_full, packed), dim=-1)
+        else:
+            history = packed
+
+        conv_output = F.conv1d(
+            history,
+            conv_weights.unsqueeze(1).contiguous(),
+            groups=history.size(1),
+            dilation=self.short_conv_dilation,
+        )
+        conv_output = F.silu(conv_output).transpose(1, 2).contiguous()
+
+        output = conv_output[pack_req_indices, pack_col_indices]
+        output = output * valid_tokens.view(-1, 1).to(output.dtype)
+
+        # Keep all current candidate inputs in the extended state. On the next
+        # target forward, ``num_accepted_tokens - 1`` selects the rollback
+        # window before processing the newly scheduled tokens.
+        if self.conv_state_len > 0:
+            state_capacity = self.conv_state_len + max_len - 1
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache cannot retain speculative tokens: "
+                    f"got {conv_state.size(-1)}, need {state_capacity}."
+                )
+            candidate_state = history[:num_reqs, :, 1 : state_capacity + 1]
+            query_lengths = q_starts[1:] - q_starts[:-1]
+            state_positions = torch.arange(
+                state_capacity, device=history.device, dtype=torch.int64
+            ).view(1, 1, state_capacity)
+            update_lengths = (self.conv_state_len + query_lengths - 1).view(
+                num_reqs, 1, 1
+            )
+            update_mask = valid_state.view(num_reqs, 1, 1) & (
+                state_positions < update_lengths
+            )
+            existing_state = cached_state[..., :state_capacity]
+            next_state = torch.where(
+                update_mask,
+                candidate_state.to(conv_state.dtype),
+                existing_state,
+            )
+            cached_state[..., :state_capacity] = next_state
+            conv_state.index_copy_(0, state_indices, cached_state)
+
+        return output
+
+    def _short_conv_dilated_dispatch(
+        self,
+        inputs: torch.Tensor,
+        metadata: PleShortConvAttentionMetadata,
+        conv_state: torch.Tensor,
+        conv_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        num_prefills = metadata.num_prefills
+        num_decodes = metadata.num_decodes
+        num_decode_tokens = metadata.num_decode_tokens
+        num_prefill_tokens = metadata.num_prefill_tokens
+        has_prefill = num_prefills > 0
+        has_decode = num_decodes > 0
+        has_spec = metadata.spec_sequence_masks is not None
+        x = inputs[: metadata.num_actual_tokens]
+
+        # Split spec / non-spec tokens.
+        if has_spec:
+            if has_prefill or has_decode:
+                assert metadata.spec_token_indx is not None
+                assert metadata.non_spec_token_indx is not None
+                x_spec = x.index_select(0, metadata.spec_token_indx.long())
+                x_non_spec = x.index_select(0, metadata.non_spec_token_indx.long())
+            else:
+                x_spec = x
+                x_non_spec = None
+        else:
+            x_spec = None
+            x_non_spec = x
+
+        spec_output = None
+        # 1. Run the multi-query speculative-decode part.
+        if has_spec:
+            assert metadata.spec_state_indices_tensor is not None
+            assert metadata.spec_query_start_loc is not None
+            assert metadata.num_accepted_tokens is not None
+            spec_output = self._short_conv_dilated_spec_batched(
+                x_spec=x_spec,
+                conv_state=conv_state,
+                conv_weights=conv_weights,
+                spec_state_indices_tensor=metadata.spec_state_indices_tensor[
+                    : metadata.num_spec_decodes
+                ],
+                spec_query_start_loc=metadata.spec_query_start_loc,
+                num_accepted_tokens=metadata.num_accepted_tokens,
+                spec_query_len=metadata.spec_query_len,
+            )
+
+        # 2. Run regular decode and prefill requests.
+        conv_out_non_spec = None
+        state_indices_tensor = metadata.state_indices_tensor
+        if x_non_spec is not None:
+            assert state_indices_tensor is not None
+            if has_prefill:
+                state_indices_tensor_d, state_indices_tensor_p = torch.split(
+                    state_indices_tensor,
+                    [num_decodes, num_prefills],
+                    dim=0,
+                )
+                x_d, x_p = torch.split(
+                    x_non_spec,
+                    [num_decode_tokens, num_prefill_tokens],
+                    dim=0,
+                )
+                non_spec_parts: list[torch.Tensor] = []
+                if has_decode:
+                    non_spec_parts.append(
+                        self._short_conv_dilated_decode_batched(
+                            x_d=x_d,
+                            conv_state=conv_state,
+                            conv_weights=conv_weights,
+                            state_indices_tensor_d=state_indices_tensor_d,
+                            has_initial_states_d=metadata.has_initial_states_d,
+                        )
+                    )
+                non_spec_parts.append(
+                    self._short_conv_dilated_prefill_batched(
+                        x_p=x_p,
+                        metadata=metadata,
+                        conv_state=conv_state,
+                        conv_weights=conv_weights,
+                        state_indices_tensor_p=state_indices_tensor_p,
+                        num_prefills=num_prefills,
+                        num_decode_tokens=num_decode_tokens,
+                        num_prefill_tokens=num_prefill_tokens,
+                    )
+                )
+                conv_out_non_spec = torch.vstack(non_spec_parts)
+            else:
+                conv_out_non_spec = self._short_conv_dilated_decode_batched(
+                    x_d=x_non_spec,
+                    conv_state=conv_state,
+                    conv_weights=conv_weights,
+                    state_indices_tensor_d=state_indices_tensor[: x_non_spec.size(0)],
+                    has_initial_states_d=metadata.has_initial_states_d,
+                )
+
+        # 3. Merge both parts back into the original token order.
+        if has_spec and conv_out_non_spec is not None:
+            assert metadata.spec_token_indx is not None
+            assert metadata.non_spec_token_indx is not None
+            assert spec_output is not None
+            output = x.new_empty((metadata.num_actual_tokens, x.size(-1)))
+            output.index_copy_(0, metadata.spec_token_indx, spec_output)
+            output.index_copy_(0, metadata.non_spec_token_indx, conv_out_non_spec)
+            return output
+        elif has_spec:
+            assert spec_output is not None
+            return spec_output
+        if conv_out_non_spec is None:
+            return x
+        return conv_out_non_spec
+
+    def _short_conv(self, inputs: torch.Tensor) -> torch.Tensor:
+        forward_context = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            return self._short_conv_fallback(inputs)
+
+        if not isinstance(attn_metadata, dict):
+            raise RuntimeError(
+                "PLE short-conv expects per-layer attention metadata dict "
+                f"during inference, got {type(attn_metadata).__name__}."
+            )
+
+        layer_attn_metadata = attn_metadata.get(self.prefix)
+        if layer_attn_metadata is None:
+            raise RuntimeError(
+                f"Missing short-conv metadata for layer '{self.prefix}'. "
+                "This would bypass conv-state updates and is not allowed."
+            )
+        if not isinstance(layer_attn_metadata, PleShortConvAttentionMetadata):
+            raise TypeError(
+                "Expected PleShortConvAttentionMetadata for layer "
+                f"'{self.prefix}', got "
+                f"{type(layer_attn_metadata).__name__}."
+            )
+
+        conv_state = self.kv_cache[0]
+        if not is_conv_state_dim_first():
+            conv_state = conv_state.transpose(-1, -2)
+        conv_weights = self.conv1d.weight.squeeze(1)
+
+        state_capacity = self.conv_state_len + self.num_spec_tokens
+        if state_capacity > 0:
+            if conv_state.size(-1) < state_capacity:
+                raise RuntimeError(
+                    "PLE short-conv cache is smaller than expected for "
+                    f"dilated convolution: got {conv_state.size(-1)}, "
+                    f"expect at least {state_capacity}."
+                )
+            conv_state = conv_state[..., -state_capacity:]
+        return self._short_conv_dilated_dispatch(
+            inputs,
+            layer_attn_metadata,
+            conv_state,
+            conv_weights.to(dtype=inputs.dtype),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        input_ids: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        ngram_context: torch.Tensor,
+    ) -> torch.Tensor:
+        input_ids = input_ids.reshape(-1)
+        if input_ids.shape[0] != hidden_states.shape[0]:
+            raise ValueError(
+                "PLE expects input_ids and hidden_states to have the same "
+                f"token length, got {input_ids.shape[0]} and "
+                f"{hidden_states.shape[0]}"
+            )
+        embeddings = self.ple_embedding(input_ids, query_start_loc, ngram_context)
+        embeddings = self._dequantize_embeddings(embeddings, hidden_states.dtype)
+        key, _ = self.key_proj(embeddings)
+        value, _ = self.value_proj(embeddings)
+        token_count = hidden_states.shape[0]
+        key = key.reshape(token_count, self.hc_count, self.hidden_size)
+        query = hidden_states.reshape(token_count, self.hc_count, self.hidden_size)
+        key = self._apply_norm(self.norm_key, key)
+        query = self._apply_norm(self.norm_query, query)
+        gate = (key * query).sum(dim=-1, keepdim=True) / math.sqrt(self.hidden_size)
+        gate = torch.sigmoid(gate.sign() * gate.abs().clamp_min(1e-6).sqrt())
+        gated_value = gate * value.unsqueeze(-2)
+        normalized = self._apply_norm(self.norm_conv, gated_value).flatten(-2)
+        conv_output = torch.zeros_like(normalized)
+        torch.ops.vllm.qwen4_exp_ple_short_conv(
+            normalized,
+            conv_output,
+            self.prefix,
+        )
+        return gated_value.flatten(-2) + conv_output
+
+
+def qwen4_exp_ple_short_conv(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    layer = get_forward_context().no_compile_layers[layer_name]
+    result = layer._short_conv(inputs)
+    output[: result.shape[0]].copy_(result)
+
+
+def qwen4_exp_ple_short_conv_fake(
+    inputs: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_ple_short_conv",
+    op_func=qwen4_exp_ple_short_conv,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_ple_short_conv_fake,
+)
+
+
+__all__ = [
+    "Qwen4ExpNGramEmbedding",
+    "Qwen4ExpPLEGroupedNorm",
+    "Qwen4ExpPLELayer",
+]

--- a/vllm_ascend/models/qwen4_exp/nvidia/qsa.py
+++ b/vllm_ascend/models/qwen4_exp/nvidia/qsa.py
@@ -1,0 +1,479 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""NVIDIA QSA owner with Triton kernels."""
+
+from __future__ import annotations
+
+from typing import ClassVar, cast
+
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig
+from vllm.config.cache import CacheDType
+from vllm.distributed import get_tensor_model_parallel_world_size
+from vllm.forward_context import get_forward_context
+from vllm.model_executor.layers.attention.attention import (
+    set_default_quant_scales,
+)
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.model_executor.layers.layernorm import GemmaRMSNorm
+from vllm.model_executor.layers.linear import QKVParallelLinear, RowParallelLinear
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.rotary_embedding import MRotaryEmbedding, get_rope
+from vllm.model_executor.models.qwen3_next import Qwen3NextAttention
+from vllm.platforms import current_platform
+from vllm.transformers_utils.configs.qwen4_exp import (
+    Qwen4ExpTextConfig,
+)
+from vllm.utils.torch_utils import (
+    LayerNameType,
+    _encode_layer_name,
+    _resolve_layer_name,
+    canonicalize_singleton_dim_strides,
+    direct_register_custom_op,
+    kv_cache_dtype_str_to_dtype,
+)
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionType,
+)
+from vllm.v1.attention.backends.fa_utils import is_flash_attn_varlen_func_available
+from vllm.v1.attention.backends.flash_attn import (
+    FlashAttentionBackend,
+    FlashAttentionImpl,
+    FlashAttentionMetadata,
+    FlashAttentionMetadataBuilder,
+)
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    get_kv_quant_mode,
+)
+
+from ..common.qsa_cache import QSAForwardMetadata
+from . import model
+from .indexer_qsa import QSAIndexer
+
+
+class Qwen4ExpQSAMetadataBuilder(FlashAttentionMetadataBuilder):
+    """Flash metadata supporting uniform decode and target-verify graphs."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class Qwen4ExpQSAFlashAttentionBackend(FlashAttentionBackend):
+    """FullAttentionSpec backend used by the merged QSA owner."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = ["auto", "bfloat16"]
+
+    @staticmethod
+    def get_name() -> str:
+        return "QWEN4_EXP_QSA_TRITON"
+
+    @staticmethod
+    def get_impl_cls() -> type[Qwen4ExpQSAFlashAttentionImpl]:
+        return Qwen4ExpQSAFlashAttentionImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[Qwen4ExpQSAMetadataBuilder]:
+        return Qwen4ExpQSAMetadataBuilder
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @classmethod
+    def supports_kv_connector(cls) -> bool:
+        return False
+
+
+class Qwen4ExpQSAFlashAttentionImpl(FlashAttentionImpl):
+    """Run paged sparse GQA with the QSA Triton kernel."""
+
+    supports_dcp: bool = False
+    supports_pcp: bool = False
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        if self.dcp_world_size != 1:
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support decode context parallelism"
+            )
+        if self.kv_cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        self.supports_quant_query_input = False
+
+    def forward_qsa(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+        output: torch.Tensor,
+        token_to_req: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        del key, value
+        if output_scale is not None or output_block_scale is not None:
+            raise NotImplementedError("QSA does not support fused output quantization")
+        if self.alibi_slopes is not None or self.sinks is not None:
+            raise NotImplementedError("QSA does not support ALiBi or attention sinks")
+        if self.sliding_window != (-1, -1):
+            raise NotImplementedError("QSA does not support sliding-window attention")
+
+        num_tokens = attn_metadata.num_actual_tokens
+        output.zero_()
+        if num_tokens == 0:
+            return output
+
+        topk_buffer = getattr(layer, "topk_indices_buffer", None)
+        if topk_buffer is None:
+            raise RuntimeError("QSA owner did not provide its top-k buffer")
+        logical_indices = topk_buffer[:num_tokens]
+        token_to_req = token_to_req[:num_tokens]
+        key_cache, value_cache = kv_cache.transpose(1, 2).split(self.head_size, dim=-1)
+        key_cache = canonicalize_singleton_dim_strides(key_cache)
+        value_cache = canonicalize_singleton_dim_strides(value_cache)
+        if key_cache.dtype != torch.bfloat16 or query.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 Q/K/V")
+
+        from .ops.qsa import qsa_sparse_paged_attention
+
+        qsa_sparse_paged_attention(
+            query[:num_tokens],
+            key_cache,
+            value_cache,
+            logical_indices,
+            attn_metadata.block_table,
+            token_to_req,
+            output[:num_tokens],
+        )
+        return output
+
+
+class Qwen4ExpQSAAttention(Qwen3NextAttention, AttentionLayerBase):
+    """Merged Qwen full-attention owner with a QSA index side branch."""
+
+    supports_dcp = False
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        config: Qwen4ExpTextConfig,
+        layer_id: int,
+        quant_config: QuantizationConfig | None = None,
+        reduce_results: bool = True,
+        prefix: str = "",
+    ) -> None:
+        nn.Module.__init__(self)
+        cache_config = vllm_config.cache_config
+        model_config = vllm_config.model_config
+        if cache_config is None:
+            raise ValueError("Qwen4Exp QSA requires a paged KV cache")
+        if model_config.dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA currently requires BF16")
+        if cache_config.cache_dtype not in ("auto", "bfloat16"):
+            raise NotImplementedError("Qwen4Exp QSA requires a BF16 main KV cache")
+        if getattr(quant_config, "kv_cache_scheme", None) is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support KV quantization")
+        parallel_config = vllm_config.parallel_config
+        if (
+            parallel_config.prefill_context_parallel_size > 1
+            or parallel_config.decode_context_parallel_size > 1
+        ):
+            raise NotImplementedError(
+                "Qwen4Exp QSA does not support context parallelism"
+            )
+        if not getattr(config, "is_causal", True):
+            raise NotImplementedError("Qwen4Exp QSA requires causal decoder attention")
+
+        self.config = config
+        self.hidden_size = int(config.hidden_size)
+        tp_size = get_tensor_model_parallel_world_size()
+        self.total_num_heads = int(config.num_attention_heads)
+        if self.total_num_heads % tp_size:
+            raise ValueError("QSA attention heads must be divisible by TP size")
+        self.num_heads = self.total_num_heads // tp_size
+        self.total_num_kv_heads = int(config.num_key_value_heads)
+        if self.total_num_kv_heads >= tp_size:
+            if self.total_num_kv_heads % tp_size:
+                raise ValueError("QSA KV heads must be divisible by TP size")
+        elif tp_size % self.total_num_kv_heads:
+            raise ValueError("TP size must be divisible by replicated QSA KV heads")
+        self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
+        self.head_dim = int(config.head_dim or self.hidden_size // self.num_heads)
+        self.q_size = self.num_heads * self.head_dim
+        self.kv_size = self.num_kv_heads * self.head_dim
+        self.scaling = self.head_dim**-0.5
+        self.dual_chunk_attention_config = getattr(
+            config, "dual_chunk_attention_config", None
+        )
+        if self.dual_chunk_attention_config is not None:
+            raise NotImplementedError("Qwen4Exp QSA does not support dual-chunk RoPE")
+        # Qwen4Exp full-attention checkpoints always pack a sigmoid output
+        # gate next to Q, even when an inherited config default says otherwise.
+        self.attn_output_gate = True
+
+        self.qkv_proj = QKVParallelLinear(
+            self.hidden_size,
+            self.head_dim,
+            self.total_num_heads * (1 + self.attn_output_gate),
+            self.total_num_kv_heads,
+            bias=False,
+            quant_config=model.without_modelopt_fp4(quant_config),
+            prefix=f"{prefix}.qkv_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.total_num_heads * self.head_dim,
+            self.hidden_size,
+            bias=False,
+            reduce_results=reduce_results,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+        self.rotary_emb = get_rope(
+            head_size=self.head_dim,
+            max_position=config.max_position_embeddings,
+            rope_parameters=config.rope_parameters,
+        )
+        self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+        mm_config = model_config.multimodal_config
+        text_only = mm_config is None or mm_config.language_model_only
+        mrope_section = getattr(self.rotary_emb, "mrope_section", None)
+        supports_mrope = bool(
+            type(self.rotary_emb) is MRotaryEmbedding
+            and mrope_section
+            and len(mrope_section) == 3
+            and sum(mrope_section) == self.rotary_emb.rotary_dim // 2
+            and getattr(self.rotary_emb, "mrope_interleaved", False)
+        )
+        supports_dtype = getattr(self.rotary_emb, "dtype", None) in (
+            torch.float16,
+            torch.bfloat16,
+        )
+        self.use_fused_qk_norm_rope_gate = (
+            self.attn_output_gate
+            and getattr(self.rotary_emb, "is_neox_style", False)
+            and current_platform.is_cuda()
+            and supports_dtype
+            and (text_only or supports_mrope)
+        )
+
+        self.layer_name = f"{prefix}.attn"
+        self.attn_type = AttentionType.DECODER
+        self.kv_cache_dtype = cache_config.cache_dtype
+        self.kv_cache_torch_dtype = kv_cache_dtype_str_to_dtype(
+            self.kv_cache_dtype, model_config
+        )
+        if self.kv_cache_torch_dtype != torch.bfloat16:
+            raise NotImplementedError("Qwen4Exp QSA requires BF16 cache storage")
+        self.kv_sharing_target_layer_name = None
+        self.kv_cache = torch.tensor([])
+        set_default_quant_scales(self, register_buffer=True)
+
+        self.attn_backend = Qwen4ExpQSAFlashAttentionBackend
+        self.impl = Qwen4ExpQSAFlashAttentionImpl(
+            self.num_heads,
+            self.head_dim,
+            self.scaling,
+            self.num_kv_heads,
+            None,
+            None,
+            self.kv_cache_dtype,
+            None,
+            AttentionType.DECODER,
+            None,
+        )
+        self.indexer = QSAIndexer(
+            vllm_config=vllm_config,
+            config=config,
+            layer_id=layer_id,
+            rotary_emb=self.rotary_emb,
+            quant_config=quant_config,
+            prefix=f"{prefix}.indexer",
+        )
+        max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self.register_buffer(
+            "topk_indices_buffer",
+            torch.empty(
+                max_tokens,
+                self.indexer.output_width,
+                dtype=torch.int32,
+            ),
+            persistent=False,
+        )
+
+        static_context = vllm_config.compilation_config.static_forward_context
+        if self.layer_name in static_context:
+            raise ValueError(f"Duplicate layer name: {self.layer_name}")
+        static_context[self.layer_name] = self
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return self.attn_backend
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        return FullAttentionSpec(
+            block_size=vllm_config.cache_config.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.head_dim,
+            dtype=self.kv_cache_torch_dtype,
+            kv_quant_mode=get_kv_quant_mode(self.kv_cache_dtype),
+        )
+
+    def _run_qsa(
+        self,
+        hidden_states: torch.Tensor,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        output: torch.Tensor,
+    ) -> None:
+        metadata = get_forward_context().attn_metadata
+        if isinstance(metadata, list):
+            metadata = metadata[0]
+        if not isinstance(metadata, dict):
+            output.zero_()
+            return
+        main_metadata = cast(FlashAttentionMetadata, metadata[self.layer_name])
+        if self.kv_cache.numel() == 0:
+            raise RuntimeError("QSA main K/V cache is not bound")
+
+        num_tokens = main_metadata.num_actual_tokens
+        side_metadata = cast(
+            QSAForwardMetadata,
+            metadata[self.indexer.raw_key_cache.prefix],
+        )
+        if side_metadata.num_actual_tokens != num_tokens:
+            raise RuntimeError("QSA main and side metadata token counts disagree")
+        selected = self.indexer(
+            hidden_states,
+            positions,
+            self.topk_indices_buffer[:num_tokens],
+        )
+        if selected.shape != (
+            num_tokens,
+            self.indexer.output_width,
+        ):
+            raise RuntimeError("QSA indexer returned an invalid selection shape")
+        impl = cast(Qwen4ExpQSAFlashAttentionImpl, self.impl)
+        impl.do_kv_cache_update(
+            self,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata.slot_mapping,
+        )
+        impl.forward_qsa(
+            self,
+            query,
+            key,
+            value,
+            self.kv_cache,
+            main_metadata,
+            output,
+            token_to_req=side_metadata.token_to_req,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v, gate = self._project_qkv_gate(qkv, positions)
+        num_tokens = hidden_states.shape[0]
+        query = q.view(num_tokens, self.num_heads, self.head_dim)
+        key = k.view(num_tokens, self.num_kv_heads, self.head_dim)
+        value = v.view(num_tokens, self.num_kv_heads, self.head_dim)
+        attn_output = torch.empty_like(query)
+        encoded_layer_name = _encode_layer_name(self.layer_name)
+        if current_platform.opaque_attention_op():
+            torch.ops.vllm.qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        else:
+            qwen4_exp_qsa_with_output(
+                hidden_states,
+                positions,
+                query,
+                key,
+                value,
+                attn_output,
+                encoded_layer_name,
+            )
+        flat_output = attn_output.view(num_tokens, -1)
+        if gate is not None:
+            flat_output = flat_output * torch.sigmoid(gate)
+        output, _ = self.o_proj(flat_output)
+        return output
+
+
+def qwen4_exp_qsa_with_output(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    """Run the complete QSA state/update/attend transaction."""
+
+    layer_name = _resolve_layer_name(layer_name)
+    layer = get_forward_context().no_compile_layers[layer_name]
+    if not isinstance(layer, Qwen4ExpQSAAttention):
+        raise TypeError(f"{layer_name} is not a Qwen4Exp QSA owner")
+    layer._run_qsa(
+        hidden_states,
+        positions,
+        query,
+        key,
+        value,
+        output,
+    )
+
+
+def qwen4_exp_qsa_with_output_fake(
+    hidden_states: torch.Tensor,
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: LayerNameType,
+) -> None:
+    del hidden_states, positions, query, key, value, output, layer_name
+
+
+direct_register_custom_op(
+    op_name="qwen4_exp_qsa_with_output",
+    op_func=qwen4_exp_qsa_with_output,
+    mutates_args=["output"],
+    fake_impl=qwen4_exp_qsa_with_output_fake,
+)
+
+
+__all__ = [
+    "QSAIndexer",
+    "Qwen4ExpQSAAttention",
+    "Qwen4ExpQSAFlashAttentionBackend",
+    "Qwen4ExpQSAFlashAttentionImpl",
+    "qwen4_exp_qsa_with_output",
+]

--- a/vllm_ascend/ops/linear.py
+++ b/vllm_ascend/ops/linear.py
@@ -36,6 +36,7 @@ from vllm.model_executor.layers.linear import (  # noqa
     RowParallelLinear,
     UnquantizedLinearMethod,
 )
+from vllm.model_executor.parameter import BasevLLMParameter
 from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
 from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -141,6 +142,12 @@ class AscendLinearBase(LinearBase):
             self.quant_method = quant_config.get_quant_method(self, prefix=prefix)
         self.return_bias = return_bias
         self.disable_tp = disable_tp
+
+    def update_param_tp_status(self):
+        for param in self.parameters():
+            if isinstance(param, BasevLLMParameter):
+                param.tp_rank = self.tp_rank
+                param.tp_size = self.tp_size
 
 
 class AscendQKVParallelLinear(QKVParallelLinear):
@@ -348,6 +355,8 @@ class AscendRowParallelLinear(RowParallelLinear):
         else:
             self.register_parameter("bias", None)
 
+        self.update_param_tp_status()
+
         if self.custom_op is not None:
             self.custom_op.update_attrs()
 
@@ -437,6 +446,8 @@ class AscendColumnParallelLinear(ColumnParallelLinear):
             )
         else:
             self.register_parameter("bias", None)
+
+        self.update_param_tp_status()
 
         if self.custom_op is not None:
             self.custom_op.update_attrs()
@@ -560,6 +571,8 @@ class AscendReplicatedLinear(ReplicatedLinear):
             )
         else:
             self.register_parameter("bias", None)
+
+        self.update_param_tp_status()
 
         if self.custom_op is not None:
             self.custom_op.update_attrs()

--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,19 +1,232 @@
+from typing import TYPE_CHECKING, Any
+
 from vllm.config.speculative import SpeculativeConfig
+from vllm.transformers_utils.configs.speculators import algos as speculator_algos
+from vllm.utils.import_utils import LazyLoader
+
+from vllm_ascend.transformers_utils.configs.kimi_k3 import (
+    K3DSparkConfig,
+    register_k3_dspark_config,
+)
 
 _orig_post_init = SpeculativeConfig.__post_init__
+
+if TYPE_CHECKING:
+    import vllm.model_executor.layers.quantization as me_quant
+    from transformers import PretrainedConfig
+else:
+    PretrainedConfig = Any
+
+    me_quant = LazyLoader("model_executor", globals(), "vllm.model_executor.layers.quantization")
+
+
+# This patch may be imported before the model plugin entry point runs. Register
+# the lightweight config here as well so ModelConfig can parse the draft before
+# speculative post-init normalizes its architecture.
+register_k3_dspark_config()
+
+
+# Backport vLLM #48639. v0.26 unconditionally rewrites Speculators DSpark
+# checkpoints to the legacy bonus-anchor layout and drops the checkpoint's
+# sample_from_anchor field before hf_config_override() runs.
+_orig_update_dspark = speculator_algos.SUPPORTED_SPECULATORS_TYPES["dspark"]
+
+
+def _update_dspark(config_dict: dict, pre_trained_config: dict) -> None:
+    _orig_update_dspark(config_dict, pre_trained_config)
+    aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
+    pre_trained_config["dflash_config"] = {
+        "mask_token_id": config_dict["mask_token_id"],
+        "target_layer_ids": [i - 1 for i in aux_layer_ids],
+    }
+    pre_trained_config["sample_from_anchor"] = config_dict.get("sample_from_anchor", False)
+
+
+speculator_algos.SUPPORTED_SPECULATORS_TYPES["dspark"] = _update_dspark
+
+
+def hf_config_override(hf_config: PretrainedConfig) -> PretrainedConfig:
+    initial_architecture = hf_config.architectures[0]
+    if initial_architecture == "DSparkDraftModel" and hf_config.model_type == "qwen3":
+        # Legacy Qwen3/GQA DSpark checkpoints keep the inference-only fields
+        # under dflash_config and use the training-time architecture name.
+        # Normalize those values before vLLM inspects the model registry.
+        dflash_config = getattr(hf_config, "dflash_config", None) or {}
+
+        def get_dflash_value(name: str) -> Any:
+            if isinstance(dflash_config, dict):
+                return dflash_config.get(name)
+            return getattr(dflash_config, name, None)
+
+        updates: dict[str, Any] = {"architectures": ["Qwen3DSparkModel"]}
+        for name in ("mask_token_id", "target_layer_ids"):
+            if (value := get_dflash_value(name)) is not None:
+                updates[name] = value
+        hf_config.update(updates)
+
+    if hf_config.model_type in ("deepseek_v3", "deepseek_v32", "deepseek_v4", "glm_moe_dsa"):
+        target_model_type = hf_config.model_type
+        hf_config.model_type = "deepseek_mtp"
+    if hf_config.model_type == "deepseek_mtp":
+        if target_model_type == "deepseek_v4":
+            hf_config.update({"architectures": ["DeepSeekV4MTPModel"]})
+        else:
+            n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+            hf_config.update({"n_predict": n_predict, "architectures": ["DeepSeekMTPModel"]})
+    if hf_config.model_type in ("pangu_ultra_moe"):
+        hf_config.model_type = "pangu_ultra_moe_mtp"
+    if hf_config.model_type == "pangu_ultra_moe_mtp":
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update({"n_predict": n_predict, "architectures": ["OpenPanguMTPModel"]})
+
+    if hf_config.architectures[0] == "MiMoForCausalLM":
+        hf_config.model_type = "mimo_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update(
+            {
+                "num_hidden_layers": 0,
+                "n_predict": n_predict,
+                "architectures": ["MiMoMTPModel"],
+            }
+        )
+
+    if hf_config.architectures[0] == "Glm4MoeForCausalLM":
+        hf_config.model_type = "glm4_moe_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update(
+            {
+                "n_predict": n_predict,
+                "architectures": ["Glm4MoeMTPModel"],
+            }
+        )
+
+    if hf_config.architectures[0] == "Glm4MoeLiteForCausalLM":
+        hf_config.model_type = "glm4_moe_lite_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update(
+            {
+                "num_hidden_layers": 0,
+                "n_predict": n_predict,
+                "architectures": ["Glm4MoeLiteMTPModel"],
+            }
+        )
+
+    if hf_config.architectures[0] == "GlmOcrForConditionalGeneration":
+        hf_config.model_type = "glm_ocr_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update(
+            {
+                "num_hidden_layers": 0,
+                "n_predict": n_predict,
+                "architectures": ["GlmOcrMTPModel"],
+            }
+        )
+
+    if hf_config.model_type == "ernie4_5_moe":
+        hf_config.model_type = "ernie_mtp"
+    if hf_config.model_type == "ernie_mtp":
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update({"n_predict": n_predict, "architectures": ["ErnieMTPModel"]})
+
+    if (
+        hf_config.model_type == "nemotron_h"
+        and hasattr(hf_config, "num_nextn_predict_layers")
+        and hf_config.num_nextn_predict_layers > 0
+    ):
+        # Check if this is an MTP variant
+        hf_config.model_type = "nemotron_h_mtp"
+    if hf_config.model_type == "nemotron_h_mtp":
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
+        hf_config.update({"n_predict": n_predict, "architectures": ["NemotronHMTPModel"]})
+
+    if hf_config.model_type == "qwen3_next":
+        hf_config.model_type = "qwen3_next_mtp"
+    if hf_config.model_type == "qwen3_next_mtp":
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update({"n_predict": n_predict, "architectures": ["Qwen3NextMTP"]})
+
+    if hf_config.model_type == "exaone_moe":
+        hf_config.model_type = "exaone_moe_mtp"
+    if hf_config.model_type == "exaone_moe_mtp":
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", None)
+        hf_config.update({"n_predict": n_predict, "architectures": ["ExaoneMoeMTP"]})
+
+    if hf_config.model_type in ("qwen3_5", "qwen3_5_moe"):
+        is_moe = hf_config.model_type == "qwen3_5_moe"
+        hf_config.model_type = "qwen3_5_mtp"
+        n_predict = getattr(hf_config, "mtp_num_hidden_layers", None)
+        hf_config.update(
+            {
+                "n_predict": n_predict,
+                "architectures": ["Qwen3_5MoeMTP" if is_moe else "Qwen3_5MTP"],
+            }
+        )
+    if hf_config.model_type == "qwen4_exp":
+        quantization_config = getattr(hf_config, "quantization_config", None)
+        hf_config = getattr(hf_config, "text_config", hf_config)
+        rope_parameters = getattr(hf_config, "rope_parameters", None)
+        if rope_parameters is not None:
+            rope_parameters.pop("mrope_section", None)
+            rope_parameters.pop("mrope_interleaved", None)
+        if (
+            quantization_config is not None
+            and getattr(hf_config, "quantization_config", None) is None
+        ):
+            hf_config.update({"quantization_config": quantization_config})
+        hf_config.model_type = "qwen4_exp_mtp"
+        n_predict = getattr(
+            hf_config,
+            "mtp_num_hidden_layers",
+            getattr(hf_config, "num_nextn_predict_layers", 1),
+        )
+        hf_config.update(
+            {"n_predict": n_predict, "architectures": ["Qwen4ExpMTP"]}
+        )
+    if hf_config.model_type in ("longcat_flash", "longcat_flash_ngram"):
+        hf_config.model_type = "longcat_flash_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
+        hf_config.update({"n_predict": n_predict, "architectures": ["LongCatFlashMTPModel"]})
+
+    if hf_config.model_type in ("step3p5", "step3p7") or hf_config.architectures[0] in (
+        "Step3p5ForCausalLM",
+        "Step3p7ForConditionalGeneration",
+    ):
+        quantization_config = getattr(hf_config, "quantization_config", None)
+        hf_config = getattr(hf_config, "text_config", hf_config)
+        if quantization_config is not None and getattr(hf_config, "quantization_config", None) is None:
+            hf_config.update({"quantization_config": quantization_config})
+        hf_config.model_type = "step3p5_mtp"
+        n_predict = getattr(hf_config, "num_nextn_predict_layers", 1)
+        hf_config.update({"n_predict": n_predict, "architectures": ["Step3p5MTP"]})
+
+    if initial_architecture == "MistralLarge3ForCausalLM":
+        hf_config.update({"architectures": ["EagleMistralLarge3ForCausalLM"]})
+
+    return hf_config
 
 
 def _dspark_post_init(self):
     _orig_post_init(self)
     if self.use_dspark():
-        draft_model_config = getattr(self, "draft_model_config", None)
-        draft_hf_config = getattr(draft_model_config, "hf_config", None)
+        draft_model_config = self.draft_model_config
+        if draft_model_config is None:
+            raise ValueError("DSpark requires a draft model config.")
+        draft_hf_config = draft_model_config.hf_config
         # deepseek v4 dspark
         if getattr(draft_hf_config, "ptd_token_id", None) is None:  # type: ignore
             draft_hf_config.ptd_token_id = getattr(draft_hf_config, "dspark_noise_token_id", None)  # type: ignore
         # gqa backend dspark
         if getattr(draft_hf_config, "ptd_token_id", None) is None:  # type: ignore
             draft_hf_config.ptd_token_id = getattr(draft_hf_config, "mask_token_id", None)  # type: ignore
+        # Upstream DSpark normalization rewrites the config's model_type and
+        # architecture in place. The concrete config class remains intact, so
+        # restore K3 from that explicit type contract instead of probing for
+        # optional sentinel attributes shared by other draft families.
+        if isinstance(draft_hf_config, K3DSparkConfig):
+            draft_hf_config.model_type = K3DSparkConfig.model_type
+            draft_hf_config.architectures = ["K3DSparkModel"]
+            self.update_arch_()
 
 
+SpeculativeConfig.hf_config_override = hf_config_override
 SpeculativeConfig.__post_init__ = _dspark_post_init

--- a/vllm_ascend/spec_decode/llm_base_proposer.py
+++ b/vllm_ascend/spec_decode/llm_base_proposer.py
@@ -1652,13 +1652,14 @@ class AscendSpecDecodeBaseProposer(SpecDecodeBaseProposer):
             hf_config = getattr(draft_model_config, "hf_config", None)
             architectures = getattr(hf_config, "architectures", []) or []
             if vllm_version_is("0.27.1"):
-                return bool({"DeepSeekMTPModel", "KimiK3MTPModel"}.intersection(architectures))
+                return bool({"DeepSeekMTPModel", "KimiK3MTPModel", "Qwen4ExpMTP"}.intersection(architectures))
             else:
                 return bool(
                     {
                         "DeepSeekMTPModel",
                         "DeepseekV32MTPModel",
                         "KimiK3MTPModel",
+                        "Qwen4ExpMTP",
                     }.intersection(architectures)
                 )
         return self.method not in ("mtp", "draft_model", "dflash", "dspark")


### PR DESCRIPTION
### What this PR does / why we need it?

Adds **Qwen3.8 Flash Next** model and MTP (Multi-Token Prediction) speculative decoding support on Ascend NPU.

### What we did
- **vllm_ascend/models/qwen4_exp/**: full model implementation — config, common modules (hyperconnection / ple / qsa_cache), nvidia & amd backends (model / model_state / mtp / ops / ple_layer / qsa), Ascend bootstrap support.
- **vllm_ascend/models/__init__.py**: register qwen4_exp.
- **vllm_ascend/patch/platform/patch_speculative_config.py**: add `qwen4_exp` -> `qwen4_exp_mtp` remap (n_predict from mtp_num_hidden_layers / num_nextn_predict_layers, architecture -> Qwen4ExpMTP).
- **vllm_ascend/spec_decode/llm_base_proposer.py**: register `Qwen4ExpMTP` as a tuple-returning MTP family (alongside DeepSeek / KimiK3).
- **vllm_ascend/ops/linear.py**: helper for the new path.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
