### PR TITLE
[CI] Align daily build OS with release, add selective CANN chip builds, disable triton-ascend by default for daily, and upgrade default CANN version

### DIFF
--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -42,7 +42,7 @@ on:
       cann_version:
         required: false
         type: string
-        default: '2026.08.03'
+        default: '9.1.0_20260731131545'
         description: "CANN version for base image tag"
       base_image_date:
         required: false

--- a/.github/workflows/_schedule_image_build.yaml
+++ b/.github/workflows/_schedule_image_build.yaml
@@ -91,7 +91,7 @@ on:
         description: 'Memcache date'
         required: false
         type: string
-        default: '20260725.3'
+        default: '20260811.14'
       memfabric_version:
         description: 'Memfabric version'
         required: false
@@ -101,7 +101,7 @@ on:
         description: 'Memfabric date'
         required: false
         type: string
-        default: '20260725.3'
+        default: '20260811.7'
       torch_npu_version:
         description: 'Torch NPU version'
         required: false
@@ -111,7 +111,7 @@ on:
         description: 'Torch NPU date'
         required: false
         type: string
-        default: '20260715.4'
+        default: '20260725.3'
       cann_quay_url:
         description: 'CANN Quay URL'
         required: false
@@ -121,7 +121,7 @@ on:
         description: 'CANN version'
         required: false
         type: string
-        default: '2026.08.03'
+        default: '9.1.0_20260731131545'
       triton_ascend_version:
         description: 'Triton Ascend version'
         required: false
@@ -340,11 +340,11 @@ jobs:
           VLLM_COMMIT=${{ inputs.vllm_commit }}
           BUILD_TYPE=${{ inputs.build_type || 'release' }}
           MEMCACHE_VERSION=${{ inputs.memcache_version || '1.2.0' }}
-          MEMCACHE_DATE=${{ inputs.memcache_date || '20260725.3' }}
+          MEMCACHE_DATE=${{ inputs.memcache_date || '20260811.14' }}
           MEMFABRIC_VERSION=${{ inputs.memfabric_version || '1.2.0' }}
-          MEMFABRIC_DATE=${{ inputs.memfabric_date || '20260725.3' }}
+          MEMFABRIC_DATE=${{ inputs.memfabric_date || '20260811.7' }}
           TORCH_NPU_VERSION=${{ inputs.torch_npu_version || '26.1.0' }}
-          TORCH_NPU_DATE=${{ inputs.torch_npu_date || '20260715.4' }}
+          TORCH_NPU_DATE=${{ inputs.torch_npu_date || '20260725.3' }}
           TRITON_ASCEND_VERSION=${{ inputs.triton_ascend_version || '' }}
           TRITON_ASCEND_PACKAGE_VERSION=${{ inputs.triton_ascend_package_version || '3.2.2' }}
           ${{ inputs.build_args }}

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -47,11 +47,17 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
+        type: string
+      chips:
+        description: 'Chips to build (JSON array: ["a2","a3","310p","a5"]). Default builds all.'
+        required: false
+        default: '["a2","a3","310p","a5"]'
         type: string
 
 jobs:
   build-a2:
+    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a2') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a2
@@ -69,6 +75,7 @@ jobs:
       QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   build-a3:
+    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a3') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a3
@@ -86,6 +93,7 @@ jobs:
       QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   build-310p:
+    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), '310p') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: 310p
@@ -102,6 +110,7 @@ jobs:
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
       QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
   build-a5:
+    if: ${{ contains(fromJSON(inputs.chips || '["a2","a3","310p","a5"]'), 'a5') }}
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a5

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: Filter build matrix by chips
         id: filter
         run: |
