### PR TITLE
[Performance] Fuse shrink and expand into sgmv_lora/bgmv_lora

### DIFF
--- a/csrc/kernels/sgmv_lora.cpp
+++ b/csrc/kernels/sgmv_lora.cpp
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2024. All rights reserved.
+ *
+ * Fused LoRA: y[:, off:off+H] += scale * (x @ A) @ B.
+ * The rank intermediate stays in UB (no GM round-trip, no separate expand).
+ */
+
+#include "kernel_operator.h"
+#include "types.h"
+
+template <typename scalar_t, bool USE_SEQ_LEN>
+class SGMVLora {
+public:
+    using X_T = scalar_t;
+    using W_T = scalar_t;
+    using Y_T = scalar_t;
+
+    static constexpr uint64_t LORA_RANK_8 = 8;
+    static constexpr uint64_t LORA_RANK_16 = 16;
+    static constexpr uint64_t LORA_RANK_32 = 32;
+    static constexpr uint64_t LORA_RANK_64 = 64;
+    static constexpr int32_t BUFFER_NUM = 2;
+    static constexpr int32_t SHRINK_TILE = 8192;  // H=5120 one ReduceSum; 4096 vs shrink 11776 was 1 ulp
+    static constexpr int32_t NUM_BYTES_PER_REPEAT = 256;
+    static constexpr int32_t NUM_BLOCKS_PER_REPEAT = 8;
+    static constexpr int32_t NUM_ELEMENTS_PER_REPEAT = NUM_BYTES_PER_REPEAT / sizeof(float);
+    static constexpr int32_t MASK_COUNT = NUM_ELEMENTS_PER_REPEAT;
+    static constexpr int32_t W_IN_TILE_NUM_ELEMENTS = 8192;  // match sgmv_expand.cpp
+    static constexpr int32_t Y_OUT_TILE_NUM_ELEMENTS = 4096;
+    static constexpr int32_t BLOCK_REDUCE_NUM_REPEATS = W_IN_TILE_NUM_ELEMENTS / NUM_ELEMENTS_PER_REPEAT;
+    static constexpr int32_t PAIR_REDUCE_NUM_REPEATS_16 =
+        (BLOCK_REDUCE_NUM_REPEATS * NUM_BLOCKS_PER_REPEAT + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
+    static constexpr int32_t PAIR_REDUCE_NUM_REPEATS_32 = (PAIR_REDUCE_NUM_REPEATS_16 + 1) / 2;
+
+public:
+    __aicore__ inline SGMVLora(AscendC::TPipe *pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(__gm__ void *x, __gm__ void *weightA, __gm__ void *weightB, __gm__ void *loraIndices,
+                                uint32_t loraIndicesSize, __gm__ void *seqLen, uint32_t seqLenSize, __gm__ void *y,
+                                uint32_t batchSize, uint32_t numTokensPerCore, uint32_t inputHiddenDim,
+                                uint32_t maxLoRARank, uint32_t outputHiddenDim, uint32_t sliceOffset,
+                                uint32_t outputFullDim, float scale)
+    {
+        batchSize_ = batchSize;
+        numTokensPerCore_ = numTokensPerCore;
+        inputHiddenDim_ = inputHiddenDim;
+        maxLoRARank_ = maxLoRARank;
+        outputHiddenDim_ = outputHiddenDim;
+        sliceOffset_ = sliceOffset;
+        outputFullDim_ = outputFullDim;
+        scale_ = scale;
+        incremental_ = inputHiddenDim_ > SHRINK_TILE;
+        singleALen_ = inputHiddenDim_ * maxLoRARank_;
+        singleBLen_ = maxLoRARank_ * outputHiddenDim_;
+
+        xGm_.SetGlobalBuffer((__gm__ X_T *)x);
+        wAGm_.SetGlobalBuffer((__gm__ W_T *)weightA);
+        wBGm_.SetGlobalBuffer((__gm__ W_T *)weightB);
+        yInGm_.SetGlobalBuffer((__gm__ Y_T *)y);
+        yOutGm_.SetGlobalBuffer((__gm__ Y_T *)y);
+        loraIndicesGm_.SetGlobalBuffer((__gm__ int64_t *)loraIndices, loraIndicesSize);
+        if constexpr (USE_SEQ_LEN) {
+            seqLenGm_.SetGlobalBuffer((__gm__ int64_t *)seqLen, seqLenSize);
+        }
+
+        pipe_->InitBuffer(inQueueX_, 1, SHRINK_TILE * sizeof(X_T));
+        pipe_->InitBuffer(inQueueW_, BUFFER_NUM, W_IN_TILE_NUM_ELEMENTS * sizeof(W_T));
+        pipe_->InitBuffer(inQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
+        pipe_->InitBuffer(outQueueY_, BUFFER_NUM, Y_OUT_TILE_NUM_ELEMENTS * sizeof(Y_T));
+        pipe_->InitBuffer(tmpBufferX_, SHRINK_TILE * sizeof(float));
+        pipe_->InitBuffer(tmpBufferW_, W_IN_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(dupBufferX_, NUM_ELEMENTS_PER_REPEAT * sizeof(float));
+        pipe_->InitBuffer(inBufferY_, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(tmpBufferY_, Y_OUT_TILE_NUM_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(tBuf_, LORA_RANK_64 * sizeof(float));
+
+        numOutputElementsPerInputTile_ = BLOCK_REDUCE_NUM_REPEATS * (NUM_ELEMENTS_PER_REPEAT / maxLoRARank_);
+        numStreamInPerOutputTile_ = Y_OUT_TILE_NUM_ELEMENTS / numOutputElementsPerInputTile_;
+    }
+
+    __aicore__ inline void Process()
+    {
+        int64_t blockIdx = AscendC::GetBlockIdx();
+        int64_t startIdx = blockIdx * numTokensPerCore_;
+        int64_t endIdx = startIdx + numTokensPerCore_;
+        if (endIdx > batchSize_) {
+            endIdx = batchSize_;
+        }
+        for (int64_t idx = startIdx; idx < endIdx; idx++) {
+            CopyInIndex(idx);
+            if (reqLoRAIndex_ < 0) {
+                continue;
+            }
+            reqAOffset_ = reqLoRAIndex_ * singleALen_;
+            reqBOffset_ = reqLoRAIndex_ * singleBLen_;
+            yOffset_ = outputFullDim_ * idx + sliceOffset_;
+
+            if (incremental_) {
+                ShrinkImpl<true>(idx);
+            } else {
+                ShrinkImpl<false>(idx);
+            }
+            ScaleT();
+            DuplicateT();
+            ExpandImpl();
+        }
+    }
+
+private:
+    __aicore__ inline void CopyInIndex(const int64_t idx)
+    {
+        if constexpr (USE_SEQ_LEN) {
+            int64_t weightIdx = idx;
+            uint64_t i = 0;
+            for (; i < seqLenGm_.GetSize(); i++) {
+                int64_t repeatValue = seqLenGm_.GetValue(i);
+                if (weightIdx >= repeatValue) {
+                    weightIdx -= repeatValue;
+                    continue;
+                }
+                break;
+            }
+            reqLoRAIndex_ = (i < seqLenGm_.GetSize()) ? loraIndicesGm_.GetValue(i) : -1;
+        } else {
+            reqLoRAIndex_ = loraIndicesGm_.GetValue(idx);
+        }
+    }
+
+    template <bool INCREMENTAL_MODE>
+    __aicore__ inline void ShrinkImpl(const int64_t idx)
+    {
+        AscendC::LocalTensor<float> tLocal = tBuf_.Get<float>();
+        if constexpr (!INCREMENTAL_MODE) {
+            CopyInX(idx, 0, inputHiddenDim_);
+            AscendC::LocalTensor<float> xTmpTensor = tmpBufferX_.Get<float>();
+            AscendC::LocalTensor<X_T> xLocal = inQueueX_.DeQue<X_T>();
+            Cast(xTmpTensor, xLocal, AscendC::RoundMode::CAST_NONE, inputHiddenDim_);
+            AscendC::PipeBarrier<PIPE_V>();
+            inQueueX_.FreeTensor(xLocal);
+        }
+        for (int i = 0; i < maxLoRARank_; i++) {
+            float acc(0);
+            for (int32_t j = 0; j < inputHiddenDim_ / SHRINK_TILE; j++) {
+                if constexpr (INCREMENTAL_MODE) {
+                    CopyInX(idx, j);
+                }
+                CopyInWA(i, j);
+                ShrinkDot<INCREMENTAL_MODE>(acc);
+            }
+            ShrinkLast<INCREMENTAL_MODE>(idx, i, acc);
+            tLocal.SetValue(i, acc);
+        }
+    }
+
+    __aicore__ inline void CopyInX(const int64_t idx, int32_t colIdx, int32_t numElements = SHRINK_TILE)
+    {
+        AscendC::LocalTensor<X_T> xLocal = inQueueX_.AllocTensor<X_T>();
+        DataCopy(xLocal, xGm_[inputHiddenDim_ * idx + colIdx * SHRINK_TILE], numElements);
+        inQueueX_.EnQue(xLocal);
+    }
+
+    __aicore__ inline void CopyInWA(int32_t rowIdx, int32_t colIdx, int32_t numElements = SHRINK_TILE)
+    {
+        AscendC::LocalTensor<W_T> wLocal = inQueueW_.AllocTensor<W_T>();
+        DataCopy(wLocal, wAGm_[reqAOffset_ + rowIdx * inputHiddenDim_ + colIdx * SHRINK_TILE], numElements);
+        inQueueW_.EnQue(wLocal);
+    }
+
+    template <bool INCREMENTAL_MODE>
+    __aicore__ inline void ShrinkDot(float &acc, int32_t numElements = SHRINK_TILE)
+    {
+        AscendC::LocalTensor<W_T> wLocal = inQueueW_.DeQue<W_T>();
+        AscendC::LocalTensor<float> xTmpTensor = tmpBufferX_.Get<float>();
+        AscendC::LocalTensor<float> wTmpTensor = tmpBufferW_.Get<float>();
+        if constexpr (INCREMENTAL_MODE) {
+            AscendC::LocalTensor<X_T> xLocal = inQueueX_.DeQue<X_T>();
+            Cast(xTmpTensor, xLocal, AscendC::RoundMode::CAST_NONE, numElements);
+            Cast(wTmpTensor, wLocal, AscendC::RoundMode::CAST_NONE, numElements);
+            AscendC::PipeBarrier<PIPE_V>();
+            inQueueX_.FreeTensor(xLocal);
+            inQueueW_.FreeTensor(wLocal);
+        } else {
+            Cast(wTmpTensor, wLocal, AscendC::RoundMode::CAST_NONE, numElements);
+            AscendC::PipeBarrier<PIPE_V>();
+            inQueueW_.FreeTensor(wLocal);
+        }
+        Mul(wTmpTensor, xTmpTensor, wTmpTensor, numElements);
+        AscendC::PipeBarrier<PIPE_V>();
+        ReduceSum<float>(wTmpTensor, wTmpTensor, wTmpTensor, numElements);
+        AscendC::PipeBarrier<PIPE_V>();
+        acc += wTmpTensor.GetValue(0);
+    }
+
+    template <bool INCREMENTAL_MODE>
+    __aicore__ inline void ShrinkLast(const int64_t idx, int32_t rowIdx, float &acc)
+    {
+        int32_t colIdx = inputHiddenDim_ / SHRINK_TILE;
+        int32_t remaining = inputHiddenDim_ % SHRINK_TILE;
+        if (remaining == 0) {
+            return;
+        }
+        if constexpr (INCREMENTAL_MODE) {
+            CopyInX(idx, colIdx, remaining);
+        }
+        CopyInWA(rowIdx, colIdx, remaining);
+        ShrinkDot<INCREMENTAL_MODE>(acc, remaining);
+    }
+
+    __aicore__ inline void ScaleT()
+    {
+        AscendC::LocalTensor<float> tLocal = tBuf_.Get<float>();
+        Muls(tLocal, tLocal, scale_, maxLoRARank_);
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void DuplicateT()
+    {
+        AscendC::LocalTensor<float> tLocal = tBuf_.Get<float>();
+        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
+        for (int32_t i = 0; i < NUM_ELEMENTS_PER_REPEAT; i += maxLoRARank_) {
+            for (int32_t j = 0; j < maxLoRARank_; j++) {
+                xDup.SetValue(i + j, tLocal.GetValue(j));
+            }
+        }
+    }
+
+    __aicore__ inline void ExpandImpl()
+    {
+        int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
+        for (int32_t i = 0; i < numStreamOut; i++) {
+            AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+            Duplicate(yLocal, static_cast<float>(0), Y_OUT_TILE_NUM_ELEMENTS);
+            AscendC::PipeBarrier<PIPE_V>();
+            CopyInY(i);
+            for (int32_t j = 0; j < numStreamInPerOutputTile_; j++) {
+                CopyInWB(i * numStreamInPerOutputTile_ + j);
+                ExpandCompute(j * numOutputElementsPerInputTile_);
+            }
+            ScaleOutput();
+            CopyOutY(i);
+        }
+        ExpandLast();
+    }
+
+    __aicore__ inline void ExpandLast()
+    {
+        int32_t remainingY = outputHiddenDim_ % Y_OUT_TILE_NUM_ELEMENTS;
+        if (remainingY == 0) {
+            return;
+        }
+        int32_t numStreamOut = outputHiddenDim_ / Y_OUT_TILE_NUM_ELEMENTS;
+        int32_t remainingW = remainingY * maxLoRARank_;
+        int32_t numCompleteWTile = remainingW / W_IN_TILE_NUM_ELEMENTS;
+        int32_t remainingWLast = remainingW % W_IN_TILE_NUM_ELEMENTS;
+
+        CopyInY(numStreamOut, remainingY);
+        {
+            AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+            Duplicate(yLocal, static_cast<float>(0), Y_OUT_TILE_NUM_ELEMENTS);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+        int32_t outputIdx = 0;
+        for (outputIdx = 0; outputIdx < numCompleteWTile; outputIdx++) {
+            CopyInWB(numStreamOut * numStreamInPerOutputTile_ + outputIdx);
+            ExpandCompute(outputIdx * numOutputElementsPerInputTile_);
+        }
+        if (remainingWLast != 0) {
+            CopyInWB(numStreamOut * numStreamInPerOutputTile_ + numCompleteWTile, remainingWLast);
+            int32_t lastRepeatCount = remainingWLast / NUM_ELEMENTS_PER_REPEAT;
+            int32_t pairReduceRepeat16 =
+                (lastRepeatCount * NUM_BLOCKS_PER_REPEAT + NUM_ELEMENTS_PER_REPEAT - 1) / NUM_ELEMENTS_PER_REPEAT;
+            int32_t pairReduceRepeat32 = (pairReduceRepeat16 + 1) / 2;
+            ExpandCompute(outputIdx * numOutputElementsPerInputTile_, lastRepeatCount, pairReduceRepeat16,
+                          pairReduceRepeat32);
+        }
+        ScaleOutput(remainingY);
+        CopyOutY(numStreamOut, remainingY);
+    }
+
+    __aicore__ inline void CopyInY(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
+    {
+        AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.AllocTensor<Y_T>();
+        DataCopy(yInLocal, yInGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], numElements);
+        inQueueY_.EnQue(yInLocal);
+    }
+
+    __aicore__ inline void CopyInWB(int32_t progress, int32_t numElements = W_IN_TILE_NUM_ELEMENTS)
+    {
+        AscendC::LocalTensor<W_T> wLocal = inQueueW_.AllocTensor<W_T>();
+        DataCopy(wLocal, wBGm_[reqBOffset_ + progress * W_IN_TILE_NUM_ELEMENTS], numElements);
+        inQueueW_.EnQue(wLocal);
+    }
+
+    __aicore__ inline void ExpandCompute(int32_t progress, int32_t blockReduceRepeatCount = BLOCK_REDUCE_NUM_REPEATS,
+                                         int32_t pairReduceRepeat16 = PAIR_REDUCE_NUM_REPEATS_16,
+                                         int32_t pairReduceRepeat32 = PAIR_REDUCE_NUM_REPEATS_32)
+    {
+        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+        AscendC::LocalTensor<float> xDup = dupBufferX_.Get<float>();
+        AscendC::LocalTensor<W_T> wLocal = inQueueW_.DeQue<W_T>();
+        AscendC::LocalTensor<float> wTmpTensor = tmpBufferW_.Get<float>();
+
+        Cast(wTmpTensor, wLocal, AscendC::RoundMode::CAST_NONE, MASK_COUNT, blockReduceRepeatCount, castParams_);
+        AscendC::PipeBarrier<PIPE_V>();
+        inQueueW_.FreeTensor(wLocal);
+
+        Mul(wTmpTensor, xDup, wTmpTensor, MASK_COUNT, blockReduceRepeatCount, dotProductParams_);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        if (maxLoRARank_ == LORA_RANK_8) {
+            BlockReduceSum(yLocal[progress], wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+        } else if (maxLoRARank_ == LORA_RANK_16) {
+            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            PairReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
+                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+        } else if (maxLoRARank_ == LORA_RANK_32) {
+            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            PairReduceSum(wTmpTensor, wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
+                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            PairReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat32, MASK_COUNT, reduceSumParams_.dstRepStride,
+                          reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+        } else if (maxLoRARank_ == LORA_RANK_64) {
+            BlockReduceSum(wTmpTensor, wTmpTensor, blockReduceRepeatCount, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+            BlockReduceSum(yLocal[progress], wTmpTensor, pairReduceRepeat16, MASK_COUNT, reduceSumParams_.dstRepStride,
+                           reduceSumParams_.srcBlkStride, reduceSumParams_.srcRepStride);
+            AscendC::PipeBarrier<PIPE_V>();
+        }
+    }
+
+    __aicore__ inline void ScaleOutput(int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
+    {
+        AscendC::LocalTensor<float> yLocal = tmpBufferY_.Get<float>();
+        AscendC::LocalTensor<Y_T> yInLocal = inQueueY_.DeQue<Y_T>();
+        AscendC::LocalTensor<float> yInLocalFP32 = inBufferY_.Get<float>();
+        Cast(yInLocalFP32, yInLocal, AscendC::RoundMode::CAST_NONE, numElements);
+        AscendC::PipeBarrier<PIPE_V>();
+        inQueueY_.FreeTensor(yInLocal);
+
+        Add(yLocal, yLocal, yInLocalFP32, numElements);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.AllocTensor<Y_T>();
+        Cast(yOutLocal, yLocal, AscendC::RoundMode::CAST_RINT, numElements);
+        AscendC::PipeBarrier<PIPE_V>();
+        outQueueY_.EnQue<Y_T>(yOutLocal);
+    }
+
+    __aicore__ inline void CopyOutY(int32_t progress, int32_t numElements = Y_OUT_TILE_NUM_ELEMENTS)
+    {
+        AscendC::LocalTensor<Y_T> yOutLocal = outQueueY_.DeQue<Y_T>();
+        DataCopy(yOutGm_[yOffset_ + progress * Y_OUT_TILE_NUM_ELEMENTS], yOutLocal, numElements);
+        outQueueY_.FreeTensor(yOutLocal);
+    }
+
+private:
+    AscendC::TPipe *pipe_;
+    AscendC::TQue<AscendC::QuePosition::VECIN, 1> inQueueX_;
+    AscendC::TQue<AscendC::QuePosition::VECIN, BUFFER_NUM> inQueueW_, inQueueY_;
+    AscendC::TQue<AscendC::QuePosition::VECOUT, BUFFER_NUM> outQueueY_;
+    AscendC::TBuf<AscendC::QuePosition::VECCALC> tmpBufferX_, tmpBufferW_, dupBufferX_, inBufferY_, tmpBufferY_, tBuf_;
+    AscendC::GlobalTensor<X_T> xGm_;
+    AscendC::GlobalTensor<W_T> wAGm_, wBGm_;
+    AscendC::GlobalTensor<Y_T> yInGm_, yOutGm_;
+    AscendC::GlobalTensor<int64_t> loraIndicesGm_;
+    AscendC::GlobalTensor<int64_t> seqLenGm_;
+    uint32_t batchSize_;
+    uint32_t numTokensPerCore_;
+    uint32_t inputHiddenDim_;
+    uint32_t maxLoRARank_;
+    uint32_t outputHiddenDim_;
+    uint32_t sliceOffset_;
+    uint32_t outputFullDim_;
+    float scale_;
+    uint32_t singleALen_;
+    uint32_t singleBLen_;
+    int64_t reqLoRAIndex_;
+    uint64_t reqAOffset_;
+    uint64_t reqBOffset_;
+    uint32_t numOutputElementsPerInputTile_;
+    uint32_t numStreamInPerOutputTile_;
+    uint64_t yOffset_;
+    bool incremental_;
+
+    AscendC::UnaryRepeatParams castParams_ = {1, 1, 8, 4};
+    AscendC::UnaryRepeatParams reduceSumParams_ = {1, 1, 1, 8};
+    AscendC::BinaryRepeatParams dotProductParams_ = {1, 1, 1, 8, 0, 8};
+};
+
+#define SGMV_LORA_DECLARE(TYPE)                                                                                        \
+    extern "C" __global__ __aicore__ void sgmv_lora_##TYPE(                                                            \
+        __gm__ void* x, __gm__ void* weightA, __gm__ void* weightB, __gm__ void* loraIndices,                          \
+        uint32_t loraIndicesSize, __gm__ void* seqLen, uint32_t seqLenSize, __gm__ void* y, uint32_t batchSize,        \
+        uint32_t numTokensPerCore, uint32_t inputHiddenDim, uint32_t maxLoRARank, uint32_t outputHiddenDim,            \
+        uint32_t sliceOffset, uint32_t outputFullDim, float scale)                                                     \
+    {                                                                                                                  \
+        AscendC::TPipe pipe;                                                                                           \
+        SGMVLora<TYPE, true> op(&pipe);                                                                                \
+        op.Init(x, weightA, weightB, loraIndices, loraIndicesSize, seqLen, seqLenSize, y, batchSize, numTokensPerCore, \
+                inputHiddenDim, maxLoRARank, outputHiddenDim, sliceOffset, outputFullDim, scale);                      \
+        op.Process();                                                                                                  \
+    }
+
+#define BGMV_LORA_DECLARE(TYPE)                                                                                        \
+    extern "C" __global__ __aicore__ void bgmv_lora_##TYPE(                                                            \
+        __gm__ void* x, __gm__ void* weightA, __gm__ void* weightB, __gm__ void* indices, uint32_t indicesSize,        \
+        __gm__ void* y, uint32_t batchSize, uint32_t numTokensPerCore, uint32_t inputHiddenDim, uint32_t maxLoRARank,  \
+        uint32_t outputHiddenDim, uint32_t sliceOffset, uint32_t outputFullDim, float scale)                           \
+    {                                                                                                                  \
+        AscendC::TPipe pipe;                                                                                           \
+        SGMVLora<TYPE, false> op(&pipe);                                                                               \
+        op.Init(x, weightA, weightB, indices, indicesSize, nullptr, 0, y, batchSize, numTokensPerCore, inputHiddenDim, \
+                maxLoRARank, outputHiddenDim, sliceOffset, outputFullDim, scale);                                      \
+        op.Process();                                                                                                  \
+    }
+
+SGMV_LORA_DECLARE(half)
+BGMV_LORA_DECLARE(half)
+#if !defined(__CCE_AICORE__) || (__CCE_AICORE__ >= 220)
+SGMV_LORA_DECLARE(bfloat16_t)
+BGMV_LORA_DECLARE(bfloat16_t)
+#endif
+
+namespace vllm_ascend {
+extern void sgmv_lora_impl(AscendType type, void *stream, void *x, void *weightA, void *weightB, void *loraIndices,
+                           uint32_t loraIndicesSize, void *seqLen, uint32_t seqLenSize, void *y, uint32_t batchSize,
+                           uint32_t numTokensPerCore, uint32_t inputHiddenDim, uint32_t maxLoRARank,
+                           uint32_t outputHiddenDim, uint32_t sliceOffset, uint32_t outputFullDim, float scale)
+{
+    uint32_t blockDim = (batchSize + numTokensPerCore - 1) / numTokensPerCore;
+    if (type == AscendType::FP16) {
+        sgmv_lora_half<<<blockDim, nullptr, stream>>>(x, weightA, weightB, loraIndices, loraIndicesSize, seqLen,
+                                                      seqLenSize, y, batchSize, numTokensPerCore, inputHiddenDim,
+                                                      maxLoRARank, outputHiddenDim, sliceOffset, outputFullDim, scale);
+    } else if (type == AscendType::BF16) {
+#if !defined(__CCE_AICORE__) || (__CCE_AICORE__ >= 220)
+        sgmv_lora_bfloat16_t<<<blockDim, nullptr, stream>>>(x, weightA, weightB, loraIndices, loraIndicesSize, seqLen,
+                                                            seqLenSize, y, batchSize, numTokensPerCore, inputHiddenDim,
+                                                            maxLoRARank, outputHiddenDim, sliceOffset, outputFullDim,
+                                                            scale);
+#endif
+    }
+}
+
+extern void bgmv_lora_impl(AscendType type, void *stream, void *x, void *weightA, void *weightB, void *indices,
+                           uint32_t indicesSize, void *y, uint32_t batchSize, uint32_t numTokensPerCore,
+                           uint32_t inputHiddenDim, uint32_t maxLoRARank, uint32_t outputHiddenDim,
+                           uint32_t sliceOffset, uint32_t outputFullDim, float scale)
+{
+    uint32_t blockDim = (batchSize + numTokensPerCore - 1) / numTokensPerCore;
+    if (type == AscendType::FP16) {
+        bgmv_lora_half<<<blockDim, nullptr, stream>>>(x, weightA, weightB, indices, indicesSize, y, batchSize,
+                                                      numTokensPerCore, inputHiddenDim, maxLoRARank, outputHiddenDim,
+                                                      sliceOffset, outputFullDim, scale);
+    } else if (type == AscendType::BF16) {
+#if !defined(__CCE_AICORE__) || (__CCE_AICORE__ >= 220)
+        bgmv_lora_bfloat16_t<<<blockDim, nullptr, stream>>>(x, weightA, weightB, indices, indicesSize, y, batchSize,
+                                                            numTokensPerCore, inputHiddenDim, maxLoRARank,
+                                                            outputHiddenDim, sliceOffset, outputFullDim, scale);
+#endif
+    }
+}
+} // namespace vllm_ascend

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -88,6 +88,44 @@ namespace vllm_ascend {
         uint32_t slice_offset,
         uint32_t output_full_dim);
 
+    extern void sgmv_lora_impl(
+        AscendType type,
+        void *stream,
+        void *x,
+        void *weightA,
+        void *weightB,
+        void *loraIndices,
+        uint32_t loraIndicesSize,
+        void *seqLen,
+        uint32_t seqLenSize,
+        void *y,
+        uint32_t batch_size,
+        uint32_t num_tokens_per_core,
+        uint32_t input_hidden_dim,
+        uint32_t lora_rank,
+        uint32_t output_hidden_dim,
+        uint32_t slice_offset,
+        uint32_t output_full_dim,
+        float scale);
+
+    extern void bgmv_lora_impl(
+        AscendType type,
+        void *stream,
+        void *x,
+        void *weightA,
+        void *weightB,
+        void *indices,
+        uint32_t indicesSize,
+        void *y,
+        uint32_t batch_size,
+        uint32_t num_tokens_per_core,
+        uint32_t input_hidden_dim,
+        uint32_t lora_rank,
+        uint32_t output_hidden_dim,
+        uint32_t slice_offset,
+        uint32_t output_full_dim,
+        float scale);
+
     extern void mla_preprocess_impl(
         void* stream,
         void* hidden_state,

--- a/csrc/torch_binding.cpp
+++ b/csrc/torch_binding.cpp
@@ -498,6 +498,108 @@ at::Tensor sgmv_expand(at::Tensor &x, at::Tensor &weight, at::Tensor &lora_indic
     cmd.Run();
     return y_out;
 }
+
+static bool lora_rank_supported(int64_t rank)
+{
+    return rank == 8 || rank == 16 || rank == 32 || rank == 64;
+}
+
+at::Tensor sgmv_lora(at::Tensor &x, at::Tensor &weight_a, at::Tensor &weight_b, at::Tensor &lora_indices,
+                     at::Tensor &seq_len, at::Tensor &y, double scale, int64_t slice_offset, int64_t slice_size)
+{
+    at::ScalarType scalar_type = y.scalar_type();
+    TORCH_CHECK(scalar_type == torch::kHalf || scalar_type == torch::kBFloat16, "only support half and bf16");
+    TORCH_CHECK(x.dim() == 2, "x should be [batch_size, hidden_in]");
+    TORCH_CHECK(y.dim() == 2, "y should be [batch_size, hidden_out]");
+    TORCH_CHECK(weight_a.dim() == 3 || weight_a.dim() == 4, "LoRA A rank/layout invalid");
+    TORCH_CHECK(weight_b.dim() == 3 || weight_b.dim() == 4, "LoRA B rank/layout invalid");
+    int64_t lora_rank = weight_a.size(-2);
+    TORCH_CHECK(lora_rank_supported(lora_rank), "fused lora rank must be 8/16/32/64");
+    TORCH_CHECK(weight_b.size(-1) == lora_rank, "A rank and B hidden_in must match");
+    TORCH_CHECK(x.size(0) == y.size(0), "x/y batch must match");
+    TORCH_CHECK(slice_offset >= 0, "slice offset should be no smaller than 0");
+    TORCH_CHECK((slice_size + slice_offset) <= y.size(1), "slice exceeds y");
+    TORCH_CHECK(lora_rank <= slice_size, "rank should be smaller than slice");
+
+    void *x_ptr = x.data_ptr();
+    void *wa_ptr = weight_a.data_ptr();
+    void *wb_ptr = weight_b.data_ptr();
+    void *lora_indices_ptr = lora_indices.data_ptr();
+    void *seq_len_ptr = seq_len.data_ptr();
+    void *y_ptr = y.data_ptr();
+    int lora_indices_size = lora_indices.size(0);
+    int seq_len_size = seq_len.size(0);
+    int batch_size = x.size(0);
+    int input_hidden = x.size(1);
+    int output_full_dim = y.size(1);
+    float scale_f = static_cast<float>(scale);
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    at_npu::native::OpCommand cmd;
+    cmd.Name("sgmv_lora");
+    cmd.SetCustomHandler([scalar_type, stream, x_ptr, wa_ptr, wb_ptr, lora_indices_ptr, lora_indices_size, seq_len_ptr,
+                          seq_len_size, y_ptr, batch_size, input_hidden, lora_rank, slice_offset, slice_size,
+                          output_full_dim, scale_f]() -> int {
+        auto dtype = get_dtype_from_torch(scalar_type);
+        int device_id = 0;
+        int64_t aiv_num = 0;
+        TORCH_CHECK(aclGetDeviceCapability(device_id, ACL_DEVICE_INFO_VECTOR_CORE_NUM, &aiv_num) == ACL_SUCCESS);
+        int num_tokens_per_core = (batch_size + aiv_num - 1) / aiv_num;
+        TORCH_CHECK(num_tokens_per_core != 0, "num_tokens_per_core should not be 0");
+        sgmv_lora_impl(dtype, stream, x_ptr, wa_ptr, wb_ptr, lora_indices_ptr, lora_indices_size, seq_len_ptr,
+                       seq_len_size, y_ptr, batch_size, num_tokens_per_core, input_hidden,
+                       static_cast<uint32_t>(lora_rank), static_cast<uint32_t>(slice_size),
+                       static_cast<uint32_t>(slice_offset), output_full_dim, scale_f);
+        return 0;
+    });
+    cmd.Run();
+    return y;
+}
+
+at::Tensor bgmv_lora(at::Tensor &x, at::Tensor &weight_a, at::Tensor &weight_b, at::Tensor &indices, at::Tensor &y,
+                     double scale, int64_t slice_offset, int64_t slice_size)
+{
+    at::ScalarType scalar_type = y.scalar_type();
+    TORCH_CHECK(scalar_type == torch::kHalf || scalar_type == torch::kBFloat16, "only support half and bf16");
+    TORCH_CHECK(x.dim() == 2, "x should be [batch_size, hidden_in]");
+    TORCH_CHECK(y.dim() == 2, "y should be [batch_size, hidden_out]");
+    TORCH_CHECK(indices.dim() == 1, "indices should be [batch_size]");
+    int64_t lora_rank = weight_a.size(-2);
+    TORCH_CHECK(lora_rank_supported(lora_rank), "fused lora rank must be 8/16/32/64");
+    TORCH_CHECK(weight_b.size(-1) == lora_rank, "A rank and B hidden_in must match");
+    TORCH_CHECK(x.size(0) == y.size(0) && x.size(0) == indices.size(0), "x/y/indices batch must match");
+    TORCH_CHECK(slice_offset >= 0, "slice offset should be no smaller than 0");
+    TORCH_CHECK((slice_size + slice_offset) <= y.size(1), "slice exceeds y");
+
+    void *x_ptr = x.data_ptr();
+    void *wa_ptr = weight_a.data_ptr();
+    void *wb_ptr = weight_b.data_ptr();
+    void *indices_ptr = indices.data_ptr();
+    void *y_ptr = y.data_ptr();
+    int indices_size = indices.size(0);
+    int batch_size = x.size(0);
+    int input_hidden = x.size(1);
+    int output_full_dim = y.size(1);
+    float scale_f = static_cast<float>(scale);
+    aclrtStream stream = c10_npu::getCurrentNPUStream().stream();
+    at_npu::native::OpCommand cmd;
+    cmd.Name("bgmv_lora");
+    cmd.SetCustomHandler([scalar_type, stream, x_ptr, wa_ptr, wb_ptr, indices_ptr, indices_size, y_ptr, batch_size,
+                          input_hidden, lora_rank, slice_offset, slice_size, output_full_dim, scale_f]() -> int {
+        auto dtype = get_dtype_from_torch(scalar_type);
+        int device_id = 0;
+        int64_t aiv_num = 0;
+        TORCH_CHECK(aclGetDeviceCapability(device_id, ACL_DEVICE_INFO_VECTOR_CORE_NUM, &aiv_num) == ACL_SUCCESS);
+        int num_tokens_per_core = (batch_size + aiv_num - 1) / aiv_num;
+        TORCH_CHECK(num_tokens_per_core != 0, "num_tokens_per_core should not be 0");
+        bgmv_lora_impl(dtype, stream, x_ptr, wa_ptr, wb_ptr, indices_ptr, indices_size, y_ptr, batch_size,
+                       num_tokens_per_core, input_hidden, static_cast<uint32_t>(lora_rank),
+                       static_cast<uint32_t>(slice_size), static_cast<uint32_t>(slice_offset), output_full_dim,
+                       scale_f);
+        return 0;
+    });
+    cmd.Run();
+    return y;
+}
 #endif
 
 at::Tensor npu_sign_bits_pack(const at::Tensor& input,
@@ -2075,6 +2177,16 @@ TORCH_LIBRARY_EXPAND(CONCAT(_C, _ascend), ops)
         "sgmv_expand(Tensor! x, Tensor! weight, Tensor! lora_indices, Tensor! seq_len, Tensor! y,"
         "            int slice_offset, int slice_size) -> Tensor");
     ops.impl("sgmv_expand", torch::kPrivateUse1, &vllm_ascend::sgmv_expand);
+
+    ops.def(
+        "sgmv_lora(Tensor! x, Tensor! weight_a, Tensor! weight_b, Tensor! lora_indices, Tensor! seq_len, Tensor! y,"
+        "          float scale, int slice_offset, int slice_size) -> Tensor");
+    ops.impl("sgmv_lora", torch::kPrivateUse1, &vllm_ascend::sgmv_lora);
+
+    ops.def(
+        "bgmv_lora(Tensor! x, Tensor! weight_a, Tensor! weight_b, Tensor! indices, Tensor! y,"
+        "          float scale, int slice_offset, int slice_size) -> Tensor");
+    ops.impl("bgmv_lora", torch::kPrivateUse1, &vllm_ascend::bgmv_lora);
 
     ops.def(
         "mla_preprocess(Tensor hiddenState, Tensor wdqkv,"

--- a/csrc/torch_binding_meta.cpp
+++ b/csrc/torch_binding_meta.cpp
@@ -57,6 +57,18 @@ at::Tensor sgmv_expand_meta(at::Tensor &x, at::Tensor &weight, at::Tensor &lora_
     return y_out;
 }
 
+at::Tensor sgmv_lora_meta(at::Tensor &x, at::Tensor &weight_a, at::Tensor &weight_b, at::Tensor &lora_indices,
+                          at::Tensor &seq_len, at::Tensor &y, double scale, int64_t slice_offset, int64_t slice_size) {
+    // Alias y: the impl mutates y in place and returns it. empty_like() makes
+    // ACL graphs treat the result as a new tensor and drop the custom op.
+    return y;
+}
+
+at::Tensor bgmv_lora_meta(at::Tensor &x, at::Tensor &weight_a, at::Tensor &weight_b, at::Tensor &indices,
+                          at::Tensor &y, double scale, int64_t slice_offset, int64_t slice_size) {
+    return y;
+}
+
 std::tuple<at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &, at::Tensor &> mla_preprocess(
     const at::Tensor &hiddenState,
     const at::Tensor &wdqkv,
@@ -1949,6 +1961,8 @@ TORCH_LIBRARY_IMPL_EXPAND(CONCAT(_C, _ascend), Meta, ops) {
     ops.impl("bgmv_expand", &vllm_ascend::meta::bgmv_expand_meta);
     // Sgmv expand
     ops.impl("sgmv_expand", &vllm_ascend::meta::sgmv_expand_meta);
+    ops.impl("sgmv_lora", &vllm_ascend::meta::sgmv_lora_meta);
+    ops.impl("bgmv_lora", &vllm_ascend::meta::bgmv_lora_meta);
     // MLA preprocess
     ops.impl("mla_preprocess", &vllm_ascend::meta::mla_preprocess);
     // batch_matmul_transpose

--- a/vllm_ascend/lora/lora_ops.py
+++ b/vllm_ascend/lora/lora_ops.py
@@ -120,3 +120,53 @@ def sgmv_expand_slice(
     return torch.ops._C_ascend.sgmv_expand(
         inputs, lora_b_weights, lora_indices_tensor, seq_len_tensor, output_tensor, slice_offset, slice_size
     )
+
+
+def sgmv_lora(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    b_seq_start_loc: torch.Tensor,
+    seq_len_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    batches: int,
+    max_seq_length: int,
+    token_nums: int,
+    scaling: float,
+    slice_offset: int,
+    slice_size: int,
+):
+    return torch.ops._C_ascend.sgmv_lora(
+        inputs,
+        lora_a_weights,
+        lora_b_weights,
+        lora_indices_tensor,
+        seq_len_tensor,
+        output_tensor,
+        scaling,
+        slice_offset,
+        slice_size,
+    )
+
+
+def bgmv_lora(
+    inputs: torch.Tensor,
+    lora_a_weights: torch.Tensor,
+    lora_b_weights: torch.Tensor,
+    output_tensor: torch.Tensor,
+    lora_indices_tensor: torch.Tensor,
+    scaling: float,
+    slice_offset: int,
+    slice_size: int,
+):
+    return torch.ops._C_ascend.bgmv_lora(
+        inputs,
+        lora_a_weights,
+        lora_b_weights,
+        lora_indices_tensor,
+        output_tensor,
+        scaling,
+        slice_offset,
+        slice_size,
+    )

--- a/vllm_ascend/lora/punica_npu.py
+++ b/vllm_ascend/lora/punica_npu.py
@@ -37,9 +37,11 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             from vllm_ascend.lora.lora_ops import (
                 bgmv_expand,
                 bgmv_expand_slice,
+                bgmv_lora,
                 bgmv_shrink,
                 sgmv_expand,
                 sgmv_expand_slice,
+                sgmv_lora,
                 sgmv_shrink,
             )
         self.bgmv_expand = bgmv_expand
@@ -48,6 +50,14 @@ class PunicaWrapperNPU(PunicaWrapperBase):
         self.sgmv_expand = sgmv_expand
         self.sgmv_expand_slice = sgmv_expand_slice
         self.sgmv_shrink = sgmv_shrink
+        if not get_current_hardware_profile().supports(HardwareCapability.LORA_CUSTOM_OPS) or (
+            self.lora_config is not None and self.lora_config.max_lora_rank >= 128
+        ):
+            self.sgmv_lora = None
+            self.bgmv_lora = None
+        else:
+            self.sgmv_lora = sgmv_lora
+            self.bgmv_lora = bgmv_lora
 
     def update_metadata(
         self,
@@ -330,6 +340,12 @@ class PunicaWrapperNPU(PunicaWrapperBase):
 
         assert len(lora_a_stacked) == len(lora_b_stacked) == len(output_slices)
 
+        a_use = kwargs.get("full_rank_lora_a") or lora_a_stacked
+        if buffer is None:
+            fused = self.apply_fused_lora_linear(y, x, a_use, lora_b_stacked, output_slices=output_slices, scale=scale)
+            if fused is not None:
+                return
+
         if buffer is None:
             r = lora_b_stacked[0].size(-1)
             # We set the buffer to be float32 by default, consistent with the
@@ -337,8 +353,73 @@ class PunicaWrapperNPU(PunicaWrapperBase):
             buffer = tuple(
                 torch.zeros((x.size(0), r), dtype=torch.float32, device=x.device) for _ in range(len(output_slices))
             )
-        self.add_shrink(buffer, x, lora_a_stacked, scale, **kwargs)
+        self.add_shrink(buffer, x, a_use, scale, **kwargs)
         self.add_expand(y, buffer, lora_b_stacked, output_slices, add_inputs=True, **kwargs)
+
+    @staticmethod
+    def _fused_lora_rank_ok(lora_a: torch.Tensor, lora_b: torch.Tensor) -> bool:
+        r = int(lora_b.size(-1))
+        return r in (8, 16, 32, 64) and int(lora_a.size(-2)) == r
+
+    def can_fused_lora_linear(
+        self,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+    ) -> bool:
+        if self.sgmv_lora is None or self.bgmv_lora is None:
+            return False
+        if len(lora_a_stacked) != len(lora_b_stacked):
+            return False
+        return all(self._fused_lora_rank_ok(a, b) for a, b in zip(lora_a_stacked, lora_b_stacked))
+
+    def apply_fused_lora_linear(
+        self,
+        y: torch.Tensor,
+        x: torch.Tensor,
+        lora_a_stacked: tuple[torch.Tensor, ...],
+        lora_b_stacked: tuple[torch.Tensor, ...],
+        output_slices: tuple[int, ...],
+        scale: float,
+    ) -> torch.Tensor | None:
+        """One kernel per slice: y += (x @ A) @ B. Returns y so ACL graphs keep the op."""
+        sgmv: Callable | None = self.sgmv_lora
+        bgmv: Callable | None = self.bgmv_lora
+        if sgmv is None or bgmv is None:
+            return None
+        if not self.can_fused_lora_linear(lora_a_stacked, lora_b_stacked):
+            return None
+        y_org = y
+        y2 = y.view(-1, y.shape[-1])
+        x2 = x.view(-1, x.shape[-1])
+        offset = 0
+        for i in range(len(lora_a_stacked)):
+            sl = output_slices[i]
+            if self.is_prefill:
+                if self.no_lora:
+                    return y_org
+                y2 = sgmv(
+                    x2,
+                    lora_a_stacked[i],
+                    lora_b_stacked[i],
+                    y2,
+                    *self.prefill_metadata,
+                    scale,
+                    offset,
+                    sl,
+                )
+            else:
+                y2 = bgmv(
+                    x2,
+                    lora_a_stacked[i],
+                    lora_b_stacked[i],
+                    y2,
+                    self._get_token_lora_indices(x2),
+                    scale,
+                    offset,
+                    sl,
+                )
+            offset += sl
+        return y2.view_as(y_org)
 
     def add_lora_fused_moe(
         self,

--- a/vllm_ascend/lora/utils.py
+++ b/vllm_ascend/lora/utils.py
@@ -1,9 +1,20 @@
+import importlib
+
+import torch
 import vllm
 
 from vllm_ascend.lora.fused_moe import (
     AscendFusedMoE3DWithLoRA,
     AscendFusedMoEWithLoRA,
 )
+
+# Full-rank A after TP all-gather (fully-sharded LoRA). Eager set_lora only.
+# Used only by add_lora_linear (non-mcp layers). Do not divert _mcp_apply:
+# official shrink → all_gather → expand is what this stack's ACL graphs keep.
+# e389704 patched _mcp_apply to return fused y; chat identity became the base model.
+FULL_RANK_LORA_A_ATTR = "_full_rank_lora_a"
+_LINEAR_LORA_HOOKS_INSTALLED = False
+_SKIP_NAME_PARTS = ("MoE", "Embedding", "Logits", "Vocab")
 
 
 def refresh_all_lora_classes():
@@ -17,3 +28,96 @@ def refresh_all_lora_classes():
         *ascend_classes,
         *vllm.lora.utils._all_lora_classes,
     )
+    install_linear_lora_hooks()
+
+
+def gather_sharded_lora_a(layer) -> None:
+    """All-gather LoRA A on the rank dim so fused kernels see the full rank."""
+    if torch.compiler.is_compiling():
+        return
+    stacked = getattr(layer, "lora_a_stacked", None)
+    bstack = getattr(layer, "lora_b_stacked", None)
+    if not isinstance(stacked, (tuple, list)) or not isinstance(bstack, (tuple, list)):
+        return
+    if not stacked or not bstack or not torch.is_tensor(stacked[0]):
+        return
+    r_a = stacked[0].size(-2)
+    r_b = bstack[0].size(-1)
+    if r_a >= r_b:
+        setattr(layer, FULL_RANK_LORA_A_ATTR, tuple(stacked))
+        return
+    try:
+        from vllm.distributed import tensor_model_parallel_all_gather
+    except ImportError:
+        return
+    if tensor_model_parallel_all_gather is None:
+        return
+    full = []
+    for src in stacked:
+        t = src.transpose(-1, -2).contiguous()
+        g = tensor_model_parallel_all_gather(t, dim=-1)
+        full.append(g.transpose(-1, -2).contiguous())
+    setattr(layer, FULL_RANK_LORA_A_ATTR, tuple(full))
+
+
+def _wrap_after_gather(orig):
+    def wrapped(self, *args, **kwargs):
+        out = orig(self, *args, **kwargs)
+        gather_sharded_lora_a(self)
+        return out
+
+    return wrapped
+
+
+def _iter_linear_lora_classes():
+    seen: set[type] = set()
+    classes = list(getattr(vllm.lora.utils, "_all_lora_classes", ()))
+    extra_targets = (
+        ("vllm.lora.layers.base_linear", "BaseLinearLayerWithLoRA"),
+        ("vllm.lora.layers.column_parallel_linear", "ColumnParallelLinearWithLoRA"),
+        ("vllm.lora.layers.column_parallel_linear", "MergedColumnParallelLinearWithLoRA"),
+        ("vllm.lora.layers.column_parallel_linear", "MergedQKVParallelLinearWithLoRA"),
+        ("vllm.lora.layers.column_parallel_linear", "ColumnParallelLinearWithShardedLoRA"),
+        ("vllm.lora.layers.column_parallel_linear", "MergedColumnParallelLinearWithShardedLoRA"),
+        ("vllm.lora.layers.column_parallel_linear", "QKVParallelLinearWithShardedLoRA"),
+        ("vllm.lora.layers.column_parallel_linear", "MergedQKVParallelLinearWithShardedLoRA"),
+        ("vllm.lora.layers.row_parallel_linear", "RowParallelLinearWithLoRA"),
+        ("vllm.lora.layers.row_parallel_linear", "RowParallelLinearWithShardedLoRA"),
+        ("vllm.lora.layers", "BaseLinearLayerWithLoRA"),
+        ("vllm.lora.layers", "MergedColumnParallelLinearWithLoRA"),
+        ("vllm.lora.layers", "MergedQKVParallelLinearWithLoRA"),
+        ("vllm.lora.layers", "ColumnParallelLinearWithShardedLoRA"),
+        ("vllm.lora.layers", "MergedColumnParallelLinearWithShardedLoRA"),
+        ("vllm.lora.layers", "MergedQKVParallelLinearWithShardedLoRA"),
+    )
+    for mod_name, attr in extra_targets:
+        try:
+            mod = importlib.import_module(mod_name)
+        except ImportError:
+            continue
+        cls = getattr(mod, attr, None)
+        if isinstance(cls, type):
+            classes.append(cls)
+    for cls in classes:
+        if not isinstance(cls, type) or cls in seen:
+            continue
+        name = getattr(cls, "__name__", "")
+        if any(part in name for part in _SKIP_NAME_PARTS):
+            continue
+        seen.add(cls)
+        yield cls
+
+
+def install_linear_lora_hooks():
+    """Gather sharded A at set_lora. Do not patch apply/_mcp_apply/_apply_lora_to_output."""
+    global _LINEAR_LORA_HOOKS_INSTALLED
+    for cls in _iter_linear_lora_classes():
+        if getattr(cls, "_fused_lora_hooked", False):
+            continue
+        for name in ("create_lora_weights", "set_lora", "reset_lora", "set_mapping"):
+            orig = getattr(cls, name, None)
+            if orig is None or not callable(orig):
+                continue
+            setattr(cls, name, _wrap_after_gather(orig))
+        cls._fused_lora_hooked = True  # type: ignore[attr-defined]
+    _LINEAR_LORA_HOOKS_INSTALLED = True


### PR DESCRIPTION
### What this PR does / why we need it?

Linear LoRA currently launches `sgmv_shrink` then `sgmv_expand` per slice, writing the rank buffer to GM. This PR adds one vector kernel `sgmv_lora` / `bgmv_lora` that computes `y += scale * (x @ A) @ B` with the rank intermediate kept in UB.

- Supported ranks: 8 / 16 / 32 / 64. Other ranks keep shrink+expand.
- Fully-sharded LoRA: all-gather A on the rank dim at `set_lora` only.
- Devices without `HardwareCapability.LORA_CUSTOM_OPS` (including 310P) and `max_lora_rank >= 128` stay on the PyTorch punica path.
- Do **not** patch `apply()`, `_mcp_apply`, or `_apply_lora_to_output`. FSL QKV/gate_up stays on official shrink → all_gather → expand. Replacing that path made `/v1/chat/completions` look like the base model.
- Fusion is attempted in `add_lora_linear` for layers that already call it. Fallback is shrink+expand.

Rebased onto current `main` (includes the hardware-profile refactor in #15256). The previous PR head targeted `453f409` and would not merge.

Fixes #15110

### Does this PR introduce _any_ user-facing change?

No API change. Linear LoRA with supported ranks uses the fused kernel automatically when `add_lora_linear` is on the hot path.

### How was this patch tested?

- Single-card kernel vs shrink+expand (rank=8, hidden=5120): T=1 and T=32 `max_abs_err=0` after `SHRINK_TILE` / `W_IN_TILE_NUM_ELEMENTS` = 8192.
- Official main `875cb55` + this kernel + `HardwareCapability` gate, 910B4 TP=4, FSL off, prefix-cache off: `/v1/chat/completions` adapter identity OK. Fused and official no-FSL decode throughput are comparable; this PR does not claim an e2e speedup.
- Production 0.19.1 overlay numbers are a different stack and are not the merge target.
- Unit tests were not added because the kernel requires NPU + CANN.

**CheckList**
- [x] Pre-commit: ruff check/format, codespell, typos, long-functions, symbolic-meta, forbidden imports. Windows cannot run bash gitleaks (`/bin/bash`); Linux CI will.
- [x] One commit, DCO `Signed-off-by`, no Cursor co-author.
- [x] Docs/assets: not involved.
- [x] User-facing API: not involved.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
