### PR TITLE
[Test][Misc] Move 2 size cases to double_node

### DIFF
--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -259,10 +259,6 @@ a3:
         config_file_path: Qwen3.5-122B-A10B-w4a8-984k-1k-0-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
-      - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
-        config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
       - name: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD
         config_file_path: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config

--- a/.github/workflows/configs/weekly_config.yaml
+++ b/.github/workflows/configs/weekly_config.yaml
@@ -93,46 +93,10 @@ a3:
         config_file_path: QWEN3_235B_PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 3
-      - name: Kimi-K2.6-W4A8-3.5k-1.5k-TPOT50-PD
-        config_file_path: Kimi-K2.6-W4A8-3.5k-1.5k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Kimi-K2.6-W4A8-128k-1k-TPOT50-PD
-        config_file_path: Kimi-K2.6-W4A8-128k-1k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Kimi-K2.6-W4A8-254k-1k-TPOT20-PD
-        config_file_path: Kimi-K2.6-W4A8-254k-1k-TPOT20-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Kimi-K2.7-W4A8-3.5k-1.5k-TPOT50-PD
-        config_file_path: Kimi-K2.7-W4A8-3.5k-1.5k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Kimi-K2.7-W4A8-64k-1k-TPOT50-PD
-        config_file_path: Kimi-K2.7-W4A8-64k-1k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Kimi-K2.7-W4A8-128k-1k-TPOT50-PD
-        config_file_path: Kimi-K2.7-W4A8-128k-1k-TPOT50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Kimi-K2.7-W4A8-254k-1k-TPOT20-PD
-        config_file_path: Kimi-K2.7-W4A8-254k-1k-TPOT20-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
-      - name: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD
-        config_file_path: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
       - name: Qwen3.5-122B-A10B-w4a8-128k-1k-TPOT50-90-PD
         config_file_path: Qwen3.5-122B-A10B-w4a8-128k-1k-TPOT50-90-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 3
-      - name: Qwen3.5-122B-A10B-w4a8-984k-1k-0-PD
-        config_file_path: Qwen3.5-122B-A10B-w4a8-984k-1k-0-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
       - name: GLM-5.1-W8A8C8-3.5k-1.5k-0-20-PD
         config_file_path: GLM-5.1-W8A8C8-3.5k-1.5k-0-20-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
@@ -173,10 +137,6 @@ a3:
         config_file_path: Minimax_m2.7_in198_prefix99.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 3
-      - name: Qwen3.5-397B-w4a8_3.5k-1.5k-0-50
-        config_file_path: Qwen3.5-397B-w4a8_3.5k-1.5k-0-50-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
       - name: Qwen3.5-397B-w4a8_64k-1k-90-50
         config_file_path: Qwen3.5-397B-w4a8_64k-1k-90-50-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
@@ -185,14 +145,14 @@ a3:
         config_file_path: Qwen3.5-397B-w4a8_128k-1k-90-50-PD.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 3
-      - name: Qwen3.5-397B-w4a8_986k-function
-        config_file_path: Qwen3.5-397B-w4a8_986k-function-PD.yaml
-        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
       - name: GLM-5.2-W4A8C8-1M-PD-DCP
         config_file_path: GLM-5.2-W4A8C8-1M-PD-DCP.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
-        size: 2
+        size: 4
+      - name: GLM-5.2-W8A8C8-A3-Memcache-PD
+        config_file_path: GLM-5.2-W8A8C8-A3-Memcache-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 4
   double_node:
     test_config:
       - name: DeepSeek-V3_2-W8A8-EP_weekly
@@ -287,6 +247,26 @@ a3:
         config_file_path: DeepSeek-V4-Flash-Memcache-PD-acc.yaml
         config_base_path: tests/e2e/weekly/multi_node/external_dp/config
         size: 2
+      - name: Qwen3.5-397B-w4a8_986k-function
+        config_file_path: Qwen3.5-397B-w4a8_986k-function-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
+      - name: Qwen3.5-397B-w4a8_3.5k-1.5k-0-50
+        config_file_path: Qwen3.5-397B-w4a8_3.5k-1.5k-0-50-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
+      - name: Qwen3.5-122B-A10B-w4a8-984k-1k-0-PD
+        config_file_path: Qwen3.5-122B-A10B-w4a8-984k-1k-0-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
+      - name: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD
+        config_file_path: Kimi-K2.6-W4A8-64k-1k-TPOT50-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
+      - name: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD
+        config_file_path: Qwen3.5-122B-A10B-w4a8-16k-1k-TPOT50-0-PD.yaml
+        config_base_path: tests/e2e/weekly/multi_node/external_dp/config
+        size: 2
   single_node:
     test_config:
       # pytest-driven tests
