### PR TITLE
[Feature][Model] Support reduced-layer Kimi K3 debug runs

### DIFF
--- a/tests/ut/models/test_kimi_k3_adapter.py
+++ b/tests/ut/models/test_kimi_k3_adapter.py
@@ -4,18 +4,52 @@
 from types import MethodType, SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 import torch
 from safetensors.torch import save_file
 from torch import nn
 
 from vllm_ascend.models import kimi_k3
 from vllm_ascend.models.kimi_k3 import (
+    AscendKimiLinearForCausalLM,
     AscendKimiK3MultiModalProjector,
     AscendKimiLinearModel,
 )
 from vllm_ascend.models.kimi_k3_dspark import (
     AscendK3DSparkForCausalLM,
 )
+
+
+@pytest.mark.parametrize(
+    ("configured_value", "expected"),
+    [("0", 8), ("1", 1), ("8", 8)],
+)
+def test_kimi_num_loaded_layers(monkeypatch, configured_value, expected):
+    monkeypatch.setenv("VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS", configured_value)
+
+    assert kimi_k3._get_kimi_k3_num_loaded_layers(8) == expected
+
+
+@pytest.mark.parametrize("configured_value", ["-1", "9", "not-an-integer"])
+def test_kimi_num_loaded_layers_rejects_invalid_values(monkeypatch, configured_value):
+    monkeypatch.setenv("VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS", configured_value)
+
+    with pytest.raises(ValueError, match="VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS"):
+        kimi_k3._get_kimi_k3_num_loaded_layers(8)
+
+
+@pytest.mark.parametrize(
+    ("weight_name", "expected"),
+    [
+        ("layers.0.self_attn.q_proj.weight", 0),
+        ("model.layers.12.mlp.down_proj.weight", 12),
+        ("language_model.model.layers.3.router.weight", 3),
+        ("model.embed_tokens.weight", None),
+        ("model.layers.invalid.weight", None),
+    ],
+)
+def test_kimi_decoder_layer_idx_from_weight_name(weight_name, expected):
+    assert kimi_k3._get_decoder_layer_idx_from_weight_name(weight_name) == expected
 
 
 def test_ascend_attn_res_matches_canonical_k3_math():
@@ -67,6 +101,7 @@ def test_k3_dspark_reports_draft_attention_causality():
 def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):
     model = AscendKimiLinearModel.__new__(AscendKimiLinearModel)
     nn.Module.__init__(model)
+    model.num_loaded_layers = 1
     layer = nn.Module()
     layer.self_attn = nn.Module()
     layer.self_attn.in_proj_gfab = nn.Module()
@@ -88,6 +123,7 @@ def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):
     )
     source_weights = [
         ("layers.0.router.weight", torch.full((1, 4), 0.5)),
+        ("layers.1.router.weight", torch.full((1, 4), 9.0)),
         ("layers.0.self_attn.g_proj.weight", torch.full((1,), 1.0)),
         ("layers.0.self_attn.f_a_proj.weight", torch.full((1,), 2.0)),
         ("layers.0.self_attn.b_proj.weight", torch.full((1,), 3.0)),
@@ -98,6 +134,7 @@ def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):
 
     assert remaining[0] == source_weights[0]
     assert remaining[-1] == source_weights[-1]
+    assert all(name != "layers.1.router.weight" for name, *_ in remaining)
     assert [name for name, _, _ in remaining[1:4]] == [
         "layers.0.self_attn.in_proj_gfab.weight",
     ] * 3
@@ -108,6 +145,35 @@ def test_kimi_mixed_kda_gate_weights_use_upstream_packed_loader(monkeypatch):
         "layers.0.router.weight",
         "layers.0.self_attn.o_proj.weight",
     }
+
+
+def test_reduced_kimi_remaps_materialized_dspark_aux_layers(monkeypatch):
+    model = AscendKimiLinearForCausalLM.__new__(AscendKimiLinearForCausalLM)
+    captured_layers = []
+    model.model = SimpleNamespace(
+        num_loaded_layers=2,
+        config=SimpleNamespace(num_hidden_layers=4),
+        aux_hidden_state_layers=(1, 3),
+        _set_aux_hidden_state_layers=lambda layers: captured_layers.append(layers),
+    )
+    monkeypatch.setattr(kimi_k3.logger, "warning_once", lambda *_args: None)
+
+    model.set_dspark_aux_capture_materialized(True)
+
+    assert model.model.dspark_aux_capture_materialized is True
+    assert captured_layers == [(0, 1)]
+
+
+def test_reduced_kimi_rejects_too_many_materialized_dspark_aux_layers():
+    model = AscendKimiLinearForCausalLM.__new__(AscendKimiLinearForCausalLM)
+    model.model = SimpleNamespace(
+        num_loaded_layers=1,
+        config=SimpleNamespace(num_hidden_layers=4),
+        aux_hidden_state_layers=(0, 1),
+    )
+
+    with pytest.raises(ValueError, match="cannot provide 2 distinct DSpark"):
+        model.set_dspark_aux_capture_materialized(True)
 
 
 def test_kimi_attention_residual_stays_sequence_sharded(monkeypatch):

