### PR TITLE
[v0.26.0][Performance][Spec Decode] Shard DeepSeek V4 DSpark main projection across TP ranks

### DIFF
--- a/vllm_ascend/models/deepseek_v4_dspark.py
+++ b/vllm_ascend/models/deepseek_v4_dspark.py
@@ -24,7 +24,7 @@ from vllm.distributed import (
 from vllm.logger import logger
 from vllm.model_executor.layers.fused_moe import fused_moe_make_expert_params_mapping
 from vllm.model_executor.layers.layernorm import RMSNorm
-from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.linear import ColumnParallelLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -120,13 +120,14 @@ class DeepseekV4DSparkModel(nn.Module):
         )
 
         first_layer = self.layers[str(self.mtp_start_layer_idx)]
-        self.main_proj = ReplicatedLinear(
+        self.main_proj = ColumnParallelLinear(
             config.hidden_size * len(self.target_layer_ids),
             config.hidden_size,
             bias=False,
             return_bias=False,
             quant_config=None,
             prefix=maybe_prefix(prefix, f"layers.{self.mtp_start_layer_idx}.main_proj"),
+            gather_output=True,
         )
         self.main_norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         first_layer.main_proj = self.main_proj


### PR DESCRIPTION
### What this PR does / why we need it?

DeepSeek V4 DSpark currently implements `main_proj` with `ReplicatedLinear`, so every tensor-parallel rank stores the full projection weight and executes the full projection.

This PR replaces it with `ColumnParallelLinear`. The output features are sharded across TP ranks, and `gather_output=True` restores the full hidden state before RMSNorm and the downstream draft layers.

For DeepSeek V4 Pro, the BF16 `main_proj` weight has shape `[7168, 21504]`. With TP=8, this change reduces persistent weight memory on each rank from 294 MiB to 36.75 MiB, saving 257.25 MiB per rank and about 2.01 GiB across the TP group, excluding temporary communication buffers.

It also reduces the projection weight read on each rank to one eighth of the replicated implementation. This is expected to provide a significant memory-access benefit during decode, where the small-M projection is more bandwidth-sensitive. Decode end-to-end performance has not been quantified yet.

Performance profiling on DeepSeek V4 Pro:

| Configuration | Before | After |
| --- | ---: | ---: |
| TP=8, `--max-num-batched-tokens 8192` | 9 ms | 2 ms |

### Does this PR introduce _any_ user-facing change?

No. This only changes the internal tensor-parallel execution strategy of the DSpark main projection.

### How was this patch tested?

- Profiled DeepSeek V4 Pro with TP=8 and `--max-num-batched-tokens 8192`; `main_proj` latency decreased from 9 ms to 2 ms.
- `python3 -m py_compile vllm_ascend/models/deepseek_v4/dspark.py`
- `git diff --check github/main...HEAD`

No new unit test was added because the change uses the existing `ColumnParallelLinear` output sharding and AllGather path without introducing a new operator or interface.


- vLLM version: v0.26.0
- vLLM main: https://github.com/vllm-project/vllm/commit/d02df748bf9efd99022f1a062597dc3cb3808485
