### PR TITLE
[Bugfix][Spec Decode] Disable AutoBlockify for rejection sampling

### DIFF
--- a/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
+++ b/tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py
@@ -31,7 +31,6 @@ DSPARK_MAIN_MODEL = ["UploadWeight/DeepSeek-V4-Flash-DSpark-w4a8-test"]
 MODEL = "gdydems/DeepSeek-V4-Flash-w4a8-mtp"
 
 
-@pytest.mark.skip("Temporarily skip this DeepSeek V4 test.")
 @pytest.mark.e2e_model(MODEL)
 @pytest.mark.e2e_coverage(
     arch="moe",

--- a/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
+++ b/vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py
@@ -411,6 +411,9 @@ def rejection_sample(
         num_speculative_steps,
         BLOCK_SIZE=VOCAB_BLOCK_SIZE,
         HAS_DRAFT_LOGITS=has_draft_logits,
+        # TODO: Remove this workaround after the Triton Ascend AutoBlockify
+        # bug for max-with-index reductions is fixed.
+        has_auto_blockify_blacklist_op=True,
     )
 
     # Sample up until the first rejected/bonus token, and store
@@ -481,6 +484,9 @@ def rejection_sample(
         vocab_size,
         BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
         HAS_DRAFT_LOGITS=has_draft_logits,
+        # TODO: Remove this workaround after the Triton Ascend AutoBlockify
+        # bug for max-with-index reductions is fixed.
+        has_auto_blockify_blacklist_op=True,
     )
 
     # Insert the resampled tokens into the output sampled.


### PR DESCRIPTION
### What this PR does / why we need it?

Fixes an Ascend Triton correctness issue in rejection sampling. AutoBlockify can corrupt the max-with-index reductions used by `_compute_block_stats_kernel` and `_resample_kernel`, which can produce an incorrect argmax/token ID even when the input logits are finite.

This patch opts both rejection-sampling kernels out of AutoBlockify with `has_auto_blockify_blacklist_op=True`. It also re-enables the existing DeepSeek V4 MTP eager test by removing its temporary skip marker.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

- `python -m py_compile vllm_ascend/worker/v2/spec_decode/rejection_sampler_utils.py tests/e2e/pull_request/four_card/model_runner_v2/test_deepseek_v4.py`
- DeepSeek V4 MTP eager diagnostic soak: 448 consecutive iterations completed on four Ascend NPUs without an invalid token ID or NPU device error before the run was manually stopped to reload the clean patch.

- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
