### PR TITLE
[Refactor][Attention] Dedupe FIA ACL-graph workspace resolution into shared helper

### DIFF
--- a/vllm_ascend/attention/attention_v1.py
+++ b/vllm_ascend/attention/attention_v1.py
@@ -920,6 +920,38 @@ class AscendAttentionBackendImpl(AttentionImpl):
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         super().process_weights_after_loading(act_dtype)
 
+    def _resolve_fia_graph_workspace(self, graph_params, num_tokens: int, workspace_fn, **workspace_kwargs):
+        """Resolve the ACL-graph workspace for a FIA call.
+
+        Shared by ``full_graph_fia`` and ``full_graph_fia_v2``: when
+        ``use_max_workspace`` is enabled, keep the largest required
+        workspace across layer variants sharing the same graph size
+        (some models mix attention layer shapes under the same graph
+        size); otherwise compute the workspace lazily on first capture
+        and cache it in ``graph_params.workspaces``.
+        """
+        use_max_workspace = self._use_max_workspace_for_fia_graph
+        workspace = graph_params.workspaces.get(num_tokens)
+        should_update_workspace_cache = False
+        if use_max_workspace:
+            candidate_workspace = workspace_fn(**workspace_kwargs)
+            workspace = cache_graph_workspace(
+                graph_params,
+                num_tokens,
+                candidate_workspace,
+                use_max_workspace=use_max_workspace,
+            )
+            should_update_workspace_cache = True
+        elif workspace is None:
+            workspace = workspace_fn(**workspace_kwargs)
+            should_update_workspace_cache = True
+        if should_update_workspace_cache:
+            if _EXTRA_CTX.is_draft_model:
+                update_draft_graph_params_workspaces(num_tokens, workspace)
+            else:
+                update_graph_params_workspaces(num_tokens, workspace)
+        return workspace
+
     def full_graph_fia(
         self,
         query: torch.Tensor,
@@ -968,62 +1000,27 @@ class AscendAttentionBackendImpl(AttentionImpl):
             output = output.unsqueeze(2)
             attn_mask = None
             sparse_mode = 0
-        use_max_workspace = self._use_max_workspace_for_fia_graph
-        workspace = graph_params.workspaces.get(num_tokens)
-        should_update_workspace_cache = False
-        if use_max_workspace:
-            # Some models mix attention layer shapes under the same graph size.
-            # During capture, keep the largest required workspace for that size.
-            candidate_workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_mask,
-                block_table=block_table,
-                input_layout=input_layout,
-                block_size=block_size,
-                actual_seq_lengths=actual_seq_lengths_q,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                num_heads=self.num_heads,
-                sparse_mode=sparse_mode,
-                pre_tokens=pre_tokens,
-                next_tokens=next_tokens,
-                scale=self.scale,
-                **extra_args,
-            )
-            workspace = cache_graph_workspace(
-                graph_params,
-                num_tokens,
-                candidate_workspace,
-                use_max_workspace=use_max_workspace,
-            )
-            should_update_workspace_cache = True
-        elif workspace is None:
-            workspace = torch_npu._npu_fused_infer_attention_score_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_mask,
-                block_table=block_table,
-                input_layout=input_layout,
-                block_size=block_size,
-                actual_seq_lengths=actual_seq_lengths_q,
-                actual_seq_lengths_kv=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                num_heads=self.num_heads,
-                sparse_mode=sparse_mode,
-                pre_tokens=pre_tokens,
-                next_tokens=next_tokens,
-                scale=self.scale,
-                **extra_args,
-            )
-            should_update_workspace_cache = True
-        if should_update_workspace_cache:
-            if _EXTRA_CTX.is_draft_model:
-                update_draft_graph_params_workspaces(num_tokens, workspace)
-            else:
-                update_graph_params_workspaces(num_tokens, workspace)
+        workspace = self._resolve_fia_graph_workspace(
+            graph_params,
+            num_tokens,
+            torch_npu._npu_fused_infer_attention_score_get_max_workspace,
+            query=query,
+            key=key,
+            value=value,
+            atten_mask=attn_mask,
+            block_table=block_table,
+            input_layout=input_layout,
+            block_size=block_size,
+            actual_seq_lengths=actual_seq_lengths_q,
+            actual_seq_lengths_kv=actual_seq_lengths_kv,
+            num_key_value_heads=self.num_kv_heads,
+            num_heads=self.num_heads,
+            sparse_mode=sparse_mode,
+            pre_tokens=pre_tokens,
+            next_tokens=next_tokens,
+            scale=self.scale,
+            **extra_args,
+        )
 
         # Handle graph capturing mode
         stream = torch_npu.npu.current_stream()
