### PR TITLE
[v0.26.0][BugFix][P/D] Add fully spec tokens padding on recompute_scheduler

### DIFF
--- a/vllm_ascend/core/recompute_scheduler.py
+++ b/vllm_ascend/core/recompute_scheduler.py
@@ -601,7 +601,7 @@ class RecomputeScheduler(Scheduler):
                         (self.num_spec_tokens > 0 and self.dynamic_sd_lookup is None)
                         and self.num_sampled_tokens_per_step > 0
                         and num_new_tokens == 1
-                        and (scheduled_running_reqs and not prefill_scheduled)
+                        and not prefill_scheduled
                     ):
                         num_new_tokens = 1 + self.num_spec_tokens
                         if num_new_tokens > token_budget or num_computed_tokens + num_new_tokens > self.max_model_len:


### PR DESCRIPTION
### What this PR does / why we need it?
Add fully spec tokens padding on `recompute_scheduler`.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
By CI.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
