### PR TITLE
[CI] Migrate nightly image build from Quay to SWR north-12

### DIFF
--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -123,7 +123,7 @@ jobs:
             SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
             SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend-temp"
             TAG_PREFIX="nightly-ci"
-            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
+            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
           fi
 
           CANN_VERSION_LOWER=$(echo "${{ inputs.cann_version }}" | tr '[:upper:]' '[:lower:]')

--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -120,10 +120,10 @@ jobs:
             TAG_PREFIX="daily"
             BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
           else
-            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
-            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_ci/vllm-atlas-temp"
+            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
+            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend-temp"
             TAG_PREFIX="nightly-ci"
-            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
+            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
           fi
 
           CANN_VERSION_LOWER=$(echo "${{ inputs.cann_version }}" | tr '[:upper:]' '[:lower:]')
@@ -228,7 +228,7 @@ jobs:
         run: |
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"
-          RELEASE_SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
+          RELEASE_SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
           RELEASE_TAG="nightly-ci-${BRANCH_TAG}-${{ inputs.target }}"
           # Release copy uses a stable tag without arch info (single-arch arm64 image)
           RELEASE_IMAGE="${RELEASE_SWR_REGISTRY}:${RELEASE_TAG}"

--- a/.github/workflows/_nightly_image_build.yaml
+++ b/.github/workflows/_nightly_image_build.yaml
@@ -33,12 +33,7 @@ on:
         required: false
         type: string
         default: 'release'
-        description: "Build type: 'daily' or 'release'. Daily uses swr.cn-north-4 and quay.io base image."
-      quay_daily_username:
-        required: false
-        type: string
-        default: ''
-        description: "Quay username for daily base image pull"
+        description: "Build type: 'daily' or 'release'. Daily uses swr.cn-north-12 base image."
       cann_version:
         required: false
         type: string
@@ -50,17 +45,11 @@ on:
         default: 'auto'
         description: "Base image date (YYYYMMDD). 'auto' to auto-detect latest available, or specify a custom date."
     secrets:
-      HW_USERNAME:
+      SWR_USERNAME:
         required: false
-      HW_TOKEN:
-        required: false
-      HW_USERNAME_DAILY:
-        required: false
-      HW_TOKEN_DAILY:
+      SWR_PASSWORD:
         required: false
       GITEE_TOKEN:
-        required: false
-      QUAY_DAILY_PASSWORD:
         required: false
 
 jobs:
@@ -98,30 +87,23 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.vllm_ascend_branch }}
 
-      - name: Login to Huawei Cloud SWR (Release)
+      - name: Login to Huawei Cloud SWR
         id: login-swr
         if: ${{ inputs.build_type != 'daily' || (inputs.build_type == 'daily' && matrix.os == 'ubuntu' && matrix.arch_name == 'arm64') }}
         env:
-          HW_USERNAME: ${{ secrets.HW_USERNAME }}
-          HW_TOKEN: ${{ secrets.HW_TOKEN }}
+          SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+          SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
         run: |
-          echo "$HW_TOKEN" | docker login -u "$HW_USERNAME" --password-stdin swr.cn-southwest-2.myhuaweicloud.com
+          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin swr.cn-north-12.myhuaweicloud.com
 
       - name: Login to Huawei Cloud SWR (Daily)
         id: login-swr-daily
         if: ${{ inputs.build_type == 'daily' }}
         env:
-          HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-          HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+          SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+          SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
         run: |
-          docker login -u cn-north-4@"$HW_USERNAME_DAILY" -p "$HW_TOKEN_DAILY" swr.cn-north-4.myhuaweicloud.com
-
-      - name: Login to Quay.io (for daily base image pull)
-        if: ${{ inputs.build_type == 'daily' }}
-        env:
-          QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
-        run: |
-          docker login -u "${{ inputs.quay_daily_username }}" -p "$QUAY_DAILY_PASSWORD" quay.io
+          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin swr.cn-north-12.myhuaweicloud.com
 
       - name: Build nightly-${{ inputs.target }} image
         id: build
@@ -133,15 +115,15 @@ jobs:
           BRANCH_TAG="${BRANCH_TAG//\//-}"
 
           if [ "${{ inputs.build_type }}" = "daily" ]; then
-            SWR_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend"
-            SWR_TEMP_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend-temp"
+            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
+            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp"
             TAG_PREFIX="daily"