--- a/vllm_ascend/envs.py
+++ b/vllm_ascend/envs.py
@@ -71,6 +71,12 @@ env_variables: dict[str, Callable[[], Any]] = {
     # Control the aclrtMemcpyBatchAsync compile path for KV cache offloading.
     # "1": force enable, "0": force disable, None: auto-detect from CANN headers.
     "VLLM_ASCEND_ENABLE_BATCH_MEMCPY": lambda: os.getenv("VLLM_ASCEND_ENABLE_BATCH_MEMCPY", None),
+    # Number of Kimi K3 decoder layers to instantiate and load for debugging.
+    # 0 (the default) loads the complete model; valid values are 0 through the
+    # model's configured number of decoder layers. This variable is not sensitive.
+    "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS": lambda: os.getenv(
+        "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS", "0"
+    ),
 }
 
 # end-env-vars-definition

--- a/vllm_ascend/models/kimi_k3.py
+++ b/vllm_ascend/models/kimi_k3.py
@@ -19,6 +19,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
 )
 from vllm.forward_context import get_forward_context, is_forward_context_available
+from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe import FusedMoEFactory
 from vllm.model_executor.layers.fused_moe.router.gate_linear import GateLinear
 from vllm.model_executor.layers.layernorm import RMSNorm
@@ -78,8 +79,11 @@ from vllm.sequence import IntermediateTensors
 from vllm.triton_utils import HAS_TRITON
 from vllm.utils.math_utils import cdiv
 
+from vllm_ascend import envs as envs_ascend
 from vllm_ascend.models.llama_eagle3 import get_rotation_path
 from vllm_ascend.ops.kimi_kda import AscendKimiK3DeltaAttention  # type: ignore[import-untyped]
+
+logger = init_logger(__name__)
 
 if HAS_TRITON:
     from vllm_ascend.ops.triton.kimi_k3.attention_residual import (  # type: ignore[import-untyped]
@@ -87,6 +91,41 @@ if HAS_TRITON:
     )
 else:
     apply_attn_res = None  # type: ignore[assignment]
+
+
+def _get_kimi_k3_num_loaded_layers(total_num_layers: int) -> int:
+    """Return the requested Kimi K3 decoder-layer count for debug loading."""
+    requested_num_layers_raw = envs_ascend.VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS
+    try:
+        requested_num_layers = int(requested_num_layers_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS must be an integer in "
+            f"[0, {total_num_layers}], got {requested_num_layers_raw!r}"
+        ) from exc
+    if requested_num_layers == 0:
+        return total_num_layers
+    if not 1 <= requested_num_layers <= total_num_layers:
+        raise ValueError(
+            "VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS must be in "
+            f"[0, {total_num_layers}], got {requested_num_layers}"
+        )
+    return requested_num_layers
+
+
+def _get_decoder_layer_idx_from_weight_name(weight_name: str) -> int | None:
+    """Extract a Kimi K3 decoder-layer index from an inner or VL checkpoint key."""
+    layer_prefix = "layers."
+    prefix_idx = weight_name.find(layer_prefix)
+    if prefix_idx < 0:
+        return None
+
+    layer_idx_start = prefix_idx + len(layer_prefix)
+    layer_idx_end = weight_name.find(".", layer_idx_start)
+    if layer_idx_end < 0:
+        return None
+    layer_idx_text = weight_name[layer_idx_start:layer_idx_end]
+    return int(layer_idx_text) if layer_idx_text.isdecimal() else None
 
 
 def _apply_ascend_attn_res(
@@ -535,6 +574,15 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         config = vllm_config.model_config.hf_text_config
         self.config = config
         self.vocab_size = config.vocab_size
+        self.num_loaded_layers = _get_kimi_k3_num_loaded_layers(config.num_hidden_layers)
+        if self.num_loaded_layers != config.num_hidden_layers:
+            logger.warning_once(
+                "Kimi K3 layer-reduced debug mode is enabled: loading and "
+                "executing decoder layers [0, %d) out of %d. Generated "
+                "results are not model-quality valid.",
+                self.num_loaded_layers,
+                config.num_hidden_layers,
+            )
         parallel_config = vllm_config.parallel_config
         # vLLM's generic MoE SP switch currently requires DP > 1. K3 also
         # needs the same rank-local token layout for the TP/EP, DP=1 topology
@@ -563,7 +611,7 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
             )
 
         self.start_layer, self.end_layer, self.layers = make_layers(
-            config.num_hidden_layers,
+            self.num_loaded_layers,
             get_layer,
             prefix=f"{prefix}.layers",
         )
