### PR TITLE
[Refactor][CI] Align AscendKVBlockZeroer with vllm and add test for kernel

### DIFF
--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kv_block_zeroer.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kv_block_zeroer.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""KV block zeroer tests.
+
+The first section is migrated from vLLM's tests/v1/worker/test_kv_block_zeroer.py.
+Keep it aligned with upstream except for NPU APIs, Ascend's separate K/V tensors and
+one-dimensional launch. Ascend-specific coverage follows it.
+"""
+
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    SlidingWindowSpec,
+)
+from vllm.v1.worker.utils import AttentionGroup
+
+from vllm_ascend.worker import utils as worker_utils
+from vllm_ascend.worker.utils import AscendKVBlockZeroer
+
+
+class _BlockFirstBackend:
+    @staticmethod
+    def get_kv_cache_block_dim(*args, **kwargs):
+        return 0
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+@pytest.mark.parametrize(
+    "spec",
+    [
+        SlidingWindowSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.uint8,
+            sliding_window=4,
+        ),
+        ChunkedLocalAttentionSpec(
+            block_size=2,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.uint8,
+            attention_chunk_size=4,
+        ),
+    ],
+    ids=["sliding-window", "chunked-local"],
+)
+def test_attention_blocks_are_zeroed(spec):
+    device = torch.device("npu")
+    # Ascend stores K and V in separate tensors instead of one KV tensor.
+    storages = (
+        torch.ones((4, 1, 2, 2), dtype=torch.uint8, device=device),
+        torch.ones((4, 1, 2, 2), dtype=torch.uint8, device=device),
+    )
+    layer_name = "draft.self_attn"
+    zeroer = AscendKVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(_BlockFirstBackend, [layer_name], spec, 0)  # type: ignore[arg-type]
+        ],
+        # Ascend receives one kernel block-size list per KV cache group.
+        kernel_block_sizes=[[2]],
+        cache_dtype="fp8",
+        static_forward_context={
+            layer_name: SimpleNamespace(kv_cache=storages),
+        },
+    )
+
+    zeroer.zero_block_ids([1])
+    torch.accelerator.synchronize()
+
+    for storage in storages:
+        expected = torch.ones_like(storage)
+        expected[1] = 0
+        assert torch.equal(storage, expected)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+def test_block_ids_are_not_overwritten_while_copy_is_in_flight():
+    device = torch.device("npu")
+    num_blocks = 4
+    page_size_el = 4
+    storage = torch.ones((num_blocks, page_size_el), dtype=torch.int32, device=device)
+
+    # Build the minimal zeroer state directly so the test can focus on the
+    # in-flight copy behavior without constructing model attention groups.
+    zeroer = AscendKVBlockZeroer.__new__(AscendKVBlockZeroer)
+    zeroer.device = device
+    zeroer._meta = (
+        torch.tensor([storage.data_ptr()], dtype=torch.uint64, device=device),
+        torch.tensor([page_size_el], dtype=torch.int64, device=device),
+        torch.tensor([page_size_el], dtype=torch.int64, device=device),
+        page_size_el // page_size_el,  # max_chunks = 1
+        page_size_el,  # blk_size
+        1,  # n_segs
+    )
+
+    # Ascend has no torch.cuda._sleep equivalent. Compile first, then use an NPU
+    # stream/event dependency to keep both nonblocking copies in flight.
+    zeroer.zero_block_ids([0])
+    torch.accelerator.synchronize()
+    storage.fill_(1)
+    torch.accelerator.synchronize()
+
+    blocker_stream = torch.npu.Stream()
+    stream = torch.npu.Stream()
+    with torch.npu.stream(blocker_stream):
+        blocker = torch.full(
+            (2048, 2048), 1 / 2048, dtype=torch.float16, device=device
+        )
+        blocker_result = torch.mm(blocker, blocker)
+        for _ in range(15):
+            blocker_result = torch.mm(blocker_result, blocker)
+        blocker_done = blocker_stream.record_event()
+
+    with torch.npu.stream(stream):
+        stream.wait_event(blocker_done)
+        # Keep the first nonblocking H2D copy pending while the host submits the
+        # second call. Each call must stage from its own pinned source so the
+        # first copy is not corrupted before it runs.
+        zeroer.zero_block_ids([1])
+        zeroer.zero_block_ids([2])
+    stream.synchronize()
+
+    assert torch.all(storage[0] == 1)
+    assert torch.all(storage[1] == 0)
+    assert torch.all(storage[2] == 0)
+    assert torch.all(storage[3] == 1)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+def test_non_uniform_page_sizes():
+    """Two segments with different page sizes (e.g. MLA + DSA indexer)."""
+    device = torch.device("npu")
+    num_blocks = 4
+    page_size_a = 10496  # int32 elements
+    page_size_b = 2112
+
+    storage_a = torch.ones((num_blocks, page_size_a), dtype=torch.int32, device=device)
+    storage_b = torch.ones((num_blocks, page_size_b), dtype=torch.int32, device=device)
+
+    zeroer = AscendKVBlockZeroer.__new__(AscendKVBlockZeroer)
+    zeroer.device = device
+
+    seg_page_sizes = [page_size_a, page_size_b]
+    max_ps = max(seg_page_sizes)
+
+    blk_size = min(1 << (max_ps - 1).bit_length(), 1024)
+
+    zeroer._meta = (
+        torch.tensor(
+            [storage_a.data_ptr(), storage_b.data_ptr()],
+            dtype=torch.uint64,
+            device=device,
+        ),
+        torch.tensor(seg_page_sizes, dtype=torch.int64, device=device),
+        torch.tensor(seg_page_sizes, dtype=torch.int64, device=device),
+        (max_ps + blk_size - 1) // blk_size,
+        blk_size,
+        2,
+    )
+
+    stream = torch.npu.Stream()
+    with torch.npu.stream(stream):
+        zeroer.zero_block_ids([1, 2])
+    stream.synchronize()
+
+    for storage in (storage_a, storage_b):
+        assert torch.all(storage[0] == 1)
+        assert torch.all(storage[1] == 0)
+        assert torch.all(storage[2] == 0)
+        assert torch.all(storage[3] == 1)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+def test_packed_segment_zeros_only_its_last_block_page():
+    """A packed KV segment steps by block stride but clears only its page."""
+    device = torch.device("npu")
+    num_blocks = 4
+    block_stride_el = 12
+    page_size_el = 4
+    page_offset_el = 3
+    backing = torch.ones(
+        (num_blocks, block_stride_el), dtype=torch.int32, device=device
+    )
+
+    zeroer = AscendKVBlockZeroer.__new__(AscendKVBlockZeroer)
+    zeroer.device = device
+    zeroer._meta = (
+        torch.tensor(
+            [backing.data_ptr() + page_offset_el * backing.element_size()],
+            dtype=torch.uint64,
+            device=device,
+        ),
+        torch.tensor([block_stride_el], dtype=torch.int64, device=device),
+        torch.tensor([page_size_el], dtype=torch.int64, device=device),
+        1,
+        page_size_el,
+        1,
+    )
+
+    zeroer.zero_block_ids([num_blocks - 1])
+    torch.accelerator.synchronize()
+
+    expected = torch.ones_like(backing)
+    expected[-1, page_offset_el : page_offset_el + page_size_el] = 0
+    assert torch.equal(backing, expected)
+
+
+def test_large_dsv4_launch_geometry(monkeypatch):
+    """Keep the failing DSV4 shape efficient and within launch limits."""
+    device = torch.device("cpu")
+    n_blocks, n_segs = 6870, 181
+    layer_names = [f"layer.{i}" for i in range(n_segs)]
+    page_sizes = [9344 if i % 2 == 0 else 292 for i in range(n_segs)]
+    spec = SlidingWindowSpec(
+        block_size=1,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.int32,
+        sliding_window=1,
+    )
+    storages = {
+        name: torch.ones((1, page_size), dtype=torch.int32)
+        for name, page_size in zip(layer_names, page_sizes)
+    }
+    zeroer = AscendKVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(
+                _BlockFirstBackend,  # type: ignore[arg-type]
+                [name],
+                spec,
+                group_id,
+            )
+            for group_id, name in enumerate(layer_names)
+        ],
+        # Ascend receives one kernel block-size list per KV cache group.
+        kernel_block_sizes=[[1] for _ in range(n_segs)],
+        cache_dtype="auto",
+        static_forward_context={
+            # Reuse one tensor as K/V so pointer deduplication keeps the
+            # upstream test's 181-segment geometry.
+            name: SimpleNamespace(kv_cache=(storage, storage))
+            for name, storage in storages.items()
+        },
+    )
+
+    assert zeroer._meta is not None
+    _, _, seg_page_sizes, max_chunks, blk_size, n_segs = zeroer._meta
+    assert seg_page_sizes.tolist() == page_sizes
+    assert (max_chunks, blk_size, n_segs) == (10, 1024, 181)
+
+    captured_grids = []
+
+    class FakeKernel:
+        def __getitem__(self, grid):
+            captured_grids.append(grid)
+            return lambda *args, **kwargs: None
+
+    vectorcore_num = 48
+    monkeypatch.setattr(worker_utils, "_zero_kv_blocks_kernel", FakeKernel())
+    monkeypatch.setattr(
+        worker_utils,
+        "async_tensor_h2d",
+        lambda values, **kwargs: torch.tensor(values, dtype=torch.int64),
+    )
+    # Ascend uses a fixed one-dimensional persistent grid.
+    monkeypatch.setattr(worker_utils, "get_vectorcore_num", lambda: vectorcore_num)
+
+    zeroer.zero_block_ids(list(range(n_blocks)))
+
+    old_max_chunks = max(page_sizes) // 4
+    assert math.prod((n_blocks, n_segs, old_max_chunks)) > 2**31 - 1
+    assert captured_grids == [(vectorcore_num,)]
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+def test_warmup_respects_available_block_count():
+    """An empty KV cache must not be warmed with out-of-range block IDs."""
+    device = torch.device("npu")
+    page_size_el = 4
+    storage = torch.ones((1, page_size_el), dtype=torch.int32, device=device)
+
+    zeroer = AscendKVBlockZeroer.__new__(AscendKVBlockZeroer)
+    zeroer.device = device
+    zeroer._meta = (
+        torch.tensor([storage.data_ptr()], dtype=torch.uint64, device=device),
+        torch.tensor([page_size_el], dtype=torch.int64, device=device),
+        torch.tensor([page_size_el], dtype=torch.int64, device=device),
+        1,
+        page_size_el,
+        1,
+    )
+
+    zeroer.warmup(0)
+    torch.accelerator.synchronize()
+
+    assert torch.all(storage == 1)
+
+
+# -----------------------------------------------------------------------------
+# vLLM-Ascend-specific coverage
+# -----------------------------------------------------------------------------
+
+
+def _torch_zero_kv_blocks_golden(
+    storages: list[torch.Tensor],
+    block_ids: list[int],
+    page_sizes: list[int],
+) -> list[torch.Tensor]:
+    """Build expected zeroed pages with ordinary Torch indexing."""
+    outputs = [storage.clone() for storage in storages]
+    for output, page_size in zip(outputs, page_sizes):
+        for block_id in block_ids:
+            output[block_id, :page_size] = 0
+    return outputs
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+@pytest.mark.parametrize(
+    ("num_blocks", "page_sizes", "paddings", "block_ids"),
+    [
+        (1, [1], [0], [0]),
+        (3, [1024], [0], [1]),
+        (3, [1025], [7], [2]),
+        (4, [9344, 292, 1], [3, 4, 7], [0, 1, 2, 3]),
+        (130, [33, 7], [2, 5], [129, 0, 64, 3]),
+    ],
+    ids=[
+        "minimum-page-and-block",
+        "maximum-single-chunk-page",
+        "first-multi-chunk-page-with-tail",
+        "heterogeneous-segments-with-many-masked-chunks",
+        "first-middle-last-blocks-in-nonmonotonic-order",
+    ],
+)
+def test_zero_kv_blocks_matches_torch_golden(
+    num_blocks, page_sizes, paddings, block_ids
+):
+    """Compare the Triton kernel with a Torch golden across boundary layouts."""
+    device = torch.device("npu")
+    storages = []
+    for page_size, padding in zip(page_sizes, paddings):
+        block_stride = page_size + padding
+        storage = torch.arange(
+            1,
+            num_blocks * block_stride + 1,
+            dtype=torch.int32,
+            device=device,
+        ).reshape(num_blocks, block_stride)
+        storages.append(storage)
+
+    block_strides = [storage.stride(0) for storage in storages]
+    expected = _torch_zero_kv_blocks_golden(storages, block_ids, page_sizes)
+    max_page_size = max(page_sizes)
+    block_size = min(1 << (max_page_size - 1).bit_length(), 1024)
+
+    zeroer = AscendKVBlockZeroer.__new__(AscendKVBlockZeroer)
+    zeroer.device = device
+    zeroer._meta = (
+        torch.tensor(
+            [storage.data_ptr() for storage in storages],
+            dtype=torch.uint64,
+            device=device,
+        ),
+        torch.tensor(block_strides, dtype=torch.int64, device=device),
+        torch.tensor(page_sizes, dtype=torch.int64, device=device),
+        (max_page_size + block_size - 1) // block_size,
+        block_size,
+        len(storages),
+    )
+
+    zeroer.zero_block_ids(block_ids)
+    torch.accelerator.synchronize()
+
+    for storage, expected_storage in zip(storages, expected):
+        assert torch.equal(storage, expected_storage)
+
+
+@pytest.mark.skipif(not torch.npu.is_available(), reason="NPU required")
+def test_init_adapts_kv_tuple_and_virtual_kernel_blocks():
+    """Validate fake layers for separate K/V and virtual block splitting."""
+    device = torch.device("npu")
+    num_logical_blocks = 3
+    logical_block_size = 4
+    kernel_block_size = 2
+    ratio = logical_block_size // kernel_block_size
+    num_kernel_blocks = num_logical_blocks * ratio
+    layer_name = "model.layers.0.self_attn"
+    spec = FullAttentionSpec(
+        block_size=logical_block_size,
+        num_kv_heads=1,
+        head_size=4,
+        dtype=torch.bfloat16,
+    )
+    storages = (
+        torch.ones(
+            (num_kernel_blocks, kernel_block_size, 4),
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+        torch.ones(
+            (num_kernel_blocks, kernel_block_size, 2),
+            dtype=torch.bfloat16,
+            device=device,
+        ),
+    )
+    zeroer = AscendKVBlockZeroer(
+        device,
+        attn_groups_iter=[
+            AttentionGroup(_BlockFirstBackend, [layer_name], spec, 0)  # type: ignore[arg-type]
+        ],
+        kernel_block_sizes=[[kernel_block_size]],
+        cache_dtype="auto",
+        static_forward_context={
+            layer_name: SimpleNamespace(kv_cache=storages),
+        },
+    )
+
+    zeroer.zero_block_ids([1])
+    torch.accelerator.synchronize()
+
+    for storage in storages:
+        expected = torch.ones_like(storage)
+        expected[ratio : 2 * ratio] = 0
+        assert torch.equal(storage, expected)

--- a/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kv_block_zeroer.py
+++ b/tests/e2e/nightly/single_node/ops/singlecard_ops/triton/test_kv_block_zeroer.py
@@ -13,7 +13,6 @@ from types import SimpleNamespace
 
 import pytest
 import torch
-
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
@@ -112,9 +111,7 @@ def test_block_ids_are_not_overwritten_while_copy_is_in_flight():
     blocker_stream = torch.npu.Stream()
     stream = torch.npu.Stream()
     with torch.npu.stream(blocker_stream):
-        blocker = torch.full(
-            (2048, 2048), 1 / 2048, dtype=torch.float16, device=device
-        )
+        blocker = torch.full((2048, 2048), 1 / 2048, dtype=torch.float16, device=device)
         blocker_result = torch.mm(blocker, blocker)
         for _ in range(15):
             blocker_result = torch.mm(blocker_result, blocker)
@@ -187,9 +184,7 @@ def test_packed_segment_zeros_only_its_last_block_page():
     block_stride_el = 12
     page_size_el = 4
     page_offset_el = 3
-    backing = torch.ones(
-        (num_blocks, block_stride_el), dtype=torch.int32, device=device
-    )
+    backing = torch.ones((num_blocks, block_stride_el), dtype=torch.int32, device=device)
 
     zeroer = AscendKVBlockZeroer.__new__(AscendKVBlockZeroer)
     zeroer.device = device
@@ -227,10 +222,7 @@ def test_large_dsv4_launch_geometry(monkeypatch):
         dtype=torch.int32,
         sliding_window=1,
     )
-    storages = {
-        name: torch.ones((1, page_size), dtype=torch.int32)
-        for name, page_size in zip(layer_names, page_sizes)
-    }
+    storages = {name: torch.ones((1, page_size), dtype=torch.int32) for name, page_size in zip(layer_names, page_sizes)}
     zeroer = AscendKVBlockZeroer(
         device,
         attn_groups_iter=[
@@ -342,9 +334,7 @@ def _torch_zero_kv_blocks_golden(
         "first-middle-last-blocks-in-nonmonotonic-order",
     ],
 )
-def test_zero_kv_blocks_matches_torch_golden(
-    num_blocks, page_sizes, paddings, block_ids
-):
+def test_zero_kv_blocks_matches_torch_golden(num_blocks, page_sizes, paddings, block_ids):
     """Compare the Triton kernel with a Torch golden across boundary layouts."""
     device = torch.device("npu")
     storages = []

--- a/vllm_ascend/model_executor/warmup/kernel_warmup.py
+++ b/vllm_ascend/model_executor/warmup/kernel_warmup.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING
 from vllm.logger import logger
 from vllm.triton_utils import HAS_TRITON
 
+from vllm_ascend.model_executor.warmup.kv_block_zeroer_triton_warmup import (
+    kv_block_zeroer_triton_warmup,
+)
 from vllm_ascend.model_executor.warmup.penalties_triton_warmup import (
     penalties_triton_warmup,
 )
@@ -44,6 +47,7 @@ def kernel_warmup(worker: NPUWorker) -> None:
     _run_warmup("rejection_sampler", rejection_sampler_triton_warmup, worker)
     _run_warmup("penalties", penalties_triton_warmup, worker)
     _run_warmup("rms", triton_rms_warmup, worker)
+    _run_warmup("KV block zeroer", kv_block_zeroer_triton_warmup, worker)
 
     elapsed = time.perf_counter() - start
     logger.info("Triton kernel warmup finished in %.3fs.", elapsed)

--- a/vllm_ascend/model_executor/warmup/kv_block_zeroer_triton_warmup.py
+++ b/vllm_ascend/model_executor/warmup/kv_block_zeroer_triton_warmup.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All Rights Reserved.
+"""Warm up the KV-block zeroing Triton kernel on Ascend NPU."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from vllm_ascend.worker.worker import NPUWorker
+
+
+def kv_block_zeroer_triton_warmup(worker: NPUWorker) -> None:
+    """Compile the KV-block zeroing Triton kernel before the first request."""
+    model_runner = worker.model_runner
+    if worker.use_v2_model_runner:
+        zeroer = getattr(model_runner, "kv_block_zeroer", None)
+    else:
+        zeroer = getattr(model_runner, "_kv_block_zeroer", None)
+    if zeroer is not None:
+        zeroer.warmup(model_runner.kv_cache_config.num_blocks)