-          CHIPS='${{ inputs.chips }}'
+          CHIPS='${{ inputs.chips || '["a2","a3","310p","a5"]' }}'
           ALL_MATRIX=$(jq -nc '[
             {name: "A2 Ubuntu",      dockerfile: "Dockerfile",              suffix: "",               chip: "a2"},
             {name: "A3 Ubuntu",      dockerfile: "Dockerfile.a3",            suffix: "a3",             chip: "a3"},

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -69,20 +69,15 @@ on:
         options:
           - release
           - daily
-      memcache:
-        description: 'Memcache version and date (JSON array: ["version", "date"])'
+      mem_deps:
+        description: 'Memcache and Memfabric versions (JSON object: {"memcache":["date","version"],"memfabric":["date","version"]})'
         required: false
-        default: '["1.2.0", "20260811.14"]'
-        type: string
-      memfabric:
-        description: 'Memfabric version and date (JSON array: ["version", "date"])'
-        required: false
-        default: '["1.2.0", "20260811.7"]'
+        default: '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}'
         type: string
       torch_npu:
-        description: 'Torch NPU version and date (JSON array: ["version", "date"])'
+        description: 'Torch NPU version and date (JSON array: ["date", "version"])'
         required: false
-        default: '["26.1.0", "20260725.3"]'
+        default: '["20260725.3", "26.1.0"]'
         type: string
       cann:
         description: 'CANN Quay URL and version (JSON array: ["url", "version"])'
@@ -158,12 +153,12 @@ jobs:
       
       build_args: |
         BUILD_TYPE=${{ inputs.build_type || 'release' }}
-        MEMCACHE_VERSION=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[0] }}
-        MEMCACHE_DATE=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[1] }}
-        MEMFABRIC_VERSION=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[0] }}
-        MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[1] }}
-        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[0] }}
-        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[1] }}
+        MEMCACHE_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[1] }}
+        MEMCACHE_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[0] }}
+        MEMFABRIC_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[1] }}
+        MEMFABRIC_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[0] }}
+        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[1] }}
+        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[0] }}
         ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[0]) || '' }}
         ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
         TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
@@ -205,12 +200,12 @@ jobs:
 
       build_args: |
         BUILD_TYPE=${{ inputs.build_type || 'release' }}
-        MEMCACHE_VERSION=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[0] }}
-        MEMCACHE_DATE=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[1] }}
-        MEMFABRIC_VERSION=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[0] }}
-        MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[1] }}
-        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[0] }}
-        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[1] }}
+        MEMCACHE_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[1] }}
+        MEMCACHE_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memcache[0] }}
+        MEMFABRIC_VERSION=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[1] }}
+        MEMFABRIC_DATE=${{ fromJSON(inputs.mem_deps || '{"memcache":["20260811.14","1.2.0"],"memfabric":["20260811.7","1.2.0"]}').memfabric[0] }}
+        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[1] }}
+        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["20260725.3", "26.1.0"]')[0] }}
         ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[0]) || '' }}
         ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
         TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}

--- a/.github/workflows/schedule_image_build_and_push.yaml
+++ b/.github/workflows/schedule_image_build_and_push.yaml
@@ -72,27 +72,32 @@ on:
       memcache:
         description: 'Memcache version and date (JSON array: ["version", "date"])'
         required: false
-        default: '["1.2.0", "20260725.3"]'
+        default: '["1.2.0", "20260811.14"]'
         type: string
       memfabric:
         description: 'Memfabric version and date (JSON array: ["version", "date"])'
         required: false
-        default: '["1.2.0", "20260725.3"]'
+        default: '["1.2.0", "20260811.7"]'
         type: string
       torch_npu:
         description: 'Torch NPU version and date (JSON array: ["version", "date"])'
         required: false
-        default: '["26.1.0", "20260715.4"]'
+        default: '["26.1.0", "20260725.3"]'
         type: string
       cann:
         description: 'CANN Quay URL and version (JSON array: ["url", "version"])'
         required: false
-        default: '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "2026.08.03"]'
+        default: '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]'
         type: string
       triton_ascend:
         description: 'Triton Ascend version and package version (JSON array: ["version", "package_version"])'
         required: false
         default: '["", "3.2.2"]'
+        type: string
+      chips:
+        description: 'Chips to build (JSON array: ["a2","a3","310p","a5"]). Default builds all.'
+        required: false
+        default: '["a2","a3","310p","a5"]'
         type: string
 
 permissions:
@@ -100,39 +105,38 @@ permissions:
   contents: read
 
 jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      build_meta: ${{ steps.filter.outputs.build_meta }}