@@ -603,6 +651,9 @@ class AscendKimiLinearModel(UpstreamKimiLinearModel):
         def remap_mixed_gate_weights():
             for args in weights:
                 name, loaded_weight = args[:2]
+                layer_idx = _get_decoder_layer_idx_from_weight_name(name)
+                if layer_idx is not None and layer_idx >= self.num_loaded_layers:
+                    continue
                 for source, target, shard_id in gate_mapping:
                     if source not in name:
                         continue
@@ -770,6 +821,49 @@ class AscendKimiLinearForCausalLM(UpstreamKimiLinearForCausalLM):
 
     def set_dspark_aux_capture_materialized(self, enabled: bool) -> None:
         self.model.dspark_aux_capture_materialized = enabled
+        if not enabled:
+            return
+
+        num_loaded_layers = self.model.num_loaded_layers
+        total_num_layers = self.model.config.num_hidden_layers
+        if num_loaded_layers == total_num_layers:
+            return
+
+        aux_layers = tuple(self.model.aux_hidden_state_layers)
+        if not aux_layers:
+            return
+        if len(aux_layers) > num_loaded_layers:
+            raise ValueError(
+                "Kimi K3 layer-reduced debug mode cannot provide "
+                f"{len(aux_layers)} distinct DSpark auxiliary hidden states "
+                f"from only {num_loaded_layers} loaded decoder layers."
+            )
+
+        # Qwen3 GQA DSpark consumes materialized inputs from several target
+        # layers. Preserve the number and ordering of those features in the
+        # layer-reduced debug model by projecting their relative positions
+        # onto the loaded prefix. This is only a functional-debug fallback:
+        # the remapped features are not quality-equivalent to the trained
+        # full-model target layers.
+        max_loaded_idx = num_loaded_layers - 1
+        max_full_idx = total_num_layers - 1
+        remapped_layers: list[int] = []
+        for idx, layer_idx in enumerate(aux_layers):
+            remaining = len(aux_layers) - idx - 1
+            lower_bound = remapped_layers[-1] + 1 if remapped_layers else 0
+            upper_bound = max_loaded_idx - remaining
+            scaled_idx = round(layer_idx * max_loaded_idx / max_full_idx)
+            remapped_layers.append(min(max(scaled_idx, lower_bound), upper_bound))
+
+        remapped_aux_layers = tuple(remapped_layers)
+        self.model._set_aux_hidden_state_layers(remapped_aux_layers)
+        logger.warning_once(
+            "Kimi K3 layer-reduced debug mode remapped Qwen3 GQA DSpark "
+            "auxiliary capture layers from %s to %s. Generated results are "
+            "not model-quality valid.",
+            aux_layers,
+            remapped_aux_layers,
+        )
 
 
 class AscendKimiK3MultiModalProjector(KimiK25MultiModalProjector):


### PR DESCRIPTION
### What this PR does / why we need it?

This PR adds an opt-in reduced-layer debug mode for Kimi K3 on top of the Kimi K3 support already merged in #14454.

It allows storage-constrained functional bring-up to:

- instantiate only the first N decoder layers;
- skip checkpoint tensors for unloaded decoder layers;
- validate the configured layer count and keep `0` as the unchanged full-model default;
- initialize the warning logger used by reduced-layer mode;
- remap materialized Qwen3 GQA DSpark auxiliary capture layers into the loaded prefix while preserving their count and order;
- clearly warn that reduced-layer generations are not valid for accuracy evaluation.

The four-node P/D deployment used `VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS=10`, DP2, TP16 and DSpark with seven speculative tokens. The reduced-layer and DSpark auxiliary-layer paths completed model/service bring-up. Later DSpark request-local metadata and experimental Mamba/Mooncake failures are separate issues and are intentionally excluded from this PR.

### Does this PR introduce _any_ user-facing change?

Yes, but it is fully opt-in. The default value `0` keeps full-model loading unchanged.

```bash
export VLLM_ASCEND_KIMI_K3_MAX_LOADED_LAYERS=10
```

Reduced-layer output is for functional debugging only and must not be used for semantic accuracy or full-model parity claims.

### How was this patch tested?

Per request, pytest and NPU tests were not run for this PR update.

Completed checks:

- rebased the change onto upstream main `a1affe4d3218f292c2c79c6d7666877efe526cbb`;
- `git diff --check` passed;
- Python syntax compilation passed for the three changed files;
- reviewed the final scope: 3 files, one signed-off commit;
- compared the implementation with the four-node reduced-layer deployment on P 102/105 and D 120/104.

Runtime evidence is limited to functional service bring-up. No GPQA accuracy, performance, or full-model parity claim is made.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
