### PR TITLE
[Feature] Add Watchdog for Engine and Worker Monitoring

### DIFF
--- a/.github/workflows/scripts/test_config.yaml
+++ b/.github/workflows/scripts/test_config.yaml
@@ -187,6 +187,14 @@
     - vllm_ascend/compilation/passes/noop_elimination.py
   tests: []
 
+# Common
+- name: common
+  optional: false
+  source_file_dependencies:
+    - vllm_ascend/common
+  tests:
+    - tests/ut/common
+
 # Core
 - name: core
   optional: false

--- a/tests/ut/common/test_watch_dog.py
+++ b/tests/ut/common/test_watch_dog.py
@@ -1,0 +1,464 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+"""Unit tests for vllm_ascend.common.utils.watch_dog module."""
+
+import os
+import threading
+import time
+from unittest import mock
+
+from tests.ut.base import PytestBase
+
+
+class TestWatchDogInitialization(PytestBase):
+    """Test WatchDog constructor and initialization."""
+
+    def test_watch_dog_init_default_values(self):
+        """Test WatchDog initialization with default values."""
+        from vllm_ascend.common.utils.watch_dog import _DEFAULT_INTERVAL, _DEFAULT_NAME, _DEFAULT_TIMEOUT, WatchDog
+
+        dog = WatchDog()
+
+        assert dog._name == _DEFAULT_NAME
+        assert dog._timeout == _DEFAULT_TIMEOUT
+        assert dog._check_interval == _DEFAULT_INTERVAL
+        assert dog._sequence == 1
+        assert dog._last_feed_time > 0
+        assert dog._last_timeout_log == 0.0
+        assert dog._stop_event is not None
+        assert dog._thread is None
+
+    def test_watch_dog_initial_state_consistency(self):
+        """Test that initial state prevents immediate timeout."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        now = time.monotonic()
+
+        # _last_feed_time should be set to current time to prevent immediate timeout
+        assert dog._last_feed_time >= now - 0.1
+        # _last_timeout_log should be 0.0 to ensure first timeout is always logged
+        assert dog._last_timeout_log == 0.0
+
+
+class TestWatchDogSetup(PytestBase):
+    """Test WatchDog setup method."""
+
+    def test_setup_with_custom_values(self):
+        """Test setup method with custom parameters."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.setup(name="test_dog", timeout=100, check_interval=5)
+
+        assert dog._name == "test_dog"
+        assert dog._timeout == 100
+        assert dog._check_interval == 5
+
+    def test_setup_preserves_other_fields(self):
+        """Test that setup only modifies configuration fields."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        original_feed_time = dog._last_feed_time
+        original_sequence = dog._sequence
+
+        time.sleep(0.01)
+        dog.setup(name="new_name", timeout=200, check_interval=3)
+
+        assert dog._name == "new_name"
+        assert dog._timeout == 200
+        assert dog._check_interval == 3
+        # These should not change
+        assert dog._sequence == original_sequence
+        assert dog._last_feed_time == original_feed_time
+
+
+class TestWatchDogFeed(PytestBase):
+    """Test WatchDog feed method."""
+
+    def test_feed_updates_last_feed_time(self):
+        """Test that feed updates _last_feed_time."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        time.sleep(0.01)
+        original_time = dog._last_feed_time
+
+        dog.feed()
+
+        assert dog._last_feed_time > original_time
+
+    def test_feed_makes_watch_dog_active(self):
+        """Test that feed prevents timeout after being called."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.feed()
+
+        now = time.monotonic()
+        time_since_feed = now - dog._last_feed_time
+
+        # Should not be in timeout state
+        assert time_since_feed < dog._timeout
+
+
+class TestWatchDogStartStop(PytestBase):
+    """Test WatchDog start and stop methods."""
+
+    def test_start_creates_daemon_thread(self):
+        """Test that start creates a daemon thread."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.start()
+
+        try:
+            assert dog._thread is not None
+            assert dog._thread.daemon is True
+            assert dog._thread.is_alive()
+        finally:
+            dog.stop()
+
+    def test_start_idempotent_when_already_running(self):
+        """Test that calling start multiple times is safe."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.start()
+        original_thread = dog._thread
+
+        dog.start()
+
+        assert dog._thread is original_thread
+        dog.stop()
+
+    def test_stop_sets_stop_event(self):
+        """Test that stop sets the stop event."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.start()
+        assert dog._stop_event.is_set() is False
+
+        dog.stop()
+
+        assert dog._stop_event.is_set() is True
+
+    def test_stop_waits_for_thread(self):
+        """Test that stop waits for thread to finish."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.start()
+
+        dog.stop()
+
+        # Thread should no longer be alive after stop
+        if dog._thread is not None:
+            assert dog._thread.is_alive() is False
+            assert dog._thread is None
+
+    def test_stop_idempotent(self):
+        """Test that calling stop multiple times is safe."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.start()
+        dog.stop()
+        original_thread = dog._thread
+
+        dog.stop()
+
+        assert dog._thread is original_thread
+
+
+class TestWatchDogCheckLoop(PytestBase):
+    """Test WatchDog _check_loop timeout detection logic."""
+
+    def test_check_loop_triggers_on_timeout(self):
+        """Test that _check_loop triggers _dump_stack on timeout."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog._timeout = 0  # Set timeout to 0 so any sleep will trigger it
+        dog._check_interval = 0.01  # Short interval for fast test
+
+        with mock.patch.object(dog, "_dump_stack") as mock_dump:
+            dog.start()
+            time.sleep(0.05)  # Wait for at least one check cycle
+            dog.stop()
+
+            # _dump_stack should have been called at least once
+            assert mock_dump.call_count >= 1
+
+    def test_check_loop_prevents_duplicate_timeout_logs(self):
+        """Test that _check_loop prevents duplicate timeout logging."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog._timeout = 0
+        dog._check_interval = 0.01
+
+        # Simulate: feed called, then timeout occurs, then feed called again
+        with mock.patch.object(dog, "_dump_stack") as mock_dump:
+            dog.start()
+
+            # Wait for first timeout detection
+            time.sleep(0.05)
+            first_call_count = mock_dump.call_count
+
+            # Feed to reset timeout tracking
+            dog.feed()
+
+            # Wait a bit more
+            time.sleep(0.05)
+
+            dog.stop()
+
+            # Should have logged at least once
+            assert first_call_count >= 1
+
+    def test_check_loop_no_timeout_when_fed_regularly(self):
+        """Test that _check_loop does not trigger on timeout when fed regularly."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog._timeout = 1  # 1 second timeout
+        dog._check_interval = 0.05  # Check every 50ms
+
+        with mock.patch.object(dog, "_dump_stack") as mock_dump:
+            dog.start()
+
+            # Feed regularly
+            for _ in range(5):
+                dog.feed()
+                time.sleep(0.1)
+
+            dog.stop()
+
+            # _dump_stack should not have been called
+            assert mock_dump.call_count == 0
+
+
+class TestWatchDogDumpStack(PytestBase):
+    """Test WatchDog _dump_stack method."""
+
+    def test_dump_stack_calls_faulthandler(self):
+        """Test that _dump_stack calls faulthandler.dump_traceback."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog, get_log_dir_and_basename
+
+        dog = WatchDog()
+        log_dir = "/tmp/test_log"
+        base_name = "test_process"
+
+        with (
+            mock.patch.object(dog, "_dump_stack"),
+            mock.patch(
+                "vllm_ascend.common.utils.watch_dog.get_log_dir_and_basename", return_value=(log_dir, base_name)
+            ),
+            mock.patch("vllm_ascend.common.utils.watch_dog.open", mock.mock_open()),
+            mock.patch("vllm_ascend.common.utils.watch_dog.faulthandler.dump_traceback") as mock_dump_traceback,
+        ):
+            # Simulate the actual _dump_stack call
+            from vllm_ascend.common.utils.log_file import get_log_dir_and_basename
+
+            log_dir, base_name = get_log_dir_and_basename()
+            stack_filename = os.path.join(log_dir, f"{base_name}.{dog._name}.stack")
+
+            with open(stack_filename, "a") as f:
+                f.write(f"\nCall Stack: the {dog._sequence} time at [{time.time()}] {time.ctime()}\n\n")
+                from vllm_ascend.common.utils import watch_dog
+
+                watch_dog.faulthandler.dump_traceback(file=f, all_threads=True)
+                f.write("\n================================================================\n")
+
+            # Verify faulthandler was called
+            mock_dump_traceback.assert_called_once()
+
+    def test_dump_stack_increments_sequence(self):
+        """Test that _dump_stack increments _sequence."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        initial_sequence = dog._sequence
+
+        with (
+            mock.patch("vllm_ascend.common.utils.watch_dog.get_log_dir_and_basename", return_value=("/tmp", "test")),
+            mock.patch("vllm_ascend.common.utils.watch_dog.open", mock.mock_open()),
+            mock.patch("vllm_ascend.common.utils.watch_dog.faulthandler.dump_traceback"),
+        ):
+            dog.dump_stack()
+
+            assert dog._sequence == initial_sequence + 1
+
+    def test_dump_stack_writes_to_correct_file(self):
+        """Test that _dump_stack writes to the correct log file."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog._name = "my_watch_dog"
+        log_dir = "/test/log/dir"
+        base_name = "my_process"
+
+        with (
+            mock.patch(
+                "vllm_ascend.common.utils.watch_dog.get_log_dir_and_basename", return_value=(log_dir, base_name)
+            ),
+            mock.patch("builtins.open", mock.mock_open()) as mock_file,
+            mock.patch("vllm_ascend.common.utils.watch_dog.faulthandler.dump_traceback"),
+        ):
+            dog.dump_stack()
+
+            # Verify file path
+            expected_path = os.path.join(log_dir, f"{base_name}.{dog._name}.stack")
+            mock_file.assert_called_once_with(expected_path, "a")
+
+
+class TestWatchDogSingleton(PytestBase):
+    """Test get_watch_dog singleton pattern."""
+
+    def test_get_watch_dog_returns_same_instance(self):
+        """Test that get_watch_dog returns the same instance."""
+        from vllm_ascend.common.utils import watch_dog
+
+        instance1 = watch_dog.get_watch_dog()
+        instance2 = watch_dog.get_watch_dog()
+
+        assert instance1 is instance2
+
+    def test_get_watch_dog_returns_watch_dog_instance(self):
+        """Test that get_watch_dog returns a WatchDog instance."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog, get_watch_dog
+
+        dog = get_watch_dog()
+
+        assert isinstance(dog, WatchDog)
+
+
+class TestWatchDogFactory(PytestBase):
+    """Test setup_watch_dog factory function."""
+
+    def test_setup_watch_dog_creates_new_instance(self):
+        """Test that setup_watch_dog creates a new WatchDog instance."""
+        from vllm_ascend.common.utils import watch_dog
+        from vllm_ascend.common.utils.watch_dog import get_watch_dog
+
+        original = get_watch_dog()
+        original._sequence = 999  # Mark original
+
+        new_dog = watch_dog.setup_watch_dog(name="factory_test", timeout=60, check_interval=3)
+
+        assert new_dog is not original
+        assert new_dog._name == "factory_test"
+        assert new_dog._timeout == 60
+        assert new_dog._check_interval == 3
+
+    def test_setup_watch_dog_updates_global_instance(self):
+        """Test that setup_watch_dog updates the global _watch_dog."""
+        from vllm_ascend.common.utils import watch_dog
+        from vllm_ascend.common.utils.watch_dog import get_watch_dog
+
+        original = get_watch_dog()
+        original_id = id(original)
+
+        watch_dog.setup_watch_dog(name="new_global", timeout=30, check_interval=2)
+
+        new_instance = get_watch_dog()
+        assert id(new_instance) != original_id
+        assert new_instance._name == "new_global"
+
+
+class TestWatchDogIntegration(PytestBase):
+    """Integration tests for WatchDog lifecycle."""
+
+    def test_full_lifecycle(self):
+        """Test complete start-feed-stop lifecycle."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog._timeout = 10
+        dog._check_interval = 0.1
+
+        with mock.patch.object(dog, "_dump_stack"):
+            dog.start()
+            assert dog._thread is not None
+            assert dog._thread.is_alive()
+
+            dog.feed()
+            time.sleep(0.2)
+
+            dog.feed()
+            time.sleep(0.2)
+
+            dog.stop()
+            assert dog._stop_event.is_set()
+            assert dog._thread is None or not dog._thread.is_alive()
+
+    def test_multiple_feed_calls(self):
+        """Test that multiple feed calls are handled correctly."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog._timeout = 1
+        dog._check_interval = 0.05
+
+        with mock.patch.object(dog, "_dump_stack") as mock_dump:
+            dog.start()
+
+            for _ in range(10):
+                dog.feed()
+                time.sleep(0.1)
+
+            dog.stop()
+
+            # Should not have dumped stack due to regular feeding
+            assert mock_dump.call_count == 0
+
+    def test_concurrent_feed_and_check(self):
+        """Test concurrent feed and check loop operations."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog._timeout = 0.5
+        dog._check_interval = 0.05
+
+        with mock.patch.object(dog, "_dump_stack"):
+            dog.start()
+
+            def feeder():
+                for _ in range(20):
+                    dog.feed()
+                    time.sleep(0.08)
+
+            feeder_thread = threading.Thread(target=feeder)
+            feeder_thread.start()
+            feeder_thread.join(timeout=5)
+
+            dog.stop()
+
+    def test_stop_event_is_thread_safe(self):
+        """Test that _stop_event is used correctly for thread signaling."""
+        from vllm_ascend.common.utils.watch_dog import WatchDog
+
+        dog = WatchDog()
+        dog.start()
+
+        assert dog._stop_event is not None
+        assert isinstance(dog._stop_event, threading.Event)
+
+        dog.stop()

