### PR TITLE
[CI][v0.26.0rc] add cann-950-ops-transformer.run package for A5 image

### DIFF
--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -32,6 +32,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 WORKDIR /workspace
 
+# Note: Install CANN 950 Ops Transformer Package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") ARCH="aarch64" ;; \
+        "linux/amd64"|"x86_64") ARCH="x86_64" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    CANN_OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/9.2.beta2/cann-950-ops-transformer_9.2.0-beta.2_linux-${ARCH}.run" && \
+    wget --quiet ${CANN_OPS_TRANSFORMER_URL} -O /tmp/cann-950-ops-transformer.run && \
+    chmod +x /tmp/cann-950-ops-transformer.run && \
+    /tmp/cann-950-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-950-ops-transformer.run
+
 # Install clang-15 (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1
 RUN if [ -n "$APTMIRROR" ]; then \

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -31,6 +31,19 @@ ARG PIP_TRUSTED_HOST=""
 WORKDIR /workspace
 
 SHELL ["/bin/bash", "-c"]
+# Note: Install CANN 950 Ops Transformer Package
+ARG TARGETPLATFORM
+RUN ARCH=${TARGETPLATFORM:-$(uname -m)}; \
+    case "$ARCH" in \
+        "linux/arm64"|"aarch64") ARCH="aarch64" ;; \
+        "linux/amd64"|"x86_64") ARCH="x86_64" ;; \
+        *) echo "Skipping unsupported architecture: $ARCH" && exit 0 ;; \
+    esac && \
+    CANN_OPS_TRANSFORMER_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/CANN/9.2.beta2/cann-950-ops-transformer_9.2.0-beta.2_linux-${ARCH}.run" && \
+    wget --quiet ${CANN_OPS_TRANSFORMER_URL} -O /tmp/cann-950-ops-transformer.run && \
+    chmod +x /tmp/cann-950-ops-transformer.run && \
+    /tmp/cann-950-ops-transformer.run --full --quiet --install-for-all && \
+    rm -f /tmp/cann-950-ops-transformer.run
 
 # Install clang (for triton-ascend) and Mooncake
 ARG MOONCAKE_TAG=0.3.11.post1


### PR DESCRIPTION
### What this PR does / why we need it?
Add cann-950-ops-transformer.run package to both X86 and ARM64/A5 Docker images to ensure consistent operator transformation capabilities across all supported architectures.
### Does this PR introduce _any_ user-facing change?
No. This change only affects the internal build process for the X86 and ARM64/A5 Docker images. No user-facing functionality or interfaces are modified.

### How was this patch tested?
Verified that both the X86 and ARM64/A5 Docker images build successfully with the cann-950-ops-transformer.run package included
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
