### PR TITLE
[CI]update baseline for  nightly single-node case:Deepseekv3.2-w8a8.yaml 

### DIFF
--- a/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
+++ b/tests/e2e/nightly/single_node/models/configs/DeepSeek-V3.2-W8A8.yaml
@@ -75,5 +75,5 @@ test_cases:
         max_out_len: 1500
         batch_size: 4
         request_rate: 0
-        baseline: 192.0481
+        baseline: 186.35295
         threshold: 0.97


### PR DESCRIPTION
### What this PR does / why we need it?
update baseline for  nightly single-node case:Deepseekv3.2-w8a8.yaml 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
run the case nightly

- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