--- a/tests/ut/test_logger.py
+++ b/tests/ut/test_logger.py
@@ -182,7 +182,8 @@ class TestLoggerModule(TestBase):
         from vllm_ascend.logger import RotatingAscendFileHandler
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            handler = RotatingAscendFileHandler(tmpdir, max_bytes=100)
+            base_name = "vllm_ascend_test.log"
+            handler = RotatingAscendFileHandler(tmpdir, base_name, max_bytes=100)
             handler.setFormatter(logging.Formatter("%(message)s"))
             logger = logging.getLogger("test_rotate")
             logger.addHandler(handler)

--- a/vllm_ascend/common/__init__.py
+++ b/vllm_ascend/common/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#

--- a/vllm_ascend/common/utils/__init__.py
+++ b/vllm_ascend/common/utils/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#

--- a/vllm_ascend/common/utils/log_file.py
+++ b/vllm_ascend/common/utils/log_file.py
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+import os
+from datetime import datetime
+
+DEFAULT_LOG_DIR = os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend")
+
+_log_dir = DEFAULT_LOG_DIR
+_base_name = f"vllm_ascend_{os.getpid()}"
+
+
+def get_log_dir_and_basename():
+    return _log_dir, _base_name
+
+
+def setup_log_dir_and_basename(target_dir: str | None):
+    global _log_dir, _base_name
+    if target_dir is None:
+        target_dir = DEFAULT_LOG_DIR
+    os.makedirs(target_dir, exist_ok=True)
+    _log_dir = target_dir
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    _base_name = f"vllm_ascend_{timestamp}_{os.getpid()}"
+    return get_log_dir_and_basename()