@@ -297,7 +277,7 @@ a3:
         os: linux-aarch64-a3-2
         tests: tests/e2e/weekly/single_node/features/structured_output
       - name: test_qwen3_grid_exceed_65536
-        os: linux-aarch64-a3-1
+        os: linux-aarch64-a3-2
         tests: tests/e2e/weekly/single_node/features/test_qwen3_grid_exceed_65536.py
       - name: deepseek-v3-2-w8a8
         os: linux-aarch64-a3-16

--- a/.github/workflows/schedule_weekly_test_a3.yaml
+++ b/.github/workflows/schedule_weekly_test_a3.yaml
@@ -292,7 +292,7 @@ jobs:
       bisect_no_verify_good: ${{ fromJSON(inputs.bisect_args_json || '{}').no_verify_good || false }}
       bisect_no_verify_bad: ${{ fromJSON(inputs.bisect_args_json || '{}').no_verify_bad || false }}
       bisect_force_initial_build: ${{ fromJSON(inputs.bisect_args_json || '{}').force_initial_build || false }}
-      bisect_config_base_path: tests/e2e/weekly/multi_node/internal_dp/config
+      bisect_config_base_path: ${{ matrix.test_config.config_base_path }}
       testcase_timeout: 600
       should_run: >-
         ${{

--- a/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek-V4-Pro-w4a8-PD-no-prefix.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/DeepSeek-V4-Pro-w4a8-PD-no-prefix.yaml
@@ -94,7 +94,7 @@ templates:
       - --max-model-len
       - "150000"
       - --max-num-batched-tokens
-      - "8192"
+      - "4096"
       - --max-num-seqs
       - "16"
       - --no-disable-hybrid-kv-cache-manager
@@ -147,7 +147,7 @@ templates:
       - --max-model-len
       - "150000"
       - --max-num-batched-tokens
-      - "8192"
+      - "4096"
       - --max-num-seqs
       - "16"
       - --no-disable-hybrid-kv-cache-manager

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-A3-Memcache-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-A3-Memcache-PD.yaml
@@ -1,0 +1,210 @@
+test_name: "GLM-5.2-W8A8C8-A3-Memcache-PD"
+model: "Eco-Tech/GLM-5.2-W8A8C8"
+num_nodes: 4
+npu_per_node: 16
+
+routing:
+  type: "disaggregated_prefill"
+  groups:
+    prefiller: [ 0, 1 ]
+    decoder: [ 2, 3 ]
+
+kv_pool:
+  type: memcache
+  meta_service_port: 5002
+  config_store_port: 6002
+  config:
+    meta:
+      ock.mmc.meta_service.metrics_url: "http://${MASTER_IP}:8002"
+      ock.mmc.log_level: info
+    local:
+      ock.mmc.log_level: info
+      ock.mmc.local_service.world_size: 256
+      ock.mmc.local_service.protocol: device_sdma
+      ock.mmc.local_service.dram.size: 10GB
+
+config:
+  - node_index: 0
+    port_start: 7100
+    dp_rpc_port: 13389
+    dp_size: 2
+    dp_size_local: 1
+    dp_rank_start: 0
+    tp_size: 16
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 1
+    port_start: 7100
+    dp_rpc_port: 13389
+    dp_size: 2
+    dp_size_local: 1
+    dp_rank_start: 1
+    tp_size: 16
+    dp_address: "${NODE_0_IP}"
+
+  - node_index: 2
+    port_start: 7100
+    dp_rpc_port: 13390
+    dp_size: 2
+    dp_size_local: 1
+    dp_rank_start: 0
+    tp_size: 16
+    dp_address: "${NODE_2_IP}"
+
+  - node_index: 3
+    port_start: 7100
+    dp_rpc_port: 13390
+    dp_size: 2
+    dp_size_local: 1
+    dp_rank_start: 1
+    tp_size: 16
+    dp_address: "${NODE_2_IP}"
+
+env_common: &env_common
+  SERVER_PORT: "${PORT}"
+  ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
+  VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
+  HCCL_OP_EXPANSION_MODE: "AIV"
+  VLLM_ENGINE_READY_TIMEOUT_S: "100000"
+  VLLM_RPC_TIMEOUT: "3600000"
+  VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS: "30000"
+  HCCL_EXEC_TIMEOUT: "204"
+  HCCL_CONNECT_TIMEOUT: "7200"
+  ASCEND_CONNECT_TIMEOUT: "10000"
+  ASCEND_TRANSFER_TIMEOUT: "10000"
+  MF_GROUP_JOIN_MAX_TIMEOUT: "1200"
+  OMP_PROC_BIND: "false"
+  OMP_NUM_THREADS: "1"
+  PYTORCH_NPU_ALLOC_CONF: "expandable_segments:True"
+  HCCL_BUFFSIZE: "400"
+  ACL_OP_INIT_MODE: "1"
+  ASCEND_A3_ENABLE: "1"
+  LD_LIBRARY_PATH: "/usr/local/python3.11.10/lib/python3.11/site-packages/memcache_hybrid/lib:$PYTHON_LIB_DIR:$LD_LIBRARY_PATH:/usr/local/lib"
+
+env_prefill: &env_prefill
+  <<: *env_common
+  VLLM_ASCEND_ENABLE_FLASHCOMM1: "1"
+
+env_decode: &env_decode
+  <<: *env_common
+  TASK_QUEUE_ENABLE: "1"
+  VLLM_ASCEND_ENABLE_MLAPO: "1"
+
+prefill_server_cmd: &prefill_server_cmd
+  - "--host"
+  - "0.0.0.0"
+  - "--port"
+  - "$SERVER_PORT"
+  - "--data-parallel-size"
+  - "${DP_SIZE}"
+  - "--data-parallel-rank"
+  - "${DP_RANK}"
+  - "--data-parallel-address"
+  - "${DP_ADDRESS}"
+  - "--data-parallel-rpc-port"
+  - "${DP_RPC_PORT}"
+  - "--tensor-parallel-size"
+  - "${TP_SIZE}"
+  - "--enable-expert-parallel"
+  - "--speculative-config"
+  - '{"num_speculative_tokens": 1, "method": "deepseek_mtp", "enforce_eager": true}'
+  - "--seed"
+  - "1024"
+  - "--max-model-len"
+  - "133120"
+  - "--additional-config"
+  - '{"fuse_muls_add": true, "enable_dsa_cp": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true, "c8_enable_reshape_optim": true}'
+  - "--max-num-batched-tokens"
+  - "8192"
+  - "--trust-remote-code"
+  - "--enable-prefix-caching"
+  - "--max-num-seqs"
+  - "64"
+  - "--quantization"
+  - "ascend"
+  - "--gpu-memory-utilization"
+  - "0.90"
+  - "--enforce-eager"
+  - "--enable-auto-tool-choice"
+  - "--tool-call-parser"
+  - "glm47"
+  - "--reasoning-parser"
+  - "glm45"
+  - "--kv-transfer-config"
+  - '{"kv_connector":"MultiConnector","kv_role":"kv_producer","kv_port":"30000","engine_id":"${DP_RANK}","kv_connector_extra_config":{"connectors":[{"kv_connector":"MooncakeConnectorV1","kv_role":"kv_producer","kv_buffer_device":"npu","kv_port":"30000","kv_connector_extra_config":{"use_ascend_direct":true,"prefill":{"dp_size":2,"tp_size":16},"decode":{"dp_size":2,"tp_size":16}}},{"kv_connector":"AscendStoreConnector","kv_role":"kv_producer","kv_connector_extra_config":{"lookup_rpc_port":"0","backend":"memcache","use_layerwise":false}}]}}'
+
+decode_server_cmd: &decode_server_cmd
+  - "--host"
+  - "0.0.0.0"
+  - "--port"
+  - "$SERVER_PORT"
+  - "--data-parallel-size"
+  - "${DP_SIZE}"
+  - "--data-parallel-rank"
+  - "${DP_RANK}"
+  - "--data-parallel-address"
+  - "${DP_ADDRESS}"
+  - "--data-parallel-rpc-port"
+  - "${DP_RPC_PORT}"
+  - "--tensor-parallel-size"
+  - "${TP_SIZE}"
+  - "--enable-expert-parallel"
+  - "--seed"
+  - "1024"
+  - "--max-model-len"
+  - "133120"
+  - "--max-num-batched-tokens"
+  - "192"
+  - "--compilation-config"
+  - '{"cudagraph_mode": "FULL_DECODE_ONLY"}'
+  - "--speculative-config"
+  - '{"num_speculative_tokens": 5, "method": "deepseek_mtp", "enforce_eager": true}'
+  - "--additional-config"
+  - '{"fuse_muls_add": true, "recompute_scheduler_enable": true, "multistream_overlap_shared_expert": true, "enable_sparse_sfa_c8": true, "enable_sparse_li_c8": true}'
+  - "--trust-remote-code"
+  - "--max-num-seqs"
+  - "32"
+  - "--gpu-memory-utilization"
+  - "0.92"
+  - "--async-scheduling"
+  - "--quantization"
+  - "ascend"
+  - "--enable-auto-tool-choice"
+  - "--tool-call-parser"
+  - "glm47"
+  - "--reasoning-parser"
+  - "glm45"
+  - "--kv-transfer-config"
+  - '{"kv_connector":"MultiConnector","kv_role":"kv_consumer","kv_port":"30000","engine_id":"${DP_RANK}","kv_connector_extra_config":{"connectors":[{"kv_connector":"MooncakeConnectorV1","kv_role":"kv_consumer","kv_buffer_device":"npu","kv_port":"30000","kv_connector_extra_config":{"use_ascend_direct":true,"prefill":{"dp_size":2,"tp_size":16},"decode":{"dp_size":2,"tp_size":16}}},{"kv_connector":"AscendStoreConnector","kv_role":"kv_consumer","kv_connector_extra_config":{"lookup_rpc_port":"0","backend":"memcache","use_layerwise":false}}]}}'
+
+templates:
+  - node_index: 0
+    envs:
+      <<: *env_prefill
+    server_cmd_template: *prefill_server_cmd
+
+  - node_index: 1
+    envs:
+      <<: *env_prefill
+    server_cmd_template: *prefill_server_cmd
+
+  - node_index: 2
+    envs:
+      <<: *env_decode
+    server_cmd_template: *decode_server_cmd
+
+  - node_index: 3
+    envs:
+      <<: *env_decode
+    server_cmd_template: *decode_server_cmd
+
+benchmarks:
+  acc:
+    case_type: accuracy
+    dataset_path: vllm-ascend/gsm8k-lite
+    request_conf: vllm_api_general_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_chat_prompt
+    max_out_len: 8192
+    batch_size: 8
+    baseline: 95
+    threshold: 10

--- a/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-A3-Memcache-PD.yaml
+++ b/tests/e2e/weekly/multi_node/external_dp/config/GLM-5.2-W8A8C8-A3-Memcache-PD.yaml
@@ -61,6 +61,7 @@ config:
     dp_address: "${NODE_2_IP}"
 
 env_common: &env_common
+  VLLM_USE_MODELSCOPE: "true"
   SERVER_PORT: "${PORT}"
   ASCEND_RT_VISIBLE_DEVICES: "${VISIBLE_DEVICES}"
   VLLM_ASCEND_ENABLE_FUSED_MC2: "1"
@@ -199,6 +200,28 @@ templates:
     server_cmd_template: *decode_server_cmd
 
 benchmarks:
+  perf_warmup:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in131072-bs500-prefix90-glm51
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 16
+    max_out_len: 1024
+    batch_size: 4
+    request_rate: 0
+    baseline: 0
+    threshold: 0.97
+  perf:
+    case_type: performance
+    dataset_path: vllm-ascend/GSM8K-in131072-bs500-prefix90-glm51
+    request_conf: vllm_api_stream_chat
+    dataset_conf: gsm8k/gsm8k_gen_0_shot_cot_str_perf
+    num_prompts: 256
+    max_out_len: 1024
+    batch_size: 64
+    request_rate: 1.52
+    baseline: 0
+    threshold: 0.97
   acc:
     case_type: accuracy
     dataset_path: vllm-ascend/gsm8k-lite


### PR DESCRIPTION
### What this PR does / why we need it?
This PR updates the test configuration for `DeepSeek-V4-Pro-w4a8-PD-no-prefix` by reducing the `--max-num-batched-tokens` from `8192` to `4096` to optimize memory usage or adjust test sizes. Additionally, it introduces a new multi-node end-to-end test configuration for `GLM-5.2-W8A8C8-A3-Memcache-PD` with disaggregated prefill routing and memcache KV pool.
### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
By running weekly test.
- vLLM version: v0.27.1
- vLLM main: https://github.com/vllm-project/vllm/commit/ba07e4a48fc951300d97eb506217dd530583dea3
