### PR TITLE
[BugFix][Spec Decode] Remove obsolete sequence length update

### DIFF
--- a/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
+++ b/vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py
@@ -256,7 +256,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             cudagraph_runtime_mode,
             mm_inputs,
         )
-        self._ascend_update_seq_lens(attn_metadata)
         return last_hidden_states, hidden_states
 
     def _generate_draft(
@@ -382,14 +381,6 @@ class AscendAutoRegressiveSpeculator(AutoRegressiveSpeculator):
             self._update_decode_attn_metadata(per_step_attn_metadata, step, self.input_batch.num_reqs)
 
         return draft_attn_metadatas
-
-    def _ascend_update_seq_lens(self, attn_metadata: dict[str, Any] | None) -> None:
-        if self.attn_architecture in ("DSA", "SFA"):
-            return
-        if attn_metadata is not None:
-            for attn_meta in attn_metadata.values():
-                attn_meta.seq_lens = attn_meta.seq_lens + 1
-                attn_meta.seq_len_list = attn_meta.seq_lens.tolist()
 
     def _init_decode_draft_attn_metadatas(self, attn_metadata: dict[str, Any] | None, num_reqs_padded: int):
         """Initialize per-step decode attention metadata for graph mode."""


### PR DESCRIPTION
### What this PR does / why we need it?

This PR removes the unused `_ascend_update_seq_lens` method and its invocation in `_run_model` within `AscendAutoRegressiveSpeculator`.

The method runs after the draft model execution has completed, and the generated `seq_len_list` is not consumed by the subsequent speculative decoding flow. Sequence lengths needed by draft attention are already prepared through the existing attention metadata update path, so this additional update is unnecessary.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m py_compile vllm_ascend/worker/v2/spec_decode/autoregressive/speculator.py`
- `git diff --check`