+    steps:
+      - name: Filter build matrix by chips
+        id: filter
+        run: |
+          CHIPS='${{ inputs.chips }}'
+          ALL_MATRIX=$(jq -nc '[
+            {name: "A2 Ubuntu",      dockerfile: "Dockerfile",              suffix: "",               chip: "a2"},
+            {name: "A3 Ubuntu",      dockerfile: "Dockerfile.a3",            suffix: "a3",             chip: "a3"},
+            {name: "310P Ubuntu",    dockerfile: "Dockerfile.310p",          suffix: "310p",           chip: "310p"},
+            {name: "A5 Ubuntu",      dockerfile: "Dockerfile.a5",            suffix: "a5",             chip: "a5"},
+            {name: "A2 openeuler",   dockerfile: "Dockerfile.openEuler",     suffix: "openeuler",      chip: "a2"},
+            {name: "A3 openEuler",   dockerfile: "Dockerfile.a3.openEuler",  suffix: "a3-openeuler",   chip: "a3"},
+            {name: "310P openEuler", dockerfile: "Dockerfile.310p.openEuler",suffix: "310p-openeuler",  chip: "310p"},
+            {name: "A5 openEuler",   dockerfile: "Dockerfile.a5.openEuler",  suffix: "a5-openeuler",   chip: "a5"}
+          ]')
+          FILTERED=$(echo "$ALL_MATRIX" | jq -c --argjson chips "$CHIPS" '[.[] | select(.chip as $c | $chips | index($c))]')
+          echo "build_meta=$FILTERED" >> $GITHUB_OUTPUT
+
   image_build:
     name: ${{ matrix.build_meta.name }}
+    needs: setup-matrix
     if: ${{ !((github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'image-build')))
         && !(github.event_name == 'workflow_dispatch' && inputs.vllm_commit != '' && inputs.vllm_ascend_commit != '') }}
     strategy:
       fail-fast: false
       max-parallel: 4
       matrix:
-        build_meta:
-          - name: A2 Ubuntu
-            dockerfile: Dockerfile
-            suffix: ''        
-          - name: A3 Ubuntu
-            dockerfile: Dockerfile.a3
-            suffix: 'a3'
-          - name: 310P Ubuntu
-            dockerfile: Dockerfile.310p
-            suffix: '310p'
-          - name: A5 Ubuntu
-            dockerfile: Dockerfile.a5
-            suffix: 'a5'
-          - name: A2 openeuler
-            dockerfile: Dockerfile.openEuler
-            suffix: 'openeuler'
-          - name: A3 openEuler
-            dockerfile: Dockerfile.a3.openEuler
-            suffix: 'a3-openeuler'        
-          - name: 310P openEuler
-            dockerfile: Dockerfile.310p.openEuler
-            suffix: '310p-openeuler'
-          - name: A5 openEuler
-            dockerfile: Dockerfile.a5.openEuler
-            suffix: 'a5-openeuler'
+        build_meta: ${{ fromJSON(needs.setup-matrix.outputs.build_meta) }}
     uses: ./.github/workflows/_schedule_image_build.yaml
     with:
       dockerfile: ${{ matrix.build_meta.dockerfile }}
@@ -150,19 +154,18 @@ jobs:
       branch_ref: ${{ inputs.branch != 'none' && inputs.branch || '' }}
       schedule_tag_pattern: 'main'
       build_type: ${{ inputs.build_type || 'release' }}
-      cann_version: ${{ fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1] }}
+      cann_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1] }}
       
       build_args: |
         BUILD_TYPE=${{ inputs.build_type || 'release' }}
-        ${{ inputs.build_type == 'daily' && format('BASE_OS={0}', contains(matrix.build_meta.suffix, 'openeuler') && 'openeuler24.03-lts-sp4' || 'ubuntu24.04') || '' }}
-        MEMCACHE_VERSION=${{ fromJSON(inputs.memcache || '["1.2.0", "20260725.3"]')[0] }}
-        MEMCACHE_DATE=${{ fromJSON(inputs.memcache || '["1.2.0", "20260725.3"]')[1] }}
-        MEMFABRIC_VERSION=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260725.3"]')[0] }}
-        MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260725.3"]')[1] }}
-        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[0] }}
-        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[1] }}
-        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[0]) || '' }}
-        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1]) || '' }}
+        MEMCACHE_VERSION=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[0] }}
+        MEMCACHE_DATE=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[1] }}
+        MEMFABRIC_VERSION=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[0] }}
+        MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[1] }}
+        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[0] }}
+        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[1] }}
+        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[0]) || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
         TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
         TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
       
@@ -174,6 +177,7 @@ jobs:
 
   image_build_by_commit:
     name: ${{ matrix.build_meta.name }} (commit mode)
