### PR TITLE
[CI] Switch image build and push from Quay to SWR north-12

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -21,7 +21,9 @@ self-hosted-runner:
     - linux-aarch64-a5-4
     - linux-aarch64-a5-8
     - linux-amd64-cpu-2-hk
+    - linux-amd64-cpu-4
     - linux-amd64-cpu-4-hk
+    - linux-aarch64-cpu-4
     - linux-amd64-cpu-8-hk
     - linux-amd64-cpu-16-hk
     - linux-arm64-cpu-16

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -165,7 +165,7 @@ jobs:
     name: build
     runs-on: ${{ matrix.runner_info.runner }}
     container:
-      image: ${{ format('{0}:{1}-{2}-{3}-py3.12', inputs.cann_swr_url, inputs.cann_image_version, inputs.soc, inputs.base_os) }}
+      image: ${{ format('{0}:{1}-{2}-ubuntu22.04-py3.12', inputs.cann_swr_url, inputs.cann_image_version, inputs.soc) }}
       env:
         SOC: ${{ inputs.soc }}
     permissions:
@@ -223,7 +223,7 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.vllm_ascend_commit != '' }}
       with:
-        submodules: false
+        submodules: recursive
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.vllm_ascend_commit }}
@@ -231,7 +231,7 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name != 'workflow_dispatch' }}
       with:
-        submodules: false
+        submodules: recursive
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.branch_ref }}
@@ -239,7 +239,7 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag != '' }}
       with:
-        submodules: false
+        submodules: recursive
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.workflow_dispatch_tag }}
@@ -247,20 +247,10 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag == '' && inputs.vllm_ascend_commit == '' }}
       with:
-        submodules: false
+        submodules: recursive
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.branch_ref }}
-
-    - name: Checkout git submodules
-      run: |
-        set -euo pipefail
-        # gitcode.com presents a chain rooted at the TrustAsia TLS RSA Root CA.
-        # The runner job container already trusts this CA via the squid-ca-cert
-        # ConfigMap (GIT_SSL_CAINFO / SSL_CERT_FILE point to the merged bundle),
-        # so no repository-bundled cert is needed here.
-        git config --global --add safe.directory "$(pwd)"
-        git submodule update --init --recursive
 
     - name: Compute cache tag
       id: cache-tag
@@ -310,19 +300,11 @@ jobs:
 
     - name: Install csrc cache dependencies
       run: |