--- a/vllm_ascend/common/utils/watch_dog.py
+++ b/vllm_ascend/common/utils/watch_dog.py
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+import faulthandler
+import os
+import threading
+import time
+
+from vllm_ascend.common.utils.log_file import get_log_dir_and_basename
+
+_DEFAULT_NAME = "vllm_ascend"
+_DEFAULT_TIMEOUT = 300
+_DEFAULT_INTERVAL = 10
+
+
+class WatchDog:
+    def __init__(self, name=_DEFAULT_NAME, timeout=_DEFAULT_TIMEOUT, check_interval=_DEFAULT_INTERVAL):
+        """
+        :param timeout: Timeout threshold in seconds
+        :param check_interval: Check interval in seconds
+        """
+        self._name = name
+        self._timeout = timeout
+        self._check_interval = check_interval
+        self._sequence = 1
+
+        # Initialize feed time to current time to avoid immediate timeout on startup
+        self._last_feed_time = time.monotonic()
+        # Last timeout log time, initialized to 0 to ensure first timeout is always logged
+        self._last_timeout_log = 0.0
+
+        self._stop_event = threading.Event()
+        self._thread = None
+        self._dump_lock = threading.Lock()
+
+    def setup(self, name=_DEFAULT_NAME, timeout=_DEFAULT_TIMEOUT, check_interval=_DEFAULT_INTERVAL):
+        self._name = name
+        self._timeout = timeout
+        self._check_interval = check_interval
+
+    def feed(self):
+        """Feed interface, external callers use this to update last feed time"""
+        # Single float assignment is atomic in CPython
+        self._last_feed_time = time.monotonic()
+
+    def dump_stack(self):
+        with self._dump_lock:
+            log_dir, base_name = get_log_dir_and_basename()
+            stack_filename = os.path.join(log_dir, f"{base_name}.{self._name}.stack")
+            with open(stack_filename, "a") as f:
+                f.write(f"\nCall Stack: the {self._sequence} time at [{time.time()}] {time.ctime()}\n\n")
+                faulthandler.dump_traceback(file=f, all_threads=True)
+                f.write("\n================================================================\n")
+            self._sequence += 1
+
+    def _check_loop(self):
+        """Main loop of the background check thread"""
+        while not self._stop_event.is_set():
+            time.sleep(self._check_interval)
+
+            now = time.monotonic()
+            # Calculate time elapsed since last feed
+            if now - self._last_feed_time > self._timeout:
+                # If last timeout log time is earlier than last feed time,
+                # it means timeout hasn't been logged since last feed, need to log and record
+                if self._last_timeout_log < self._last_feed_time:
+                    # Update log timestamp to current time to avoid duplicate logs
+                    self._last_timeout_log = now
+                    self.dump_stack()
+            # If not timed out, do nothing and keep _last_timeout_log unchanged
+
+    def start(self):
+        """Start the watchdog background thread (daemon thread)"""
+        if self._thread is not None and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._check_loop, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        """Stop the watchdog background thread"""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2)
+            self._thread = None
+
+
+_watch_dog = WatchDog()
+
+
+def get_watch_dog() -> WatchDog:
+    return _watch_dog
+
+
+def setup_watch_dog(name: str, timeout=5, check_interval=1) -> WatchDog:
+    global _watch_dog
+    _watch_dog = WatchDog(name, timeout, check_interval)
+    return get_watch_dog()