+    needs: setup-matrix
     if: ${{ github.event_name == 'workflow_dispatch'
         && inputs.vllm_commit != ''
         && inputs.vllm_ascend_commit != ''
@@ -183,31 +187,7 @@ jobs:
       fail-fast: false
       max-parallel: 4
       matrix:
-        build_meta:
-          - name: A2 Ubuntu
-            dockerfile: Dockerfile
-            suffix: ''        
-          - name: A3 Ubuntu
-            dockerfile: Dockerfile.a3
-            suffix: 'a3'
-          - name: 310P Ubuntu
-            dockerfile: Dockerfile.310p
-            suffix: '310p'
-          - name: A5 Ubuntu
-            dockerfile: Dockerfile.a5
-            suffix: 'a5'
-          - name: A2 openeuler
-            dockerfile: Dockerfile.openEuler
-            suffix: 'openeuler'
-          - name: A3 openEuler
-            dockerfile: Dockerfile.a3.openEuler
-            suffix: 'a3-openeuler'        
-          - name: 310P openEuler
-            dockerfile: Dockerfile.310p.openEuler
-            suffix: '310p-openeuler'
-          - name: A5 openEuler
-            dockerfile: Dockerfile.a5.openEuler
-            suffix: 'a5-openeuler'
+        build_meta: ${{ fromJSON(needs.setup-matrix.outputs.build_meta) }}
     uses: ./.github/workflows/_schedule_image_build.yaml
     with:
       dockerfile: ${{ matrix.build_meta.dockerfile }}
@@ -221,19 +201,18 @@ jobs:
       workflow_dispatch_tag: ''
       branch_ref: ''
       build_type: ${{ inputs.build_type || 'release' }}
-      cann_version: ${{ fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1] }}
+      cann_version: ${{ fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1] }}
 
       build_args: |
         BUILD_TYPE=${{ inputs.build_type || 'release' }}