-            BASE_IMAGE="quay.io/atlas_inference/vllm-ascend"
+            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
           else
-            SWR_REGISTRY="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
-            SWR_TEMP_REGISTRY="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend-temp"
+            SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
+            SWR_TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_ci/vllm-atlas-temp"
             TAG_PREFIX="nightly-ci"
-            BASE_IMAGE=""
+            BASE_IMAGE="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
           fi
 
           CANN_VERSION_LOWER=$(echo "${{ inputs.cann_version }}" | tr '[:upper:]' '[:lower:]')
@@ -152,14 +134,14 @@ jobs:
           fi
           if [ "${{ inputs.build_type }}" = "daily" ]; then
             # Resolve the base image date: 'auto' backtracks day-by-day from today to find
-            # the latest date for which the quay base image exists; otherwise use the
+            # the latest date for which the north-12 base image exists; otherwise use the
             # user-supplied date (YYYYMMDD).
             if [ "${{ inputs.base_image_date }}" = "auto" ] || [ -z "${{ inputs.base_image_date }}" ]; then
               DATE=""
               for i in $(seq 0 30); do
                 CANDIDATE_DATE=$(date -d "$i days ago" +'%Y%m%d')
                 CANDIDATE_TAG="nightly-${BRANCH_TAG}${OS_MARK}-cann${CANN_VERSION_LOWER}-${CANDIDATE_DATE}"
-                if docker manifest inspect "quay.io/atlas_inference/vllm-ascend:${CANDIDATE_TAG}" > /dev/null 2>&1; then
+                if docker manifest inspect "swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend:${CANDIDATE_TAG}" > /dev/null 2>&1; then
                   DATE="$CANDIDATE_DATE"
                   echo "Found base image date: $DATE (tag: $CANDIDATE_TAG)"
                   break
@@ -246,7 +228,7 @@ jobs:
         run: |
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"
-          RELEASE_SWR_REGISTRY="swr.cn-southwest-2.myhuaweicloud.com/base_image/ascend-ci/vllm-ascend"
+          RELEASE_SWR_REGISTRY="swr.cn-north-12.myhuaweicloud.com/ascend/vllm-ascend"
           RELEASE_TAG="nightly-ci-${BRANCH_TAG}-${{ inputs.target }}"
           # Release copy uses a stable tag without arch info (single-arch arm64 image)
           RELEASE_IMAGE="${RELEASE_SWR_REGISTRY}:${RELEASE_TAG}"
@@ -262,19 +244,19 @@ jobs:
     # only when BOTH arch images exist. Owner gate keeps it disabled in upstream forks.
     if: ${{ always() && github.repository_owner == 'vllm-project' && inputs.build_type == 'daily' }}
     steps:
-      - name: Login to Huawei Cloud SWR (Daily)
+      - name: Login to Huawei Cloud SWR
         env:
-          HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-          HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+          SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+          SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
         run: |
-          docker login -u cn-north-4@"$HW_USERNAME_DAILY" -p "$HW_TOKEN_DAILY" swr.cn-north-4.myhuaweicloud.com
+          echo "$SWR_PASSWORD" | docker login -u "$SWR_USERNAME" --password-stdin swr.cn-north-12.myhuaweicloud.com
 
       - name: Create multi-arch manifest
         run: |
           # Registry and tag are recomputed here (not from matrix outputs) so merge still
           # works even when the last-completed matrix instance failed to push.
-          MAIN_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend"
-          TEMP_REGISTRY="swr.cn-north-4.myhuaweicloud.com/inference/vllm-ascend-temp"
+          MAIN_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-ascend"
+          TEMP_REGISTRY="swr.cn-north-12.myhuaweicloud.com/atlas_inference/vllm-atlas-temp"
 
           BRANCH_TAG="${{ inputs.vllm_ascend_branch }}"
           BRANCH_TAG="${BRANCH_TAG//\//-}"

--- a/.github/workflows/nightly_image_build.yaml
+++ b/.github/workflows/nightly_image_build.yaml
@@ -57,16 +57,12 @@ jobs:
       target: a2
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   build-a3:
     uses: ./.github/workflows/_nightly_image_build.yaml
@@ -74,16 +70,12 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   build-310p:
     uses: ./.github/workflows/_nightly_image_build.yaml