@@ -1110,62 +1107,27 @@ class AscendAttentionBackendImpl(AttentionImpl):
 
         actual_seq_lengths_q = attn_metadata.actual_seq_lengths_q
         softmax_lse = torch.empty(1, dtype=query.dtype, device=query.device)
-        use_max_workspace = self._use_max_workspace_for_fia_graph
-        workspace = graph_params.workspaces.get(num_tokens)
-        should_update_workspace_cache = False
-        if use_max_workspace:
-            # See full_graph_fia: this path needs the max workspace across layer
-            # variants sharing the same graph size.
-            candidate_workspace = torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_metadata.attn_mask,
-                block_table=block_table,
-                input_layout="TND",
-                block_size=block_size,
-                actual_seq_qlen=actual_seq_lengths_q,
-                actual_seq_kvlen=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                softmax_scale=self.scale,
-                num_query_heads=self.num_heads,
-                sparse_mode=4 if self.sliding_window is not None else 3,
-                pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
-                next_tokens=0,
-                learnable_sink=self.sinks,
-            )
-            workspace = cache_graph_workspace(
-                graph_params,
-                num_tokens,
-                candidate_workspace,
-                use_max_workspace=use_max_workspace,
-            )
-            should_update_workspace_cache = True
-        elif workspace is None:
-            workspace = torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace(
-                query=query,
-                key=key,
-                value=value,
-                atten_mask=attn_metadata.attn_mask,
-                block_table=block_table,
-                input_layout="TND",
-                block_size=block_size,
-                actual_seq_qlen=actual_seq_lengths_q,
-                actual_seq_kvlen=actual_seq_lengths_kv,
-                num_key_value_heads=self.num_kv_heads,
-                softmax_scale=self.scale,
-                num_query_heads=self.num_heads,
-                sparse_mode=4 if self.sliding_window is not None else 3,
-                pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
-                next_tokens=0,
-                learnable_sink=self.sinks,
-            )
-            should_update_workspace_cache = True
-        if should_update_workspace_cache:
-            if _EXTRA_CTX.is_draft_model:
-                update_draft_graph_params_workspaces(num_tokens, workspace)
-            else:
-                update_graph_params_workspaces(num_tokens, workspace)
+        workspace = self._resolve_fia_graph_workspace(
+            graph_params,
+            num_tokens,
+            torch_npu._npu_fused_infer_attention_score_v2_get_max_workspace,
+            query=query,
+            key=key,
+            value=value,
+            atten_mask=attn_metadata.attn_mask,
+            block_table=block_table,
+            input_layout="TND",
+            block_size=block_size,
+            actual_seq_qlen=actual_seq_lengths_q,
+            actual_seq_kvlen=actual_seq_lengths_kv,
+            num_key_value_heads=self.num_kv_heads,
+            softmax_scale=self.scale,
+            num_query_heads=self.num_heads,
+            sparse_mode=4 if self.sliding_window is not None else 3,
+            pre_tokens=self.sliding_window if self.sliding_window is not None else SWA_INT_MAX,
+            next_tokens=0,
+            learnable_sink=self.sinks,
+        )
 
         # Handle graph capturing mode
         stream = torch_npu.npu.current_stream()


### PR DESCRIPTION
## Motivation

`full_graph_fia` and `full_graph_fia_v2` in `vllm_ascend/attention/attention_v1.py` contained two nearly identical ~50-line workspace-resolution blocks (the `use_max_workspace` branch + lazy computation + cache update via `cache_graph_workspace` / `update_graph_params_workspaces` / `update_draft_graph_params_workspaces`), differing only in the `workspace_fn` callable and its keyword arguments. This duplicates the resolution flow and makes the two paths drift-prone.

## Modification

- Extract the shared flow into a private helper `_resolve_fia_graph_workspace(graph_params, num_tokens, workspace_fn, **workspace_kwargs)` and call it from both `full_graph_fia` and `full_graph_fia_v2`.
- `full_graph_pa` is intentionally left untouched: its workspace flow (no `use_max_workspace` branch, different caching) does not share this shape.
- Net -38 lines, single file, no public API change.

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

- Trace-equivalence check: recorded call sequences of the new helper vs the old inline logic (mocked `workspace_fn` / `cache_graph_workspace` / `update_*_graph_params_workspaces`) across all 8 combinations of `use_max_workspace` x cache-hit x draft-model - identical call traces and return values vs the pre-refactor code.
- `ruff check` + `ruff format` pass.
- No runtime NPU environment available locally; behavior preservation relies on the trace equivalence check above.

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