--- a/vllm_ascend/worker/model_runner_v1.py
+++ b/vllm_ascend/worker/model_runner_v1.py
@@ -4918,16 +4918,15 @@ class NPUModelRunner(GPUModelRunner):
     def _init_kv_zero_meta(self) -> None:
         """One-time precomputation for _zero_block_ids.
 
-        Delegates to KVBlockZeroer.init_meta with the runner's state.
         Called from gpu_worker.py outside the CuMem pool context.
         """
-        self._kv_block_zeroer = AscendKVBlockZeroer(self.device, self.pin_memory)
-        self._kv_block_zeroer.init_meta(
+        self._kv_block_zeroer = AscendKVBlockZeroer(
+            self.device,
             attn_groups_iter=self._kv_cache_spec_attn_group_iterator(),
             kernel_block_sizes=self.kernel_block_sizes,
             cache_dtype=self.cache_config.cache_dtype,
             runner_only_attn_layers=self.runner_only_attn_layers,
-            static_forward_context=(self.compilation_config.static_forward_context),
+            static_forward_context=self.compilation_config.static_forward_context,
         )
 
 

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -1,25 +1,27 @@
 from collections.abc import Iterable
-from itertools import product as iprod
+from types import SimpleNamespace
 from typing import Any
 
 import torch
 from vllm.triton_utils import tl, triton
-from vllm.utils.math_utils import largest_power_of_2_divisor
-from vllm.v1.kv_cache_interface import FullAttentionSpec
+from vllm.utils.torch_utils import async_tensor_h2d
+from vllm.v1.kv_cache_interface import AttentionSpec
 from vllm.v1.worker.utils import AttentionGroup, KVBlockZeroer
 
 from vllm_ascend.ops.triton.triton_utils import get_vectorcore_num
 
 
-@triton.jit
+@triton.jit(do_not_specialize=["n_blocks"])
 def _zero_kv_blocks_kernel(
     seg_addrs_ptr,
+    seg_block_strides_ptr,
+    seg_page_sizes_ptr,
     block_ids_ptr,
     n_blocks,
     N_SEGS: tl.constexpr,
-    PAGE_SIZE_EL: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
+    MAX_CHUNKS: tl.constexpr,
     GRID_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
     """Zero KV cache blocks across all segments in a single launch.
 
@@ -29,156 +31,127 @@ def _zero_kv_blocks_kernel(
     two segments per buffer (one for K, one for V).
 
     seg_addrs_ptr holds absolute byte addresses (int64) for each segment,
-    allowing segments to live in different CUDA allocations.
+    allowing segments to live in different device allocations.
 
     Programs are mapped as (block_index, seg_index, chunk_index).
     """
     pid = tl.program_id(0)
-    chunks = PAGE_SIZE_EL // BLOCK_SIZE
-    work_per_block = N_SEGS * chunks
-    total_work = n_blocks * work_per_block
-    for work_idx in range(pid, total_work, GRID_SIZE):
-        block_index = work_idx // work_per_block
-        remainder = work_idx % work_per_block
-        seg_index = remainder // chunks
-        chunk_index = remainder % chunks
+    work_per_block = N_SEGS * MAX_CHUNKS
+    total_works = n_blocks.to(tl.int64) * work_per_block
+    for work_index in range(pid, total_works, GRID_SIZE):
+        block_index = work_index // work_per_block
+        remainder = work_index % work_per_block
+        seg_index = remainder // MAX_CHUNKS
+        chunk_index = remainder % MAX_CHUNKS
+        block_stride_el = tl.load(seg_block_strides_ptr + seg_index)
+        page_size_el = tl.load(seg_page_sizes_ptr + seg_index)
+        chunk_offset = chunk_index.to(tl.int64) * BLOCK_SIZE
         block_id = tl.load(block_ids_ptr + block_index)
         seg_addr = tl.load(seg_addrs_ptr + seg_index)
         ptr = tl.cast(seg_addr, tl.pointer_type(tl.int32))
-        offset = block_id.to(tl.int64) * PAGE_SIZE_EL + chunk_index.to(tl.int64) * BLOCK_SIZE
-        cols = tl.arange(0, BLOCK_SIZE).to(tl.int64)
-        tl.store(ptr + offset + cols, tl.zeros([BLOCK_SIZE], dtype=tl.int32))
+        block_offset = block_id.to(tl.int64) * block_stride_el.to(tl.int64)
+        cols = chunk_offset + tl.arange(0, BLOCK_SIZE).to(tl.int64)
+        tl.store(
+            ptr + block_offset + cols,
+            tl.zeros([BLOCK_SIZE], dtype=tl.int32),
+            mask=cols < page_size_el,
+        )
 
 
 class AscendKVBlockZeroer(KVBlockZeroer):
     """Manages efficient zeroing of KV cache blocks via a Triton kernel.
 
-    Call :meth:`init_meta` once after KV caches are allocated to precompute
-    segment addresses, then call :meth:`zero_block_ids` each step to zero
-    newly-allocated blocks.
+    Adapt ascend's separate K/V tensors to vllm upstream metadata planner,
+    while retaining specific triton launch strategy.
     """
 
-    def __init__(self, device: torch.device, pin_memory: bool) -> None:
-        self.device = device
-        self.pin_memory = pin_memory
-        self._meta: tuple[torch.Tensor, int, int, int] | None = None
-        self._id_cap: int = 0
-        self._ids_pinned: torch.Tensor | None = None
-        self._ids_gpu: torch.Tensor | None = None
+    class _BlockFirstBackend:
+        """Expose ascend's separate K/V tensors as block-first caches."""
 
-    def init_meta(
+        @staticmethod
+        def get_kv_cache_block_dim(*args, **kwargs) -> int:
+            return 0
+
+    def __init__(
         self,
+        device: torch.device,
         attn_groups_iter: Iterable["AttentionGroup"],
         kernel_block_sizes: list[list[int]],
         cache_dtype: str,
-        runner_only_attn_layers: set[str],
         static_forward_context: dict[str, Any],
+        runner_only_attn_layers: set[str] | None = None,
     ) -> None:
-        """One-time precomputation for zero_block_ids.
-
-        Builds absolute-address table for the Triton zeroing kernel.
-        Each entry is the absolute byte address of a segment start on the
-        GPU, so segments in different CUDA allocations work correctly.
-
-        Block IDs from the scheduler reference logical blocks whose size
-        may differ from the kernel block size (virtual block splitting).
-        PAGE_SIZE_EL accounts for this ratio so that
-        ``block_id * PAGE_SIZE_EL`` lands at the correct offset.
-
-        Only AttentionSpec layers are processed; Mamba layers are skipped.
-        """
-        seen_ptrs: set[int] = set()
-        seg_addrs: list[int] = []
-        page_size_el: int | None = None
+        """Adapt ascend's separate K/V tensors for creating metadata."""
+        adapted_attn_groups: list[Any] = []
+        adapted_forward_context: dict[str, Any] = {}
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if not isinstance(spec, FullAttentionSpec):
+            group_id = group.kv_cache_group_id
+            if (
+                not isinstance(spec, AttentionSpec)
+                or group_id >= len(kernel_block_sizes)
+            ):
+                adapted_attn_groups.append(group)
                 continue
-            if group.kv_cache_group_id >= len(kernel_block_sizes):
-                continue
-            kernel_bs = kernel_block_sizes[group.kv_cache_group_id][0]
-            ratio = spec.block_size // kernel_bs
-            block_dim = 0
-
+            pseudo_layer_names: list[str] = []
             for layer_name in group.layer_names:
-                if layer_name in runner_only_attn_layers:
+                if (
+                    runner_only_attn_layers is not None
+                    and layer_name in runner_only_attn_layers
+                ):
+                    pseudo_layer_names.append(layer_name)
                     continue
                 kv_tuple = static_forward_context[layer_name].kv_cache
-                assert len(kv_tuple) == 2, "K and V are not stored separately"
-                for kv in kv_tuple:
-                    block_dim = 0
-                    dp = kv.data_ptr()
-                    if dp in seen_ptrs:
-                        continue
-                    seen_ptrs.add(dp)
+                assert isinstance(kv_tuple, tuple) and len(kv_tuple) > 0
+                for tensor_index, kv in enumerate(kv_tuple):
+                    pseudo_name = f"{layer_name}.kv_zeroer.{tensor_index}"
+                    pseudo_layer_names.append(pseudo_name)
+                    adapted_forward_context[pseudo_name] = SimpleNamespace(kv_cache=kv)
+            adapted_attn_groups.append(
+                SimpleNamespace(
+                    backend=self._BlockFirstBackend,
+                    layer_names=pseudo_layer_names,
+                    kv_cache_group_id=group_id,
+                    kv_cache_spec=spec,
+                )
+            )
 
-                    el = kv.element_size()
-                    cur_bytes = kv.stride(block_dim) * el
-                    assert cur_bytes % 4 == 0
-                    kernel_block_el = cur_bytes // 4
-                    cur_page_el = kernel_block_el * ratio
-                    if page_size_el is None:
-                        page_size_el = cur_page_el
-                    else:
-                        assert page_size_el == cur_page_el, f"Non-uniform page sizes: {page_size_el} vs {cur_page_el}"
-
-                    block_stride_bytes = cur_bytes
-                    outer_dims = [d for d in range(block_dim) if kv.stride(d) * el > block_stride_bytes]
-                    outer_strides = [kv.stride(d) * el for d in outer_dims]
-                    for outer in iprod(*(range(kv.shape[d]) for d in outer_dims)):
-                        off_bytes = sum(i * s for i, s in zip(outer, outer_strides))
-                        seg_addrs.append(dp + off_bytes)
-
-        if not seg_addrs or page_size_el is None:
-            self._meta = None
-            return
-
-        # _zero_kv_blocks_kernel will use int64 zeros, to meet the UB size, we use blk_size=64B/8B=8192
-        blk_size = min(largest_power_of_2_divisor(page_size_el), 8192)
-        self._id_cap = 8192
-        self._ids_pinned = torch.empty(
-            self._id_cap,
-            dtype=torch.int64,
-            pin_memory=self.pin_memory,
-        )
-        self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
-        self._meta = (
-            torch.tensor(seg_addrs, dtype=torch.uint64, device=self.device),
-            page_size_el,
-            blk_size,
-            len(seg_addrs),
+        super().__init__(
+            device=device,
+            attn_groups_iter=adapted_attn_groups,
+            kernel_block_sizes=[size[0] for size in kernel_block_sizes],
+            cache_dtype=cache_dtype,
+            static_forward_context=adapted_forward_context,
+            runner_only_attn_layers=runner_only_attn_layers,
         )
 
     def zero_block_ids(self, block_ids: list[int]) -> None:
         """Zero the KV cache memory for the given block IDs."""
         if not block_ids or self._meta is None:
             return
-        seg_addrs, page_size_el, blk_size, n_segs = self._meta
-        n_blocks = len(block_ids)
-        if n_blocks > self._id_cap:
-            self._id_cap = n_blocks * 2
-            self._ids_pinned = torch.empty(
-                self._id_cap,
-                dtype=torch.int64,
-                pin_memory=self.pin_memory,
-            )
-            self._ids_gpu = torch.empty(self._id_cap, dtype=torch.int64, device=self.device)
-        assert self._ids_pinned is not None and self._ids_gpu is not None
-        self._ids_pinned[:n_blocks].numpy()[:] = block_ids
-        idx = self._ids_gpu[:n_blocks]
-        idx.copy_(self._ids_pinned[:n_blocks], non_blocking=True)
-        chunks = page_size_el // blk_size
-        total_work = n_blocks * n_segs * chunks
-        grid = min(total_work, get_vectorcore_num()) if total_work > 0 else 0
-        if grid == 0:
-            return
-        _zero_kv_blocks_kernel[(grid,)](
+        (
             seg_addrs,
+            seg_block_strides,
+            seg_page_sizes,
+            max_chunks,
+            blk_size,
+            n_segs,
+        ) = self._meta
+        n_blocks = len(block_ids)
+        idx = async_tensor_h2d(block_ids, device=self.device, dtype=torch.int64)
+        total_works = n_blocks * n_segs * max_chunks
+        if total_works == 0:
+            return
+        grid_size = get_vectorcore_num()
+        _zero_kv_blocks_kernel[(grid_size,)](
+            seg_addrs,
+            seg_block_strides,
+            seg_page_sizes,
             idx,
             n_blocks,
+            MAX_CHUNKS=max_chunks,
             N_SEGS=n_segs,
-            PAGE_SIZE_EL=page_size_el,
+            GRID_SIZE=grid_size,
             BLOCK_SIZE=blk_size,
-            GRID_SIZE=grid,
         )

--- a/vllm_ascend/worker/utils.py
+++ b/vllm_ascend/worker/utils.py
@@ -88,18 +88,12 @@ class AscendKVBlockZeroer(KVBlockZeroer):
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
             group_id = group.kv_cache_group_id
-            if (
-                not isinstance(spec, AttentionSpec)
-                or group_id >= len(kernel_block_sizes)
-            ):
+            if not isinstance(spec, AttentionSpec) or group_id >= len(kernel_block_sizes):
                 adapted_attn_groups.append(group)
                 continue
             pseudo_layer_names: list[str] = []
             for layer_name in group.layer_names:
-                if (
-                    runner_only_attn_layers is not None
-                    and layer_name in runner_only_attn_layers
-                ):
+                if runner_only_attn_layers is not None and layer_name in runner_only_attn_layers:
                     pseudo_layer_names.append(layer_name)
                     continue
                 kv_tuple = static_forward_context[layer_name].kv_cache


### PR DESCRIPTION
### What this PR does / why we need it?
This PR aims to refactor AscendKVBlockZeroer for aligning it with vllm and add ci test for zeroing kernel. The key strategy is to construct fake attention groups to meet vllm upstream interface. We also migrate vllm test and add vllm-ascend test, and warmup is also introduced as other triton kernels.

### Does this PR introduce _any_ user-facing change?
N/A

### How was this patch tested?
by ci

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
