### PR TITLE
[v0.26.0rc][BugFix] Recognize K3 DSpark as MLA

### DIFF
--- a/vllm_ascend/patch/platform/patch_speculative_config.py
+++ b/vllm_ascend/patch/platform/patch_speculative_config.py
@@ -1,7 +1,9 @@
+from functools import wraps
 from typing import TYPE_CHECKING, Any
 
 from vllm.config.speculative import SpeculativeConfig
 from vllm.transformers_utils.configs.speculators import algos as speculator_algos
+from vllm.transformers_utils.model_arch_config_convertor import ModelArchConfigConvertorBase
 from vllm.utils.import_utils import LazyLoader
 
 from vllm_ascend.transformers_utils.configs.kimi_k3 import (
@@ -24,6 +26,30 @@ else:
 # the lightweight config here as well so ModelConfig can parse the draft before
 # speculative post-init normalizes its architecture.
 register_k3_dspark_config()
+
+
+# vLLM v0.26 predates the K3 MLA classification added by vLLM #50000. Patch
+# the converter before either target or draft ModelConfig is constructed so
+# the compressed KV-cache geometry and DCP validation both see use_mla=True.
+def _patch_k3_dspark_mla_detection() -> None:
+    current = ModelArchConfigConvertorBase.is_deepseek_mla
+    if getattr(current, "_vllm_ascend_k3_dspark_mla", False):
+        return
+
+    @wraps(current)
+    def is_deepseek_mla(self: ModelArchConfigConvertorBase) -> bool:
+        if (
+            getattr(self.hf_text_config, "model_type", None) == "k3_dspark"
+            and getattr(self.hf_text_config, "kv_lora_rank", None) is not None
+        ):
+            return True
+        return current(self)
+
+    is_deepseek_mla._vllm_ascend_k3_dspark_mla = True  # type: ignore[attr-defined]
+    ModelArchConfigConvertorBase.is_deepseek_mla = is_deepseek_mla
+
+
+_patch_k3_dspark_mla_detection()
 
 
 # Backport vLLM #48639. v0.26 unconditionally rewrites Speculators DSpark


### PR DESCRIPTION
## What this PR does / why we need it

The vLLM 0.26 model-architecture converter predates vLLM PR #50000 and does not classify model_type k3_dspark as MLA. As a result, Inferact/Kimi-K3-DSpark is interpreted using its 64 logical KV heads as a GQA draft model. That derives the wrong KV-cache head size and reaches the GQA-only DCP validation path.

This patch extends the existing v0.26 DSpark compatibility patch so an exact k3_dspark config with kv_lora_rank is recognized as MLA before the draft ModelConfig is constructed. The existing MLA DCP path can then apply without weakening DCP validation for actual GQA draft models.

Related upstream change: https://github.com/vllm-project/vllm/pull/50000

## Validation

- ruff check
- ruff format --check
- Python syntax compilation
- git diff --check

No regression test is included in this backport.
- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
