### PR TITLE
[Kernel] Feed merged qkv into Kimi K3 KDA attention via a vllm-ascend-local kda_attention_qkv op

### DIFF
--- a/vllm_ascend/ops/kimi_kda.py
+++ b/vllm_ascend/ops/kimi_kda.py
@@ -19,7 +19,11 @@
 The vLLM implementation provides the projections, cache specification, and
 opaque ``kda_attention`` custom op.  This OOT replacement keeps that public
 surface while routing prefill through the Kimi AscendC kernels and decode
-through the recurrent KDA AscendC kernel.
+through the recurrent KDA AscendC kernel.  The one deliberate deviation is
+the Ascend-local ``kda_attention_qkv`` op below: it takes the merged qkv
+projection so the fused QKV linear feeds the op boundary directly (no
+split/cat round trip) while the upstream ``(q, k, v)`` op and the reference
+path on other platforms stay untouched.
 """
 
 from collections.abc import Callable
@@ -30,6 +34,7 @@ from einops import rearrange
 from vllm.config import VllmConfig
 from vllm.distributed import get_pcp_group, get_tensor_model_parallel_rank
 from vllm.forward_context import get_forward_context
+from vllm.utils.torch_utils import direct_register_custom_op
 
 try:
     from vllm.model_executor.layers.fla.ops.l2norm import l2norm_fwd  # type: ignore[import-not-found]
@@ -69,6 +74,7 @@ if HAS_TRITON:
 _KDA_CHUNK_SIZE = 64
 _PACKED_CONV_WEIGHT_NAME = "packed_conv_weights"
 _FUSED_QKV_NAME = "fused_qkv"
+_KDA_ATTENTION_QKV_OP = "vllm::kda_attention_qkv"
 
 
 def _zero_padded_spec_output(
@@ -93,6 +99,46 @@ def _zero_padded_spec_output(
         output,
         0.0,
     )
+
+
+def _kda_attention_qkv_impl(
+    qkv: torch.Tensor,
+    g1: torch.Tensor,
+    beta: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Ascend-local counterpart of vLLM's ``kda_attention`` custom op.
+
+    Identical mechanics (opaque boundary that resolves the layer from
+    ``no_compile_layers`` and calls its ``_forward`` eagerly), but takes the
+    merged qkv projection so the fused QKV linear feeds the op boundary
+    directly — no ``split`` before / ``cat`` after. Keeping this op local
+    lets the upstream ``vllm::kda_attention`` and its ``(q, k, v)`` signature
+    stay untouched, so vllm-ascend works against stock vLLM.
+    """
+    forward_context = get_forward_context()
+    self = forward_context.no_compile_layers[layer_name]
+    self._forward(qkv=qkv, g1=g1, beta=beta, core_attn_out=core_attn_out)
+
+
+def _kda_attention_qkv_fake(
+    qkv: torch.Tensor,
+    g1: torch.Tensor,
+    beta: torch.Tensor,
+    core_attn_out: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="kda_attention_qkv",
+    op_func=_kda_attention_qkv_impl,
+    mutates_args=["core_attn_out"],
+    fake_impl=_kda_attention_qkv_fake,
+    dispatch_key="PrivateUse1",
+)
 
 
 def uses_kimi_k3_global_inputs_embeds(vllm_config: VllmConfig) -> bool:
@@ -166,6 +212,15 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
 
     def __init__(self, config, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__(config, vllm_config, prefix)
+
+        # Piecewise cudagraphs split the compiled graph at attention ops by
+        # name; ``vllm::kda_attention_qkv`` is registered on our side and thus
+        # absent from vLLM's built-in list. Model construction runs before
+        # compilation, so appending here is in time. FULL cudagraph and eager
+        # modes never consult the list and are unaffected.
+        splitting_ops = vllm_config.compilation_config.splitting_ops
+        if splitting_ops is not None and _KDA_ATTENTION_QKV_OP not in splitting_ops:
+            splitting_ops.append(_KDA_ATTENTION_QKV_OP)
 
         kda_config = config.linear_attn_config
         assert kda_config is not None, "linear_attn_config must be set"
@@ -266,8 +321,6 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         )
         num_tokens = hidden_states.size(0)
         qkv = self.fused_qkv(hidden_states)[0]
-        projection_size = self.local_num_heads * self.head_dim
-        q, k, v = qkv.split([projection_size] * 3, dim=-1)
 
         beta = self.b_proj(hidden_states)[0].float().sigmoid().unsqueeze(0)
         raw_gate = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