@@ -91,29 +83,21 @@ jobs:
       target: 310p
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
   build-a5:
     uses: ./.github/workflows/_nightly_image_build.yaml
     with:
       target: a5
       vllm_ascend_branch: ${{ inputs.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}

--- a/.github/workflows/schedule_nightly_test_310p.yaml
+++ b/.github/workflows/schedule_nightly_test_310p.yaml
@@ -184,16 +184,12 @@ jobs:
       target: 310p
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   single-node-tests:
     name: single-node

--- a/.github/workflows/schedule_nightly_test_a2.yaml
+++ b/.github/workflows/schedule_nightly_test_a2.yaml
@@ -191,16 +191,12 @@ jobs:
       target: a2
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_nightly_test_a3.yaml
+++ b/.github/workflows/schedule_nightly_test_a3.yaml
@@ -190,16 +190,12 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_nightly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_nightly_test_a3_560t.yaml
@@ -191,16 +191,12 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_nightly_test_a5.yaml
+++ b/.github/workflows/schedule_nightly_test_a5.yaml
@@ -186,16 +186,12 @@ jobs:
       target: a5
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_weekly_test_310p.yaml
+++ b/.github/workflows/schedule_weekly_test_310p.yaml
@@ -192,16 +192,12 @@ jobs:
       target: 310p
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   single-node-tests:
     name: single-node

--- a/.github/workflows/schedule_weekly_test_a2.yaml
+++ b/.github/workflows/schedule_weekly_test_a2.yaml
@@ -186,16 +186,12 @@ jobs:
       target: a2
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   single-node-accuracy-tests:
     needs: [setup-vars, parse-trigger, build-image]

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -192,16 +192,12 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node

--- a/.github/workflows/schedule_weekly_test_a3_560t.yaml
+++ b/.github/workflows/schedule_weekly_test_a3_560t.yaml
@@ -191,16 +191,12 @@ jobs:
       target: a3
       vllm_ascend_branch: ${{ matrix.vllm_ascend_branch }}
       build_type: ${{ inputs.build_type }}
-      quay_daily_username: ${{ vars.QUAY_DAILY_USERNAME }}
       cann_version: ${{ fromJSON(inputs.base_image_tag).cann_version }}
       base_image_date: ${{ fromJSON(inputs.base_image_tag).base_image_date }}
     secrets:
-      HW_USERNAME: ${{ secrets.HW_USERNAME }}
-      HW_TOKEN: ${{ secrets.HW_TOKEN }}
-      HW_USERNAME_DAILY: ${{ secrets.HW_USERNAME_DAILY }}
-      HW_TOKEN_DAILY: ${{ secrets.HW_TOKEN_DAILY }}
+      SWR_USERNAME: ${{ secrets.SWR_USERNAME }}
+      SWR_PASSWORD: ${{ secrets.SWR_PASSWORD }}
       GITEE_TOKEN: ${{ secrets.GITEE_TOKEN }}
-      QUAY_DAILY_PASSWORD: ${{ secrets.QUAY_DAILY_PASSWORD }}
 
   multi-node-tests:
     name: multi-node


### PR DESCRIPTION
### What this PR does / why we need it?

Migrate the nightly image build pipeline from Quay to SWR (swr.cn-north-12).

- Daily nightly images: base image pulled from `swr.cn-north-12/atlas_inference/vllm-ascend` (was quay.io), final to `atlas_inference/vllm-ascend`, temp to `atlas_inference/vllm-atlas-temp`.
- Release nightly images: final to `ascend/vllm-ascend`, temp to `atlas_ci/vllm-atlas-temp`.
- `BASE_IMAGE` build-arg is passed explicitly in both daily and release modes, so the Dockerfile default (quay.io/ascend/vllm-ascend) is never used.
- Replace `HW_*` / `QUAY_DAILY_*` credentials with `SWR_USERNAME` / `SWR_PASSWORD` for north-12 authentication.
- Update the 9 nightly/weekly test workflow callers (`schedule_nightly_test_*`, `schedule_weekly_test_*`) to match the new inputs/secrets interface.

### Does this PR introduce _any_ user-facing change?

No. CI/internal registry changes only.

### How was this patch tested?

- YAML syntax validated.
- Caller/reusable workflow interface cross-checked (no unexpected inputs/secrets, no missing required fields).
- All repo paths verified against existing SWR buckets (atlas_ci, atlas_inference, ascend, base_image).

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
