### PR TITLE
[v0.26.0rc][Doc][Misc] Prepare v0.26.0rc1 release

### DIFF
--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -29,6 +29,7 @@ on:
         type: choice
         options:
           - main
+          - v0.26.0rc1
           - v0.23.0
           - v0.23.0rc1
           - v0.22.1rc1
@@ -42,6 +43,7 @@ on:
         type: choice
         options:
           - main
+          - releases/v0.26.0rc
           - releases/v0.24.0rc
           - releases/v0.23.0
           - releases/v0.22.1rc

--- a/.github/workflows/schedule_release_code_and_wheel.yml
+++ b/.github/workflows/schedule_release_code_and_wheel.yml
@@ -33,6 +33,7 @@ on:
         type: choice
         options:
           - main
+          - v0.26.0rc1
           - v0.23.0
           - v0.23.0rc1
           - v0.22.1rc1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ vLLM Ascend Plugin
 ---
 *Latest News* 🔥
 
+- [2026/09] We released the new release candidate [v0.26.0rc1](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.26.0rc1)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.26.0rc1/) to start using vLLM Ascend Plugin on Ascend.
 - [2026/08] We released the new official version [v0.23.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.23.0/) to start using vLLM Ascend Plugin on Ascend.
 - [2026/05] We released the new official version [v0.18.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.18.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.18.0/) to start using vLLM Ascend Plugin on Ascend.
 - [2026/02] We released the new official version [v0.13.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.13.0)! Please follow the [official guide](https://docs.vllm.ai/projects/ascend/en/v0.13.0/) to start using vLLM Ascend Plugin on Ascend.
@@ -77,6 +78,7 @@ Please use the following recommended versions to get started quickly:
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
+| v0.26.0rc1 | Release candidate | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.26.0rc1/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.26.0rc1/installation.html) for more details |
 | v0.23.0 | Latest stable version | See [QuickStart](https://docs.vllm.ai/projects/ascend/en/v0.23.0/quick_start.html) and [Installation](https://docs.vllm.ai/projects/ascend/en/v0.23.0/installation.html) for more details |
 
 ## Branch

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,7 @@ vLLM Ascend Plugin
 ---
 *最新消息* 🔥
 
+- [2026/09] 我们发布了新的候选版本 [v0.26.0rc1](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.26.0rc1)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.26.0rc1/)开始在 Ascend 上部署 vLLM Ascend Plugin。
 - [2026/08] 我们发布了新的正式版本 [v0.23.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.23.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0/)开始在 Ascend 上部署 vLLM Ascend Plugin。
 - [2026/05] 我们发布了新的正式版本 [v0.18.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.18.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.18.0/)开始在Ascend上部署vLLM Ascend Plugin。
 - [2026/02] 我们发布了新的正式版本 [v0.13.0](https://github.com/vllm-project/vllm-ascend/releases/tag/v0.13.0)! 请按照[官方指南](https://docs.vllm.ai/projects/ascend/en/v0.13.0/)开始在Ascend上部署vLLM Ascend Plugin。
@@ -71,6 +72,7 @@ vLLM 昇腾插件 (`vllm-ascend`) 是一个由社区维护的让vLLM在Ascend NP
 
 | Version    | Release type | Doc                                  |
 |------------|--------------|--------------------------------------|
+| v0.26.0rc1 | 候选版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.26.0rc1/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.26.0rc1/installation.html)了解更多 |
 | v0.23.0    | 最新正式/稳定版本 | 请查看[快速开始](https://docs.vllm.ai/projects/ascend/en/v0.23.0/quick_start.html)和[安装指南](https://docs.vllm.ai/projects/ascend/en/v0.23.0/installation.html)了解更多 |
 
 ## 分支策略

--- a/docs/hooks/nav_titles.py
+++ b/docs/hooks/nav_titles.py
@@ -108,6 +108,7 @@ TITLES = {
     "tutorials/models/DeepSeek-V4-Flash.md": {"en": "DeepSeek-V4-Flash", "zh": "DeepSeek-V4-Flash"},
     "tutorials/models/DeepSeek-V4-Pro.md": {"en": "DeepSeek-V4-Pro", "zh": "DeepSeek-V4-Pro"},
     "tutorials/models/DeepSeekOCR2.md": {"en": "DeepSeekOCR2", "zh": "DeepSeekOCR2"},
+    "tutorials/models/Gemma4.md": {"en": "Gemma4", "zh": "Gemma4"},
     "tutorials/models/GLM4.x.md": {"en": "GLM-4.x", "zh": "GLM-4.x"},
     "tutorials/models/GLM5.2.md": {"en": "GLM-5.2", "zh": "GLM-5.2"},
     "tutorials/models/GLM5.md": {"en": "GLM-5", "zh": "GLM-5"},

--- a/docs/source/_templates/sections/header.html
+++ b/docs/source/_templates/sections/header.html
@@ -54,5 +54,5 @@
   </style>
   
   <div class="notification-bar">
-    <p>You are viewing the latest developer preview docs. <a href="https://docs.vllm.ai/projects/ascend/en/v0.18.0">Click here</a> to view docs for the latest stable release(v0.18.0).</p>
+    <p>You are viewing the latest developer preview docs. <a href="https://docs.vllm.ai/projects/ascend/en/v0.23.0">Click here</a> to view docs for the latest stable release(v0.23.0).</p>
   </div>

--- a/docs/source/community/contributors.md
+++ b/docs/source/community/contributors.md
@@ -21,38 +21,62 @@
 | LinFeng Yuan| [@linfeng-yuan](https://github.com/linfeng-yuan) | 2026/05 |
 
 ## Contributors
-<!-- last_commit: edcae83da32af8e1f1b7b97c7e19e8114e0535a5 -->
+<!-- last_commit: 5f5ea8af8c9e93ce7ce62455014c6b0491d0ce1d -->
 
 Every release of vLLM Ascend would not have been possible without the following contributors:
 
-Updated on 2026-08-16:
+Updated on 2026-09-03:
 
 | Number | Contributor | Date | Commit ID |
 |:------:|:-----------:|:-----:|:---------:|
-| 518 | [@DavidJiang9](https://github.com/DavidJiang9) | 2026/08/13 | [c10e1c0](https://github.com/vllm-project/vllm-ascend/commit/c10e1c01d51c533021ae4bc5eeebf784ae36dafc) |
-| 517 | [@hw-zhoutianyang](https://github.com/hw-zhoutianyang) | 2026/08/12 | [6c47fb9](https://github.com/vllm-project/vllm-ascend/commit/6c47fb9e3ac8af04c873fce79318bc2afabf9188) |
-| 516 | [@lrf-vm](https://github.com/lrf-vm) | 2026/08/08 | [462154e](https://github.com/vllm-project/vllm-ascend/commit/462154e6cd99084d81b94fcfdf26b4aed2cac914) |
-| 515 | [@voidvelocity](https://github.com/voidvelocity) | 2026/08/07 | [60eacbe](https://github.com/vllm-project/vllm-ascend/commit/60eacbe8bd20ad9dcd7615896184110e556c0584) |
-| 514 | [@xqchen7](https://github.com/xqchen7) | 2026/08/07 | [7c0f6e6](https://github.com/vllm-project/vllm-ascend/commit/7c0f6e6d8cc3134019ea6ebd71a3dad6733492e5) |
-| 513 | [@Karryking3](https://github.com/Karryking3) | 2026/08/06 | [bb630a6](https://github.com/vllm-project/vllm-ascend/commit/bb630a62a210059ba04041bdb952e3fca22f94df) |
-| 512 | [@ella1107](https://github.com/ella1107) | 2026/07/30 | [71d136c](https://github.com/vllm-project/vllm-ascend/commit/71d136ca26c4692db6b1e5bd07f507b73f09887b) |
-| 511 | [@axx-ty911](https://github.com/axx-ty911) | 2026/07/30 | [7890de8](https://github.com/vllm-project/vllm-ascend/commit/7890de8eb72ff669c4962ff379090a14dc19b21a) |
-| 510 | [@ffggs](https://github.com/ffggs) | 2026/07/29 | [5cf0420](https://github.com/vllm-project/vllm-ascend/commit/5cf0420ab3a4ca5f8ba2a707e4e5c31eef1cc968) |
-| 509 | [@jiaqi-lee](https://github.com/jiaqi-lee) | 2026/07/25 | [5225ae2](https://github.com/vllm-project/vllm-ascend/commit/5225ae20fb09aa41cc3278b294aad23c9dc33f22) |
-| 508 | [@Oranbean258](https://github.com/Oranbean258) | 2026/07/23 | [e6f3f49](https://github.com/vllm-project/vllm-ascend/commit/e6f3f4954602a3d2fc41857e0c61806b9c8840ff) |
-| 507 | [@lyur01](https://github.com/lyur01) | 2026/07/23 | [f9602a1](https://github.com/vllm-project/vllm-ascend/commit/f9602a13c52359fe1b56dc8318436d31f03012ba) |
-| 506 | [@zhangjiale-zjl](https://github.com/zhangjiale-zjl) | 2026/07/23 | [9d03a3a](https://github.com/vllm-project/vllm-ascend/commit/9d03a3a682d196cb534885a7cbdf86ef0b0694aa) |
-| 505 | [@aisong1988](https://github.com/aisong1988) | 2026/07/22 | [c926c21](https://github.com/vllm-project/vllm-ascend/commit/c926c213cbf2ca0c1d13d4bdaea97d39a5748b15) |
-| 504 | [@q664171689](https://github.com/q664171689) | 2026/07/18 | [ebad45e](https://github.com/vllm-project/vllm-ascend/commit/ebad45e3666f8453e045ade27d02b47a7fe1669c) |
-| 503 | [@qijiajin](https://github.com/qijiajin) | 2026/07/18 | [d42948a](https://github.com/vllm-project/vllm-ascend/commit/d42948ac2c1cba80fe30acd0bd61e4991beb58d2) |
-| 502 | [@Wyz-134](https://github.com/Wyz-134) | 2026/07/17 | [9b8423e](https://github.com/vllm-project/vllm-ascend/commit/9b8423e15a836f1b011b61aece5305459f939c32) |
-| 501 | [@zh98530](https://github.com/zh98530) | 2026/07/17 | [a272c88](https://github.com/vllm-project/vllm-ascend/commit/a272c88a5c6560c2ef655b05970a05b895d342e4) |
-| 500 | [@singzhou](https://github.com/singzhou) | 2026/07/15 | [f924703](https://github.com/vllm-project/vllm-ascend/commit/f924703d7d97a90c5d72d58bf32865501b7f87c0) |
-| 499 | [@ZhangwenTaoHW](https://github.com/ZhangwenTaoHW) | 2026/07/13 | [b89a491](https://github.com/vllm-project/vllm-ascend/commit/b89a491644cd02a16a5b17c1a124cec254866559) |
-| 498 | [@zhaochuang001](https://github.com/zhaochuang001) | 2026/07/11 | [7be596c](https://github.com/vllm-project/vllm-ascend/commit/7be596cd3fa93c45a4ef4ff5384d0c852659d83c) |
-| 497 | [@Liuchenbing-2026](https://github.com/Liuchenbing-2026) | 2026/07/10 | [123c5cc](https://github.com/vllm-project/vllm-ascend/commit/123c5ccc78d3aabe3f793223e096ee5e97606a20) |
-| 496 | [@KadenZhang3321](https://github.com/KadenZhang3321) | 2026/07/08 | [d17a99c](https://github.com/vllm-project/vllm-ascend/commit/d17a99cd51d535c4026ffb596bafa0a23fa87064) |
-| 495 | [@TYYTao](https://github.com/TYYTao) | 2026/07/06 | [79928c2](https://github.com/vllm-project/vllm-ascend/commit/79928c2ff1b5521d7f57c58233c87782ec77afc1) |
+| 542 | [@MaybeChz](https://github.com/MaybeChz) | 2026/08/31 | [fa3537f](https://github.com/vllm-project/vllm-ascend/commit/fa3537f92b4c47d97a17bc9443924a1f9d69aec2) |
+| 541 | [@chenzhh69](https://github.com/chenzhh69) | 2026/08/28 | [e20c2b0](https://github.com/vllm-project/vllm-ascend/commit/e20c2b061fa72cc581b6513cbc3e2995527b934f) |
+| 540 | [@lsjfy-open-com](https://github.com/lsjfy-open-com) | 2026/08/28 | [3827486](https://github.com/vllm-project/vllm-ascend/commit/3827486f19db928809af401ea0121ca7d487448f) |
+| 539 | [@JavaPythonAIForBAT](https://github.com/JavaPythonAIForBAT) | 2026/08/27 | [f347522](https://github.com/vllm-project/vllm-ascend/commit/f3475221a3e1e0de81806de25c1fa58f64216ca3) |
+| 538 | [@du-ping1](https://github.com/du-ping1) | 2026/07/30 | [3cba6f7](https://github.com/vllm-project/vllm-ascend/commit/3cba6f774544d8fae4506debb98d37cda6e2c3ec) |
+| 537 | [@Zhaocen](https://github.com/Zhaocen) | 2026/08/25 | [c120a6e](https://github.com/vllm-project/vllm-ascend/commit/c120a6e6d91a102f3a4d267b08601905021a4318) |
+| 536 | [@DavidJiang9](https://github.com/DavidJiang9) | 2026/08/13 | [c10e1c0](https://github.com/vllm-project/vllm-ascend/commit/c10e1c01d51c533021ae4bc5eeebf784ae36dafc) |
+| 535 | [@hw-zhoutianyang](https://github.com/hw-zhoutianyang) | 2026/08/12 | [6c47fb9](https://github.com/vllm-project/vllm-ascend/commit/6c47fb9e3ac8af04c873fce79318bc2afabf9188) |
+| 534 | [@lrf-vm](https://github.com/lrf-vm) | 2026/08/08 | [462154e](https://github.com/vllm-project/vllm-ascend/commit/462154e6cd99084d81b94fcfdf26b4aed2cac914) |
+| 533 | [@xqchen7](https://github.com/xqchen7) | 2026/08/07 | [7c0f6e6](https://github.com/vllm-project/vllm-ascend/commit/7c0f6e6d8cc3134019ea6ebd71a3dad6733492e5) |
+| 532 | [@voidvelocity](https://github.com/voidvelocity) | 2026/08/07 | [60eacbe](https://github.com/vllm-project/vllm-ascend/commit/60eacbe8bd20ad9dcd7615896184110e556c0584) |
+| 531 | [@Karryking3](https://github.com/Karryking3) | 2026/08/06 | [bb630a6](https://github.com/vllm-project/vllm-ascend/commit/bb630a62a210059ba04041bdb952e3fca22f94df) |
+| 530 | [@zongersama](https://github.com/zongersama) | 2026/08/04 | [a7e415e](https://github.com/vllm-project/vllm-ascend/commit/a7e415e5bd3551486ccf01c3002ad8fd0d8cf725) |
+| 529 | [@axx-ty911](https://github.com/axx-ty911) | 2026/07/30 | [7890de8](https://github.com/vllm-project/vllm-ascend/commit/7890de8eb72ff669c4962ff379090a14dc19b21a) |
+| 528 | [@ella1107](https://github.com/ella1107) | 2026/07/30 | [71d136c](https://github.com/vllm-project/vllm-ascend/commit/71d136ca26c4692db6b1e5bd07f507b73f09887b) |
+| 527 | [@RuiningWANG](https://github.com/RuiningWANG) | 2026/07/30 | [c9e95ba](https://github.com/vllm-project/vllm-ascend/commit/c9e95ba32421fd4a29176db1e67d13896ef70406) |
+| 526 | [@ffggs](https://github.com/ffggs) | 2026/07/29 | [5cf0420](https://github.com/vllm-project/vllm-ascend/commit/5cf0420ab3a4ca5f8ba2a707e4e5c31eef1cc968) |
+| 525 | [@zmc1997](https://github.com/zmc1997) | 2026/07/27 | [ee618ae](https://github.com/vllm-project/vllm-ascend/commit/ee618ae8fa9b2c8a3eca6d200f0fc8a96c50a2be) |
+| 524 | [@jiaqi-lee](https://github.com/jiaqi-lee) | 2026/07/25 | [5225ae2](https://github.com/vllm-project/vllm-ascend/commit/5225ae20fb09aa41cc3278b294aad23c9dc33f22) |
+| 523 | [@zhangjiale-zjl](https://github.com/zhangjiale-zjl) | 2026/07/23 | [9d03a3a](https://github.com/vllm-project/vllm-ascend/commit/9d03a3a682d196cb534885a7cbdf86ef0b0694aa) |
+| 522 | [@lyur01](https://github.com/lyur01) | 2026/07/23 | [f9602a1](https://github.com/vllm-project/vllm-ascend/commit/f9602a13c52359fe1b56dc8318436d31f03012ba) |
+| 521 | [@Oranbean258](https://github.com/Oranbean258) | 2026/07/23 | [e6f3f49](https://github.com/vllm-project/vllm-ascend/commit/e6f3f4954602a3d2fc41857e0c61806b9c8840ff) |
+| 520 | [@floatlibai](https://github.com/floatlibai) | 2026/07/22 | [f5b5514](https://github.com/vllm-project/vllm-ascend/commit/f5b5514afdb9ed53e7382ce8abdefec0bd0e5c62) |
+| 519 | [@aisong1988](https://github.com/aisong1988) | 2026/07/22 | [c926c21](https://github.com/vllm-project/vllm-ascend/commit/c926c213cbf2ca0c1d13d4bdaea97d39a5748b15) |
+| 518 | [@LYMAXPUP](https://github.com/LYMAXPUP) | 2026/07/20 | [753d7ba](https://github.com/vllm-project/vllm-ascend/commit/753d7ba875e623a83fec86440e8c00603880c0b1) |
+| 517 | [@KINGFIOX](https://github.com/KINGFIOX) | 2026/07/20 | [093ce8c](https://github.com/vllm-project/vllm-ascend/commit/093ce8cb78fa3d558482098110704d53eed16f88) |
+| 516 | [@q664171689](https://github.com/q664171689) | 2026/07/18 | [ebad45e](https://github.com/vllm-project/vllm-ascend/commit/ebad45e3666f8453e045ade27d02b47a7fe1669c) |
+| 515 | [@qijiajin](https://github.com/qijiajin) | 2026/07/18 | [d42948a](https://github.com/vllm-project/vllm-ascend/commit/d42948ac2c1cba80fe30acd0bd61e4991beb58d2) |
+| 514 | [@hughpu](https://github.com/hughpu) | 2026/07/17 | [12ddf3c](https://github.com/vllm-project/vllm-ascend/commit/12ddf3ce42b5029eb6292c4cf992921e1b00d845) |
+| 513 | [@wanqi01](https://github.com/wanqi01) | 2026/07/17 | [4919119](https://github.com/vllm-project/vllm-ascend/commit/491911909068e34e11b114e21878e2b2a25d7a4e) |
+| 512 | [@zh98530](https://github.com/zh98530) | 2026/07/17 | [a272c88](https://github.com/vllm-project/vllm-ascend/commit/a272c88a5c6560c2ef655b05970a05b895d342e4) |
+| 511 | [@Wyz-134](https://github.com/Wyz-134) | 2026/07/17 | [9b8423e](https://github.com/vllm-project/vllm-ascend/commit/9b8423e15a836f1b011b61aece5305459f939c32) |
+| 510 | [@singzhou](https://github.com/singzhou) | 2026/07/15 | [f924703](https://github.com/vllm-project/vllm-ascend/commit/f924703d7d97a90c5d72d58bf32865501b7f87c0) |
+| 509 | [@grandolantow](https://github.com/grandolantow) | 2026/07/14 | [1a1392b](https://github.com/vllm-project/vllm-ascend/commit/1a1392bf0adc0630bc7f4b3f2a385ed46b272c5a) |
+| 508 | [@earthmanylf](https://github.com/earthmanylf) | 2026/07/13 | [15474a6](https://github.com/vllm-project/vllm-ascend/commit/15474a661e4cfd28a135e1f87a193911829d0c50) |
+| 507 | [@Jingzhe0518](https://github.com/Jingzhe0518) | 2026/07/13 | [96b1b50](https://github.com/vllm-project/vllm-ascend/commit/96b1b507b272a497b1419a806631322a18bc9212) |
+| 506 | [@ZhangwenTaoHW](https://github.com/ZhangwenTaoHW) | 2026/07/13 | [b89a491](https://github.com/vllm-project/vllm-ascend/commit/b89a491644cd02a16a5b17c1a124cec254866559) |
+| 505 | [@zhaochuang001](https://github.com/zhaochuang001) | 2026/07/11 | [7be596c](https://github.com/vllm-project/vllm-ascend/commit/7be596cd3fa93c45a4ef4ff5384d0c852659d83c) |
+| 504 | [@Liuchenbing-2026](https://github.com/Liuchenbing-2026) | 2026/07/10 | [123c5cc](https://github.com/vllm-project/vllm-ascend/commit/123c5ccc78d3aabe3f793223e096ee5e97606a20) |
+| 503 | [@wangyichao1999](https://github.com/wangyichao1999) | 2026/07/10 | [cc348a0](https://github.com/vllm-project/vllm-ascend/commit/cc348a087aaee1e5bccf0c3260f57336984f30c8) |
+| 502 | [@immengzi](https://github.com/immengzi) | 2026/07/10 | [064fb9a](https://github.com/vllm-project/vllm-ascend/commit/064fb9a7dc17639975e343c4a81bab4f75c51f36) |
+| 501 | [@suluner](https://github.com/suluner) | 2026/07/10 | [7d953ad](https://github.com/vllm-project/vllm-ascend/commit/7d953ad85b0f807e0ffaae9a7e30cfd861f821c1) |
+| 500 | [@0moyi0-2024](https://github.com/0moyi0-2024) | 2026/07/10 | [eb0ce34](https://github.com/vllm-project/vllm-ascend/commit/eb0ce34e98ea66d83482d1573283fb98afa93b83) |
+| 499 | [@KadenZhang3321](https://github.com/KadenZhang3321) | 2026/07/08 | [d17a99c](https://github.com/vllm-project/vllm-ascend/commit/d17a99cd51d535c4026ffb596bafa0a23fa87064) |
+| 498 | [@a741855259](https://github.com/a741855259) | 2026/07/07 | [fbcc143](https://github.com/vllm-project/vllm-ascend/commit/fbcc143a4ce050d3456f08c64757c8ac16063c01) |
+| 497 | [@jingmao-yan](https://github.com/jingmao-yan) | 2026/07/07 | [a2e9139](https://github.com/vllm-project/vllm-ascend/commit/a2e91398a989e507343abc6bf311fc35ce168c0f) |
+| 496 | [@TYYTao](https://github.com/TYYTao) | 2026/07/06 | [79928c2](https://github.com/vllm-project/vllm-ascend/commit/79928c2ff1b5521d7f57c58233c87782ec77afc1) |
+| 495 | [@DHX98](https://github.com/DHX98) | 2026/07/06 | [8116bcd](https://github.com/vllm-project/vllm-ascend/commit/8116bcdc4528759e832a5dbd4d4cc7cee1786ca3) |
 | 494 | [@ShySummer](https://github.com/ShySummer) | 2026/07/05 | [9154baa](https://github.com/vllm-project/vllm-ascend/commit/9154baadc9dbac857fe197d03bccb1731664f3df) |
 | 493 | [@tyy0829](https://github.com/tyy0829) | 2026/07/05 | [a0219ac](https://github.com/vllm-project/vllm-ascend/commit/a0219ac14caad375c74793539ad230688b58f9d6) |
 | 492 | [@xinhai9906](https://github.com/xinhai9906) | 2026/07/04 | [f81dd51](https://github.com/vllm-project/vllm-ascend/commit/f81dd51845185d18ea26cfbef2042f9b3bc0de2e) |

--- a/docs/source/community/versioning_policy.md
+++ b/docs/source/community/versioning_policy.md
@@ -23,6 +23,7 @@ The table below is the release compatibility matrix for vLLM Ascend release.
 
 | vLLM Ascend | vLLM              | Python          | Stable CANN |        PyTorch/torch_npu        |   Triton Ascend   |    Mooncake  |
 |-------------|-------------------|-----------------|-------------|---------------------------------|-------------------|--------------|
+| v0.26.0rc1  | v0.26.0           | >= 3.10, < 3.13 | 9.1.0       | 2.10.0 / 2.10.0.post4           | 3.2.2             | v0.3.11.post1 |
 | v0.23.0     | v0.23.0           | >= 3.10, < 3.13 | 9.1.0       | 2.10.0 / 2.10.0.post4           | 3.2.2             | v0.3.11.post1 |
 | v0.23.0rc1  | v0.23.0           | >= 3.10, < 3.13 | 9.0.1       | 2.10.0 / 2.10.0.post2           | 3.2.1             | v0.3.11.post1 |
 | v0.22.1rc1  | v0.22.1           | >= 3.10, < 3.13 | 9.0.0       | 2.10.0 / 2.10.0                 | 3.2.1             | v0.3.9       |
@@ -88,6 +89,7 @@ Using `--no-build-isolation` can bypass build-environment resolution, so run
 
 | Date       | Event                                     |
 |------------|-------------------------------------------|
+| 2026.09.03 | Release candidates, v0.26.0rc1            |
 | 2026.08.16 | v0.23.0 Final release, v0.23.0            |
 | 2026.07.20 | Release candidates, v0.23.0rc1            |
 | 2026.06.30 | Release candidates, v0.22.1rc1            |

--- a/docs/source/faqs.md
+++ b/docs/source/faqs.md
@@ -2,6 +2,7 @@
 
 ## Version Specific FAQs
 
+- [[v0.26.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/14766)
 - [[v0.23.0] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/12916)
 - [[v0.23.0rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/12238)
 - [[v0.22.1rc1] FAQ & Feedback](https://github.com/vllm-project/vllm-ascend/issues/10593)

--- a/docs/source/user_guide/release_notes.md
+++ b/docs/source/user_guide/release_notes.md
@@ -1,5 +1,125 @@
 # Release Notes
 
+## v0.26.0rc1 - 2026.09.03
+
+This is the first release candidate of v0.26.0 for vLLM Ascend, aligned with upstream vLLM v0.26.0. This release is a model‑restricted version. Fully validated models include Kimi K3, GLM‑5.2, DeepSeek V4 Flash 0731, DeepSeek V4 Pro 0813. Availability is not guaranteed for other models. For the full test report, see: [v0.26.0rc1 Test Conclusion](https://github.com/vllm-project/vllm-ascend/blob/releases/v0.26.0rc/tests/vllm_ascend_v0.26.0rc1_test_conclusion.md). Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/latest) to get started.
+
+### Highlights
+
+- **Kimi K3 on Ascend**: Added end-to-end Kimi K3 support, including MLA DSpark speculative decoding, no-RoPE MLAPO on Ascend 950, fused QKV projections, fused norm gate and attention residual, and projector rotation. [#12950](https://github.com/vllm-project/vllm-ascend/pull/12950) [#13277](https://github.com/vllm-project/vllm-ascend/pull/13277) [#13507](https://github.com/vllm-project/vllm-ascend/pull/13507) [#13989](https://github.com/vllm-project/vllm-ascend/pull/13989) [#13509](https://github.com/vllm-project/vllm-ascend/pull/13509) [#14231](https://github.com/vllm-project/vllm-ascend/pull/14231)
+- **GLM-5.2 / DeepSeek V4 Flash 0731 / DeepSeek V4 Pro 0813 accuracy and performance**: Resolved GLM-5.2 DSpark acceptance regressions and DeepSeek V4 Flash-0731 / Pro-0813 accuracy issues (reasoning-effort alignment, routed SwiGLU limit, and frontend behavior), and reused DSV4 compressor metadata across layers for better performance. [#12262](https://github.com/vllm-project/vllm-ascend/pull/12262) [#13531](https://github.com/vllm-project/vllm-ascend/pull/13531) [#13993](https://github.com/vllm-project/vllm-ascend/pull/13993) [#14074](https://github.com/vllm-project/vllm-ascend/pull/14074) [#14397](https://github.com/vllm-project/vllm-ascend/pull/14397) [#14624](https://github.com/vllm-project/vllm-ascend/pull/14624) [#14994](https://github.com/vllm-project/vllm-ascend/pull/14994)
+- **DeepSeek V4 DSpark**: Refactored DSv4 DSpark speculative decoding with aligned SP handling and QuaRot weight support for Qwen3 DSpark. [#11431](https://github.com/vllm-project/vllm-ascend/pull/11431) [#12662](https://github.com/vllm-project/vllm-ascend/pull/12662)
+- **Sparse-attention context parallelism**: Added SFA DCP with a replicated indexer, compact KV gather, and C8 support. Enabled P/D disaggregation for DCP with replicate-indexer. [#11443](https://github.com/vllm-project/vllm-ascend/pull/11443) [#11870](https://github.com/vllm-project/vllm-ascend/pull/11870) [#11980](https://github.com/vllm-project/vllm-ascend/pull/11980) [#11696](https://github.com/vllm-project/vllm-ascend/pull/11696)
+- **Deprecation cleanup**: Removed layer sharding, FlashComm2, multistream overlap gate, dynamic-batch SLO, weight prefetch, matmul all-reduce fusions, and kv offload in KV Pool to streamline the codebase. [#11953](https://github.com/vllm-project/vllm-ascend/pull/11953) [#12117](https://github.com/vllm-project/vllm-ascend/pull/12117) [#11956](https://github.com/vllm-project/vllm-ascend/pull/11956) [#11933](https://github.com/vllm-project/vllm-ascend/pull/11933) [#11949](https://github.com/vllm-project/vllm-ascend/pull/11949) [#12119](https://github.com/vllm-project/vllm-ascend/pull/12119) [#11904](https://github.com/vllm-project/vllm-ascend/pull/11904)
+
+### Features
+
+- Added LoRA with unquantized MoE models and AlltoAll + EP + LoRA support. [#10977](https://github.com/vllm-project/vllm-ascend/pull/10977) [#12451](https://github.com/vllm-project/vllm-ascend/pull/12451)
+- Added Gemma4 E2B and E4B model support with graph execution on A2/A3 and ModelSlim quantization. [#11536](https://github.com/vllm-project/vllm-ascend/pull/11536) [#11575](https://github.com/vllm-project/vllm-ascend/pull/11575) [#11791](https://github.com/vllm-project/vllm-ascend/pull/11791)
+- Added Step3.5/3.7 Flash support for Ascend 950. [#10556](https://github.com/vllm-project/vllm-ascend/pull/10556)
+- Added KV sliding window for Eagle3 and DFlash. [#10023](https://github.com/vllm-project/vllm-ascend/pull/10023)
+- Added ShortRequestFirst scheduling and batch job aware scheduler. [#11576](https://github.com/vllm-project/vllm-ascend/pull/11576) [#12240](https://github.com/vllm-project/vllm-ascend/pull/12240) [#12719](https://github.com/vllm-project/vllm-ascend/pull/12719)
+- Added NZ static buffers for prefetch offload. [#11945](https://github.com/vllm-project/vllm-ascend/pull/11945)
+- Added update config and reload weights to NPU Worker. [#10126](https://github.com/vllm-project/vllm-ascend/pull/10126)
+- Added SFA C8 support: unified packed KV cache layout on A3, and DCP replicated indexer for sparse‑attention paths. [#11228](https://github.com/vllm-project/vllm-ascend/pull/11228) [#11870](https://github.com/vllm-project/vllm-ascend/pull/11870)
+
+### Hardware and Operator Support
+
+- Expanded Ascend 950 supports: MXFP quant for token dispatch, and CPU binding with topo clusters. [#11614](https://github.com/vllm-project/vllm-ascend/pull/11614) [#11717](https://github.com/vllm-project/vllm-ascend/pull/11717)
+- Expanded Atlas 300I DUO support: disabled npugraph_ex by default, added Qwen3.5-Dense documentation, and fixed 310P spec decoding accuracy. [#10874](https://github.com/vllm-project/vllm-ascend/pull/10874) [#12077](https://github.com/vllm-project/vllm-ascend/pull/12077) [#11918](https://github.com/vllm-project/vllm-ascend/pull/11918)
+- Added operator supports: KV quant sparse flash attention, and Triton SwiGLuStep kernel (replaced AscendC‑based fused_gdn_gating). [#11626](https://github.com/vllm-project/vllm-ascend/pull/11626) [#11467](https://github.com/vllm-project/vllm-ascend/pull/11467) [#12035](https://github.com/vllm-project/vllm-ascend/pull/12035)
+
+### Performance
+
+Unless stated otherwise, these optimizations are selected automatically for the targeted path and need no additional configuration.
+
+- Optimized PCP FA restore and output merge to reduce overhead. [#11586](https://github.com/vllm-project/vllm-ascend/pull/11586)
+- Vectorized local sequence-length computation in SFA metadata to remove per-request NPU-to-CPU synchronization. [#11762](https://github.com/vllm-project/vllm-ascend/pull/11762)
+- Avoided H2D synchronization in context-parallel speculative-proposer metadata. [#11496](https://github.com/vllm-project/vllm-ascend/pull/11496)
+- Optimized DSA-CP local token metadata with a fused Triton kernel and caching. [#12193](https://github.com/vllm-project/vllm-ascend/pull/12193)
+- Split mixed ChunkedPrefill into separate decode and prefill attention calls. [#11948](https://github.com/vllm-project/vllm-ascend/pull/11948)
+- Optimized AscendStore key construction and miss-path handling. [#12814](https://github.com/vllm-project/vllm-ascend/pull/12814)
+- Removed D2H sync in QLIMetadata builder for DSA-CP. [#12536](https://github.com/vllm-project/vllm-ascend/pull/12536)
+- Bound Mooncake receiver threads to KV cache device. [#12126](https://github.com/vllm-project/vllm-ascend/pull/12126)
+- Sharded DeepSeek V4 DSpark main projection across TP ranks for better parallelism. [#15144](https://github.com/vllm-project/vllm-ascend/pull/15144)
+- Reused DeepSeek V4 compressor metadata across layers to avoid redundant computation. [#14994](https://github.com/vllm-project/vllm-ascend/pull/14994)
+
+### Dependencies
+
+- **Upstream vLLM**: v0.26.0.
+- **Python**: >= 3.10, < 3.13.
+- **CANN**: 9.1.0.
+- **PyTorch / torch_npu**: 2.10.0 / 2.10.0.post4.
+- **Triton Ascend**: 3.2.2 for A2, A3, and Ascend 950; Triton Ascend is not supported on Atlas 300I DUO.
+- **Mooncake**: 0.3.11.post1 in the release images.
+
+### Deprecation and Breaking Changes
+
+- Removed layer sharding. [#11953](https://github.com/vllm-project/vllm-ascend/pull/11953)
+- Removed FlashComm2 optimization techniques. [#12117](https://github.com/vllm-project/vllm-ascend/pull/12117)
+- Removed multistream overlap gate. [#11956](https://github.com/vllm-project/vllm-ascend/pull/11956)
+- Removed dynamic-batch SLO. [#11933](https://github.com/vllm-project/vllm-ascend/pull/11933)
+- Removed weight prefetch config. [#11949](https://github.com/vllm-project/vllm-ascend/pull/11949)
+- Removed matmul all-reduce and matmul all-reduce RMSNorm fusions. [#12119](https://github.com/vllm-project/vllm-ascend/pull/12119)
+- Removed KV offload in KV Pool. [#11904](https://github.com/vllm-project/vllm-ascend/pull/11904)
+- Removed `dp_allreduce_on_npu` additional config option. [#12496](https://github.com/vllm-project/vllm-ascend/pull/12496)
+- Removed PCP from MRV1; use MRV2 for prefill context parallelism. [#12592](https://github.com/vllm-project/vllm-ascend/pull/12592)
+- Removed custom top-k top-p AscendC implementation in favor of CANN operator. [#12232](https://github.com/vllm-project/vllm-ascend/pull/12232)
+- Refactored hamming ops and removed sparse action. [#12049](https://github.com/vllm-project/vllm-ascend/pull/12049)
+- Deprecated `ASCEND_BUFFER_POOL` environment variable; use `ASCEND_ENABLE_USE_FABRIC_MEM=1` or `HCCL_INTRA_ROCE_ENABLE=1`. [#13856](https://github.com/vllm-project/vllm-ascend/pull/13856)
+
+### Ready to Deprecate
+
+The following features are deprecated or subject to change:
+
+- Added deprecation warnings for W4A8 linear, W4A8 MoE per-group, and W8A8 PDMix MoE quantization. These quantization paths will be removed in a future release. [#13850](https://github.com/vllm-project/vllm-ascend/pull/13850)
+- The `mega_moe_max_tokens` and `enable_fused_mc2` configurations in `additional-config` will be moved into a new dedicated dict for centralized maintenance in the next release.
+- DeepSeek-V3, DeepSeek-V3.1, and DeepSeek-R1 model support will be removed in v0.28.0.
+
+### Documentation
+
+- Added Kimi-K3 deployment guide on Ascend. [#14125](https://github.com/vllm-project/vllm-ascend/pull/14125)
+- Refreshed DeepSeek-V4, GLM-5.2, Kimi-K2.x, and Gemma4 model deployment guides. [#11525](https://github.com/vllm-project/vllm-ascend/pull/11525) [#11534](https://github.com/vllm-project/vllm-ascend/pull/11534) [#11055](https://github.com/vllm-project/vllm-ascend/pull/11055)
+- Added KV Pool and Memcache SSD cache configuration guides. [#12600](https://github.com/vllm-project/vllm-ascend/pull/12600) [#12670](https://github.com/vllm-project/vllm-ascend/pull/12670)
+- Added RLHF LoRA HTTP API example and e2e RLHF async pause/resume example. [#14672](https://github.com/vllm-project/vllm-ascend/pull/14672) [#12300](https://github.com/vllm-project/vllm-ascend/pull/12300)
+
+### Stability and Bug Fixes
+
+- Fixed GDN state and graph-dispatch accuracy regressions across P/D, PCP, MTP, and DCP. [#11195](https://github.com/vllm-project/vllm-ascend/pull/11195) [#11893](https://github.com/vllm-project/vllm-ascend/pull/11893) [#12027](https://github.com/vllm-project/vllm-ascend/pull/12027)
+- Fixed Qwen3.5 PCP + chunked prefill accuracy and small-chunk problems. [#11508](https://github.com/vllm-project/vllm-ascend/pull/11508) [#11807](https://github.com/vllm-project/vllm-ascend/pull/11807)
+- Fixed DeepSeek V4 MXFP routing precision and W4A16MXFP communication accuracy. [#11663](https://github.com/vllm-project/vllm-ascend/pull/11663) [#12585](https://github.com/vllm-project/vllm-ascend/pull/12585)
+- Fixed KV-transfer ordering, Mooncake grouping, and AscendStore hash/lease handling. [#11887](https://github.com/vllm-project/vllm-ascend/pull/11887) [#12252](https://github.com/vllm-project/vllm-ascend/pull/12252) [#12012](https://github.com/vllm-project/vllm-ascend/pull/12012)
+- Fixed DCP/DP service hangs and restricted recompute scheduler to decode nodes. [#12036](https://github.com/vllm-project/vllm-ascend/pull/12036) [#11265](https://github.com/vllm-project/vllm-ascend/pull/11265) [#11537](https://github.com/vllm-project/vllm-ascend/pull/11537)
+- Fixed 310P spec decoding accuracy, SDMA errors, and memory calculation. [#11918](https://github.com/vllm-project/vllm-ascend/pull/11918) [#11678](https://github.com/vllm-project/vllm-ascend/pull/11678) [#11959](https://github.com/vllm-project/vllm-ascend/pull/11959)
+- Fixed DSpark multi-DP bugs and SP handling. [#12612](https://github.com/vllm-project/vllm-ascend/pull/12612) [#12777](https://github.com/vllm-project/vllm-ascend/pull/12777)
+- Fixed GLM-5.2 DSpark W8A8 eager acceptance. [#12262](https://github.com/vllm-project/vllm-ascend/pull/12262)
+- Fixed fused_infer_attention contiguous errors in MLA-CP and GQA paths. [#11986](https://github.com/vllm-project/vllm-ascend/pull/11986) [#12025](https://github.com/vllm-project/vllm-ascend/pull/12025)
+- Fixed DSA-CP invalid local sequence lengths for graph padding. [#12840](https://github.com/vllm-project/vllm-ascend/pull/12840)
+- Fixed invalid GVA handling in layerwise KV Pool. [#12705](https://github.com/vllm-project/vllm-ascend/pull/12705)
+- Fixed AllGather MoE finalize order with DP and PCP. [#11921](https://github.com/vllm-project/vllm-ascend/pull/11921)
+- Fixed batch invariance not taking effect. [#11818](https://github.com/vllm-project/vllm-ascend/pull/11818)
+- Fixed Qwen3.x KV cache binding for multiple layers. [#11470](https://github.com/vllm-project/vllm-ascend/pull/11470)
+- Fixed spec decode rejection sampling length-1 bug in Triton. [#11458](https://github.com/vllm-project/vllm-ascend/pull/11458)
+- Fixed CPU binding device mapping. [#15518](https://github.com/vllm-project/vllm-ascend/pull/15518)
+- Backported structured output fixes for vLLM 0.26. [#15433](https://github.com/vllm-project/vllm-ascend/pull/15433)
+- Invalidated dummy slots before attention metadata build. [#15409](https://github.com/vllm-project/vllm-ascend/pull/15409)
+- Skipped generate_mtp_attention_mask_for_decode with sparse attention to avoid hostbound. [#15130](https://github.com/vllm-project/vllm-ascend/pull/15130)
+- Selected DeepSeek V4 effort mapping by checkpoint config. [#14952](https://github.com/vllm-project/vllm-ascend/pull/14952)
+
+### Known Issues
+
+- Kimi K3 DSpark speculative decoding has a low draft acceptance rate for long input sequences, reducing the expected performance benefit. [#15237](https://github.com/vllm-project/vllm-ascend/issues/15237)
+- DeepSeek-V4-Flash may show a performance regression for 128K-input/1K-output workloads when pooling is enabled, especially for single-prefix requests. [#15649](https://github.com/vllm-project/vllm-ascend/issues/15649)
+- Qwen3-32B W8A8/QuaRot may show a small performance regression in PD-disaggregated or pooling-enabled scenarios on v0.26.0rc. [#15295](https://github.com/vllm-project/vllm-ascend/issues/15295)
+- DeepSeek-V3.1 may hang or fail during PD-disaggregated serving and high-concurrency PD-mixed inference. These scenarios are outside the supported export-model scope. [#14911](https://github.com/vllm-project/vllm-ascend/issues/14911)
+- Qwen3-235B-A22B W8A8 and Qwen3-235B W4A8 may show lower performance than the baseline in some A3 PD-mixed aclgraph scenarios. [#15296](https://github.com/vllm-project/vllm-ascend/issues/15296)
+- GLM5.1-W4A4C8-mxfp4 may show a performance regression on Ascend 950 due to CPU-binding and load-balancing effects. [#15268](https://github.com/vllm-project/vllm-ascend/issues/15268)
+- Qwen3.6-27B DFlash with mixed sliding-window and full attention requires the V2 model runner. [#15650](https://github.com/vllm-project/vllm-ascend/issues/15650)
+- DeepSeek-V3.2-W8A8 may show a partial performance regression in A3 single-node mixed deployment. [#15651](https://github.com/vllm-project/vllm-ascend/issues/15651)
+- DeepSeek-V4 sleep mode with `sleep_mode_extra_cleanup` may fail to recover after wakeup. Sleep mode is mainly intended for training scenarios. [#15648](https://github.com/vllm-project/vllm-ascend/issues/15648)
+- KV pooling may cause a small single-prefix performance regression in some long-context workloads, including DeepSeek-V4-Flash 128K-1K and Qwen3-32B A2 PD-mixed scenarios. Investigation is ongoing. [#15649](https://github.com/vllm-project/vllm-ascend/issues/15649) [#15295](https://github.com/vllm-project/vllm-ascend/issues/15295) [#12234](https://github.com/vllm-project/vllm-ascend/issues/12234)
+- MiniMax-M2.7 W8A8 shows a performance regression in the A3 single-node scenario. The 128K-input/1K-output double-node result also fell below the baseline threshold, but more samples are needed to determine whether it is a persistent regression or normal performance variation. [#15658](https://github.com/vllm-project/vllm-ascend/issues/15658)
+
 ## v0.23.0 - 2026.08.16
 
 We're excited to announce the official vLLM Ascend v0.23.0 release, aligned with upstream vLLM v0.23.0. This note summarizes the cumulative user-facing changes since the previous official release, v0.18.0, including the v0.19.1rc1, v0.20.2rc1, v0.21.0rc1, v0.22.1rc1, and v0.23.0rc1 development cycles. Please follow the [official documentation](https://docs.vllm.ai/projects/ascend/en/v0.23.0/) to get started.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -157,10 +157,10 @@ extra:
   rtd_version: !ENV [READTHEDOCS_VERSION, latest]
   docs_lang: !ENV [DOCS_LANG, en]
   # Version substitutions used by macros plugin
-  vllm_version: v0.23.0
-  vllm_ascend_version: v0.23.0
-  pip_vllm_ascend_version: v0.23.0
-  pip_vllm_version: v0.23.0
+  vllm_version: v0.26.0
+  vllm_ascend_version: v0.26.0rc1
+  pip_vllm_ascend_version: v0.26.0rc1
+  pip_vllm_version: v0.26.0
   cann_image_tag: 9.1.0-910b-ubuntu22.04-py3.12
   main_python_version: ">= 3.10, < 3.13"
   main_cann_version: "9.1.0"
@@ -206,6 +206,7 @@ nav:
         - tutorials/models/DeepSeek-V4-Pro.md
         - tutorials/models/DeepSeek-R1.md
         - tutorials/models/DeepSeekOCR2.md
+        - tutorials/models/Gemma4.md
         - tutorials/models/GLM4.x.md
         - tutorials/models/GLM5.md
         - tutorials/models/GLM5.2.md

--- a/tests/vllm_ascend_v0.26.0rc1_test_conclusion.md
+++ b/tests/vllm_ascend_v0.26.0rc1_test_conclusion.md
@@ -1,0 +1,76 @@
+# vLLM-Ascend V0.26.0RC1 Test Conclusion
+
+## 1. Model Validation
+
+Targeted validation was conducted on the following 4 models, which are the only models supported in this release:
+
+| Model | Quantization | Hardware / Deployment | Validation Scope |
+|-------|--------------|------------------------|------------------|
+| GLM-5.2 | w8a8c8 | A3, 4 nodes, large EP, 1P1D | Performance validation; GPQA accuracy validation |
+| Kimi K3 | w4a8 | A3, 8 nodes, large EP, 1P1D; Ascend 950, large EP, 4 nodes, 1P1D | Performance validation; GPQA and OCRBench accuracy validation |
+| DeepSeek-V4-Flash | w8a8c8 | A3, 4 nodes, large DP, 1P1D | Performance validation; GPQA accuracy validation |
+| DeepSeek-V4-Pro | w8a8c8 | A3, 2 nodes, large EP, 1P1D | Performance validation; GPQA accuracy validation |
+
+### Performance Scenarios
+
+| Scenario Type | Input Length | Output Length | Prefix Cache |
+|---------------|--------------|---------------|--------------|
+| Prefill-only (Pure P) | 16k | 1k | — |
+| Prefill-only (Pure P) | 128K | 1k | — |
+| Prefill-only (Pure P) | Variable 40K–80K | 2.5k | — |
+| Decode-only (Pure D) | 16k | 1k | — |
+| Decode-only (Pure D) | 128K | 1k | — |
+| Decode-only (Pure D) | Variable 40K–80K | 2.5k | — |
+| End-to-End | 16k | 1k | 0% |
+| End-to-End | 128K | 1K | 90% |
+| End-to-End | 1M | 1k | — |
+
+### Accuracy
+
+| Dataset | Model | Score |
+|---------|-------|-------|
+| GPQA | GLM-5.2 | 92.165 |
+| GPQA | Kimi K3 | 92.42 |
+| GPQA | DeepSeek-V4-Flash | 91.67 |
+| GPQA | DeepSeek-V4-Pro | 91.92 |
+| OCRBench | Kimi K3 | 0.88 |
+
+---
+
+## 2. Reliability Validation
+
+Small-scale online real-business validation was conducted on a subset of models, each running for more than 3 days:
+
+| No. | Model | Validation Method | Running Duration |
+|-----|-------|-------------------|------------------|
+| 1 | Qwen3.5-122B | Online real-business validation (small scale) | More than 3 days |
+| 2 | Qwen3.6-35B | Online real-business validation (small scale) | More than 3 days |
+| 3 | Qwen3.5-397B | Online real-business validation (small scale) | More than 3 days |
+| 4 | DeepSeek-V4-Flash | Online real-business validation (small scale) | More than 3 days |
+| 5 | GLM-5.2 | Online real-business validation (small scale) | More than 3 days |
+| 6 | Kimi K3 | Online real-business validation (small scale) | More than 3 days |
+
+## 3. Known Issues
+
+Some issues found during validation remain unresolved in this release. The table below is compiled from the release known-issues list; the community-side records are also available in the Known Issues section of the version [release note](../docs/source/user_guide/release_notes.md).
+
+| No. | Issue | Description | Impact |
+|-----|-------|-------------|--------|
+| 1 | [#15237](https://github.com/vllm-project/vllm-ascend/issues/15237) | Kimi K3 128k-1k case performance below expectations: DSpark weights are weak, with generally low acceptance rate | Performance only: the DSpark draft acceptance rate is very low for long inputs (~20K–40K tokens), so speculative decoding provides no effective benefit; fix planned in v0.27 |
+| 2 | [#15649](https://github.com/vllm-project/vllm-ascend/issues/15649) | DSV4-Flash with pooling enabled: 128k-1k, prefix 90 scenario shows performance regression vs. no pooling (>10%, pool misses) | After enabling pooling, the 128K-1K case shows lower performance than without pooling — a single-prefix regression (>10%); no confirmed root cause or workaround yet; improvement planned for a future Q3 release |
+| 3 | [#15649](https://github.com/vllm-project/vllm-ascend/issues/15649) | Qwen3-32B w8a8 A2 PD co-location pooling test: TPS 2313 with pooling vs. 2443 without, >3% regression (measured >5%) | Same pooling single-prefix regression: TPS drops from 2443 to 2313 (~5.3%) with pooling enabled; planned for a future Q3 release |
+| 4 | [#15648](https://github.com/vllm-project/vllm-ascend/issues/15648) | DeepSeek-V4 with sleep_mode_extra_cleanup enabled: service fails to start after sleep then wakeup | After the sleep/wakeup sequence with `sleep_mode_extra_cleanup` enabled, the service fails to start or serve requests; sleep mode is mainly intended for training scenarios; upstream fix planned for v0.27 |
+| 5 | [#14911](https://github.com/vllm-project/vllm-ascend/issues/14911) | PD disaggregation: DeepSeek-V3.1_w8a8 service starts, then the D node hangs on inference | DeepSeek-V3.1 is being sunset per the model sunsetting process; only the four export models are supported in this release (see release note); retest ongoing on main |
+| 6 | [#14911](https://github.com/vllm-project/vllm-ascend/issues/14911) | DeepSeek-V3.1-w4a8 PD co-location: multi-concurrency inference causes service hang | model being sunset, outside the supported export-model scope; retest ongoing on main |
+| 7 | [#15678](https://github.com/vllm-project/vllm-ascend/issues/15678) | A3 dual-node co-located GLM-5.2-W4A8C8: server-side error on inference after service start | The service starts successfully, but inference requests fail on the server side in the A3 double-node co-located scenario; this model/weight is sunset and outside the supported export-model scope |
+| 8 | [#15677](https://github.com/vllm-project/vllm-ascend/issues/15677) | PD disaggregation: DeepSeek-V3.1 layerwise gain below target in 64K+1k (expected 2%) | The measured layerwise gain is below the expected 2% target in the 64K-1K case; the layerwise RP3 path is intended for KV-offload use only and is not a standalone export feature — recorded as a feature-scope limitation rather than a general model performance regression |
+| 9 | [#15296](https://github.com/vllm-project/vllm-ascend/issues/15296) | Qwen3-235B-A22B-w8a8 PD co-location, A3 single-node graph mode aclgraph_32768_4096_TPOT50ms performance regression (W8A8 ~10%) | Some PD separation/disaggregation tests show lower accuracy or performance than the baseline (W8A8 ~10% regression); tracked in the follow-up sunset plan |
+| 10 | [#15296](https://github.com/vllm-project/vllm-ascend/issues/15296) | Qwen3-235B W4A8 quantization, 800IA3 PD co-location aclgraph performance regression (W4A8 ~4%) |lower performance than baseline in PD tests (W4A8 ~4%); tracked in the follow-up sunset plan |
+| 11 | [#14911](https://github.com/vllm-project/vllm-ascend/issues/14911) | A3 single-node DeepSeek-V3.1-w8a8: server-side error on inference after service start | Model being sunset, outside the supported export-model scope; retest ongoing on main |
+| 12 | [#15268](https://github.com/vllm-project/vllm-ascend/issues/15268) | Ascend 950 GLM-5.1-W4A4C8 dual-node co-located performance regression of 40% (baseline 133.85, measured 84.91/77.16/76.75) | Load imbalance across Ascend 950 cards after vLLM v0.24.0: uneven card execution speed, uneven work distribution, some cards hostbound; short-term workaround via msboost (not independently verified) |
+| 13 | [#15296](https://github.com/vllm-project/vllm-ascend/issues/15296) | Qwen3-32B-QuaRot v0.26.0rc performance regression | Performance regression caused by the aclnnscatterpakvcache operator (reshape_and_cache switched to scatter_nd_update) plus CPU-binding impact; not an export model; planned for 0.27 |
+| 14 | [#15650](https://github.com/vllm-project/vllm-ascend/issues/15650) | Ascend 950 Qwen3.6-27B with d-flash: service start fails with NotImplementedError (DFlash drafters require the V2 model runner) | DFlash drafters with mixed sliding/full attention require the V2 model runner: `NotImplementedError: ... relaunch with VLLM_USE_V2_MODEL_RUNNER=1`; documented workaround is relaunching with `VLLM_USE_V2_MODEL_RUNNER=1`; support expected in 0.27/0.28 |
+| 15 | [#15268](https://github.com/vllm-project/vllm-ascend/issues/15268) | Ascend 950 GLM-5.1-W4A4C8 co-located service start hangs then errors (NPUEvent 507034) | C16 combined with dsa_cp hangs on Ascend 950; root cause still under investigation (suspected impact of the new operator package in the Ascend 950 image); not an export model |
+| 16 | [#14911](https://github.com/vllm-project/vllm-ascend/issues/14911) | A3 four-node DeepSeek_V3.1T_MTP1_PD: D node hangs on inference (AclrtSynchronizeStreamWithTimeout 507001) | Model being sunset, outside the supported export-model scope; retest ongoing on main |
+| 17 | [#15651](https://github.com/vllm-project/vllm-ascend/issues/15651) | A3 DeepSeek-V3.2-w8a8 single-node co-located case: partial performance regression | Partial performance regression vs. the baseline in the A3 single-node mixed deployment scenario; CPU binding identified as one possible contributor, an operator issue cannot be ruled out; not an export model; 0.27 expected to include improvements |
+| 18 | [#15658](https://github.com/vllm-project/vllm-ascend/issues/15658) | Minimax_m2.7_w8a8_A3 main-branch nightly smoke performance regression | Single-node W8A8 case shows a clear regression below the 3% thresholds (3609.53 < 4302.74; 1836.65 < 2162.26); the double-node case (669.56 < 698.50) may be variation — more samples needed; not an export model; planned for 0.27 |


### PR DESCRIPTION
### What this PR does / why we need it?

This pull request prepares the `v0.26.0rc1` release candidate for the vLLM Ascend plugin, aligning it with upstream vLLM `v0.26.0`. 
It updates version references across the documentation, READMEs, and configuration files, and adds the comprehensive release notes for `v0.26.0rc1`.

Related release tracking:

- Feedback: https://github.com/vllm-project/vllm-ascend/issues/14766
- Checklist: https://github.com/vllm-project/vllm-ascend/issues/14767

### Does this PR introduce _any_ user-facing change?

Yes. It updates the published documentation and release notes for the `v0.26.0rc1` release candidate.

### How was this patch tested?


- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