-        ${{ inputs.build_type == 'daily' && format('BASE_OS={0}', contains(matrix.build_meta.suffix, 'openeuler') && 'openeuler24.03-lts-sp4' || 'ubuntu24.04') || '' }}
-        MEMCACHE_VERSION=${{ fromJSON(inputs.memcache || '["1.2.0", "20260725.3"]')[0] }}
-        MEMCACHE_DATE=${{ fromJSON(inputs.memcache || '["1.2.0", "20260725.3"]')[1] }}
-        MEMFABRIC_VERSION=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260725.3"]')[0] }}
-        MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260725.3"]')[1] }}
-        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[0] }}
-        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260715.4"]')[1] }}
-        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[0]) || '' }}
-        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["quay.io/atlas_inference/cann", "2026.08.03"]')[1]) || '' }}
+        MEMCACHE_VERSION=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[0] }}
+        MEMCACHE_DATE=${{ fromJSON(inputs.memcache || '["1.2.0", "20260811.14"]')[1] }}
+        MEMFABRIC_VERSION=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[0] }}
+        MEMFABRIC_DATE=${{ fromJSON(inputs.memfabric || '["1.2.0", "20260811.7"]')[1] }}
+        TORCH_NPU_VERSION=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[0] }}
+        TORCH_NPU_DATE=${{ fromJSON(inputs.torch_npu || '["26.1.0", "20260725.3"]')[1] }}
+        ${{ inputs.build_type == 'daily' && format('CANN_QUAY_URL={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[0]) || '' }}
+        ${{ inputs.build_type == 'daily' && format('CANN_VERSION={0}', fromJSON(inputs.cann || '["swr.cn-north-4.myhuaweicloud.com/inference/cann", "9.1.0_20260731131545"]')[1]) || '' }}
         TRITON_ASCEND_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[0] }}
         TRITON_ASCEND_PACKAGE_VERSION=${{ fromJSON(inputs.triton_ascend || '["", "3.2.2"]')[1] }}
 

--- a/.github/workflows/schedule_nightly_test_310p.yaml
+++ b/.github/workflows/schedule_nightly_test_310p.yaml
@@ -64,7 +64,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
 
 permissions:

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -63,7 +63,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -64,7 +64,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -64,7 +64,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'

--- a/.github/workflows/schedule_nightly_test_a5.yaml
+++ b/.github/workflows/schedule_nightly_test_a5.yaml
@@ -62,7 +62,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'

--- a/.github/workflows/schedule_weekly_test_310p.yaml
+++ b/.github/workflows/schedule_weekly_test_310p.yaml
@@ -69,7 +69,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -66,7 +66,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
 
 permissions:

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -67,7 +67,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'

--- a/.github/workflows/schedule_weekly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_weekly_test_a3_560t.yaml
@@ -64,7 +64,7 @@ on:
       base_image_tag:
         description: 'Base image tag params. Default auto-picks latest image; set a date (YYYYMMDD) to pin it.'
         required: false
-        default: '{"cann_version":"2026.08.03","base_image_date":"auto"}'
+        default: '{"cann_version":"9.1.0_20260731131545","base_image_date":"auto"}'
         type: string
       bisect_good_commit:
         description: 'explicit good commit for bisect (overrides good_table lookup)'

--- a/.github/workflows/scripts/install_daily_deps.sh
+++ b/.github/workflows/scripts/install_daily_deps.sh
@@ -21,7 +21,7 @@ if [ "$DAILY_DEPS_MODE" = "torch_npu_only" ]; then
     # ---- torch-npu only ----
     echo "Download, extract and install torch-npu..."
     mkdir -p /tmp/torch_npu
-    wget --retry-connrefused --tries=5 --timeout=30 --waitretry=10 \
+    wget -q --retry-connrefused --tries=5 --timeout=30 --waitretry=10 \
         -O /tmp/torch_npu/torch_npu.tar.gz \
         "https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.10.0-${TORCH_NPU_VERSION}/${TORCH_NPU_DATE}/pytorch_v2.10.0-${TORCH_NPU_VERSION}_py312.tar.gz"
     tar -xzf /tmp/torch_npu/torch_npu.tar.gz -C /tmp/torch_npu
@@ -36,30 +36,36 @@ fi
 # ---- memfabric_hybrid ----
 echo "Install memfabric_hybrid based on architecture..."
 if [ "$ARCH" = "x86_64" ]; then
-    MEMFABRIC_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/mf/develop/${MEMFABRIC_DATE}/memfabric_hybrid-${MEMFABRIC_VERSION}-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    MEMFABRIC_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/mf/v1.2.0/${MEMFABRIC_DATE}/memfabric_hybrid-${MEMFABRIC_VERSION}-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
 else
-    MEMFABRIC_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/mf/develop/${MEMFABRIC_DATE}/memfabric_hybrid-${MEMFABRIC_VERSION}-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl"
+    MEMFABRIC_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/mf/v1.2.0/${MEMFABRIC_DATE}/memfabric_hybrid-${MEMFABRIC_VERSION}-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl"
 fi
 python3 -m pip install "$MEMFABRIC_URL" --force-reinstall --no-deps
 
 # ---- memcache_hybrid ----
 echo "Install memcache_hybrid based on architecture..."
 if [ "$ARCH" = "x86_64" ]; then
-    MEMCACHE_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/memcache/develop/${MEMCACHE_DATE}/memcache_hybrid-${MEMCACHE_VERSION}-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
+    MEMCACHE_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/memcache/v1.2.0/${MEMCACHE_DATE}/memcache_hybrid-${MEMCACHE_VERSION}-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl"
 else
-    MEMCACHE_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/memcache/develop/${MEMCACHE_DATE}/memcache_hybrid-${MEMCACHE_VERSION}-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl"
+    MEMCACHE_URL="https://obs-memfabric-hybrid.obs.cn-north-4.myhuaweicloud.com/memcache/v1.2.0/${MEMCACHE_DATE}/memcache_hybrid-${MEMCACHE_VERSION}-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl"
 fi
 python3 -m pip install "$MEMCACHE_URL" --force-reinstall --no-deps
 
 # ---- triton-ascend ----
-echo "Install triton-ascend..."
-TRITON_ASCEND_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/Triton_Innersource/B_Version/Triton%20Performance%20Optimization%20${TRITON_ASCEND_VERSION}/triton_ascend-${TRITON_ASCEND_PACKAGE_VERSION}-cp312-cp312-manylinux_2_27_${ARCH}.manylinux_2_28_${ARCH}.whl"
-python3 -m pip install "$TRITON_ASCEND_URL" --force-reinstall
+# Controlled by INSTALL_TRITON_ASCEND env var (default: false).
+# Set INSTALL_TRITON_ASCEND=true to enable triton-ascend daily installation.
+if [ "${INSTALL_TRITON_ASCEND:-false}" = "true" ]; then
+    echo "Install triton-ascend..."
+    TRITON_ASCEND_URL="https://ascend-cann-open.obs.cn-north-4.myhuaweicloud.com/Triton_Innersource/B_Version/Triton%20Performance%20Optimization%20${TRITON_ASCEND_VERSION}/triton_ascend-${TRITON_ASCEND_PACKAGE_VERSION}-cp312-cp312-manylinux_2_27_${ARCH}.manylinux_2_28_${ARCH}.whl"
+    python3 -m pip install "$TRITON_ASCEND_URL" --force-reinstall
+else
+    echo "Skipping triton-ascend (set INSTALL_TRITON_ASCEND=true to enable)"
+fi
 
 # ---- torch-npu ----
 echo "Download, extract and install torch-npu..."
 mkdir -p /tmp/torch_npu
-wget --retry-connrefused --tries=5 --timeout=30 --waitretry=10 \
+wget -q --retry-connrefused --tries=5 --timeout=30 --waitretry=10 \
     -O /tmp/torch_npu/torch_npu.tar.gz \
     "https://pytorch-package.obs.cn-north-4.myhuaweicloud.com/pta/Daily/v2.10.0-${TORCH_NPU_VERSION}/${TORCH_NPU_DATE}/pytorch_v2.10.0-${TORCH_NPU_VERSION}_py312.tar.gz"
 tar -xzf /tmp/torch_npu/torch_npu.tar.gz -C /tmp/torch_npu

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@
 #
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="ubuntu22.04"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-910b-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-910b-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"

--- a/Dockerfile.310p
+++ b/Dockerfile.310p
@@ -17,8 +17,7 @@
 
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="ubuntu22.04"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-310p-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-310p-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"

--- a/Dockerfile.310p.openEuler
+++ b/Dockerfile.310p.openEuler
@@ -17,8 +17,7 @@
 
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="openeuler24.03"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-310p-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-310p-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"

--- a/Dockerfile.a3
+++ b/Dockerfile.a3
@@ -17,8 +17,7 @@
 
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="ubuntu22.04"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-a3-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-a3-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"

--- a/Dockerfile.a3.openEuler
+++ b/Dockerfile.a3.openEuler
@@ -17,8 +17,7 @@
 
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="openeuler24.03"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-a3-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-a3-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"

--- a/Dockerfile.a5
+++ b/Dockerfile.a5
@@ -17,8 +17,7 @@
 
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="ubuntu22.04"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-950-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-950-ubuntu22.04-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"

--- a/Dockerfile.a5.openEuler
+++ b/Dockerfile.a5.openEuler
@@ -17,8 +17,7 @@
 
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="openeuler24.03"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-950-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-950-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"

--- a/Dockerfile.openEuler
+++ b/Dockerfile.openEuler
@@ -17,8 +17,7 @@
 
 ARG CANN_QUAY_URL="quay.io/ascend/cann"
 ARG CANN_VERSION="9.1.0"
-ARG BASE_OS="openeuler24.03"
-FROM ${CANN_QUAY_URL}:${CANN_VERSION}-910b-${BASE_OS}-py3.12
+FROM ${CANN_QUAY_URL}:${CANN_VERSION}-910b-openeuler24.03-py3.12
 
 ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
 ARG MOONCAKE_INDEX_URL="https://mirrors.aliyun.com/pypi/web/simple"


### PR DESCRIPTION
What this PR does / why we need it?
This PR aligns daily builds with release standards and improves build flexibility:
• Unify OS versions: Daily builds now use Ubuntu 22.04 and openEuler 24.03 (same as release)
• Selective chip builds: Support building specific CANN chips via CHIP_TARGETS arg instead of always building all
• Disable triton-ascend by default: Only for daily builds; can be enabled via INSTALL_TRITON_ASCEND=true

Does this PR introduce any user-facing change?
No. This is an internal improvement to daily build pipelines and image building tooling, with no impact on end users.

How was this patch tested?
Manually tested Image Build and Push and Nightly Image Build Schedule pipelines. Verified image tags and base OS versions are correct and match expectations.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