-        if [ -f /etc/apt/sources.list ]; then
-          if [ -n "$APTMIRROR" ]; then
-            sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list
-          fi
-          apt-get update -y
-          apt-get install -y zstd
-        elif command -v dnf &>/dev/null; then
-          if ! command -v zstd &>/dev/null; then
-            # Replace yum repos with the internal mirror (same logic as _build_csrc_cache.yaml)
-            sed -Ei 's@https?://[^/]+/(openeuler|centos|fedora)@http://cache-service.nginx-pypi-cache.svc.cluster.local:8081/\1@g' /etc/yum.repos.d/*.repo
-            dnf install -y zstd || echo "warning: failed to install zstd via dnf"
-          fi
+        if [ -n "$APTMIRROR" ]; then
+          sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list
         fi
+        apt-get update -y
+        apt-get install -y zstd
 
     - name: Restore vllm-ascend csrc cache
       id: cache-csrc

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -165,7 +165,7 @@ jobs:
     name: build
     runs-on: ${{ matrix.runner_info.runner }}
     container:
-      image: ${{ matrix.runner_info.tag == 'arm64' && 'arm64v8/ubuntu:22.04' || 'ubuntu:latest' }}
+      image: ${{ format('{0}:{1}-{2}-ubuntu22.04-py3.12', inputs.cann_swr_url, inputs.cann_image_version, inputs.soc) }}
       env:
         SOC: ${{ inputs.soc }}
     permissions:
@@ -181,13 +181,13 @@ jobs:
 
     steps:
 
-    - name: Install build tools
+    - name: Install zstd
       run: |
         if [ -n "$APTMIRROR" ]; then
           sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list
         fi
         apt-get update -y
-        apt-get install -y git zstd
+        apt-get install -y zstd
 
     - name: Validate inputs (workflow_dispatch only)
       if: ${{ github.event_name == 'workflow_dispatch' }}

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -165,7 +165,7 @@ jobs:
     name: build
     runs-on: ${{ matrix.runner_info.runner }}
     container:
-      image: ${{ format('{0}:{1}-{2}-ubuntu22.04-py3.12', inputs.cann_swr_url, inputs.cann_image_version, inputs.soc) }}
+      image: ${{ matrix.runner_info.tag == 'arm64' && 'arm64v8/ubuntu:22.04' || 'ubuntu:latest' }}
       env:
         SOC: ${{ inputs.soc }}
     permissions:
@@ -180,6 +180,14 @@ jobs:
           - {runner: linux-amd64-cpu-4, tag: amd64}
 
     steps:
+
+    - name: Install build tools
+      run: |
+        if [ -n "$APTMIRROR" ]; then
+          sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list
+        fi
+        apt-get update -y
+        apt-get install -y git zstd
 
     - name: Validate inputs (workflow_dispatch only)
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -297,14 +305,6 @@ jobs:
           aarch64) echo "arch=ARM64" >> "$GITHUB_OUTPUT" ;;
           *) echo "arch=$ARCH" >> "$GITHUB_OUTPUT" ;;
         esac
-
-    - name: Install csrc cache dependencies
-      run: |
-        if [ -n "$APTMIRROR" ]; then
-          sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list
-        fi
-        apt-get update -y
-        apt-get install -y zstd
 
     - name: Restore vllm-ascend csrc cache
       id: cache-csrc

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -2,26 +2,21 @@ name: Image_oncall
 on:
   workflow_call:
     inputs:
-      quay_repo:
-        description: 'Quay repository for final images'
+      swr_repo:
+        description: 'SWR repository for final multi-arch images (same name as the quay.io repo, sync tool mirrors it to quay.io)'
         required: false
         type: string
-        default: 'quay.io/ascend/vllm-ascend'
-      quay_temp_repo:
-        description: 'Quay repository for temp images'
-        required: false
-        type: string
-        default: 'quay.io/atlas-ci/vllm-atlas-temp'
+        default: 'swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend'
       swr_registry:
-        description: 'swr repository for temp images'
+        description: 'SWR registry domain'
         required: false
         type: string
         default: 'swr.cn-north-12.myhuaweicloud.com'
       swr_temp_repo:
-        description: 'swr repository for temp images'
+        description: 'SWR repository for single-arch temp images (mirrors quay.io/atlas-ci/vllm-atlas-temp)'
         required: false
         type: string
-        default: 'swr.cn-north-12.myhuaweicloud.com/modelfoundry/buildkit-test'    
+        default: 'swr.cn-north-12.myhuaweicloud.com/atlas_ci/vllm-atlas-temp'
       suffix:
         description: 'The tag subfix to use'
         required: true
@@ -33,14 +28,6 @@ on:
         default: False
       dockerfile:
         description: 'The Dockerfile to use'
-        required: false
-        type: string
-      quay_username:
-        description: 'Quay username for pushing images'
-        required: false
-        type: string
-      quay_temp_username:
-        description: 'Quay username for pushing temp tag digests'
         required: false
         type: string
       workflow_dispatch_tag:
@@ -73,7 +60,7 @@ on:
         type: string
         default: ''
       temp_only:
-        description: 'If true, push only to QUAY_TEMP_REPO and skip the merge-image job (no push to QUAY_REPO).'
+        description: 'If true, push only to SWR temp repo and skip the merge-image job (no push to SWR_REPO).'
         required: false
         type: boolean
         default: false
@@ -112,16 +99,31 @@ on:
         required: false
         type: string
         default: '20260725.3'
-      cann_quay_url:
-        description: 'CANN Quay URL'
+      cann_swr_url:
+        description: 'CANN base image URL (SWR registry)'
         required: false
         type: string
         default: 'swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann'
       cann_version:
-        description: 'CANN version'
+        description: 'CANN version for daily tag naming (e.g. 2026.08.03)'
         required: false
         type: string
         default: '9.1.0_20260731131545'
+      cann_image_version:
+        description: 'CANN version for the build container image tag (default matches Dockerfile FROM: 9.1.0)'
+        required: false
+        type: string
+        default: '9.1.0'
+      soc:
+        description: 'Ascend SoC type for the CANN base image (e.g. 910b, a3, 310p, 950)'
+        required: false
+        type: string
+        default: '910b'
+      base_os:
+        description: 'Base OS for the CANN base image (e.g. ubuntu22.04, openeuler24.03)'
+        required: false
+        type: string
+        default: 'ubuntu22.04'
       triton_ascend_version:
         description: 'Triton Ascend version'
         required: false
@@ -137,34 +139,35 @@ on:
         required: false
         type: string
         default: ''
+      aptmirror:
+        description: 'APT mirror URL for Ubuntu (replaces archive.ubuntu.com / ports.ubuntu.com)'
+        required: false
+        type: string
+        default: 'http://cache-service.nginx-pypi-cache.svc.cluster.local:8081'
     secrets:
-        QUAY_PASSWORD:
-            description: 'Quay password for pushing images'
-            required: false
-        QUAY_TEMP_PASSWORD:
-            description: 'Quay password for pushing temp tag digests'
-            required: false
-        SWR_USERNAME:
-            description: 'SWR username for pulling and pushing CANN base images'
-            required: false
-        SWR_PASSWORD:
-            description: 'SWR password for pulling and pushing CANN base images'
-            required: false
+      SWR_USERNAME:
+        description: 'SWR username for pushing images'
+        required: false
+      SWR_PASSWORD:
+        description: 'SWR password for pushing images'
+        required: false
 
 defaults:
   run:
     shell: bash -el {0}
 
 env:
-  QUAY_REPO: ${{ inputs.quay_repo }}
-  QUAY_TEMP_REPO: ${{ inputs.quay_temp_repo }}
+  SWR_REPO: ${{ inputs.swr_repo }}
+  APTMIRROR: ${{ inputs.aptmirror }}
 
 jobs:
   build-push-digest:
     name: build
     runs-on: ${{ matrix.runner_info.runner }}
     container:
-      image: swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann:9.1.0-a3-ubuntu22.04-py3.12
+      image: ${{ format('{0}:{1}-{2}-{3}-py3.12', inputs.cann_swr_url, inputs.cann_image_version, inputs.soc, inputs.base_os) }}
+      env:
+        SOC: ${{ inputs.soc }}
     permissions:
       packages: write
       contents: read
@@ -220,7 +223,7 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.vllm_ascend_commit != '' }}
       with:
-        submodules: recursive
+        submodules: false
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.vllm_ascend_commit }}
@@ -228,7 +231,7 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name != 'workflow_dispatch' }}
       with:
-        submodules: recursive
+        submodules: false
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.branch_ref }}
@@ -236,7 +239,7 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag != '' }}
       with:
-        submodules: recursive
+        submodules: false
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.workflow_dispatch_tag }}
@@ -244,10 +247,20 @@ jobs:
     - uses: actions/checkout@v7
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag == '' && inputs.vllm_ascend_commit == '' }}
       with:
-        submodules: recursive
+        submodules: false
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ inputs.branch_ref }}
+
+    - name: Checkout git submodules
+      run: |
+        set -euo pipefail
+        # gitcode.com presents a chain rooted at the TrustAsia TLS RSA Root CA.
+        # The runner job container already trusts this CA via the squid-ca-cert
+        # ConfigMap (GIT_SSL_CAINFO / SSL_CERT_FILE point to the merged bundle),
+        # so no repository-bundled cert is needed here.
+        git config --global --add safe.directory "$(pwd)"
+        git submodule update --init --recursive
 
     - name: Compute cache tag
       id: cache-tag
@@ -262,7 +275,9 @@ jobs:
       id: get_base_image_tag
       run: |
         DOCKERFILE="${{ inputs.dockerfile || 'Dockerfile' }}"
-        BASE_IMAGE_TAG=$(grep -m1 '^FROM' "$DOCKERFILE" | awk -F: '{print $NF}')
+        BASE_IMAGE_TAG=$(grep -m1 '^FROM' "$DOCKERFILE" | awk -F: '{print $NF}' \
+          | sed -e "s|\${CANN_VERSION}|${{ inputs.cann_image_version }}|g" \
+                -e "s|\${BASE_OS}|${{ inputs.base_os }}|g")
         echo "BASE_IMAGE_TAG=$BASE_IMAGE_TAG" >> $GITHUB_OUTPUT
 
     - name: Get csrc hash
@@ -295,8 +310,19 @@ jobs:
 
     - name: Install csrc cache dependencies
       run: |
-        apt-get update -y
-        apt-get install -y zstd
+        if [ -f /etc/apt/sources.list ]; then
+          if [ -n "$APTMIRROR" ]; then
+            sed -Ei "s@(ports|archive).ubuntu.com@${APTMIRROR#http://}@g" /etc/apt/sources.list
+          fi
+          apt-get update -y
+          apt-get install -y zstd
+        elif command -v dnf &>/dev/null; then
+          if ! command -v zstd &>/dev/null; then
+            # Replace yum repos with the internal mirror (same logic as _build_csrc_cache.yaml)
+            sed -Ei 's@https?://[^/]+/(openeuler|centos|fedora)@http://cache-service.nginx-pypi-cache.svc.cluster.local:8081/\1@g' /etc/yum.repos.d/*.repo
+            dnf install -y zstd || echo "warning: failed to install zstd via dnf"
+          fi
+        fi
 
     - name: Restore vllm-ascend csrc cache
       id: cache-csrc
@@ -310,6 +336,7 @@ jobs:
         key: vllm-ascend-build-v2-${{ steps.get_arch.outputs.arch }}-${{ steps.get_base_image_tag.outputs.BASE_IMAGE_TAG }}-${{ steps.get_csrc_hash.outputs.CSRC_HASH }}
 
     - name: Login to SWR
+      if: ${{ inputs.should_push }}
       uses: docker/login-action@v4
       with:
         registry: ${{ inputs.swr_registry }}
@@ -329,8 +356,12 @@ jobs:
         # Image builds can compile inside Docker and therefore keep a fallback;
         # NPU test jobs use fail-on-cache-miss instead.
         build-args: |
-          CANN_QUAY_URL=${{ inputs.cann_quay_url }}
+          CANN_QUAY_URL=${{ inputs.cann_swr_url }}
+          CANN_VERSION=${{ inputs.cann_image_version }}
           APTMIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8081
+          YUM_MIRROR=http://cache-service.nginx-pypi-cache.svc.cluster.local:8083
+          RUSTUP_DIST_SERVER=http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup
+          RUSTUP_UPDATE_ROOT=http://cache-service.nginx-pypi-cache.svc.cluster.local:8082/rustup
           PIP_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/pypi/simple
           PIP_TRUSTED_HOST=cache-service.nginx-pypi-cache.svc.cluster.local
           PYTORCH_INDEX_URL=http://cache-service.nginx-pypi-cache.svc.cluster.local/whl/cpu
@@ -375,7 +406,7 @@ jobs:
             TAG="nightly-${{ inputs.schedule_tag_pattern }}${SUFFIX}-${{ matrix.runner_info.tag }}-${DATE}-temp"
           fi
         fi
-        echo "Creating temp tag: ${{ env.swr_temp_repo }}:$TAG"
+        echo "Creating temp tag: ${{ inputs.swr_temp_repo }}:$TAG"
 
         # Install skopeo if not present (image is Ubuntu-based).
         if ! command -v skopeo >/dev/null 2>&1; then
@@ -404,24 +435,10 @@ jobs:
         retention-days: 1
 
   merge-image:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-4
     needs: build-push-digest
     if: ${{ inputs.should_push && !inputs.temp_only }}
     steps:
-      - name: Checkout branch
-        uses: actions/checkout@v7
-        if: ${{ github.event_name != 'workflow_dispatch' || (github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag == '') }}
-        with:
-          submodules: recursive
-          ref: ${{ inputs.branch_ref }}
-
-      - name: Checkout tag
-        uses: actions/checkout@v7
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.workflow_dispatch_tag != '' }}
-        with:
-          submodules: recursive
-          ref: ${{ inputs.workflow_dispatch_tag }}
-
       - name: Download arm64 digests
         uses: actions/download-artifact@v8
         with:
@@ -481,7 +498,7 @@ jobs:
         with:
           # TODO(yikun): add more hub image and a note on release policy for container image
           images: |
-            ${{ env.QUAY_REPO }}
+            ${{ env.SWR_REPO }}
           # Three trigger scenarios and resulting image tags:
           # https://github.com/marketplace/actions/docker-metadata-action#typeref
           #
@@ -515,18 +532,12 @@ jobs:
             latest=false
 
       - name: Login to SWR
+        if: ${{ inputs.should_push }}
         uses: docker/login-action@v4
         with:
           registry: ${{ inputs.swr_registry }}
           username: ${{ secrets.SWR_USERNAME }}
           password: ${{ secrets.SWR_PASSWORD }}
-
-      - name: Login to Quay
-        uses: docker/login-action@v4
-        with:
-          registry: quay.io
-          username: ${{ inputs.quay_username }}
-          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -534,7 +545,8 @@ jobs:
       - name: Merge and push multi-arch image
         env:
           # Source digests live in SWR (where build-push-digest pushed them);
-          # destination tags come from $TAGS (metadata-action → QUAY_REPO).
+          # destination tags come from $TAGS (metadata-action → SWR_REPO, same name as
+          # the quay.io repo; the sync tool then mirrors swr.cn-north-12 → quay.io).
           SOURCE_IMAGE: ${{ inputs.swr_temp_repo }}
           TAGS: ${{ steps.meta.outputs.tags }}
           BUILD_TYPE: ${{ inputs.build_type }}
@@ -552,7 +564,7 @@ jobs:
           UNWANTED_TAG="nightly-${SCHEDULE_TAG_PATTERN}${SUFFIX}"
 
           for tag in $TAGS; do
-            if [ "$BUILD_TYPE" = "daily" ] && [ "$tag" = "${{ env.QUAY_REPO }}:${UNWANTED_TAG}" ]; then
+            if [ "$BUILD_TYPE" = "daily" ] && [ "$tag" = "${{ env.SWR_REPO }}:${UNWANTED_TAG}" ]; then
               echo "Skipping unwanted schedule tag: $tag"
               continue
             fi
@@ -574,13 +586,14 @@ jobs:
           # Temp tags were created in SWR by build-push-digest, so clean them up there.
           for arch in amd64 arm64; do
             TAG="nightly-${{ inputs.schedule_tag_pattern }}${SUFFIX}-${arch}-${DATE}-temp"
-            skopeo delete --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
+            skopeo delete \
+              --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
               "docker://${{ inputs.swr_temp_repo }}:${TAG}" || true
           done
 
   merge-image-temp:
     name: merge-image-temp
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-4
     needs: build-push-digest
     if: ${{ inputs.should_push && inputs.temp_only }}
     steps:
@@ -599,27 +612,21 @@ jobs:
           merge-multiple: true
 
       - name: Login to SWR
+        if: ${{ inputs.should_push }}
         uses: docker/login-action@v4
         with:
           registry: ${{ inputs.swr_registry }}
           username: ${{ secrets.SWR_USERNAME }}
           password: ${{ secrets.SWR_PASSWORD }}
 
-      - name: Login to Quay Temp
-        uses: docker/login-action@v4
-        with:
-          registry: quay.io
-          username: ${{ inputs.quay_temp_username }}
-          password: ${{ secrets.QUAY_TEMP_PASSWORD }}
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Merge and push multi-arch manifest to QUAY_TEMP_REPO
+      - name: Merge and push multi-arch manifest to SWR temp
         env:
-          # IMAGE is the destination (Quay temp); SOURCE_IMAGE is where the
+          # IMAGE is the destination (SWR temp); SOURCE_IMAGE is where the
           # single-arch digests actually live (SWR, pushed by build-push-digest).
-          IMAGE: ${{ env.QUAY_TEMP_REPO }}
+          IMAGE: ${{ inputs.swr_temp_repo }}
           SOURCE_IMAGE: ${{ inputs.swr_temp_repo }}
         run: |
           set -euo pipefail
@@ -666,6 +673,7 @@ jobs:
           # Temp tags were created in SWR by build-push-digest, so clean them up there.
           for arch in amd64 arm64; do
             TAG="vllm-ascend-${VLLM_SHORT}-${ASCEND_SHORT}${SUFFIX}-${arch}-temp"
-            skopeo delete --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
+            skopeo delete \
+              --creds "${{ secrets.SWR_USERNAME }}:${{ secrets.SWR_PASSWORD }}" \
               "docker://${{ inputs.swr_temp_repo }}:${TAG}" || true
           done

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -2,7 +2,7 @@
 # 1. PR Triggered docker image build check
 #   - 'image-build' label should be added
 #   - is for image build check
-#   - Enable on main/releases branch
+#   - Enable on main/releases branches
 #   - push: ${{ github.event_name != 'pull_request' }} ==> false
 # 2. branches push trigger image publish
 #   - is for branch/dev/nightly image
@@ -10,6 +10,9 @@
 # 3. tags push trigger image publish
 #   - is for final release image
 #   - Publish when tag with v* (pep440 version)  ===>  vllm-ascend:v1.2.3 / vllm-ascend:v1.2.3rc1
+# Note: single-arch images are built and pushed to swr.cn-north-12, merged into a
+# multi-arch manifest and pushed to swr.cn-north-12 (same repo path as quay.io);
+# the sync tool then mirrors swr.cn-north-12 -> quay.io.
 name: Image Build and Push
 on:
   push:
@@ -53,12 +56,12 @@ on:
           - releases/v0.18.0
           - none
       vllm_commit:
-        description: 'vLLM commit hash (must be paired with vllm_ascend_commit; mutually exclusive with tag/branch). Image will be pushed only to QUAY_TEMP_USERNAME.'
+        description: 'vLLM commit hash (must be paired with vllm_ascend_commit; mutually exclusive with tag/branch). Image will be pushed only to SWR temp repo.'
         required: false
         default: ''
         type: string
       vllm_ascend_commit:
-        description: 'vllm-ascend commit hash (must be paired with vllm_commit; mutually exclusive with tag/branch). Image will be pushed only to QUAY_TEMP_USERNAME.'
+        description: 'vllm-ascend commit hash (must be paired with vllm_commit; mutually exclusive with tag/branch). Image will be pushed only to SWR temp repo.'
         required: false
         default: ''
         type: string
@@ -81,9 +84,9 @@ on:
         default: '["20260725.3", "26.1.0"]'
         type: string
       cann:
-        description: 'CANN Quay URL and version (JSON array: ["url", "version"])'
+        description: 'CANN URL, version and image tag (JSON array: ["url", "version", "image_tag"])'
         required: false
-        default: '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]'
+        default: '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "9.1.0_20260731131545"]'
         type: string
       triton_ascend:
         description: 'Triton Ascend version and package version (JSON array: ["version", "package_version"])'
@@ -102,7 +105,7 @@ permissions:
 
 jobs:
   setup-matrix:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu-2-hk
     outputs:
       build_meta: ${{ steps.filter.outputs.build_meta }}
     steps:
@@ -111,14 +114,14 @@ jobs:
         run: |
           CHIPS='${{ inputs.chips || '["a2","a3","310p","a5"]' }}'
           ALL_MATRIX=$(jq -nc '[
-            {name: "A2 Ubuntu",      dockerfile: "Dockerfile",              suffix: "",               chip: "a2"},
-            {name: "A3 Ubuntu",      dockerfile: "Dockerfile.a3",            suffix: "a3",             chip: "a3"},
-            {name: "310P Ubuntu",    dockerfile: "Dockerfile.310p",          suffix: "310p",           chip: "310p"},
-            {name: "A5 Ubuntu",      dockerfile: "Dockerfile.a5",            suffix: "a5",             chip: "a5"},
-            {name: "A2 openeuler",   dockerfile: "Dockerfile.openEuler",     suffix: "openeuler",      chip: "a2"},
-            {name: "A3 openEuler",   dockerfile: "Dockerfile.a3.openEuler",  suffix: "a3-openeuler",   chip: "a3"},
-            {name: "310P openEuler", dockerfile: "Dockerfile.310p.openEuler",suffix: "310p-openeuler",  chip: "310p"},
-            {name: "A5 openEuler",   dockerfile: "Dockerfile.a5.openEuler",  suffix: "a5-openeuler",   chip: "a5"}
+            {name: "A2 Ubuntu",      dockerfile: "Dockerfile",              suffix: "",               chip: "a2", soc: "910b", base_os: "ubuntu22.04"},
+            {name: "A3 Ubuntu",      dockerfile: "Dockerfile.a3",            suffix: "a3",             chip: "a3", soc: "a3",   base_os: "ubuntu22.04"},
+            {name: "310P Ubuntu",    dockerfile: "Dockerfile.310p",          suffix: "310p",           chip: "310p", soc: "310p", base_os: "ubuntu22.04"},
+            {name: "A5 Ubuntu",      dockerfile: "Dockerfile.a5",            suffix: "a5",             chip: "a5", soc: "950",  base_os: "ubuntu22.04"},
+            {name: "A2 openeuler",   dockerfile: "Dockerfile.openEuler",     suffix: "openeuler",      chip: "a2", soc: "910b", base_os: "openeuler24.03"},
+            {name: "A3 openEuler",   dockerfile: "Dockerfile.a3.openEuler",  suffix: "a3-openeuler",   chip: "a3", soc: "a3",   base_os: "openeuler24.03"},
+            {name: "310P openEuler", dockerfile: "Dockerfile.310p.openEuler",suffix: "310p-openeuler",  chip: "310p", soc: "310p", base_os: "openeuler24.03"},
+            {name: "A5 openEuler",   dockerfile: "Dockerfile.a5.openEuler",  suffix: "a5-openeuler",   chip: "a5", soc: "950",  base_os: "openeuler24.03"}
           ]')
           FILTERED=$(echo "$ALL_MATRIX" | jq -c --argjson chips "$CHIPS" '[.[] | select(.chip as $c | $chips | index($c))]')
           echo "build_meta=$FILTERED" >> $GITHUB_OUTPUT
@@ -130,44 +133,45 @@ jobs:
         && !(github.event_name == 'workflow_dispatch' && inputs.vllm_commit != '' && inputs.vllm_ascend_commit != '') }}
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         build_meta: ${{ fromJSON(needs.setup-matrix.outputs.build_meta) }}
     uses: ./.github/workflows/_schedule_image_build.yaml
     with:
       dockerfile: ${{ matrix.build_meta.dockerfile }}
       suffix: ${{ matrix.build_meta.suffix }}
+      soc: ${{ matrix.build_meta.soc }}
+      base_os: ${{ matrix.build_meta.base_os }}
+      cann_image_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "2026.08.03", "9.1.0"]')[2] || '9.1.0' }}
+      cann_swr_url: ${{ inputs.build_type == 'daily' && fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "9.1.0_20260731131545"]')[0] || 'swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann' }}
       
-      # ===== Dynamic repository and authentication based on build_type =====
-      quay_repo: ${{ inputs.build_type == 'daily' && 'quay.io/atlas_inference/vllm-ascend' || 'quay.io/ascend/vllm-ascend' }}
-      quay_temp_repo: ${{ inputs.build_type == 'daily' && 'quay.io/atlas_inference/vllm-atlas-temp' || 'quay.io/atlas-ci/vllm-atlas-temp' }}
-      quay_username: ${{ inputs.build_type == 'daily' && vars.QUAY_DAILY_USERNAME || vars.QUAY_USERNAME }}
-      quay_temp_username: ${{ inputs.build_type == 'daily' && vars.QUAY_DAILY_TEMP_USERNAME || vars.QUAY_TEMP_USERNAME }}
-      # ====================================================================
+      # ===== Dynamic SWR repositories based on build_type =====
+      # Final multi-arch images are pushed to swr.cn-north-12 with the same repo
+      # path as quay.io; the sync tool then mirrors them to quay.io.
+      swr_registry: 'swr.cn-north-12.myhuaweicloud.com'
+      swr_repo: ${{ inputs.build_type == 'daily' && 'swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend' || 'swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend' }}
+      swr_temp_repo: ${{ inputs.build_type == 'daily' && 'swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp' || 'swr.cn-north-12.myhuaweicloud.com/atlas_ci/vllm-atlas-temp' }}
+      # ======================================================================
       
       should_push: ${{ github.repository == 'vllm-project/vllm-ascend' && github.event_name != 'pull_request' }}
       workflow_dispatch_tag: ${{ inputs.tag != 'none' && inputs.tag || '' }}
       branch_ref: ${{ inputs.branch != 'none' && inputs.branch || '' }}
       schedule_tag_pattern: 'main'
       build_type: ${{ inputs.build_type || 'release' }}
-      cann_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1] }}
+      cann_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "9.1.0_20260731131545"]')[1] }}
+      memcache_version: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[1] }}
+      memcache_date: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[0] }}
+      memfabric_version: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[1] }}
+      memfabric_date: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[0] }}
+      torch_npu_version: ${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[1] }}
+      torch_npu_date: ${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[0] }}
+      triton_ascend_version: ${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
+      triton_ascend_package_version: ${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
       
       build_args: |
-        BUILD_TYPE=${{ inputs.build_type || 'release' }}
-        MEMCACHE_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[1] }}
-        MEMCACHE_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[0] }}
-        MEMFABRIC_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[1] }}
-        MEMFABRIC_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[0] }}
-        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[1] }}
-        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[0] }}
-        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[0]) || '' }}
-        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
-        TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
-        TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
-      
+        ${{ inputs.build_type == 'daily' && format('BASE_OS={0}', contains(matrix.build_meta.suffix, 'openeuler') && 'openeuler24.03-lts-sp4' || 'ubuntu24.04') || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
     secrets:
-      quay_password: ${{ inputs.build_type == 'daily' && secrets.QUAY_DAILY_PASSWORD || secrets.QUAY_PASSWORD }}
-      quay_temp_password: ${{ inputs.build_type == 'daily' && secrets.QUAY_DAILY_TEMP_PASSWORD || secrets.QUAY_TEMP_PASSWORD }}
       SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
       SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
 
@@ -181,15 +185,19 @@ jobs:
         && inputs.branch == 'none' }}
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         build_meta: ${{ fromJSON(needs.setup-matrix.outputs.build_meta) }}
     uses: ./.github/workflows/_schedule_image_build.yaml
     with:
       dockerfile: ${{ matrix.build_meta.dockerfile }}
       suffix: ${{ matrix.build_meta.suffix }}
-      quay_temp_repo: ${{ inputs.build_type == 'daily' && 'quay.io/atlas_inference/vllm-atlas-temp' || 'quay.io/atlas-ci/vllm-atlas-temp' }}
-      quay_temp_username: ${{ inputs.build_type == 'daily' && vars.QUAY_DAILY_TEMP_USERNAME || vars.QUAY_TEMP_USERNAME }}
+      soc: ${{ matrix.build_meta.soc }}
+      base_os: ${{ matrix.build_meta.base_os }}
+      cann_image_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "2026.08.03", "9.1.0"]')[2] || '9.1.0' }}
+      cann_swr_url: ${{ inputs.build_type == 'daily' && fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "9.1.0_20260731131545"]')[0] || 'swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/cann' }}
+      swr_registry: 'swr.cn-north-12.myhuaweicloud.com'
+      swr_temp_repo: ${{ inputs.build_type == 'daily' && 'swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp' || 'swr.cn-north-12.myhuaweicloud.com/atlas_ci/vllm-atlas-temp' }}
       should_push: true
       temp_only: true
       vllm_commit: ${{ inputs.vllm_commit }}
@@ -197,22 +205,32 @@ jobs:
       workflow_dispatch_tag: ''
       branch_ref: ''
       build_type: ${{ inputs.build_type || 'release' }}
-      cann_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1] }}
+      cann_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "9.1.0_20260731131545"]')[1] }}
+      memcache_version: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[1] }}
+      memcache_date: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[0] }}
+      memfabric_version: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[1] }}
+      memfabric_date: ${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[0] }}
+      torch_npu_version: ${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[1] }}
+      torch_npu_date: ${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[0] }}
+      triton_ascend_version: ${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
+      triton_ascend_package_version: ${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
 
       build_args: |
-        BUILD_TYPE=${{ inputs.build_type || 'release' }}
-        MEMCACHE_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[1] }}
-        MEMCACHE_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[0] }}
-        MEMFABRIC_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[1] }}
-        MEMFABRIC_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[0] }}
-        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[1] }}
-        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[0] }}
-        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[0]) || '' }}
-        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
-        TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
-        TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
-
+        ${{ inputs.build_type == 'daily' && format('BASE_OS={0}', contains(matrix.build_meta.suffix, 'openeuler') && 'openeuler24.03-lts-sp4' || 'ubuntu24.04') || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-12.myhuaweicloud.com/atlas_inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
     secrets:
-      quay_temp_password: ${{ inputs.build_type == 'daily' && secrets.QUAY_DAILY_TEMP_PASSWORD || secrets.QUAY_TEMP_PASSWORD }}
       SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
       SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
+
+  trigger-image-sync:
+    name: Trigger quay.io sync
+    if: ${{ !cancelled() && (needs.image_build.result == 'success' || needs.image_build_by_commit.result == 'success') }}
+    needs: [image_build, image_build_by_commit]
+    runs-on: linux-amd64-cpu-4
+    steps:
+      - name: Dispatch sync-vllm-ascend
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_TOOLS_TOKEN }}
+        run: |
+          gh workflow run sync-vllm-ascend.yml \
+            --repo ascend-gha-runners/sync-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     fi
 
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,9 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
+
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -57,7 +57,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     fi
 
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -55,8 +55,9 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
+
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -59,7 +59,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     fi
 
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -24,14 +24,20 @@ ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
 ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
 ARG APTMIRROR=""
+ARG YUM_MIRROR=""
 ARG GIT_PROXY=""
 ARG PIP_TRUSTED_HOST=""
 
 WORKDIR /workspace
 
-RUN yum update -y && \
-    yum install -y python3-pip git vim wget protobuf-compiler curl net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc patch && \
+RUN if [ -n "$YUM_MIRROR" ]; then \
+        sed -Ei "s@https?://[^/]+@${YUM_MIRROR}@g" /etc/yum.repos.d/*.repo; \
+    fi && \
+    yum update -y && \
+        yum install -y python3-pip git vim wget protobuf protobuf-devel protobuf-compiler curl net-tools gcc gcc-c++ make cmake numactl numactl-devel jemalloc patch && \
     rm -rf /var/cache/yum
+
+
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
@@ -51,8 +57,9 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
+
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -73,6 +80,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
+    export PROTOC_INCLUDE=/usr/include && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -63,8 +63,9 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
+
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -65,7 +65,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     fi
 
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -24,6 +24,7 @@ ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
 ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
 ARG APTMIRROR=""
+ARG YUM_MIRROR=""
 ARG GIT_PROXY=""
 ARG PIP_TRUSTED_HOST=""
 
@@ -33,11 +34,16 @@ SHELL ["/bin/bash", "-c"]
 
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
-RUN yum update -y && \
-    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+RUN if [ -n "$YUM_MIRROR" ]; then \
+        sed -Ei "s@https?://[^/]+@${YUM_MIRROR}@g" /etc/yum.repos.d/*.repo; \
+    fi && \
+    yum update -y && \
+    yum install -y git vim wget curl protobuf protobuf-compiler protobuf-devel net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
+
+
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
@@ -57,8 +63,9 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
+
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -82,6 +89,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
+    export PROTOC_INCLUDE=/usr/include && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -65,7 +65,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
     fi
 
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -57,17 +57,25 @@ ARG VLLM_TAG=v0.27.1
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend950dt_9582"
 ARG COMPILE_CUSTOM_KERNELS=1
-ENV DEBIAN_FRONTEND=noninteractive
+# Limit cargo parallelism to avoid OOM in constrained build environments.
+# Overridable via --build-arg CARGO_BUILD_JOBS=N (e.g. 32-CPU/128Gi buildkitd
+# runs up to 2 builds in parallel, so 16 jobs keep memory within ~64Gi per build).
+ARG CARGO_BUILD_JOBS=16
+# Limit opc/c++ build parallelism to avoid OOM. Mirrors
+# .github/workflows/_build_csrc_cache.yaml.
+ARG MAX_JOBS=16
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+    OMP_NUM_THREADS=1 \
+    CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS \
+    MAX_JOBS=$MAX_JOBS
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -70,6 +70,7 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ARG CARGO_BUILD_JOBS=16
 # Limit opc/c++ build parallelism to avoid OOM. Mirrors
 # .github/workflows/_build_csrc_cache.yaml.
+# TODO: auto-detect buildkitd CPU cores and set MAX_JOBS accordingly
 ARG MAX_JOBS=16
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -57,7 +57,7 @@ ARG VLLM_TAG=v0.27.1
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -70,6 +70,7 @@ ARG COMPILE_CUSTOM_KERNELS=1
 ARG CARGO_BUILD_JOBS=16
 # Limit opc/c++ build parallelism to avoid OOM. Mirrors
 # .github/workflows/_build_csrc_cache.yaml.
+# TODO: auto-detect buildkitd CPU cores and set MAX_JOBS accordingly
 ARG MAX_JOBS=16
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -24,6 +24,7 @@ ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
 ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
 ARG APTMIRROR=""
+ARG YUM_MIRROR=""
 ARG GIT_PROXY=""
 ARG PIP_TRUSTED_HOST=""
 
@@ -33,11 +34,16 @@ SHELL ["/bin/bash", "-c"]
 
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
-RUN yum update -y && \
-    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+RUN if [ -n "$YUM_MIRROR" ]; then \
+        sed -Ei "s@https?://[^/]+@${YUM_MIRROR}@g" /etc/yum.repos.d/*.repo; \
+    fi && \
+    yum update -y && \
+    yum install -y git vim wget curl protobuf protobuf-devel protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
+
+
 
 # Install modelscope (for fast download) and ray (for multinode)
 RUN pip config set global.index-url ${PIP_INDEX_URL} && \
@@ -51,16 +57,25 @@ ARG VLLM_TAG=v0.27.1
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
 # Install vllm-ascend
 ARG SOC_VERSION="ascend950dt_9582"
 ARG COMPILE_CUSTOM_KERNELS=1
+# Limit cargo parallelism to avoid OOM in constrained build environments.
+# Overridable via --build-arg CARGO_BUILD_JOBS=N (e.g. 32-CPU/128Gi buildkitd
+# runs up to 2 builds in parallel, so 16 jobs keep memory within ~64Gi per build).
+ARG CARGO_BUILD_JOBS=16
+# Limit opc/c++ build parallelism to avoid OOM. Mirrors
+# .github/workflows/_build_csrc_cache.yaml.
+ARG MAX_JOBS=16
 ENV SOC_VERSION=$SOC_VERSION \
     TASK_QUEUE_ENABLE=1 \
-    OMP_NUM_THREADS=1
+    OMP_NUM_THREADS=1 \
+    CARGO_BUILD_JOBS=$CARGO_BUILD_JOBS \
+    MAX_JOBS=$MAX_JOBS
 COPY . /vllm-workspace/vllm-ascend/
 
 RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
@@ -74,6 +89,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
+    export PROTOC_INCLUDE=/usr/include && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -57,7 +57,7 @@ ARG VLLM_TAG=v0.27.1
 RUN if [ -n "$GIT_PROXY" ]; then git config --global url."${GIT_PROXY}https://github.com/".insteadOf https://github.com/; fi && \
     git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -62,7 +62,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -24,6 +24,7 @@ ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"
 ARG PYTORCH_INDEX_URL="https://download.pytorch.org/whl/cpu/"
 ARG ASCEND_INDEX_URL="https://mirrors.huaweicloud.com/ascend/repos/pypi"
 ARG APTMIRROR=""
+ARG YUM_MIRROR=""
 ARG GIT_PROXY=""
 ARG PIP_TRUSTED_HOST=""
 
@@ -33,8 +34,11 @@ SHELL ["/bin/bash", "-c"]
 
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
-RUN yum update -y && \
-    yum install -y git vim wget curl protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
+RUN if [ -n "$YUM_MIRROR" ]; then \
+        sed -Ei "s@https?://[^/]+@${YUM_MIRROR}@g" /etc/yum.repos.d/*.repo; \
+    fi && \
+    yum update -y && \
+    yum install -y git vim wget curl protobuf protobuf-devel protobuf-compiler net-tools gcc gcc-c++ make cmake numactl numactl-devel libibverbs-devel jemalloc hiredis-devel clang patch && \
     source /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     python3 -m pip install mooncake-transfer-engine-npu==${MOONCAKE_TAG} --extra-index-url ${MOONCAKE_INDEX_URL} && \
     rm -rf /var/cache/yum/*
@@ -58,7 +62,7 @@ RUN if [ -n "$VLLM_COMMIT" ]; then \
       git clone --depth 1 -b $VLLM_TAG $VLLM_REPO /vllm-workspace/vllm; \
     fi
 # In x86, triton will be installed by vllm. But in Ascend, triton doesn't work correctly. we need to uninstall it.
-RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
+RUN VLLM_TARGET_DEVICE="empty" python3 -m pip install --timeout 300 -e /vllm-workspace/vllm/[audio] --extra-index-url ${PYTORCH_INDEX_URL} && \
     python3 -m pip uninstall -y triton && \
     python3 -m pip cache purge
 
@@ -82,6 +86,7 @@ RUN export PIP_EXTRA_INDEX_URL="${ASCEND_INDEX_URL}" && \
 
 # Install _rust_tool_parser for the Rust frontend.
 RUN cd /vllm-workspace/vllm && \
+    export PROTOC_INCLUDE=/usr/include && \
     python3 -m pip install setuptools-rust && \
     ./build_rust.sh
 


### PR DESCRIPTION
### What this PR does / why we need it?

Switch the main image build & publish pipeline from Quay to SWR (swr.cn-north-12).

- Single-arch images are built and pushed to the SWR temp repo (atlas_ci/vllm-atlas-temp for release, atlas_inference/vllm-atlas-temp for daily), then merged into a multi-arch manifest in the final SWR repo (ascend/vllm-ascend for release, atlas_inference/vllm-ascend for daily). A sync tool mirrors `swr.cn-north-12 → quay.io`.
- Remove Quay login steps, quay_repo/quay_temp_repo inputs and QUAY_* secrets from the reusable workflow.
- `swr_temp_repo` defaults to `atlas_ci/vllm-atlas-temp` (release) and `atlas_inference/vllm-atlas-temp` (daily).
- Replace HW_* credentials with SWR_USERNAME/SWR_PASSWORD for north-12 authentication.
- CANN base image URL defaults to `base_image/ascend-ci/cann`.

### Does this PR introduce _any_ user-facing change?

No. CI/internal registry changes only.

### How was this patch tested?

- YAML syntax validated.
- Caller/reusable workflow interface cross-checked (no unexpected inputs/secrets, no missing required fields).
- All north-12 repo paths verified against existing SWR buckets (atlas_ci, atlas_inference, ascend, base_image).

- vLLM main: https://github.com/vllm-project/vllm/commit/b2f685834a6456197e7033966fdef52a23f1abcd
