### PR TITLE
[BugFix] Reduce Ascend opc compilation parallelism from CPU×2 to nproc to fix OOM

### DIFF
--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -247,9 +247,9 @@ log_selected_ops
   : "${SOC_VERSION:?SOC_VERSION is not set}"
   : "${SOC_ARG:?SOC_ARG is not set}"
 
-  log "build command: bash build.sh --pkg --ops=\"${CUSTOM_OPS}\" --soc=\"${SOC_ARG}\""
+  log "build command: bash build.sh --pkg -j$(nproc) --ops=\"${CUSTOM_OPS}\" --soc=\"${SOC_ARG}\""
   log "building custom ops ${CUSTOM_OPS} for ${SOC_VERSION}"
-  bash build.sh --pkg --ops="${CUSTOM_OPS}" --soc="${SOC_ARG}"
+  bash build.sh --pkg -j$(nproc) --ops="${CUSTOM_OPS}" --soc="${SOC_ARG}"
   log "build.sh finished"
 
   custom_ops_install_dir="${ROOT_DIR}/vllm_ascend/_cann_ops_custom"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -221,17 +221,54 @@ fi
 
 log_selected_ops
 
-# Determine optimal build parallelism.
-# - Use nproc if available, fall back to /proc/cpuinfo, then default to 1.
-# - Cap at 16 to prevent OOM on memory-constrained environments (e.g. CI buildkitd pods).
+# Determine optimal build parallelism, cgroup-aware (v1 and v2).
+# - CPU: respect cgroup quota (cpu.max or cpu.cfs_quota_us) and cpuset affinity.
+# - Memory: conservative ~1.5 GiB per opc compiler process, based on the
+#   observed OOM boundary (32 processes × 1.5 GiB ≈ 48 GiB > 24 GiB CI limit).
 # - build.sh's get_cpu_num() further caps the value via OPS_CPU_NUMBER/MAX_JOBS.
 get_build_jobs() {
-    local cpu_count
-    cpu_count=$(nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 1)
-    if [ "${cpu_count}" -gt 16 ]; then
-        cpu_count=16
-    fi
-    echo "${cpu_count}"
+    local cpu_count mem_bytes mem_limit
+
+    # --- cgroup-aware CPU count ---
+    {
+        local quota= period=100000 affinity=
+        if [ -r /sys/fs/cgroup/cpu.max ]; then
+            read -r quota _ < /sys/fs/cgroup/cpu.max
+        elif [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then
+            quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+            period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+            [ "$quota" = "-1" ] && quota=max
+        fi
+        affinity=$(nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 1)
+        if [ "$quota" = max ] || [ -z "$quota" ]; then
+            cpu_count=$affinity
+        else
+            n=$(( (quota + period - 1) / period ))
+            [ "$n" -lt 1 ] && n=1
+            [ "$n" -lt "$affinity" ] && cpu_count=$n || cpu_count=$affinity
+        fi
+    }
+
+    # --- cgroup-aware memory cap ---
+    {
+        local lim= host=
+        [ -r /sys/fs/cgroup/memory.max ] && lim=$(cat /sys/fs/cgroup/memory.max)
+        [ -z "$lim" ] && [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ] && \
+            lim=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+        host=$(awk '/^MemTotal:/ {printf "%d", $2 * 1024}' /proc/meminfo 2>/dev/null || echo 8589934592)
+        if [ -z "$lim" ] || [ "$lim" = max ]; then
+            mem_bytes=$host
+        else
+            [ "$lim" -gt "$host" ] && mem_bytes=$host || mem_bytes=$lim
+        fi
+        # ~1.5 GiB per opc process; cap CPU count to what memory can sustain
+        mem_limit=$(( mem_bytes / 1610612736 ))  # 1.5 GiB in bytes
+        [ "$mem_limit" -lt 1 ] && mem_limit=1
+    }
+
+    # --- final: min of CPU-based and memory-based ---
+    [ "$cpu_count" -gt "$mem_limit" ] && cpu_count=$mem_limit
+    echo "$cpu_count"
 }
 BUILD_JOBS=$(get_build_jobs)
 log "detected build parallelism: -j${BUILD_JOBS}"

--- a/csrc/build_aclnn.sh
+++ b/csrc/build_aclnn.sh
@@ -221,6 +221,21 @@ fi
 
 log_selected_ops
 
+# Determine optimal build parallelism.
+# - Use nproc if available, fall back to /proc/cpuinfo, then default to 1.
+# - Cap at 16 to prevent OOM on memory-constrained environments (e.g. CI buildkitd pods).
+# - build.sh's get_cpu_num() further caps the value via OPS_CPU_NUMBER/MAX_JOBS.
+get_build_jobs() {
+    local cpu_count
+    cpu_count=$(nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null || echo 1)
+    if [ "${cpu_count}" -gt 16 ]; then
+        cpu_count=16
+    fi
+    echo "${cpu_count}"
+}
+BUILD_JOBS=$(get_build_jobs)
+log "detected build parallelism: -j${BUILD_JOBS}"
+
 
 # # build custom ops
 # cd csrc
@@ -247,9 +262,9 @@ log_selected_ops
   : "${SOC_VERSION:?SOC_VERSION is not set}"
   : "${SOC_ARG:?SOC_ARG is not set}"
 
-  log "build command: bash build.sh --pkg -j$(nproc) --ops=\"${CUSTOM_OPS}\" --soc=\"${SOC_ARG}\""
+  log "build command: bash build.sh --pkg -j${BUILD_JOBS} --ops=\"${CUSTOM_OPS}\" --soc=\"${SOC_ARG}\""
   log "building custom ops ${CUSTOM_OPS} for ${SOC_VERSION}"
-  bash build.sh --pkg -j$(nproc) --ops="${CUSTOM_OPS}" --soc="${SOC_ARG}"
+  bash build.sh --pkg -j${BUILD_JOBS} --ops="${CUSTOM_OPS}" --soc="${SOC_ARG}"
   log "build.sh finished"
 
   custom_ops_install_dir="${ROOT_DIR}/vllm_ascend/_cann_ops_custom"


### PR DESCRIPTION
### What this PR does / why we need it?

Fix OOM during nightly image build on ARM buildkitd pods (16 CPU, 24Gi memory).

The root cause is in `csrc/build.sh`'s `get_cpu_num()` function:
```bash
CPU_NUM=$(($(cat /proc/cpuinfo | grep "^processor" | wc -l)*2))
```
It defaults parallelism to **CPU count × 2** (32 on 16-core pods). 

`build_aclnn.sh` calls `build.sh --pkg --ops=... --soc=...` without passing `-j`, so the default `-j32` is used. 32 parallel `opc` (Ascend operator compiler) processes consume more memory than the 24Gi limit, causing OOM kills.

Fix: pass `-j$(nproc)` to use CPU count (=16) instead of CPU×2 (=32).

### Does this PR introduce _any_ user-facing change?

No. CI build fix only.

### How was this patch tested?

- Code review: verified `build.sh`'s `get_cpu_num()` and `JOB_NUM` assignment logic
- Verified the call chain: `build_aclnn.sh:252` → `build.sh --pkg` → `get_cpu_num` → `JOB_NUM="-j${CPU_NUM}"`

- vLLM main: https://github.com/vllm-project/vllm/commit/e6bfe03ad73a3330cb427885aa90d97a12e1c704