@@ -284,10 +337,8 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
             dtype=hidden_states.dtype,
             device=hidden_states.device,
         )
-        torch.ops.vllm.kda_attention(
-            q,
-            k,
-            v,
+        torch.ops.vllm.kda_attention_qkv(
+            qkv,
             raw_gate,
             beta,
             core_attn_out,
@@ -524,9 +575,7 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
 
     def _forward(
         self,
-        q_proj_states: torch.Tensor,
-        k_proj_states: torch.Tensor,
-        v_proj_states: torch.Tensor,
+        qkv: torch.Tensor,
         g1: torch.Tensor,
         beta: torch.Tensor,
         core_attn_out: torch.Tensor,
@@ -541,14 +590,11 @@ class AscendKimiGatedDeltaNetAttention(KimiGatedDeltaNetAttention):
         assert isinstance(attn_metadata, GDNAttentionMetadata)
 
         num_actual_tokens = attn_metadata.num_actual_tokens
-        q_proj_states = q_proj_states[:num_actual_tokens]
-        k_proj_states = k_proj_states[:num_actual_tokens]
-        v_proj_states = v_proj_states[:num_actual_tokens]
+        mixed_qkv = qkv[:num_actual_tokens]
         g1 = g1[:, :num_actual_tokens]
         beta = beta[:, :num_actual_tokens]
 
         conv_state, recurrent_state = self.kv_cache
-        mixed_qkv = torch.cat((q_proj_states, k_proj_states, v_proj_states), dim=-1)
         conv_weights_t = self._conv_weights_t()
 
         spec_masks = attn_metadata.spec_sequence_masks


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ https://docs.vllm.ai/en/latest/contributing/overview.html

-->
### What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

NPU profiling of the Kimi K3 KDA (gated delta-net) layer shows the merged `fused_qkv` projection output is split into q/k/v just so the attention op can take three separate tensors, after which the pieces are re-concatenated (`torch.cat`) before the fused `CausalConv1d`. The front 3 Slices + 1 ConcatD add no semantic value — the conv weights are already packed as `[conv_size, 3*C]` and the kernel natively processes q/k/v together — and are part of a `split → cat → conv → chunk` layout round-trip that dominates the conv sub-graph time.

This PR keeps the merged qkv all the way to the conv instead of splitting it just to re-concatenate. It registers a vllm-ascend-local `vllm::kda_attention_qkv` custom op with the merged-qkv signature, using the same opaque-boundary mechanics as the upstream `vllm::kda_attention` op (the impl resolves the layer from `no_compile_layers` and calls its `_forward` eagerly). The shared upstream op signature is deliberately not changed, so the upstream op, its `(q, k, v)` schema, and the reference path on other platforms stay untouched and vllm-ascend keeps working against stock vLLM. The result is bit-identical (`qkv == cat(split(qkv))`).

The op is appended to `compilation_config.splitting_ops` at layer init so piecewise cudagraphs still split the compiled graph at the attention boundary (model construction runs before compilation; FULL cudagraph and eager modes don't consult the list).

The change is pure Python (`vllm_ascend/ops/kimi_kda.py` only) — no kernel or `.so` rebuild required.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

Additive only:

- New custom op `vllm::kda_attention_qkv` (registered on the vllm-ascend side); the upstream `vllm::kda_attention` op and its `(q, k, v)` schema are untouched.
- `AscendKimiGatedDeltaNetAttention._forward` (private method) signature changes to take the merged `qkv`.
- `vllm::kda_attention_qkv` is appended to `compilation_config.splitting_ops` at KDA layer init (no user action needed).
- No numerical change: bit-identical end to end.

### How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

- **End-to-end A/B** (editable install, single-node TP16/DP1/EP16 on Atlas A3, cudagraph `FULL_DECODE_ONLY`, dspark speculative decoding): the same greedy prompt run on pre-PR code and on this PR produces **token-identical outputs**.
- **Profile comparison** over the same 128-token decode window (`/start_profile` → identical decode request → `/stop_profile`, `torch_npu.profiler.analyse`, rank0 `op_statistic.csv`): the ConcatD / `CausalConv1d` / `RecurrentKda` numbers above; `CausalConv1d` and `RecurrentKda` invocation counts and durations flat, confirming conv and SSM run exactly as before (pure I/O optimization).
- No unit test was added: the change is a graph-level I/O re-plumbing verified bit-identical end to end; there is no new kernel or numerical code path to assert on.