### PR TITLE
[CI][Misc]migrates the nightly single-node a3 test cases to the 560T A3 machine and obtains baseline results

### DIFF
--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -303,9 +303,6 @@ a3:
 a3-560t:
   single_node:
     test_config:
-      - name: Kimi-K2.6-w4a8-A3
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: Kimi-K2.6-w4a8-A3.yaml
       - name: Minimax_m2.7_w8a8_A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: Minimax_m2.7_w8a8_A3.yaml
@@ -324,54 +321,21 @@ a3-560t:
       - name: Qwen3_32b_W8A8_wl_A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: Qwen3_32b_W8A8_wl_A3.yaml
-      - name: Deepseek_R1_W8A8_Reasoning_output_A3
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: Deepseek_R1_W8A8_Reasoning_output_A3.yaml
       - name: qwen_3_6_27b_w8a8_A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: qwen_3_6_27b_w8a8_A3.yaml
-      - name: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3.yaml
-      - name: glm-5.2-w4a8c8-sfa-dcp
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: GLM-5.2-W4A8C8-SFA-DCP.yaml
-      - name: MiniMax-M3-BF16-A3
-        os: linux-aarch64-nightly-a3-16
-        config_file_path: MiniMax-M3-BF16-A3.yaml
       - name: MiniMax-M3-W8A8-A3
         os: linux-aarch64-nightly-a3-16
         config_file_path: MiniMax-M3-W8A8-A3.yaml
-      - name: mtpx-deepseek-r1-0528-w8a8
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: MTPX-DeepSeek-R1-0528-W8A8.yaml
-      - name: deepseek-r1-0528-w8a8
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: DeepSeek-R1-0528-W8A8.yaml
       - name: DeepSeek-V4-Flash-W8A8-A3
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: DeepSeek-V4-Flash-W8A8-A3.yaml
       - name: kimi-k2-thinking
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: Kimi-K2-Thinking.yaml
-      - name: kimi-k2.5
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: Kimi-K2.5.yaml
       - name: Qwen3.5-122B-A10B-W8A8-A3
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3.5-122B-A10B-W8A8-A3.yaml
-      - name: deepseek-v3-2-w8a8
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: DeepSeek-V3.2-W8A8.yaml
-      - name: glm-5.1-w8a8-prefill-mc2
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: GLM-5.1-W8A8-PrefillMC2.yaml
-      - name: glm-5.2-w4a8-dspark
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: GLM-5.2-W4A8-DSpark-A3.yaml
-      - name: glm-5.2-w4a8-mtp
-        os: linux-aarch64-a3-16-cn12-001
-        config_file_path: GLM-5.2-W4A8-MTP-A3.yaml
       - name: qwen3-235b-a22b-w8a8
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: Qwen3-235B-A22B-W8A8.yaml
@@ -400,27 +364,16 @@ a3-560t:
       - name: Qwen3.5-27B-w8a8-A3
         os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3.5-27B-w8a8-A3.yaml
-      - name: qwen3-32b-int8
-        os: linux-aarch64-a3-4-cn12-001
-        config_file_path: Qwen3-32B-Int8.yaml
-      - name: Qwen3-32B-QuaRot
-        os: linux-aarch64-a3-2-cn12-001
-        config_file_path: Qwen3-32B-QuaRot-eagle3.yaml
+
       - name: qwen3-30b-a3b-w8a8
         os: linux-aarch64-a3-4-cn12-001
         config_file_path: Qwen3-30B-A3B-W8A8.yaml
       - name: Qwen3-32B-W8A8C8-A3
         os: linux-aarch64-a3-4-cn12-001
         config_file_path: Qwen3-32B-W8A8C8-A3.yaml
-      - name: qwen3-32b-int8-prefix-cache
-        os: linux-aarch64-a3-4-cn12-001
-        config_file_path: Prefix-Cache-Qwen3-32B-Int8.yaml
       - name: Qwen3-30B-A3B-W4A8-llm-compressor
         os: linux-aarch64-a3-2-cn12-001
         config_file_path: Qwen3-30B-A3B-W4A8-llm-compressor.yaml
-      - name: Qwen3-30B-QuaRot
-        os: linux-aarch64-a3-2-cn12-001
-        config_file_path: Qwen3-30B-QuaRot-eagle3.yaml
 
 310p:
   single_node:

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -303,6 +303,45 @@ a3:
 a3-560t:
   single_node:
     test_config:
+      - name: Kimi-K2.6-w4a8-A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Kimi-K2.6-w4a8-A3.yaml
+      - name: Minimax_m2.7_w8a8_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Minimax_m2.7_w8a8_A3.yaml
+      - name: Qwen3_32b_w8a8_ml_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Qwen3_32b_w8a8_ml_A3.yaml
+      - name: Deepseek_R1_W8A8_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Deepseek_R1_W8A8_A3.yaml
+      - name: Qwen3.8-27B-w8a8-A3
+        os: linux-aarch64-nightly-a3-2
+        config_file_path: Qwen3.8-27B-w8a8-A3.yaml
+      - name: Qwq_32b_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Qwq_32b_A3.yaml
+      - name: Qwen3_32b_W8A8_wl_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Qwen3_32b_W8A8_wl_A3.yaml
+      - name: Deepseek_R1_W8A8_Reasoning_output_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Deepseek_R1_W8A8_Reasoning_output_A3.yaml
+      - name: qwen_3_6_27b_w8a8_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: qwen_3_6_27b_w8a8_A3.yaml
+      - name: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: Qwen3-235B-A22B-W8A8_piecewise_fullgraph_A3.yaml
+      - name: glm-5.2-w4a8c8-sfa-dcp
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: GLM-5.2-W4A8C8-SFA-DCP.yaml
+      - name: MiniMax-M3-BF16-A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: MiniMax-M3-BF16-A3.yaml
+      - name: MiniMax-M3-W8A8-A3
+        os: linux-aarch64-nightly-a3-16
+        config_file_path: MiniMax-M3-W8A8-A3.yaml
       - name: mtpx-deepseek-r1-0528-w8a8
         os: linux-aarch64-a3-16-cn12-001
         config_file_path: MTPX-DeepSeek-R1-0528-W8A8.yaml

--- a/.github/workflows/configs/nightly_config.yaml
+++ b/.github/workflows/configs/nightly_config.yaml
@@ -354,6 +354,9 @@ a3-560t:
       - name: qwen3-30b-acc
         os: linux-aarch64-a3-4-cn12-001
         tests: tests/e2e/weekly/single_node/models/test_qwen3_30b_acc.py
+      - name: compressor-metadata-cross-stream
+        os: linux-aarch64-a3-2-cn12-001
+        tests: tests/e2e/nightly/single_node/ops/singlecard_ops/test_compressor_metadata.py
       # YAML-driven tests
       - name: Qwen3.5-27B-w8a8-A3
         os: linux-aarch64-a3-2-cn12-001


### PR DESCRIPTION
### What this PR does / why we need it?
This PR migrates the nightly single-node a3 test cases to the 560T A3 machine and obtains baseline results

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
run the cases nightly


- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
