### PR TITLE
[CI] Temporarily avoid the issue DTS2608260106811 by disabling the MC2 feature switch.

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
@@ -75,5 +75,5 @@ test_cases:
         max_out_len: 1500
         batch_size: 4
         request_rate: 0
-        baseline: 192.0481
+        baseline: 186.35295
         threshold: 0.97

--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
@@ -75,5 +75,5 @@ test_cases:
         max_out_len: 1500
         batch_size: 4
         request_rate: 0
-        baseline: 186.35295
+        baseline: 192.0481
         threshold: 0.97

--- a/tests/e2e/nightly/single_node/models/configs/GLM-4.7.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/GLM-4.7.yaml
@@ -33,7 +33,7 @@ _server_cmd: &server_cmd
   - "--speculative-config"
   - '{"num_speculative_tokens": 3, "method":"mtp"}'
   - "--additional-config"
-  - '{"enable_shared_expert_dp":true,"ascend_fusion_config":{"fusion_ops_gmmswigluquant":false},"enable_fused_mc2":1,"scheduler_config":{"enable_balance_scheduling":true}}'
+  - '{"enable_shared_expert_dp":true,"ascend_fusion_config":{"fusion_ops_gmmswigluquant":false},"enable_fused_mc2":0,"scheduler_config":{"enable_balance_scheduling":true}}'
 
 _benchmarks: &benchmarks
   acc:

--- a/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/Qwen3.5-397B-A17B-W8A8-mtp-A3.yaml
@@ -35,7 +35,7 @@ test_cases:
       - "--gpu-memory-utilization"
       - "0.9"
       - "--additional-config"
-      - '{"enable_cpu_binding":true,"enable_fused_mc2":1}'
+      - '{"enable_cpu_binding":true,"enable_fused_mc2":0}'
       - "--speculative_config"
       - '{"method": "qwen3_5_mtp", "num_speculative_tokens": 5, "enforce_eager": true}'
       - "--compilation-config"


### PR DESCRIPTION
### What this PR does / why we need it?
Temporarily avoid the issue DTS2608260106811 by disabling the MC2 feature switch.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
run the cases nightly

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