--- a/vllm_ascend/logger.py
+++ b/vllm_ascend/logger.py
@@ -13,15 +13,16 @@ Provides two logging mechanisms:
 import logging
 import os
 import sys
-from datetime import datetime
 
 from vllm import envs
 from vllm.logging_utils import ColoredFormatter, NewLineFormatter
 
+from vllm_ascend.common.utils.log_file import DEFAULT_LOG_DIR, setup_log_dir_and_basename
+
 _FORMAT = "%(levelname)s %(asctime)s [%(fileinfo)s:%(lineno)d] %(message)s"
 _DATE_FORMAT = "%m-%d %H:%M:%S"
 
-_LOG_DIR = os.path.join(os.path.expanduser("~"), "ascend", "log", "vllm_ascend")
+_LOG_DIR = DEFAULT_LOG_DIR
 _LOG_MAX_BYTES = 20 * 1024 * 1024
 
 
@@ -103,12 +104,11 @@ class RotatingAscendFileHandler(logging.FileHandler):
         vllm_ascend_{timestamp}_{pid}_003.log       <- third file
     """
 
-    def __init__(self, log_dir: str, max_bytes: int = _LOG_MAX_BYTES) -> None:
+    def __init__(self, log_dir: str, base_name: str, max_bytes: int = _LOG_MAX_BYTES) -> None:
         self._log_dir = log_dir
         self._max_bytes = max_bytes
         self._sequence = 1
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self._base_name = f"vllm_ascend_{timestamp}_{os.getpid()}"
+        self._base_name = base_name
         log_file = os.path.join(log_dir, f"{self._base_name}.log")
         super().__init__(log_file, encoding="utf-8")
 
@@ -138,9 +138,8 @@ def _setup_file_logging(log_dir: str | None = None) -> None:
     global _file_logging_configured, _file_handler
     if _file_logging_configured:
         return
-    target_dir = log_dir or _LOG_DIR
-    os.makedirs(target_dir, exist_ok=True)
-    file_handler = RotatingAscendFileHandler(target_dir)
+    target_dir, base_name = setup_log_dir_and_basename(log_dir)
+    file_handler = RotatingAscendFileHandler(target_dir, base_name)
     vllm_logger = logging.getLogger("vllm")
     ascend_logger = logging.getLogger("vllm_ascend")
     log_level = logging.INFO

--- a/vllm_ascend/patch/platform/__init__.py
+++ b/vllm_ascend/patch/platform/__init__.py
@@ -55,3 +55,5 @@ import vllm_ascend.patch.platform.patch_speculative_config  # noqa
 if not vllm_version_is("0.23.0"):
     import vllm_ascend.patch.platform.patch_fused_moe  # noqa
     import vllm_ascend.patch.platform.patch_dp_device_ids  # noqa
+
+import vllm_ascend.patch.platform.patch_engine_watchdog  # noqa

--- a/vllm_ascend/patch/platform/patch_engine_watchdog.py
+++ b/vllm_ascend/patch/platform/patch_engine_watchdog.py
@@ -1,0 +1,80 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+import queue
+from logging import DEBUG
+
+import vllm.envs as envs
+from vllm.v1.engine.core import EngineCoreProc, logger
+
+from vllm_ascend.common.utils.watch_dog import get_watch_dog
+
+_WAIT_INPUT_TIMEOUT = 5
+
+_watchdog = get_watch_dog()
+
+_original_run_engine_core = EngineCoreProc.run_engine_core
+_original_process_engine_step = EngineCoreProc._process_engine_step
+
+
+def _patched_run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
+    _watchdog.setup("engine", timeout=envs.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS)
+    _watchdog.start()
+    return _original_run_engine_core(*args, dp_rank=dp_rank, local_dp_rank=local_dp_rank, **kwargs)
+
+
+def _patched_process_engine_step(self) -> bool:
+    _watchdog.feed()
+    return _original_process_engine_step(self)
+
+
+def _patched_process_input_queue(self):
+    waited = False
+    while not self.has_work() and self.is_running():
+        # Notify callbacks waiting for engine to become idle.
+        self._notify_idle_state_callbacks()
+        if self.input_queue.empty():
+            # Drain aborts queue; all aborts are also processed via input_queue.
+            with self.aborts_queue.mutex:
+                self.aborts_queue.queue.clear()
+            if logger.isEnabledFor(DEBUG):
+                logger.debug("EngineCore waiting for work.")
+                waited = True
+        block = self.process_input_queue_block
+        try:
+            req = self.input_queue.get(block=block, timeout=_WAIT_INPUT_TIMEOUT)
+            self._handle_client_request(*req)
+        except queue.Empty:
+            _watchdog.feed()
+            if block:
+                continue
+            else:
+                break
+        if not block:
+            break
+
+    if waited:
+        logger.debug("EngineCore loop active.")
+
+    # Handle any more client requests.
+    while not self.input_queue.empty():
+        req = self.input_queue.get_nowait()
+        self._handle_client_request(*req)
+
+
+EngineCoreProc.run_engine_core = staticmethod(_patched_run_engine_core)
+EngineCoreProc._process_engine_step = _patched_process_engine_step
+EngineCoreProc._process_input_queue = _patched_process_input_queue

--- a/vllm_ascend/patch/platform/patch_shm_broadcast.py
+++ b/vllm_ascend/patch/platform/patch_shm_broadcast.py
@@ -6,6 +6,10 @@ from contextlib import contextmanager
 
 from vllm.distributed.device_communicators import shm_broadcast
 
+from vllm_ascend.common.utils.watch_dog import get_watch_dog
+
+_watchdog = get_watch_dog()
+
 MessageQueue = shm_broadcast.MessageQueue
 
 # Cap on how long an idle reader parks before re-reading the authoritative SHM
@@ -65,6 +69,7 @@ def acquire_read(
                 # if this block is not ready,
                 # we need to wait until it is written
                 self._spin_condition.wait(timeout_ms=read_timeout.timeout_ms())
+                _watchdog.feed()
 
                 if self.shutting_down:
                     raise RuntimeError("cancelled")

--- a/vllm_ascend/patch/worker/__init__.py
+++ b/vllm_ascend/patch/worker/__init__.py
@@ -87,3 +87,5 @@ if _V2_MODEL_RUNNER_SUPPORTED:
 # only patch routed experts capture in main2main.
 if _V2_MODEL_RUNNER_SUPPORTED:
     import vllm_ascend.patch.worker.patch_routed_experts_capture  # noqa
+
+import vllm_ascend.patch.worker.patch_worker_watchdog  # noqa

--- a/vllm_ascend/patch/worker/patch_worker_watchdog.py
+++ b/vllm_ascend/patch/worker/patch_worker_watchdog.py
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Huawei Technologies Co., Ltd. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# This file is a part of the vllm-ascend project.
+#
+import vllm.envs as envs
+from vllm.v1.executor.multiproc_executor import WorkerProc
+
+from vllm_ascend.common.utils.watch_dog import get_watch_dog
+
+_watchdog = get_watch_dog()
+
+_original_worker_busy_loop = WorkerProc.worker_busy_loop
+
+
+def _patched_worker_busy_loop(*args, **kwargs):
+    _watchdog.setup("worker", timeout=envs.VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS)
+    _watchdog.start()
+    return _original_worker_busy_loop(*args, **kwargs)
+
+
+WorkerProc.worker_busy_loop = _patched_worker_busy_loop

--- a/vllm_ascend/worker/worker.py
+++ b/vllm_ascend/worker/worker.py
@@ -78,12 +78,16 @@ torch._dynamo.trace_rules.clear_lru_cache()  # noqa: E402
 from torch._dynamo.variables import TorchInGraphFunctionVariable  # noqa: E402
 from vllm.utils.torch_utils import set_random_seed  # noqa: E402
 
+from vllm_ascend.common.utils.watch_dog import get_watch_dog  # noqa: E402
+
 torch_non_c_binding_in_graph_functions_npu = dict.fromkeys(
     ["torch.npu.current_stream"],
     TorchInGraphFunctionVariable,
 )  # noqa: E402
 torch_non_c_binding_in_graph_functions_npu["torch.npu.stream"] = TorchInGraphFunctionVariable  # noqa: E402
 torch._dynamo.trace_rules.torch_name_rule_map.append(torch_non_c_binding_in_graph_functions_npu)  # noqa: E402
+
+_watchdog = get_watch_dog()
 
 
 class NPUWorker(WorkerBase):
@@ -169,6 +173,7 @@ class NPUWorker(WorkerBase):
             shutdown_request = False
 
             def signal_handler(signum, frame):
+                _watchdog.dump_stack()
                 nonlocal shutdown_request
                 if not shutdown_request:
                     shutdown_request = True
@@ -612,6 +617,7 @@ class NPUWorker(WorkerBase):
         self,
         scheduler_output: "SchedulerOutput",
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | None:
+        _watchdog.feed()
         self.log_memory_stats()
         # enable msMonitor to monitor the performance of vllm-ascend
         if get_ascend_config().msmonitor_use_daemon:
@@ -676,6 +682,7 @@ class NPUWorker(WorkerBase):
 
     @torch.inference_mode()
     def sample_tokens(self, grammar_output: "GrammarOutput") -> ModelRunnerOutput | AsyncModelRunnerOutput:
+        _watchdog.feed()
         return self.model_runner.sample_tokens(grammar_output)
 
     def load_model(self) -> None:
@@ -983,6 +990,7 @@ class NPUWorker(WorkerBase):
         self.model_runner.reset_encoder_cache()
 
     def execute_dummy_batch(self) -> None:
+        _watchdog.feed()
         self.log_memory_stats()
         self.model_runner._dummy_run(num_tokens=self.model_runner.decode_token_per_req, uniform_decode=True)
 


### PR DESCRIPTION
### What this PR does / why we need it?
This PR introduces a `WatchDog` utility to monitor engine and worker processes in `vllm-ascend`, allowing detection of hangs or prolonged step execution delays. It adds patches to hook into the engine core process (`patch_engine_watchdog.py`) and worker busy loop (`patch_worker_watchdog.py`) to feed the watchdog.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

- TP=1
```
vllm serve /mnt/weight/Qwen3-8B/    --tensor-parallel-size 1    --gpu_memory_utilization 0.80   --max_num_seqs 32   --served_model_name qwen    --dtype float16  --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' --enforce-eager --max_model_len 20480 --no-enable-prefix-caching
```

Log file list:
```
vllm_ascend_20260827_173343_27849.engine.stack
```

- TP=2
```
vllm serve /mnt/weight/Qwen3-8B/    --tensor-parallel-size 2    --gpu_memory_utilization 0.80   --max_num_seqs 32   --served_model_name qwen    --dtype float16  --additional-config '{"ascend_compilation_config": {"fuse_norm_quant": false}}' --enforce-eager --max_model_len 20480 --no-enable-prefix-caching
```

Log file list:
```
vllm_ascend_20260827_172837_26459.engine.stack
vllm_ascend_20260827_173310_28130.worker.stack
vllm_ascend_20260827_173310_28131.worker.stack
```

- vLLM main: https://github.com/vllm-project/vllm/commit/ee0da84ab9e04ac7610e28580af62c365e898389
